### PR TITLE
ci: ensure core can be built with no_std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -246,6 +246,60 @@ jobs:
       - name: Stop sccache
         run: sccache --stop-server
 
+  no_std:
+    runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+    steps:
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          target: thumbv7m-none-eabi
+
+      - uses: actions/checkout@v2
+
+      - name: Install sccache
+        uses: actions-rs/install@v0.1
+        with:
+          crate: sccache
+          use-tool-cache: true
+          version: latest
+
+      - name: Generate Cargo.lock
+        run: cargo update
+
+      - name: Cache cargo registry
+        uses: actions/cache@v2
+        continue-on-error: true
+        with:
+          path: ~/.cargo/registry/cache
+          key: ${{ runner.os }}-${{ matrix.rust }}-no-std-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.rust }}-no-std-cargo-registry-
+
+      - name: Cache sccache output
+        uses: actions/cache@v2
+        continue-on-error: true
+        with:
+          path: ${{ github.workspace }}/.sccache
+          key: ${{ runner.os }}-${{ matrix.rust }}-no-std-sccache-${{ hashFiles('**/Cargo.*') }}
+          restore-keys: ${{ runner.os }}-${{ matrix.rust }}-no-std-sccache-
+
+      - name: Start sccache
+        run: sccache --start-server
+
+      # see https://github.com/rust-lang/cargo/issues/7916
+      - name: Run cargo build
+        run: |
+          cd quic/s2n-quic-core && \
+            cargo build \
+              -Z features=dev_dep \
+              --no-default-features \
+              --target thumbv7m-none-eabi
+
+      - name: Stop sccache
+        run: sccache --stop-server
+
   coverage:
     runs-on: ubuntu-latest
     env:

--- a/common/s2n-codec/src/lib.rs
+++ b/common/s2n-codec/src/lib.rs
@@ -1,5 +1,5 @@
-#![cfg_attr(all(not(feature = "checked_range_unsafe")), forbid(unsafe_code))]
-#![cfg_attr(all(not(test), not(feature = "std")), no_std)]
+#![cfg_attr(not(feature = "checked_range_unsafe"), forbid(unsafe_code))]
+#![cfg_attr(not(any(test, feature = "std")), no_std)]
 
 #[cfg(any(feature = "testing", test))]
 #[macro_use]

--- a/quic/s2n-quic-core/src/packet/decoding.rs
+++ b/quic/s2n-quic-core/src/packet/decoding.rs
@@ -10,7 +10,7 @@ use crate::{
     },
     varint::VarInt,
 };
-use core::mem::size_of;
+use core::{convert::TryInto, mem::size_of};
 use s2n_codec::{CheckedRange, DecoderBuffer, DecoderBufferMut, DecoderError, DecoderValue};
 
 pub struct HeaderDecoder<'a> {
@@ -76,7 +76,7 @@ impl<'a> HeaderDecoder<'a> {
         Ok(source_connection_id)
     }
 
-    pub fn decode_checked_range<'b, Len: DecoderValue<'a> + Into<usize>>(
+    pub fn decode_checked_range<'b, Len: DecoderValue<'a> + TryInto<usize>>(
         &mut self,
         buffer: &DecoderBufferMut<'b>,
     ) -> Result<CheckedRange, DecoderError> {

--- a/quic/s2n-quic-core/src/transport/error.rs
+++ b/quic/s2n-quic-core/src/transport/error.rs
@@ -260,15 +260,10 @@ macro_rules! transport_error {
 impl From<DecoderError> for TransportError {
     fn from(decoder_error: DecoderError) -> Self {
         match decoder_error {
-            DecoderError::UnexpectedEof(_) => {
-                transport_error!(PROTOCOL_VIOLATION, "malformed packet")
-            }
-            DecoderError::UnexpectedBytes(_) => {
-                transport_error!(PROTOCOL_VIOLATION, "malformed packet")
-            }
             DecoderError::InvariantViolation(reason) => {
                 transport_error!(PROTOCOL_VIOLATION, reason)
             }
+            _ => transport_error!(PROTOCOL_VIOLATION, "malformed packet"),
         }
     }
 }

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -306,11 +306,7 @@ impl core::fmt::Display for ValidationError {
 
 impl From<DecoderError> for ValidationError {
     fn from(error: DecoderError) -> Self {
-        ValidationError(match error {
-            DecoderError::InvariantViolation(message) => message,
-            DecoderError::UnexpectedEof(_) => "unexpected eof",
-            DecoderError::UnexpectedBytes(_) => "unexpected bytes",
-        })
+        ValidationError(error.into())
     }
 }
 

--- a/quic/s2n-quic-core/src/varint/mod.rs
+++ b/quic/s2n-quic-core/src/varint/mod.rs
@@ -1,4 +1,7 @@
-use core::{convert::TryFrom, ops::Deref};
+use core::{
+    convert::{TryFrom, TryInto},
+    ops::Deref,
+};
 use s2n_codec::{decoder_value, Encoder, EncoderValue};
 
 //= https://quicwg.org/base-drafts/draft-ietf-quic-transport.html#rfc.section.16
@@ -352,13 +355,6 @@ impl_from_lesser!(u8);
 impl_from_lesser!(u16);
 impl_from_lesser!(u32);
 
-#[cfg(target_pointer_width = "64")]
-impl Into<usize> for VarInt {
-    fn into(self) -> usize {
-        self.0 as usize
-    }
-}
-
 impl Into<u64> for VarInt {
     fn into(self) -> u64 {
         self.0
@@ -370,6 +366,14 @@ impl TryFrom<usize> for VarInt {
 
     fn try_from(value: usize) -> Result<Self, Self::Error> {
         Self::new(value as u64)
+    }
+}
+
+impl TryInto<usize> for VarInt {
+    type Error = <usize as TryFrom<u64>>::Error;
+
+    fn try_into(self) -> Result<usize, Self::Error> {
+        self.0.try_into()
     }
 }
 

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_ranges.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_ranges.rs
@@ -1,5 +1,6 @@
 use crate::interval_set::{IntervalSet, RangeInclusiveIter};
 use core::{
+    convert::TryInto,
     num::NonZeroUsize,
     ops::{Deref, DerefMut, RangeInclusive},
 };
@@ -47,7 +48,7 @@ impl AckRanges {
             (Some(min), Some(max)) => {
                 let min = PacketNumber::as_varint(min);
                 let max = PacketNumber::as_varint(max);
-                (max - min).into()
+                (max - min).try_into().unwrap_or(core::usize::MAX)
             }
             _ => 0,
         }


### PR DESCRIPTION
*Description of changes:*

We want to make sure that the core crate is as portable as possible so building for the `thumbv7m-none-eabi` target ensures that it can be built for a 32-bit platform that is missing access to `std`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
