### PR TITLE
compliance: add sourcemap module

### DIFF
--- a/common/compliance/cargo-compliance/src/main.rs
+++ b/common/compliance/cargo-compliance/src/main.rs
@@ -7,6 +7,7 @@ mod pattern;
 mod project;
 mod report;
 mod source;
+mod sourcemap;
 mod specification;
 mod target;
 

--- a/common/compliance/cargo-compliance/src/pattern.rs
+++ b/common/compliance/cargo-compliance/src/pattern.rs
@@ -1,6 +1,7 @@
 use crate::{
     annotation::{Annotation, AnnotationSet},
     parser::ParsedAnnotation,
+    sourcemap::{LinesIter, Str},
     Error,
 };
 use std::path::Path;
@@ -41,9 +42,12 @@ impl<'a> Pattern<'a> {
     ) -> Result<(), Error> {
         let mut state = ParserState::Search;
 
-        for (line_no, line) in source.lines().enumerate() {
-            // lines start at 1
-            let line_no = line_no + 1;
+        for Str {
+            value: line,
+            line: line_no,
+            ..
+        } in LinesIter::new(source)
+        {
             let content = line.trim_start();
 
             match core::mem::replace(&mut state, ParserState::Search) {

--- a/common/compliance/cargo-compliance/src/project.rs
+++ b/common/compliance/cargo-compliance/src/project.rs
@@ -1,4 +1,4 @@
-use crate::{pattern::Pattern, source::SourceFile, Error};
+use crate::{pattern::Pattern, source::SourceFile, sourcemap::LinesIter, Error};
 use glob::glob;
 use serde::Deserialize;
 use std::{
@@ -117,8 +117,8 @@ impl Project {
 
         let stdout = core::str::from_utf8(&output.stdout)?;
 
-        for line in stdout.lines() {
-            if let Ok(event) = serde_json::from_str::<Event>(line) {
+        for line in LinesIter::new(stdout) {
+            if let Ok(event) = serde_json::from_str::<Event>(line.value) {
                 if let Some(executable) = event.executable {
                     sources.insert(SourceFile::Object(PathBuf::from(executable)));
                 }

--- a/common/compliance/cargo-compliance/src/sourcemap.rs
+++ b/common/compliance/cargo-compliance/src/sourcemap.rs
@@ -1,0 +1,114 @@
+use core::{
+    fmt,
+    ops::{Deref, Range},
+};
+
+#[derive(Clone, Copy, Debug)]
+pub struct LinesIter<'a> {
+    content: &'a str,
+    line: usize,
+    offset: usize,
+}
+
+impl<'a> LinesIter<'a> {
+    pub fn new(content: &'a str) -> Self {
+        Self {
+            content,
+            offset: 0,
+            line: 1,
+        }
+    }
+}
+
+impl<'a> Iterator for LinesIter<'a> {
+    type Item = Str<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let content = &self.content[self.offset..];
+
+        if content.is_empty() {
+            return None;
+        }
+
+        let rel_offset = content.find('\n').unwrap_or_else(|| content.len());
+
+        let value = Str {
+            value: &content[..rel_offset].trim_end_matches('\r'),
+            pos: self.offset,
+            line: self.line,
+        };
+
+        self.offset += rel_offset + 1; // trim \n
+        self.line += 1;
+        Some(value)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Str<'a> {
+    pub value: &'a str,
+    pub pos: usize,
+    pub line: usize,
+}
+
+impl<'a> fmt::Debug for Str<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
+impl<'a> fmt::Display for Str<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
+impl<'a> Str<'a> {
+    pub fn indentation(&self) -> usize {
+        let trimmed_line = self.trim_start();
+        self.len() - trimmed_line.len()
+    }
+
+    pub fn slice(&self, bounds: Range<usize>) -> Self {
+        let pos = self.pos + bounds.start;
+        let value = &self.value[bounds];
+        Self {
+            value,
+            pos,
+            line: self.line,
+        }
+    }
+
+    pub fn range(&self) -> Range<usize> {
+        let pos = self.pos;
+        pos..(pos + self.value.len())
+    }
+
+    pub fn trim(&self) -> Self {
+        let value = self.value.trim_start();
+        let pos = self.pos + (self.len() - value.len());
+        let value = value.trim_end();
+        Self {
+            value,
+            pos,
+            line: self.line,
+        }
+    }
+
+    pub fn trim_end_matches(&self, pat: char) -> Self {
+        let value = self.value.trim_end_matches(pat);
+        Self {
+            value,
+            pos: self.pos,
+            line: self.line,
+        }
+    }
+}
+
+impl<'a> Deref for Str<'a> {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        self.value
+    }
+}


### PR DESCRIPTION
* Moved `Content` into `sourcemap` and renamed to `Str`
* Created a `LinesIter` to correctly handle newlines across platforms

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
