### PR TITLE
Initial commit of QNS docker files

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+on:
+  push:
+    branches:
+      - master
+
+  release:
+    types: [published]
+
+jobs:
+  qns:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build and push image
+        uses: docker/build-push-action@v1
+        with:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: awslabs/s2n-quic/s2n-quic-qns
+          tag_with_ref: true
+          dockerfile: qns/Dockerfile
+
+

--- a/qns/Dockerfile
+++ b/qns/Dockerfile
@@ -1,0 +1,22 @@
+FROM rust:latest AS builder
+
+# remove debug symbols
+ENV RUSTFLAGS="-C link-arg=-s -C panic=abort"
+
+# copy sources
+COPY Cargo.* /s2n-quic/
+COPY common /s2n-quic/common
+COPY quic /s2n-quic/quic
+WORKDIR /s2n-quic
+
+# build server
+RUN cargo build --bin interop-server --release
+
+FROM martenseemann/quic-network-simulator-endpoint:latest
+
+COPY --from=builder /s2n-quic/target/release/interop-server /usr/bin/s2n-quic-qns
+
+# copy run script and run it
+COPY qns/run_endpoint.sh .
+RUN chmod +x run_endpoint.sh
+ENTRYPOINT [ "./run_endpoint.sh" ]

--- a/qns/run_endpoint.sh
+++ b/qns/run_endpoint.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# Set up the routing needed for the simulation
+/setup.sh
+
+# The following variables are available for use:
+# - ROLE contains the role of this execution context, client or server
+# - SERVER_PARAMS contains user-supplied command line parameters
+# - CLIENT_PARAMS contains user-supplied command line parameters
+
+if [ "$ROLE" == "client" ]; then
+    # Wait for the simulator to start up.
+    /wait-for-it.sh sim:57832 -s -t 30
+elif [ "$ROLE" == "server" ]; then
+    echo "Running QUIC server on 0.0.0.0:4433"
+    echo "$@"
+    s2n-quic-qns -p 4433
+fi


### PR DESCRIPTION
*Issue #, if available:*

Partial #16 #15 

*Description of changes:*

These are the initial steps required for working with the [quic-network-simulator](https://github.com/marten-seemann/quic-network-simulator) and [https://github.com/marten-seemann/quic-interop-runner](quic-iterop-runner) projects.

The docker file builds the project inside the rust builder, copying the `interop-server` artifact into the `quic-network-simulator-endpoint` image. The `run_endpoint.sh` script only works in server mode for this package.

Includes a github action to build and publish to github packages on pushes to the main branch and releases.

Tested by executing the following from within the `s2n-quic` top level:

```
$ docker build . -f ./qns/Dockerfile
$ docker run -it --entrypoint bash 1ba25def30ba
root@f916e1749000:/# ROLE=server ./run_endpoint.sh
Setting up routes...
Cannot set device feature settings: Operation not permitted
SIOCADDRT: Operation not permitted
SIOCDELRT: Operation not permitted
Running QUIC server on 0.0.0.0:4433

Server listening on port 4433
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
