### PR TITLE
ci: use rust-covfix for coverage exclusions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,6 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
-    env:
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions-rs/toolchain@v1
         id: toolchain
@@ -108,6 +106,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --all-targets -- -D warnings
+        env:
+          RUSTC_WRAPPER: sccache
 
       - name: Stop sccache
         run: sccache --stop-server
@@ -140,8 +140,6 @@ jobs:
       matrix:
         rust: ${{ fromJson(needs.env.outputs.rust-versions) }}
         os: [ubuntu-latest, macOS-latest]
-    env:
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions-rs/toolchain@v1
         id: toolchain
@@ -190,6 +188,8 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+        env:
+          RUSTC_WRAPPER: sccache
 
       - name: Stop sccache
         run: sccache --stop-server
@@ -199,8 +199,6 @@ jobs:
     strategy:
       matrix:
         crate: [quic/s2n-quic-core]
-    env:
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions-rs/toolchain@v1
         id: toolchain
@@ -242,14 +240,14 @@ jobs:
 
       - name: ${{ matrix.crate }}
         run: cd ${{ matrix.crate }} && cargo miri test
+        env:
+          RUSTC_WRAPPER: sccache
 
       - name: Stop sccache
         run: sccache --stop-server
 
   no_std:
     runs-on: ubuntu-latest
-    env:
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions-rs/toolchain@v1
         id: toolchain
@@ -297,14 +295,14 @@ jobs:
               -Z features=dev_dep \
               --no-default-features \
               --target thumbv7m-none-eabi
+        env:
+          RUSTC_WRAPPER: sccache
 
       - name: Stop sccache
         run: sccache --stop-server
 
   compliance:
     runs-on: ubuntu-latest
-    env:
-      RUSTC_WRAPPER: sccache
     steps:
       - uses: actions/checkout@v1
 
@@ -352,6 +350,8 @@ jobs:
 
       - name: Build cargo compliance
         run: test -f target/release/cargo-compliance || cargo build --bin cargo-compliance --release
+        env:
+          RUSTC_WRAPPER: sccache
 
       - name: Run cargo compliance
         run: ./target/release/cargo-compliance report --lcov compliance --source-pattern 'quic/**/*.rs' --workspace --exclude compliance --exclude cargo-compliance
@@ -369,13 +369,8 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     env:
-      # From https://github.com/mozilla/grcov#example-how-to-generate-gcda-files-for-a-rust-project
-      RUSTFLAGS: -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests
       GRCOV_CONFIG: --branch --llvm --ignore-not-existing --source-dir .
-      GRCOV_EXCL: --excl-start '#\[cfg\(test\)\]' --excl-stop COVERAGE_END_TEST --excl-line '#\[derive\('
-      GRCOV_EXCL_BR: --excl-br-start '#\[cfg\(test\)\]' --excl-br-stop COVERAGE_END_TEST --excl-br-line '#\[derive\('
-      GRCOV_IGNORE: --ignore '**/compliance/**' --ignore 'quic/interop-server/**' --ignore '**/tests/**' --ignore '**/test/**' --ignore '**/testing/**' --ignore '**/testing.rs' --ignore '**/tests.rs'
-      RUSTC_WRAPPER: sccache
+      GRCOV_IGNORE: --ignore '**/compliance/**' --ignore 'quic/interop-server/**' --ignore '**/tests/**' --ignore '**/test/**' --ignore '**/testing/**' --ignore '**/testing.rs' --ignore '**/tests.rs' --ignore '**/.cargo/registry/**'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -395,6 +390,13 @@ jobs:
         uses: actions-rs/install@v0.1
         with:
           crate: grcov
+          use-tool-cache: true
+          version: latest
+
+      - name: Install covfix
+        uses: actions-rs/install@v0.1
+        with:
+          crate: rust-covfix
           use-tool-cache: true
           version: latest
 
@@ -432,10 +434,17 @@ jobs:
         with:
           command: test
           args: --no-fail-fast --workspace --exclude s2n-quic-rustls --exclude interop-server --all-features
+        env:
+          # From https://github.com/mozilla/grcov#example-how-to-generate-gcda-files-for-a-rust-project
+          RUSTFLAGS: -Zprofile -Ccodegen-units=1 -Copt-level=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests
+          RUSTC_WRAPPER: sccache
 
       - name: Run grcov lcov
         run: |
-          eval grcov $GRCOV_CONFIG $GRCOV_EXCL $GRCOV_EXCL_BR $GRCOV_IGNORE --output-type lcov --output-path coverage.lcov ./target/debug
+          eval grcov $GRCOV_CONFIG $GRCOV_IGNORE --output-type lcov --output-path coverage.unfiltered.lcov ./target/debug
+
+      - name: Run covfix
+        run: rust-covfix -o coverage.lcov coverage.unfiltered.lcov
 
       - name: Upload report to codecov
         uses: codecov/codecov-action@v1

--- a/quic/s2n-quic-core/src/frame/mod.rs
+++ b/quic/s2n-quic-core/src/frame/mod.rs
@@ -146,7 +146,6 @@ macro_rules! frames {
                 }
             )*
         }
-        // COVERAGE_END_TEST
     };
 }
 

--- a/quic/s2n-quic-core/src/packet/number/packet_number.rs
+++ b/quic/s2n-quic-core/src/packet/number/packet_number.rs
@@ -204,4 +204,3 @@ mod tests {
             .checked_distance(PacketNumberSpace::Handshake.new_packet_number(VarInt::from_u8(0)));
     }
 }
-// COVERAGE_END_TEST

--- a/quic/s2n-quic-core/src/packet/number/packet_number_space.rs
+++ b/quic/s2n-quic-core/src/packet/number/packet_number_space.rs
@@ -105,4 +105,3 @@ mod tests {
         }
     }
 }
-// COVERAGE_END_TEST

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -664,7 +664,6 @@ mod ack_settings_tests {
         }
     }
 }
-// COVERAGE_END_TEST
 
 //= https://tools.ietf.org/id/draft-ietf-quic-transport-27.txt#18.2
 //# disable_active_migration (0x0c):  The disable active migration
@@ -1255,4 +1254,3 @@ mod snapshot_tests {
         assert_eq!(0, remaining.len());
     }
 }
-// COVERAGE_END_TEST

--- a/quic/s2n-quic-core/src/varint/mod.rs
+++ b/quic/s2n-quic-core/src/varint/mod.rs
@@ -120,7 +120,6 @@ mod tests {
 
     sequence_test!(one_byte_sequence_test([0x25], 37));
 }
-// COVERAGE_END_TEST
 
 // === API ===
 
@@ -320,7 +319,6 @@ mod encoder_tests {
         test_update(initial, VarInt::from_u32(1 << 30), &mut encoder);
     }
 }
-// COVERAGE_END_TEST
 
 impl AsRef<u64> for VarInt {
     fn as_ref(&self) -> &u64 {

--- a/quic/s2n-quic-transport/src/contexts/mod.rs
+++ b/quic/s2n-quic-transport/src/contexts/mod.rs
@@ -96,4 +96,3 @@ impl<'a> ConnectionApiCallContext<'a> {
 
 #[cfg(test)]
 pub mod testing;
-// COVERAGE_END_TEST

--- a/quic/s2n-quic-transport/src/interval_set/mod.rs
+++ b/quic/s2n-quic-transport/src/interval_set/mod.rs
@@ -7,7 +7,6 @@ mod remove;
 
 #[cfg(test)]
 mod fuzz_target;
-// COVERAGE_END_TEST
 
 use alloc::collections::vec_deque::{self, VecDeque};
 use core::{

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_eliciting_transmission.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_eliciting_transmission.rs
@@ -190,4 +190,3 @@ mod tests {
         );
     }
 }
-// COVERAGE_END_TEST

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_manager.rs
@@ -479,4 +479,3 @@ mod tests {
         );
     }
 }
-// COVERAGE_END_TEST

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_ranges.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_ranges.rs
@@ -138,4 +138,3 @@ pub mod tests {
         assert_debug_snapshot!("AckRanges", size_of::<AckRanges>());
     }
 }
-// COVERAGE_END_TEST

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_transmission_state.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_transmission_state.rs
@@ -253,4 +253,3 @@ mod tests {
         assert_debug_snapshot!("AckTransmissionState", size_of::<AckTransmissionState>());
     }
 }
-// COVERAGE_END_TEST

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/mod.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/mod.rs
@@ -8,4 +8,3 @@ pub use ack_ranges::DEFAULT_ACK_RANGES_LIMIT;
 
 #[cfg(test)]
 mod tests;
-// COVERAGE_END_TEST

--- a/quic/s2n-quic-transport/src/stream/incoming_connection_flow_controller.rs
+++ b/quic/s2n-quic-transport/src/stream/incoming_connection_flow_controller.rs
@@ -68,8 +68,6 @@ impl IncomingConnectionFlowControllerImpl {
         self.read_window_sync.latest_value()
     }
 
-    // COVERAGE_END_TEST
-
     pub fn release_window(&mut self, amount: VarInt) {
         self.consumed_window += amount;
         debug_assert!(
@@ -171,8 +169,6 @@ impl IncomingConnectionFlowController {
         self.inner.borrow_mut().remaining_window()
     }
 
-    // COVERAGE_END_TEST
-
     /// Returns the MAX_DATA window that is currently synchronized
     /// towards the peer.
     #[cfg(test)]
@@ -180,13 +176,10 @@ impl IncomingConnectionFlowController {
         self.inner.borrow().current_receive_window()
     }
 
-    // COVERAGE_END_TEST
-
     #[cfg(test)]
     pub fn desired_flow_control_window(&self) -> u32 {
         self.inner.borrow().desired_flow_control_window
     }
-    // COVERAGE_END_TEST
 }
 
 impl FrameExchangeInterestProvider for IncomingConnectionFlowController {

--- a/quic/s2n-quic-transport/src/stream/receive_stream.rs
+++ b/quic/s2n-quic-transport/src/stream/receive_stream.rs
@@ -325,13 +325,10 @@ impl ReceiveStreamFlowController {
         self.read_window_sync.latest_value()
     }
 
-    // COVERAGE_END_TEST
-
     #[cfg(test)]
     pub(super) fn remaining_connection_receive_window(&self) -> VarInt {
         self.connection_flow_controller.remaining_window()
     }
-    // COVERAGE_END_TEST
 }
 
 /// The read half of a stream

--- a/quic/s2n-quic-transport/src/sync/data_sender.rs
+++ b/quic/s2n-quic-transport/src/sync/data_sender.rs
@@ -248,8 +248,6 @@ impl<
         self.total_acknowledged = total_acknowledged;
     }
 
-    // COVERAGE_END_TEST
-
     /// Returns the amount of data that can be additionally buffered for sending
     ///
     /// This depends on the configured maximum buffer size.


### PR DESCRIPTION
This change uses [`rust-covfix`](https://github.com/Kogia-sima/rust-covfix) to exclude insignificant lines in coverage output. You can see a list of the included fixes [here](https://github.com/Kogia-sima/rust-covfix#how-is-the-incorrect-line-coverage-detected).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
