### PR TITLE
core: add generator feature

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -8,9 +8,11 @@ license = "Apache-2.0"
 [features]
 default = ["std"]
 std = []
-testing = ["std"]
+testing = ["std", "generator"]
 checked_range_unsafe = []
+generator = ["bolero-generator"]
 
 [dependencies]
+bolero-generator = { version = "0.5", default-features = false, optional = true }
 byteorder = { version = "1.1", default-features = false }
 zerocopy = "0.3"

--- a/common/s2n-codec/src/unaligned.rs
+++ b/common/s2n-codec/src/unaligned.rs
@@ -25,6 +25,13 @@ macro_rules! unaligned_integer_type {
             }
         }
 
+        #[cfg(feature = "generator")]
+        impl bolero_generator::TypeGenerator for $name {
+            fn generate<D: bolero_generator::Driver>(driver: &mut D) -> Option<Self> {
+                Some(Self::new_truncated(driver.gen()?))
+            }
+        }
+
         impl TryFrom<$storage_type> for $name {
             type Error = TryFromIntError;
 

--- a/common/s2n-codec/src/zerocopy.rs
+++ b/common/s2n-codec/src/zerocopy.rs
@@ -6,6 +6,9 @@ use core::{
 };
 pub use zerocopy::*;
 
+#[cfg(feature = "generator")]
+use bolero_generator::*;
+
 /// Define a codec implementation for a zerocopy value that implements
 /// `FromBytes`, `AsBytes`, and `Unaligned`.
 #[macro_export]
@@ -124,6 +127,16 @@ macro_rules! zerocopy_network_integer {
         #[repr(C)]
         pub struct $name(::zerocopy::byteorder::$name<NetworkEndian>);
 
+        impl $name {
+            pub fn new(value: $native) -> Self {
+                value.into()
+            }
+
+            pub fn set(&mut self, value: $native) {
+                self.0.set(value);
+            }
+        }
+
         impl PartialEq for $name {
             fn eq(&self, other: &Self) -> bool {
                 self.cmp(other) == Ordering::Equal
@@ -181,6 +194,13 @@ macro_rules! zerocopy_network_integer {
         impl Into<$native> for $name {
             fn into(self) -> $native {
                 self.0.get()
+            }
+        }
+
+        #[cfg(feature = "generator")]
+        impl TypeGenerator for $name {
+            fn generate<D: Driver>(driver: &mut D) -> Option<Self> {
+                Some(Self::new(driver.gen()?))
             }
         }
 

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -8,9 +8,11 @@ license = "Apache-2.0"
 [features]
 default = ["std"]
 std = []
-
+testing = ["std", "generator", "s2n-codec/testing"]
+generator = ["bolero-generator"]
 
 [dependencies]
+bolero-generator = { version = "0.5", default-features = false, optional = true }
 byteorder = { version = "1.1", default-features = false }
 bytes = { version = "0.5", default-features = false }
 hex-literal = "0.2"

--- a/quic/s2n-quic-core/src/inet/ecn.rs
+++ b/quic/s2n-quic-core/src/inet/ecn.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "generator")]
+use bolero_generator::*;
+
 //= https://tools.ietf.org/rfc/rfc3168.txt#5
 //# This document specifies that the Internet provide a congestion
 //# indication for incipient congestion (as in RED and earlier work
@@ -44,6 +47,7 @@
 /// Explicit Congestion Notification
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[cfg_attr(feature = "generator", derive(TypeGenerator))]
 pub enum ExplicitCongestionNotification {
     /// The not-ECT codepoint '00' indicates a packet that is not using ECN.
     NotECT = 0b00,

--- a/quic/s2n-quic-core/src/inet/ip.rs
+++ b/quic/s2n-quic-core/src/inet/ip.rs
@@ -5,6 +5,9 @@ use crate::inet::{
 };
 use core::fmt;
 
+#[cfg(feature = "generator")]
+use bolero_generator::*;
+
 /// An IP address, either IPv4 or IPv6.
 ///
 /// Instead of using `std::net::IPAddr`, this implementation
@@ -12,6 +15,7 @@ use core::fmt;
 ///
 /// The size is also consistent across target operating systems.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "generator", derive(TypeGenerator))]
 pub enum IPAddress {
     IPv4(IPv4Address),
     IPv6(IPv6Address),
@@ -63,6 +67,7 @@ impl<'a> From<&'a IPv6Address> for IPAddressRef<'a> {
 ///
 /// The size is also consistent across target operating systems.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "generator", derive(TypeGenerator))]
 pub enum SocketAddress {
     IPv4(SocketAddressV4),
     IPv6(SocketAddressV6),

--- a/quic/s2n-quic-core/src/inet/ipv4.rs
+++ b/quic/s2n-quic-core/src/inet/ipv4.rs
@@ -54,6 +54,10 @@ impl SocketAddressV4 {
     pub fn port(&self) -> u16 {
         self.port.into()
     }
+
+    pub fn set_port(&mut self, port: u16) {
+        self.port.set(port)
+    }
 }
 
 impl fmt::Debug for SocketAddressV4 {

--- a/quic/s2n-quic-core/src/inet/ipv6.rs
+++ b/quic/s2n-quic-core/src/inet/ipv6.rs
@@ -91,6 +91,10 @@ impl SocketAddressV6 {
     pub fn port(&self) -> u16 {
         self.port.into()
     }
+
+    pub fn set_port(&mut self, port: u16) {
+        self.port.set(port)
+    }
 }
 
 impl fmt::Debug for SocketAddressV6 {

--- a/quic/s2n-quic-core/src/inet/macros.rs
+++ b/quic/s2n-quic-core/src/inet/macros.rs
@@ -5,7 +5,12 @@ macro_rules! define_inet_type {
         ),*
         $(,)*
     }) => {
+        #[allow(unused_imports)]
+        #[cfg(feature = "generator")]
+        use bolero_generator::*;
+
         #[derive(Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, zerocopy::FromBytes, zerocopy::AsBytes, zerocopy::Unaligned)]
+        #[cfg_attr(feature = "generator", derive(bolero_generator::TypeGenerator))]
         #[repr(C)]
         $($vis)? struct $name {
             $(

--- a/quic/s2n-quic-core/src/packet/number/packet_number.rs
+++ b/quic/s2n-quic-core/src/packet/number/packet_number.rs
@@ -13,6 +13,9 @@ use core::{
     num::NonZeroU64,
 };
 
+#[cfg(feature = "generator")]
+use bolero_generator::*;
+
 const PACKET_SPACE_BITLEN: usize = 2;
 const PACKET_SPACE_SHIFT: usize = (size_of::<PacketNumber>() * 8) - PACKET_SPACE_BITLEN;
 const PACKET_NUMBER_MASK: u64 = core::u64::MAX >> PACKET_SPACE_BITLEN;
@@ -27,6 +30,7 @@ const PACKET_NUMBER_MASK: u64 = core::u64::MAX >> PACKET_SPACE_BITLEN;
 /// there are only 3 spaces, the zero state is never used, which is why
 /// [`NonZeroU64`] can be used instead of `u64`.
 #[derive(Clone, Copy, Eq)]
+#[cfg_attr(feature = "generator", derive(TypeGenerator))]
 pub struct PacketNumber(NonZeroU64);
 
 impl Default for PacketNumber {

--- a/quic/s2n-quic-core/src/packet/number/packet_number_space.rs
+++ b/quic/s2n-quic-core/src/packet/number/packet_number_space.rs
@@ -3,8 +3,12 @@ use crate::{
     varint::VarInt,
 };
 
+#[cfg(feature = "generator")]
+use bolero_generator::*;
+
 /// Contains all of the available packet spaces for QUIC packets
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "generator", derive(TypeGenerator))]
 #[repr(u8)]
 pub enum PacketNumberSpace {
     // This MUST start with 1 to enable optimized memory layout

--- a/quic/s2n-quic-core/src/packet/number/truncated_packet_number.rs
+++ b/quic/s2n-quic-core/src/packet/number/truncated_packet_number.rs
@@ -6,8 +6,12 @@ use crate::packet::number::{
 };
 use s2n_codec::{u24, DecoderBuffer, DecoderBufferResult, DecoderValue, Encoder, EncoderValue};
 
+#[cfg(feature = "generator")]
+use bolero_generator::*;
+
 /// A truncated packet number, which is derived from the largest acknowledged packet number
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "generator", derive(TypeGenerator))]
 pub struct TruncatedPacketNumber {
     pub(crate) space: PacketNumberSpace,
     pub(crate) value: TruncatedPacketNumberValue,
@@ -81,7 +85,8 @@ impl EncoderValue for TruncatedPacketNumber {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) enum TruncatedPacketNumberValue {
+#[cfg_attr(feature = "generator", derive(TypeGenerator))]
+pub enum TruncatedPacketNumberValue {
     U8(u8),
     U16(u16),
     U24(u24),

--- a/quic/s2n-quic-core/src/varint/mod.rs
+++ b/quic/s2n-quic-core/src/varint/mod.rs
@@ -4,6 +4,9 @@ use core::{
 };
 use s2n_codec::{decoder_value, Encoder, EncoderValue};
 
+#[cfg(feature = "generator")]
+use bolero_generator::*;
+
 //= https://tools.ietf.org/id/draft-ietf-quic-transport-29.txt#16
 //# QUIC packets and frames commonly use a variable-length encoding for
 //# non-negative integer values.  This encoding ensures that smaller
@@ -124,7 +127,8 @@ mod tests {
 // === API ===
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
-pub struct VarInt(u64);
+#[cfg_attr(feature = "generator", derive(TypeGenerator))]
+pub struct VarInt(#[cfg_attr(feature = "generator", generator(0..=MAX_VARINT_VALUE))] u64);
 
 impl core::fmt::Display for VarInt {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {


### PR DESCRIPTION
This change adds [`TypeGenerator`](https://docs.rs/bolero-generator/0.5.2/bolero_generator/trait.TypeGenerator.html) implementations to a handful of core values. This makes it easy to generate a valid value in fuzz/property tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
