### PR TITLE
platform: pass crate features to feature probes

### DIFF
--- a/quic/s2n-quic-platform/features/socket_mmsg.rs
+++ b/quic/s2n-quic-platform/features/socket_mmsg.rs
@@ -10,6 +10,7 @@ fn main() {
 /// Try to resolve the required references from the linker
 ///
 /// The build will fail if they don't exist.
+#[cfg(all(unix, feature = "std"))]
 extern "C" {
     #[link_name = "sendmmsg"]
     static SENDMMSG: *const u8;

--- a/quic/s2n-quic-platform/features/socket_msg.rs
+++ b/quic/s2n-quic-platform/features/socket_msg.rs
@@ -10,6 +10,7 @@ fn main() {
 /// Try to resolve the required references from the linker
 ///
 /// The build will fail if they don't exist.
+#[cfg(all(unix, feature = "std"))]
 extern "C" {
     #[link_name = "sendmsg"]
     static SENDMSG: *const u8;


### PR DESCRIPTION
The msg and mmsg calls require access to the std library right now so we need a way to ensure the `std` feature is enabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
