### PR TITLE
core: improve error structs and enums

### DIFF
--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [features]
 default = ["std"]
-std = []
+std = ["thiserror"]
 testing = ["std", "generator", "s2n-codec/testing"]
 generator = ["bolero-generator"]
 
@@ -15,8 +15,10 @@ generator = ["bolero-generator"]
 bolero-generator = { version = "0.5", default-features = false, optional = true }
 byteorder = { version = "1.1", default-features = false }
 bytes = { version = "0.5", default-features = false }
+displaydoc = { version = "0.1", default-features = false }
 hex-literal = "0.2"
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features = false }
+thiserror = { version = "1", optional = true }
 zerocopy = "0.3"
 
 [dev-dependencies]

--- a/quic/s2n-quic-core/src/connection/error.rs
+++ b/quic/s2n-quic-core/src/connection/error.rs
@@ -5,8 +5,9 @@ use crate::{
 };
 
 /// Errors that a connection can encounter.
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Debug, Copy, Clone, displaydoc::Display)]
 #[non_exhaustive]
+#[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 pub enum ConnectionError {
     /// The connection was closed on application level either locally or
     /// by the peer. The argument contains the error code which the application

--- a/quic/s2n-quic-core/src/connection/id.rs
+++ b/quic/s2n-quic-core/src/connection/id.rs
@@ -102,11 +102,7 @@ pub struct TryFromSliceError(());
 
 impl From<TryFromSliceError> for TransportError {
     fn from(_: TryFromSliceError) -> TransportError {
-        TransportError::new(
-            TransportError::PROTOCOL_VIOLATION,
-            "invalid connection id",
-            None,
-        )
+        TransportError::PROTOCOL_VIOLATION.with_reason("invalid connection id")
     }
 }
 

--- a/quic/s2n-quic-core/src/packet/handshake.rs
+++ b/quic/s2n-quic-core/src/packet/handshake.rs
@@ -134,7 +134,7 @@ impl<'a> ProtectedHandshake<'a> {
 
         let packet_number = truncated_packet_number
             .expand(largest_acknowledged_packet_number)
-            .ok_or_else(CryptoError::decode_error)?;
+            .ok_or(CryptoError::DECODE_ERROR)?;
 
         Ok(Handshake {
             version,

--- a/quic/s2n-quic-core/src/packet/initial.rs
+++ b/quic/s2n-quic-core/src/packet/initial.rs
@@ -173,7 +173,7 @@ impl<'a> ProtectedInitial<'a> {
 
         let packet_number = truncated_packet_number
             .expand(largest_acknowledged_packet_number)
-            .ok_or_else(CryptoError::decode_error)?;
+            .ok_or(CryptoError::DECODE_ERROR)?;
 
         Ok(Initial {
             version,

--- a/quic/s2n-quic-core/src/packet/short.rs
+++ b/quic/s2n-quic-core/src/packet/short.rs
@@ -212,7 +212,7 @@ impl<'a> ProtectedShort<'a> {
 
         let packet_number = truncated_packet_number
             .expand(largest_acknowledged_packet_number)
-            .ok_or_else(CryptoError::decode_error)?;
+            .ok_or(CryptoError::DECODE_ERROR)?;
 
         Ok(Short {
             spin_bit,

--- a/quic/s2n-quic-core/src/packet/zero_rtt.rs
+++ b/quic/s2n-quic-core/src/packet/zero_rtt.rs
@@ -150,7 +150,7 @@ impl<'a> ProtectedZeroRTT<'a> {
 
         let packet_number = truncated_packet_number
             .expand(largest_acknowledged_packet_number)
-            .ok_or_else(CryptoError::decode_error)?;
+            .ok_or(CryptoError::DECODE_ERROR)?;
 
         Ok(ZeroRTT {
             version,

--- a/quic/s2n-quic-core/src/stream/error.rs
+++ b/quic/s2n-quic-core/src/stream/error.rs
@@ -6,7 +6,8 @@ use crate::{
 };
 
 /// Errors that a stream can encounter.
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(PartialEq, Debug, Copy, Clone, displaydoc::Display)]
+#[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 #[non_exhaustive]
 pub enum StreamError {
     /// The Stream ID which was referenced is invalid and/or no longer tracked

--- a/quic/s2n-quic-core/tests/crypto/fuzz_target.rs
+++ b/quic/s2n-quic-core/tests/crypto/fuzz_target.rs
@@ -55,13 +55,13 @@ fn fuzz_unprotect(
 
     let packet_number = truncated_packet_number
         .expand(largest_packet_number)
-        .ok_or_else(CryptoError::decode_error)?;
+        .ok_or(CryptoError::DECODE_ERROR)?;
 
     // make sure the packet number can be truncated and is canonical
     packet_number
         .truncate(largest_packet_number)
         .filter(|actual| truncated_packet_number.eq(actual))
-        .ok_or_else(CryptoError::decode_error)?;
+        .ok_or(CryptoError::DECODE_ERROR)?;
 
     let (_header, _payload) = s2n_quic_core::crypto::decrypt(&FuzzCrypto, packet_number, payload)?;
 

--- a/quic/s2n-quic-ring/src/ciphersuite/mod.rs
+++ b/quic/s2n-quic-ring/src/ciphersuite/mod.rs
@@ -140,7 +140,7 @@ macro_rules! impl_ciphersuite {
 
                 self.aead_key()
                     .open_in_place(nonce, aead, payload)
-                    .map_err(|_| CryptoError::decrypt_error())?;
+                    .map_err(|_| CryptoError::DECRYPT_ERROR)?;
 
                 Ok(())
             }
@@ -162,7 +162,7 @@ macro_rules! impl_ciphersuite {
                 let tagged = self
                     .aead_key()
                     .seal_in_place_separate_tag(nonce, aead, &mut payload[..payload_len])
-                    .map_err(|_| CryptoError::decrypt_error())?;
+                    .map_err(|_| CryptoError::DECRYPT_ERROR)?;
 
                 payload[payload_len..].copy_from_slice(tagged.as_ref());
 

--- a/quic/s2n-quic-rustls/src/lib.rs
+++ b/quic/s2n-quic-rustls/src/lib.rs
@@ -195,7 +195,7 @@ macro_rules! impl_tls {
                 Ok(TLSApplicationParameters {
                     alpn_protocol: self.0.session.get_alpn_protocol(),
                     transport_parameters: self.0.session.get_quic_transport_parameters().ok_or(
-                        CryptoError::missing_extension()
+                        CryptoError::MISSING_EXTENSION
                             .with_reason("Missing QUIC transport parameters"),
                     )?,
                     sni: self.sni(),

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -26,7 +26,6 @@ use s2n_quic_core::{
     },
     time::Timestamp,
     transport::error::TransportError,
-    transport_error,
     varint::VarInt,
 };
 
@@ -403,11 +402,9 @@ pub trait ConnectionTrait: Sized {
                     //# PROTOCOL_VIOLATION.
 
                     if Self::Config::ENDPOINT_TYPE.is_server() {
-                        return Err(transport_error!(
-                            PROTOCOL_VIOLATION,
-                            "Clients MUST NOT send HANDSHAKE_DONE frames",
-                            frame.tag()
-                        ));
+                        return Err(TransportError::PROTOCOL_VIOLATION
+                            .with_reason("Clients MUST NOT send HANDSHAKE_DONE frames")
+                            .with_frame_type(frame.tag().into()));
                     }
 
                     let on_error = with_frame_type!(frame);

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -14,7 +14,6 @@ use s2n_quic_core::{
     inet::DatagramInfo,
     packet::initial::ProtectedInitial,
     transport::error::TransportError,
-    transport_error,
 };
 
 //= https://tools.ietf.org/id/draft-ietf-quic-transport-27.txt#14
@@ -49,17 +48,15 @@ impl<ConfigType: EndpointConfig> Endpoint<ConfigType> {
         // TODO: Check that the connection ID is at least 8 byte
         // But maybe we really would need to do this before or inside parsing
         if datagram.payload_len < MINIMUM_INITIAL_PACKET_LEN {
-            return Err(transport_error!(PROTOCOL_VIOLATION, "packet too small"));
+            return Err(TransportError::PROTOCOL_VIOLATION.with_reason("packet too small"));
         }
 
         let destination_connection_id: ConnectionId =
             packet.destination_connection_id().try_into()?;
 
         if destination_connection_id.len() < DESTINATION_CONNECTION_ID_MIN_LEN {
-            return Err(transport_error!(
-                PROTOCOL_VIOLATION,
-                "destination connection id too short"
-            ));
+            return Err(TransportError::PROTOCOL_VIOLATION
+                .with_reason("destination connection id too short"));
         }
 
         let source_connection_id: ConnectionId = packet.source_connection_id().try_into()?;

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -21,7 +21,6 @@ use s2n_quic_core::{
     },
     time::Timestamp,
     transport::error::TransportError,
-    transport_error,
 };
 
 #[derive(Debug)]
@@ -160,11 +159,9 @@ impl<StreamType: StreamTrait, Suite: CryptoSuite> PacketSpace
         _datagram: &DatagramInfo,
         frame: CryptoRef,
     ) -> Result<(), TransportError> {
-        Err(transport_error!(
-            INTERNAL_ERROR,
-            "crypto frames are not currently supported in application space",
-            frame.tag()
-        ))
+        Err(TransportError::INTERNAL_ERROR
+            .with_reason("crypto frames are not currently supported in application space")
+            .with_frame_type(frame.tag().into()))
     }
 
     fn handle_ack_frame<A: AckRanges>(

--- a/quic/s2n-quic-transport/src/space/crypto_stream.rs
+++ b/quic/s2n-quic-transport/src/space/crypto_stream.rs
@@ -9,7 +9,6 @@ use s2n_quic_core::{
     frame::{crypto::CryptoRef, MaxPayloadSizeForFrame},
     packet::number::PacketNumber,
     transport::error::TransportError,
-    transport_error,
     varint::VarInt,
 };
 
@@ -109,7 +108,7 @@ impl CryptoStream {
 
         self.rx
             .write_at(frame.offset, frame.data)
-            .map_err(|_| transport_error!(CRYPTO_BUFFER_EXCEEDED))?;
+            .map_err(|_| TransportError::CRYPTO_BUFFER_EXCEEDED)?;
 
         Ok(())
     }

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -21,7 +21,6 @@ use s2n_quic_core::{
     },
     time::Timestamp,
     transport::error::TransportError,
-    transport_error,
 };
 
 mod application;
@@ -192,11 +191,9 @@ impl<ConnectionConfigType: ConnectionConfig> PacketSpaceManager<ConnectionConfig
 macro_rules! default_frame_handler {
     ($name:ident, $frame:ty) => {
         fn $name(&mut self, _datagram: &DatagramInfo, frame: $frame) -> Result<(), TransportError> {
-            Err(transport_error!(
-                PROTOCOL_VIOLATION,
-                Self::INVALID_FRAME_ERROR,
-                frame.tag()
-            ))
+            Err(TransportError::PROTOCOL_VIOLATION
+                .with_reason(Self::INVALID_FRAME_ERROR)
+                .with_frame_type(frame.tag().into()))
         }
     };
 }

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -82,14 +82,15 @@ impl<'a, ConnectionConfigType: ConnectionConfig> TLSContext<ConnectionConfigType
             Ok(parameters) => parameters,
             Err(_e) => {
                 return Err(
-                    CryptoError::missing_extension().with_reason("Invalid transport parameters")
+                    CryptoError::MISSING_EXTENSION.with_reason("Invalid transport parameters")
                 );
             }
         };
 
         if !remaining.is_empty() {
-            return Err(CryptoError::missing_extension()
-                .with_reason("Invalid bytes in transport parameters"));
+            return Err(
+                CryptoError::MISSING_EXTENSION.with_reason("Invalid bytes in transport parameters")
+            );
         }
 
         let peer_limits = peer_parameters.flow_control_limits();

--- a/quic/s2n-quic-transport/src/space/tx_packet_numbers.rs
+++ b/quic/s2n-quic-transport/src/space/tx_packet_numbers.rs
@@ -4,7 +4,6 @@ use s2n_quic_core::{
     packet::number::{PacketNumber, PacketNumberSpace},
     time::Timestamp,
     transport::error::TransportError,
-    transport_error,
     varint::VarInt,
 };
 
@@ -38,10 +37,8 @@ impl TxPacketNumbers {
         //# is able to detect the condition.
 
         if largest >= self.next {
-            return Err(transport_error!(
-                PROTOCOL_VIOLATION,
-                "received an ACK for a packet that was not sent"
-            ));
+            return Err(TransportError::PROTOCOL_VIOLATION
+                .with_reason("received an ACK for a packet that was not sent"));
         }
 
         // record the largest packet acked

--- a/quic/s2n-quic-transport/src/stream/stream_manager.rs
+++ b/quic/s2n-quic-transport/src/stream/stream_manager.rs
@@ -269,12 +269,7 @@ impl<S: StreamTrait> StreamManagerState<S> {
                 // to create a new Stream instance
 
                 if self.close_reason.is_some() {
-                    return Err(TransportError::new(
-                        TransportError::NO_ERROR,
-                        "Connection was closed",
-                        // Threading the frame tag into this function is a lot of overhead
-                        None,
-                    ));
+                    return Err(TransportError::NO_ERROR.with_reason("Connection was closed"));
                 }
 
                 // TODO: Check if the peer is allowed to open the stream according to `MAX_STREAMS`.
@@ -323,12 +318,9 @@ impl<S: StreamTrait> StreamManagerState<S> {
             // Future Stream IDs we might use. We also will not accept this and
             // close the connection.
             if stream_id >= first_unopened_id {
-                return Err(TransportError::new(
-                    TransportError::STREAM_STATE_ERROR,
-                    "Stream was not yet opened",
-                    // Threading the frame tag into this function is a lot of overhead
-                    None,
-                ));
+                return Err(
+                    TransportError::STREAM_STATE_ERROR.with_reason("Stream was not yet opened")
+                );
             }
         }
 

--- a/quic/s2n-quic-transport/src/stream/tests/mod.rs
+++ b/quic/s2n-quic-transport/src/stream/tests/mod.rs
@@ -27,10 +27,10 @@ pub fn stream_data<Data>(
 /// error code.
 fn assert_is_transport_error<T: core::fmt::Debug>(
     result: Result<T, TransportError>,
-    error_code: VarInt,
+    expected: TransportError,
 ) {
-    let err = result.unwrap_err();
-    assert_eq!(error_code, err.code);
+    let actual = result.unwrap_err();
+    assert_eq!(expected.code, actual.code);
 }
 
 /// Generates test data using a pattern which is identifieable. For a given

--- a/quic/s2n-quic-transport/src/stream/tests/stream_managers_tests.rs
+++ b/quic/s2n-quic-transport/src/stream/tests/stream_managers_tests.rs
@@ -571,11 +571,8 @@ fn remote_messages_which_target_locally_initiated_unopened_streams_error() {
                     assert!(!manager.active_streams().contains(&target_stream_id));
 
                     assert_eq!(
-                        Err(TransportError::new(
-                            TransportError::STREAM_STATE_ERROR,
-                            "Stream was not yet opened",
-                            None
-                        )),
+                        Err(TransportError::STREAM_STATE_ERROR
+                            .with_reason("Stream was not yet opened")),
                         manager.on_reset_stream(&reset_frame)
                     );
                 }
@@ -1450,11 +1447,7 @@ fn forwards_on_data() {
     manager.with_asserted_stream(stream_1, |stream| {
         assert_eq!(stream.on_data_count, 1);
         stream.write_waker_to_return = Some(write_waker);
-        stream.next_packet_error = Some(TransportError::new(
-            TransportError::INTERNAL_ERROR,
-            "",
-            None,
-        ));
+        stream.next_packet_error = Some(TransportError::INTERNAL_ERROR);
     });
 
     assert_is_transport_error(manager.on_data(&frame), TransportError::INTERNAL_ERROR);
@@ -1500,11 +1493,7 @@ fn forwards_on_stream_data_blocked() {
     manager.with_asserted_stream(stream_1, |stream| {
         assert_eq!(stream.on_stream_data_blocked_count, 1);
         assert_eq!(Some(frame), stream.last_on_stream_data_blocked);
-        stream.next_packet_error = Some(TransportError::new(
-            TransportError::INTERNAL_ERROR,
-            "",
-            None,
-        ));
+        stream.next_packet_error = Some(TransportError::INTERNAL_ERROR);
         stream.write_waker_to_return = Some(write_waker);
     });
 
@@ -1557,11 +1546,7 @@ fn forwards_on_max_stream_data() {
     manager.with_asserted_stream(stream_1, |stream| {
         assert_eq!(stream.on_max_stream_data_count, 1);
         assert_eq!(Some(frame), stream.last_max_stream_data);
-        stream.next_packet_error = Some(TransportError::new(
-            TransportError::INTERNAL_ERROR,
-            "",
-            None,
-        ));
+        stream.next_packet_error = Some(TransportError::INTERNAL_ERROR);
         stream.write_waker_to_return = Some(write_waker);
     });
 
@@ -1614,11 +1599,7 @@ fn forwards_on_stop_sending() {
     manager.with_asserted_stream(stream_1, |stream| {
         assert_eq!(stream.on_stop_sending_count, 1);
         assert_eq!(Some(frame), stream.last_stop_sending);
-        stream.next_packet_error = Some(TransportError::new(
-            TransportError::INTERNAL_ERROR,
-            "",
-            None,
-        ));
+        stream.next_packet_error = Some(TransportError::INTERNAL_ERROR);
         stream.write_waker_to_return = Some(write_waker);
     });
 
@@ -1673,11 +1654,7 @@ fn forwards_on_reset() {
         assert_eq!(Some(frame), stream.last_reset);
         stream.write_waker_to_return = Some(write_waker);
         stream.read_waker_to_return = None;
-        stream.next_packet_error = Some(TransportError::new(
-            TransportError::INTERNAL_ERROR,
-            "",
-            None,
-        ));
+        stream.next_packet_error = Some(TransportError::INTERNAL_ERROR);
     });
 
     assert_is_transport_error(


### PR DESCRIPTION
This changeset:

* Updates the `TransportError`s to draft 29
* Derives [`thiserror`](https://docs.rs/thiserror) implementations for core errors, which enables easy interoperability with [`std::error::Error`](https://doc.rust-lang.org/std/error/trait.Error.html)
* Removes the `transport_error!` macro in favor of method chaining, which is a lot more flexible and easy to follow.
* Adds `description` methods to both `CryptoError` and `TransportError` to enable debugging error codes without having to look them up.
 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
