### PR TITLE
platform: add default module

### DIFF
--- a/quic/s2n-quic-core/src/io/mod.rs
+++ b/quic/s2n-quic-core/src/io/mod.rs
@@ -1,2 +1,43 @@
 pub mod rx;
 pub mod tx;
+
+/// A pair of Rx and Tx IO implementations
+#[derive(Debug)]
+pub struct Pair<Rx, Tx> {
+    pub rx: Rx,
+    pub tx: Tx,
+}
+
+impl<'a, Rx: rx::Rx<'a>, Tx> rx::Rx<'a> for Pair<Rx, Tx> {
+    type Queue = Rx::Queue;
+    type Error = Rx::Error;
+
+    fn queue(&'a mut self) -> Self::Queue {
+        self.rx.queue()
+    }
+
+    fn len(&self) -> usize {
+        self.rx.len()
+    }
+
+    fn receive(&mut self) -> Result<usize, Self::Error> {
+        self.rx.receive()
+    }
+}
+
+impl<'a, Rx, Tx: tx::Tx<'a>> tx::Tx<'a> for Pair<Rx, Tx> {
+    type Queue = Tx::Queue;
+    type Error = Tx::Error;
+
+    fn queue(&'a mut self) -> Self::Queue {
+        self.tx.queue()
+    }
+
+    fn len(&self) -> usize {
+        self.tx.len()
+    }
+
+    fn transmit(&mut self) -> Result<usize, Self::Error> {
+        self.tx.transmit()
+    }
+}

--- a/quic/s2n-quic-platform/src/lib.rs
+++ b/quic/s2n-quic-platform/src/lib.rs
@@ -12,3 +12,13 @@ pub mod buffer;
 pub mod io;
 pub mod message;
 pub mod time;
+
+pub mod default {
+    use crate::{buffer::default as buffer, io::default as io, socket::default as socket};
+
+    pub type Buffer = buffer::Buffer;
+    pub type Rx = io::rx::Rx<buffer::Buffer, socket::Socket>;
+    pub type Tx = io::tx::Tx<buffer::Buffer, socket::Socket>;
+    pub type Pair = s2n_quic_core::io::Pair<Rx, Tx>;
+    pub type Socket = socket::Socket;
+}


### PR DESCRIPTION
This changeset:

* Adds the `core::io::Pair` struct which is a pair of Rx and Tx IO implementations
* Adds a `default` module in platform which will be used by the main crate to pick default implementations for the given compilation target.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
