### PR TITLE
transport: integrate handshake status into application space

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -402,18 +402,6 @@ pub trait ConnectionTrait: Sized {
                         .map_err(on_error)?;
                 }
                 Frame::HandshakeDone(frame) => {
-                    //= https://tools.ietf.org/id/draft-ietf-quic-transport-27.txt#19.20
-                    //# This frame can only be sent by the server.  Servers MUST NOT send a
-                    //# HANDSHAKE_DONE frame before completing the handshake.  A server MUST
-                    //# treat receipt of a HANDSHAKE_DONE frame as a connection error of type
-                    //# PROTOCOL_VIOLATION.
-
-                    if Self::Config::ENDPOINT_TYPE.is_server() {
-                        return Err(TransportError::PROTOCOL_VIOLATION
-                            .with_reason("Clients MUST NOT send HANDSHAKE_DONE frames")
-                            .with_frame_type(frame.tag().into()));
-                    }
-
                     let on_error = with_frame_type!(frame);
                     processed_packet.on_processed_frame(&frame);
                     space

--- a/quic/s2n-quic-transport/src/space/handshake_status.rs
+++ b/quic/s2n-quic-transport/src/space/handshake_status.rs
@@ -1,5 +1,3 @@
-#![allow(unused)] // TODO remove this after integrated
-
 use crate::{
     contexts::{OnTransmitError, WriteContext},
     frame_exchange_interests::{FrameExchangeInterestProvider, FrameExchangeInterests},

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -39,7 +39,6 @@ pub(crate) use application_transmission::ApplicationTransmission;
 pub(crate) use crypto_stream::CryptoStream;
 pub(crate) use early_transmission::EarlyTransmission;
 pub(crate) use handshake::HandshakeSpace;
-#[allow(unused)] // TODO remove this after integrated
 pub(crate) use handshake_status::HandshakeStatus;
 pub(crate) use initial::InitialSpace;
 pub(crate) use session_context::SessionContext;


### PR DESCRIPTION
This change integrates the HandshakeStatus component from #83 into the application space.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
