### PR TITLE
clippy: fix new warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   SCCACHE_IDLE_TIMEOUT: 0
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2020-07-11
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2020-08-25
 
 jobs:
   env:

--- a/quic/s2n-quic-core/src/frame/ack_elicitation.rs
+++ b/quic/s2n-quic-core/src/frame/ack_elicitation.rs
@@ -21,10 +21,7 @@ impl Default for AckElicitation {
 impl AckElicitation {
     /// Returns true if the `AckElicitation` is set to `Eliciting`
     pub fn is_ack_eliciting(self) -> bool {
-        match self {
-            Self::Eliciting => true,
-            _ => false,
-        }
+        matches!(self, Self::Eliciting)
     }
 }
 

--- a/quic/s2n-quic-core/src/packet/number/packet_number_space.rs
+++ b/quic/s2n-quic-core/src/packet/number/packet_number_space.rs
@@ -27,28 +27,19 @@ impl PacketNumberSpace {
     /// Returns `true` if the `PacketNumberSpace` is set to `Initial`
     #[inline]
     pub fn is_initial(self) -> bool {
-        match self {
-            Self::Initial => true,
-            _ => false,
-        }
+        matches!(self, Self::Initial)
     }
 
     /// Returns `true` if the `PacketNumberSpace` is set to `Handshake`
     #[inline]
     pub fn is_handshake(self) -> bool {
-        match self {
-            Self::Handshake => true,
-            _ => false,
-        }
+        matches!(self, Self::Handshake)
     }
 
     /// Returns `true` if the `PacketNumberSpace` is set to `ApplicationData`
     #[inline]
     pub fn is_application_data(self) -> bool {
-        match self {
-            Self::ApplicationData => true,
-            _ => false,
-        }
+        matches!(self, Self::ApplicationData)
     }
 
     /// Create a new `PacketNumber` for the given `PacketNumberSpace`

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_transmission_state.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_transmission_state.rs
@@ -33,20 +33,12 @@ impl Default for AckTransmissionState {
 impl AckTransmissionState {
     /// Returns `true` if the state is set to `Active`
     pub fn is_active(&self) -> bool {
-        if let Self::Active { .. } = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Self::Active { .. })
     }
 
     /// Returns `true` if ACK frames should be transmitted, either actively or passively
     pub fn should_transmit(&self) -> bool {
-        if let Self::Disabled = self {
-            false
-        } else {
-            true
-        }
+        !matches!(self, Self::Disabled)
     }
 
     /// Transitions the transmission to active if there are pending retransmissions

--- a/quic/s2n-quic-transport/src/sync/incremental_value_sync.rs
+++ b/quic/s2n-quic-transport/src/sync/incremental_value_sync.rs
@@ -52,11 +52,7 @@ impl<
 
     /// Returns `true` if the synchronization has been cancelled
     pub fn is_cancelled(&self) -> bool {
-        if let DeliveryState::Cancelled(_) = self.delivery {
-            true
-        } else {
-            false
-        }
+        matches!(self.delivery, DeliveryState::Cancelled(_))
     }
 
     /// Sets the new value that needs to get synchronized to the peer.

--- a/quic/s2n-quic-transport/src/sync/mod.rs
+++ b/quic/s2n-quic-transport/src/sync/mod.rs
@@ -58,30 +58,18 @@ impl<T> DeliveryState<T> {
 
     /// Returns `true` if the delivery of the value had been cancelled
     pub fn is_cancelled(&self) -> bool {
-        if let DeliveryState::Cancelled(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Self::Cancelled(_))
     }
 
     /// Returns `true` if the delivery of a value is requested
     pub fn is_requested(&self) -> bool {
-        if let DeliveryState::Requested(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Self::Requested(_))
     }
 
     /// Returns `true` if the delivery is current in progress.
     /// A packet has been sent, but no acknowledgement has been retrieved so far.
     pub fn is_inflight(&self) -> bool {
-        if let DeliveryState::InFlight(_) = self {
-            true
-        } else {
-            false
-        }
+        matches!(self, Self::InFlight(_))
     }
 }
 

--- a/quic/s2n-quic-transport/src/sync/once_sync.rs
+++ b/quic/s2n-quic-transport/src/sync/once_sync.rs
@@ -20,36 +20,33 @@ pub struct OnceSync<T, S> {
     writer: S,
 }
 
-impl<T: Copy + Clone + Eq + PartialEq, S: ValueToFrameWriter<T>> OnceSync<T, S> {
-    pub fn new() -> Self {
-        OnceSync {
+impl<T, S: Default> Default for OnceSync<T, S> {
+    fn default() -> Self {
+        Self {
             delivery: DeliveryState::NotRequested,
             writer: S::default(),
         }
+    }
+}
+
+impl<T: Copy + Clone + Eq + PartialEq, S: ValueToFrameWriter<T>> OnceSync<T, S> {
+    /// Creates a new OnceSync
+    pub fn new() -> Self {
+        Self::default()
     }
 
     /// Returns `true` if the payload had been delivered to the peer and had
     /// been acknowledged by the peer.
     pub fn is_delivered(&self) -> bool {
-        if let DeliveryState::Delivered(_) = self.delivery {
-            true
-        } else {
-            false
-        }
+        matches!(self.delivery, DeliveryState::Delivered(_))
     }
 
     /// Returns `true` if the synchronization has been cancelled
     pub fn is_cancelled(&self) -> bool {
-        if let DeliveryState::Cancelled(_) = self.delivery {
-            true
-        } else {
-            false
-        }
+        matches!(self.delivery, DeliveryState::Cancelled(_))
     }
 
     /// Requested delivery of the given value.
-    /// Returns `true` if delivery had not bee previously requested, and `false`
-    /// otherwise.
     pub fn request_delivery(&mut self, value: T) {
         if let DeliveryState::NotRequested = self.delivery {
             self.delivery = DeliveryState::Requested(value);


### PR DESCRIPTION
Clippy recently added a new lint for locations that can use the `matches!` macro: see https://rust-lang.github.io/rust-clippy/master/#match_like_matches_macro

I've also updated the pinned version of nightly to the latest version with all of the required components.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
