### PR TITLE
api: expose default TLS provider

### DIFF
--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -6,16 +6,19 @@ edition = "2018"
 license = "Apache-2.0"
 
 [features]
-default = ["std", "protocol-extensions", "tokio"]
+default = ["std", "protocol-extensions", "tokio", "rustls"]
 protocol-extensions = []
 std = ["bytes/std", "futures/std", "s2n-quic-core/std", "s2n-quic-platform/std", "thiserror"]
+rustls = ["s2n-quic-rustls"]
 
 [dependencies]
 bytes = { version = "0.5", default-features = false }
+cfg-if = "0.1"
 futures = { version = "0.3", default-features = false }
 s2n-quic-core = { version = "0.1", path = "../s2n-quic-core", default-features = false }
 s2n-quic-platform = { version = "0.1", path = "../s2n-quic-platform", default-features = false }
-thiserror = { version = "1", optional = true }
+s2n-quic-rustls = { version = "0.1", path = "../s2n-quic-rustls", optional = true }
+thiserror = { version = "1.0", optional = true }
 tokio = { version = "0.2", optional = true, features = ["rt-core", "time", "udp"] }
 
 [dev-dependencies]

--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -4,14 +4,13 @@ An implementation of the IETF QUIC protocol
 ### Server Example
 
 ```rust,no_run
-use std::error::Error;
-use std::net::UdpSocket;
+use std::{error::Error, path::Path};
 use s2n_quic::Server;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     let mut server = Server::builder()
-        .with_tls("./certs/key.pem")?
+        .with_tls((Path::new("./certs/cert.pem"), Path::new("./certs/key.pem")))?
         .with_io("127.0.0.1:443")?
         .build()?;
 

--- a/quic/s2n-quic/src/provider/tls.rs
+++ b/quic/s2n-quic/src/provider/tls.rs
@@ -1,24 +1,99 @@
-use std::io;
+use cfg_if::cfg_if;
+use s2n_quic_core::crypto;
 
 /// Provides TLS support for an endpoint
 pub trait Provider {
-    // TODO
-}
+    type Server: crypto::tls::Endpoint;
+    type Client: crypto::tls::Endpoint;
+    type Error;
 
-#[derive(Debug, Default)]
-pub struct Default {
-    // TODO
-}
+    /// Creates a server endpoint for the given provider
+    fn server(self) -> Result<Self::Server, Self::Error>;
 
-impl Provider for Default {}
-
-impl TryInto for &str {
-    type Error = io::Error;
-    type Provider = Default;
-
-    fn try_into(self) -> Result<Self::Provider, Self::Error> {
-        Ok(Default::default())
-    }
+    /// Creates a client endpoint for the given provider
+    fn client(self) -> Result<Self::Client, Self::Error>;
 }
 
 impl_provider_utils!();
+
+cfg_if! {
+    // TODO prefer s2n-tls
+    if #[cfg(feature = "rustls")] {
+        pub use rustls as default;
+    } else {
+        pub mod default {
+            // TODO stub out implementations that panic on initialization
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Default;
+
+impl Provider for Default {
+    type Server = default::Server;
+    type Client = default::Client;
+    type Error = core::convert::Infallible;
+
+    fn server(self) -> Result<Self::Server, Self::Error> {
+        Ok(Self::Server::default())
+    }
+
+    fn client(self) -> Result<Self::Client, Self::Error> {
+        Ok(Self::Client::default())
+    }
+}
+
+impl Provider for (&std::path::Path, &std::path::Path) {
+    type Server = <Default as Provider>::Server;
+    type Client = <Default as Provider>::Client;
+    type Error = Box<dyn std::error::Error>;
+
+    fn server(self) -> Result<Self::Server, Self::Error> {
+        let cert = std::fs::read(self.0)?;
+        let key = std::fs::read(self.1)?;
+
+        let server = default::Server::builder()
+            .with_certificate(cert, key)?
+            .build()?;
+
+        Ok(server)
+    }
+
+    fn client(self) -> Result<Self::Client, Self::Error> {
+        Ok(default::Client::default())
+    }
+}
+
+#[cfg(feature = "rustls")]
+pub mod rustls {
+    pub use s2n_quic_rustls::{rustls::TLSError, *};
+
+    impl super::Provider for Server {
+        type Server = Self;
+        type Client = Client;
+        type Error = TLSError;
+
+        fn server(self) -> Result<Self::Server, Self::Error> {
+            Ok(self)
+        }
+
+        fn client(self) -> Result<Self::Client, Self::Error> {
+            panic!("cannot create a client from a server");
+        }
+    }
+
+    impl super::Provider for Client {
+        type Server = Server;
+        type Client = Self;
+        type Error = TLSError;
+
+        fn server(self) -> Result<Self::Server, Self::Error> {
+            panic!("cannot create a server from a client");
+        }
+
+        fn client(self) -> Result<Self::Client, Self::Error> {
+            Ok(self)
+        }
+    }
+}

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -264,12 +264,12 @@ impl<Providers: ServerProviders> Builder<Providers> {
         /// path to the private key.
         ///
         /// ```rust
-        /// # use std::error::Error;
+        /// # use std::{error::Error, path::Path};
         /// # use s2n_quic::Server;
         /// #
         /// # fn main() -> Result<(), Box<dyn Error>> {
         /// let server = Server::builder()
-        ///     .with_tls("./certs/key.pem")?
+        ///     .with_tls((Path::new("./certs/cert.pem"), Path::new("./certs/key.pem")))?
         ///     .build()?;
         /// #
         /// #    Ok(())
@@ -279,12 +279,12 @@ impl<Providers: ServerProviders> Builder<Providers> {
         /// Sets the TLS provider to a TLS server builder
         ///
         /// ```rust,ignore
-        /// # use std::error::Error;
+        /// # use std::{error::Error, path::Path};
         /// # use s2n_quic::Server;
         /// #
         /// # fn main() -> Result<(), Box<dyn Error>> {
         /// let tls = s2n::tls::Server::builder()
-        ///     .with_certificate("./certs/key.pem")?
+        ///     .with_certificate(Path::new("./certs/cert.pem"), Path::new("./certs/key.pem"))?
         ///     .with_security_policy(s2n::tls::security_policy::S2N_20190802)?;
         ///
         /// let server = Server::builder()
@@ -303,12 +303,12 @@ impl<Providers: ServerProviders> Builder<Providers> {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use std::error::Error;
+    /// # use std::{error::Error, path::Path};
     /// # use s2n_quic::Server;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let server = Server::builder()
-    ///     .with_tls("./certs/key.pem")?
+    ///     .with_tls((Path::new("./certs/cert.pem"), Path::new("./certs/key.pem")))?
     ///     .with_io("127.0.0.1:443")?
     ///     .build()?;
     /// #

--- a/quic/s2n-quic/src/server/mod.rs
+++ b/quic/s2n-quic/src/server/mod.rs
@@ -66,12 +66,12 @@ impl Server {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// # use std::error::Error;
+    /// # use std::{error::Error, path::Path};
     /// # use s2n_quic::Server;
     /// #
     /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let server = Server::builder()
-    ///     .with_tls("./certs/key.pem")?
+    ///     .with_tls((Path::new("./certs/cert.pem"), Path::new("./certs/key.pem")))?
     ///     .with_io("127.0.0.1:443")?
     ///     .build()?;
     /// #


### PR DESCRIPTION
This change sets rustls as the default TLS provider. I've put a TODO to enable s2n-tls instead when it's ready.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
