### PR TITLE
core: add connection id Generator and Validator traits

### DIFF
--- a/quic/s2n-quic-core/benches/packet.rs
+++ b/quic/s2n-quic-core/benches/packet.rs
@@ -22,7 +22,7 @@ fn decoding(c: &mut Criterion) {
                         });
 
                         let buffer = DecoderBufferMut::new(&mut data);
-                        let _ = black_box(ProtectedPacket::decode(buffer, 20).unwrap());
+                        let _ = black_box(ProtectedPacket::decode(buffer, &20).unwrap());
                     })
                 })
                 .throughput(Throughput::Bytes(test.len() as u64)),

--- a/quic/s2n-quic-core/src/connection/id.rs
+++ b/quic/s2n-quic-core/src/connection/id.rs
@@ -165,6 +165,39 @@ impl EncoderValue for ConnectionId {
     }
 }
 
+/// Format for connection IDs
+pub trait Format: Validator + Generator {}
+
+/// Implement Format for all types that implement the required subtraits
+impl<T: Validator + Generator> Format for T {}
+
+/// A validator for a connection ID format
+pub trait Validator {
+    /// Validates a connection ID from a buffer
+    ///
+    /// Implementations should handle situations where the buffer will include extra
+    /// data after the connection ID.
+    ///
+    /// Returns the length of the connection id if successful, otherwise `None` is returned.
+    fn validate(&self, buffer: &[u8]) -> Option<usize>;
+}
+
+impl Validator for usize {
+    fn validate(&self, buffer: &[u8]) -> Option<usize> {
+        if buffer.len() >= *self {
+            Some(*self)
+        } else {
+            None
+        }
+    }
+}
+
+/// A generator for a connection ID format
+pub trait Generator {
+    /// Generates a connection ID with an optional validity duration
+    fn generate(&mut self) -> (ConnectionId, Option<core::time::Duration>);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/quic/s2n-quic-core/src/connection/mod.rs
+++ b/quic/s2n-quic-core/src/connection/mod.rs
@@ -1,5 +1,5 @@
 mod error;
-mod id;
+pub mod id;
 
 pub use error::*;
 pub use id::*;

--- a/quic/s2n-quic-core/src/packet/short.rs
+++ b/quic/s2n-quic-core/src/packet/short.rs
@@ -1,4 +1,5 @@
 use crate::{
+    connection,
     crypto::{CryptoError, EncryptedPayload, HeaderCrypto, OneRTTCrypto, ProtectedPayload},
     packet::{
         decoding::HeaderDecoder,
@@ -7,7 +8,7 @@ use crate::{
             PacketNumber, PacketNumberLen, PacketNumberSpace, ProtectedPacketNumber,
             TruncatedPacketNumber,
         },
-        DestinationConnectionIDDecoder, Tag,
+        Tag,
     },
 };
 use s2n_codec::{CheckedRange, DecoderBufferMut, DecoderBufferMutResult, Encoder, EncoderValue};
@@ -166,10 +167,10 @@ pub type CleartextShort<'a> = Short<&'a [u8], KeyPhase, PacketNumber, DecoderBuf
 
 impl<'a> ProtectedShort<'a> {
     #[inline]
-    pub(crate) fn decode<DCID: DestinationConnectionIDDecoder>(
+    pub(crate) fn decode<Validator: connection::id::Validator>(
         tag: Tag,
         buffer: DecoderBufferMut<'a>,
-        destination_connection_id_decoder: DCID,
+        destination_connection_id_decoder: &Validator,
     ) -> DecoderBufferMutResult<'a, ProtectedShort<'a>> {
         let mut decoder = HeaderDecoder::new_short(&buffer);
 

--- a/quic/s2n-quic-core/tests/packet/fuzz_target.rs
+++ b/quic/s2n-quic-core/tests/packet/fuzz_target.rs
@@ -17,7 +17,7 @@ fn main() {
         let mut decoder_buffer = DecoderBufferMut::new(&mut data);
         let mut encoder_buffer = EncoderBuffer::new(&mut encoder_data);
 
-        while let Ok((packet, remaining)) = ProtectedPacket::decode(decoder_buffer, 20) {
+        while let Ok((packet, remaining)) = ProtectedPacket::decode(decoder_buffer, &20) {
             if let Ok(cleartext_packet) = decrypt_packet(packet) {
                 encoder_buffer = encode_packet(cleartext_packet, encoder_buffer);
             }

--- a/quic/s2n-quic-ring/src/initial.rs
+++ b/quic/s2n-quic-ring/src/initial.rs
@@ -180,7 +180,7 @@ mod tests {
         on_decrypt: F,
     ) -> O {
         let decoder = DecoderBufferMut::new(&mut protected_packet);
-        let (packet, _) = ProtectedPacket::decode(decoder, 20).unwrap();
+        let (packet, _) = ProtectedPacket::decode(decoder, &20).unwrap();
 
         let packet = match packet {
             ProtectedPacket::Initial(initial) => initial,

--- a/quic/s2n-quic-transport/src/connection/mod.rs
+++ b/quic/s2n-quic-transport/src/connection/mod.rs
@@ -8,7 +8,6 @@ use s2n_quic_core::{
     endpoint,
     frame::ConnectionClose,
     inet::SocketAddress,
-    packet::DestinationConnectionIDDecoder,
     stream::StreamError,
     time::Timestamp,
     transport::{
@@ -42,6 +41,8 @@ pub(crate) use transmission::{ConnectionTransmission, ConnectionTransmissionCont
 
 pub use api::Connection;
 pub use connection_impl::ConnectionImpl;
+/// re-export core
+pub use s2n_quic_core::connection::*;
 
 /// Stores configuration parameters for a connection which might be shared
 /// between multiple connections of the same type.
@@ -50,8 +51,6 @@ pub trait ConnectionConfig: 'static + Send {
     type StreamType: StreamTrait;
     /// Session type
     type TLSSession: tls::Session;
-    /// The type which is used for decoding destination connection IDs
-    type DestinationConnectionIDDecoderType: DestinationConnectionIDDecoder;
 
     const ENDPOINT_TYPE: endpoint::EndpointType;
 
@@ -62,8 +61,6 @@ pub trait ConnectionConfig: 'static + Send {
     /// Returns the limits for this connection that are not defined through
     /// transport parameters
     fn connection_limits(&self) -> &ConnectionLimits;
-    /// Returns the destination connection ID decoder for this connection
-    fn destination_connnection_id_decoder(&self) -> Self::DestinationConnectionIDDecoderType;
 }
 
 /// Parameters which are passed to a Connection.

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -1,11 +1,7 @@
 //! Configuration parameters for `Endpoint`s
 
-use crate::connection::{ConnectionConfig, ConnectionTrait};
-use core::time::Duration;
-use s2n_quic_core::{
-    connection::ConnectionId, crypto::tls, endpoint::EndpointType,
-    packet::DestinationConnectionIDDecoder,
-};
+use crate::connection::{self, ConnectionConfig, ConnectionTrait};
+use s2n_quic_core::{crypto::tls, endpoint::EndpointType};
 
 /// Configuration paramters for a QUIC endpoint
 pub trait EndpointConfig {
@@ -19,7 +15,7 @@ pub trait EndpointConfig {
     /// The connections type
     type ConnectionType: ConnectionTrait<Config = Self::ConnectionConfigType>;
     /// The type of the generator of new connection IDs
-    type ConnectionIdGeneratorType: ConnectionIdGenerator<DestinationConnectionIDDecoderType = <Self::ConnectionConfigType as ConnectionConfig>::DestinationConnectionIDDecoderType>;
+    type ConnectionIdFormat: connection::id::Format;
 
     /// The type of the local endpoint
     const ENDPOINT_TYPE: EndpointType =
@@ -27,16 +23,7 @@ pub trait EndpointConfig {
 
     /// Obtain the configuration for the next connection to be handled
     fn create_connection_config(&mut self) -> Self::ConnectionConfigType;
-}
 
-/// Generates connection IDs for incoming connections
-pub trait ConnectionIdGenerator {
-    /// The type which is used to decode connection IDs
-    type DestinationConnectionIDDecoderType: DestinationConnectionIDDecoder;
-
-    /// Generates a local connection ID for a new connection
-    fn generate_connection_id(&mut self) -> (ConnectionId, Option<Duration>);
-
-    /// Returns a connection id decoder for cononections created by this generator
-    fn destination_connection_id_decoder(&self) -> Self::DestinationConnectionIDDecoderType;
+    /// Returns the connection ID format for the endpoint
+    fn connection_id_format(&mut self) -> &mut Self::ConnectionIdFormat;
 }

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -1,8 +1,9 @@
 use crate::{
     connection::{
-        ConnectionConfig, ConnectionParameters, ConnectionTrait, SynchronizedSharedConnectionState,
+        id::Generator as _, ConnectionConfig, ConnectionParameters, ConnectionTrait,
+        SynchronizedSharedConnectionState,
     },
-    endpoint::{ConnectionIdGenerator, Endpoint, EndpointConfig},
+    endpoint::{Endpoint, EndpointConfig},
     space::PacketSpaceManager,
 };
 use alloc::sync::Arc;
@@ -16,22 +17,6 @@ use s2n_quic_core::{
     transport::{error::TransportError, parameters::ServerTransportParameters},
 };
 
-//= https://tools.ietf.org/id/draft-ietf-quic-transport-27.txt#14
-//# A client MUST expand the payload of all UDP datagrams carrying
-//# Initial packets to at least 1200 bytes, by adding PADDING frames to
-//# the Initial packet or by coalescing the Initial packet (see
-//# Section 12.2).
-
-const MINIMUM_INITIAL_PACKET_LEN: usize = 1200;
-
-//= https://tools.ietf.org/id/draft-ietf-quic-transport-27.txt#7.2
-//# When an Initial packet is sent by a client that has not previously
-//# received an Initial or Retry packet from the server, it populates the
-//# Destination Connection ID field with an unpredictable value.  This
-//# MUST be at least 8 bytes in length.
-
-const DESTINATION_CONNECTION_ID_MIN_LEN: usize = 8;
-
 impl<ConfigType: EndpointConfig> Endpoint<ConfigType> {
     pub(super) fn handle_initial_packet(
         &mut self,
@@ -44,17 +29,25 @@ impl<ConfigType: EndpointConfig> Endpoint<ConfigType> {
             "only servers can accept new initial connections"
         );
 
-        // TODO: Validate version
-        // TODO: Check that the connection ID is at least 8 byte
-        // But maybe we really would need to do this before or inside parsing
-        if datagram.payload_len < MINIMUM_INITIAL_PACKET_LEN {
+        //= https://tools.ietf.org/id/draft-ietf-quic-transport-29.txt#14.1
+        //# A client MUST expand the payload of all UDP datagrams carrying
+        //# Initial packets to at least the smallest allowed maximum packet size
+        //# (1200 bytes) by adding PADDING frames to the Initial packet or by
+        //# coalescing the Initial packet
+        if datagram.payload_len < 1200 {
             return Err(TransportError::PROTOCOL_VIOLATION.with_reason("packet too small"));
         }
 
         let destination_connection_id: ConnectionId =
             packet.destination_connection_id().try_into()?;
 
-        if destination_connection_id.len() < DESTINATION_CONNECTION_ID_MIN_LEN {
+        //= https://tools.ietf.org/id/draft-ietf-quic-transport-29.txt#7.2
+        //# When an Initial packet is sent by a client that has not previously
+        //# received an Initial or Retry packet from the server, the client
+        //# populates the Destination Connection ID field with an unpredictable
+        //# value.  This Destination Connection ID MUST be at least 8 bytes in
+        //# length.
+        if destination_connection_id.len() < 8 {
             return Err(TransportError::PROTOCOL_VIOLATION
                 .with_reason("destination connection id too short"));
         }
@@ -76,8 +69,9 @@ impl<ConfigType: EndpointConfig> Endpoint<ConfigType> {
         // TODO handle token with stateless retry
 
         let internal_connection_id = self.connection_id_generator.generate_id();
+        // TODO store the expiration of the connection ID
         let (local_connection_id, _connection_id_expiration) =
-            self.local_connection_id_generator.generate_connection_id();
+            self.config.connection_id_format().generate();
         let mut connection_id_mapper_registration = self
             .connection_id_mapper
             .create_registration(internal_connection_id);
@@ -88,13 +82,14 @@ impl<ConfigType: EndpointConfig> Endpoint<ConfigType> {
         let timer = self.timer_manager.create_timer(
             internal_connection_id,
             datagram.timestamp + Duration::from_secs(3600),
-        ); // TODO: Fixme
+        ); // TODO: make it so we don't arm for a given time and immediately change it
 
         let wakeup_handle = self
             .wakeup_queue
             .create_wakeup_handle(internal_connection_id);
 
         // TODO initialize transport parameters from provider values
+        // TODO pass connection_ids for authentication
         let transport_parameters = ServerTransportParameters::default();
 
         let tls_session = self.tls_endpoint.new_server_session(&transport_parameters);
@@ -135,6 +130,7 @@ impl<ConfigType: EndpointConfig> Endpoint<ConfigType> {
                 locked_shared_state,
                 datagram,
                 destination_connection_id,
+                self.config.connection_id_format(),
                 remaining,
             )?;
         }


### PR DESCRIPTION
As I was implementing the connection ID provider, I felt like it was awkward to use the current traits. This change unifies generation and validation under the `connection::id::Format` trait, which makes it easier to implement and reason about.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
