### PR TITLE
transport: return owned limits in connection config

### DIFF
--- a/quic/s2n-quic-transport/src/connection/mod.rs
+++ b/quic/s2n-quic-transport/src/connection/mod.rs
@@ -54,12 +54,12 @@ pub trait Config: 'static + Send {
     const ENDPOINT_TYPE: endpoint::EndpointType;
 
     /// Our initial flow control limits as advertised in transport parameters.
-    fn local_flow_control_limits(&self) -> &InitialFlowControlLimits;
+    fn local_flow_control_limits(&self) -> InitialFlowControlLimits;
     /// Our ack settings as advertised in transport parameters.
-    fn local_ack_settings(&self) -> &AckSettings;
+    fn local_ack_settings(&self) -> AckSettings;
     /// Returns the limits for this connection that are not defined through
     /// transport parameters
-    fn connection_limits(&self) -> &Limits;
+    fn connection_limits(&self) -> Limits;
 }
 
 /// Parameters which are passed to a Connection.

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -92,19 +92,20 @@ impl<'a, ConnectionConfigType: connection::Config> tls::Context<ConnectionConfig
             );
         }
 
-        let peer_limits = peer_parameters.flow_control_limits();
-        let local_flow_control_limits = *self.connection_config.local_flow_control_limits();
+        let peer_flow_control_limits = peer_parameters.flow_control_limits();
+        let local_flow_control_limits = self.connection_config.local_flow_control_limits();
+        let connection_limits = self.connection_config.connection_limits();
 
         let stream_manager = AbstractStreamManager::new(
-            self.connection_config.connection_limits(),
+            &connection_limits,
             ConnectionConfigType::ENDPOINT_TYPE,
             local_flow_control_limits,
-            peer_limits,
+            peer_flow_control_limits,
         );
 
         // TODO ack interval limit configurable
         let ack_interval_limit = DEFAULT_ACK_RANGES_LIMIT;
-        let ack_settings = *self.connection_config.local_ack_settings();
+        let ack_settings = self.connection_config.local_ack_settings();
         let ack_manager = AckManager::new(
             PacketNumberSpace::ApplicationData,
             ack_settings,


### PR DESCRIPTION
Returning the borrowed value from before made it so the values had to be known and stored at the time of config construction. By returning owned values, they can be dynamically constructed instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
