### PR TITLE
api: implement clock provider

### DIFF
--- a/quic/s2n-quic/src/provider/clock.rs
+++ b/quic/s2n-quic/src/provider/clock.rs
@@ -1,13 +1,38 @@
-/// Provides clock support for an endpoint
-pub trait Provider {
-    // TODO
+pub use s2n_quic_core::time::Clock;
+
+pub trait Provider: 'static {
+    type Clock: 'static + Clock + Send;
+    type Error: core::fmt::Display;
+
+    fn start(self) -> Result<Self::Clock, Self::Error>;
 }
 
-#[derive(Debug, Default)]
-pub struct Default {
-    // TODO
-}
-
-impl Provider for Default {}
+pub use platform::Provider as Default;
 
 impl_provider_utils!();
+
+mod platform {
+    use s2n_quic_core::time::Timestamp;
+    use s2n_quic_platform::time::now;
+
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct Provider;
+
+    impl super::Provider for Provider {
+        type Clock = Clock;
+        type Error = core::convert::Infallible;
+
+        fn start(self) -> Result<Self::Clock, Self::Error> {
+            Ok(Clock)
+        }
+    }
+
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct Clock;
+
+    impl super::Clock for Clock {
+        fn get_time(&self) -> Timestamp {
+            now()
+        }
+    }
+}


### PR DESCRIPTION
This change creates a clock provider for the public API. It also creates a default clock provider that uses the platform crate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
