### PR TITLE
api: implement connection id provider

### DIFF
--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [features]
-default = ["std", "protocol-extensions", "tokio", "rustls"]
+default = ["std", "protocol-extensions", "rand", "rustls", "tokio"]
 protocol-extensions = []
 std = ["bytes/std", "futures/std", "s2n-quic-core/std", "s2n-quic-platform/std", "thiserror"]
 rustls = ["s2n-quic-rustls"]
@@ -15,6 +15,7 @@ rustls = ["s2n-quic-rustls"]
 bytes = { version = "0.5", default-features = false }
 cfg-if = "0.1"
 futures = { version = "0.3", default-features = false }
+rand = { version = "0.7", optional = true }
 s2n-quic-core = { version = "0.1", path = "../s2n-quic-core", default-features = false }
 s2n-quic-platform = { version = "0.1", path = "../s2n-quic-platform", default-features = false }
 s2n-quic-rustls = { version = "0.1", path = "../s2n-quic-rustls", optional = true }

--- a/quic/s2n-quic/src/provider/connection_id.rs
+++ b/quic/s2n-quic/src/provider/connection_id.rs
@@ -1,13 +1,135 @@
+use s2n_quic_core::connection::id::Format;
+pub use s2n_quic_core::connection::id::{Generator, Validator};
+
 /// Provides connection id support for an endpoint
-pub trait Provider {
-    // TODO
+pub trait Provider: 'static {
+    type Format: 'static + Format;
+    type Error: core::fmt::Display;
+
+    fn start(self) -> Result<Self::Format, Self::Error>;
 }
 
-#[derive(Debug, Default)]
-pub struct Default {
-    // TODO
+cfg_if::cfg_if! {
+    if #[cfg(feature = "rand")] {
+        pub use random::Provider as Default;
+    } else {
+        // TODO implement stub that panics
+    }
 }
-
-impl Provider for Default {}
 
 impl_provider_utils!();
+
+#[cfg(feature = "rand")]
+pub mod random {
+    use core::{
+        convert::{Infallible, TryInto},
+        time::Duration,
+    };
+    use rand::prelude::*;
+    use s2n_quic_core::connection::{
+        self,
+        id::{Generator, Validator},
+    };
+
+    #[derive(Debug, Default)]
+    pub struct Provider(Format);
+
+    impl super::Provider for Provider {
+        type Format = Format;
+        type Error = Infallible;
+
+        fn start(self) -> Result<Self::Format, Self::Error> {
+            Ok(self.0)
+        }
+    }
+
+    impl super::TryInto for Format {
+        type Provider = Provider;
+        type Error = Infallible;
+
+        fn try_into(self) -> Result<Self::Provider, Self::Error> {
+            Ok(Provider(self))
+        }
+    }
+
+    /// 16 bytes should be big enough for a randomly generated Id
+    const DEFAULT_LEN: usize = 16;
+
+    /// Randomly generated connection Id format.
+    ///
+    /// By default, connection Ids of length 16 bytes are generated.
+    #[derive(Debug)]
+    pub struct Format {
+        len: usize,
+    }
+
+    impl Default for Format {
+        fn default() -> Self {
+            Self { len: DEFAULT_LEN }
+        }
+    }
+
+    impl Format {
+        /// Creates a builder for the format
+        pub fn builder() -> Builder {
+            Builder::default()
+        }
+    }
+
+    /// A builder for [`Format`] providers
+    #[derive(Debug)]
+    pub struct Builder {
+        len: usize,
+    }
+
+    impl Default for Builder {
+        fn default() -> Self {
+            Self { len: DEFAULT_LEN }
+        }
+    }
+
+    impl Builder {
+        /// Sets the length of the generated connection Id
+        pub fn with_len(mut self, len: usize) -> Result<Self, connection::id::Error> {
+            if len > connection::id::MAX_LEN {
+                return Err(connection::id::Error);
+            }
+            self.len = len;
+            Ok(self)
+        }
+
+        /// Builds the [`Format`] into a provider
+        pub fn build(self) -> Result<Format, core::convert::Infallible> {
+            Ok(Format { len: self.len })
+        }
+    }
+
+    impl Generator for Format {
+        fn generate(&mut self) -> (connection::Id, Option<Duration>) {
+            let mut id = [0u8; connection::id::MAX_LEN];
+            rand::thread_rng().fill_bytes(&mut id[..self.len]);
+            let id = id.try_into().expect("length already checked");
+            (id, None)
+        }
+    }
+
+    impl Validator for Format {
+        fn validate(&self, buffer: &[u8]) -> Option<usize> {
+            if buffer.len() >= self.len {
+                Some(self.len)
+            } else {
+                None
+            }
+        }
+    }
+
+    #[test]
+    fn generator_test() {
+        for len in 0..connection::id::MAX_LEN {
+            let mut format = Format::builder().with_len(len).unwrap().build().unwrap();
+
+            let (id, _) = format.generate();
+            assert_eq!(format.validate(id.as_ref()), Some(len));
+        }
+    }
+}


### PR DESCRIPTION
This change implements the connection Id provider for the public API. It also implements a default provider that randomly generates Ids using the `rand` crate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
