### PR TITLE
transport: send connection id transport parameters

### DIFF
--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -87,8 +87,25 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             .create_wakeup_handle(internal_connection_id);
 
         // TODO initialize transport parameters from provider values
-        // TODO pass connection_ids for authentication
-        let transport_parameters = ServerTransportParameters::default();
+        let mut transport_parameters = ServerTransportParameters::default();
+
+        //= https://tools.ietf.org/id/draft-ietf-quic-transport-29.txt#7.3
+        //# A server includes the Destination Connection ID field from the first
+        //# Initial packet it received from the client in the
+        //# original_destination_connection_id transport parameter
+        transport_parameters.original_destination_connection_id = destination_connection_id
+            .try_into()
+            .expect("connection ID already validated");
+
+        //= https://tools.ietf.org/id/draft-ietf-quic-transport-29.txt#7.3
+        //# Each endpoint includes the value of the Source Connection ID field
+        //# from the first Initial packet it sent in the
+        //# initial_source_connection_id transport parameter
+        transport_parameters.initial_source_connection_id = local_connection_id
+            .try_into()
+            .expect("connection ID already validated");
+
+        // TODO send retry_source_connection_id
 
         let tls_session = self
             .config

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -92,6 +92,10 @@ impl<'a, ConnectionConfigType: connection::Config> tls::Context<ConnectionConfig
             );
         }
 
+        // TODO authenticate initial_source_connection_id
+        // TODO authenticate original_destination_connection_id
+        // https://tools.ietf.org/html/draft-ietf-quic-transport-29#section-7.3
+
         let peer_flow_control_limits = peer_parameters.flow_control_limits();
         let local_flow_control_limits = self.connection_config.local_flow_control_limits();
         let connection_limits = self.connection_config.connection_limits();


### PR DESCRIPTION
This change implements the sending side of [connection Id authentication](https://tools.ietf.org/html/draft-ietf-quic-transport-29#section-7.3) by sending the required fields in the server transport parameters. I also added a couple of TODOs for the receiving side.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
