### PR TITLE
api: implement no-op providers for unimplemented traits

### DIFF
--- a/quic/s2n-quic/src/provider/congestion_controller.rs
+++ b/quic/s2n-quic/src/provider/congestion_controller.rs
@@ -1,23 +1,26 @@
 /// Provides congestion controller support for an endpoint
 pub trait Provider {
-    // TODO
+    type CongestionController: 'static + Send;
+    type Error: core::fmt::Display;
+
+    fn start(self) -> Result<Self::CongestionController, Self::Error>;
 }
 
-#[derive(Debug, Default)]
-pub struct Default {
-    // TODO
-}
-
-impl Provider for Default {}
-
-#[derive(Default, Debug)]
-pub struct Cubic {}
-
-impl Provider for Cubic {}
-
-#[derive(Default, Debug)]
-pub struct Reno {}
-
-impl Provider for Reno {}
+pub use default::Provider as Default;
 
 impl_provider_utils!();
+
+pub mod default {
+    #[derive(Debug, Default)]
+    pub struct Provider;
+
+    impl super::Provider for Provider {
+        type CongestionController = (); // TODO
+        type Error = core::convert::Infallible;
+
+        fn start(self) -> Result<Self::CongestionController, Self::Error> {
+            // TODO
+            Ok(())
+        }
+    }
+}

--- a/quic/s2n-quic/src/provider/limits.rs
+++ b/quic/s2n-quic/src/provider/limits.rs
@@ -1,32 +1,26 @@
-use core::{convert::Infallible, time::Duration};
-
 /// Provides limits support for an endpoint
 pub trait Provider {
-    // TODO
+    type Limits: 'static + Send;
+    type Error: core::fmt::Display;
+
+    fn start(self) -> Result<Self::Limits, Self::Error>;
 }
 
-#[derive(Debug, Default)]
-pub struct Default {
-    // TODO
-}
-
-impl Provider for Default {}
-
-#[derive(Debug, Default)]
-pub struct Builder {
-    // TODO
-    limits: Default,
-}
-
-impl Builder {
-    pub fn with_max_idle_time(self, duration: Duration) -> Result<Self, Infallible> {
-        let _ = duration;
-        Ok(self)
-    }
-
-    pub fn build(self) -> Result<Default, Infallible> {
-        Ok(self.limits)
-    }
-}
+pub use default::Provider as Default;
 
 impl_provider_utils!();
+
+pub mod default {
+    #[derive(Debug, Default)]
+    pub struct Provider;
+
+    impl super::Provider for Provider {
+        type Limits = (); // TODO
+        type Error = core::convert::Infallible;
+
+        fn start(self) -> Result<Self::Limits, Self::Error> {
+            // TODO
+            Ok(())
+        }
+    }
+}

--- a/quic/s2n-quic/src/provider/log.rs
+++ b/quic/s2n-quic/src/provider/log.rs
@@ -1,13 +1,26 @@
 /// Provides logging support for an endpoint
 pub trait Provider {
-    // TODO
+    type Log: 'static + Send;
+    type Error: core::fmt::Display;
+
+    fn start(self) -> Result<Self::Log, Self::Error>;
 }
 
-#[derive(Debug, Default)]
-pub struct Default {
-    // TODO
-}
-
-impl Provider for Default {}
+pub use default::Provider as Default;
 
 impl_provider_utils!();
+
+pub mod default {
+    #[derive(Debug, Default)]
+    pub struct Provider;
+
+    impl super::Provider for Provider {
+        type Log = (); // TODO
+        type Error = core::convert::Infallible;
+
+        fn start(self) -> Result<Self::Log, Self::Error> {
+            // TODO
+            Ok(())
+        }
+    }
+}

--- a/quic/s2n-quic/src/provider/retry_token.rs
+++ b/quic/s2n-quic/src/provider/retry_token.rs
@@ -1,13 +1,26 @@
 /// Provides retry token support for an endpoint
 pub trait Provider {
-    // TODO
+    type RetryToken: 'static + Send;
+    type Error: core::fmt::Display;
+
+    fn start(self) -> Result<Self::RetryToken, Self::Error>;
 }
 
-#[derive(Debug, Default)]
-pub struct Default {
-    // TODO
-}
-
-impl Provider for Default {}
+pub use default::Provider as Default;
 
 impl_provider_utils!();
+
+pub mod default {
+    #[derive(Debug, Default)]
+    pub struct Provider;
+
+    impl super::Provider for Provider {
+        type RetryToken = (); // TODO
+        type Error = core::convert::Infallible;
+
+        fn start(self) -> Result<Self::RetryToken, Self::Error> {
+            // TODO
+            Ok(())
+        }
+    }
+}

--- a/quic/s2n-quic/src/provider/sync.rs
+++ b/quic/s2n-quic/src/provider/sync.rs
@@ -1,20 +1,26 @@
 /// Provides synchronization support for an endpoint
 pub trait Provider {
-    // TODO
+    type Sync: 'static + Send;
+    type Error: core::fmt::Display;
+
+    fn start(self) -> Result<Self::Sync, Self::Error>;
 }
 
-#[derive(Debug, Default)]
-pub struct Default {
-    // TODO
-}
-
-impl Provider for Default {}
-
-#[derive(Debug, Default)]
-pub struct Mutex {
-    // TODO
-}
-
-impl Provider for Mutex {}
+pub use default::Provider as Default;
 
 impl_provider_utils!();
+
+pub mod default {
+    #[derive(Debug, Default)]
+    pub struct Provider;
+
+    impl super::Provider for Provider {
+        type Sync = (); // TODO
+        type Error = core::convert::Infallible;
+
+        fn start(self) -> Result<Self::Sync, Self::Error> {
+            // TODO
+            Ok(())
+        }
+    }
+}

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -48,7 +48,7 @@ impl<Providers: ServerProviders> Builder<Providers> {
         ///
         /// Sets the congestion controller to `Reno` with the default configuration.
         ///
-        /// ```rust
+        /// ```rust,ignore
         /// # use std::error::Error;
         /// use s2n_quic::{Server, provider::congestion_controller};
         /// #
@@ -100,11 +100,7 @@ impl<Providers: ServerProviders> Builder<Providers> {
         /// #
         /// # fn main() -> Result<(), Box<dyn Error>> {
         /// let server = Server::builder()
-        ///     .with_limits(
-        ///         limits::Builder::default()
-        ///             .with_max_idle_time(Duration::from_secs(30))?
-        ///             .build()?
-        ///     )?
+        ///     .with_limits(limits::Default::default())?
         ///     .build()?;
         /// #
         /// #    Ok(())
@@ -240,7 +236,7 @@ impl<Providers: ServerProviders> Builder<Providers> {
         ///
         /// Uses [`std::sync::Mutex`] to perform synchronization.
         ///
-        /// ```rust
+        /// ```rust,ignore
         /// # use std::{error::Error, time::Duration};
         /// use s2n_quic::{Server, provider::sync};
         /// #


### PR DESCRIPTION
There's a handful of providers that don't have a way to wire up in the current implementation. In this change, I've implemented a few no-op traits and default implementations so we can make progress on getting the server running.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
