### PR TITLE
transport: implement ReceiveBuffer::pop_transform

### DIFF
--- a/quic/s2n-quic-transport/src/buffer/tests.rs
+++ b/quic/s2n-quic-transport/src/buffer/tests.rs
@@ -684,3 +684,48 @@ fn fail_to_push_out_of_bounds_data_with_long_buffer() {
         );
     }
 }
+
+#[test]
+fn pop_transform_test() {
+    let mut buffer = StreamReceiveBuffer::new();
+
+    assert_eq!(
+        None,
+        buffer.pop_transform(|buffer| Some(buffer.split())),
+        "an empty buffer should always return none"
+    );
+
+    buffer
+        .write_at(0u32.into(), &[0, 1, 2, 3, 4, 5, 6, 7])
+        .unwrap();
+
+    assert_eq!(
+        None,
+        buffer.pop_transform(|_| None),
+        "returning none should not pop the buffer"
+    );
+
+    assert_eq!(
+        Some(bytes::BytesMut::from(&[0, 1, 2][..])),
+        buffer.pop_transform(|buffer| Some(buffer.split_to(3))),
+        "the transform should be able to split off a piece of the buffer",
+    );
+
+    assert_eq!(
+        None,
+        buffer.pop_transform(|_buffer| Some(bytes::BytesMut::new())),
+        "popping an empty buffer should return None"
+    );
+
+    assert_eq!(
+        Some(bytes::BytesMut::from(&[3, 4, 5, 6, 7][..])),
+        buffer.pop_transform(|buffer| Some(buffer.split())),
+        "splitting the buffer should consume the entire thing",
+    );
+
+    assert_eq!(
+        None,
+        buffer.pop_transform(|buffer| Some(buffer.split())),
+        "the receive buffer should be empty after splitting"
+    );
+}


### PR DESCRIPTION
In order to support the [`AsyncRead`](https://docs.rs/futures/0.3.5/futures/io/trait.AsyncRead.html) API, the receive buffer needs a way to pull off a maximum number of bytes. This change adds a `pop_transform` function that will allow callers to transform the front `BytesMut` buffer with a callback.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
