### PR TITLE
ci: update rust nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   SCCACHE_IDLE_TIMEOUT: 0
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2020-08-25
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2020-11-09
 
 jobs:
   env:
@@ -268,6 +268,8 @@ jobs:
         run: cd ${{ matrix.crate }} && cargo miri test
         env:
           RUSTC_WRAPPER: sccache
+          # needed to read corpus files from filesystem
+          MIRIFLAGS: -Zmiri-disable-isolation
 
       - name: Stop sccache
         run: sccache --stop-server


### PR DESCRIPTION
This allows MIRI to execute bolero tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
