### PR TITLE
api: implement public stream apis

### DIFF
--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -21,8 +21,8 @@ ring = { version = "0.16", optional = true, default-features = false }
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "0.1", path = "../s2n-quic-core", default-features = false }
 s2n-quic-platform = { version = "0.1", path = "../s2n-quic-platform", default-features = false }
-s2n-quic-transport = { version = "0.1", path = "../s2n-quic-transport", default-features = false }
 s2n-quic-rustls = { version = "0.1", path = "../s2n-quic-rustls", optional = true }
+s2n-quic-transport = { version = "0.1", path = "../s2n-quic-transport", default-features = false }
 thiserror = { version = "1.0", optional = true }
 tokio = { version = "0.2", optional = true, features = ["rt-core", "time", "udp"] }
 zerocopy = { version = "0.3", optional = true }

--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -25,8 +25,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     eprintln!("Stream opened from {:?}", stream.connection().remote_addr());
 
                     // echo any data back to the stream
-                    while let Ok(Some(data)) = stream.pop().await {
-                        stream.push(data).await.expect("stream should be open");
+                    while let Ok(Some(data)) = stream.receive().await {
+                        stream.send(data).await.expect("stream should be open");
                     }
                 });
             }

--- a/quic/s2n-quic/src/stream/bidirectional.rs
+++ b/quic/s2n-quic/src/stream/bidirectional.rs
@@ -1,16 +1,20 @@
+use s2n_quic_transport::stream::Stream;
+
 /// An QUIC stream that may both send and receive data.
 ///
 /// The [`BidirectionalStream`] implements the required send and receive operations described in the
 /// [QUIC Transport RFC](https://tools.ietf.org/html/draft-ietf-quic-transport-28#section-2)
 #[derive(Debug)]
-pub struct BidirectionalStream {
-    // TODO
-}
+pub struct BidirectionalStream(Stream);
 
 impl BidirectionalStream {
-    impl_receive_stream_api!(|stream, call| call!(stream));
+    pub(crate) const fn new(stream: Stream) -> Self {
+        Self(stream)
+    }
 
-    impl_send_stream_api!(|stream, call| call!(stream));
+    impl_receive_stream_api!(|stream, call| call!(stream.0));
+
+    impl_send_stream_api!(|stream, call| call!(stream.0));
 
     impl_splittable_stream_api!(|_stream| {
         todo!();
@@ -21,8 +25,8 @@ impl BidirectionalStream {
     impl_metric_api!();
 }
 
-impl_receive_stream_trait!(BidirectionalStream, |stream, call| call!(stream));
-impl_send_stream_trait!(BidirectionalStream, |stream, call| call!(stream));
+impl_receive_stream_trait!(BidirectionalStream, |stream, call| call!(stream.0));
+impl_send_stream_trait!(BidirectionalStream, |stream, call| call!(stream.0));
 impl_splittable_stream_trait!(BidirectionalStream, |_stream| {
     todo!();
 });

--- a/quic/s2n-quic/src/stream/peer.rs
+++ b/quic/s2n-quic/src/stream/peer.rs
@@ -46,3 +46,15 @@ impl_splittable_stream_trait!(PeerStream, |stream| match stream {
     PeerStream::Bidirectional(stream) => stream.split(),
     PeerStream::Receive(stream) => stream.split(),
 });
+
+impl From<ReceiveStream> for PeerStream {
+    fn from(stream: ReceiveStream) -> Self {
+        Self::Receive(stream)
+    }
+}
+
+impl From<BidirectionalStream> for PeerStream {
+    fn from(stream: BidirectionalStream) -> Self {
+        Self::Bidirectional(stream)
+    }
+}


### PR DESCRIPTION
After merging #129 we can finally wire all of the stream APIs up in the public interface.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
