### PR TITLE
implement server event loop

### DIFF
--- a/quic/s2n-quic-qns/src/server.rs
+++ b/quic/s2n-quic-qns/src/server.rs
@@ -81,7 +81,7 @@ impl Interop {
         let server = Server::builder()
             .with_io(("0.0.0.0", self.port))?
             .with_tls(tls)?
-            .build()?;
+            .start()?;
 
         eprintln!("Server listening on port {}", self.port);
 

--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -12,7 +12,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let mut server = Server::builder()
         .with_tls((Path::new("./certs/cert.pem"), Path::new("./certs/key.pem")))?
         .with_io("127.0.0.1:443")?
-        .build()?;
+        .start()?;
 
     while let Some(mut connection) = server.accept().await {
         // spawn a new task for the connection

--- a/quic/s2n-quic/src/provider/congestion_controller.rs
+++ b/quic/s2n-quic/src/provider/congestion_controller.rs
@@ -1,9 +1,14 @@
+pub use s2n_quic_core::{
+    inet::SocketAddress,
+    recovery::congestion_controller::{CongestionController, Endpoint, PathInfo},
+};
+
 /// Provides congestion controller support for an endpoint
 pub trait Provider {
-    type CongestionController: 'static + Send;
-    type Error: core::fmt::Display;
+    type Endpoint: Endpoint;
+    type Error: 'static + core::fmt::Display;
 
-    fn start(self) -> Result<Self::CongestionController, Self::Error>;
+    fn start(self) -> Result<Self::Endpoint, Self::Error>;
 }
 
 pub use default::Provider as Default;
@@ -15,12 +20,32 @@ pub mod default {
     pub struct Provider;
 
     impl super::Provider for Provider {
-        type CongestionController = (); // TODO
+        type Endpoint = Endpoint;
         type Error = core::convert::Infallible;
 
-        fn start(self) -> Result<Self::CongestionController, Self::Error> {
-            // TODO
-            Ok(())
+        fn start(self) -> Result<Self::Endpoint, Self::Error> {
+            Ok(Endpoint {})
         }
+    }
+
+    #[derive(Debug, Default)]
+    pub struct Endpoint {}
+
+    impl super::Endpoint for Endpoint {
+        type CongestionController = CongestionController;
+
+        fn new_congestion_controller(
+            &mut self,
+            _path_info: super::PathInfo,
+        ) -> Self::CongestionController {
+            CongestionController::default()
+        }
+    }
+
+    #[derive(Clone, Debug, Default)]
+    pub struct CongestionController {}
+
+    impl super::CongestionController for CongestionController {
+        // TODO implement callbacks once defined
     }
 }

--- a/quic/s2n-quic/src/provider/io.rs
+++ b/quic/s2n-quic/src/provider/io.rs
@@ -10,7 +10,7 @@ where
 {
     type Rx;
     type Tx;
-    type Error: core::fmt::Display;
+    type Error: 'static + core::fmt::Display;
 
     fn start(self) -> Result<Duplex<Self::Rx, Self::Tx>, Self::Error>;
 }

--- a/quic/s2n-quic/src/provider/limits.rs
+++ b/quic/s2n-quic/src/provider/limits.rs
@@ -1,7 +1,7 @@
 /// Provides limits support for an endpoint
 pub trait Provider {
     type Limits: 'static + Send;
-    type Error: core::fmt::Display;
+    type Error: 'static + core::fmt::Display;
 
     fn start(self) -> Result<Self::Limits, Self::Error>;
 }

--- a/quic/s2n-quic/src/provider/log.rs
+++ b/quic/s2n-quic/src/provider/log.rs
@@ -1,7 +1,7 @@
 /// Provides logging support for an endpoint
 pub trait Provider {
     type Log: 'static + Send;
-    type Error: core::fmt::Display;
+    type Error: 'static + core::fmt::Display;
 
     fn start(self) -> Result<Self::Log, Self::Error>;
 }

--- a/quic/s2n-quic/src/provider/macros.rs
+++ b/quic/s2n-quic/src/provider/macros.rs
@@ -3,7 +3,7 @@ macro_rules! impl_provider_utils {
         /// Converts a value into a `Provider`
         pub trait TryInto {
             type Provider: Provider;
-            type Error;
+            type Error: 'static + core::fmt::Display;
 
             fn try_into(self) -> Result<Self::Provider, Self::Error>;
         }

--- a/quic/s2n-quic/src/provider/runtime/mod.rs
+++ b/quic/s2n-quic/src/provider/runtime/mod.rs
@@ -4,7 +4,7 @@ use core::{future::Future, time::Duration};
 /// Provides runtime support for an endpoint
 pub trait Provider {
     type Environment: Environment;
-    type Error: core::fmt::Display;
+    type Error: 'static + core::fmt::Display;
 
     /// Starts the runtime with the given future
     fn start<Start, Fut>(self, start: Start) -> Result<(), Self::Error>

--- a/quic/s2n-quic/src/provider/sync.rs
+++ b/quic/s2n-quic/src/provider/sync.rs
@@ -1,7 +1,7 @@
 /// Provides synchronization support for an endpoint
 pub trait Provider {
     type Sync: 'static + Send;
-    type Error: core::fmt::Display;
+    type Error: 'static + core::fmt::Display;
 
     fn start(self) -> Result<Self::Sync, Self::Error>;
 }

--- a/quic/s2n-quic/src/provider/tls.rs
+++ b/quic/s2n-quic/src/provider/tls.rs
@@ -5,7 +5,7 @@ use s2n_quic_core::crypto;
 pub trait Provider {
     type Server: 'static + crypto::tls::Endpoint;
     type Client: 'static + crypto::tls::Endpoint;
-    type Error: core::fmt::Display;
+    type Error: 'static + core::fmt::Display;
 
     /// Creates a server endpoint for the given provider
     fn start_server(self) -> Result<Self::Server, Self::Error>;

--- a/quic/s2n-quic/src/provider/token/mod.rs
+++ b/quic/s2n-quic/src/provider/token/mod.rs
@@ -8,7 +8,7 @@ pub use s2n_quic_core::token::Format;
 
 pub trait Provider: 'static {
     type Format: 'static + Format;
-    type Error: core::fmt::Display;
+    type Error: 'static + core::fmt::Display;
 
     /// Starts the token provider
     fn start(self) -> Result<Self::Format, Self::Error>;

--- a/quic/s2n-quic/src/server/providers.rs
+++ b/quic/s2n-quic/src/server/providers.rs
@@ -1,0 +1,243 @@
+use super::*;
+use core::{marker::PhantomData, time::Duration};
+use futures::{select_biased, FutureExt};
+use s2n_quic_core::{crypto, recovery, transport};
+use s2n_quic_transport::{acceptor::Acceptor, connection, endpoint, stream};
+
+impl_providers_state! {
+    #[derive(Debug, Default)]
+    struct Providers {
+        clock: Clock,
+        congestion_controller: CongestionController,
+        connection_id: ConnectionID,
+        limits: Limits,
+        log: Log,
+        runtime: Runtime,
+        io: IO,
+        sync: Sync,
+        tls: Tls,
+        token: Token,
+    }
+
+    /// Opaque trait containing all of the configured providers
+    trait ServerProviders {}
+}
+
+impl<
+        Clock: clock::Provider,
+        CongestionController: congestion_controller::Provider,
+        ConnectionID: connection_id::Provider,
+        Limits: limits::Provider,
+        Log: log::Provider,
+        Runtime: runtime::Provider,
+        IO: io::Provider,
+        Sync: sync::Provider,
+        Tls: tls::Provider,
+        Token: token::Provider,
+    >
+    Providers<Clock, CongestionController, ConnectionID, Limits, Log, Runtime, IO, Sync, Tls, Token>
+{
+    pub fn start(self) -> Result<Acceptor, StartError> {
+        use crate::provider::runtime::Environment;
+
+        let Self {
+            clock,
+            congestion_controller,
+            connection_id,
+            limits,
+            log,
+            token,
+            runtime,
+            io,
+            sync,
+            tls,
+        } = self;
+
+        let clock = clock.start().map_err(StartError::new)?;
+        let congestion_controller = congestion_controller.start().map_err(StartError::new)?;
+        let connection_id = connection_id.start().map_err(StartError::new)?;
+        let limits = limits.start().map_err(StartError::new)?;
+        let log = log.start().map_err(StartError::new)?;
+        let token = token.start().map_err(StartError::new)?;
+        let sync = sync.start().map_err(StartError::new)?;
+        let tls = tls.start_server().map_err(StartError::new)?;
+
+        // Start the IO last
+        let io = io.start().map_err(StartError::new)?;
+        let mut rx = io.rx;
+        let mut tx = io.tx;
+
+        let endpoint_config = EndpointConfig {
+            congestion_controller,
+            connection_id,
+            limits,
+            log,
+            token,
+            sync,
+            tls,
+        };
+
+        let (mut endpoint, acceptor) = endpoint::Endpoint::new(endpoint_config);
+
+        runtime
+            .start(move |environment| {
+                use s2n_quic_core::{
+                    io::{rx::Rx, tx::Tx},
+                    time::Clock,
+                };
+
+                async move {
+                    loop {
+                        // TODO read a `is_closed` atomic value and shutdown if true
+
+                        let now = clock.get_time();
+
+                        let delay = endpoint
+                            .next_timer_expiration()
+                            .map(|timeout| timeout.saturating_duration_since(now))
+                            .unwrap_or_else(|| Duration::from_secs(1));
+
+                        let tx_future = async {
+                            // If the TX queue is empty, allow other tasks to make progress by returning
+                            // a future which never resolves.
+                            if tx.is_empty() {
+                                futures::future::pending().await
+                            } else {
+                                match tx.transmit().await {
+                                    Ok(len) => Ok(len),
+                                    Err(err) => Err(err.to_string()),
+                                }
+                            }
+                        };
+
+                        // This list of futures is ordered by priority of execution
+                        select_biased! {
+                            tx_result = tx_future.fuse() => {
+                                match tx_result {
+                                    Ok(_) => {}
+                                    Err(err) => {
+                                        // TODO log error
+                                        eprintln!("TX ERROR: {}", err);
+                                        break;
+                                    }
+                                }
+                            }
+                            rx_result = rx.receive().fuse() => {
+                                match rx_result {
+                                    Ok(0) => continue,
+                                    Ok(_) => {
+                                        endpoint.receive(&mut rx, clock.get_time());
+                                    }
+                                    Err(err) => {
+                                        // TODO log error
+                                        eprintln!("RX ERROR: {}", err);
+                                        break;
+                                    }
+                                }
+                            }
+                            _ = endpoint.pending_wakeups(now).fuse() => {
+                                // do nothing; the wakeups are handled inside the endpoint
+                            }
+                            _ = environment.delay(delay).fuse() => {
+                                // do nothing; timer expiration is handled on each iteration
+                            }
+                        }
+
+                        endpoint.handle_timers(clock.get_time());
+                        endpoint.transmit(&mut tx, clock.get_time());
+                    }
+
+                    // TODO gracefully shutdown endpoint
+                    eprintln!("shutting down endpoint")
+                }
+            })
+            .map_err(StartError::new)?;
+
+        Ok(acceptor)
+    }
+}
+
+#[allow(dead_code)] // don't warn on unused providers for now
+struct EndpointConfig<CongestionController, ConnectionID, Limits, Log, Sync, Tls, Token> {
+    congestion_controller: CongestionController,
+    connection_id: ConnectionID,
+    limits: Limits,
+    log: Log,
+    sync: Sync,
+    tls: Tls,
+    token: Token,
+}
+
+impl<
+        CongestionController: congestion_controller::Endpoint,
+        ConnectionID: connection::id::Format,
+        Limits,
+        Log,
+        Sync,
+        Tls: 'static + crypto::tls::Endpoint,
+        Token: 'static + token::Format,
+    > endpoint::Config
+    for EndpointConfig<CongestionController, ConnectionID, Limits, Log, Sync, Tls, Token>
+{
+    type ConnectionConfig =
+        ConnectionConfig<CongestionController::CongestionController, Tls::Session>;
+    type ConnectionIdFormat = ConnectionID;
+    type Connection = connection::Implementation<Self::ConnectionConfig>;
+    type CongestionControllerEndpoint = CongestionController;
+    type TLSEndpoint = Tls;
+    type TokenFormat = Token;
+
+    fn create_connection_config(&mut self) -> Self::ConnectionConfig {
+        ConnectionConfig {
+            congestion_controller: PhantomData,
+            tls: PhantomData,
+        }
+    }
+
+    fn context(&mut self) -> endpoint::Context<Self> {
+        endpoint::Context {
+            congestion_controller: &mut self.congestion_controller,
+            connection_id_format: &mut self.connection_id,
+            tls: &mut self.tls,
+        }
+    }
+}
+
+struct ConnectionConfig<CC, Tls> {
+    congestion_controller: PhantomData<CC>,
+    tls: PhantomData<Tls>,
+}
+
+impl<CC: recovery::CongestionController, Tls: 'static + crypto::tls::Session> connection::Config
+    for ConnectionConfig<CC, Tls>
+{
+    type Stream = stream::StreamImpl;
+    type CongestionController = CC;
+    type TLSSession = Tls;
+
+    const ENDPOINT_TYPE: endpoint::EndpointType = endpoint::EndpointType::Server;
+
+    fn local_flow_control_limits(&self) -> transport::parameters::InitialFlowControlLimits {
+        // TODO ask the limits provider
+        let max = s2n_quic_core::varint::VarInt::from_u32(core::u32::MAX);
+
+        transport::parameters::InitialFlowControlLimits {
+            stream_limits: transport::parameters::InitialStreamLimits {
+                max_data_bidi_local: max,
+                max_data_bidi_remote: max,
+                max_data_uni: max,
+            },
+            max_data: max,
+            max_streams_bidi: max,
+            max_streams_uni: max,
+        }
+    }
+
+    fn local_ack_settings(&self) -> transport::parameters::AckSettings {
+        Default::default()
+    }
+
+    fn connection_limits(&self) -> connection::Limits {
+        Default::default()
+    }
+}


### PR DESCRIPTION
This change pulls in all of the configured providers for the built server and creates an QUIC endpoint. There's a few things remaining to clean up around shutdown but this should finally get us a working server implementation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
