### PR TITLE
Limit payload to the available congestion window

### DIFF
--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -31,9 +31,6 @@ impl<'a> PathInfo<'a> {
 }
 
 pub trait CongestionController: 'static + Clone + Send {
-    /// Gets the current congestion window size in bytes
-    fn congestion_window(&self) -> u32;
-
     /// Gets the numbers of bytes remaining in the congestion window
     /// considering the current bytes in flight
     fn available_congestion_window(&self) -> u32;
@@ -82,9 +79,6 @@ pub mod testing {
     pub struct Unlimited {}
 
     impl CongestionController for Unlimited {
-        fn congestion_window(&self) -> u32 {
-            u32::max_value()
-        }
         fn available_congestion_window(&self) -> u32 {
             u32::max_value()
         }

--- a/quic/s2n-quic-transport/src/recovery/cubic.rs
+++ b/quic/s2n-quic-transport/src/recovery/cubic.rs
@@ -97,10 +97,6 @@ impl AddAssign<usize> for BytesInFlight {
 }
 
 impl CongestionController for CubicCongestionController {
-    fn congestion_window(&self) -> u32 {
-        self.congestion_window
-    }
-
     fn available_congestion_window(&self) -> u32 {
         self.congestion_window
             .saturating_sub(self.bytes_in_flight.0)
@@ -735,7 +731,7 @@ mod test {
 
         assert_eq!(cc.bytes_in_flight.0, 100_000 - 100);
         assert_eq!(cc.state, Recovery(now + Duration::from_secs(10)));
-        assert_eq!(cc.congestion_window(), (100_000.0 * BETA_CUBIC) as u32);
+        assert_eq!(cc.congestion_window, (100_000.0 * BETA_CUBIC) as u32);
         assert_eq!(cc.slow_start.threshold, (100_000.0 * BETA_CUBIC) as u32);
         assert_eq!(cc.slow_start.threshold, (100_000.0 * BETA_CUBIC) as u32);
     }
@@ -750,7 +746,7 @@ mod test {
         cc.on_packets_lost(LossInfo::default(), Duration::from_secs(5), now);
 
         // No change to the congestion window
-        assert_eq!(cc.congestion_window(), 10000);
+        assert_eq!(cc.congestion_window, 10000);
     }
 
     #[test]
@@ -766,7 +762,7 @@ mod test {
         cc.on_packets_lost(loss_info, Duration::from_secs(5), now);
 
         assert_eq!(cc.state, SlowStart);
-        assert_eq!(cc.congestion_window(), cc.minimum_window());
+        assert_eq!(cc.congestion_window, cc.minimum_window());
     }
 
     #[test]
@@ -779,7 +775,7 @@ mod test {
         assert_eq!(cc.cubic.max_datagram_size, 5000);
 
         assert_eq!(
-            cc.congestion_window(),
+            cc.congestion_window,
             CubicCongestionController::initial_window(5000)
         );
     }
@@ -794,7 +790,7 @@ mod test {
         assert_eq!(cc.max_datagram_size, 10000);
         assert_eq!(cc.cubic.max_datagram_size, 10000);
 
-        assert_eq!(cc.congestion_window(), 200_000);
+        assert_eq!(cc.congestion_window, 200_000);
     }
 
     #[test]
@@ -818,7 +814,7 @@ mod test {
 
         cc.on_packet_ack(now, 1, &RTTEstimator::new(Duration::from_secs(0)), now);
 
-        assert_eq!(cc.congestion_window(), 100_000);
+        assert_eq!(cc.congestion_window, 100_000);
     }
 
     #[test]
@@ -862,7 +858,7 @@ mod test {
             now + Duration::from_millis(2),
         );
 
-        assert_eq!(cc.congestion_window(), 10100);
+        assert_eq!(cc.congestion_window, 10100);
         assert_eq!(cc.packets_to_bytes(cc.cubic.w_max), cc.congestion_window);
         assert_eq!(
             cc.state,
@@ -887,7 +883,7 @@ mod test {
         );
 
         // Congestion window stays the same in recovery
-        assert_eq!(cc.congestion_window(), 10000);
+        assert_eq!(cc.congestion_window, 10000);
         assert_eq!(cc.state, Recovery(now));
     }
 
@@ -921,7 +917,7 @@ mod test {
 
         cc2.congestion_avoidance(t, rtt, 1000);
 
-        assert_eq!(cc.congestion_window(), cc2.congestion_window());
+        assert_eq!(cc.congestion_window, cc2.congestion_window);
     }
 
     #[test]
@@ -939,7 +935,7 @@ mod test {
 
         assert!(cc.cubic.w_cubic(t) < cc.cubic.w_est(t, rtt));
         assert_eq!(
-            cc.congestion_window(),
+            cc.congestion_window,
             (cc.cubic.w_est(t, rtt) * 5000.0) as u32
         );
     }
@@ -968,7 +964,7 @@ mod test {
         // cwnd = ((2300.8 - 2000)/2000 + 2000) * max_datagram_size
         // cwnd = 2400180.48
 
-        assert_eq!(cc.congestion_window(), 2_400_180);
+        assert_eq!(cc.congestion_window, 2_400_180);
     }
 
     #[test]
@@ -995,7 +991,7 @@ mod test {
         // cwnd = ((3401.6 - 3000)/3000 + 3000) * max_datagram_size
         // cwnd = 3600160.64
 
-        assert_eq!(cc.congestion_window(), 3_600_160);
+        assert_eq!(cc.congestion_window, 3_600_160);
     }
 
     #[test]
@@ -1012,6 +1008,6 @@ mod test {
         cc.congestion_avoidance(t, rtt, 1000);
 
         assert!(cc.cubic.w_cubic(t) > cc.cubic.w_est(t, rtt));
-        assert_eq!(cc.congestion_window(), 3_600_000 + 1000 / 2);
+        assert_eq!(cc.congestion_window, 3_600_000 + 1000 / 2);
     }
 }


### PR DESCRIPTION
Adds an available_congestion_window function to the CongestionController trait and uses it in ConnectionTransmission to limit the buffer size.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.