### PR TITLE
qns: implement http 0.9 requests

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -18,9 +18,9 @@ env:
   SCCACHE_IDLE_TIMEOUT: 0
   # This kept breaking builds so we're pinning for now. We should do our best to keep
   # up with the changes, though.
-  INTEROP_RUNNER_REF: 0ea8c726b611b89a8b4b88055bbca0e78b402c54
-  NETWORK_SIMULATOR_REF: sha256:ac823d71fa280390de86737edc7eb89a1afdd7a261ee36ea12da89dc70ae8121
-  IPERF_ENDPOINT_REF: sha256:17112dfc557ea7aa002209229cc8d58dbc1d4f12c84161623aa6a975de85f14f
+  INTEROP_RUNNER_REF: 18a87278621e9bdf166b9e294f4095e213cb4845
+  NETWORK_SIMULATOR_REF: sha256:d36e1ffd9369e41e9fd5cb8d2af5fb69d4bfaf1b1983fc538a5a3bf7777af4ba
+  IPERF_ENDPOINT_REF: sha256:cb50cc8019d45d9cad5faecbe46a3c21dd5e871949819a5175423755a9045106
 
 jobs:
   env:
@@ -96,14 +96,15 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --bin s2n-quic-qns --release
+          # build in debug to have better stacktraces when things go wrong
+          args: --bin s2n-quic-qns
         env:
           RUSTC_WRAPPER: sccache
 
       - name: Prepare artifact
         run: |
           mkdir -p s2n-quic-qns
-          cp target/release/s2n-quic-qns s2n-quic-qns/
+          cp target/debug/s2n-quic-qns s2n-quic-qns/
           cp qns/Dockerfile s2n-quic-qns/
           cp qns/run_endpoint.sh s2n-quic-qns/
 
@@ -130,7 +131,7 @@ jobs:
         working-directory: s2n-quic-qns
         run: |
           docker build . --file Dockerfile --tag awslabs/s2n-quic-qns
- 
+
       - uses: actions/checkout@v2
         with:
           repository: marten-seemann/quic-interop-runner
@@ -155,15 +156,20 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.8
+          python-version: 3.7
 
       - name: Install dependencies
         working-directory: quic-interop-runner
         run: |
-          sudo apt-get update
-          sudo apt-get install -y tshark
+          sudo add-apt-repository ppa:wireshark-dev/stable
+
+          # azure packages are flaky! so add some retries
+          sudo apt-get -o Acquire::Retries=3 update
+          sudo apt-get -o Acquire::Retries=3 install -y tshark
+
           python3 -m pip install --upgrade pip
-          pip3 install -r requirements.txt
+          pip3 install wheel
+          pip3 install --upgrade -r requirements.txt
 
       - name: Run quic-interop-server
         working-directory: quic-interop-runner
@@ -171,7 +177,7 @@ jobs:
           mkdir -p results
           # enable IPv6 support
           sudo modprobe ip6table_filter
-          python3 run.py --client ${{ matrix.client }} --server ${{ matrix.server }} --json results/results.json --debug --log-dir results/logs --save-files true
+          python3 run.py --client ${{ matrix.client }} --server ${{ matrix.server }} --json results/results.json --debug --log-dir results/logs || true
 
       - name: Prepare artifacts
         working-directory: quic-interop-runner
@@ -183,6 +189,9 @@ jobs:
             to=$(echo $from | sed 's/:/_/g')
             mv $from $to
           done
+          # remove files we don't do anything with to reduce the artifact size
+          find results -name '*.pcap' -exec rm {} \;
+          find results -name '*.qlog' -exec rm {} \;
 
       - uses: actions/upload-artifact@v2
         with:

--- a/qns/Dockerfile
+++ b/qns/Dockerfile
@@ -12,3 +12,6 @@ RUN set -eux; \
   # ensure the binary works \
   s2n-quic-qns --help; \
   echo done
+
+# help with debugging
+ENV RUST_BACKTRACE=1

--- a/qns/Dockerfile.build
+++ b/qns/Dockerfile.build
@@ -1,7 +1,6 @@
 FROM rust:latest AS builder
 
-# remove debug symbols
-ENV RUSTFLAGS="-C link-arg=-s -C panic=abort"
+ARG release="false"
 
 # copy sources
 COPY Cargo.* /s2n-quic/
@@ -10,16 +9,27 @@ COPY quic /s2n-quic/quic
 WORKDIR /s2n-quic
 
 # build runner
-RUN cargo build --bin s2n-quic-qns --release
+RUN set -eux; \
+  if [ "$release" = "true" ]; then \
+    RUSTFLAGS="-C link-arg=-s -C panic=abort" \
+      cargo build --bin s2n-quic-qns --release; \
+    cp target/release/s2n-quic-qns .; \
+  else \
+    cargo build --bin s2n-quic-qns; \
+    cp target/debug/s2n-quic-qns .; \
+  fi; \
+  rm -rf target
 
 FROM martenseemann/quic-network-simulator-endpoint:latest
+
+ENV RUST_BACKTRACE="1"
 
 # copy entrypoint
 COPY qns/run_endpoint.sh .
 RUN chmod +x run_endpoint.sh
 
 # copy runner
-COPY --from=builder /s2n-quic/target/release/s2n-quic-qns /usr/bin/s2n-quic-qns
+COPY --from=builder /s2n-quic/s2n-quic-qns /usr/bin/s2n-quic-qns
 RUN set -eux; \
   chmod +x /usr/bin/s2n-quic-qns; \
   ldd /usr/bin/s2n-quic-qns; \

--- a/quic/s2n-quic-qns/src/main.rs
+++ b/quic/s2n-quic-qns/src/main.rs
@@ -1,6 +1,6 @@
 use structopt::StructOpt;
 
-pub type Error = Box<dyn std::error::Error>;
+pub type Error = Box<dyn 'static + std::error::Error + Send + Sync>;
 pub type Result<T> = core::result::Result<T, Error>;
 mod client;
 mod server;


### PR DESCRIPTION
This change implements a HTTP/0.9 server, which is required to run interop tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
