### PR TITLE
Synchronize definitions of under utilized and congestion limited

### DIFF
--- a/quic/s2n-quic-core/src/path.rs
+++ b/quic/s2n-quic-core/src/path.rs
@@ -135,7 +135,7 @@ impl<CC: CongestionController> Path<CC> {
             //# recovery if the data in the lost packet is retransmitted and is
             //# similar to TCP as described in Section 5 of [RFC6675].
             transmission::Constraint::RetransmissionOnly
-        } else if self.congestion_controller.available_congestion_window() < (self.mtu as u32) {
+        } else if self.congestion_controller.is_congestion_limited() {
             //= https://tools.ietf.org/id/draft-ietf-quic-recovery-32.txt#7
             //# An endpoint MUST NOT send a packet if it would cause bytes_in_flight
             //# (see Appendix B.2) to be larger than the congestion window, unless

--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -31,9 +31,10 @@ impl<'a> PathInfo<'a> {
 }
 
 pub trait CongestionController: 'static + Clone + Send {
-    /// Gets the numbers of bytes remaining in the congestion window
-    /// considering the current bytes in flight
-    fn available_congestion_window(&self) -> u32;
+    /// Returns `true` if the congestion window does not have sufficient
+    /// space for a packet of `max_datagram_size` considering the current
+    /// bytes in flight
+    fn is_congestion_limited(&self) -> bool;
 
     /// Returns `true` if the current state of the congestion controller
     /// requires a packet to be transmitted without respecting the
@@ -84,8 +85,8 @@ pub mod testing {
     pub struct Unlimited {}
 
     impl CongestionController for Unlimited {
-        fn available_congestion_window(&self) -> u32 {
-            u32::max_value()
+        fn is_congestion_limited(&self) -> bool {
+            false
         }
 
         fn requires_fast_retransmission(&self) -> bool {


### PR DESCRIPTION
This change removes the is_under_utilized and available_congestion_window methods and replaces them with a single is_congestion_limited function based on whether the available congestion window is less than the MTU.

The spec describes "under utilized" as:

```
https://tools.ietf.org/id/draft-ietf-quic-recovery-31.txt#7.8
When bytes in flight is smaller than the congestion window and
sending is not pacing limited, the congestion window is under-
utilized.
```

but I don't see a reason why the definition should be any different than the inverse of

```
https://tools.ietf.org/id/draft-ietf-quic-recovery-32.txt#7
An endpoint MUST NOT send a packet if it would cause bytes_in_flight
(see Appendix B.2) to be larger than the congestion window
```

If the endpoint cannot send a packet because of the congestion controller, it is limited by the congestion controller and thus the congestion window is not under utilized. 

If the congestion controller is not blocking the endpoint from sending a packet but it doesn't send one anyway, the congestion window is under utilized.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.