### PR TITLE
transport: move handshake status to space manager

### DIFF
--- a/quic/s2n-quic-transport/src/connection/shared_state.rs
+++ b/quic/s2n-quic-transport/src/connection/shared_state.rs
@@ -62,6 +62,7 @@ impl<ConnectionConfigType: connection::Config>
             .space_manager
             .application_mut()
             .expect("Stream manager must be available")
+            .0
             .stream_manager;
 
         func(stream_id, stream_manager, &mut api_call_context)
@@ -114,6 +115,7 @@ impl<ConnectionConfigType: connection::Config> ConnectionApiProvider
             .space_manager
             .application_mut()
             .expect("Application space must be available on active connections")
+            .0
             .stream_manager;
 
         macro_rules! poll_accept {
@@ -151,7 +153,7 @@ impl<ConnectionConfigType: connection::Config> ConnectionApiProvider
         let mut shared_state = self.lock();
 
         let application_space = match shared_state.space_manager.application_mut() {
-            Some(space) => space,
+            Some((space, _handshake_status)) => space,
             None => return,
         };
 

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -493,8 +493,10 @@ impl Manager {
         let persistent_congestion =
             max_persistent_congestion_period > path.rtt_estimator.persistent_congestion_threshold();
 
-        path.congestion_controller
-            .on_packets_lost(lost_bytes, persistent_congestion, now);
+        if lost_bytes > 0 {
+            path.congestion_controller
+                .on_packets_lost(lost_bytes, persistent_congestion, now);
+        }
     }
 
     fn calculate_loss_time_threshold(rtt_estimator: &RTTEstimator) -> Duration {
@@ -516,9 +518,7 @@ impl Manager {
 pub trait Context {
     const ENDPOINT_TYPE: EndpointType;
 
-    fn is_handshake_confirmed(&self) -> bool {
-        panic!("Handshake status is not currently available in this packet space")
-    }
+    fn is_handshake_confirmed(&self) -> bool;
 
     fn validate_packet_ack(
         &mut self,

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -2,7 +2,9 @@ use crate::{
     connection::{self, ConnectionTransmissionContext},
     processed_packet::ProcessedPacket,
     recovery,
-    space::{rx_packet_numbers::AckManager, CryptoStream, PacketSpace, TxPacketNumbers},
+    space::{
+        rx_packet_numbers::AckManager, CryptoStream, HandshakeStatus, PacketSpace, TxPacketNumbers,
+    },
     transmission,
 };
 use core::marker::PhantomData;
@@ -69,6 +71,7 @@ impl<Config: connection::Config> HandshakeSpace<Config> {
         &mut self,
         context: &mut ConnectionTransmissionContext<Config>,
         transmission_constraint: transmission::Constraint,
+        handshake_status: &HandshakeStatus,
         buffer: EncoderBuffer<'a>,
     ) -> Result<EncoderBuffer<'a>, PacketEncodingError<'a>> {
         let mut packet_number = self.tx_packet_numbers.next();
@@ -109,7 +112,7 @@ impl<Config: connection::Config> HandshakeSpace<Config> {
         let (_protected_packet, buffer) =
             packet.encode_packet(&self.crypto, packet_number_encoder, buffer)?;
 
-        let (recovery_manager, recovery_context) = self.recovery();
+        let (recovery_manager, recovery_context) = self.recovery(handshake_status);
         recovery_manager.on_packet_sent(
             packet_number,
             outcome,
@@ -154,11 +157,12 @@ impl<Config: connection::Config> HandshakeSpace<Config> {
     pub fn on_timeout(
         &mut self,
         path: &mut Path<Config::CongestionController>,
+        handshake_status: &HandshakeStatus,
         timestamp: Timestamp,
     ) {
         self.ack_manager.on_timeout(timestamp);
 
-        let (recovery_manager, mut context) = self.recovery();
+        let (recovery_manager, mut context) = self.recovery(handshake_status);
         recovery_manager.on_timeout(path, timestamp, &mut context)
     }
 
@@ -181,13 +185,17 @@ impl<Config: connection::Config> HandshakeSpace<Config> {
         self.tx_packet_numbers.largest_sent_packet_number_acked()
     }
 
-    fn recovery(&mut self) -> (&mut recovery::Manager, RecoveryContext<Config>) {
+    fn recovery<'a>(
+        &'a mut self,
+        handshake_status: &'a HandshakeStatus,
+    ) -> (&'a mut recovery::Manager, RecoveryContext<'a, Config>) {
         (
             &mut self.recovery_manager,
             RecoveryContext {
                 ack_manager: &mut self.ack_manager,
                 crypto_stream: &mut self.crypto_stream,
                 tx_packet_numbers: &mut self.tx_packet_numbers,
+                handshake_status,
                 config: PhantomData,
             },
         )
@@ -214,11 +222,16 @@ struct RecoveryContext<'a, Config> {
     ack_manager: &'a mut AckManager,
     crypto_stream: &'a mut CryptoStream,
     tx_packet_numbers: &'a mut TxPacketNumbers,
+    handshake_status: &'a HandshakeStatus,
     config: PhantomData<Config>,
 }
 
 impl<'a, Config: connection::Config> recovery::Context for RecoveryContext<'a, Config> {
     const ENDPOINT_TYPE: EndpointType = Config::ENDPOINT_TYPE;
+
+    fn is_handshake_confirmed(&self) -> bool {
+        self.handshake_status.is_confirmed()
+    }
 
     fn validate_packet_ack(
         &mut self,
@@ -272,9 +285,10 @@ impl<Config: connection::Config> PacketSpace<Config> for HandshakeSpace<Config> 
         frame: Ack<A>,
         datagram: &DatagramInfo,
         path: &mut Path<Config::CongestionController>,
+        handshake_status: &mut HandshakeStatus,
     ) -> Result<(), TransportError> {
         path.on_peer_validated();
-        let (recovery_manager, mut context) = self.recovery();
+        let (recovery_manager, mut context) = self.recovery(handshake_status);
         recovery_manager.on_ack_frame(datagram, frame, path, &mut context)
     }
 


### PR DESCRIPTION
The handshake status needs to be moved to the space manager so it's easier for the other spaces to query if the handshake is confirmed or not.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
