### PR TITLE
Only call on_packets_lost if packets were lost

### DIFF
--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -120,6 +120,7 @@ pub mod testing {
         pub bytes_in_flight: u32,
         pub lost_bytes: u32,
         pub persistent_congestion: Option<bool>,
+        pub on_packets_lost: u32,
     }
 
     impl CongestionController for MockCongestionController {
@@ -153,6 +154,7 @@ pub mod testing {
             self.bytes_in_flight = self.bytes_in_flight.saturating_sub(lost_bytes);
             self.lost_bytes += lost_bytes;
             self.persistent_congestion = Some(persistent_congestion);
+            self.on_packets_lost += 1;
         }
 
         fn on_congestion_event(&mut self, _event_time: Timestamp) {}

--- a/quic/s2n-quic-transport/src/recovery/cubic.rs
+++ b/quic/s2n-quic-transport/src/recovery/cubic.rs
@@ -246,6 +246,8 @@ impl CongestionController for CubicCongestionController {
         persistent_congestion: bool,
         timestamp: Timestamp,
     ) {
+        debug_assert!(lost_bytes > 0);
+
         self.bytes_in_flight -= lost_bytes;
         self.on_congestion_event(timestamp);
 
@@ -842,9 +844,10 @@ mod test {
         let mut cc = CubicCongestionController::new(1000);
         let now = s2n_quic_platform::time::now();
         cc.congestion_window = 10000;
+        cc.bytes_in_flight = BytesInFlight(1000);
         cc.state = Recovery(now, Idle);
 
-        cc.on_packets_lost(0, true, now);
+        cc.on_packets_lost(100, true, now);
 
         assert_eq!(cc.state, SlowStart);
         assert_eq!(cc.congestion_window, cc.minimum_window());


### PR DESCRIPTION
on_packets_lost should only be called on the congestion controller when a positive number of bytes were lost

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.