### PR TITLE
transport: make stream::Send::finish a sync call

### DIFF
--- a/quic/s2n-quic-qns/src/server.rs
+++ b/quic/s2n-quic-qns/src/server.rs
@@ -73,7 +73,6 @@ impl Interop {
             );
             let mut file = File::open(&abs_path).await?;
             io::copy(&mut file, &mut stream).await?;
-            stream.finish().await?;
             Ok(())
         }
 


### PR DESCRIPTION
After discussing with @Matthias247, I've made the following changes:

* `finish` should be a synchronous call that _doesn't_ flush the stream. This means the stream buffer could be non-empty. If the application wishes to ensure it is empty before dropping the stream it can call `flush`.
* we should mimic drop behavior from the rest of the networking ecosystem (e.g. std::net::TcpStream) and finish the stream on drop, rather than reset.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
