### PR TITLE
Don't change the congestion window if the target is smaller than the current window

### DIFF
--- a/quic/s2n-quic-transport/src/recovery/cubic.rs
+++ b/quic/s2n-quic-transport/src/recovery/cubic.rs
@@ -407,6 +407,7 @@ impl CubicCongestionController {
             // TODO: This is slightly different than Linux, which adds a "very small increment" to
             //       the congestion window in this case. Investigate if this is needed. See
             //       https://github.com/torvalds/linux/blob/master/net/ipv4/tcp_cubic.c#L293-L297
+            //       Issue: https://github.com/awslabs/s2n-quic/issues/209
             if target_congestion_window <= self.congestion_window {
                 return;
             }


### PR DESCRIPTION
In the case of fast convergence, which lowers the w_max value of cubic additionally, Cubic may be in a state where the target congestion window (defined by w_cubic) is actually lower than the current congestion window. This change will ensure we don't attempt to modify the congestion window in this case, which would result in a subtraction underflow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.