### PR TITLE
fix clippy warnings for 1.48

### DIFF
--- a/common/compliance/cargo-compliance/src/pattern.rs
+++ b/common/compliance/cargo-compliance/src/pattern.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::unknown_clippy_lints, clippy::manual_strip)] // strip functions were added in 1.45
+
 use crate::{
     annotation::{Annotation, AnnotationSet, AnnotationType},
     parser::ParsedAnnotation,

--- a/quic/s2n-quic-core/src/crypto/retry.rs
+++ b/quic/s2n-quic-core/src/crypto/retry.rs
@@ -56,7 +56,7 @@ pub mod example {
 
     pub const ODCID: [u8; 8] = hex!("8394c8f03e515708");
 
-    pub const VERSION: u32 = 0xff000020;
+    pub const VERSION: u32 = 0xff00_0020;
 
     pub const TOKEN: [u8; 5] = hex!("746f6b656e");
 }

--- a/quic/s2n-quic-platform/src/message/queue/slice.rs
+++ b/quic/s2n-quic-platform/src/message/queue/slice.rs
@@ -103,7 +103,7 @@ impl<'a, Message: tx::Entry + message::Message, B: Behavior> tx::Queue for Slice
         let index = self
             .primary
             .index(&self.secondary)
-            .ok_or_else(|| tx::Error::AtCapacity)?;
+            .ok_or(tx::Error::AtCapacity)?;
 
         self.messages[index].set(message)?;
         self.advance(1);

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -63,7 +63,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             endpoint::limits::Outcome::Allow => {
                 // No action
             }
-            endpoint::limits::Outcome::Retry { delay: _ } => {
+            endpoint::limits::Outcome::Retry { .. } => {
                 //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#8.1.2
                 //# A server can also use a Retry packet to defer the state and
                 //# processing costs of connection establishment.
@@ -72,7 +72,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                 // Stop processing
                 return Ok(());
             }
-            endpoint::limits::Outcome::Close { delay: _ } => {
+            endpoint::limits::Outcome::Close { .. } => {
                 // Queue close packet
             }
         }

--- a/quic/s2n-quic/src/provider/token/default.rs
+++ b/quic/s2n-quic/src/provider/token/default.rs
@@ -314,11 +314,11 @@ impl Header {
         Header(header)
     }
 
-    fn version(&self) -> u8 {
+    fn version(self) -> u8 {
         (self.0 & VERSION_MASK) >> VERSION_SHIFT
     }
 
-    fn key_id(&self) -> u8 {
+    fn key_id(self) -> u8 {
         (self.0 & KEY_ID_MASK) >> KEY_ID_SHIFT
     }
 
@@ -327,7 +327,7 @@ impl Header {
     //# constructed in a way that allows the server to identify how it was
     //# provided to a client.  These tokens are carried in the same field,
     //# but require different handling from servers.
-    fn token_source(&self) -> Source {
+    fn token_source(self) -> Source {
         match (self.0 & TOKEN_SOURCE_MASK) >> TOKEN_SOURCE_SHIFT {
             0 => Source::NewTokenFrame,
             1 => Source::RetryPacket,


### PR DESCRIPTION
A new version of rust means a new set of lints we need to fix :)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
