### PR TITLE
interop: use more recent version of wireshark

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -214,7 +214,7 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: tshark
-          path: tshark
+          path: .
 
       - name: Install tshark
         run: |


### PR DESCRIPTION
Older version of wireshark can't inspect recent versions of QUIC so we need to compile the most recent version for interop tests.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
