### PR TITLE
ring: only compute the key schedule upon creation

### DIFF
--- a/quic/s2n-quic-ring/src/ciphersuite/snapshots/s2n_quic_ring__ciphersuite__tls_aes_128_gcm_sha256_test.snap
+++ b/quic/s2n-quic-ring/src/ciphersuite/snapshots/s2n_quic_ring__ciphersuite__tls_aes_128_gcm_sha256_test.snap
@@ -2,4 +2,4 @@
 source: quic/s2n-quic-ring/src/ciphersuite/mod.rs
 expression: "core::mem::size_of::<TLS_AES_128_GCM_SHA256>()"
 ---
-208
+992

--- a/quic/s2n-quic-ring/src/ciphersuite/snapshots/s2n_quic_ring__ciphersuite__tls_aes_256_gcm_sha384_test.snap
+++ b/quic/s2n-quic-ring/src/ciphersuite/snapshots/s2n_quic_ring__ciphersuite__tls_aes_256_gcm_sha384_test.snap
@@ -2,4 +2,4 @@
 source: quic/s2n-quic-ring/src/ciphersuite/mod.rs
 expression: "core::mem::size_of::<TLS_AES_256_GCM_SHA384>()"
 ---
-240
+1008

--- a/quic/s2n-quic-ring/src/ciphersuite/snapshots/s2n_quic_ring__ciphersuite__tls_chacha20_poly1305_sha256_test.snap
+++ b/quic/s2n-quic-ring/src/ciphersuite/snapshots/s2n_quic_ring__ciphersuite__tls_chacha20_poly1305_sha256_test.snap
@@ -2,4 +2,4 @@
 source: quic/s2n-quic-ring/src/ciphersuite/mod.rs
 expression: "core::mem::size_of::<TLS_CHACHA20_POLY1305_SHA256>()"
 ---
-240
+1008


### PR DESCRIPTION
This comes at a trade-off of storing more data rather than computing the key every time. This will most likely increase overall throughput so it's worth the cost.

Note that I've added #295 to track fixing the header protection cloning issue, that I will address in another PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
