### PR TITLE
scripts: add compliance script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,7 @@ jobs:
           RUSTC_WRAPPER: sccache
 
       - name: Run cargo compliance
-        run: ./target/release/cargo-compliance report --lcov compliance --spec-pattern 'specs/**/*.toml' --source-pattern 'quic/**/*.rs' --workspace --exclude compliance --exclude cargo-compliance --require-citations --require-tests false --blob-link https://github.com/awslabs/s2n-quic/blob/${{ github.sha }} --issue-link https://github.com/awslabs/s2n-quic/issues/ --html compliance/index.html
+        run: ./scripts/compliance ${{ github.sha }}
 
       - name: Stop sccache
         run: sccache --stop-server
@@ -401,7 +401,7 @@ jobs:
       - name: Upload to S3
         id: s3
         run: |
-          aws s3 cp compliance/index.html s3://s2n-quic-ci-artifacts/compliance/${{ github.sha }}/index.html --acl private --follow-symlinks
+          aws s3 cp target/compliance/report.html s3://s2n-quic-ci-artifacts/compliance/${{ github.sha }}/index.html --acl private --follow-symlinks
           # generate a presigned url that is valid for 30 days
           URL=$(aws s3 presign s3://s2n-quic-ci-artifacts/compliance/${{ github.sha }}/index.html --expires-in 2592000)
           echo "::set-output name=URL::$URL"

--- a/scripts/compliance
+++ b/scripts/compliance
@@ -1,0 +1,26 @@
+#/usr/bin/env bash
+
+set -e
+
+mkdir -p target/compliance
+
+BLOB=${1:-main}
+
+# ensure the tool is built
+test -f target/release/cargo-compliance || \
+  cargo build --bin cargo-compliance --release
+
+./target/release/cargo-compliance \
+  report \
+  --spec-pattern 'specs/**/*.toml' \
+  --source-pattern 'quic/**/*.rs' \
+  --workspace \
+  --exclude compliance \
+  --exclude cargo-compliance \
+  --require-tests false \
+  --blob-link "https://github.com/awslabs/s2n-quic/blob/$BLOB" \
+  --issue-link 'https://github.com/awslabs/s2n-quic/issues' \
+  --no-cargo \
+  --html target/compliance/report.html
+
+echo "compliance report available in 'target/compliance/report.html'"

--- a/scripts/interop/run
+++ b/scripts/interop/run
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -x
+set -e
 
 # Setup the s2n-quic docker image
 sudo docker build . --file qns/Dockerfile.build --tag awslabs/s2n-quic-qns


### PR DESCRIPTION
This change extracts what the GHA does into a script so it's easy to generate compliance reports locally

Report for this PR: https://s2n-quic-ci-artifacts.s3.amazonaws.com/compliance/827adcad3bc37cd28ccd7de90d451fc7d5dbbd1a/index.html?AWSAccessKeyId=AKIAQLOT4IGNIYNLZH7B&Expires=1610051012&Signature=iufHe85WmST8faiQHLklOQrRBYM%3D#/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
