### PR TITLE
Transport parameter refactor

### DIFF
--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__ClientTransportParameters default.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__ClientTransportParameters default.snap
@@ -66,9 +66,7 @@ TransportParameters {
     preferred_address: DisabledParameter(
         PhantomData,
     ),
-    initial_source_connection_id: InitialSourceConnectionId(
-        ConnectionId([]),
-    ),
+    initial_source_connection_id: None,
     retry_source_connection_id: DisabledParameter(
         PhantomData,
     ),

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__ServerTransportParameters default.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__ServerTransportParameters default.snap
@@ -62,8 +62,6 @@ TransportParameters {
     ),
     stateless_reset_token: None,
     preferred_address: None,
-    initial_source_connection_id: InitialSourceConnectionId(
-        ConnectionId([]),
-    ),
+    initial_source_connection_id: None,
     retry_source_connection_id: None,
 }

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__server_snapshot_with_empty_initial_scid_test.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__server_snapshot_with_empty_initial_scid_test.snap
@@ -1,0 +1,8 @@
+---
+source: quic/s2n-quic-core/src/transport/parameters/mod.rs
+expression: encoded_output
+---
+[
+    15,
+    0,
+]

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -118,9 +118,11 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
         //# Each endpoint includes the value of the Source Connection ID field
         //# from the first Initial packet it sent in the
         //# initial_source_connection_id transport parameter
-        transport_parameters.initial_source_connection_id = initial_connection_id
-            .try_into()
-            .expect("connection ID already validated");
+        transport_parameters.initial_source_connection_id = Some(
+            initial_connection_id
+                .try_into()
+                .expect("connection ID already validated"),
+        );
 
         // TODO send retry_source_connection_id
         let tls_session = endpoint_context

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -124,7 +124,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
             .context()
             .endpoint_limits
             .on_connection_attempt(&attempt);
-        let result = match outcome {
+        match outcome {
             Outcome::Allow => Some(()),
             Outcome::Retry { delay: _ } => {
                 //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#8.1.2
@@ -154,9 +154,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
             // TODO https://github.com/awslabs/s2n-quic/issues/270
             #[allow(unused_variables)]
             Outcome::Close { delay } => None,
-        };
-
-        result
+        }
     }
 
     /// Ingests a single datagram


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Refactors that allow the Initial Source Connection ID transport parameter to be empty, but still sent over the wire

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
