### PR TITLE
interop: fix typo in test matching

### DIFF
--- a/quic/s2n-quic-qns/src/server.rs
+++ b/quic/s2n-quic-qns/src/server.rs
@@ -197,7 +197,7 @@ impl Interop {
             Some("resumption") => false,
             Some("zerortt") => false,
             Some("http3") => false,
-            Some("mutliconnect") => true,
+            Some("multiconnect") => true,
             Some("handshakecorruption") => true,
             Some("transfercorruption") => true,
             Some("ecn") => false,


### PR DESCRIPTION
It helps to spell things correctly...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
