### PR TITLE
Slight updates to make the qns runner more robust

### DIFF
--- a/scripts/interop/run
+++ b/scripts/interop/run
@@ -2,15 +2,22 @@
 
 set -e
 
+INTEROP_DIR=target/quic-interop-runner
+
 # Setup the s2n-quic docker image
 sudo docker build . --file qns/Dockerfile.build --tag awslabs/s2n-quic-qns
 
-if [ ! -d target/quic-interop-runner ]; then
-  git clone https://github.com/marten-seemann/quic-interop-runner target/quic-interop-runner
+if [ ! -d $INTEROP_DIR ]; then
+  git clone https://github.com/marten-seemann/quic-interop-runner $INTEROP_DIR
   # make sure to keep this up to date with the interop workflow
-  cd target/quic-interop-runner
+  cd $INTEROP_DIR
   git checkout 3d292c252e0c0159db93b62292abcf6b040a7060
   git apply --3way ../../.github/interop/runner.patch
+  cd ../../
+fi
+
+if [ ! -d $INTEROP_DIR/.venv ]; then
+  cd $INTEROP_DIR
   python3 -m venv .venv
   source .venv/bin/activate
   pip install --upgrade pip
@@ -37,7 +44,7 @@ case "$(uname -s)" in
      ;;
 esac
 
-cd target/quic-interop-runner
+cd $INTEROP_DIR
 source .venv/bin/activate
 pip install --upgrade -r requirements.txt
 


### PR DESCRIPTION
*Description of changes:*
Treat the interop runner directory and Python virtual env differently. This way a developer can nuke their target dir and the runner will rebuild the Python virtual env correctly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
