### PR TITLE
interop: use provided certs if present

### DIFF
--- a/.github/interop/Dockerfile
+++ b/.github/interop/Dockerfile
@@ -1,5 +1,14 @@
 FROM martenseemann/quic-network-simulator-endpoint:latest
 
+# install openssl to convert PEM to DER
+RUN set -eux; \
+  apt-get update; \
+  apt-get -y install openssl; \
+  rm -rf /var/lib/apt/lists/*; \
+  apt-get clean; \
+  rm -rf /tmp/*; \
+  echo done;
+
 # copy entrypoint
 COPY run_endpoint.sh /
 RUN chmod +x run_endpoint.sh

--- a/qns/Dockerfile
+++ b/qns/Dockerfile
@@ -1,5 +1,14 @@
 FROM martenseemann/quic-network-simulator-endpoint:latest
 
+# install openssl to convert PEM to DER
+RUN set -eux; \
+  apt-get update; \
+  apt-get -y install openssl; \
+  rm -rf /var/lib/apt/lists/*; \
+  apt-get clean; \
+  rm -rf /tmp/*; \
+  echo done;
+
 # copy entrypoint
 COPY run_endpoint.sh /
 RUN chmod +x run_endpoint.sh

--- a/qns/Dockerfile.build
+++ b/qns/Dockerfile.build
@@ -24,6 +24,15 @@ FROM martenseemann/quic-network-simulator-endpoint:latest
 
 ENV RUST_BACKTRACE="1"
 
+# install openssl to convert PEM to DER
+RUN set -eux; \
+  apt-get update; \
+  apt-get -y install openssl; \
+  rm -rf /var/lib/apt/lists/*; \
+  apt-get clean; \
+  rm -rf /tmp/*; \
+  echo done;
+
 # copy entrypoint
 COPY qns/run_endpoint.sh .
 RUN chmod +x run_endpoint.sh


### PR DESCRIPTION
From the [interop runner readme](https://github.com/marten-seemann/quic-interop-runner#building-a-quic-endpoint):

> The Interop Runner generates a key and a certificate chain and mounts it into /certs. The server needs to load its private key from priv.key, and the certificate chain from cert.pem.

This is a prerequisite for getting the amplificationlimit test to pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
