### PR TITLE
api: implement split methods

### DIFF
--- a/quic/s2n-quic/src/connection/acceptor.rs
+++ b/quic/s2n-quic/src/connection/acceptor.rs
@@ -104,7 +104,7 @@ macro_rules! impl_acceptor_api {
 }
 
 #[derive(Debug)]
-pub struct StreamAcceptor(s2n_quic_transport::connection::Connection);
+pub struct StreamAcceptor(pub(crate) s2n_quic_transport::connection::Connection);
 
 impl StreamAcceptor {
     impl_acceptor_api!(|acceptor, call| call!(acceptor));
@@ -117,7 +117,9 @@ impl StreamAcceptor {
     /// // TODO
     /// ```
     pub fn split(self) -> (BidirectionalStreamAcceptor, ReceiveStreamAcceptor) {
-        todo!()
+        let bidi = BidirectionalStreamAcceptor(self.0.clone());
+        let recv = ReceiveStreamAcceptor(self.0);
+        (bidi, recv)
     }
 }
 
@@ -138,9 +140,7 @@ impl futures::stream::Stream for StreamAcceptor {
 }
 
 #[derive(Debug)]
-pub struct BidirectionalStreamAcceptor {
-    // TODO
-}
+pub struct BidirectionalStreamAcceptor(s2n_quic_transport::connection::Connection);
 
 impl BidirectionalStreamAcceptor {
     /// TODO
@@ -183,9 +183,7 @@ impl futures::stream::Stream for BidirectionalStreamAcceptor {
 }
 
 #[derive(Debug)]
-pub struct ReceiveStreamAcceptor {
-    // TODO
-}
+pub struct ReceiveStreamAcceptor(s2n_quic_transport::connection::Connection);
 
 impl ReceiveStreamAcceptor {
     /// TODO

--- a/quic/s2n-quic/src/connection/handle.rs
+++ b/quic/s2n-quic/src/connection/handle.rs
@@ -201,7 +201,7 @@ macro_rules! impl_handle_api {
 }
 
 #[derive(Clone, Debug)]
-pub struct Handle(s2n_quic_transport::connection::Connection);
+pub struct Handle(pub(crate) s2n_quic_transport::connection::Connection);
 
 impl Handle {
     impl_handle_api!(|handle, call| call!(handle));

--- a/quic/s2n-quic/src/connection/mod.rs
+++ b/quic/s2n-quic/src/connection/mod.rs
@@ -46,6 +46,8 @@ impl Connection {
     /// // TODO
     /// ```
     pub fn split(self) -> (Handle, StreamAcceptor) {
-        todo!()
+        let handle = Handle(self.0.clone());
+        let acceptor = StreamAcceptor(self.0);
+        (handle, acceptor)
     }
 }


### PR DESCRIPTION
Implementing a `split` method allows applications to split responsibility of accepting streams from opening streams. It also means `connection::Handle`s can be cloned and passed around with streams themselves.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
