### PR TITLE
api: improve split implementation

### DIFF
--- a/quic/s2n-quic/src/connection/acceptor.rs
+++ b/quic/s2n-quic/src/connection/acceptor.rs
@@ -35,7 +35,7 @@ macro_rules! impl_accept_api {
             Ok(
                 futures::ready!(self.0.poll_accept(None, cx))?.map(|stream| {
                     match stream.id().stream_type() {
-                        StreamType::Unidirectional => ReceiveStream::new(stream).into(),
+                        StreamType::Unidirectional => ReceiveStream::new(stream.into()).into(),
                         StreamType::Bidirectional => BidirectionalStream::new(stream).into(),
                     }
                 }),
@@ -113,7 +113,7 @@ macro_rules! impl_accept_receive_api {
             Ok(futures::ready!(self
                 .0
                 .poll_accept(Some(s2n_quic_core::stream::StreamType::Unidirectional), cx))?
-            .map($crate::stream::ReceiveStream::new))
+            .map(|stream| $crate::stream::ReceiveStream::new(stream.into())))
             .into()
         }
     };

--- a/quic/s2n-quic/src/connection/handle.rs
+++ b/quic/s2n-quic/src/connection/handle.rs
@@ -32,7 +32,7 @@ macro_rules! impl_handle_api {
             Ok(
                 match futures::ready!(self.0.poll_open_stream(stream_type, cx))? {
                     stream if stream_type == StreamType::Unidirectional => {
-                        SendStream::new(stream).into()
+                        SendStream::new(stream.into()).into()
                     }
                     stream => BidirectionalStream::new(stream).into(),
                 },
@@ -101,7 +101,7 @@ macro_rules! impl_handle_api {
 
             let stream = futures::ready!(self.0.poll_open_stream(StreamType::Unidirectional, cx))?;
 
-            Ok(SendStream::new(stream)).into()
+            Ok(SendStream::new(stream.into())).into()
         }
 
         /// Returns the local address that this connection is bound to.

--- a/quic/s2n-quic/src/stream/bidirectional.rs
+++ b/quic/s2n-quic/src/stream/bidirectional.rs
@@ -16,15 +16,20 @@ impl BidirectionalStream {
 
     impl_send_stream_api!(|stream, call| call!(stream.0));
 
-    impl_splittable_stream_api!(|_stream| {
-        todo!();
-    });
+    pub fn split(self) -> (crate::stream::ReceiveStream, crate::stream::SendStream) {
+        let (recv, send) = self.0.split();
+        (
+            crate::stream::ReceiveStream::new(recv),
+            crate::stream::SendStream::new(send),
+        )
+    }
 
     impl_connection_api!(|_stream| todo!());
 }
 
 impl_receive_stream_trait!(BidirectionalStream, |stream, call| call!(stream.0));
 impl_send_stream_trait!(BidirectionalStream, |stream, call| call!(stream.0));
-impl_splittable_stream_trait!(BidirectionalStream, |_stream| {
-    todo!();
+impl_splittable_stream_trait!(BidirectionalStream, |stream| {
+    let (recv, send) = Self::split(stream);
+    (Some(recv), Some(send))
 });

--- a/quic/s2n-quic/src/stream/local.rs
+++ b/quic/s2n-quic/src/stream/local.rs
@@ -21,10 +21,7 @@ impl LocalStream {
         LocalStream::Send(stream) => dispatch!(stream),
     });
 
-    impl_splittable_stream_api!(|stream| match stream {
-        LocalStream::Bidirectional(stream) => stream.split(),
-        LocalStream::Send(stream) => stream.split(),
-    });
+    impl_splittable_stream_api!();
 
     impl_connection_api!(|stream| match stream {
         LocalStream::Bidirectional(stream) => stream.connection(),
@@ -41,8 +38,8 @@ impl_send_stream_trait!(LocalStream, |stream, dispatch| match stream {
     LocalStream::Send(stream) => dispatch!(stream),
 });
 impl_splittable_stream_trait!(LocalStream, |stream| match stream {
-    LocalStream::Bidirectional(stream) => stream.split(),
-    LocalStream::Send(stream) => stream.split(),
+    LocalStream::Bidirectional(stream) => super::SplittableStream::split(stream),
+    LocalStream::Send(stream) => super::SplittableStream::split(stream),
 });
 
 impl From<SendStream> for LocalStream {

--- a/quic/s2n-quic/src/stream/mod.rs
+++ b/quic/s2n-quic/src/stream/mod.rs
@@ -47,11 +47,7 @@ impl Stream {
         Stream::Send(stream) => dispatch!(stream),
     });
 
-    impl_splittable_stream_api!(|stream| match stream {
-        Stream::Bidirectional(stream) => stream.split(),
-        Stream::Receive(stream) => stream.split(),
-        Stream::Send(stream) => stream.split(),
-    });
+    impl_splittable_stream_api!();
 
     impl_connection_api!(|stream| match stream {
         Stream::Bidirectional(stream) => stream.connection(),
@@ -71,7 +67,7 @@ impl_send_stream_trait!(Stream, |stream, dispatch| match stream {
     Stream::Send(stream) => dispatch!(stream),
 });
 impl_splittable_stream_trait!(Stream, |stream| match stream {
-    Stream::Bidirectional(stream) => stream.split(),
-    Stream::Receive(stream) => stream.split(),
-    Stream::Send(stream) => stream.split(),
+    Stream::Bidirectional(stream) => SplittableStream::split(stream),
+    Stream::Receive(stream) => SplittableStream::split(stream),
+    Stream::Send(stream) => SplittableStream::split(stream),
 });

--- a/quic/s2n-quic/src/stream/peer.rs
+++ b/quic/s2n-quic/src/stream/peer.rs
@@ -21,10 +21,7 @@ impl PeerStream {
         PeerStream::Receive(_stream) => dispatch!(),
     });
 
-    impl_splittable_stream_api!(|stream| match stream {
-        PeerStream::Bidirectional(stream) => stream.split(),
-        PeerStream::Receive(stream) => stream.split(),
-    });
+    impl_splittable_stream_api!();
 
     impl_connection_api!(|stream| match stream {
         PeerStream::Bidirectional(stream) => stream.connection(),
@@ -41,8 +38,8 @@ impl_send_stream_trait!(PeerStream, |stream, dispatch| match stream {
     PeerStream::Receive(_stream) => dispatch!(),
 });
 impl_splittable_stream_trait!(PeerStream, |stream| match stream {
-    PeerStream::Bidirectional(stream) => stream.split(),
-    PeerStream::Receive(stream) => stream.split(),
+    PeerStream::Bidirectional(stream) => super::SplittableStream::split(stream),
+    PeerStream::Receive(stream) => super::SplittableStream::split(stream),
 });
 
 impl From<ReceiveStream> for PeerStream {

--- a/quic/s2n-quic/src/stream/receive.rs
+++ b/quic/s2n-quic/src/stream/receive.rs
@@ -1,11 +1,11 @@
-use s2n_quic_transport::stream::Stream;
+use s2n_quic_transport::stream;
 
 /// A QUIC stream that is only allowed to receive data.
 ///
 /// The [`ReceiveStream`] implements the required operations receive described in the
 /// [QUIC Transport RFC](https://tools.ietf.org/html/draft-ietf-quic-transport-28#section-2)
 #[derive(Debug)]
-pub struct ReceiveStream(Stream);
+pub struct ReceiveStream(stream::ReceiveStream);
 
 macro_rules! impl_receive_stream_api {
     (| $stream:ident, $dispatch:ident | $dispatch_body:expr) => {
@@ -260,16 +260,14 @@ macro_rules! impl_receive_stream_trait {
 }
 
 impl ReceiveStream {
-    pub(crate) const fn new(stream: Stream) -> Self {
+    pub(crate) const fn new(stream: stream::ReceiveStream) -> Self {
         Self(stream)
     }
 
     impl_receive_stream_api!(|stream, dispatch| dispatch!(stream.0));
 
-    impl_splittable_stream_api!(|stream| (Some(stream), None));
-
     impl_connection_api!(|_stream| todo!());
 }
 
-impl_splittable_stream_trait!(ReceiveStream, |stream| (None, Some(stream)));
+impl_splittable_stream_trait!(ReceiveStream, |stream| (Some(stream), None));
 impl_receive_stream_trait!(ReceiveStream, |stream, dispatch| dispatch!(stream.0));

--- a/quic/s2n-quic/src/stream/send.rs
+++ b/quic/s2n-quic/src/stream/send.rs
@@ -1,11 +1,11 @@
-use s2n_quic_transport::stream::Stream;
+use s2n_quic_transport::stream;
 
 /// A QUIC stream that is only allowed to send data.
 ///
 /// The [`SendStream`] implements the required send operations described in the
 /// [QUIC Transport RFC](https://tools.ietf.org/html/draft-ietf-quic-transport-28#section-2)
 #[derive(Debug)]
-pub struct SendStream(Stream);
+pub struct SendStream(stream::SendStream);
 
 macro_rules! impl_send_stream_api {
     (| $stream:ident, $dispatch:ident | $dispatch_body:expr) => {
@@ -357,13 +357,11 @@ macro_rules! impl_send_stream_trait {
 }
 
 impl SendStream {
-    pub(crate) const fn new(stream: Stream) -> Self {
+    pub(crate) const fn new(stream: stream::SendStream) -> Self {
         Self(stream)
     }
 
     impl_send_stream_api!(|stream, dispatch| dispatch!(stream.0));
-
-    impl_splittable_stream_api!(|stream| (None, Some(stream)));
 
     impl_connection_api!(|_stream| todo!());
 }

--- a/quic/s2n-quic/src/stream/splittable.rs
+++ b/quic/s2n-quic/src/stream/splittable.rs
@@ -16,7 +16,7 @@ pub trait SplittableStream {
 }
 
 macro_rules! impl_splittable_stream_api {
-    (| $self:ident | $convert:expr) => {
+    () => {
         /// Splits the stream into [`ReceiveStream`] and [`SendStream`] halves
         ///
         /// # Examples
@@ -30,8 +30,7 @@ macro_rules! impl_splittable_stream_api {
             Option<$crate::stream::ReceiveStream>,
             Option<$crate::stream::SendStream>,
         ) {
-            let $self = self;
-            $convert
+            $crate::stream::SplittableStream::split(self)
         }
     };
 }
@@ -45,7 +44,8 @@ macro_rules! impl_splittable_stream_trait {
                 Option<$crate::stream::ReceiveStream>,
                 Option<$crate::stream::SendStream>,
             ) {
-                Self::split(self)
+                let $self = self;
+                $convert
             }
         }
     };


### PR DESCRIPTION
This implements the remaining public split APIs for streams.

I've also moved the drop implementation to the stream state struct, which fixed an less-than-optional implementation of incrementing and decrementing ref counters. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
