### PR TITLE
api: implement specialized acceptors

### DIFF
--- a/quic/s2n-quic-integration/src/s2n_quic/api.rs
+++ b/quic/s2n-quic-integration/src/s2n_quic/api.rs
@@ -41,7 +41,7 @@ impl api::Acceptor for StreamAcceptor {
 impl crate::api::Handle for Handle {
     type BidiStream = stream::BidirectionalStream;
     type SendStream = stream::SendStream;
-    type Error = stream::Error;
+    type Error = connection::Error;
 
     fn poll_open_send(&mut self, cx: &mut Context) -> Poll<Result<Self::SendStream, Self::Error>> {
         Handle::poll_open_send_stream(self, cx)

--- a/quic/s2n-quic/src/connection/handle.rs
+++ b/quic/s2n-quic/src/connection/handle.rs
@@ -10,7 +10,7 @@ macro_rules! impl_handle_api {
         pub async fn open_stream(
             &mut self,
             stream_type: $crate::stream::Type,
-        ) -> $crate::stream::Result<$crate::stream::LocalStream> {
+        ) -> $crate::connection::Result<$crate::stream::LocalStream> {
             futures::future::poll_fn(|cx| self.poll_open_stream(stream_type, cx)).await
         }
 
@@ -25,7 +25,7 @@ macro_rules! impl_handle_api {
             &mut self,
             stream_type: $crate::stream::Type,
             cx: &mut core::task::Context,
-        ) -> core::task::Poll<$crate::stream::Result<$crate::stream::LocalStream>> {
+        ) -> core::task::Poll<$crate::connection::Result<$crate::stream::LocalStream>> {
             use s2n_quic_core::stream::StreamType;
             use $crate::stream::{BidirectionalStream, SendStream};
 
@@ -49,7 +49,7 @@ macro_rules! impl_handle_api {
         /// ```
         pub async fn open_bidirectional_stream(
             &mut self,
-        ) -> $crate::stream::Result<$crate::stream::BidirectionalStream> {
+        ) -> $crate::connection::Result<$crate::stream::BidirectionalStream> {
             futures::future::poll_fn(|cx| self.poll_open_bidirectional_stream(cx)).await
         }
 
@@ -63,7 +63,7 @@ macro_rules! impl_handle_api {
         pub fn poll_open_bidirectional_stream(
             &mut self,
             cx: &mut core::task::Context,
-        ) -> core::task::Poll<$crate::stream::Result<$crate::stream::BidirectionalStream>> {
+        ) -> core::task::Poll<$crate::connection::Result<$crate::stream::BidirectionalStream>> {
             use s2n_quic_core::stream::StreamType;
             use $crate::stream::BidirectionalStream;
 
@@ -81,7 +81,7 @@ macro_rules! impl_handle_api {
         /// ```
         pub async fn open_send_stream(
             &mut self,
-        ) -> $crate::stream::Result<$crate::stream::SendStream> {
+        ) -> $crate::connection::Result<$crate::stream::SendStream> {
             futures::future::poll_fn(|cx| self.poll_open_send_stream(cx)).await
         }
 
@@ -95,7 +95,7 @@ macro_rules! impl_handle_api {
         pub fn poll_open_send_stream(
             &mut self,
             cx: &mut core::task::Context,
-        ) -> core::task::Poll<$crate::stream::Result<$crate::stream::SendStream>> {
+        ) -> core::task::Poll<$crate::connection::Result<$crate::stream::SendStream>> {
             use s2n_quic_core::stream::StreamType;
             use $crate::stream::SendStream;
 

--- a/quic/s2n-quic/src/connection/mod.rs
+++ b/quic/s2n-quic/src/connection/mod.rs
@@ -35,7 +35,7 @@ impl Connection {
         Self(inner)
     }
 
-    impl_acceptor_api!(|handle, call| call!(handle));
+    impl_accept_api!();
     impl_handle_api!(|handle, call| call!(handle));
 
     /// TODO


### PR DESCRIPTION
This allows the acceptor to be split further into bidirectional and receive stream acceptors.

I've also fixed an oversight where we were returning a stream error rather than a connection error on stream open calls.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
