### PR TITLE
ignore difference warning

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -6,6 +6,7 @@ yanked = "deny"
 ignore = [
     "RUSTSEC-2019-0031", # ring currently uses 'spin' for feature detection
     "RUSTSEC-2020-0016", # mio 0.6 uses 'net2' (removed in 0.7) but tokio is still pinned to 0.6
+    "RUSTSEC-2020-0095", # insta (a dev dependency) uses `difference`
 ]
 
 [bans]


### PR DESCRIPTION
The `difference` crate is used by `insta` (a dev dependency only), which means this is very low impact and priority. We'll just wait until insta switches to something else.

Closes #425 .

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
