### PR TITLE
tls: fix the qns release and add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ This project is licensed under the Apache-2.0 License.
 - Install [rustup](https://rustup.rs/)
 - Run `rustup component add rustfmt clippy rls rust-analysis`
 
+### Initialization
+
+```sh
+# Initialize the project's submodules
+$ git submodule update --init
+```
+
 ### Running a fuzz target
 
 You'll need to have `cargo-bolero` installed first.

--- a/qns/Dockerfile.build
+++ b/qns/Dockerfile.build
@@ -6,6 +6,7 @@ ARG release="false"
 COPY Cargo.* /s2n-quic/
 COPY common /s2n-quic/common
 COPY quic /s2n-quic/quic
+COPY tls /s2n-quic/tls
 WORKDIR /s2n-quic
 
 # build runner


### PR DESCRIPTION
The `tls` directory needs to be added to the docker build image.

I've also updated the README to include initializing submodules


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
