### PR TITLE
tls: implement s2n-tls provider

### DIFF
--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "s2n-quic-tls-default"
+version = "0.1.0"
+authors = ["Cameron Bytheway <bythewc@amazon.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[target.'cfg(unix)'.dependencies]
+s2n-quic-tls = { version = "0.1", path = "../s2n-quic-tls" }
+
+[target.'cfg(not(unix))'.dependencies]
+s2n-quic-rustls = { version = "0.1", path = "../s2n-quic-rustls" }

--- a/quic/s2n-quic-tls-default/src/lib.rs
+++ b/quic/s2n-quic-tls-default/src/lib.rs
@@ -1,0 +1,4 @@
+#[cfg(not(unix))]
+pub use s2n_quic_rustls::*;
+#[cfg(unix)]
+pub use s2n_quic_tls::*;

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -6,12 +6,21 @@ edition = "2018"
 license = "Apache-2.0"
 
 [features]
-default = ["default-token-provider", "std", "protocol-extensions", "rand-provider", "rustls", "tokio-runtime"]
+default = [
+    "default-tls-provider",
+    "default-token-provider",
+    "protocol-extensions",
+    "rand-provider",
+    "std",
+    "tokio-runtime"
+]
 default-token-provider = ["ring", "zerocopy"]
+default-tls-provider = ["s2n-quic-tls-default"]
 protocol-extensions = []
 rand-provider = ["rand", "rand_chacha"]
-std = ["bytes/std", "futures/std", "s2n-quic-core/std", "s2n-quic-platform/std", "thiserror"]
 rustls = ["s2n-quic-rustls"]
+s2n-tls = ["s2n-quic-tls"]
+std = ["bytes/std", "futures/std", "s2n-quic-core/std", "s2n-quic-platform/std", "thiserror"]
 tokio-runtime = ["tokio", "s2n-quic-platform/tokio-runtime"]
 
 [dependencies]
@@ -27,6 +36,8 @@ s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features
 s2n-quic-core = { version = "0.1", path = "../s2n-quic-core", default-features = false }
 s2n-quic-platform = { version = "0.1", path = "../s2n-quic-platform", default-features = false }
 s2n-quic-rustls = { version = "0.1", path = "../s2n-quic-rustls", optional = true }
+s2n-quic-tls = { version = "0.1", path = "../s2n-quic-tls", optional = true }
+s2n-quic-tls-default = { version = "0.1", path = "../s2n-quic-tls-default", optional = true }
 s2n-quic-transport = { version = "0.1", path = "../s2n-quic-transport", default-features = false }
 thiserror = { version = "1.0", optional = true }
 tokio = { version = "0.2", optional = true, features = ["rt-core", "time", "udp"] }


### PR DESCRIPTION
This enables s2n-tls by default on unix platforms. Because of some of the limitations of cargo, I had to create a new `s2n-quic-tls-default` crate that switches its tls implementation based on operating system environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
