### PR TITLE
perf: update quinn to latest commit

### DIFF
--- a/scripts/server-perf/client/Cargo.toml
+++ b/scripts/server-perf/client/Cargo.toml
@@ -7,10 +7,10 @@ edition = "2018"
 [dependencies]
 anyhow = "1"
 byte-unit = "4"
-quinn = { git = "https://github.com/quinn-rs/quinn", rev = "fc2016103dadb45158b3699a63e9046e4383ca63" }
+quinn = { git = "https://github.com/quinn-rs/quinn", rev = "2a8c93bf0f987b4118fdaf1d0d1489c452810e19" }
 s2n-quic-core = { path = "../../../quic/s2n-quic-core", features = ["testing"] }
 structopt = "0.3"
-tokio = { version = "0.2", features = ["macros", "rt-core"] }
+tokio = { version = "1", features = ["macros", "rt"] }
 url = "2"
 
 [workspace]


### PR DESCRIPTION
Hopefully the core issue was fixed?

for reference https://github.com/awslabs/s2n-quic/pull/489/checks?check_run_id=1867831125

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
