### PR TITLE
qns: general cleanup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 **/target
 **/corpus
 **/corpus.tar.gz
+Dockerfile*

--- a/.github/interop/Dockerfile
+++ b/.github/interop/Dockerfile
@@ -1,9 +1,9 @@
 FROM martenseemann/quic-network-simulator-endpoint:latest
 
-# install openssl to convert PEM to DER
+# install libcrypto
 RUN set -eux; \
   apt-get update; \
-  apt-get -y install openssl; \
+  apt-get -y install libssl-dev; \
   rm -rf /var/lib/apt/lists/*; \
   apt-get clean; \
   rm -rf /tmp/*; \
@@ -15,15 +15,15 @@ RUN chmod +x run_endpoint.sh
 
 # copy runner
 COPY s2n-quic-qns-debug /usr/bin/s2n-quic-qns
-COPY s2n-quic-qns-release /usr/bin/s2n-quic-qns-perf
+COPY s2n-quic-qns-release /usr/bin/s2n-quic-qns-release
 
 RUN set -eux; \
   chmod +x /usr/bin/s2n-quic-qns; \
-  chmod +x /usr/bin/s2n-quic-qns-perf; \
+  chmod +x /usr/bin/s2n-quic-qns-release; \
   ldd /usr/bin/s2n-quic-qns; \
   # ensure the binary works \
   s2n-quic-qns --help; \
-  s2n-quic-qns-perf --help; \
+  s2n-quic-qns-release --help; \
   echo done
 
 # help with debugging

--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -152,7 +152,7 @@ jobs:
         working-directory: s2n-quic-qns
         run: |
           cp ../s2n-quic/.github/interop/Dockerfile .
-          cp ../s2n-quic/qns/run_endpoint.sh .
+          cp ../s2n-quic/quic/s2n-quic-qns/etc/run_endpoint.sh .
 
       - name: Run docker build
         working-directory: s2n-quic-qns

--- a/quic/s2n-quic-qns/etc/Dockerfile
+++ b/quic/s2n-quic-qns/etc/Dockerfile
@@ -1,9 +1,9 @@
 FROM martenseemann/quic-network-simulator-endpoint:latest
 
-# install openssl to convert PEM to DER
+# install libcrypto
 RUN set -eux; \
   apt-get update; \
-  apt-get -y install openssl; \
+  apt-get -y install libssl-dev; \
   rm -rf /var/lib/apt/lists/*; \
   apt-get clean; \
   rm -rf /tmp/*; \

--- a/quic/s2n-quic-qns/etc/Dockerfile.build
+++ b/quic/s2n-quic-qns/etc/Dockerfile.build
@@ -2,6 +2,10 @@ FROM rust:latest AS builder
 
 ARG release="false"
 
+RUN set -eux; \
+  apt-get update; \
+  apt-get install -y cmake clang;
+
 # copy sources
 COPY Cargo.* /s2n-quic/
 COPY common /s2n-quic/common
@@ -25,17 +29,17 @@ FROM martenseemann/quic-network-simulator-endpoint:latest
 
 ENV RUST_BACKTRACE="1"
 
-# install openssl to convert PEM to DER
+# install libcrypto
 RUN set -eux; \
   apt-get update; \
-  apt-get -y install openssl; \
+  apt-get -y install libssl-dev; \
   rm -rf /var/lib/apt/lists/*; \
   apt-get clean; \
   rm -rf /tmp/*; \
   echo done;
 
 # copy entrypoint
-COPY qns/run_endpoint.sh .
+COPY quic/s2n-quic-qns/etc/run_endpoint.sh .
 RUN chmod +x run_endpoint.sh
 
 # copy runner

--- a/quic/s2n-quic-qns/etc/run_endpoint.sh
+++ b/quic/s2n-quic-qns/etc/run_endpoint.sh
@@ -15,18 +15,15 @@ LOG=$LOG_DIR/logs.txt
 
 QNS_BIN="s2n-quic-qns"
 
-if [ "$TEST_TYPE" == "MEASUREMENT" ] && [ -x "$(command -v s2n-quic-qns-perf)" ]; then
+if [ "$TEST_TYPE" == "MEASUREMENT" ] && [ -x "$(command -v s2n-quic-qns-release)" ]; then
     echo "using optimized build"
-    QNS_BIN="s2n-quic-qns-perf"
+    QNS_BIN="s2n-quic-qns-release"
 fi
 
 CERT_ARGS=""
 
 if [ -d "/certs" ]; then
-    # Rustls only reads RSA private keys, not the PKCS#8 private key format
-    openssl rsa -in /certs/priv.key -outform pem -out /tmp/rsa_priv_key.pem
-
-    CERT_ARGS="--private-key /tmp/rsa_priv_key.pem --certificate /certs/cert.pem"
+    CERT_ARGS="--private-key /certs/priv.key --certificate /certs/cert.pem"
 fi
 
 if [ "$ROLE" == "client" ]; then

--- a/quic/s2n-quic-rustls/src/certificate.rs
+++ b/quic/s2n-quic-rustls/src/certificate.rs
@@ -53,20 +53,16 @@ macro_rules! cert_type {
         impl $trait for &std::path::Path {
             fn $method(self) -> Result<$name, Error> {
                 match self.extension() {
-                    Some(ext) if ext == "pem" => {
-                        let pem = std::fs::read_to_string(self)
-                            .map_err(|err| Error::General(err.to_string()))?;
-                        pem.$method()
-                    }
                     Some(ext) if ext == "der" => {
                         let pem =
                             std::fs::read(self).map_err(|err| Error::General(err.to_string()))?;
                         pem.$method()
                     }
-                    Some(ext) => Err(Error::General(format!("unknown extension: {:?}", ext))),
-                    None => Err(Error::General(
-                        "cannot not infer certificate type without extension".to_string(),
-                    )),
+                    _ => {
+                        let pem = std::fs::read_to_string(self)
+                            .map_err(|err| Error::General(err.to_string()))?;
+                        pem.$method()
+                    }
                 }
             }
         }

--- a/scripts/interop/run
+++ b/scripts/interop/run
@@ -5,7 +5,7 @@ set -e
 INTEROP_DIR=target/quic-interop-runner
 
 # Setup the s2n-quic docker image
-sudo docker build . --file qns/Dockerfile.build --tag awslabs/s2n-quic-qns
+sudo docker build . --file quic/s2n-quic-qns/etc/Dockerfile.build --tag awslabs/s2n-quic-qns
 
 if [ ! -d $INTEROP_DIR ]; then
   git clone https://github.com/marten-seemann/quic-interop-runner $INTEROP_DIR


### PR DESCRIPTION
## Changes

* Moves the root `qns` directory into `quic/s2n-quic-qns/etc`
* Makes rustls consistent with the s2n-quic-tls certificate loading (if the extension is not `der`, then assume it's in pem)
* Removes the openssl cli dependency and just pull in `libssl-dev` for the libcrypto dependency in s2n-tls
* Adds `cmake` in the docker build environment so we can build `s2n-tls`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
