### PR TITLE
perf: disable target-cpu=native to maybe improve reliability in ci

### DIFF
--- a/scripts/server-perf/build
+++ b/scripts/server-perf/build
@@ -6,13 +6,13 @@ if ! command -v "inferno-collapse-perf" &> /dev/null; then
   cargo install inferno
 fi
 
-RUSTFLAGS="-g -Ctarget-cpu=native" cargo \
+RUSTFLAGS="-g" cargo \
   +stable \
   build \
   --bin s2n-quic-qns \
   --release
 
 cd ./scripts/server-perf/client
-RUSTFLAGS="-Ctarget-cpu=native" cargo +stable build --release
+cargo +stable build --release
 cd ../../../
 


### PR DESCRIPTION
Maybe this is what's causing the illegal instructions?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
