### PR TITLE
Only retire the connection ID used during the handshake when the handshake has completed

### DIFF
--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -241,8 +241,8 @@ impl<Config: connection::Config> ApplicationSpace<Config> {
         local_id_registry: &mut connection::LocalIdRegistry,
         timestamp: Timestamp,
     ) {
-        // Retire the initial local connection ID used during the handshake to reduce linkability
-        local_id_registry.retire_initial_id(timestamp);
+        // Retire the local connection ID used during the handshake to reduce linkability
+        local_id_registry.retire_handshake_connection_id(timestamp);
 
         //= https://tools.ietf.org/id/draft-ietf-quic-recovery-32.txt#6.2.1
         //# A sender SHOULD restart its PTO timer every time an ack-eliciting


### PR DESCRIPTION
The interop transfer test for msquic was failing because the msquic client was sending a RETIRE_CONNECTION_ID frame with a sequence number that referred to the destination ID on the packet the retire frame was sent in. 

> server          | [quic/s2n-quic-transport/src/connection/connection_impl.rs:989] &transport_error = TransportError {
server          |     code: VarInt(
server          |         10,
server          |     ),
server          |     description: "PROTOCOL_VIOLATION",
server          |     reason: "Invalid sequence number",
server          |     frame_type: VarInt(
server          |         25,
server          |     ),
server          | }


While digging into this, I noticed that prior to retiring connection IDs used during the handshake, we were sending NEW_CONNECTION_ID frames. These new connection IDs were then immediately retired when the handshake was completed. Changing this behavior to only retire the initial connection ID fixed the msquic interop test and is less wasteful anyway.

Before & After:
<img width="371" alt="Screen Shot 2021-02-15 at 6 13 11 PM" src="https://user-images.githubusercontent.com/55108558/108010394-9be45f00-6fb9-11eb-8a27-d126f218159b.png"><img width="266" alt="Screen Shot 2021-02-15 at 6 50 24 PM" src="https://user-images.githubusercontent.com/55108558/108012688-ddc3d400-6fbe-11eb-92da-d495ccaf3160.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.