### PR TITLE
core: implement the limits provider

### DIFF
--- a/quic/s2n-quic-core/src/ack.rs
+++ b/quic/s2n-quic-core/src/ack.rs
@@ -1,0 +1,5 @@
+pub mod set;
+pub mod settings;
+
+pub use set::Set;
+pub use settings::Settings;

--- a/quic/s2n-quic-core/src/ack/set.rs
+++ b/quic/s2n-quic-core/src/ack/set.rs
@@ -7,8 +7,8 @@ use core::ops::RangeInclusive;
 ///
 /// The implementation of the set is allowed to store packet numbers in
 /// an arbitrary form.
-pub trait AckSet {
-    /// Returns whether the [`AckSet`] contains a given packet number
+pub trait Set {
+    /// Returns whether the [`Set`] contains a given packet number
     fn contains(&self, packet_number: PacketNumber) -> bool;
 
     /// Smallest packet number in the set
@@ -20,7 +20,7 @@ pub trait AckSet {
 
 // A single packet number is also a set
 
-impl AckSet for PacketNumber {
+impl Set for PacketNumber {
     fn contains(&self, packet_number: PacketNumber) -> bool {
         *self == packet_number
     }
@@ -34,7 +34,7 @@ impl AckSet for PacketNumber {
     }
 }
 
-impl AckSet for RangeInclusive<PacketNumber> {
+impl Set for RangeInclusive<PacketNumber> {
     fn contains(&self, packet_number: PacketNumber) -> bool {
         RangeInclusive::contains(self, &packet_number)
     }
@@ -48,7 +48,7 @@ impl AckSet for RangeInclusive<PacketNumber> {
     }
 }
 
-impl AckSet for PacketNumberRange {
+impl Set for PacketNumberRange {
     fn contains(&self, packet_number: PacketNumber) -> bool {
         PacketNumberRange::contains(self, packet_number)
     }

--- a/quic/s2n-quic-core/src/ack/settings.rs
+++ b/quic/s2n-quic-core/src/ack/settings.rs
@@ -1,0 +1,122 @@
+use crate::{
+    transport::parameters::{AckDelayExponent, MaxAckDelay},
+    varint::VarInt,
+};
+use core::{convert::TryInto, time::Duration};
+
+// After running simulations, this seemed to be a good baseline
+// TODO experiment more with this
+/// The recommended value for the ack_elicitation_interval setting
+const RECOMMENDED_ELICITATION_INTERVAL: u8 = 4;
+
+// TODO experiment more with this
+/// The recommended number of packet number ranges that an endpoint should store
+const RECOMMENDED_RANGES_LIMIT: u8 = 10;
+
+/// Settings for ACK frames
+#[derive(Clone, Copy, Debug)]
+pub struct Settings {
+    /// The maximum ACK delay indicates the maximum amount of time by which the
+    /// endpoint will delay sending acknowledgments.
+    pub max_ack_delay: Duration,
+    /// The ACK delay exponent is an integer value indicating an exponent used
+    /// to decode the ACK Delay field in the ACK frame
+    pub ack_delay_exponent: u8,
+
+    //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#13.2.4
+    //# A receiver that sends only non-ack-eliciting packets, such as ACK
+    //# frames, might not receive an acknowledgement for a long period of
+    //# time.  This could cause the receiver to maintain state for a large
+    //# number of ACK frames for a long period of time, and ACK frames it
+    //# sends could be unnecessarily large.  In such a case, a receiver could
+    //# send a PING or other small ack-eliciting frame occasionally, such as
+    //# once per round trip, to elicit an ACK from the peer.
+    /// The number of packets received before sending an ACK-eliciting packet
+    pub ack_elicitation_interval: u8,
+
+    /// The number of packet number intervals an endpoint is willing to store
+    pub ack_ranges_limit: u8,
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self::RECOMMENDED
+    }
+}
+
+//= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#19.3
+//# ACK Delay:  A variable-length integer encoding the acknowledgement
+//#    delay in microseconds; see Section 13.2.5.  It is decoded by
+//#    multiplying the value in the field by 2 to the power of the
+//#    ack_delay_exponent transport parameter sent by the sender of the
+//#    ACK frame; see Section 18.2.  Compared to simply expressing the
+//#    delay as an integer, this encoding allows for a larger range of
+//#    values within the same number of bytes, at the cost of lower
+//#    resolution.
+
+impl Settings {
+    //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#13.2.1
+    //# An endpoint MUST acknowledge all ack-eliciting Initial and Handshake
+    //# packets immediately
+    pub const EARLY: Self = Self {
+        max_ack_delay: Duration::from_secs(0),
+        ack_delay_exponent: 0,
+        ..Self::RECOMMENDED
+    };
+
+    pub const RECOMMENDED: Self = Self {
+        max_ack_delay: MaxAckDelay::RECOMMENDED.as_duration(),
+        ack_delay_exponent: AckDelayExponent::RECOMMENDED.as_u8(),
+        ack_elicitation_interval: RECOMMENDED_ELICITATION_INTERVAL,
+        ack_ranges_limit: RECOMMENDED_RANGES_LIMIT,
+    };
+
+    /// Decodes the peer's `Ack Delay` field
+    pub fn decode_ack_delay(&self, delay: VarInt) -> Duration {
+        Duration::from_micros(*delay) * self.scale()
+    }
+
+    /// Encodes the local `Ack Delay` field
+    pub fn encode_ack_delay(&self, delay: Duration) -> VarInt {
+        let micros = delay.as_micros();
+        let scale = self.scale() as u128;
+        (micros / scale).try_into().unwrap_or(VarInt::MAX)
+    }
+
+    /// Computes the scale from the exponent
+    fn scale(&self) -> u32 {
+        2u32.pow(self.ack_delay_exponent as u32)
+    }
+}
+
+#[cfg(test)]
+mod ack_settings_tests {
+    use super::*;
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // this test is too expensive for miri
+    fn ack_settings_test() {
+        for ack_delay_exponent in 0..=20 {
+            let settings = Settings {
+                ack_delay_exponent,
+                ..Default::default()
+            };
+            // use an epsilon instead of comparing the values directly,
+            // as there will be some precision loss
+            let epsilon = settings.scale() as u128;
+
+            for delay in (0..1000).map(|v| v * 100).map(Duration::from_micros) {
+                let delay_varint = settings.encode_ack_delay(delay);
+                let expected_us = delay.as_micros();
+                let actual_us = settings.decode_ack_delay(delay_varint).as_micros();
+                let actual_difference = expected_us - actual_us;
+                assert!(actual_difference < epsilon);
+            }
+
+            // ensure MAX values are handled correctly and don't overflow
+            let delay = settings.decode_ack_delay(VarInt::MAX);
+            let delay_varint = settings.encode_ack_delay(delay);
+            assert_eq!(VarInt::MAX, delay_varint);
+        }
+    }
+}

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -1,0 +1,159 @@
+use crate::{
+    ack,
+    inet::SocketAddress,
+    stream,
+    transport::parameters::{
+        AckDelayExponent, ActiveConnectionIdLimit, InitialFlowControlLimits, InitialMaxData,
+        InitialMaxStreamDataBidiLocal, InitialMaxStreamDataBidiRemote, InitialMaxStreamDataUni,
+        InitialMaxStreamsBidi, InitialMaxStreamsUni, InitialStreamLimits, MaxAckDelay,
+        MaxIdleTimeout,
+    },
+};
+use core::{convert::TryInto, time::Duration};
+
+pub use crate::transport::parameters::ValidationError;
+
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct ConnectionInfo<'a> {
+    pub source_adddress: &'a SocketAddress,
+}
+
+impl<'a> ConnectionInfo<'a> {
+    pub fn new(source_adddress: &'a SocketAddress) -> Self {
+        Self { source_adddress }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Limits {
+    pub(crate) max_idle_timeout: MaxIdleTimeout,
+    pub(crate) data_window: InitialMaxData,
+    pub(crate) bidirectional_local_data_window: InitialMaxStreamDataBidiLocal,
+    pub(crate) bidirectional_remote_data_window: InitialMaxStreamDataBidiRemote,
+    pub(crate) unidirectional_data_window: InitialMaxStreamDataUni,
+    pub(crate) max_open_bidirectional_streams: InitialMaxStreamsBidi,
+    pub(crate) max_open_unidirectional_streams: InitialMaxStreamsUni,
+    pub(crate) max_ack_delay: MaxAckDelay,
+    pub(crate) ack_delay_exponent: AckDelayExponent,
+    pub(crate) max_active_connection_ids: ActiveConnectionIdLimit,
+    pub(crate) ack_elicitation_interval: u8,
+    pub(crate) ack_ranges_limit: u8,
+    pub(crate) max_send_buffer_size: u32,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+macro_rules! setter {
+    ($name:ident, $field:ident, $inner:ty) => {
+        pub fn $name(mut self, value: $inner) -> Result<Self, ValidationError> {
+            self.$field = value.try_into()?;
+            Ok(self)
+        }
+    };
+}
+
+impl Limits {
+    pub const fn new() -> Self {
+        Self {
+            max_idle_timeout: MaxIdleTimeout::RECOMMENDED,
+            data_window: InitialMaxData::RECOMMENDED,
+            bidirectional_local_data_window: InitialMaxStreamDataBidiLocal::RECOMMENDED,
+            bidirectional_remote_data_window: InitialMaxStreamDataBidiRemote::RECOMMENDED,
+            unidirectional_data_window: InitialMaxStreamDataUni::RECOMMENDED,
+            max_open_bidirectional_streams: InitialMaxStreamsBidi::RECOMMENDED,
+            max_open_unidirectional_streams: InitialMaxStreamsUni::RECOMMENDED,
+            max_ack_delay: MaxAckDelay::RECOMMENDED,
+            ack_delay_exponent: AckDelayExponent::RECOMMENDED,
+            max_active_connection_ids: ActiveConnectionIdLimit::RECOMMENDED,
+            ack_elicitation_interval: ack::Settings::RECOMMENDED.ack_elicitation_interval,
+            ack_ranges_limit: ack::Settings::RECOMMENDED.ack_ranges_limit,
+            max_send_buffer_size: stream::Limits::RECOMMENDED.max_send_buffer_size,
+        }
+    }
+
+    setter!(with_max_idle_timeout, max_idle_timeout, Duration);
+    setter!(with_data_window, data_window, u64);
+    setter!(
+        with_bidirectional_local_data_window,
+        bidirectional_local_data_window,
+        u64
+    );
+    setter!(
+        with_bidirectional_remote_data_window,
+        bidirectional_remote_data_window,
+        u64
+    );
+    setter!(
+        with_unidirectional_data_window,
+        unidirectional_data_window,
+        u64
+    );
+    setter!(
+        with_max_open_bidirectional_streams,
+        max_open_bidirectional_streams,
+        u64
+    );
+    setter!(
+        with_max_open_unidirectional_streams,
+        max_open_unidirectional_streams,
+        u64
+    );
+    setter!(with_max_ack_delay, max_ack_delay, Duration);
+    setter!(
+        with_max_active_connection_ids,
+        max_active_connection_ids,
+        u64
+    );
+    setter!(with_ack_elicitation_interval, ack_elicitation_interval, u8);
+    setter!(with_max_ack_ranges, ack_ranges_limit, u8);
+    setter!(with_max_send_buffer_size, max_send_buffer_size, u32);
+
+    pub const fn ack_settings(&self) -> ack::Settings {
+        ack::Settings {
+            ack_delay_exponent: self.ack_delay_exponent.as_u8(),
+            max_ack_delay: self.max_ack_delay.as_duration(),
+            ack_ranges_limit: self.ack_ranges_limit,
+            ack_elicitation_interval: self.ack_elicitation_interval,
+        }
+    }
+
+    pub const fn initial_flow_control_limits(&self) -> InitialFlowControlLimits {
+        InitialFlowControlLimits {
+            stream_limits: self.initial_stream_limits(),
+            max_data: self.data_window.as_varint(),
+            max_streams_bidi: self.max_open_bidirectional_streams.as_varint(),
+            max_streams_uni: self.max_open_unidirectional_streams.as_varint(),
+        }
+    }
+
+    pub const fn initial_stream_limits(&self) -> InitialStreamLimits {
+        InitialStreamLimits {
+            max_data_bidi_local: self.bidirectional_local_data_window.as_varint(),
+            max_data_bidi_remote: self.bidirectional_remote_data_window.as_varint(),
+            max_data_uni: self.unidirectional_data_window.as_varint(),
+        }
+    }
+
+    pub const fn stream_limits(&self) -> stream::Limits {
+        stream::Limits {
+            max_send_buffer_size: self.max_send_buffer_size,
+        }
+    }
+}
+
+/// Creates limits for a given connection
+pub trait Limiter {
+    fn on_connection(&mut self, info: &ConnectionInfo) -> Limits;
+}
+
+/// Implement Limiter for a Limits struct
+impl Limiter for Limits {
+    fn on_connection(&mut self, _into: &ConnectionInfo) -> Limits {
+        *self
+    }
+}

--- a/quic/s2n-quic-core/src/connection/mod.rs
+++ b/quic/s2n-quic-core/src/connection/mod.rs
@@ -1,5 +1,7 @@
 mod error;
 pub mod id;
+pub mod limits;
 
 pub use error::*;
 pub use id::{InitialId, LocalId, PeerId, UnboundedId};
+pub use limits::Limits;

--- a/quic/s2n-quic-core/src/lib.rs
+++ b/quic/s2n-quic-core/src/lib.rs
@@ -1,6 +1,6 @@
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 
-pub mod ack_set;
+pub mod ack;
 pub mod application;
 pub mod connection;
 pub mod counter;

--- a/quic/s2n-quic-core/src/stream/limits.rs
+++ b/quic/s2n-quic-core/src/stream/limits.rs
@@ -3,15 +3,19 @@ const DEFAULT_STREAM_MAX_SEND_BUFFER_SIZE: u32 = 64 * 1024;
 
 /// Per-stream limits
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-pub struct StreamLimits {
+pub struct Limits {
     /// The maximum send buffer size for a Stream
     pub max_send_buffer_size: u32,
 }
 
-impl Default for StreamLimits {
+impl Default for Limits {
     fn default() -> Self {
-        Self {
-            max_send_buffer_size: DEFAULT_STREAM_MAX_SEND_BUFFER_SIZE,
-        }
+        Self::RECOMMENDED
     }
+}
+
+impl Limits {
+    pub const RECOMMENDED: Self = Self {
+        max_send_buffer_size: DEFAULT_STREAM_MAX_SEND_BUFFER_SIZE,
+    };
 }

--- a/quic/s2n-quic-core/src/stream/mod.rs
+++ b/quic/s2n-quic-core/src/stream/mod.rs
@@ -1,8 +1,10 @@
 mod error;
 mod id;
+pub mod limits;
 pub mod ops;
 mod type_;
 
 pub use error::*;
 pub use id::*;
+pub use limits::Limits;
 pub use type_::*;

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -2,7 +2,7 @@
 
 use crate::{
     connection::{
-        self, id::ConnectionInfo, local_id_registry::LocalIdRegistrationError,
+        self, id::ConnectionInfo, limits::Limits, local_id_registry::LocalIdRegistrationError,
         CloseReason as ConnectionCloseReason, ConnectionIdMapper, ConnectionInterests,
         ConnectionTimerEntry, ConnectionTimers, ConnectionTransmission,
         ConnectionTransmissionContext, InternalConnectionId, Parameters as ConnectionParameters,
@@ -11,7 +11,7 @@ use crate::{
     contexts::ConnectionOnTransmitError,
     path,
     recovery::{congestion_controller, RTTEstimator},
-    space::{PacketSpace, EARLY_ACK_SETTINGS},
+    space::PacketSpace,
     transmission,
 };
 use core::time::Duration;
@@ -130,6 +130,8 @@ pub struct ConnectionImpl<Config: connection::Config> {
     //# of received packets that fail authentication during the lifetime of a
     //# connection.
     packet_decryption_failures: u64,
+    /// The limits applied to the current connection
+    limits: Limits,
 }
 
 #[cfg(debug_assertions)]
@@ -215,6 +217,7 @@ impl<ConfigType: connection::Config> ConnectionImpl<ConfigType> {
             &self.config,
             self.path_manager.active_path(),
             &mut self.local_id_registry,
+            &self.limits,
             datagram.timestamp,
         )?;
 
@@ -298,7 +301,7 @@ impl<Config: connection::Config> connection::Trait for ConnectionImpl<Config> {
     fn new(parameters: ConnectionParameters<Self::Config>) -> Self {
         // The path manager always starts with a single path containing the known peer and local
         // connection ids.
-        let rtt_estimator = RTTEstimator::new(EARLY_ACK_SETTINGS.max_ack_delay);
+        let rtt_estimator = RTTEstimator::new(parameters.limits.ack_settings().max_ack_delay);
         // Assume clients validate the server's address implicitly.
         let peer_validated = Self::Config::ENDPOINT_TYPE.is_server();
         let initial_path = path::Path::new(
@@ -323,6 +326,7 @@ impl<Config: connection::Config> connection::Trait for ConnectionImpl<Config> {
             state: ConnectionState::Handshaking,
             path_manager,
             packet_decryption_failures: 0,
+            limits: parameters.limits,
         }
     }
 
@@ -617,13 +621,16 @@ impl<Config: connection::Config> connection::Trait for ConnectionImpl<Config> {
     ) -> Result<path::Id, TransportError> {
         let is_handshake_confirmed = shared_state.space_manager.is_handshake_confirmed();
 
-        let (id, unblocked) =
-            self.path_manager
-                .on_datagram_received(datagram, is_handshake_confirmed, || {
-                    let path_info = congestion_controller::PathInfo::new(&datagram.remote_address);
-                    // TODO set alpn if available
-                    congestion_controller_endpoint.new_congestion_controller(path_info)
-                })?;
+        let (id, unblocked) = self.path_manager.on_datagram_received(
+            datagram,
+            &self.limits,
+            is_handshake_confirmed,
+            || {
+                let path_info = congestion_controller::PathInfo::new(&datagram.remote_address);
+                // TODO set alpn if available
+                congestion_controller_endpoint.new_congestion_controller(path_info)
+            },
+        )?;
 
         if unblocked {
             //= https://tools.ietf.org/id/draft-ietf-quic-recovery-32.txt#A.6

--- a/quic/s2n-quic-transport/src/connection/local_id_registry.rs
+++ b/quic/s2n-quic-transport/src/connection/local_id_registry.rs
@@ -3,8 +3,7 @@ use core::{cell::RefCell, convert::TryInto};
 use smallvec::SmallVec;
 
 use s2n_quic_core::{
-    ack_set::AckSet,
-    connection, frame,
+    ack, connection, frame,
     packet::number::PacketNumber,
     stateless_reset,
     time::{Duration, Timer, Timestamp},
@@ -491,7 +490,7 @@ impl LocalIdRegistry {
     }
 
     /// Activates connection IDs that were pending acknowledgement
-    pub fn on_packet_ack<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A) {
         for mut id_info in self.registered_ids.iter_mut() {
             if let PendingAcknowledgement(packet_number) = id_info.status {
                 if ack_set.contains(packet_number) {
@@ -505,7 +504,7 @@ impl LocalIdRegistry {
     }
 
     /// Moves connection IDs pending acknowledgement into pending reissue
-    pub fn on_packet_loss<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A) {
         for mut id_info in self.registered_ids.iter_mut() {
             if let PendingAcknowledgement(packet_number) = id_info.status {
                 if ack_set.contains(packet_number) {

--- a/quic/s2n-quic-transport/src/connection/peer_id_registry.rs
+++ b/quic/s2n-quic-transport/src/connection/peer_id_registry.rs
@@ -19,7 +19,7 @@ use crate::{
 use alloc::rc::Rc;
 use core::cell::RefCell;
 use s2n_quic_core::{
-    ack_set::AckSet, connection, frame, packet::number::PacketNumber, stateless_reset,
+    ack, connection, frame, packet::number::PacketNumber, stateless_reset,
     transport::error::TransportError,
 };
 use smallvec::SmallVec;
@@ -382,7 +382,7 @@ impl PeerIdRegistry {
     }
 
     /// Removes connection IDs that were pending acknowledgement
-    pub fn on_packet_ack<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A) {
         let mut mapper_state = self.state.borrow_mut();
 
         self.registered_ids.retain(|id_info| {
@@ -410,7 +410,7 @@ impl PeerIdRegistry {
 
     /// Sets the retransmit flag to true for connection IDs pending acknowledgement with a lost
     /// packet number
-    pub fn on_packet_loss<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A) {
         for id_info in self.registered_ids.iter_mut() {
             if let PendingAcknowledgement(packet_number) = id_info.status {
                 if ack_set.contains(packet_number) {

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -29,6 +29,8 @@ pub trait Config: Sized {
     type TokenFormat: s2n_quic_core::token::Format;
     /// The endpoint limits
     type EndpointLimits: endpoint::Limits;
+    /// The connection limits
+    type ConnectionLimits: connection::limits::Limiter;
 
     /// The type of the local endpoint
     const ENDPOINT_TYPE: endpoint::Type =
@@ -62,4 +64,6 @@ pub struct Context<'a, Cfg: Config> {
 
     /// Token generator / validator
     pub token: &'a mut Cfg::TokenFormat,
+
+    pub connection_limits: &'a mut Cfg::ConnectionLimits,
 }

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -648,6 +648,7 @@ pub mod testing {
         type StatelessResetTokenGenerator = stateless_reset::token::testing::Generator;
         type RandomGenerator = random::testing::Generator;
         type TokenFormat = s2n_quic_core::token::testing::Format;
+        type ConnectionLimits = s2n_quic_core::connection::limits::Limits;
 
         fn create_connection_config(&mut self) -> Self::ConnectionConfig {
             todo!()
@@ -671,6 +672,7 @@ pub mod testing {
         type StatelessResetTokenGenerator = stateless_reset::token::testing::Generator;
         type RandomGenerator = random::testing::Generator;
         type TokenFormat = s2n_quic_core::token::testing::Format;
+        type ConnectionLimits = s2n_quic_core::connection::limits::Limits;
 
         fn create_connection_config(&mut self) -> Self::ConnectionConfig {
             todo!()

--- a/quic/s2n-quic-transport/src/space/crypto_stream.rs
+++ b/quic/s2n-quic-transport/src/space/crypto_stream.rs
@@ -5,7 +5,7 @@ use crate::{
     transmission,
 };
 use s2n_quic_core::{
-    ack_set::AckSet,
+    ack,
     frame::{crypto::CryptoRef, MaxPayloadSizeForFrame},
     packet::number::PacketNumber,
     transport::error::TransportError,
@@ -150,12 +150,12 @@ impl CryptoStream {
     }
 
     /// This method gets called when a packet delivery got acknowledged
-    pub fn on_packet_ack<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A) {
         self.tx.on_packet_ack(ack_set);
     }
 
     /// This method gets called when a packet loss is reported
-    pub fn on_packet_loss<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A) {
         self.tx.on_packet_loss(ack_set);
     }
 }

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_eliciting_transmission.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_eliciting_transmission.rs
@@ -1,5 +1,5 @@
 use core::ops::RangeInclusive;
-use s2n_quic_core::{ack_set::AckSet, packet::number::PacketNumber};
+use s2n_quic_core::{ack, packet::number::PacketNumber};
 
 pub type AckRange = RangeInclusive<PacketNumber>;
 
@@ -32,7 +32,7 @@ impl AckElicitingTransmissionSet {
     }
 
     /// Called when a set of packets was acknowledged or lost
-    pub fn on_update<A: AckSet>(&mut self, ack_set: &A) -> Option<AckRange> {
+    pub fn on_update<A: ack::Set>(&mut self, ack_set: &A) -> Option<AckRange> {
         if let Some(ack_range) = self
             .latest
             .as_ref()
@@ -73,7 +73,7 @@ pub struct AckElicitingTransmission {
 
 impl AckElicitingTransmission {
     /// Called when a set of packets was acknowledged or lost
-    pub fn ack_range<A: AckSet>(&self, ack_set: &A) -> Option<AckRange> {
+    pub fn ack_range<A: ack::Set>(&self, ack_set: &A) -> Option<AckRange> {
         //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#13.2.4
         //# When a packet containing an
         //# ACK frame is acknowledged, the receiver can stop acknowledging

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_ranges.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_ranges.rs
@@ -4,18 +4,16 @@ use core::{
     num::NonZeroUsize,
     ops::{Deref, DerefMut, RangeInclusive},
 };
-use s2n_quic_core::{frame::ack, packet::number::PacketNumber, varint::VarInt};
+use s2n_quic_core::{ack::Settings, frame::ack, packet::number::PacketNumber, varint::VarInt};
 
 #[derive(Clone, Debug)]
 pub struct AckRanges(IntervalSet<PacketNumber>);
 
 impl Default for AckRanges {
     fn default() -> Self {
-        Self::new(DEFAULT_ACK_RANGES_LIMIT)
+        Self::new(Settings::default().ack_ranges_limit as usize)
     }
 }
-
-pub const DEFAULT_ACK_RANGES_LIMIT: usize = 10;
 
 impl AckRanges {
     pub fn new(limit: usize) -> Self {

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/mod.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/mod.rs
@@ -4,7 +4,6 @@ pub(crate) mod ack_ranges;
 mod ack_transmission_state;
 
 pub use ack_manager::*;
-pub use ack_ranges::DEFAULT_ACK_RANGES_LIMIT;
 
 #[cfg(test)]
 mod tests;

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/tests/endpoint.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/tests/endpoint.rs
@@ -1,18 +1,15 @@
 use super::{generator::gen_ack_settings, Packet, TestEnvironment};
 use crate::{
-    contexts::WriteContext,
-    processed_packet::ProcessedPacket,
-    space::rx_packet_numbers::{ack_manager::AckManager, ack_ranges::DEFAULT_ACK_RANGES_LIMIT},
-    transmission::interest::Provider,
+    contexts::WriteContext, processed_packet::ProcessedPacket,
+    space::rx_packet_numbers::ack_manager::AckManager, transmission::interest::Provider,
 };
 use bolero::generator::*;
 use s2n_quic_core::{
-    connection, endpoint,
+    ack, connection, endpoint,
     frame::{ack_elicitation::AckElicitation, Ack, Frame, Ping},
     inet::DatagramInfo,
     packet::number::PacketNumberSpace,
     time::Timestamp,
-    transport::parameters::AckSettings,
 };
 
 #[derive(Clone, Debug, TypeGenerator)]
@@ -24,16 +21,12 @@ pub struct Endpoint {
     pub ack_manager: AckManager,
 }
 
-fn new_ack_manager(ack_settings: AckSettings) -> AckManager {
-    AckManager::new(
-        PacketNumberSpace::ApplicationData,
-        ack_settings,
-        DEFAULT_ACK_RANGES_LIMIT,
-    )
+fn new_ack_manager(ack_settings: ack::Settings) -> AckManager {
+    AckManager::new(PacketNumberSpace::ApplicationData, ack_settings)
 }
 
 impl Endpoint {
-    pub fn new(ack_settings: AckSettings) -> Self {
+    pub fn new(ack_settings: ack::Settings) -> Self {
         Self {
             env: TestEnvironment::new(),
             ack_manager: new_ack_manager(ack_settings),

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/tests/generator.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/tests/generator.rs
@@ -1,11 +1,12 @@
 use bolero::generator::*;
 use core::time::Duration;
-use s2n_quic_core::{inet::ExplicitCongestionNotification, transport::parameters::AckSettings};
+use s2n_quic_core::{ack, inet::ExplicitCongestionNotification};
 
-pub fn gen_ack_settings() -> impl ValueGenerator<Output = AckSettings> {
-    (gen_duration(), 0..20).map(|(max_ack_delay, ack_delay_exponent)| AckSettings {
+pub fn gen_ack_settings() -> impl ValueGenerator<Output = ack::Settings> {
+    (gen_duration(), 0..20).map(|(max_ack_delay, ack_delay_exponent)| ack::Settings {
         max_ack_delay,
         ack_delay_exponent,
+        ..Default::default()
     })
 }
 

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/tests/mod.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/tests/mod.rs
@@ -43,7 +43,7 @@ pub use simulation::*;
 #[test]
 fn simulation_harness_test() {
     use core::time::Duration;
-    use s2n_quic_core::transport::parameters::AckSettings;
+    use s2n_quic_core::ack;
 
     let client_transmissions = 100;
     let server_transmissions = 10;
@@ -51,9 +51,10 @@ fn simulation_harness_test() {
     let mut simulation = Simulation {
         network: Network {
             client: Application::new(
-                Endpoint::new(AckSettings {
+                Endpoint::new(ack::Settings {
                     max_ack_delay: Duration::from_millis(25),
                     ack_delay_exponent: 1,
+                    ..Default::default()
                 }),
                 // send an ack-eliciting packet every 5ms, 100 times
                 [Duration::from_millis(5)]
@@ -64,9 +65,10 @@ fn simulation_harness_test() {
             )
             .into(),
             server: Application::new(
-                Endpoint::new(AckSettings {
+                Endpoint::new(ack::Settings {
                     max_ack_delay: Duration::from_millis(25),
                     ack_delay_exponent: 1,
+                    ..Default::default()
                 }),
                 // send an ack-eliciting packet every 800ms, 10 times
                 [Duration::from_millis(800)]

--- a/quic/s2n-quic-transport/src/space/tx_packet_numbers.rs
+++ b/quic/s2n-quic-transport/src/space/tx_packet_numbers.rs
@@ -1,5 +1,5 @@
 use s2n_quic_core::{
-    ack_set::AckSet,
+    ack,
     inet::DatagramInfo,
     packet::number::{PacketNumber, PacketNumberSpace},
     time::Timestamp,
@@ -24,7 +24,7 @@ impl TxPacketNumbers {
     }
 
     /// This method gets called when a packet delivery got acknowledged
-    pub fn on_packet_ack<A: AckSet>(
+    pub fn on_packet_ack<A: ack::Set>(
         &mut self,
         datagram: &DatagramInfo,
         ack_set: &A,

--- a/quic/s2n-quic-transport/src/stream/incoming_connection_flow_controller.rs
+++ b/quic/s2n-quic-transport/src/stream/incoming_connection_flow_controller.rs
@@ -8,7 +8,7 @@ use crate::{
 use alloc::rc::Rc;
 use core::cell::RefCell;
 use s2n_quic_core::{
-    ack_set::AckSet, frame::max_data::MaxData, packet::number::PacketNumber, stream::StreamId,
+    ack, frame::max_data::MaxData, packet::number::PacketNumber, stream::StreamId,
     transport::error::TransportError, varint::VarInt,
 };
 
@@ -99,11 +99,11 @@ impl IncomingConnectionFlowControllerImpl {
         Ok(())
     }
 
-    pub fn on_packet_ack<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A) {
         self.read_window_sync.on_packet_ack(ack_set)
     }
 
-    pub fn on_packet_loss<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A) {
         self.read_window_sync.on_packet_loss(ack_set)
     }
 
@@ -159,12 +159,12 @@ impl IncomingConnectionFlowController {
     }
 
     /// This method gets called when a packet delivery got acknowledged
-    pub fn on_packet_ack<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A) {
         self.inner.borrow_mut().on_packet_ack(ack_set)
     }
 
     /// This method gets called when a packet loss is reported
-    pub fn on_packet_loss<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A) {
         self.inner.borrow_mut().on_packet_loss(ack_set)
     }
 

--- a/quic/s2n-quic-transport/src/stream/mod.rs
+++ b/quic/s2n-quic-transport/src/stream/mod.rs
@@ -2,7 +2,6 @@
 
 mod api;
 mod incoming_connection_flow_controller;
-mod limits;
 mod outgoing_connection_flow_controller;
 mod receive_stream;
 mod send_stream;
@@ -16,7 +15,7 @@ mod stream_manager;
 pub(crate) mod contract;
 
 pub use api::*;
-pub use limits::StreamLimits;
+pub use s2n_quic_core::stream::limits::Limits;
 pub use stream_events::StreamEvents;
 pub use stream_impl::{StreamImpl, StreamTrait};
 pub use stream_manager::AbstractStreamManager;

--- a/quic/s2n-quic-transport/src/stream/receive_stream.rs
+++ b/quic/s2n-quic-transport/src/stream/receive_stream.rs
@@ -15,7 +15,7 @@ use core::{
     task::{Context, Waker},
 };
 use s2n_quic_core::{
-    ack_set::AckSet,
+    ack,
     application::ApplicationErrorCode,
     frame::{stream::StreamRef, MaxStreamData, ResetStream, StopSending, StreamDataBlocked},
     packet::number::PacketNumber,
@@ -620,14 +620,14 @@ impl ReceiveStream {
     }
 
     /// This method gets called when a packet delivery got acknowledged
-    pub fn on_packet_ack<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A) {
         self.flow_controller.read_window_sync.on_packet_ack(ack_set);
 
         self.stop_sending_sync.on_packet_ack(ack_set);
     }
 
     /// This method gets called when a packet loss is reported
-    pub fn on_packet_loss<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A) {
         self.flow_controller
             .read_window_sync
             .on_packet_loss(ack_set);

--- a/quic/s2n-quic-transport/src/stream/send_stream.rs
+++ b/quic/s2n-quic-transport/src/stream/send_stream.rs
@@ -18,7 +18,7 @@ use core::{
     task::{Context, Waker},
 };
 use s2n_quic_core::{
-    ack_set::AckSet,
+    ack,
     application::ApplicationErrorCode,
     frame::{stream::StreamRef, MaxPayloadSizeForFrame, MaxStreamData, ResetStream, StopSending},
     packet::number::PacketNumber,
@@ -524,7 +524,7 @@ impl SendStream {
     }
 
     /// This method gets called when a packet delivery got acknowledged
-    pub fn on_packet_ack<A: AckSet>(&mut self, ack_set: &A, events: &mut StreamEvents) {
+    pub fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A, events: &mut StreamEvents) {
         self.data_sender.on_packet_ack(ack_set);
 
         let should_flush = self.write_waiter.as_ref().map_or(false, |w| w.1);
@@ -577,7 +577,7 @@ impl SendStream {
     }
 
     /// This method gets called when a packet loss is reported
-    pub fn on_packet_loss<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A) {
         self.data_sender.on_packet_loss(ack_set);
         self.reset_sync.on_packet_loss(ack_set);
     }

--- a/quic/s2n-quic-transport/src/stream/stream_impl.rs
+++ b/quic/s2n-quic-transport/src/stream/stream_impl.rs
@@ -12,8 +12,7 @@ use crate::{
 };
 use core::task::Context;
 use s2n_quic_core::{
-    ack_set::AckSet,
-    endpoint,
+    ack, endpoint,
     frame::{stream::StreamRef, MaxStreamData, ResetStream, StopSending, StreamDataBlocked},
     stream::{ops, StreamId},
     transport::error::TransportError,
@@ -91,10 +90,10 @@ pub trait StreamTrait: StreamInterestProvider {
     ) -> Result<(), TransportError>;
 
     /// This method gets called when a packet delivery got acknowledged
-    fn on_packet_ack<A: AckSet>(&mut self, ack_set: &A, events: &mut StreamEvents);
+    fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A, events: &mut StreamEvents);
 
     /// This method gets called when a packet loss is reported
-    fn on_packet_loss<A: AckSet>(&mut self, ack_set: &A, events: &mut StreamEvents);
+    fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A, events: &mut StreamEvents);
 
     /// This method gets called when a stream gets reset due to a reason that is
     /// not related to a frame. E.g. due to a connection failure.
@@ -214,12 +213,12 @@ impl StreamTrait for StreamImpl {
         self.send_stream.on_stop_sending(frame, events)
     }
 
-    fn on_packet_ack<A: AckSet>(&mut self, ack_set: &A, events: &mut StreamEvents) {
+    fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A, events: &mut StreamEvents) {
         self.receive_stream.on_packet_ack(ack_set);
         self.send_stream.on_packet_ack(ack_set, events);
     }
 
-    fn on_packet_loss<A: AckSet>(&mut self, ack_set: &A, _events: &mut StreamEvents) {
+    fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A, _events: &mut StreamEvents) {
         self.receive_stream.on_packet_loss(ack_set);
         self.send_stream.on_packet_loss(ack_set);
     }

--- a/quic/s2n-quic-transport/src/stream/tests/stream_managers_tests.rs
+++ b/quic/s2n-quic-transport/src/stream/tests/stream_managers_tests.rs
@@ -11,7 +11,7 @@ use crate::{
     stream::{
         stream_impl::StreamConfig,
         stream_interests::{StreamInterestProvider, StreamInterests},
-        AbstractStreamManager, StreamError, StreamEvents, StreamLimits, StreamTrait,
+        AbstractStreamManager, StreamError, StreamEvents, StreamTrait,
     },
     transmission,
     transmission::interest::Provider as TransmissionInterestProvider,
@@ -22,7 +22,7 @@ use bytes::Bytes;
 use core::task::{Context, Poll, Waker};
 use futures_test::task::new_count_waker;
 use s2n_quic_core::{
-    ack_set::AckSet,
+    ack::Set as AckSet,
     application::ApplicationErrorCode,
     connection,
     frame::{
@@ -339,12 +339,9 @@ fn create_stream_manager(local_ep_type: endpoint::Type) -> AbstractStreamManager
     let initial_local_limits = create_default_initial_flow_control_limits();
     let initial_peer_limits = create_default_initial_flow_control_limits();
 
-    let limits = ConnectionLimits {
-        stream_limits: StreamLimits {
-            max_send_buffer_size: 4096,
-        },
-        ..Default::default()
-    };
+    let limits = ConnectionLimits::default()
+        .with_max_send_buffer_size(4096)
+        .unwrap();
 
     AbstractStreamManager::<MockStream>::new(
         &limits,

--- a/quic/s2n-quic-transport/src/sync/data_sender.rs
+++ b/quic/s2n-quic-transport/src/sync/data_sender.rs
@@ -5,7 +5,7 @@ use crate::{
 use alloc::collections::VecDeque;
 use bytes::{Buf, Bytes};
 use s2n_quic_core::{
-    ack_set::AckSet, frame::MaxPayloadSizeForFrame, packet::number::PacketNumber, varint::VarInt,
+    ack, frame::MaxPayloadSizeForFrame, packet::number::PacketNumber, varint::VarInt,
 };
 
 /// Manages the outgoing flow control window for a sending data on a particular
@@ -371,7 +371,7 @@ impl<
     }
 
     /// This method gets called when a packet delivery got acknowledged
-    pub fn on_packet_ack<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A) {
         // This flag is just an optimization. If we do not get acknowledgements
         // for data at the head of the queue, we not need to dequeue data.
         let mut check_released = false;
@@ -444,7 +444,7 @@ impl<
     }
 
     /// This method gets called when a packet loss is reported
-    pub fn on_packet_loss<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A) {
         for chunk in self.tracking.iter_mut() {
             if let ChunkTransmissionState::InFlight(inflight_packet_nr) = chunk.state {
                 if ack_set.contains(inflight_packet_nr) {

--- a/quic/s2n-quic-transport/src/sync/flag.rs
+++ b/quic/s2n-quic-transport/src/sync/flag.rs
@@ -9,7 +9,7 @@ use crate::{
     contexts::{OnTransmitError, WriteContext},
     transmission,
 };
-use s2n_quic_core::{ack_set::AckSet, packet::number::PacketNumber};
+use s2n_quic_core::{ack, packet::number::PacketNumber};
 
 #[derive(Debug, Default)]
 pub struct Flag<W: Writer> {
@@ -85,7 +85,7 @@ impl<W: Writer> Flag<W> {
     }
 
     /// This method gets called when a packet delivery got acknowledged
-    pub fn on_packet_ack<A: AckSet>(&mut self, ack_set: &A) -> bool {
+    pub fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A) -> bool {
         if let DeliveryState::InFlight { stable, latest } = &self.delivery {
             if ack_set.contains(*stable) || ack_set.contains(*latest) {
                 self.finish();
@@ -97,7 +97,7 @@ impl<W: Writer> Flag<W> {
     }
 
     /// This method gets called when a packet loss is reported
-    pub fn on_packet_loss<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A) {
         if let DeliveryState::InFlight { stable, latest } = &mut self.delivery {
             // If stable is lost, fall back on latest
             if ack_set.contains(*stable) {

--- a/quic/s2n-quic-transport/src/sync/incremental_value_sync.rs
+++ b/quic/s2n-quic-transport/src/sync/incremental_value_sync.rs
@@ -5,7 +5,7 @@ use crate::{
     sync::{DeliveryState, InFlightDelivery, InflightPacketInfo, ValueToFrameWriter},
     transmission,
 };
-use s2n_quic_core::{ack_set::AckSet, stream::StreamId};
+use s2n_quic_core::{ack, stream::StreamId};
 
 /// Synchronizes a strictly increasing value of type `T` towards the remote peer.
 ///
@@ -122,7 +122,7 @@ impl<
     }
 
     /// This method gets called when a packet delivery got acknowledged
-    pub fn on_packet_ack<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A) {
         // If the frame gets acknowledged, remove the in_flight information
         if let DeliveryState::InFlight(in_flight) = self.delivery {
             if ack_set.contains(in_flight.packet.packet_nr) {
@@ -136,7 +136,7 @@ impl<
     }
 
     /// This method gets called when a packet loss is reported
-    pub fn on_packet_loss<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A) {
         // If the frame was lost, remove the in_flight information.
         // This will trigger resending it.
         if let DeliveryState::InFlight(in_flight) = self.delivery {

--- a/quic/s2n-quic-transport/src/sync/once_sync.rs
+++ b/quic/s2n-quic-transport/src/sync/once_sync.rs
@@ -5,7 +5,7 @@ use crate::{
     sync::{DeliveryState, InFlightDelivery, InflightPacketInfo, ValueToFrameWriter},
     transmission,
 };
-use s2n_quic_core::{ack_set::AckSet, stream::StreamId};
+use s2n_quic_core::{ack, stream::StreamId};
 
 /// Synchronizes a value of type `T` exactly once towards the remote peer.
 ///
@@ -65,7 +65,7 @@ impl<T: Copy + Clone + Eq + PartialEq, S: ValueToFrameWriter<T>> OnceSync<T, S> 
     }
 
     /// This method gets called when a packet delivery got acknowledged
-    pub fn on_packet_ack<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A) {
         // If the packet containing the frame gets acknowledged, mark the delivery as
         // succeeded.
         if let DeliveryState::InFlight(in_flight) = self.delivery {
@@ -76,7 +76,7 @@ impl<T: Copy + Clone + Eq + PartialEq, S: ValueToFrameWriter<T>> OnceSync<T, S> 
     }
 
     /// This method gets called when a packet loss is reported
-    pub fn on_packet_loss<A: AckSet>(&mut self, ack_set: &A) {
+    pub fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A) {
         // If the packet containing the frame was lost, remove the in_flight information.
         // This will trigger resending it.
         if let DeliveryState::InFlight(in_flight) = self.delivery {

--- a/quic/s2n-quic/src/provider/limits.rs
+++ b/quic/s2n-quic/src/provider/limits.rs
@@ -1,6 +1,8 @@
+pub use s2n_quic_core::connection::limits::{ConnectionInfo, Limiter, Limits};
+
 /// Provides limits support for an endpoint
 pub trait Provider {
-    type Limits: 'static + Send;
+    type Limits: 'static + Send + Limiter;
     type Error: 'static + core::fmt::Display;
 
     fn start(self) -> Result<Self::Limits, Self::Error>;
@@ -15,12 +17,11 @@ pub mod default {
     pub struct Provider;
 
     impl super::Provider for Provider {
-        type Limits = (); // TODO
+        type Limits = super::Limits;
         type Error = core::convert::Infallible;
 
         fn start(self) -> Result<Self::Limits, Self::Error> {
-            // TODO
-            Ok(())
+            Ok(Self::Limits::default())
         }
     }
 }


### PR DESCRIPTION
### Changes

* Added a `s2n_quic_core::connection::limits` module with a provider trait that returns limits for a connection
* Moved `s2n_quic_core::ack_set` to `s2n_quic_core::ack::set`
* Moved `s2n_quic_core::transport::parameters::AckSettings` to `s2n_quic_core::ack::settings`
* Added `RECOMMENDED` associated const on several transport parameters that are used for limit defaults
* General cleanup of transport parameters
* Wired up the stream manager, ack manager, path manager to use the new limits values.

### Interop

Before and after:

![2021-02-16-194820_335x787_scrot](https://user-images.githubusercontent.com/799311/108153410-f51ec200-708f-11eb-9e54-8c4b38623c7a.png) ![2021-02-16-195015_333x784_scrot](https://user-images.githubusercontent.com/799311/108153539-3a42f400-7090-11eb-8604-c0cb3edf0a74.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
