### PR TITLE
Test the effect of disabling retiring handshake connection IDs on interop

### DIFF
--- a/quic/s2n-quic-transport/src/connection/local_id_registry.rs
+++ b/quic/s2n-quic-transport/src/connection/local_id_registry.rs
@@ -516,6 +516,7 @@ impl LocalIdRegistry {
 
     /// Retires the connection id used during the handshake
     pub fn retire_handshake_connection_id(&mut self, timestamp: Timestamp) {
+        return;
         if let Some(handshake_id_info) = self
             .registered_ids
             .iter_mut()


### PR DESCRIPTION
Not for commiting, testing the effect of disabling the automatic retirement of the handshake connection ID after handshake connection on the interop tests

Result:
<img width="373" alt="Screen Shot 2021-02-19 at 3 01 26 PM" src="https://user-images.githubusercontent.com/55108558/108570854-ae191280-72c3-11eb-84e5-1619cac0a476.png">

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

