### PR TITLE
core: optimize hot path encoding size estimators

### DIFF
--- a/quic/s2n-quic-core/tests/frame/fuzz_target.rs
+++ b/quic/s2n-quic-core/tests/frame/fuzz_target.rs
@@ -1,10 +1,18 @@
 use bolero::check;
-use s2n_codec::assert_codec_round_trip_bytes_mut;
+use s2n_codec::{assert_codec_round_trip_bytes_mut, Encoder, EncoderLenEstimator, EncoderValue};
 use s2n_quic_core::frame::FrameRef;
 
 fn main() {
     check!().for_each(|input| {
         let mut input = input.to_vec();
-        assert_codec_round_trip_bytes_mut!(FrameRef, &mut input);
+        let frames = assert_codec_round_trip_bytes_mut!(FrameRef, &mut input);
+
+        for frame in frames {
+            // make sure the frames encoding size matches what would actually
+            // be written to an encoder
+            let mut estimator = EncoderLenEstimator::new(core::usize::MAX);
+            frame.encode(&mut estimator);
+            assert_eq!(frame.encoding_size(), estimator.len());
+        }
     });
 }


### PR DESCRIPTION
I've added an optimized version of `EncoderValue::encoding_size` for `VarInt` and `Stream`, since those are in the critical path.

I've also added `#[track_caller]` on the ops impls for VarInt so stack traces are a little easier to follow.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
