### PR TITLE
transport: optimize local-id-registry transmission interests

### DIFF
--- a/quic/s2n-quic-transport/src/connection/local_id_registry.rs
+++ b/quic/s2n-quic-transport/src/connection/local_id_registry.rs
@@ -609,25 +609,17 @@ impl LocalIdRegistry {
 
 impl crate::transmission::interest::Provider for LocalIdRegistry {
     fn transmission_interest(&self) -> crate::transmission::Interest {
-        let has_ids_pending_reissue = self
-            .registered_ids
-            .iter()
-            .any(|id_info| id_info.status == PendingReissue);
+        let mut interest = crate::transmission::Interest::None;
 
-        if has_ids_pending_reissue {
-            return crate::transmission::Interest::LostData;
+        for id_info in self.registered_ids.iter() {
+            match id_info.status {
+                PendingReissue => return crate::transmission::Interest::LostData,
+                PendingIssuance => interest = crate::transmission::Interest::NewData,
+                _ => {}
+            }
         }
 
-        let has_ids_pending_issuance = self
-            .registered_ids
-            .iter()
-            .any(|id_info| id_info.status == PendingIssuance);
-
-        if has_ids_pending_issuance {
-            crate::transmission::Interest::NewData
-        } else {
-            crate::transmission::Interest::None
-        }
+        interest
     }
 }
 


### PR DESCRIPTION
The current implementation iterates over the list twice. The new one just does it once and bails if any need retransmission.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
