### PR TITLE
Fix github event syntax

### DIFF
--- a/.github/workflows/interop.yml
+++ b/.github/workflows/interop.yml
@@ -282,7 +282,7 @@ jobs:
               web/logs/latest/result.json
 
       - name: Generate report for push to main
-        if: github.event.push
+        if: github.event_name == 'push'
         run: |
           mkdir -p web/logs/latest
           python3 .github/interop/merge.py \


### PR DESCRIPTION
Interop report generation was failing on the push to main, because the "Generate report for push to main" step was getting skipped. This should correct that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.