### PR TITLE
perf: add connection limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -412,6 +412,12 @@ jobs:
           toolchain: stable
           override: true
 
+      - uses: camshaft/gha-perf@v0.1
+
+      - name: Setup perf
+        run: |
+          sudo sh -c 'echo -1 >/proc/sys/kernel/perf_event_paranoid'
+
       - uses: camshaft/rust-cache@v1
         with:
           key: ${{ matrix.script }}
@@ -420,12 +426,13 @@ jobs:
         uses: camshaft/install@v1
         with:
           crate: inferno
+          bins: inferno-collapse-perf,inferno-flamegraph
 
       - name: Build
         run: ./scripts/${{ matrix.script }}-perf/build
 
       - name: Run script
-        run: ./scripts/${{ matrix.script }}-perf/run
+        run: sudo env "PATH=$PATH" ./scripts/${{ matrix.script }}-perf/test
 
       - uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/scripts/server-perf/client/src/main.rs
+++ b/scripts/server-perf/client/src/main.rs
@@ -76,5 +76,10 @@ async fn client(
         Byte::from(bytes_per_sec as u64).get_appropriate_unit(true)
     );
 
+    connection.close(0u16.into(), b"bye");
+
+    // wait until the connection is fully closed
+    endpoint.wait_idle().await;
+
     Ok(())
 }

--- a/scripts/server-perf/run
+++ b/scripts/server-perf/run
@@ -2,58 +2,6 @@
 
 set -e
 
-SIZE=${1:-1G}
-
-DIR=$(mktemp -d -t s2n-quic-perf-XXXXXXXXXX)
-
 ./scripts/server-perf/build
 
-mkdir -p ./target/perf
-
-sudo echo "starting"
-
-sudo sh -c "perf record \
-  --output $DIR/$SIZE.perf \
-  --call-graph dwarf \
- ./target/release/s2n-quic-qns \
-  perf \
-  server \
-  --port 4433" &
-SUDO_PID=$!
-
-function stop_server() {
-  SHELL_PID=$(ps --ppid $SUDO_PID -o pid=)
-  PERF_PID=$(ps --ppid $SHELL_PID -o pid=)
-  sudo kill -SIGINT $PERF_PID
-
-  wait $SUDO_PID || true
-  if [ ! -z "$1" ]; then
-    echo $1
-    exit 1
-  fi
-}
-
-echo "waiting for server to boot"
-sleep 3
-
-echo "executing request"
-./scripts/server-perf/client/target/release/perf-client \
-  https://localhost:4433 --download $SIZE || stop_server "failed to finish the request"
-
-sleep 1
-stop_server
-
-sudo perf script \
-  --input $DIR/$SIZE.perf \
-  2>/dev/null \
-  | inferno-collapse-perf \
-  > $DIR/$SIZE.folded
-
-cat $DIR/$SIZE.folded \
-  | inferno-flamegraph \
-  > ./target/perf/$SIZE.svg
-
-sudo rm -f $DIR/$SIZE.perf
-sudo rm -f $DIR/$SIZE.folded
-
-echo "flamegraph available in ./target/perf/$SIZE.svg"
+sudo env "PATH=$PATH" ./scripts/server-perf/test $@

--- a/scripts/server-perf/test
+++ b/scripts/server-perf/test
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -e
+
+SIZE=${1:-1G}
+
+DIR=$(mktemp -d -t s2n-quic-perf-XXXXXXXXXX)
+
+mkdir -p ./target/perf
+
+perf record \
+  --output $DIR/$SIZE.perf \
+  --call-graph dwarf \
+  --event cycles \
+  -- \
+  ./target/release/s2n-quic-qns \
+  perf \
+  server \
+  --connections 1 \
+  --port 4433 &
+PERF_PID=$!
+
+function stop_server() {
+  echo "shutting down server"
+  kill $PERF_PID
+  echo $1
+  exit 1
+}
+
+echo "waiting for server to boot"
+sleep 3
+
+echo "executing request"
+./scripts/server-perf/client/target/release/perf-client \
+  https://localhost:4433 --download $SIZE || stop_server "failed to finish the request"
+
+echo "waiting for server to shut down"
+wait $PERF_PID
+
+echo "folding events"
+perf script \
+  --input $DIR/$SIZE.perf \
+  2>/dev/null \
+  | inferno-collapse-perf \
+  > $DIR/$SIZE.folded
+
+echo "generating flamegraph"
+inferno-flamegraph $DIR/$SIZE.folded \
+  --title $SIZE \
+  > ./target/perf/$SIZE.svg
+
+rm -rf $DIR
+
+echo "flamegraph available in ./target/perf/$SIZE.svg"


### PR DESCRIPTION
This adds a connection limit to the perf script for clean shutdown. I've also pulled in a static build of perf which runs _much_ faster now.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
