### PR TITLE
core: add try_fit functions to crypto and stream frames

### DIFF
--- a/quic/s2n-quic-core/src/frame/mod.rs
+++ b/quic/s2n-quic-core/src/frame/mod.rs
@@ -1,5 +1,6 @@
 #![forbid(unsafe_code)]
 
+use core::fmt;
 use s2n_codec::{
     DecoderBuffer, DecoderBufferMut, DecoderBufferMutResult, DecoderError,
     DecoderParameterizedValueMut, DecoderValueMut, Encoder, EncoderValue,
@@ -217,4 +218,14 @@ pub struct MaxPayloadSizeForFrame {
     /// The maximum amount of payload data which can be stored in a frame,
     /// even if the frame carries explicit length information.
     pub max_payload_in_all_frames: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+/// Indicates the packet will not fit into the provided capacity
+pub struct FitError;
+
+impl fmt::Display for FitError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "the frame could not fit into the provided capacity")
+    }
 }

--- a/quic/s2n-quic-core/src/frame/padding.rs
+++ b/quic/s2n-quic-core/src/frame/padding.rs
@@ -62,8 +62,6 @@ decoder_parameterized_value!(
 
 impl EncoderValue for Padding {
     fn encode<E: Encoder>(&self, encoder: &mut E) {
-        // Padding will flex based on the available bytes in the encoder
-        let len = encoder.remaining_capacity().min(self.length);
-        encoder.write_repeated(len, 0)
+        encoder.write_repeated(self.length, 0)
     }
 }

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__crypto__tests__max_frame_size_snapshot.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__crypto__tests__max_frame_size_snapshot.snap
@@ -1,5 +1,0 @@
----
-source: quic/s2n-quic-core/src/frame/crypto.rs
-expression: "CryptoRef::get_max_frame_size(16)"
----
-29

--- a/quic/s2n-quic-core/src/stream/testing.rs
+++ b/quic/s2n-quic-core/src/stream/testing.rs
@@ -1,7 +1,11 @@
 //! A model that ensures stream data is correctly sent and received between peers
 
 #[cfg(feature = "generator")]
-use bolero_generator::{constant, TypeGenerator};
+use bolero_generator::*;
+
+#[cfg(test)]
+use bolero::generator::*;
+
 use bytes::Bytes;
 
 static DATA: Bytes = {
@@ -23,11 +27,11 @@ const DEFAULT_STREAM_LEN: u64 = 1024;
 const DATA_MOD: usize = 256; // Only the first 256 offsets of DATA are unique
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord)]
-#[cfg_attr(feature = "generator", derive(TypeGenerator))]
+#[cfg_attr(any(feature = "generator", test), derive(TypeGenerator))]
 pub struct Data {
-    #[cfg_attr(feature = "generator", generator(0..=DEFAULT_STREAM_LEN))]
+    #[cfg_attr(any(feature = "generator", test), generator(0..=DEFAULT_STREAM_LEN))]
     len: u64,
-    #[cfg_attr(feature = "generator", generator(constant(0)))]
+    #[cfg_attr(any(feature = "generator", test), generator(constant(0)))]
     offset: u64,
 }
 

--- a/quic/s2n-quic-core/src/varint/mod.rs
+++ b/quic/s2n-quic-core/src/varint/mod.rs
@@ -7,6 +7,9 @@ use s2n_codec::{decoder_value, Encoder, EncoderValue};
 #[cfg(feature = "generator")]
 use bolero_generator::*;
 
+#[cfg(test)]
+use bolero::generator::*;
+
 //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#16
 //# QUIC packets and frames commonly use a variable-length encoding for
 //# non-negative integer values.  This encoding ensures that smaller
@@ -152,8 +155,10 @@ mod tests {
 // === API ===
 
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
-#[cfg_attr(feature = "generator", derive(TypeGenerator))]
-pub struct VarInt(#[cfg_attr(feature = "generator", generator(0..=MAX_VARINT_VALUE))] u64);
+#[cfg_attr(any(feature = "generator", test), derive(TypeGenerator))]
+pub struct VarInt(
+    #[cfg_attr(any(feature = "generator", test), generator(0..=MAX_VARINT_VALUE))] u64,
+);
 
 impl core::fmt::Display for VarInt {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {


### PR DESCRIPTION
Crypto and Stream frames need to efficiently calculate the size of the frame encoding for a given packet capacity.

This change adds a `try_fit` method that will be used by the data sender component to do so. These new methods will be used over `max_payload_size` in a later PR.

I've added bolero tests for both with a model to ensure the output is optimal for all generated scenarios (different offsets, payload lengths, capacities, etc)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
