### PR TITLE
transport: add Interval::set_len

### DIFF
--- a/quic/s2n-quic-transport/src/interval_set/insert.rs
+++ b/quic/s2n-quic-transport/src/interval_set/insert.rs
@@ -212,15 +212,16 @@ impl Insertion {
             }
         };
 
-        if replace_range.start > replace_range.end {
+        let index = replace_range.start;
+        let replace_count = if let Some(count) = replace_range.end.checked_sub(index) {
+            count
+        } else {
             ensure_can_insert()?;
 
+            // add it to the end
             ranges.push_back(range);
             return Ok(prev_len);
-        }
-
-        let replace_count = replace_range.end - replace_range.start;
-        let index = replace_range.start;
+        };
 
         match replace_count {
             0 => {
@@ -231,8 +232,8 @@ impl Insertion {
                 ranges[index] = range;
             }
             2 => {
-                ranges.remove(index);
                 ranges[index] = range;
+                ranges.remove(index + 1);
             }
             _ => {
                 ranges[index] = range;

--- a/quic/s2n-quic-transport/src/interval_set/mod.rs
+++ b/quic/s2n-quic-transport/src/interval_set/mod.rs
@@ -640,36 +640,32 @@ impl<T: IntervalBound> IntervalSet<T> {
     }
 
     /// Internal check for integrity - only used when debug_assertions are enabled
-    #[cfg(debug_assertions)]
-    fn check_integrity(&self) {
-        let mut prev_end: Option<T> = None;
-
-        for interval in self.intervals.iter() {
-            // make sure that a few items exist
-            for value in interval.clone().take(3) {
-                assert!(self.contains(&value), "set should contain value");
-            }
-            for value in interval.clone().rev().take(3) {
-                assert!(self.contains(&value), "set should contain value");
-            }
-
-            if let Some(prev_end) = prev_end.as_ref() {
-                assert!(
-                    *prev_end < interval.start_exclusive(),
-                    "the previous end should be less than the next start",
-                );
-            }
-
-            assert!(interval.is_valid(), "interval should be valid");
-
-            prev_end = Some(interval.end);
-        }
-    }
-
-    #[cfg(not(debug_assertions))]
     #[inline]
     fn check_integrity(&self) {
-        // noop without debug_assertions
+        if cfg!(debug_assertions) {
+            let mut prev_end: Option<T> = None;
+
+            for interval in self.intervals.iter() {
+                // make sure that a few items exist
+                for value in interval.clone().take(3) {
+                    assert!(self.contains(&value), "set should contain value");
+                }
+                for value in interval.clone().rev().take(3) {
+                    assert!(self.contains(&value), "set should contain value");
+                }
+
+                if let Some(prev_end) = prev_end.as_ref() {
+                    assert!(
+                        *prev_end < interval.start_exclusive(),
+                        "the previous end should be less than the next start",
+                    );
+                }
+
+                assert!(interval.is_valid(), "interval should be valid");
+
+                prev_end = Some(interval.end);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
The new data sender uses `IntervalSet` to track pending transmissions. This change adds a `set_len` on the interval data type to make it easy to trim ranges to a particular length.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
