### PR TITLE
transport: limit pto backoff to 2 times per timer expiration

### DIFF
--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -125,6 +125,9 @@ impl Manager {
             //# When a PTO timer expires, the PTO backoff MUST be increased,
             //# resulting in the PTO period being set to twice its current value.
             if pto_expired {
+                // Note: the psuedocode updates the pto timer in OnLossDetectionTimeout
+                // (see section A.9). We don't do that here since it will be rearmed in
+                // `on_packet_sent`, which immediately follows a timeout.
                 context.path_mut().pto_backoff *= 2;
             }
         }

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -177,7 +177,7 @@ impl<Config: connection::Config> PacketSpaceManager<Config> {
     ) {
         let path = path_manager.active_path_mut();
 
-        // ensure the backoff doesn't grow too quicly
+        // ensure the backoff doesn't grow too quickly
         let max_backoff = path.pto_backoff * 2;
 
         if let Some((space, handshake_status)) = self.initial_mut() {
@@ -191,7 +191,6 @@ impl<Config: connection::Config> PacketSpaceManager<Config> {
         }
 
         let path = path_manager.active_path_mut();
-
         path.pto_backoff = path.pto_backoff.min(max_backoff);
     }
 


### PR DESCRIPTION
*Issue #, if available:* #545

*Description of changes:*

During periods of severe packet loss, probes packets may be dropped in multiple packet spaces, which results in a PTO timer expiration in multiple spaces. This results in the PTO backoff being doubled for each packet space that had a timeout, which can quickly cause the PTO timer to reach a very high value, resulting in few actual probes being sent out. This change limits the pto backoff to 2 times per timer expiration regardless of how many packet spaces experienced timeouts

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
