### PR TITLE
Pin zerocopy to 0.3.0

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -15,4 +15,4 @@ generator = ["bolero-generator"]
 [dependencies]
 bolero-generator = { version = "0.6", default-features = false, optional = true }
 byteorder = { version = "1.1", default-features = false }
-zerocopy = "0.3"
+zerocopy = "=0.3.0"

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -22,7 +22,7 @@ num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features = false }
 subtle = { version = "2", default-features = false }
 thiserror = { version = "1", optional = true }
-zerocopy = "0.3"
+zerocopy = "=0.3.0"
 
 [dev-dependencies]
 bolero = "0.6"

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -41,7 +41,7 @@ s2n-quic-tls-default = { version = "0.1", path = "../s2n-quic-tls-default", opti
 s2n-quic-transport = { version = "0.1", path = "../s2n-quic-transport", default-features = false }
 thiserror = { version = "1.0", optional = true }
 tokio = { version = "0.2", optional = true, features = ["rt-core", "time", "udp"] }
-zerocopy = { version = "0.3", optional = true }
+zerocopy = { version = "=0.3.0", optional = true }
 
 [dev-dependencies]
 bolero = { version = "0.6" }


### PR DESCRIPTION
zerocopy 0.3.1 does not build in Stable rust

``` Compiling zerocopy v0.3.1
error[E0658]: const generics are unstable
    --> /usr/local/cargo/registry/src/github.com-1ecc6299db9ec823/zerocopy-0.3.1/src/lib.rs:71:38
     |
 71  |         unsafe impl<T: $trait, const N: usize> $trait for [T; N] {
     |                                      ^
 ...
 263 | impl_for_composite_types!(FromBytes);
     | ------------------------------------- in this macro invocation
     |
     = note: see issue #74878 <https://github.com/rust-lang/rust/issues/74878> for more information
     = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
```
This PR (https://github.com/openrr/openrr/pull/216) has tagged the zerocopy author, we can see if he responds on whether this was intentional 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.