### PR TITLE
Unpin zerocopy

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -15,4 +15,4 @@ generator = ["bolero-generator"]
 [dependencies]
 bolero-generator = { version = "0.6", default-features = false, optional = true }
 byteorder = { version = "1.1", default-features = false }
-zerocopy = "=0.3.0"
+zerocopy = "0.3"

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -22,7 +22,7 @@ num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features = false }
 subtle = { version = "2", default-features = false }
 thiserror = { version = "1", optional = true }
-zerocopy = "=0.3.0"
+zerocopy = "0.3"
 
 [dev-dependencies]
 bolero = "0.6"

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -41,7 +41,7 @@ s2n-quic-tls-default = { version = "0.1", path = "../s2n-quic-tls-default", opti
 s2n-quic-transport = { version = "0.1", path = "../s2n-quic-transport", default-features = false }
 thiserror = { version = "1.0", optional = true }
 tokio = { version = "0.2", optional = true, features = ["rt-core", "time", "udp"] }
-zerocopy = { version = "=0.3.0", optional = true }
+zerocopy = { version = "0.3", optional = true }
 
 [dev-dependencies]
 bolero = { version = "0.6" }


### PR DESCRIPTION
The version of zerocopy that does not build in Rust stable (0.3.1) has been yanked, so we can unpin zerocopy.

See https://github.com/openrr/openrr/pull/216#issuecomment-791580247

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.