### PR TITLE
Fix RFC compliance bug when calculating PTO

### DIFF
--- a/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
@@ -92,7 +92,7 @@ impl RTTEstimator {
     //= https://tools.ietf.org/id/draft-ietf-quic-recovery-32.txt#6.2.1
     //# The PTO period is the amount of time that a sender ought to wait for
     //# an acknowledgement of a sent packet.
-    pub fn pto_period(&self, pto_backoff: u32, space: &PacketNumberSpace) -> Duration {
+    pub fn pto_period(&self, pto_backoff: u32, space: PacketNumberSpace) -> Duration {
         //= https://tools.ietf.org/id/draft-ietf-quic-recovery-32.txt#6.2.1
         //# When an ack-eliciting packet is transmitted, the sender schedules a
         //# timer for the PTO period as follows:
@@ -278,15 +278,15 @@ mod test {
         assert_eq!(rtt_estimator.smoothed_rtt(), DEFAULT_INITIAL_RTT);
         assert_eq!(rtt_estimator.rttvar(), DEFAULT_INITIAL_RTT / 2);
         assert_eq!(
-            rtt_estimator.pto_period(INITIAL_PTO_BACKOFF, &PacketNumberSpace::Initial),
+            rtt_estimator.pto_period(INITIAL_PTO_BACKOFF, PacketNumberSpace::Initial),
             Duration::from_millis(999)
         );
         assert_eq!(
-            rtt_estimator.pto_period(INITIAL_PTO_BACKOFF, &PacketNumberSpace::Handshake),
+            rtt_estimator.pto_period(INITIAL_PTO_BACKOFF, PacketNumberSpace::Handshake),
             Duration::from_millis(999)
         );
         assert_eq!(
-            rtt_estimator.pto_period(INITIAL_PTO_BACKOFF, &PacketNumberSpace::ApplicationData),
+            rtt_estimator.pto_period(INITIAL_PTO_BACKOFF, PacketNumberSpace::ApplicationData),
             Duration::from_millis(1009)
         );
     }
@@ -307,7 +307,7 @@ mod test {
         assert_eq!(rtt_estimator.latest_rtt(), Duration::from_millis(1));
         assert_eq!(rtt_estimator.first_rtt_sample(), Some(now));
         assert_eq!(
-            rtt_estimator.pto_period(INITIAL_PTO_BACKOFF, &PacketNumberSpace::Initial),
+            rtt_estimator.pto_period(INITIAL_PTO_BACKOFF, PacketNumberSpace::Initial),
             Duration::from_millis(3)
         );
     }
@@ -445,7 +445,7 @@ mod test {
         );
         assert_eq!(rtt_estimator.first_rtt_sample, Some(now));
         assert_eq!(
-            rtt_estimator.pto_period(INITIAL_PTO_BACKOFF, &PacketNumberSpace::ApplicationData),
+            rtt_estimator.pto_period(INITIAL_PTO_BACKOFF, PacketNumberSpace::ApplicationData),
             Duration::from_nanos(1551249998)
         );
     }
@@ -638,7 +638,7 @@ mod test {
             space,
         );
 
-        let pto_period = rtt_estimator.pto_period(INITIAL_PTO_BACKOFF, &space);
+        let pto_period = rtt_estimator.pto_period(INITIAL_PTO_BACKOFF, space);
         assert!(pto_period >= K_GRANULARITY);
     }
 }

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -235,7 +235,7 @@ impl Manager {
         } else {
             self.pto.update(
                 pto_base_timestamp,
-                path.rtt_estimator.pto_period(path.pto_backoff, &self.space),
+                path.rtt_estimator.pto_period(path.pto_backoff, self.space),
             );
         }
     }
@@ -805,7 +805,7 @@ mod test {
 
         manager
             .pto
-            .update(now, path.rtt_estimator.pto_period(path.pto_backoff, &space));
+            .update(now, path.rtt_estimator.pto_period(path.pto_backoff, space));
 
         assert!(manager.pto.timer.is_armed());
         assert_eq!(
@@ -1684,7 +1684,7 @@ mod test {
 
         manager
             .pto
-            .update(now, path.rtt_estimator.pto_period(path.pto_backoff, &space));
+            .update(now, path.rtt_estimator.pto_period(path.pto_backoff, space));
 
         assert!(manager.pto.timer.is_armed());
         assert!(manager.pto.timer.iter().next().cloned().unwrap() >= now + K_GRANULARITY);

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -322,7 +322,7 @@ impl<Config: connection::Config> ApplicationSpace<Config> {
             //# (PTO; see [QUIC-RECOVERY]) after receiving a packet that uses the new
             //# key generation before it creates the next set of packet protection
             //# keys.
-            datagram.timestamp + rtt_estimator.pto_period(1, &PacketNumberSpace::ApplicationData),
+            datagram.timestamp + rtt_estimator.pto_period(1, PacketNumberSpace::ApplicationData),
         )
     }
 }


### PR DESCRIPTION
*Description of changes:*
Require a packet space when calculating the PTO.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
