### PR TITLE
Pin interop docker images to pre-Version 1 versions

### DIFF
--- a/.github/interop/runner.patch
+++ b/.github/interop/runner.patch
@@ -57,7 +57,7 @@ index 708e1ae..6ce3a8b 100644
 +  },
    "quic-go": {
 -    "image": "martenseemann/quic-go-interop:latest",
-+    "image": "martenseemann/quic-go-interop@sha256:f8bb3f8c836899b1f416a1a2bb387b66343f4ffe4eac5b90a62968d34fc05249",
++    "image": "martenseemann/quic-go-interop@sha256:eac3cf0ef25574082bdfbe2bb362d30633ac453270732bdc1e3945aabc39ef2d",
      "url": "https://github.com/lucas-clemente/quic-go",
      "role": "both"
    },


### PR DESCRIPTION
Several other quic implementations have updated to supporting Quic Version 1, but we are not ready to update yet. This change will pin the Docker image versions used in interop to the image built prior to the Version 1 support for each Quic implementation. For implementations that don't support Version 1 yet, the latest digest is used for pinning so the test doesn't suddenly break once the implementation does support Version 1.

These implementations are pinned to the latest digest as of 03-08-2021:
- aioquic
- lsquic
- msquic
- mvfst
- quiche
- quicly
- xquic
- pquic

These implementations are pinned to earlier digests:
- kwik
- neqo
- ngtcp2
- picoquic
- ~~quant~~ #564
- quic-go

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.