### PR TITLE
Unpin quant

### DIFF
--- a/.github/interop/runner.patch
+++ b/.github/interop/runner.patch
@@ -45,10 +45,10 @@ index 7541cae..12f9c70 100644
        - "server6:fd00:cafe:cafe:100::110"
        - "server46:193.167.100.110"
 diff --git a/implementations.json b/implementations.json
-index 708e1ae..6ce3a8b 100644
+index 708e1ae..aac0f66 100644
 --- a/implementations.json
 +++ b/implementations.json
-@@ -1,51 +1,56 @@
+@@ -1,16 +1,21 @@
  {
 +  "s2n-quic": {
 +    "image": "awslabs/s2n-quic-qns:latest",
@@ -73,10 +73,7 @@ index 708e1ae..6ce3a8b 100644
      "url": "https://github.com/ngtcp2/ngtcp2",
      "role": "both"
    },
-   "quant": {
--    "image": "ntap/quant:interop",
-+    "image": "ntap/quant@sha256:cb50cc8019d45d9cad5faecbe46a3c21dd5e871949819a5175423755a9045106",
-     "url": "https://github.com/NTAP/quant",
+@@ -20,32 +25,32 @@
      "role": "both"
    },
    "mvfst": {


### PR DESCRIPTION
Quant has multiple issues causing Interop to fail (see #563). These aren't fixed by pinning the docker image, and the revision that was pinned actually has a bug where it runs the Quant server instead of the Quant client. This change will unpin Quant while we sort out the other issues with it. This also means that Quant won't be able to pass interop until both the bug mentioned in #563 is fixed and we upgrade to Version 1 initial salt.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice. 