### PR TITLE
Add a max_lifetime for connection IDs

### DIFF
--- a/quic/s2n-quic-core/src/connection/id.rs
+++ b/quic/s2n-quic-core/src/connection/id.rs
@@ -22,6 +22,10 @@ pub const MAX_LEN: usize = crate::packet::long::DESTINATION_CONNECTION_ID_MAX_LE
 /// The minimum lifetime of a connection ID.
 pub const MIN_LIFETIME: Duration = Duration::from_secs(60);
 
+/// The maximum bounded lifetime of a connection ID. Connection IDs may have no specified
+/// lifetime at all, but if a lifetime is specified, it cannot exceed this value.
+pub const MAX_LIFETIME: Duration = Duration::from_secs(24 * 60 * 60); // one day
+
 macro_rules! id {
     ($type:ident, $min_len:expr) => {
         /// Uniquely identifies a QUIC connection between 2 peers

--- a/quic/s2n-quic/src/provider/connection_id.rs
+++ b/quic/s2n-quic/src/provider/connection_id.rs
@@ -111,7 +111,7 @@ pub mod random {
 
         /// Sets the lifetime of each generated connection Id
         pub fn with_lifetime(mut self, lifetime: Duration) -> Result<Self, connection::id::Error> {
-            if lifetime < connection::id::MIN_LIFETIME {
+            if !(connection::id::MIN_LIFETIME..=connection::id::MAX_LIFETIME).contains(&lifetime) {
                 return Err(connection::id::Error::InvalidLifetime);
             }
             self.lifetime = Some(lifetime);
@@ -201,6 +201,13 @@ pub mod random {
                 Some(connection::id::Error::InvalidLifetime),
                 Format::builder()
                     .with_lifetime(connection::id::MIN_LIFETIME - Duration::from_millis(1))
+                    .err()
+            );
+
+            assert_eq!(
+                Some(connection::id::Error::InvalidLifetime),
+                Format::builder()
+                    .with_lifetime(connection::id::MAX_LIFETIME + Duration::from_millis(1))
                     .err()
             );
         }

--- a/quic/s2n-quic/src/server/providers.rs
+++ b/quic/s2n-quic/src/server/providers.rs
@@ -93,9 +93,12 @@ impl<
 
         // Validate providers
         // TODO: Add more validation https://github.com/awslabs/s2n-quic/issues/285
+        let valid_lifetime = |lifetime| {
+            (connection::id::MIN_LIFETIME..=connection::id::MAX_LIFETIME).contains(&lifetime)
+        };
         if connection_id
             .lifetime()
-            .map_or(false, |lifetime| lifetime < connection::id::MIN_LIFETIME)
+            .map_or(false, |lifetime| !valid_lifetime(lifetime))
         {
             return Err(StartError::new(connection::id::Error::InvalidLifetime));
         };


### PR DESCRIPTION
In the case a customer has configured an exceptionally long lifetime for connection IDs (> 200,000,000 days), we could panic when adding that lifetime to the current time. This change will validate that a configured connection ID lifetime does not exceed 1 day.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.