### PR TITLE
integration: use flume fork to support 1.46 MSRV

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -25,6 +25,14 @@ skip-tree = [
 unknown-registry = "deny"
 unknown-git = "deny"
 
+allow-git = [
+    # The main flume has dependencies which don't have a rolling 6-month MSRV
+    #
+    # This fork uses `parking_lot` instead, which does. Since this is only a dev-dependency, it
+    # shouldn't prevent us from publishing to crates.io.
+    "https://github.com/camshaft/flume",
+]
+
 [licenses]
 unlicensed = "deny"
 allow-osi-fsf-free = "neither"

--- a/quic/s2n-quic-integration/Cargo.toml
+++ b/quic/s2n-quic-integration/Cargo.toml
@@ -22,4 +22,8 @@ tokio = { version = "0.2", features = ["full"] }
 
 [dev-dependencies]
 bolero = "0.6"
-flume = { version = "0.10", default-features = false, features = ["async"] }
+# The main flume has dependencies which don't have a rolling 6-month MSRV
+#
+# This fork uses `parking_lot` instead, which does. Since this is only a dev-dependency, it
+# shouldn't prevent us from publishing to crates.io.
+flume = { git = "https://github.com/camshaft/flume", default-features = false, features = ["async"] }


### PR DESCRIPTION
The main flume has dependencies which don't have a rolling 6-month MSRV

This fork uses `parking_lot` instead, which does. Since this is only a dev-dependency, it
shouldn't prevent us from publishing to crates.io.

Long term, this isn't a great solution and instead, we'll probably just need to use something like `crossbeam-channel`, which does have an acceptable MSRV policy. But this should be ok for now to unblock the existing PRs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
