### PR TITLE
core: add connection close formatter

### DIFF
--- a/quic/s2n-quic-core/src/application/error.rs
+++ b/quic/s2n-quic-core/src/application/error.rs
@@ -3,7 +3,10 @@
 
 //! Defines QUIC Application Error Codes
 
-use crate::varint::{VarInt, VarIntError};
+use crate::{
+    frame::ConnectionClose,
+    varint::{VarInt, VarIntError},
+};
 use core::{convert::TryFrom, ops};
 
 //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#20.2
@@ -64,6 +67,16 @@ impl From<Error> for VarInt {
 impl From<Error> for u64 {
     fn from(e: Error) -> Self {
         e.0.as_u64()
+    }
+}
+
+impl<'a> From<Error> for ConnectionClose<'a> {
+    fn from(error: Error) -> Self {
+        ConnectionClose {
+            error_code: error.0,
+            frame_type: None,
+            reason: None,
+        }
     }
 }
 

--- a/quic/s2n-quic-core/src/connection/close.rs
+++ b/quic/s2n-quic-core/src/connection/close.rs
@@ -1,0 +1,149 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{application, transport};
+pub use crate::{frame::ConnectionClose, inet::SocketAddress};
+
+/// Provides a hook for applications to rewrite CONNECTION_CLOSE frames
+///
+/// Implementations should take care to not leak potentially sensitive information
+/// to peers. This includes removing `reason` fields and making error codes more general.
+pub trait Formatter: 'static {
+    /// Formats a transport error for use in 1-RTT (application data) packets
+    fn format_transport_error(&self, context: &Context, error: transport::Error)
+        -> ConnectionClose;
+
+    /// Formats an application error for use in 1-RTT (application data) packets
+    fn format_application_error(
+        &self,
+        context: &Context,
+        error: application::Error,
+    ) -> ConnectionClose;
+
+    /// Formats a transport error for use in early (initial, handshake) packets
+    fn format_early_transport_error(
+        &self,
+        context: &Context,
+        error: transport::Error,
+    ) -> ConnectionClose;
+
+    /// Formats an application error for use in early (initial, handshake) packets
+    fn format_early_application_error(
+        &self,
+        context: &Context,
+        error: application::Error,
+    ) -> ConnectionClose;
+}
+
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct Context<'a> {
+    pub remote_address: &'a SocketAddress,
+}
+
+impl<'a> Context<'a> {
+    pub fn new(remote_address: &'a SocketAddress) -> Self {
+        Self { remote_address }
+    }
+}
+
+/// A formatter that passes errors through, unmodified
+///
+/// WARNING: This formatter should only be used in application development,
+///          as it can leak potentially sensitive information to the peer.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Development;
+
+impl Formatter for Development {
+    fn format_transport_error(
+        &self,
+        _context: &Context,
+        error: transport::Error,
+    ) -> ConnectionClose {
+        error.into()
+    }
+
+    fn format_application_error(
+        &self,
+        _context: &Context,
+        error: application::Error,
+    ) -> ConnectionClose {
+        error.into()
+    }
+
+    fn format_early_transport_error(
+        &self,
+        _context: &Context,
+        error: transport::Error,
+    ) -> ConnectionClose {
+        error.into()
+    }
+
+    fn format_early_application_error(
+        &self,
+        _context: &Context,
+        error: application::Error,
+    ) -> ConnectionClose {
+        error.into()
+    }
+}
+
+/// A formatter that removes potentially sensitive information
+///
+/// The following is performed:
+///
+/// * Reasons and frame_types are hidden
+/// * INTERNAL_ERROR is transformed into PROTOCOL_VIOLATION
+/// * Application codes are hidden in early (initial, handshake) packets
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Production;
+
+impl Formatter for Production {
+    fn format_transport_error(
+        &self,
+        _context: &Context,
+        error: transport::Error,
+    ) -> ConnectionClose {
+        // rewrite internal errors as PROTOCOL_VIOLATION
+        if error.code == transport::Error::INTERNAL_ERROR.code {
+            return transport::Error::PROTOCOL_VIOLATION.into();
+        }
+
+        // only preserve the error code
+        transport::Error::new(*error.code).into()
+    }
+
+    fn format_application_error(
+        &self,
+        _context: &Context,
+        error: application::Error,
+    ) -> ConnectionClose {
+        error.into()
+    }
+
+    fn format_early_transport_error(
+        &self,
+        context: &Context,
+        error: transport::Error,
+    ) -> ConnectionClose {
+        Self.format_transport_error(context, error)
+    }
+
+    fn format_early_application_error(
+        &self,
+        _context: &Context,
+        _error: application::Error,
+    ) -> ConnectionClose {
+        //= https://tools.ietf.org/id/draft-ietf-quic-transport-34.txt#10.2.3
+        //# Sending a CONNECTION_CLOSE of type 0x1d in an Initial or Handshake
+        //# packet could expose application state or be used to alter application
+        //# state.  A CONNECTION_CLOSE of type 0x1d MUST be replaced by a
+        //# CONNECTION_CLOSE of type 0x1c when sending the frame in Initial or
+        //# Handshake packets.  Otherwise, information about the application
+        //# state might be revealed.  Endpoints MUST clear the value of the
+        //# Reason Phrase field and SHOULD use the APPLICATION_ERROR code when
+        //# converting to a CONNECTION_CLOSE of type 0x1c.
+
+        transport::Error::APPLICATION_ERROR.into()
+    }
+}

--- a/quic/s2n-quic-core/src/connection/mod.rs
+++ b/quic/s2n-quic-core/src/connection/mod.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod close;
 pub mod error;
 pub mod id;
 pub mod limits;

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -50,6 +50,7 @@ pub trait ConnectionTrait: Sized {
         &mut self,
         shared_state: Option<&mut SharedConnectionState<Self::Config>>,
         error: connection::Error,
+        close_formatter: &<Self::Config as endpoint::Config>::ConnectionCloseFormatter,
         packet_buffer: &mut endpoint::PacketBuffer,
         timestamp: Timestamp,
     );

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -27,8 +27,10 @@ pub trait Config: 'static + Sized + core::fmt::Debug {
     type EndpointLimits: endpoint::Limits;
     /// The connection limits
     type ConnectionLimits: connection::limits::Limiter;
-    /// The stream
+    /// The type of stream
     type Stream: stream::StreamTrait;
+    /// The connection close formatter
+    type ConnectionCloseFormatter: connection::close::Formatter;
 
     /// The type of the local endpoint
     const ENDPOINT_TYPE: endpoint::Type;
@@ -60,5 +62,8 @@ pub struct Context<'a, Cfg: Config> {
     /// Token generator / validator
     pub token: &'a mut Cfg::TokenFormat,
 
+    /// The connection limits
     pub connection_limits: &'a mut Cfg::ConnectionLimits,
+
+    pub connection_close_formatter: &'a mut Cfg::ConnectionCloseFormatter,
 }

--- a/quic/s2n-quic-transport/src/stream/receive_stream.rs
+++ b/quic/s2n-quic-transport/src/stream/receive_stream.rs
@@ -178,7 +178,7 @@ impl ReceiveStreamFlowController {
 
             return Err(transport::Error::FLOW_CONTROL_ERROR
                 .with_reason("Stream flow control window exceeded")
-                .with_optional_frame_type(source_frame_type.map(|ty| ty.into())));
+                .with_frame_type(source_frame_type.unwrap_or_default().into()));
         }
         // Remark: Actually this read window might not have yet been
         // transmitted to the peer. In that case it might have now
@@ -204,7 +204,7 @@ impl ReceiveStreamFlowController {
                     //# (Section 11) if the sender violates the advertised connection or
                     //# stream data limits.
                     err.with_reason("Connection flow control window exceeded")
-                        .with_optional_frame_type(source_frame_type.map(|ty| ty.into()))
+                        .with_frame_type(source_frame_type.unwrap_or_default().into())
                 })?;
             // The connection window was acquired successfully
             self.acquired_connection_window += additional_connection_window;
@@ -573,7 +573,7 @@ impl ReceiveStream {
                             .with_reason(
                                 "Final size in reset frame did not match previous final size",
                             )
-                            .with_optional_frame_type(frame_tag.map(|tag| tag.into())));
+                            .with_frame_type(frame_tag.unwrap_or_default().into()));
                     }
                 }
 

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -14,6 +14,8 @@ default = [
     "std",
     "tokio-runtime"
 ]
+# Sends debug information in CONNECTION_CLOSE frames
+connection-close-debug = []
 default-token-provider = ["ring", "zerocopy"]
 default-tls-provider = ["s2n-quic-tls-default"]
 protocol-extensions = []

--- a/quic/s2n-quic/src/provider/connection_close_formatter.rs
+++ b/quic/s2n-quic/src/provider/connection_close_formatter.rs
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provider for formatting CONNECTION_CLOSE frames
+
+pub use s2n_quic_core::connection::close::*;
+
+/// Provider for formatting CONNECTION_CLOSE frames
+pub trait Provider: 'static {
+    type Formatter: 'static + Formatter;
+    type Error: core::fmt::Display;
+
+    /// Starts the token provider
+    fn start(self) -> Result<Self::Formatter, Self::Error>;
+}
+
+#[cfg(feature = "connection-close-debug")]
+pub type Default = Development;
+#[cfg(not(feature = "connection-close-debug"))]
+pub type Default = Production;
+
+/// Implement Provider for all implementations of Formatter
+impl<T: Formatter> Provider for T {
+    type Formatter = T;
+    type Error = core::convert::Infallible;
+
+    fn start(self) -> Result<Self::Formatter, Self::Error> {
+        Ok(self)
+    }
+}
+
+impl_provider_utils!();

--- a/quic/s2n-quic/src/provider/mod.rs
+++ b/quic/s2n-quic/src/provider/mod.rs
@@ -11,9 +11,12 @@ pub mod endpoint_limits;
 pub mod io;
 pub mod limits;
 pub mod log;
-pub(crate) mod random;
 pub mod runtime;
 pub mod stateless_reset_token;
 pub mod sync;
 pub mod tls;
 pub mod token;
+
+// These providers are not currently exposed to applications
+pub(crate) mod connection_close_formatter;
+pub(crate) mod random;


### PR DESCRIPTION
Currently we are applying a default error formatter to CONNECTION_CLOSE frames.

This change adds a `connection::close::Formatter` trait which will allow applications to alter the behavior with a feature flag. It also allows for, if we choose to, expose the formatter as a provider which applications can customize even further.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
