### PR TITLE
core: fix frame try_fit models

### DIFF
--- a/quic/s2n-quic-core/src/frame/stream.rs
+++ b/quic/s2n-quic-core/src/frame/stream.rs
@@ -300,19 +300,20 @@ mod tests {
 
         if let Ok(new_length) = frame.try_fit(capacity) {
             frame.data = Padding { length: new_length };
+
+            // we should never exceed the capacity
+            assert!(
+                frame.encoding_size() <= capacity,
+                "the encoding_size should not exceed capacity {:#?}",
+                frame
+            );
+
             if new_length < length {
                 // the payload was trimmed so we should be at full capacity
                 assert_eq!(
                     frame.encoding_size(),
                     capacity,
                     "should match capacity {:#?}",
-                    frame
-                );
-            } else {
-                // we should never exceed the capacity
-                assert!(
-                    frame.encoding_size() <= capacity,
-                    "the encoding_size should not exceed capacity {:#?}",
                     frame
                 );
             }


### PR DESCRIPTION
Fixes #583 

The current `frame::Crypto` try_fit test doesn't have any tolerance for when the frame data is trimmed to fit the length prefix encoding size. This change fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
