### PR TITLE
Disable codecov upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,12 +364,8 @@ jobs:
       - name: Run covfix
         run: rust-covfix -o coverage.lcov coverage.unfiltered.lcov
 
-      - name: Upload report to codecov
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage.lcov
-          flags: unit-tests
+      # TODO: Switch to source coverage and create coverage report
+      #       See https://github.com/awslabs/s2n-quic/issues/226
 
   examples:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change disables the upload of coverage data to codecov.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

