### PR TITLE
deps: pin zerocopy-derive

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -16,3 +16,4 @@ generator = ["bolero-generator"]
 bolero-generator = { version = "0.6", default-features = false, optional = true }
 byteorder = { version = "1.1", default-features = false }
 zerocopy = "0.3"
+zerocopy-derive = "=0.2.0"

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -24,6 +24,7 @@ s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features
 subtle = { version = "2", default-features = false }
 thiserror = { version = "1", optional = true }
 zerocopy = "0.3"
+zerocopy-derive = "=0.2.0"
 
 [dev-dependencies]
 bolero = "0.6"

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -16,7 +16,7 @@ default = [
 ]
 # Sends debug information in CONNECTION_CLOSE frames
 connection-close-debug = []
-default-token-provider = ["ring", "zerocopy"]
+default-token-provider = ["ring", "zerocopy", "zerocopy-derive"]
 default-tls-provider = ["s2n-quic-tls-default"]
 protocol-extensions = []
 rand-provider = ["rand", "rand_chacha"]
@@ -45,6 +45,7 @@ s2n-quic-transport = { version = "0.1", path = "../s2n-quic-transport", default-
 thiserror = { version = "1.0", optional = true }
 tokio = { version = "0.2", optional = true, features = ["rt-core", "time", "udp"] }
 zerocopy = { version = "0.3", optional = true }
+zerocopy-derive = { version = "=0.2.0", optional = true }
 zeroize = { version = "1", default-features = false }
 tracing = { version = "0.1", optional = true }
 


### PR DESCRIPTION
zerocopy-derive recently published a patch version that breaks our MSRV. We'll have to pin to `0.2.0` until they yank and bump the minor version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
