### PR TITLE
compliance: fix sections without a period

### DIFF
--- a/common/compliance/cargo-compliance/src/extract.rs
+++ b/common/compliance/cargo-compliance/src/extract.rs
@@ -130,6 +130,11 @@ fn extract_section<'a>(section: &'a Section<'a>) -> (&'a Section<'a>, Vec<Featur
 
                     #[allow(clippy::needless_range_loop)]
                     for i in start.0..=end.0 {
+                        // The requirement didn't end with a period so stop processing
+                        if i == lines.len() {
+                            break;
+                        }
+
                         let mut line = &lines[i][..];
 
                         if i == end.0 {


### PR DESCRIPTION
When extracting requirements from specs, the current code assumes the section ends with a period. This PR removes this assumption.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
