### PR TITLE
Move Path to s2n-quic-transport

### DIFF
--- a/quic/s2n-quic-transport/src/connection/close_sender.rs
+++ b/quic/s2n-quic-transport/src/connection/close_sender.rs
@@ -1,22 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use core::{task::Poll, time::Duration};
-
+use crate::{
+    connection::finalization,
+    path::Path,
+    transmission::{self, interest::Provider as _},
+};
 use bytes::Bytes;
-
+use core::{task::Poll, time::Duration};
 use s2n_quic_core::{
     counter::{self, Counter},
     inet::{ExplicitCongestionNotification, SocketAddress},
     io::tx,
     recovery::CongestionController,
     time::{Timer, Timestamp},
-};
-
-use crate::{
-    connection::finalization,
-    path::Path,
-    transmission::{self, interest::Provider as _},
 };
 
 #[derive(Debug, Default)]
@@ -272,15 +269,13 @@ impl Limiter {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::path::testing::test_path;
     use s2n_quic_core::{
         io::tx::Message as _,
         path::MINIMUM_MTU,
         time::{testing::Clock, Clock as _},
     };
-
-    use crate::path::testing::test_path;
-
-    use super::*;
 
     static PACKET: Bytes = Bytes::from_static(b"CLOSE");
 

--- a/quic/s2n-quic-transport/src/connection/transmission.rs
+++ b/quic/s2n-quic-transport/src/connection/transmission.rs
@@ -1,8 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::{
+    connection::{self, SharedConnectionState},
+    endpoint, path,
+    path::Path,
+    recovery::congestion_controller,
+    transmission,
+};
 use core::time::Duration;
-
 use s2n_codec::{Encoder, EncoderBuffer};
 use s2n_quic_core::{
     frame::ack_elicitation::AckElicitable,
@@ -10,14 +16,6 @@ use s2n_quic_core::{
     io::tx,
     packet::{encoding::PacketEncodingError, number::PacketNumberSpace},
     time::Timestamp,
-};
-
-use crate::{
-    connection::{self, SharedConnectionState},
-    endpoint, path,
-    path::Path,
-    recovery::congestion_controller,
-    transmission,
 };
 
 #[derive(Debug)]

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -3,8 +3,11 @@
 
 //! This module contains the Manager implementation
 
-use smallvec::SmallVec;
-
+use crate::{
+    connection::PeerIdRegistry,
+    path::{challenge, Path},
+    transmission,
+};
 use s2n_quic_core::{
     ack, connection, frame,
     inet::{DatagramInfo, SocketAddress},
@@ -14,12 +17,7 @@ use s2n_quic_core::{
     time::Timestamp,
     transport,
 };
-
-use crate::{
-    connection::PeerIdRegistry,
-    path::{challenge, Path},
-    transmission,
-};
+use smallvec::SmallVec;
 
 /// The amount of Paths that can be maintained without using the heap
 const INLINE_PATH_LEN: usize = 5;
@@ -456,9 +454,9 @@ impl<'a, CCE: congestion_controller::Endpoint> PendingPaths<'a, CCE> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::connection::{ConnectionIdMapper, InternalConnectionIdGenerator};
     use core::time::Duration;
-    use std::net::SocketAddr;
-
     use s2n_quic_core::{
         endpoint,
         inet::{DatagramInfo, ExplicitCongestionNotification},
@@ -468,10 +466,7 @@ mod tests {
         stateless_reset::token::testing::TEST_TOKEN_1,
         time::{Clock, NoopClock},
     };
-
-    use crate::connection::{ConnectionIdMapper, InternalConnectionIdGenerator};
-
-    use super::*;
+    use std::net::SocketAddr;
 
     // Helper function to easily create a PathManager
     fn manager(

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -2,8 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! This module contains the Path implementation
+mod manager;
 
 pub use manager::*;
+
 /// re-export core
 pub use s2n_quic_core::path::*;
 use s2n_quic_core::time::Timestamp;
@@ -15,8 +17,6 @@ use crate::{
     recovery::{CongestionController, RttEstimator},
     transmission,
 };
-
-mod manager;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 #[allow(dead_code)]
@@ -309,11 +309,11 @@ impl<CC: CongestionController> Path<CC> {
 
 #[cfg(any(test, feature = "testing"))]
 pub mod testing {
+    use crate::{
+        path::Path,
+        recovery::congestion_controller::testing::unlimited::CongestionController as Unlimited,
+    };
     use core::time::Duration;
-
-    use crate::path::Path;
-
-    use crate::recovery::congestion_controller::testing::unlimited::CongestionController as Unlimited;
     use s2n_quic_core::{connection, inet::SocketAddress, recovery::RttEstimator};
 
     pub fn test_path() -> Path<Unlimited> {

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -1,10 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::{
+    contexts::WriteContext,
+    path::Path,
+    recovery::{SentPacketInfo, SentPackets},
+    timer::VirtualTimer,
+    transmission,
+};
 use core::{cmp::max, time::Duration};
-
-use smallvec::SmallVec;
-
 use s2n_quic_core::{
     endpoint, frame,
     inet::DatagramInfo,
@@ -14,14 +18,7 @@ use s2n_quic_core::{
     transport,
     varint::VarInt,
 };
-
-use crate::{
-    contexts::WriteContext,
-    path::Path,
-    recovery::{SentPacketInfo, SentPackets},
-    timer::VirtualTimer,
-    transmission,
-};
+use smallvec::SmallVec;
 
 #[derive(Debug)]
 pub struct Manager {
@@ -772,9 +769,14 @@ impl transmission::interest::Provider for Pto {
 
 #[cfg(test)]
 mod test {
+    use super::*;
+    use crate::{
+        contexts::testing::{MockWriteContext, OutgoingFrameBuffer},
+        recovery,
+        recovery::manager::PtoState::RequiresTransmission,
+        space::rx_packet_numbers::ack_ranges::AckRanges,
+    };
     use core::{ops::RangeInclusive, time::Duration};
-    use std::collections::HashSet;
-
     use s2n_quic_core::{
         connection, endpoint,
         frame::ack_elicitation::AckElicitation,
@@ -789,15 +791,7 @@ mod test {
         },
         varint::VarInt,
     };
-
-    use crate::{
-        contexts::testing::{MockWriteContext, OutgoingFrameBuffer},
-        recovery,
-        recovery::manager::PtoState::RequiresTransmission,
-        space::rx_packet_numbers::ack_ranges::AckRanges,
-    };
-
-    use super::*;
+    use std::collections::HashSet;
 
     //= https://tools.ietf.org/id/draft-ietf-quic-recovery-32.txt#6.2.2
     //= type=test

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -1,8 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::{
+    connection::{self, ConnectionTransmissionContext, ProcessingError},
+    endpoint, path,
+    path::Path,
+    processed_packet::ProcessedPacket,
+    recovery,
+    recovery::congestion_controller,
+    space::{
+        rx_packet_numbers::AckManager, CryptoStream, HandshakeStatus, PacketSpace, TxPacketNumbers,
+    },
+    transmission,
+};
 use core::marker::PhantomData;
-
 use s2n_codec::EncoderBuffer;
 use s2n_quic_core::{
     crypto::{tls, CryptoSuite},
@@ -17,19 +28,6 @@ use s2n_quic_core::{
     },
     time::Timestamp,
     transport,
-};
-
-use crate::{
-    connection::{self, ConnectionTransmissionContext, ProcessingError},
-    endpoint, path,
-    path::Path,
-    processed_packet::ProcessedPacket,
-    recovery,
-    recovery::congestion_controller,
-    space::{
-        rx_packet_numbers::AckManager, CryptoStream, HandshakeStatus, PacketSpace, TxPacketNumbers,
-    },
-    transmission,
 };
 
 pub struct HandshakeSpace<Config: endpoint::Config> {

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -1,8 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::{
+    connection::{self, ConnectionTransmissionContext, ProcessingError},
+    endpoint, path,
+    path::Path,
+    processed_packet::ProcessedPacket,
+    recovery,
+    recovery::congestion_controller,
+    space::{
+        rx_packet_numbers::AckManager, CryptoStream, HandshakeStatus, PacketSpace, TxPacketNumbers,
+    },
+    transmission,
+};
 use core::marker::PhantomData;
-
 use s2n_codec::EncoderBuffer;
 use s2n_quic_core::{
     crypto::{tls, CryptoSuite},
@@ -17,19 +28,6 @@ use s2n_quic_core::{
     },
     time::Timestamp,
     transport,
-};
-
-use crate::{
-    connection::{self, ConnectionTransmissionContext, ProcessingError},
-    endpoint, path,
-    path::Path,
-    processed_packet::ProcessedPacket,
-    recovery,
-    recovery::congestion_controller,
-    space::{
-        rx_packet_numbers::AckManager, CryptoStream, HandshakeStatus, PacketSpace, TxPacketNumbers,
-    },
-    transmission,
 };
 
 pub struct InitialSpace<Config: endpoint::Config> {

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -1,13 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::{
+    connection, endpoint, path, path::Path, processed_packet::ProcessedPacket,
+    recovery::congestion_controller, space::rx_packet_numbers::AckManager, transmission,
+};
 use bytes::Bytes;
-
-pub(crate) use application::ApplicationSpace;
-pub(crate) use crypto_stream::CryptoStream;
-pub(crate) use handshake::HandshakeSpace;
-pub(crate) use handshake_status::HandshakeStatus;
-pub(crate) use initial::InitialSpace;
 use s2n_codec::DecoderBufferMut;
 use s2n_quic_core::{
     ack,
@@ -24,13 +22,6 @@ use s2n_quic_core::{
     time::Timestamp,
     transport,
 };
-pub(crate) use session_context::SessionContext;
-pub(crate) use tx_packet_numbers::TxPacketNumbers;
-
-use crate::{
-    connection, endpoint, path, path::Path, processed_packet::ProcessedPacket,
-    recovery::congestion_controller, space::rx_packet_numbers::AckManager, transmission,
-};
 
 mod application;
 mod crypto_stream;
@@ -40,6 +31,14 @@ mod initial;
 pub(crate) mod rx_packet_numbers;
 mod session_context;
 mod tx_packet_numbers;
+
+pub(crate) use application::ApplicationSpace;
+pub(crate) use crypto_stream::CryptoStream;
+pub(crate) use handshake::HandshakeSpace;
+pub(crate) use handshake_status::HandshakeStatus;
+pub(crate) use initial::InitialSpace;
+pub(crate) use session_context::SessionContext;
+pub(crate) use tx_packet_numbers::TxPacketNumbers;
 
 pub struct PacketSpaceManager<Config: endpoint::Config> {
     session: Option<<Config::TLSEndpoint as tls::Endpoint>::Session>,

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -1,17 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use bytes::Bytes;
-
-use s2n_codec::{DecoderBuffer, DecoderValue};
-use s2n_quic_core::{
-    ack,
-    crypto::{tls, CryptoSuite},
-    packet::number::PacketNumberSpace,
-    time::Timestamp,
-    transport::{self, parameters::ClientTransportParameters},
-};
-
 use crate::{
     connection::{self, limits::Limits},
     endpoint,
@@ -22,6 +11,15 @@ use crate::{
         InitialSpace,
     },
     stream::AbstractStreamManager,
+};
+use bytes::Bytes;
+use s2n_codec::{DecoderBuffer, DecoderValue};
+use s2n_quic_core::{
+    ack,
+    crypto::{tls, CryptoSuite},
+    packet::number::PacketNumberSpace,
+    time::Timestamp,
+    transport::{self, parameters::ClientTransportParameters},
 };
 
 pub struct SessionContext<'a, Config: endpoint::Config> {


### PR DESCRIPTION
With PMTU probing, the Path struct is becoming more sophisticated and will need transmission code currently present in s2n-quic-transport. This change moves the Path struct to transport. Longer term we may combine s2n-quic-core and s2n-quic-transport.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.