### PR TITLE
generate rand data as part of path challenge frame

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -616,6 +616,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         shared_state: Option<&mut SharedConnectionState<Config>>,
         datagram: &DatagramInfo,
         congestion_controller_endpoint: &mut Config::CongestionControllerEndpoint,
+        random: &mut Config::RandomGenerator,
     ) -> Result<path::Id, connection::Error> {
         //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#9
         //# The design of QUIC relies on endpoints retaining a stable address
@@ -638,6 +639,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             &self.limits,
             can_migrate,
             congestion_controller_endpoint,
+            random,
         )?;
 
         if let Some(shared_state) = shared_state {

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -181,6 +181,7 @@ pub trait ConnectionTrait: Sized {
         shared_state: Option<&mut SharedConnectionState<Self::Config>>,
         datagram: &DatagramInfo,
         congestion_controller_endpoint: &mut <Self::Config as endpoint::Config>::CongestionControllerEndpoint,
+        random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
     ) -> Result<path::Id, connection::Error>;
 
     /// Returns the Connections interests

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -258,6 +258,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                 Some(locked_shared_state),
                 datagram,
                 endpoint_context.congestion_controller,
+                endpoint_context.random_generator,
             )?;
 
             connection

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -356,6 +356,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                             shared_state.as_deref_mut(),
                             datagram,
                             endpoint_context.congestion_controller,
+                            endpoint_context.random_generator,
                         )
                         .map_err(|_| {
                             //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#9

--- a/specs/todos/transport/8.2.toml
+++ b/specs/todos/transport/8.2.toml
@@ -1,15 +1,5 @@
 [[TODO]]
 target = "https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#8.2.1"
-tracking-issue = "408"
-feature = "Connection migration"
-quote = '''
-The endpoint MUST use unpredictable data in every PATH_CHALLENGE
-frame so that it can associate the peer's response with the
-corresponding PATH_CHALLENGE.
-'''
-
-[[TODO]]
-target = "https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#8.2.1"
 tracking-issue = "409"
 feature = "Connection migration"
 quote = '''


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/s2n-quic/issues/408

*Description of changes:*
generate rand data as part of path challenge frame

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
