### PR TITLE
Implement Provider for Limits

### DIFF
--- a/quic/s2n-quic/src/provider/connection_id.rs
+++ b/quic/s2n-quic/src/provider/connection_id.rs
@@ -21,16 +21,6 @@ cfg_if::cfg_if! {
 
 impl_provider_utils!();
 
-/// Implement Provider for all types that implement Format
-impl<T: Format> Provider for T {
-    type Format = T;
-    type Error = core::convert::Infallible;
-
-    fn start(self) -> Result<Self::Format, Self::Error> {
-        Ok(self)
-    }
-}
-
 #[cfg(feature = "rand")]
 pub mod random {
     use core::{
@@ -52,6 +42,15 @@ pub mod random {
 
         fn start(self) -> Result<Self::Format, Self::Error> {
             Ok(self.0)
+        }
+    }
+
+    impl super::TryInto for Format {
+        type Provider = Provider;
+        type Error = Infallible;
+
+        fn try_into(self) -> Result<Self::Provider, Self::Error> {
+            Ok(Provider(self))
         }
     }
 


### PR DESCRIPTION
In order to make it easier for customers to specify limits, this change implements Provider for Limits. This will let Limits be specified without the customer needing to implement Provider as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.