### PR TITLE
Allow cert_resolver to be specified for Rustls and reverse default Cipher preferences

### DIFF
--- a/quic/s2n-quic-rustls/src/lib.rs
+++ b/quic/s2n-quic-rustls/src/lib.rs
@@ -32,9 +32,13 @@ pub mod certificate;
 
 // The first 3 ciphers are TLS1.3
 // https://github.com/ctz/rustls/blob/1287510bece905b7e45cf31d6e7cf3334b98bb2e/rustls/src/suites.rs#L379
-// We fetch the top 3 ciphersuites from rustls::ALL_CIPHERSUITES. This is an internal implementation
-// and can change in future versions of rustls. Therefore care must be taken to maintain the same order
-// of ciphersuites when upgrading rustls version.
+// We fetch the top 3 ciphersuites from rustls::ALL_CIPHERSUITES and reverse the order to end up
+// with a default preference of:
+// 1. TLS13_AES_128_GCM_SHA256
+// 2. TLS13_AES_256_GCM_SHA384
+// 3. TLS13_CHACHA20_POLY1305_SHA256
+// This is an internal implementation and can change in future versions of rustls. Therefore care
+// must be taken to maintain the same order of ciphersuites when upgrading rustls version.
 pub fn default_ciphersuites() -> Vec<&'static SupportedCipherSuite> {
     rustls::ALL_CIPHERSUITES
         .iter()


### PR DESCRIPTION
This change adds a `with_cert_resolver` method to the Rustls Server builder so that a cert resolver may be specified. In addition, the default cipher preferences are reversed, which will result in AES128 being the most preferred. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.