### PR TITLE
feat: change the pattern delimiter to `,` from ` `

### DIFF
--- a/common/compliance/cargo-compliance/src/pattern.rs
+++ b/common/compliance/cargo-compliance/src/pattern.rs
@@ -27,7 +27,7 @@ impl<'a> Default for Pattern<'a> {
 
 impl<'a> Pattern<'a> {
     pub fn from_arg(arg: &'a str) -> Result<Self, Error> {
-        let mut parts = arg.split(' ').filter(|p| !p.is_empty());
+        let mut parts = arg.split(',').filter(|p| !p.is_empty());
         let meta = parts.next().expect("should have at least one pattern");
         if meta.is_empty() {
             return Err(anyhow!("compliance pattern cannot be empty"));


### PR DESCRIPTION
In Java, JS, Rust, and C you can use `//` as a comment
BUT, in Python comments MUST start with `#`
So you would think that you use just use `#=` and  `##`
for the meta and content delimiters.
BUT, Python linters require a space like this `# here is my comment`

To adjust the meta and content patterns the report tool can use the following pattern
`--source-patter (meta content)path`
This pattern requires using a space to delimit the meta and content tokens.
Also, this pattern is not passed to the HTML report.

The goal is to be able to
`--source-patter (# //=,# //#)path/to/*.py`

This resolves both the Python linters and does not require an update to the report JSON file to pass this custom pattern.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
