### PR TITLE
Return dummy local_addr and remote_addr from Server and Connection Handle

### DIFF
--- a/quic/s2n-quic/src/connection/handle.rs
+++ b/quic/s2n-quic/src/connection/handle.rs
@@ -116,7 +116,8 @@ macro_rules! impl_handle_api {
         /// ```
         #[cfg(feature = "std")]
         pub fn local_addr(&self) -> $crate::connection::Result<std::net::SocketAddr> {
-            todo!()
+            // TODO: Return the actual local address
+            Ok("127.0.0.1:443".parse().unwrap())
         }
 
         /// Returns the remote address that this connection is connected to.
@@ -128,7 +129,8 @@ macro_rules! impl_handle_api {
         /// ```
         #[cfg(feature = "std")]
         pub fn remote_addr(&self) -> $crate::connection::Result<std::net::SocketAddr> {
-            todo!()
+            // TODO: Return the actual remote address
+            Ok("127.0.0.2:8000".parse().unwrap())
         }
 
         /// TODO

--- a/quic/s2n-quic/src/server/mod.rs
+++ b/quic/s2n-quic/src/server/mod.rs
@@ -140,7 +140,8 @@ impl Server {
     /// ```
     #[cfg(feature = "std")]
     pub fn local_addr(&self) -> Result<std::net::SocketAddr, std::io::Error> {
-        todo!()
+        // TODO: Return the actual local address
+        Ok("127.0.0.1:443".parse().unwrap())
     }
 }
 


### PR DESCRIPTION
To unblock customers, this change returns dummy values for the local_addr and remote_addr methods on Server and Connection handle. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.