### PR TITLE
Clippy fixes

### DIFF
--- a/quic/s2n-quic-core/src/crypto/application/keyset.rs
+++ b/quic/s2n-quic-core/src/crypto/application/keyset.rs
@@ -485,7 +485,7 @@ mod tests {
         // The first encryption should use the expected keyphase, and put us into the
         // KEY_UPDATE_WINDOW.
         assert_eq!(keyset.active_key().encrypted_packets(), 0);
-        assert_eq!(keyset.active_key().needs_update(), false);
+        assert!(!keyset.active_key().needs_update());
         assert!(keyset
             .encrypt_packet(buffer, |buffer, _key, _phase| {
                 let payload = ProtectedPayload::new(0, &mut decoder_bytes);
@@ -502,7 +502,7 @@ mod tests {
 
         // Subsequent encryptions should be in the next phase and our key should need an update.
         assert_eq!(keyset.encryption_phase(), KeyPhase::One);
-        assert_eq!(keyset.active_key().needs_update(), true);
+        assert!(keyset.active_key().needs_update());
     }
 
     //= https://tools.ietf.org/id/draft-ietf-quic-tls-32.txt#6.6

--- a/quic/s2n-quic-core/src/frame/path_validation.rs
+++ b/quic/s2n-quic-core/src/frame/path_validation.rs
@@ -102,7 +102,7 @@ mod test {
         let mut probe = Probe::Probing;
         probe |= Probe::Probing;
 
-        assert_eq!(true, probe.is_probing())
+        assert!(probe.is_probing())
     }
 
     #[test]
@@ -110,6 +110,6 @@ mod test {
         let mut probe = Probe::Probing;
         probe |= Probe::NonProbing;
 
-        assert_eq!(false, probe.is_probing())
+        assert!(!probe.is_probing())
     }
 }

--- a/quic/s2n-quic-core/src/inet/ip.rs
+++ b/quic/s2n-quic-core/src/inet/ip.rs
@@ -92,10 +92,10 @@ impl SocketAddress {
     }
 
     /// Converts the IP address into a IPv6 mapped address
-    pub fn to_ipv6_mapped(&self) -> SocketAddressV6 {
+    pub fn to_ipv6_mapped(self) -> SocketAddressV6 {
         match self {
             Self::IpV4(addr) => addr.to_ipv6_mapped(),
-            Self::IpV6(addr) => *addr,
+            Self::IpV6(addr) => addr,
         }
     }
 }

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -581,13 +581,12 @@ impl Cubic {
         //# for this flow to increase its congestion window because the reduced
         //# W_max forces the flow to have the plateau earlier.  This allows more
         //# time for the new flow to catch up to its congestion window size.
-        if self.w_max < self.w_last_max {
-            self.w_last_max = self.w_max;
-            self.w_max = (self.w_max * (1.0 + BETA_CUBIC) / 2.0)
+        let w_max = self.w_max;
+        if w_max < self.w_last_max {
+            self.w_max = (w_max * (1.0 + BETA_CUBIC) / 2.0)
                 .max(self.bytes_to_packets(self.minimum_window()));
-        } else {
-            self.w_last_max = self.w_max;
         }
+        self.w_last_max = w_max;
 
         let cwnd_start = (cwnd * BETA_CUBIC).max(self.minimum_window());
 

--- a/quic/s2n-quic-core/src/time/timer.rs
+++ b/quic/s2n-quic-core/src/time/timer.rs
@@ -80,13 +80,13 @@ mod tests {
         let now = NoopClock.get_time();
         let mut timer = Timer::default();
 
-        assert_eq!(false, timer.is_armed());
+        assert!(!timer.is_armed());
 
         timer.set(now);
-        assert_eq!(true, timer.is_armed());
+        assert!(timer.is_armed());
 
         timer.cancel();
-        assert_eq!(false, timer.is_armed());
+        assert!(!timer.is_armed());
     }
 
     #[test]
@@ -94,18 +94,18 @@ mod tests {
         let mut now = NoopClock.get_time();
         let mut timer = Timer::default();
 
-        assert_eq!(false, timer.is_expired(now));
+        assert!(!timer.is_expired(now));
 
         timer.set(now + Duration::from_millis(100));
 
         now += Duration::from_millis(99);
-        assert_eq!(false, timer.is_expired(now));
+        assert!(!timer.is_expired(now));
 
         now += Duration::from_millis(1);
-        assert_eq!(true, timer.is_expired(now));
+        assert!(timer.is_expired(now));
 
         timer.cancel();
-        assert_eq!(false, timer.is_expired(now));
+        assert!(!timer.is_expired(now));
     }
 
     #[test]
@@ -115,12 +115,12 @@ mod tests {
 
         timer.set(now + Duration::from_millis(100));
 
-        assert_eq!(false, timer.poll_expiration(now).is_ready());
-        assert_eq!(true, timer.is_armed());
+        assert!(!timer.poll_expiration(now).is_ready());
+        assert!(timer.is_armed());
 
         now += Duration::from_millis(100);
 
-        assert_eq!(true, timer.poll_expiration(now).is_ready());
-        assert_eq!(false, timer.is_armed());
+        assert!(timer.poll_expiration(now).is_ready());
+        assert!(!timer.is_armed());
     }
 }

--- a/quic/s2n-quic-transport/src/buffer/tests.rs
+++ b/quic/s2n-quic-transport/src/buffer/tests.rs
@@ -305,15 +305,15 @@ fn write_and_read_buffer() {
     let mut buf = StreamReceiveBuffer::new();
 
     assert_eq!(0, buf.len());
-    assert_eq!(true, buf.is_empty());
+    assert!(buf.is_empty());
     assert_eq!(None, buf.pop());
 
     buf.write_at(0u32.into(), &[0, 1, 2, 3]).unwrap();
     assert_eq!(4, buf.len());
-    assert_eq!(false, buf.is_empty());
+    assert!(!buf.is_empty());
     assert_eq!(&[0u8, 1, 2, 3], buf.pop().unwrap().deref());
     assert_eq!(0, buf.len());
-    assert_eq!(true, buf.is_empty());
+    assert!(buf.is_empty());
     assert_eq!(None, buf.pop());
 
     buf.write_at(0u32.into(), &[0, 1, 2, 3]).unwrap();

--- a/quic/s2n-quic-transport/src/connection/peer_id_registry.rs
+++ b/quic/s2n-quic-transport/src/connection/peer_id_registry.rs
@@ -937,7 +937,7 @@ pub(crate) mod tests {
             Some(TEST_TOKEN_1),
         );
 
-        assert_eq!(true, reg.is_active(&id_1));
+        assert!(reg.is_active(&id_1));
     }
 
     #[test]
@@ -951,9 +951,9 @@ pub(crate) mod tests {
             Some(TEST_TOKEN_1),
         );
 
-        assert_eq!(true, reg.is_active(&id_1));
+        assert!(reg.is_active(&id_1));
         reg.registered_ids[0].status = PendingRetirement;
-        assert_eq!(false, reg.is_active(&id_1));
+        assert!(!reg.is_active(&id_1));
     }
 
     #[test]
@@ -967,9 +967,9 @@ pub(crate) mod tests {
             Some(TEST_TOKEN_1),
         );
 
-        assert_eq!(true, reg.is_active(&id_1));
+        assert!(reg.is_active(&id_1));
         let id_unknown = id(b"unknown");
-        assert_eq!(false, reg.is_active(&id_unknown));
+        assert!(!reg.is_active(&id_unknown));
     }
 
     #[test]

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -137,9 +137,9 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
             return Poll::Ready(Err(s2n_quic_core::endpoint::CloseError));
         }
 
-        // The mem::replace is needed to work around a limitation which does not allow us to pass
+        // The mem::take is needed to work around a limitation which does not allow us to pass
         // the new queue directly - even though we will populate the field again after the call.
-        let dequeued_wakeups = core::mem::replace(&mut self.dequeued_wakeups, VecDeque::new());
+        let dequeued_wakeups = core::mem::take(&mut self.dequeued_wakeups);
         self.dequeued_wakeups = self.wakeup_queue.poll_pending_wakeups(dequeued_wakeups, cx);
         let nr_wakeups = self.dequeued_wakeups.len();
         let close_packet_buffer = &mut self.close_packet_buffer;

--- a/quic/s2n-quic-transport/src/interval_set/mod.rs
+++ b/quic/s2n-quic-transport/src/interval_set/mod.rs
@@ -650,10 +650,10 @@ impl<T: IntervalBound> IntervalSet<T> {
 
             for interval in self.intervals.iter() {
                 // make sure that a few items exist
-                for value in interval.clone().take(3) {
+                for value in (*interval).take(3) {
                     assert!(self.contains(&value), "set should contain value");
                 }
-                for value in interval.clone().rev().take(3) {
+                for value in (*interval).rev().take(3) {
                     assert!(self.contains(&value), "set should contain value");
                 }
 

--- a/quic/s2n-quic-transport/src/path/challenge.rs
+++ b/quic/s2n-quic-transport/src/path/challenge.rs
@@ -225,13 +225,13 @@ mod tests {
             endpoint::Type::Client,
         );
         assert_eq!(helper.challenge.state, State::RequiresTransmission(2));
-        assert_eq!(helper.challenge.abandon_timer.is_armed(), false);
+        assert!(!helper.challenge.abandon_timer.is_armed());
 
         // Trigger:
         helper.challenge.on_transmit(&mut context);
 
         // Expectation:
-        assert_eq!(helper.challenge.abandon_timer.is_armed(), true);
+        assert!(helper.challenge.abandon_timer.is_armed());
     }
 
     #[test]
@@ -275,12 +275,12 @@ mod tests {
         helper
             .challenge
             .on_timeout(expiration_time - Duration::from_millis(10));
-        assert_eq!(helper.challenge.is_abandoned(), false);
+        assert!(!helper.challenge.is_abandoned());
 
         helper
             .challenge
             .on_timeout(expiration_time + Duration::from_millis(10));
-        assert_eq!(helper.challenge.is_abandoned(), true);
+        assert!(helper.challenge.is_abandoned());
     }
 
     #[test]
@@ -304,7 +304,7 @@ mod tests {
             .on_timeout(expiration_time + Duration::from_millis(10));
 
         // Expectation:
-        assert_eq!(helper.challenge.is_abandoned(), true);
+        assert!(helper.challenge.is_abandoned());
 
         // Trigger:
         helper
@@ -312,7 +312,7 @@ mod tests {
             .on_timeout(expiration_time - Duration::from_millis(10));
 
         // Expectation:
-        assert_eq!(helper.challenge.is_abandoned(), true);
+        assert!(helper.challenge.is_abandoned());
     }
 
     #[test]
@@ -330,12 +330,12 @@ mod tests {
         );
         helper.challenge.on_transmit(&mut context);
 
-        assert_eq!(helper.challenge.is_abandoned(), false);
+        assert!(!helper.challenge.is_abandoned());
 
         helper
             .challenge
             .on_timeout(expiration_time + Duration::from_millis(10));
-        assert_eq!(helper.challenge.is_abandoned(), true);
+        assert!(helper.challenge.is_abandoned());
     }
 
     #[test]
@@ -345,6 +345,6 @@ mod tests {
         assert!(helper.challenge.is_valid(&helper.expected_data));
 
         let wrong_data: [u8; 8] = [5; 8];
-        assert_eq!(helper.challenge.is_valid(&wrong_data), false);
+        assert!(!helper.challenge.is_valid(&wrong_data));
     }
 }

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -612,17 +612,11 @@ mod tests {
     fn promote_validated_path_to_last_known_validated_path() {
         // Setup:
         let mut helper = helper_manager_with_paths();
-        assert_eq!(
-            helper.manager.paths[helper.first_path_id.0 as usize].is_validated(),
-            false
-        );
+        assert!(!helper.manager.paths[helper.first_path_id.0 as usize].is_validated());
 
         // Trigger:
         helper.manager.paths[helper.first_path_id.0 as usize].on_validated();
-        assert_eq!(
-            helper.manager.paths[helper.first_path_id.0 as usize].is_validated(),
-            true
-        );
+        assert!(helper.manager.paths[helper.first_path_id.0 as usize].is_validated());
         helper
             .manager
             .update_active_path(helper.second_path_id)
@@ -637,10 +631,7 @@ mod tests {
     fn dont_promote_non_validated_path_to_last_known_validated_path() {
         // Setup:
         let mut helper = helper_manager_with_paths();
-        assert_eq!(
-            helper.manager.paths[helper.first_path_id.0 as usize].is_validated(),
-            false
-        );
+        assert!(!helper.manager.paths[helper.first_path_id.0 as usize].is_validated());
 
         // Trigger:
         helper
@@ -723,10 +714,7 @@ mod tests {
             endpoint::Type::Client,
         );
         helper.manager[helper.second_path_id].on_transmit(&mut context);
-        assert_eq!(
-            helper.manager[helper.second_path_id].is_challenge_pending(),
-            true
-        );
+        assert!(helper.manager[helper.second_path_id].is_challenge_pending());
 
         // Trigger 1:
         // A response 100ms before the challenge is abandoned
@@ -735,11 +723,8 @@ mod tests {
             .on_timeout(helper.now + helper.challenge_expiration - Duration::from_millis(100));
 
         // Expectation 1:
-        assert_eq!(
-            helper.manager[helper.second_path_id].is_challenge_pending(),
-            true
-        );
-        assert_eq!(helper.manager[helper.second_path_id].is_validated(), false);
+        assert!(helper.manager[helper.second_path_id].is_challenge_pending(),);
+        assert!(!helper.manager[helper.second_path_id].is_validated());
 
         // Trigger 2:
         //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#8.2.2
@@ -761,7 +746,7 @@ mod tests {
         helper.manager.on_path_response(&frame);
 
         // Expectation 2:
-        assert_eq!(helper.manager[helper.second_path_id].is_validated(), true);
+        assert!(helper.manager[helper.second_path_id].is_validated());
     }
 
     #[test]
@@ -801,10 +786,7 @@ mod tests {
             endpoint::Type::Client,
         );
         helper.manager[helper.second_path_id].on_transmit(&mut context);
-        assert_eq!(
-            helper.manager[helper.second_path_id].is_challenge_pending(),
-            true
-        );
+        assert!(helper.manager[helper.second_path_id].is_challenge_pending());
 
         // Trigger 1:
         //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#8.2.4
@@ -816,11 +798,8 @@ mod tests {
             .on_timeout(helper.now + helper.challenge_expiration + Duration::from_millis(100));
 
         // Expectation 1:
-        assert_eq!(
-            helper.manager[helper.second_path_id].is_challenge_pending(),
-            false
-        );
-        assert_eq!(helper.manager[helper.second_path_id].is_validated(), false);
+        assert!(!helper.manager[helper.second_path_id].is_challenge_pending());
+        assert!(!helper.manager[helper.second_path_id].is_validated());
 
         // Trigger 2:
         let frame = s2n_quic_core::frame::PathResponse {
@@ -829,7 +808,7 @@ mod tests {
         helper.manager.on_path_response(&frame);
 
         // Expectation 2:
-        assert_eq!(helper.manager[helper.second_path_id].is_validated(), false);
+        assert!(!helper.manager[helper.second_path_id].is_validated());
     }
 
     #[test]
@@ -856,7 +835,7 @@ mod tests {
         let mut manager = manager(first_path, None);
 
         // verify we have one path
-        assert_eq!(manager.path(&SocketAddress::default()).is_some(), true);
+        assert!(manager.path(&SocketAddress::default()).is_some());
         let new_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
         let new_addr = SocketAddress::from(new_addr);
         assert!(manager.path(&new_addr).is_none());
@@ -882,8 +861,8 @@ mod tests {
 
         // Expectation:
         assert_eq!(path_id.0, 1);
-        assert_eq!(unblocked, false);
-        assert_eq!(manager.path(&new_addr).is_some(), true);
+        assert!(!unblocked);
+        assert!(manager.path(&new_addr).is_some());
         assert_eq!(manager.paths.len(), 2);
     }
 
@@ -935,7 +914,7 @@ mod tests {
 
         // Expectation:
         assert!(on_datagram_result.is_err());
-        assert_eq!(manager.path(&new_addr).is_some(), false);
+        assert!(!manager.path(&new_addr).is_some());
         assert_eq!(manager.paths.len(), 1);
     }
 
@@ -975,7 +954,7 @@ mod tests {
             .unwrap();
 
         // verify we have two paths
-        assert_eq!(manager.path(&new_addr).is_some(), true);
+        assert!(manager.path(&new_addr).is_some());
         assert_eq!(manager.paths.len(), 2);
 
         //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#9
@@ -1164,12 +1143,12 @@ mod tests {
         manager[second_path_id].on_timeout(abandon_time - Duration::from_millis(10));
 
         // Expectation 2:
-        assert_eq!(manager[second_path_id].is_challenge_pending(), true);
+        assert!(manager[second_path_id].is_challenge_pending());
 
         // Trigger 3:
         manager[second_path_id].on_timeout(abandon_time + Duration::from_millis(10));
         // Expectation 3:
-        assert_eq!(manager[second_path_id].is_challenge_pending(), false);
+        assert!(!manager[second_path_id].is_challenge_pending());
     }
 
     //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#5.1.2
@@ -1204,12 +1183,12 @@ mod tests {
         // Setup:
         let helper = helper_manager_with_paths();
         let fp = &helper.manager[helper.first_path_id];
-        assert_eq!(fp.at_amplification_limit(), true);
+        assert!(fp.at_amplification_limit());
         let sp = &helper.manager[helper.second_path_id];
-        assert_eq!(sp.at_amplification_limit(), true);
+        assert!(sp.at_amplification_limit());
 
         // Expectation:
-        assert_eq!(helper.manager.is_amplification_limited(), true);
+        assert!(helper.manager.is_amplification_limited());
     }
 
     #[test]
@@ -1217,13 +1196,13 @@ mod tests {
         // Setup:
         let mut helper = helper_manager_with_paths();
         let fp = &helper.manager[helper.first_path_id];
-        assert_eq!(fp.at_amplification_limit(), true);
+        assert!(fp.at_amplification_limit());
         let sp = &mut helper.manager[helper.second_path_id];
         sp.on_bytes_received(1200);
-        assert_eq!(sp.at_amplification_limit(), false);
+        assert!(!sp.at_amplification_limit());
 
         // Expectation:
-        assert_eq!(helper.manager.is_amplification_limited(), false);
+        assert!(!helper.manager.is_amplification_limited());
     }
 
     #[test]
@@ -1232,12 +1211,12 @@ mod tests {
         let helper = helper_manager_with_paths();
         let interest = transmission::Interest::Forced;
         let fp = &helper.manager[helper.first_path_id];
-        assert_eq!(interest.can_transmit(fp.transmission_constraint()), false);
+        assert!(!interest.can_transmit(fp.transmission_constraint()));
         let sp = &helper.manager[helper.second_path_id];
-        assert_eq!(interest.can_transmit(sp.transmission_constraint()), false);
+        assert!(!interest.can_transmit(sp.transmission_constraint()));
 
         // Expectation:
-        assert_eq!(helper.manager.can_transmit(interest), false);
+        assert!(!helper.manager.can_transmit(interest));
     }
 
     #[test]
@@ -1246,14 +1225,14 @@ mod tests {
         let mut helper = helper_manager_with_paths();
         let interest = transmission::Interest::Forced;
         let fp = &helper.manager[helper.first_path_id];
-        assert_eq!(interest.can_transmit(fp.transmission_constraint()), false);
+        assert!(!interest.can_transmit(fp.transmission_constraint()));
 
         let sp = &mut helper.manager[helper.second_path_id];
         sp.on_bytes_received(1200);
-        assert_eq!(interest.can_transmit(sp.transmission_constraint()), true);
+        assert!(interest.can_transmit(sp.transmission_constraint()));
 
         // Expectation:
-        assert_eq!(helper.manager.can_transmit(interest), true);
+        assert!(helper.manager.can_transmit(interest));
     }
 
     fn helper_manager_register_second_path_conn_id(register_second_conn_id: bool) -> Helper {

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -402,7 +402,7 @@ mod tests {
         //= type=test
         //# An endpoint MUST NOT send more than one PATH_RESPONSE frame in
         //# response to one PATH_CHALLENGE frame; see Section 13.3.
-        assert_eq!(path.response_data.is_some(), false);
+        assert!(!path.response_data.is_some());
 
         assert_eq!(context.frame_buffer.len(), 1);
         let written_data = match context.frame_buffer.pop_front().unwrap().as_frame() {
@@ -431,15 +431,15 @@ mod tests {
         path.on_transmit(&mut context); // send challenge and arm timer
 
         // Expectation:
-        assert_eq!(path.is_challenge_pending(), true);
-        assert_eq!(path.challenge.is_some(), true);
+        assert!(path.is_challenge_pending());
+        assert!(path.challenge.is_some());
 
         // Trigger:
         path.on_timeout(expiration_time + Duration::from_millis(10));
 
         // Expectation:
-        assert_eq!(path.is_challenge_pending(), false);
-        assert_eq!(path.challenge.is_some(), false);
+        assert!(!path.is_challenge_pending());
+        assert!(!path.challenge.is_some());
     }
 
     #[test]
@@ -449,15 +449,15 @@ mod tests {
         let helper_challenge = helper_challenge();
 
         // Expectation:
-        assert_eq!(path.is_challenge_pending(), false);
-        assert_eq!(path.challenge.is_some(), false);
+        assert!(!path.is_challenge_pending());
+        assert!(!path.challenge.is_some());
 
         // Trigger:
         path = path.with_challenge(helper_challenge.challenge);
 
         // Expectation:
-        assert_eq!(path.is_challenge_pending(), true);
-        assert_eq!(path.challenge.is_some(), true);
+        assert!(path.is_challenge_pending());
+        assert!(path.challenge.is_some());
     }
 
     #[test]
@@ -466,14 +466,14 @@ mod tests {
         let mut path = testing::helper_path();
 
         // Expectation:
-        assert_eq!(path.response_data.is_some(), false);
+        assert!(!path.response_data.is_some());
 
         // Trigger:
         let expected_data: [u8; 8] = [0; 8];
         path.on_path_challenge(&expected_data);
 
         // Expectation:
-        assert_eq!(path.response_data.is_some(), true);
+        assert!(path.response_data.is_some());
     }
 
     //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#8.2.2
@@ -509,14 +509,14 @@ mod tests {
         let helper_challenge = helper_challenge();
 
         // Expectation:
-        assert_eq!(path.is_validated(), false);
+        assert!(!path.is_validated());
 
         // Trigger:
         path = path.with_challenge(helper_challenge.challenge);
         path.on_path_response(&helper_challenge.expected_data);
 
         // Expectation:
-        assert_eq!(path.is_validated(), true);
+        assert!(path.is_validated());
     }
 
     #[test]
@@ -526,15 +526,15 @@ mod tests {
         let helper_challenge = helper_challenge();
         path = path.with_challenge(helper_challenge.challenge);
 
-        assert_eq!(path.is_validated(), false);
-        assert_eq!(path.challenge.is_some(), true);
+        assert!(!path.is_validated());
+        assert!(path.challenge.is_some());
 
         // Trigger:
         path.on_validated();
 
         // Expectation:
-        assert_eq!(path.is_validated(), true);
-        assert_eq!(path.challenge.is_some(), false);
+        assert!(path.is_validated());
+        assert!(!path.challenge.is_some());
     }
 
     #[test]
@@ -565,14 +565,14 @@ mod tests {
         let mut unblocked = path.on_bytes_received(1200);
         assert!(unblocked);
         path.on_bytes_transmitted((1200 * 2) + 1);
-        assert_eq!(path.at_amplification_limit(), true);
+        assert!(path.at_amplification_limit());
         assert_eq!(
             path.transmission_constraint(),
             transmission::Constraint::AmplificationLimited
         );
 
         unblocked = path.on_bytes_received(1200);
-        assert_eq!(path.at_amplification_limit(), false);
+        assert!(!path.at_amplification_limit());
         assert_eq!(
             path.transmission_constraint(),
             transmission::Constraint::None
@@ -580,7 +580,7 @@ mod tests {
         assert!(unblocked);
 
         path.on_bytes_transmitted((1200 * 6) + 1);
-        assert_eq!(path.at_amplification_limit(), true);
+        assert!(path.at_amplification_limit());
         assert_eq!(
             path.transmission_constraint(),
             transmission::Constraint::AmplificationLimited
@@ -591,7 +591,7 @@ mod tests {
         path.on_validated();
         path.on_bytes_transmitted(24);
         // Validated paths should always be able to transmit
-        assert_eq!(path.at_amplification_limit(), false);
+        assert!(!path.at_amplification_limit());
         assert_eq!(
             path.transmission_constraint(),
             transmission::Constraint::None

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -3243,8 +3243,8 @@ mod test {
             .on_validated();
         let first_path = path_manager.path(&first_addr).unwrap().1;
         let second_path = path_manager.path(&second_addr).unwrap().1;
-        assert_eq!(false, first_path.at_amplification_limit());
-        assert_eq!(false, second_path.at_amplification_limit());
+        assert!(!first_path.at_amplification_limit());
+        assert!(!second_path.at_amplification_limit());
         assert!(first_path.is_peer_validated());
         assert!(second_path.is_peer_validated());
 

--- a/quic/s2n-quic-transport/src/stream/tests/stream_managers_tests.rs
+++ b/quic/s2n-quic-transport/src/stream/tests/stream_managers_tests.rs
@@ -1779,12 +1779,9 @@ fn add_and_remove_streams_from_on_connection_window_lists() {
     manager.with_asserted_stream(stream_1, |stream| {
         stream.on_connection_window_available_retrieve_window = 0;
     });
-    assert_eq!(
-        true,
-        manager
-            .streams_waiting_for_connection_flow_control_credits()
-            .is_empty()
-    );
+    assert!(manager
+        .streams_waiting_for_connection_flow_control_credits()
+        .is_empty());
 }
 
 #[test]
@@ -1856,12 +1853,9 @@ fn max_data_causes_on_connection_window_available_to_be_called_on_streams() {
         assert_connection_window_state(&mut manager, *stream_id, 1, 0);
     }
     assert_connection_window_state(&mut manager, stream_2, 0, 0);
-    assert_eq!(
-        true,
-        manager
-            .streams_waiting_for_connection_flow_control_credits()
-            .is_empty()
-    );
+    assert!(manager
+        .streams_waiting_for_connection_flow_control_credits()
+        .is_empty());
 
     // Let stream_3 grab more of the connection window than it requires
     manager.with_asserted_stream(stream_3, |stream| {
@@ -1956,12 +1950,9 @@ fn max_data_causes_on_connection_window_available_to_be_called_on_streams() {
     assert_connection_window_state(&mut manager, stream_1, 3, 0);
 
     // All done
-    assert_eq!(
-        true,
-        manager
-            .streams_waiting_for_connection_flow_control_credits()
-            .is_empty()
-    );
+    assert!(manager
+        .streams_waiting_for_connection_flow_control_credits()
+        .is_empty());
 }
 
 #[test]
@@ -2002,12 +1993,9 @@ fn add_and_remove_streams_from_delivery_notification_window_lists() {
     manager.with_asserted_stream(stream_1, |stream| {
         stream.interests.delivery_notifications = false;
     });
-    assert_eq!(
-        true,
-        manager
-            .streams_waiting_for_delivery_notifications()
-            .is_empty()
-    );
+    assert!(manager
+        .streams_waiting_for_delivery_notifications()
+        .is_empty());
 }
 
 #[test]
@@ -2143,12 +2131,9 @@ fn close_is_forwarded_to_all_streams() {
         [stream_2],
         *manager.streams_waiting_for_connection_flow_control_credits()
     );
-    assert_eq!(
-        true,
-        manager
-            .streams_waiting_for_delivery_notifications()
-            .is_empty()
-    );
+    assert!(manager
+        .streams_waiting_for_delivery_notifications()
+        .is_empty());
     assert_eq!([stream_4], *manager.streams_waiting_for_transmission());
 }
 
@@ -2189,7 +2174,7 @@ fn add_and_remove_streams_from_transmission_lists() {
     manager.with_asserted_stream(stream_1, |stream| {
         stream.on_transmit_try_write_frames = 0;
     });
-    assert_eq!(true, manager.streams_waiting_for_transmission().is_empty());
+    assert!(manager.streams_waiting_for_transmission().is_empty());
 }
 
 #[test]
@@ -2230,10 +2215,7 @@ fn add_and_remove_streams_from_retransmission_lists() {
     manager.with_asserted_stream(stream_1, |stream| {
         stream.on_transmit_try_write_frames = 0;
     });
-    assert_eq!(
-        true,
-        manager.streams_waiting_for_retransmission().is_empty()
-    );
+    assert!(manager.streams_waiting_for_retransmission().is_empty());
 }
 
 #[test]
@@ -2305,10 +2287,7 @@ fn on_transmit_queries_streams_for_data() {
     // Only lost data may be written when constrained to retransmission only
     assert_stream_write_state(&mut manager, stream_5, 1, 0);
     assert_eq!(1, write_context.frame_buffer.len());
-    assert_eq!(
-        true,
-        manager.streams_waiting_for_retransmission().is_empty()
-    );
+    assert!(manager.streams_waiting_for_retransmission().is_empty());
 
     write_context.transmission_constraint = transmission::Constraint::None;
 
@@ -2321,7 +2300,7 @@ fn on_transmit_queries_streams_for_data() {
     // All streams have written a frame
     assert_eq!(4, frame_buffer.len());
     frame_buffer.clear();
-    assert_eq!(true, manager.streams_waiting_for_transmission().is_empty());
+    assert!(manager.streams_waiting_for_transmission().is_empty());
 
     manager.with_asserted_stream(stream_1, |stream| {
         stream.on_transmit_try_write_frames = 10;
@@ -2459,7 +2438,7 @@ fn on_transmit_queries_streams_for_data() {
 
     assert_eq!(10, frame_buffer.len());
     frame_buffer.clear();
-    assert_eq!(true, manager.streams_waiting_for_transmission().is_empty());
+    assert!(manager.streams_waiting_for_transmission().is_empty());
 }
 
 fn invalid_stream_id(local_ep_type: endpoint::Type) -> StreamId {


### PR DESCRIPTION
Addresses the following new Clippy lints in the latest stable Clippy:

```Rust
error: methods with the following characteristics: (`to_*` and `self` type is `Copy`) usually take `self` by value
  --> quic/s2n-quic-core/src/inet/ip.rs:95:27
   |
95 |     pub fn to_ipv6_mapped(&self) -> SocketAddressV6 {
   |                           ^^^^^
   |
   = note: `-D clippy::wrong-self-convention` implied by `-D warnings`
   = help: consider choosing a less ambiguous name
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#wrong_self_convention
```

```Rust
error: all if blocks contain the same code at the start
   --> quic/s2n-quic-core/src/recovery/cubic.rs:584:9
    |
584 | /         if self.w_max < self.w_last_max {
585 | |             self.w_last_max = self.w_max;
    | |_________________________________________^
    |
    = note: `-D clippy::branches-sharing-code` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#branches_sharing_code
help: consider moving the start statements out like this
    |
584 |         self.w_last_max = self.w_max;
585 |         if self.w_max < self.w_last_max {
    |
```

```Rust
error: used `assert_eq!` with a literal bool
   --> quic/s2n-quic-core/src/time/timer.rs:124:9
    |
124 |         assert_eq!(false, timer.is_armed());
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace it with: `assert!(..)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_assert_comparison
```

```Rust
error: using `clone` on type `interval_set::interval::Interval<T>` which implements the `Copy` trait
   --> quic/s2n-quic-transport/src/interval_set/mod.rs:656:30
    |
656 |                 for value in interval.clone().rev().take(3) {
    |                              ^^^^^^^^^^^^^^^^ help: try dereferencing it: `(*interval)`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#clone_on_copy
```

```Rust
error: replacing a value of type `T` with `T::default()` is better expressed using `std::mem::take`
   --> quic/s2n-quic-transport/src/endpoint/mod.rs:142:32
    |
142 |         let dequeued_wakeups = core::mem::replace(&mut self.dequeued_wakeups, VecDeque::new());
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: consider using: `std::mem::take(&mut self.dequeued_wakeups)`
    |
    = note: `-D clippy::mem-replace-with-default` implied by `-D warnings`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#mem_replace_with_default
```

```Rust
error: all if blocks contain the same code at the end
    --> quic/s2n-quic-transport/src/stream/tests/send_stream_tests.rs:1297:9
     |
1297 | /             assert_eq!(stream_interests(&["fin"]), test_env.stream.interests());
1298 | |         }
     | |_________^
     |
     = note: `-D clippy::branches-sharing-code` implied by `-D warnings`
     = warning: Some moved values might need to be renamed to avoid wrong references
     = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#branches_sharing_code
help: consider moving the end statements out like this
     |
1297 |         }
1298 |         assert_eq!(stream_interests(&["fin"]), test_env.stream.interests());
     |
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.