### PR TITLE
core: increase default stream max send buffer size

### DIFF
--- a/quic/s2n-quic-core/src/stream/limits.rs
+++ b/quic/s2n-quic-core/src/stream/limits.rs
@@ -3,8 +3,9 @@
 
 use crate::{transport::parameters::InitialMaxStreamsUni, varint::VarInt};
 
+// TODO investigate a good default
 /// The default send buffer size for Streams
-const DEFAULT_STREAM_MAX_SEND_BUFFER_SIZE: u32 = 64 * 1024;
+const DEFAULT_STREAM_MAX_SEND_BUFFER_SIZE: u32 = 512 * 1024;
 
 /// Per-stream limits
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]

--- a/quic/s2n-quic-core/src/stream/testing.rs
+++ b/quic/s2n-quic-core/src/stream/testing.rs
@@ -25,7 +25,7 @@ static DATA: Bytes = {
     Bytes::from_static(&INNER)
 };
 
-const DATA_LEN: usize = (DEFAULT_STREAM_LEN as usize) * 8;
+const DATA_LEN: usize = (DEFAULT_STREAM_LEN as usize) * 128;
 const DEFAULT_STREAM_LEN: u64 = 1024;
 const DATA_MOD: usize = 256; // Only the first 256 offsets of DATA are unique
 

--- a/quic/s2n-quic-qns/src/server/perf.rs
+++ b/quic/s2n-quic-qns/src/server/perf.rs
@@ -145,7 +145,7 @@ impl Perf {
         }
 
         async fn handle_receive_stream(mut stream: ReceiveStream) -> Result<()> {
-            let mut chunks = vec![Bytes::new(); 16];
+            let mut chunks = vec![Bytes::new(); 64];
 
             loop {
                 let (len, is_open) = stream.receive_vectored(&mut chunks).await?;
@@ -164,7 +164,7 @@ impl Perf {
         }
 
         async fn handle_send_stream(mut stream: SendStream, len: u64) -> Result<()> {
-            let mut chunks = vec![Bytes::new(); 16];
+            let mut chunks = vec![Bytes::new(); 64];
 
             //= https://tools.ietf.org/id/draft-banks-quic-performance-00.txt#4.1
             //# Since the goal here is to measure the efficiency of the QUIC


### PR DESCRIPTION
The existing default value for the stream send buffer is 64KB, which limits throughput. This PR bumps the size to 512KB pending a deeper investigation of an appropriate value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
