### PR TITLE
core: call on_event in event handlers

### DIFF
--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -16,3 +16,4 @@ s2n-quic = { path = "../s2n-quic", features = ["tracing-provider"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 structopt = "0.3"
 tokio = { version = "1", features = ["full"] }
+tracing-subscriber = "0.2"

--- a/quic/s2n-quic-qns/src/main.rs
+++ b/quic/s2n-quic-qns/src/main.rs
@@ -11,6 +11,8 @@ mod server;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
     Arguments::from_args().run().await
 }
 

--- a/quic/s2n-quic/src/provider/event/tracing.rs
+++ b/quic/s2n-quic/src/provider/event/tracing.rs
@@ -21,7 +21,6 @@ pub struct Subscriber;
 // TODO we should implement Display for Events or maybe opt into serde as a feature
 impl super::Subscriber for Subscriber {
     fn on_event<E: Event>(&mut self, meta: &common::Meta, event: &E) {
-        info!("{:?}", meta);
-        info!("{:?}", event);
+        info!(group_id = meta.group_id, "{:?}", event);
     }
 }


### PR DESCRIPTION
The event handlers were missing a call to the generic `on_event` callback and this PR fixes that.

I've also added a tracing subscriber to the qns server which can be enabled by passing `RUST_LOG=info`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
