### PR TITLE
return no valid path error to close connection if there is no path

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -656,7 +656,11 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             connection_id_mapper.remove_initial_id(&self.internal_connection_id);
         }
 
-        self.path_manager.on_timeout(timestamp)?;
+        if let Some(shared_state) = shared_state.as_ref() {
+            let handshake_confirmed = shared_state.space_manager.is_handshake_confirmed();
+            self.path_manager
+                .on_timeout(timestamp, handshake_confirmed)?;
+        };
         self.local_id_registry.on_timeout(timestamp);
 
         if let Some(shared_state) = shared_state {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR handles the following requirement:

```
 //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#9
 //# When an endpoint has no validated path on which to send packets, it
 //# MAY discard connection state.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
