### PR TITLE
transport: add has_transmission_interest

### DIFF
--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -543,6 +543,14 @@ impl<CCE: congestion_controller::Endpoint> transmission::interest::Provider for 
             .chain(self.paths.iter().map(|path| path.transmission_interest()))
             .sum()
     }
+
+    fn has_transmission_interest(&self) -> bool {
+        self.peer_id_registry.has_transmission_interest()
+            || self
+                .paths
+                .iter()
+                .any(|path| path.has_transmission_interest())
+    }
 }
 
 /// Internal Id of a path in the manager

--- a/quic/s2n-quic-transport/src/stream/controller.rs
+++ b/quic/s2n-quic-transport/src/stream/controller.rs
@@ -241,6 +241,18 @@ impl transmission::interest::Provider for Controller {
                 .streams_blocked_sync
                 .transmission_interest()
     }
+
+    fn has_transmission_interest(&self) -> bool {
+        self.bidi_controller.has_transmission_interest()
+            || self
+                .incoming_controller
+                .max_streams_sync
+                .has_transmission_interest()
+            || self
+                .outgoing_controller
+                .streams_blocked_sync
+                .has_transmission_interest()
+    }
 }
 
 /// The bidirectional controller consists of both outgoing and incoming

--- a/quic/s2n-quic-transport/src/stream/stream_manager.rs
+++ b/quic/s2n-quic-transport/src/stream/stream_manager.rs
@@ -964,6 +964,19 @@ impl<S: StreamTrait> transmission::interest::Provider for AbstractStreamManager<
                 .outgoing_connection_flow_controller
                 .transmission_interest()
     }
+
+    fn has_transmission_interest(&self) -> bool {
+        self.inner.streams.has_transmission_interest()
+            || self.inner.stream_controller.has_transmission_interest()
+            || self
+                .inner
+                .incoming_connection_flow_controller
+                .has_transmission_interest()
+            || self
+                .inner
+                .outgoing_connection_flow_controller
+                .has_transmission_interest()
+    }
 }
 
 impl<S: StreamTrait> connection::finalization::Provider for AbstractStreamManager<S> {

--- a/quic/s2n-quic-transport/src/transmission/interest.rs
+++ b/quic/s2n-quic-transport/src/transmission/interest.rs
@@ -78,6 +78,14 @@ impl core::iter::Sum for Interest {
 
 pub trait Provider {
     fn transmission_interest(&self) -> Interest;
+
+    /// Returns if there is any interest in transmission
+    ///
+    /// This can be used to quickly check a set of providers, rather than having to sum up all of
+    /// the interests.
+    fn has_transmission_interest(&self) -> bool {
+        !self.transmission_interest().is_none()
+    }
 }
 
 #[cfg(test)]

--- a/quic/s2n-quic-transport/src/transmission/mod.rs
+++ b/quic/s2n-quic-transport/src/transmission/mod.rs
@@ -53,7 +53,7 @@ impl<'a, Config: endpoint::Config, P: Payload> PacketPayloadEncoder
     for Transmission<'a, Config, P>
 {
     fn encoding_size_hint<E: Encoder>(&mut self, encoder: &E, minimum_len: usize) -> usize {
-        if !self.transmission_interest().is_none() {
+        if self.has_transmission_interest() {
             self.payload.size_hint(minimum_len..=encoder.capacity())
         } else {
             0
@@ -115,5 +115,9 @@ impl<'a, Config: endpoint::Config, P: Payload> transmission::interest::Provider
 {
     fn transmission_interest(&self) -> transmission::Interest {
         self.payload.transmission_interest()
+    }
+
+    fn has_transmission_interest(&self) -> bool {
+        self.payload.has_transmission_interest()
     }
 }


### PR DESCRIPTION
We're currently asking the transmission payload if it has interest before commiting to writing the packet. This ends up asking all of the components and doesn't short circuit if it does. This ends up costing about the same as the packet protection code.

This change adds a `has_transmission_interest` to the provider trait to query a binary yes/no on interest, rather than figuring out the type of interest. It really only needs to be implemented for components that aggregate others.

### Before
[![](https://dnglbrstg7yg.cloudfront.net/c15e66354e234eef9f208ff1a0b3656ed88e1d0f/perf/1000MB-down-0MB-up.svg)](https://dnglbrstg7yg.cloudfront.net/c15e66354e234eef9f208ff1a0b3656ed88e1d0f/perf/1000MB-down-0MB-up.svg?x=2857&y=565)

### After

[![](https://dnglbrstg7yg.cloudfront.net/b37199661815970bc9c2014386cc8f0b3a3fc39a/perf/1000MB-down-0MB-up.svg?x=2804&y=581)](https://dnglbrstg7yg.cloudfront.net/b37199661815970bc9c2014386cc8f0b3a3fc39a/perf/1000MB-down-0MB-up.svg?x=2804&y=581)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.