### PR TITLE
Update qns workflow to use ghcr.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Login to GitHub Packages
         uses: docker/login-action@v1
         with:
-          registry: docker.pkg.github.com
+          registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
The Docker registry has now been replaced by the Container registry. Seeing if this fixes the qns workflow.

See: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.