### PR TITLE
transport: fix MTU blackhole detection

### DIFF
--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -793,14 +793,14 @@ impl Manager {
                 is_mtu_probe,
             });
 
-            if is_mtu_probe {
-                path.mtu_controller.on_packet_loss(
-                    packet_number,
-                    sent_info.sent_bytes,
-                    now,
-                    &mut path.congestion_controller,
-                );
-            }
+            // Notify the MTU controller of packet loss even if it wasn't a probe since it uses
+            // that information for blackhole detection.
+            path.mtu_controller.on_packet_loss(
+                packet_number,
+                sent_info.sent_bytes,
+                now,
+                &mut path.congestion_controller,
+            );
 
             if persistent_congestion {
                 //= https://tools.ietf.org/id/draft-ietf-quic-recovery-32.txt#5.2


### PR DESCRIPTION
#761 introduced a bug where we only notify the MTU manager if the range contained a MTU probe. This is wrong as outlined in a comment:

> mtu::controller::on_packet_loss should still be called even for non-MTU probes because it uses that information for blackhole detection
https://github.com/awslabs/s2n-quic/pull/761#discussion_r677752759

This PR fixes that and adds a comment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
