### PR TITLE
transport: remove excessive allocations in `poll_wakeups`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Cargo.lock
 /.history
 .DS_Store
 /.idea
+dhat-heap.json

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -11,6 +11,7 @@ default = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }
+dhat = { version = "0.2", optional = true }
 futures = "0.3"
 s2n-quic = { path = "../s2n-quic", features = ["tracing-provider", "connection-migration"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }

--- a/quic/s2n-quic-qns/src/main.rs
+++ b/quic/s2n-quic-qns/src/main.rs
@@ -9,8 +9,16 @@ mod client;
 mod file;
 mod server;
 
+#[cfg(feature = "dhat")]
+#[global_allocator]
+static ALLOCATOR: dhat::DhatAlloc = dhat::DhatAlloc;
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
+    // setup heap profiling if enabled
+    #[cfg(feature = "dhat")]
+    let _dhat = dhat::Dhat::start_heap_profiling();
+
     tracing_subscriber::fmt::init();
 
     Arguments::from_args().run().await

--- a/quic/s2n-quic-transport/src/stream/tests/stream_managers_tests.rs
+++ b/quic/s2n-quic-transport/src/stream/tests/stream_managers_tests.rs
@@ -357,10 +357,9 @@ fn create_wakeup_queue_and_handle() -> (
 
 /// Asserts that a given number of wakeups had been enqueued
 fn assert_wakeups(wakeup_queue: &mut WakeupQueue<InternalConnectionId>, expected_wakeups: usize) {
-    let dequeued_wakeups = VecDeque::new();
+    let mut dequeued_wakeups = VecDeque::new();
     let (waker, _counter) = new_count_waker();
-    let dequeued_wakeups =
-        wakeup_queue.poll_pending_wakeups(dequeued_wakeups, &Context::from_waker(&waker));
+    wakeup_queue.poll_pending_wakeups(&mut dequeued_wakeups, &Context::from_waker(&waker));
 
     assert_eq!(expected_wakeups, dequeued_wakeups.len());
 }


### PR DESCRIPTION
I added some heap profiling with [dhat](https://docs.rs/dhat) and noticed we were allocating a new `VecDeque` on every iteration of the event loop. Note that an empty `VecDeque` is actually _not_ empty!

https://github.com/rust-lang/rust/blob/8b50cc9a2c408caef30a1cf950c948509b2f648e/library/alloc/src/collections/vec_deque/mod.rs#L509

```rust
    pub fn new_in(alloc: A) -> VecDeque<T, A> {
        VecDeque::with_capacity_in(INITIAL_CAPACITY, alloc)
    }
```

where `INITIAL_CAPACITY = 7`

https://github.com/rust-lang/rust/blob/8b50cc9a2c408caef30a1cf950c948509b2f648e/library/alloc/src/collections/vec_deque/mod.rs#L59

This change uses `core::mem::swap` instead of `core::mem::take` to entirely remove the need for any additional allocations.

I've also kept in the dhat code that I was using for future use.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
