### PR TITLE
transport: optimize timer iterators

### DIFF
--- a/quic/s2n-quic-core/src/time/timer.rs
+++ b/quic/s2n-quic-core/src/time/timer.rs
@@ -74,7 +74,26 @@ impl Iterator for Iter {
     fn next(&mut self) -> Option<Self::Item> {
         self.0.take()
     }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.iter().size_hint()
+    }
+
+    #[inline]
+    fn min(self) -> Option<Self::Item> {
+        self.0
+    }
 }
+
+impl core::iter::ExactSizeIterator for Iter {
+    fn len(&self) -> usize {
+        self.0.iter().len()
+    }
+}
+
+// Let consumers know that they don't need to do additional fusing
+impl core::iter::FusedIterator for Iter {}
 
 #[cfg(test)]
 mod tests {

--- a/quic/s2n-quic-transport/src/connection/close_sender.rs
+++ b/quic/s2n-quic-transport/src/connection/close_sender.rs
@@ -186,12 +186,11 @@ impl State {
             ..
         } = self
         {
-            Some(close_timer.iter().chain(limiter.timers()))
+            close_timer.iter().chain(limiter.timers()).min()
         } else {
             None
         }
         .into_iter()
-        .flatten()
     }
 
     pub fn on_timeout(&mut self, now: Timestamp) -> Poll<()> {

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -354,8 +354,8 @@ impl<CCE: congestion_controller::Endpoint> Manager<CCE> {
     }
 
     #[inline]
-    pub fn timers(&self) -> impl Iterator<Item = Timestamp> + '_ {
-        self.paths.iter().flat_map(|p| p.timers())
+    pub fn timers(&self) -> impl Iterator<Item = Timestamp> {
+        self.paths.iter().flat_map(|p| p.timers()).min().into_iter()
     }
 
     /// Writes any frames the path manager wishes to transmit to the given context

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -153,6 +153,8 @@ impl<CC: CongestionController> Path<CC> {
         core::iter::empty()
             .chain(self.challenge.timers())
             .chain(self.mtu_controller.timers())
+            .min()
+            .into_iter()
     }
 
     /// Only PATH_CHALLENGE and PATH_RESPONSE frames should be transmitted here.

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -108,6 +108,8 @@ impl Manager {
             .chain(self.pto.timers())
             .filter(move |_| !is_loss_timer_armed)
             .chain(self.loss_timer.iter())
+            .min()
+            .into_iter()
     }
 
     pub fn on_timeout<CC: CongestionController, Ctx: Context<CC>, Pub: event::Publisher>(

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -310,6 +310,8 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
             .chain(self.recovery_manager.timers())
             .chain(self.key_set.timers())
             .chain(self.stream_manager.timers())
+            .min()
+            .into_iter()
     }
 
     /// Called when the connection timer expired

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -223,6 +223,8 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
         core::iter::empty()
             .chain(self.ack_manager.timers())
             .chain(self.recovery_manager.timers())
+            .min()
+            .into_iter()
     }
 
     /// Called when the connection timer expired

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -226,6 +226,8 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
         core::iter::empty()
             .chain(self.ack_manager.timers())
             .chain(self.recovery_manager.timers())
+            .min()
+            .into_iter()
     }
 
     /// Called when the connection timer expired

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -178,13 +178,15 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
     }
 
     /// Returns all of the component timers
-    pub fn timers(&self) -> impl Iterator<Item = Timestamp> + '_ {
+    pub fn timers(&self) -> impl Iterator<Item = Timestamp> {
         // the spaces are `Option`s and can be iterated over, either returning
         // the value or `None`.
         core::iter::empty()
             .chain(self.initial.iter().flat_map(|space| space.timers()))
             .chain(self.handshake.iter().flat_map(|space| space.timers()))
             .chain(self.application.iter().flat_map(|space| space.timers()))
+            .min()
+            .into_iter()
     }
 
     /// Called when the connection timer expired

--- a/quic/s2n-quic-transport/src/stream/controller.rs
+++ b/quic/s2n-quic-transport/src/stream/controller.rs
@@ -196,6 +196,8 @@ impl Controller {
         core::iter::empty()
             .chain(self.bidi_controller.timers())
             .chain(self.uni_controller.timers())
+            .min()
+            .into_iter()
     }
 
     /// Called when the connection timer expires

--- a/quic/s2n-quic-transport/src/stream/stream_manager.rs
+++ b/quic/s2n-quic-transport/src/stream/stream_manager.rs
@@ -618,6 +618,8 @@ impl<S: StreamTrait> AbstractStreamManager<S> {
             .chain(self.inner.stream_controller.timers())
             .chain(self.inner.outgoing_connection_flow_controller.timers())
             .chain(self.inner.streams.timers())
+            .min()
+            .into_iter()
     }
 
     /// Called when the connection timer expires


### PR DESCRIPTION
It turns out that gathering all of the application timers and then finding the `min` is quite a bit slower than finding the `min` as we traverse the stack.

### Before

[![before](https://user-images.githubusercontent.com/799311/127375783-0c252308-496c-4c6c-b77e-8dab3c2ef1c3.png)](https://dnglbrstg7yg.cloudfront.net/d53245d5a85afe4368aa123dceb70eb128ce354d/perf/1000MB-down-0MB-up.svg?x=811&y=869)

### After

[
![after](https://user-images.githubusercontent.com/799311/127375840-c552870a-10b2-4dc0-88fd-8559e49b0894.png)](https://dnglbrstg7yg.cloudfront.net/fa6048be6af369f24e0fd7897e86ec7ec8ba5e80/perf/1000MB-down-0MB-up.svg?x=420&y=885)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
