### PR TITLE
core: endpoint trait accept clock instead of a timestamp

### DIFF
--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -24,7 +24,7 @@ use s2n_quic_core::{
     io::{rx, tx},
     packet::{initial::ProtectedInitial, ProtectedPacket},
     stateless_reset::token::LEN as StatelessResetTokenLen,
-    time::Timestamp,
+    time::{Clock, Timestamp},
     token::{self, Format},
 };
 
@@ -84,13 +84,23 @@ pub struct Endpoint<Cfg: Config> {
 unsafe impl<Cfg: Config> Send for Endpoint<Cfg> {}
 
 impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
-    fn receive<Rx: rx::Queue>(&mut self, queue: &mut Rx, timestamp: Timestamp) {
+    fn receive<Rx: rx::Queue, C: Clock>(&mut self, queue: &mut Rx, clock: &C) {
         use rx::Entry;
 
         let entries = queue.as_slice_mut();
+        let mut now: Option<Timestamp> = None;
 
         for entry in entries.iter_mut() {
             if let Some(remote_address) = entry.remote_address() {
+                let timestamp = match now {
+                    Some(now) => now,
+                    _ => {
+                        let time = clock.get_time();
+                        now = Some(time);
+                        time
+                    }
+                };
+
                 self.receive_datagram(remote_address, entry.ecn(), entry.payload_mut(), timestamp)
             }
         }
@@ -98,14 +108,26 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
         queue.finish(len);
     }
 
-    fn transmit<Tx: tx::Queue>(&mut self, queue: &mut Tx, timestamp: Timestamp) {
-        self.on_timeout(timestamp);
+    fn transmit<Tx: tx::Queue, C: Clock>(&mut self, queue: &mut Tx, clock: &C) {
+        self.on_timeout(clock.get_time());
 
         // Iterate over all connections which want to transmit data
         let mut transmit_result = Ok(());
         let endpoint_context = self.config.context();
+
+        let mut now: Option<Timestamp> = None;
+
         self.connections
             .iterate_transmission_list(|connection, shared_state| {
+                let timestamp = match now {
+                    Some(now) => now,
+                    _ => {
+                        let time = clock.get_time();
+                        now = Some(time);
+                        time
+                    }
+                };
+
                 let mut publisher = event::PublisherSubscriber::new(
                     event::builders::Meta {
                         endpoint_type: Cfg::ENDPOINT_TYPE,
@@ -132,10 +154,10 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
         }
     }
 
-    fn poll_wakeups(
+    fn poll_wakeups<C: Clock>(
         &mut self,
         cx: &mut task::Context<'_>,
-        timestamp: Timestamp,
+        clock: &C,
     ) -> Poll<Result<usize, s2n_quic_core::endpoint::CloseError>> {
         if !self.connections.is_open() {
             return Poll::Ready(Err(s2n_quic_core::endpoint::CloseError));
@@ -147,9 +169,20 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
         let close_packet_buffer = &mut self.close_packet_buffer;
         let endpoint_context = self.config.context();
 
+        let mut now: Option<Timestamp> = None;
+
         for internal_id in self.dequeued_wakeups.drain(..) {
             self.connections
                 .with_connection(internal_id, |conn, mut shared_state| {
+                    let timestamp = match now {
+                        Some(now) => now,
+                        _ => {
+                            let time = clock.get_time();
+                            now = Some(time);
+                            time
+                        }
+                    };
+
                     let mut publisher = event::PublisherSubscriber::new(
                         event::builders::Meta {
                             endpoint_type: Cfg::ENDPOINT_TYPE,
@@ -158,6 +191,7 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
                         Some(conn.quic_version()),
                         endpoint_context.event_subscriber,
                     );
+
                     if let Err(error) = conn.on_wakeup(shared_state.as_deref_mut(), timestamp) {
                         conn.close(
                             shared_state,

--- a/scripts/perf/build
+++ b/scripts/perf/build
@@ -15,7 +15,7 @@ if [ ! -f target/perf/quinn/bin/perf_client ]; then
   mkdir -p target/perf/quinn
   cargo +stable install \
     --git https://github.com/quinn-rs/quinn \
-    --rev 3f908a2c8c1ec4585212d776fafe536ea17bf2b4 \
+    --rev f97cb904c2194c6b392470022fa532b65b8c7eee \
     --bin perf_client \
     --root target/perf/quinn \
     --target-dir target/perf/quinn \


### PR DESCRIPTION
Rather than having the `Endpoint` trait accept a `Timestamp`, this changes it to accept a `Clock`. This will allow a few things:

* Lazily compute the current time - maybe not even computing it at all if we don't need to. This can result in a bit of an increase in efficiency.
* The implementation can control the granularity of the queries rather than taking a single `Timestamp` and doing a bunch of work. I've taken advantage of that here by querying the clock once for timeouts and potentially another time for transmissions. This will allow us to have some causality to the two events.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
