### PR TITLE
scripts: fix perf permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -427,7 +427,9 @@ jobs:
         run: ./scripts/perf/build
 
       - name: Run script
-        run: sudo env "PATH=$PATH" ./scripts/perf/test-all
+        run: |
+          mkdir -p ./target/perf/results
+          sudo env "PATH=$PATH" ./scripts/perf/test-all
 
       - name: Prepare artifacts
         run: |

--- a/scripts/perf/test
+++ b/scripts/perf/test
@@ -18,6 +18,7 @@ UPLOAD_B=$(($UPLOAD_MB * 1000000))
 OUT=target/perf/results
 
 mkdir -p $OUT
+chmod 766 $OUT
 
 perf record \
   --output $TMP/$FILE.perf \
@@ -57,17 +58,20 @@ perf script \
   --input $TMP/$FILE.perf \
   2>/dev/null \
   > $OUT/$FILE.script
+chmod 666 $OUT/$FILE.script
 
 cat \
   $OUT/$FILE.script \
   | inferno-collapse-perf \
   > $OUT/$FILE.folded
+chmod 666 $OUT/$FILE.folded
 
 echo "generating flamegraph"
 mkdir -p target/perf/results
 inferno-flamegraph $OUT/$FILE.folded \
   --title "$TITLE" \
   > $OUT/$FILE.svg
+chmod 666 $OUT/$FILE.svg
 
 rm -rf $TMP
 


### PR DESCRIPTION
Not sure why this wasn't caught in #760 in the ci, but the `target/perf/results` is created by root, which by default disallows other users to create files in there. This change makes it world-read-writable instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
