### PR TITLE
ci: run clippy on beta so we can catch issues before hitting stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2021-07-27
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2021-06-21
   CDN: https://dnglbrstg7yg.cloudfront.net
 
 jobs:


### PR DESCRIPTION
Rather than waiting until the day a new stable release goes out, let's also run clippy beta to make sure we catch them early.

We'll need to change the required task to `clippy (stable)` instead of `clippy`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
