### PR TITLE
core: emit event info for stream and crypto frames

### DIFF
--- a/quic/s2n-quic-core/src/event.rs
+++ b/quic/s2n-quic-core/src/event.rs
@@ -74,11 +74,16 @@ common!(
         #[non_exhaustive]
         StopSending,
         #[non_exhaustive]
-        Crypto,
+        Crypto { offset: u64, len: u16 },
         #[non_exhaustive]
         NewToken,
         #[non_exhaustive]
-        Stream,
+        Stream {
+            id: u64,
+            offset: u64,
+            len: u16,
+            is_fin: bool,
+        },
         #[non_exhaustive]
         MaxData,
         #[non_exhaustive]
@@ -163,7 +168,7 @@ events!(
     struct AlpnInformation<'a> {
         pub server_alpns: &'a [&'a [u8]],
         pub client_alpns: &'a [&'a [u8]],
-        pub chosen_alpn: u32,
+        pub chosen_alpn: &'a [u8],
     }
 
     #[name = "transport:packet_sent"]

--- a/quic/s2n-quic-core/src/event/macros.rs
+++ b/quic/s2n-quic-core/src/event/macros.rs
@@ -199,7 +199,8 @@ macro_rules! common {
             $(
                 $(#[$enum_attr:meta])? $enum_variant: ident
                     $({
-                        $( $enum_field:ident: $enum_field_type:ty )*
+                        $( $enum_field:ident: $enum_field_type:ty ),*
+                        $(,)?
                     })?
                 ,
             )*
@@ -244,7 +245,7 @@ macro_rules! common {
                 $(
                     $(#[$enum_attr])? $enum_variant
                         $({
-                            $( $enum_field: $enum_field_type )*
+                            $( $enum_field: $enum_field_type ),*
                         })?
                     ,
                 )*

--- a/quic/s2n-quic-core/src/frame/mod.rs
+++ b/quic/s2n-quic-core/src/frame/mod.rs
@@ -3,7 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-use crate::{event::common, frame::event::AsEvent as _};
+use crate::event as evt;
 use core::fmt;
 use s2n_codec::{
     DecoderBuffer, DecoderBufferMut, DecoderBufferMutResult, DecoderError,
@@ -51,9 +51,14 @@ macro_rules! frames {
                     )*
                 }
             }
+        }
 
+        impl<'a, $ack, $data> event::AsEvent for Frame<'a, $ack, $data>
+        where
+            $data: EncoderValue,
+        {
             #[inline]
-            pub fn as_event(&self)  -> common::Frame {
+            fn as_event(&self) -> evt::common::Frame {
                 match &self {
                     $(
                         Frame::$ty(inner) => inner.as_event(),

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -573,6 +573,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                             .is_ok()
                     {
                         count += 1;
+                        // TODO this is wrong - multiple packets can be sent in the same
+                        // transmission
                         publisher.on_packet_sent(event::builders::PacketSent {
                             packet_header: event::builders::PacketHeader {
                                 packet_type: outcome.packet_number.space().into(),

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -15,6 +15,7 @@ use s2n_quic_core::{
     frame::{
         ack::AckRanges,
         crypto::CryptoRef,
+        event::AsEvent as _,
         path_validation::{self, Probing},
         stream::StreamRef,
         Ack, ConnectionClose, DataBlocked, HandshakeDone, MaxData, MaxStreamData, MaxStreams,

--- a/quic/s2n-quic-transport/src/stream/stream_impl.rs
+++ b/quic/s2n-quic-transport/src/stream/stream_impl.rs
@@ -24,6 +24,7 @@ use s2n_quic_core::{
 };
 
 /// Configuration values for a Stream
+#[derive(Debug)]
 pub struct StreamConfig {
     /// The [`Stream`]s identifier
     pub stream_id: StreamId,


### PR DESCRIPTION
When logging or computing stats it's helpful to know something about the contents of the frame itself. This change adds information about Stream and Crypto frames.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.