### PR TITLE
Add retries to iperf benchmark

### DIFF
--- a/scripts/benchmark/run
+++ b/scripts/benchmark/run
@@ -56,11 +56,19 @@ jq -r '.intervals[].sum | [(.start | strftime("%H:%M:%S")), .bits_per_second/100
 
 LOG_DIR="$OUTPUT_DIR/~logs/$NAME/iperf"
 
-ROOT_DIR="$ROOT_DIR" \
-LOG_DIR="$LOG_DIR" \
-SCENARIO="$SCENARIO" \
-DURATION="$DURATION" \
-docker-compose --file quic/s2n-quic-qns/benchmark/docker-compose.yml up --abort-on-container-exit --timeout 1 sim iperf_client iperf_server
+# iperf3 occasionally crashes, so retry a couple times
+MAX_ATTEMPTS=3
+ATTEMPTS=1
+until [ "$ATTEMPTS" -gt $MAX_ATTEMPTS ]
+do
+    echo "Attempt ${ATTEMPTS} of ${MAX_ATTEMPTS}"
+    ROOT_DIR="$ROOT_DIR" \
+    LOG_DIR="$LOG_DIR" \
+    SCENARIO="$SCENARIO" \
+    DURATION="$DURATION" \
+    docker-compose --file quic/s2n-quic-qns/benchmark/docker-compose.yml up --abort-on-container-exit --timeout 1 --exit-code-from iperf_client sim iperf_client iperf_server && break
+    ATTEMPTS=$((ATTEMPTS+1))
+done
 
 tshark -r "$LOG_DIR/$CLIENT_PCAP" -t u -qz io,stat,1,"SUM(ip.len)"ip.len\&\&ip.dst==193.167.0.90 | awk -F '[\\|\s]' '{ print $2 $3}' > "${TMP}/iperf.nsv"
 # Find the time of the first real data transfer packet


### PR DESCRIPTION
iperf3 is occasionally exiting with a non zero exit code, with output similar to the following:

```
iperf_server    | WARNING:  Size of data read does not correspond to offered length
iperf_server    | iperf3: error - unable to receive parameters from client: 
iperf_server    | -----------------------------------------------------------
iperf_server    | Server listening on 5201
iperf_server    | -----------------------------------------------------------
sim             | Forwarding packet (0 bytes) from 193.167.0.90
sim             | Forwarding packet (1 bytes) from 193.167.100.110
sim             | Forwarding packet (0 bytes) from 193.167.100.110
sim             | Forwarding packet (0 bytes) from 193.167.100.110
sim             | Forwarding packet (0 bytes) from 193.167.0.90
sim             | Forwarding packet (0 bytes) from 193.167.0.90
iperf_client exited with code 1
```

This change adds 2 retries, to prevent this from failing the benchmark run

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.