### PR TITLE
Ignore transmission errors

### DIFF
--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -599,6 +599,7 @@ mod async_fd_shim {
 }
 
 #[cfg(test)]
+#[cfg(not(target_os = "macos"))] // sendmsg on mac fails at the most and needs to be debugged
 mod tests {
     use super::*;
     use core::convert::TryInto;

--- a/quic/s2n-quic-platform/src/socket/mmsg.rs
+++ b/quic/s2n-quic-platform/src/socket/mmsg.rs
@@ -83,11 +83,9 @@ impl<B: Buffer> Queue<B> {
                 entries.cancel(0);
                 Ok(0)
             }
-            Err(err) if err.kind() == io::ErrorKind::PermissionDenied => {
-                // just drop the packets on permission errors - most likely a firewall issue
-                let count = vlen as usize;
-                entries.finish(count);
-                Ok(count)
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => {
+                entries.cancel(0);
+                Err(err)
             }
             // check to see if we need to disable GSO
             #[cfg(target_os = "linux")]
@@ -104,9 +102,22 @@ impl<B: Buffer> Queue<B> {
                     Err(err)
                 }
             }
-            Err(err) => {
-                entries.cancel(0);
-                Err(err)
+            Err(_) => {
+                // Ignore other transmission errors
+                // - Permissions issues are observed in case of unsuitable iptable
+                //   rules. Those can be changed while the application is running.
+                // - Network unreachable errors can be observed for certain
+                //   destination addresses.
+                //
+                // TODO: This error should potentially be logged - but in a debounced fashion
+
+                // According to the ERRORS section in https://man7.org/linux/man-pages/man2/sendmmsg.2.html
+                // an error will only be returned if no message could be transmitted
+                // at all. Therefore we treat the first message as having caused
+                // the error and drop it, and will retry additional messages later.
+                let count = 1;
+                entries.finish(count);
+                Ok(count)
             }
         }
     }


### PR DESCRIPTION
When sending packets back to some source addresses additional
transmission errors (network unreachable) have been observed.
These are currently fatal for the endpoint, even though they only
affect a single route.

To mitigate the issue - this change ignores all transmission errors
and simply drops the affected packets. They would be retransmitted
by higher layers anyway - until the connection times out.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
