### PR TITLE
transport: fix provider Send requirements

### DIFF
--- a/quic/s2n-quic-core/src/connection/close.rs
+++ b/quic/s2n-quic-core/src/connection/close.rs
@@ -8,7 +8,7 @@ pub use crate::{frame::ConnectionClose, inet::SocketAddress};
 ///
 /// Implementations should take care to not leak potentially sensitive information
 /// to peers. This includes removing `reason` fields and making error codes more general.
-pub trait Formatter: 'static {
+pub trait Formatter: 'static + Send {
     /// Formats a transport error for use in 1-RTT (application data) packets
     fn format_transport_error(&self, context: &Context, error: transport::Error)
         -> ConnectionClose;

--- a/quic/s2n-quic-core/src/connection/id.rs
+++ b/quic/s2n-quic-core/src/connection/id.rs
@@ -236,10 +236,10 @@ impl<'a> ConnectionInfo<'a> {
 }
 
 /// Format for connection IDs
-pub trait Format: 'static + Validator + Generator {}
+pub trait Format: 'static + Validator + Generator + Send {}
 
 /// Implement Format for all types that implement the required subtraits
-impl<T: 'static + Validator + Generator> Format for T {}
+impl<T: 'static + Validator + Generator + Send> Format for T {}
 
 /// A validator for a connection ID format
 pub trait Validator {

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -169,7 +169,7 @@ impl Limits {
 }
 
 /// Creates limits for a given connection
-pub trait Limiter: 'static {
+pub trait Limiter: 'static + Send {
     fn on_connection(&mut self, info: &ConnectionInfo) -> Limits;
 }
 

--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -78,7 +78,7 @@ pub trait Context<Crypto: CryptoSuite> {
     fn send_application(&mut self, transmission: Bytes);
 }
 
-pub trait Endpoint: 'static + Sized {
+pub trait Endpoint: 'static + Sized + Send {
     type Session: Session;
 
     fn new_server_session<Params: EncoderValue>(

--- a/quic/s2n-quic-core/src/endpoint/limits.rs
+++ b/quic/s2n-quic-core/src/endpoint/limits.rs
@@ -44,7 +44,7 @@ impl<'a> ConnectionAttempt<'a> {
     }
 }
 
-pub trait Limits: 'static {
+pub trait Limits: 'static + Send {
     /// This trait is used to determine the outcome of connection attempts on an endpoint. The
     /// implementor returns an Outcome based on the ConnectionAttempt, or other information that the
     /// implementor may have.

--- a/quic/s2n-quic-core/src/event/macros.rs
+++ b/quic/s2n-quic-core/src/event/macros.rs
@@ -62,7 +62,7 @@ macro_rules! events {
         ///
         /// Applications can provide a custom implementation of `Subscriber` to perform
         /// logging, metrics recording, etc.
-        pub trait Subscriber: 'static {
+        pub trait Subscriber: 'static + Send {
             $(
                 paste!(
                     $(#[$attrs])*

--- a/quic/s2n-quic-core/src/random.rs
+++ b/quic/s2n-quic-core/src/random.rs
@@ -6,7 +6,7 @@
 /// in the clear, and one for "private" data that should remain secret. This approach
 /// lessens the risk of potential predictability weaknesses in random number generation
 /// algorithms from leaking information across contexts.
-pub trait Generator: 'static {
+pub trait Generator: 'static + Send {
     /// Fills `dest` with unpredictable bits that may be
     /// sent over the wire and viewable in the clear.
     fn public_random_fill(&mut self, dest: &mut [u8]);

--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -4,7 +4,7 @@
 use crate::{inet::SocketAddress, path::MINIMUM_MTU, recovery::RttEstimator, time::Timestamp};
 use core::fmt::Debug;
 
-pub trait Endpoint: 'static + Debug {
+pub trait Endpoint: 'static + Debug + Send {
     type CongestionController: CongestionController;
 
     fn new_congestion_controller(&mut self, path_info: PathInfo) -> Self::CongestionController;

--- a/quic/s2n-quic-core/src/stateless_reset/token.rs
+++ b/quic/s2n-quic-core/src/stateless_reset/token.rs
@@ -93,7 +93,7 @@ impl EncoderValue for Token {
 }
 
 /// A generator for a stateless reset token
-pub trait Generator: 'static {
+pub trait Generator: 'static + Send {
     /// If enabled, a stateless reset packet containing the token generated
     /// by this Generator will be sent when a packet is received that cannot
     /// be matched to an existing connection. Otherwise, the packet will be

--- a/quic/s2n-quic-core/src/token.rs
+++ b/quic/s2n-quic-core/src/token.rs
@@ -24,7 +24,7 @@ impl<'a> Context<'a> {
     }
 }
 
-pub trait Format: 'static {
+pub trait Format: 'static + Send {
     const TOKEN_LEN: usize;
 
     /// Generate a signed token to be delivered in a NEW_TOKEN frame.

--- a/quic/s2n-quic-tls/src/session.rs
+++ b/quic/s2n-quic-tls/src/session.rs
@@ -25,10 +25,6 @@ pub struct Session {
     send_buffer: BytesMut,
 }
 
-/// This is safe to do since the connection is only dealing with
-/// contexts that also implement send.
-unsafe impl Send for Session {}
-
 impl Session {
     pub fn new(endpoint: endpoint::Type, config: Config, params: &[u8]) -> Result<Self, Error> {
         let mut connection = Connection::new(match endpoint {

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -150,6 +150,10 @@ pub struct ConnectionImpl<Config: endpoint::Config> {
     close_sender: CloseSender,
 }
 
+/// Safety: we use some `Rc<RefCell<T>>` inside of the connection but these values
+/// never leave the API boundary and will be all sent together
+unsafe impl<Config: endpoint::Config> Send for ConnectionImpl<Config> {}
+
 #[cfg(debug_assertions)]
 impl<Config: endpoint::Config> Drop for ConnectionImpl<Config> {
     fn drop(&mut self) {

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -33,7 +33,7 @@ use s2n_quic_core::{
 };
 
 /// A trait which represents an internally used `Connection`
-pub trait ConnectionTrait: Sized {
+pub trait ConnectionTrait: 'static + Send + Sized {
     /// Static configuration of a connection
     type Config: endpoint::Config;
 
@@ -118,17 +118,6 @@ pub trait ConnectionTrait: Sized {
 
     // Packet handling
 
-    /// Is called when a handshake packet had been received
-    fn handle_handshake_packet<Pub: event::Publisher, Rnd: random::Generator>(
-        &mut self,
-        shared_state: &mut SharedConnectionState<Self::Config>,
-        datagram: &DatagramInfo,
-        path_id: path::Id,
-        packet: ProtectedHandshake,
-        publisher: &mut Pub,
-        random_generator: &mut Rnd,
-    ) -> Result<(), ProcessingError>;
-
     /// Is called when a initial packet had been received
     fn handle_initial_packet<Pub: event::Publisher, Rnd: random::Generator>(
         &mut self,
@@ -147,6 +136,17 @@ pub trait ConnectionTrait: Sized {
         datagram: &DatagramInfo,
         path_id: path::Id,
         packet: CleartextInitial,
+        publisher: &mut Pub,
+        random_generator: &mut Rnd,
+    ) -> Result<(), ProcessingError>;
+
+    /// Is called when a handshake packet had been received
+    fn handle_handshake_packet<Pub: event::Publisher, Rnd: random::Generator>(
+        &mut self,
+        shared_state: &mut SharedConnectionState<Self::Config>,
+        datagram: &DatagramInfo,
+        path_id: path::Id,
+        packet: ProtectedHandshake,
         publisher: &mut Pub,
         random_generator: &mut Rnd,
     ) -> Result<(), ProcessingError>;

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -9,7 +9,7 @@ use s2n_quic_core::{
 };
 
 /// Configuration paramters for a QUIC endpoint
-pub trait Config: 'static + Sized + core::fmt::Debug {
+pub trait Config: 'static + Send + Sized + core::fmt::Debug {
     /// The type of the TLS endpoint which is utilized
     type TLSEndpoint: tls::Endpoint;
     type CongestionControllerEndpoint: congestion_controller::Endpoint;

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -78,9 +78,9 @@ pub struct Endpoint<Cfg: Config> {
     max_mtu: MaxMtu,
 }
 
-// Safety: The endpoint is marked as `!Send`, because the struct contains `Rc`s.
-// However those `Rcs` are only referenced by other objects within the `Endpoint`
-// and which also get moved.
+/// Safety: The endpoint is marked as `!Send`, because the struct contains `Rc`s.
+/// However those `Rcs` are only referenced by other objects within the `Endpoint`
+/// and which also get moved.
 unsafe impl<Cfg: Config> Send for Endpoint<Cfg> {}
 
 impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {

--- a/quic/s2n-quic/src/server/providers.rs
+++ b/quic/s2n-quic/src/server/providers.rs
@@ -188,7 +188,7 @@ impl<
         EndpointLimits: s2n_quic_core::endpoint::Limits,
         Event: s2n_quic_core::event::Subscriber,
         Limits: s2n_quic_core::connection::limits::Limiter,
-        Sync: 'static,
+        Sync: 'static + Send,
         Tls: crypto::tls::Endpoint,
         Token: token::Format,
     > endpoint::Config

--- a/tls/s2n-tls/src/config.rs
+++ b/tls/s2n-tls/src/config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error::Error;
-use alloc::rc::Rc;
+use alloc::sync::Arc;
 use core::convert::TryInto;
 use s2n_tls_sys::*;
 use std::ffi::CString;
@@ -34,7 +34,10 @@ impl Drop for Owned {
 }
 
 #[derive(Clone, Default)]
-pub struct Config(Rc<Owned>);
+pub struct Config(Arc<Owned>);
+
+/// Safety: s2n_config objects can be sent across threads
+unsafe impl Send for Config {}
 
 impl Config {
     pub fn new() -> Self {
@@ -160,7 +163,7 @@ impl Builder {
     }
 
     pub fn build(self) -> Result<Config, Error> {
-        Ok(Config(Rc::new(self.0)))
+        Ok(Config(Arc::new(self.0)))
     }
 
     fn as_mut_ptr(&mut self) -> *mut s2n_config {

--- a/tls/s2n-tls/src/connection.rs
+++ b/tls/s2n-tls/src/connection.rs
@@ -17,6 +17,9 @@ pub struct Connection {
     config: Option<Config>,
 }
 
+/// Safety: s2n_connection objects can be sent across threads
+unsafe impl Send for Connection {}
+
 impl fmt::Debug for Connection {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Connection")


### PR DESCRIPTION
The current code currently overrides `Send` safety of the `Endpoint` struct:

https://github.com/awslabs/s2n-quic/blob/7804f2a6764bc0d0ae83331c09edaa738362ce3c/quic/s2n-quic-transport/src/endpoint/mod.rs#L81-L84

This is _only_ correct when `endpoint::Config: Send`, which isn't currently enforced:

https://github.com/awslabs/s2n-quic/blob/7804f2a6764bc0d0ae83331c09edaa738362ce3c/quic/s2n-quic-transport/src/endpoint/config.rs#L12

This change adds that constraint, which in turn, adds it to all providers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
