### PR TITLE
transport: add missing debug implementations

### DIFF
--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -14,7 +14,7 @@ use crate::{
     transmission,
 };
 use bytes::Bytes;
-use core::{convert::TryInto, marker::PhantomData};
+use core::{convert::TryInto, fmt, marker::PhantomData};
 use s2n_codec::EncoderBuffer;
 use s2n_quic_core::{
     crypto::{application::KeySet, tls, CryptoSuite},
@@ -72,6 +72,21 @@ pub struct ApplicationSpace<Config: endpoint::Config> {
     ping: flag::Ping,
     processed_packet_numbers: SlidingWindow,
     recovery_manager: recovery::Manager,
+}
+
+impl<Config: endpoint::Config> fmt::Debug for ApplicationSpace<Config> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ApplicationSpace")
+            .field("ack_manager", &self.ack_manager)
+            .field("alpn", &self.alpn)
+            .field("ping", &self.ping)
+            .field("processed_packet_numbers", &self.processed_packet_numbers)
+            .field("recovery_manager", &self.recovery_manager)
+            .field("sni", &self.sni)
+            .field("stream_manager", &self.stream_manager)
+            .field("tx_packet_numbers", &self.tx_packet_numbers)
+            .finish()
+    }
 }
 
 impl<Config: endpoint::Config> ApplicationSpace<Config> {

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     transmission,
 };
-use core::marker::PhantomData;
+use core::{fmt, marker::PhantomData};
 use s2n_codec::EncoderBuffer;
 use s2n_quic_core::{
     crypto::{tls, CryptoSuite},
@@ -47,6 +47,17 @@ pub struct HandshakeSpace<Config: endpoint::Config> {
     pub tx_packet_numbers: TxPacketNumbers,
     processed_packet_numbers: SlidingWindow,
     recovery_manager: recovery::Manager,
+}
+
+impl<Config: endpoint::Config> fmt::Debug for HandshakeSpace<Config> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("HandshakeSpace")
+            .field("ack_manager", &self.ack_manager)
+            .field("tx_packet_numbers", &self.tx_packet_numbers)
+            .field("processed_packet_numbers", &self.processed_packet_numbers)
+            .field("recovery_manager", &self.recovery_manager)
+            .finish()
+    }
 }
 
 impl<Config: endpoint::Config> HandshakeSpace<Config> {

--- a/quic/s2n-quic-transport/src/space/handshake_status.rs
+++ b/quic/s2n-quic-transport/src/space/handshake_status.rs
@@ -7,7 +7,7 @@ use s2n_quic_core::{frame::HandshakeDone, packet::number::PacketNumber};
 
 pub type Flag = flag::Flag<HandshakeDoneWriter>;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct HandshakeStatus(Flag);
 
 impl HandshakeStatus {
@@ -40,7 +40,7 @@ impl HandshakeStatus {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct HandshakeDoneWriter;
 
 impl flag::Writer for HandshakeDoneWriter {

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -13,7 +13,7 @@ use crate::{
     },
     transmission,
 };
-use core::marker::PhantomData;
+use core::{fmt, marker::PhantomData};
 use s2n_codec::EncoderBuffer;
 use s2n_quic_core::{
     crypto::{tls, CryptoSuite},
@@ -47,6 +47,17 @@ pub struct InitialSpace<Config: endpoint::Config> {
     pub tx_packet_numbers: TxPacketNumbers,
     processed_packet_numbers: SlidingWindow,
     recovery_manager: recovery::Manager,
+}
+
+impl<Config: endpoint::Config> fmt::Debug for InitialSpace<Config> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("InitialSpace")
+            .field("ack_manager", &self.ack_manager)
+            .field("tx_packet_numbers", &self.tx_packet_numbers)
+            .field("processed_packet_numbers", &self.processed_packet_numbers)
+            .field("recovery_manager", &self.recovery_manager)
+            .finish()
+    }
 }
 
 impl<Config: endpoint::Config> InitialSpace<Config> {

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     recovery::congestion_controller, space::rx_packet_numbers::AckManager, transmission,
 };
 use bytes::Bytes;
+use core::fmt;
 use s2n_codec::DecoderBufferMut;
 use s2n_quic_core::{
     ack,
@@ -54,6 +55,17 @@ pub struct PacketSpaceManager<Config: endpoint::Config> {
     zero_rtt_crypto:
         Option<Box<<<Config::TLSEndpoint as tls::Endpoint>::Session as CryptoSuite>::ZeroRttKey>>,
     handshake_status: HandshakeStatus,
+}
+
+impl<Config: endpoint::Config> fmt::Debug for PacketSpaceManager<Config> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PacketSpaceManager")
+            .field("initial", &self.initial)
+            .field("handshake", &self.handshake)
+            .field("application", &self.application)
+            .field("handshake_status", &self.handshake_status)
+            .finish()
+    }
 }
 
 macro_rules! packet_space_api {

--- a/quic/s2n-quic-transport/src/stream/receive_stream.rs
+++ b/quic/s2n-quic-transport/src/stream/receive_stream.rs
@@ -79,7 +79,7 @@ pub(super) enum ReceiveStreamState {
 }
 
 /// Writes the `MAX_STREAM_DATA` frames based on the streams flow control window.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(super) struct MaxStreamDataToFrameWriter {}
 
 impl ValueToFrameWriter<VarInt> for MaxStreamDataToFrameWriter {
@@ -97,7 +97,7 @@ impl ValueToFrameWriter<VarInt> for MaxStreamDataToFrameWriter {
 }
 
 /// Writes `STOP_SENDING` frames basd on `ApplicationErrorCode`s
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub(super) struct StopSendingToFrameWriter {}
 
 impl ValueToFrameWriter<application::Error> for StopSendingToFrameWriter {
@@ -117,6 +117,7 @@ impl ValueToFrameWriter<application::Error> for StopSendingToFrameWriter {
 /// A composite flow controller for receiving data.
 /// The flow controller manages the Streams individual window as well as the
 /// connection flow control window.
+#[derive(Debug)]
 pub(super) struct ReceiveStreamFlowController {
     /// The connection flow controller
     pub(super) connection_flow_controller: IncomingConnectionFlowController,
@@ -278,6 +279,7 @@ impl ReceiveStreamFlowController {
 }
 
 /// The read half of a stream
+#[derive(Debug)]
 pub struct ReceiveStream {
     /// The current state of the stream
     pub(super) state: ReceiveStreamState,

--- a/quic/s2n-quic-transport/src/stream/send_stream.rs
+++ b/quic/s2n-quic-transport/src/stream/send_stream.rs
@@ -101,7 +101,7 @@ pub struct OutgoingResetData {
 }
 
 /// Writes the `RESET` frames based on the streams flow control window.
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct ResetStreamToFrameWriter {}
 
 impl ValueToFrameWriter<OutgoingResetData> for ResetStreamToFrameWriter {
@@ -442,6 +442,7 @@ impl ValueToFrameWriter<VarInt> for StreamDataBlockedToFrameWriter {
 }
 
 /// The sending half of a stream
+#[derive(Debug)]
 pub struct SendStream {
     /// The current state of the stream
     pub(super) state: SendStreamState,

--- a/quic/s2n-quic-transport/src/stream/stream_impl.rs
+++ b/quic/s2n-quic-transport/src/stream/stream_impl.rs
@@ -45,7 +45,7 @@ pub struct StreamConfig {
 }
 
 /// A trait which represents an internally used `Stream`
-pub trait StreamTrait: StreamInterestProvider + timer::Provider {
+pub trait StreamTrait: StreamInterestProvider + timer::Provider + core::fmt::Debug {
     /// Creates a new `Stream` instance with the given configuration
     fn new(config: StreamConfig) -> Self;
 
@@ -128,6 +128,7 @@ pub trait StreamTrait: StreamInterestProvider + timer::Provider {
 
 /// The implementation of a `Stream`.
 /// This is mostly a facade over the reading and writing half of the `Stream`.
+#[derive(Debug)]
 pub struct StreamImpl {
     /// The stream ID
     pub(super) stream_id: StreamId,

--- a/quic/s2n-quic-transport/src/stream/tests/stream_managers_tests.rs
+++ b/quic/s2n-quic-transport/src/stream/tests/stream_managers_tests.rs
@@ -51,6 +51,7 @@ use s2n_quic_core::{
     varint::VarInt,
 };
 
+#[derive(Debug)]
 struct MockStream {
     config: StreamConfig,
     last_reset: Option<ResetStream>,

--- a/quic/s2n-quic-transport/src/sync/flag.rs
+++ b/quic/s2n-quic-transport/src/sync/flag.rs
@@ -162,7 +162,7 @@ impl<W: Writer> transmission::interest::Provider for Flag<W> {
 
 pub type Ping = Flag<PingWriter>;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct PingWriter;
 
 impl Writer for PingWriter {

--- a/quic/s2n-quic-transport/src/wakeup_queue.rs
+++ b/quic/s2n-quic-transport/src/wakeup_queue.rs
@@ -10,6 +10,7 @@ use core::task::{Context, Waker};
 use std::sync::Mutex;
 
 /// The shared state of the [`WakeupQueue`].
+#[derive(Debug)]
 struct QueueState<T> {
     /// The IDs of connections which have been woken
     woken_connections: VecDeque<T>,
@@ -73,6 +74,7 @@ impl<T: Copy> QueueState<T> {
 /// Each component is identified by a handle of type `T`.
 ///
 /// A single thread is expected to deque the handles of blocked components and to inform those.
+#[derive(Debug)]
 pub struct WakeupQueue<T> {
     state: Arc<Mutex<QueueState<T>>>,
 }
@@ -110,6 +112,7 @@ impl<T: Copy> WakeupQueue<T> {
 /// A handle which refers to a wakeup queue. The handles allows to notify the
 /// queue that a wakeup is required, and that after the wakeup the owner of the handle
 /// wants to be notified.
+#[derive(Debug)]
 pub struct WakeupHandle<T> {
     /// The queue this handle is referring to
     queue: Arc<Mutex<QueueState<T>>>,


### PR DESCRIPTION
Several components in transport are missing `Debug` implementations, which will be required after removing the shared state struct. The change adds the impls.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
