### PR TITLE
core: add inline attribute to CID methods

### DIFF
--- a/quic/s2n-quic-core/src/connection/id.rs
+++ b/quic/s2n-quic-core/src/connection/id.rs
@@ -50,21 +50,25 @@ macro_rules! id {
             /// If the passed byte array exceeds the maximum allowed length for
             /// Connection IDs (20 bytes in QUIC v1) `None` will be returned.
             /// All other input values are valid.
+            #[inline]
             pub fn try_from_bytes(bytes: &[u8]) -> Option<$type> {
                 Self::try_from(bytes).ok()
             }
 
             /// Returns the Connection ID in byte form
+            #[inline]
             pub fn as_bytes(&self) -> &[u8] {
                 self.as_ref()
             }
 
             /// Returns the length of the connection id
+            #[inline]
             pub const fn len(&self) -> usize {
                 self.len as usize
             }
 
             /// Returns true if this connection ID is zero-length
+            #[inline]
             pub fn is_empty(&self) -> bool {
                 self.len == 0
             }
@@ -100,6 +104,7 @@ macro_rules! id {
         }
 
         impl From<[u8; MAX_LEN]> for $type {
+            #[inline]
             fn from(bytes: [u8; MAX_LEN]) -> Self {
                 Self {
                     bytes,
@@ -111,6 +116,7 @@ macro_rules! id {
         impl TryFrom<&[u8]> for $type {
             type Error = Error;
 
+            #[inline]
             fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
                 let len = slice.len();
                 if !($type::MIN_LEN..=MAX_LEN).contains(&len) {
@@ -126,6 +132,7 @@ macro_rules! id {
         }
 
         impl AsRef<[u8]> for $type {
+            #[inline]
             fn as_ref(&self) -> &[u8] {
                 &self.bytes[0..self.len as usize]
             }
@@ -150,6 +157,7 @@ macro_rules! id {
         );
 
         impl EncoderValue for $type {
+            #[inline]
             fn encode<E: Encoder>(&self, encoder: &mut E) {
                 self.as_ref().encode(encoder)
             }
@@ -189,6 +197,7 @@ id!(InitialId, 8);
 impl TryFrom<LocalId> for InitialId {
     type Error = Error;
 
+    #[inline]
     fn try_from(value: LocalId) -> Result<Self, Self::Error> {
         value.as_bytes().try_into()
     }
@@ -216,6 +225,7 @@ impl core::fmt::Display for Error {
 }
 
 impl From<Error> for transport::Error {
+    #[inline]
     fn from(error: Error) -> Self {
         Self::PROTOCOL_VIOLATION.with_reason(error.message())
     }
@@ -230,6 +240,7 @@ pub struct ConnectionInfo<'a> {
 }
 
 impl<'a> ConnectionInfo<'a> {
+    #[inline]
     pub fn new(remote_address: &'a SocketAddress) -> Self {
         Self { remote_address }
     }
@@ -258,6 +269,7 @@ pub trait Validator {
 }
 
 impl Validator for usize {
+    #[inline]
     fn validate(&self, _connection_info: &ConnectionInfo, buffer: &[u8]) -> Option<usize> {
         if buffer.len() >= *self {
             Some(*self)
@@ -283,6 +295,7 @@ pub trait Generator {
     /// The maximum amount of time each generated connection ID should be
     /// used for. By default there is no maximum, though connection IDs
     /// may be retired due to rotation requirements or peer requests.
+    #[inline]
     fn lifetime(&self) -> Option<core::time::Duration> {
         None
     }


### PR DESCRIPTION
I noticed that the CID `as_ref` was showing up in the flamegraph, which should really just be a simple memcpy. This change adds `#[inline]` to all of the trivial CID methods to enable better optimization.

### Before

[
![before](https://user-images.githubusercontent.com/799311/128759877-ffa89c92-3584-4960-a789-f1a0f62888b0.png)
](https://dnglbrstg7yg.cloudfront.net/7804f2a6764bc0d0ae83331c09edaa738362ce3c/perf/1000MB-down-0MB-up.svg?x=3611&y=773)

### After

[
![after](https://user-images.githubusercontent.com/799311/128760108-a45c2a22-e95a-4c69-8fef-942c0e35bf07.png)
](https://dnglbrstg7yg.cloudfront.net/482fdee0ca4b4639fda70c5f605b02615a1fbe64/perf/1000MB-down-0MB-up.svg?x=3140&y=725)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
