### PR TITLE
platform: map ipv4 from ipv6 if possible

### DIFF
--- a/quic/s2n-quic-core/src/inet/ip.rs
+++ b/quic/s2n-quic-core/src/inet/ip.rs
@@ -25,12 +25,14 @@ pub enum IpAddress {
 }
 
 impl From<IpV4Address> for IpAddress {
+    #[inline]
     fn from(ip: IpV4Address) -> Self {
         Self::Ipv4(ip)
     }
 }
 
 impl From<IpV6Address> for IpAddress {
+    #[inline]
     fn from(ip: IpV6Address) -> Self {
         Self::Ipv6(ip)
     }
@@ -43,6 +45,7 @@ pub enum IpAddressRef<'a> {
 }
 
 impl<'a> IpAddressRef<'a> {
+    #[inline]
     pub fn to_owned(self) -> IpAddress {
         match self {
             Self::IPv4(addr) => IpAddress::Ipv4(*addr),
@@ -52,12 +55,14 @@ impl<'a> IpAddressRef<'a> {
 }
 
 impl<'a> From<&'a IpV4Address> for IpAddressRef<'a> {
+    #[inline]
     fn from(ip: &'a IpV4Address) -> Self {
         Self::IPv4(ip)
     }
 }
 
 impl<'a> From<&'a IpV6Address> for IpAddressRef<'a> {
+    #[inline]
     fn from(ip: &'a IpV6Address) -> Self {
         Self::IPv6(ip)
     }
@@ -77,6 +82,7 @@ pub enum SocketAddress {
 }
 
 impl SocketAddress {
+    #[inline]
     pub fn ip(&self) -> IpAddress {
         match self {
             SocketAddress::IpV4(addr) => IpAddress::Ipv4(*addr.ip()),
@@ -84,6 +90,7 @@ impl SocketAddress {
         }
     }
 
+    #[inline]
     pub fn port(&self) -> u16 {
         match self {
             SocketAddress::IpV4(addr) => addr.port(),
@@ -92,10 +99,20 @@ impl SocketAddress {
     }
 
     /// Converts the IP address into a IPv6 mapped address
+    #[inline]
     pub fn to_ipv6_mapped(self) -> SocketAddressV6 {
         match self {
             Self::IpV4(addr) => addr.to_ipv6_mapped(),
             Self::IpV6(addr) => addr,
+        }
+    }
+
+    /// Tries to convert the IP address into an IPv4 if it can
+    #[inline]
+    pub fn try_into_ipv4(self) -> Option<SocketAddressV4> {
+        match self {
+            Self::IpV4(addr) => Some(addr),
+            Self::IpV6(addr) => addr.try_into_ipv4(),
         }
     }
 }

--- a/quic/s2n-quic-platform/src/message/msg.rs
+++ b/quic/s2n-quic-platform/src/message/msg.rs
@@ -89,7 +89,13 @@ impl MessageTrait for msghdr {
                 let sockaddr: &sockaddr_in6 = unsafe { &*(self.msg_name as *const _) };
                 let port = sockaddr.sin6_port.to_be();
                 let addr: IpV6Address = sockaddr.sin6_addr.s6_addr.into();
-                Some(SocketAddressV6::new(addr, port).into())
+
+                // try converting the address to ipv4 if possible
+                if let Some(v4) = addr.try_into_ipv4() {
+                    Some(SocketAddressV4::new(v4, port).into())
+                } else {
+                    Some(SocketAddressV6::new(addr, port).into())
+                }
             }
             _ => None,
         }

--- a/quic/s2n-quic-qns/src/server/interop.rs
+++ b/quic/s2n-quic-qns/src/server/interop.rs
@@ -25,6 +25,9 @@ use tracing::info;
 
 #[derive(Debug, StructOpt)]
 pub struct Interop {
+    #[structopt(short, long, default_value = "::")]
+    address: String,
+
     #[structopt(short, long, default_value = "443")]
     port: u16,
 
@@ -186,7 +189,7 @@ impl Interop {
             .build()?;
 
         let server = Server::builder()
-            .with_io(("::", self.port))?
+            .with_io((self.address.as_str(), self.port))?
             .with_tls(tls)?
             .with_endpoint_limits(limits)?
             .with_event(EventProvider)?

--- a/quic/s2n-quic-qns/src/server/perf.rs
+++ b/quic/s2n-quic-qns/src/server/perf.rs
@@ -18,6 +18,9 @@ use tokio::spawn;
 
 #[derive(Debug, StructOpt)]
 pub struct Perf {
+    #[structopt(short, long, default_value = "::")]
+    address: String,
+
     #[structopt(short, long, default_value = "443")]
     port: u16,
 
@@ -242,7 +245,7 @@ impl Perf {
             .build()?;
 
         let server = Server::builder()
-            .with_io(("::", self.port))?
+            .with_io((self.address.as_str(), self.port))?
             .with_tls(tls)?
             .with_event(event::disabled::Provider)?
             .start()

--- a/scripts/perf/test
+++ b/scripts/perf/test
@@ -47,6 +47,7 @@ echo "executing request"
   --download-size "$DOWNLOAD_B" \
   --upload-size "$UPLOAD_B" \
   --insecure \
+  --ip 127.0.0.1 \
   --duration 10 \
   localhost:4433 || stop_server "failed to finish the request"
 


### PR DESCRIPTION
Currently, if the socket is listening on an Ipv6 address but we receive a packet from an Ipv4 address, we will pass a Ipv6 address to the connection. This causes the MTU controller to assume we're using an Ipv6 connection and will try to probe a smaller payload, as Ipv6 headers are larger.

This change tries to map Ipv4 to Ipv6 if it can, which fixes the larger MTU probing. I've also switch the `perf` script to use Ipv4 so we can get the extra bytes in the datagrams :)

### Todo
- [ ] fix the macOS tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
