### PR TITLE
core: add inline to truncated packet number methods

### DIFF
--- a/quic/s2n-quic-core/src/packet/number/truncated_packet_number.rs
+++ b/quic/s2n-quic-core/src/packet/number/truncated_packet_number.rs
@@ -49,6 +49,7 @@ impl TruncatedPacketNumber {
     /// `TruncatedPacketNumber` values should be created either
     /// by using a `PacketNumberLen` to decode a buffer, or truncating
     /// a `PacketNumber`.
+    #[inline]
     pub(crate) fn new<Value: Into<TruncatedPacketNumberValue>>(
         value: Value,
         space: PacketNumberSpace,
@@ -60,6 +61,7 @@ impl TruncatedPacketNumber {
     }
 
     /// Internal function to decode a `TruncatedPacketNumber` with a given size.
+    #[inline]
     pub(crate) fn decode<'a, Value: Into<TruncatedPacketNumberValue> + DecoderValue<'a>>(
         buffer: DecoderBuffer<'a>,
         space: PacketNumberSpace,
@@ -83,6 +85,7 @@ impl TruncatedPacketNumber {
 }
 
 impl EncoderValue for TruncatedPacketNumber {
+    #[inline]
     fn encode<E: Encoder>(&self, buffer: &mut E) {
         buffer.encode(&self.value)
     }
@@ -122,6 +125,7 @@ impl TruncatedPacketNumberValue {
 }
 
 impl EncoderValue for TruncatedPacketNumberValue {
+    #[inline]
     fn encode<E: Encoder>(&self, buffer: &mut E) {
         match self {
             Self::U8(value) => buffer.encode(value),
@@ -133,24 +137,28 @@ impl EncoderValue for TruncatedPacketNumberValue {
 }
 
 impl From<u8> for TruncatedPacketNumberValue {
+    #[inline]
     fn from(value: u8) -> Self {
         Self::U8(value)
     }
 }
 
 impl From<u16> for TruncatedPacketNumberValue {
+    #[inline]
     fn from(value: u16) -> Self {
         Self::U16(value)
     }
 }
 
 impl From<u24> for TruncatedPacketNumberValue {
+    #[inline]
     fn from(value: u24) -> Self {
         Self::U24(value)
     }
 }
 
 impl From<u32> for TruncatedPacketNumberValue {
+    #[inline]
     fn from(value: u32) -> Self {
         Self::U32(value)
     }


### PR DESCRIPTION
You know the deal... if it's showing up in the flamegraph on the transmit path; it gets inlined :smile:.

In this case, it doesn't make a massive difference but we might as well.

### Before

[
![before](https://user-images.githubusercontent.com/799311/128783958-3a77dc40-7356-4529-9ef6-2c206050e6f7.png)
](https://dnglbrstg7yg.cloudfront.net/f6dacedd526774cb8a1616c4fa9c083cb5508271/perf/1000MB-down-0MB-up.svg?x=3168&y=741)

[
![after](https://user-images.githubusercontent.com/799311/128784561-1976ef81-1d35-499c-8e35-5c1841e752cc.png)
](https://dnglbrstg7yg.cloudfront.net/e46a2710da4340859b1da2cde07f0ede9612b3ae/perf/1000MB-down-0MB-up.svg?x=3094&y=757)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
