### PR TITLE
transport: inline first transmission to reduce slab operations

### DIFF
--- a/quic/s2n-quic-transport/src/interval_set/interval.rs
+++ b/quic/s2n-quic-transport/src/interval_set/interval.rs
@@ -57,17 +57,20 @@ impl<T: IntervalBound> Interval<T> {
         self.end.step_up_saturating()
     }
 
+    #[inline]
     pub fn len(&self) -> usize {
         // Interval always has at least 1
         let interval_base_len = 1;
         interval_base_len + self.start.steps_between(&self.end)
     }
 
+    #[inline]
     pub fn set_len(&mut self, len: usize) {
         debug_assert_ne!(len, 0, "Intervals cannot be 0 length");
         self.end = self.start.steps_between_len(len);
     }
 
+    #[inline]
     pub fn is_empty(&self) -> bool {
         // Interval always has at least 1
         false
@@ -88,38 +91,45 @@ impl<T: IntervalBound> IntoIterator for &Interval<T> {
     type IntoIter = Interval<T>;
     type Item = T;
 
+    #[inline]
     fn into_iter(self) -> Self::IntoIter {
         *self
     }
 }
 
 impl<T> RangeBounds<T> for Interval<T> {
+    #[inline]
     fn start_bound(&self) -> Bound<&T> {
         Bound::Included(&self.start)
     }
 
+    #[inline]
     fn end_bound(&self) -> Bound<&T> {
         Bound::Included(&self.end)
     }
 }
 
 impl<T> RangeBounds<T> for &Interval<T> {
+    #[inline]
     fn start_bound(&self) -> Bound<&T> {
         Bound::Included(&self.start)
     }
 
+    #[inline]
     fn end_bound(&self) -> Bound<&T> {
         Bound::Included(&self.end)
     }
 }
 
 impl<T: Ord> PartialEq<T> for Interval<T> {
+    #[inline]
     fn eq(&self, value: &T) -> bool {
         self.partial_cmp(value) == Some(Ordering::Equal)
     }
 }
 
 impl<T: Ord> PartialOrd<T> for Interval<T> {
+    #[inline]
     fn partial_cmp(&self, value: &T) -> Option<Ordering> {
         use Ordering::*;
         Some(match (self.start.cmp(value), self.end.cmp(value)) {
@@ -134,6 +144,7 @@ impl<T: Ord> PartialOrd<T> for Interval<T> {
 }
 
 impl<T: IntervalBound> From<&Interval<T>> for Interval<T> {
+    #[inline]
     fn from(interval: &Interval<T>) -> Self {
         *interval
     }
@@ -142,6 +153,7 @@ impl<T: IntervalBound> From<&Interval<T>> for Interval<T> {
 macro_rules! range_impls {
     ($range_ty:ident, $into:expr, $from:expr) => {
         impl<T: IntervalBound> From<Interval<T>> for $range_ty<T> {
+            #[inline]
             fn from(range: Interval<T>) -> Self {
                 #[allow(clippy::redundant_closure_call)]
                 ($into)(range)
@@ -149,6 +161,7 @@ macro_rules! range_impls {
         }
 
         impl<T: IntervalBound> From<&Interval<T>> for $range_ty<T> {
+            #[inline]
             fn from(range: &Interval<T>) -> Self {
                 #[allow(clippy::redundant_closure_call)]
                 ($into)(*range)
@@ -156,6 +169,7 @@ macro_rules! range_impls {
         }
 
         impl<T: IntervalBound> From<$range_ty<T>> for Interval<T> {
+            #[inline]
             fn from(range: $range_ty<T>) -> Self {
                 #[allow(clippy::redundant_closure_call)]
                 ($from)(range)
@@ -163,6 +177,7 @@ macro_rules! range_impls {
         }
 
         impl<'a, T: IntervalBound> From<&'a $range_ty<T>> for Interval<T> {
+            #[inline]
             fn from(range: &'a $range_ty<T>) -> Self {
                 #[allow(clippy::redundant_closure_call)]
                 ($from)(range.clone())
@@ -170,18 +185,21 @@ macro_rules! range_impls {
         }
 
         impl<T: IntervalBound> PartialEq<$range_ty<T>> for Interval<T> {
+            #[inline]
             fn eq(&self, other: &$range_ty<T>) -> bool {
                 self.partial_cmp(other) == Some(Ordering::Equal)
             }
         }
 
         impl<T: IntervalBound> PartialEq<$range_ty<T>> for &Interval<T> {
+            #[inline]
             fn eq(&self, other: &$range_ty<T>) -> bool {
                 self.partial_cmp(other) == Some(Ordering::Equal)
             }
         }
 
         impl<T: IntervalBound> PartialOrd<$range_ty<T>> for Interval<T> {
+            #[inline]
             fn partial_cmp(&self, other: &$range_ty<T>) -> Option<Ordering> {
                 let other: Self = other.into();
                 self.partial_cmp(&other)
@@ -189,6 +207,7 @@ macro_rules! range_impls {
         }
 
         impl<T: IntervalBound> PartialOrd<$range_ty<T>> for &Interval<T> {
+            #[inline]
             fn partial_cmp(&self, other: &$range_ty<T>) -> Option<Ordering> {
                 let other: Interval<_> = other.into();
                 (*self).partial_cmp(&other)
@@ -218,6 +237,7 @@ range_impls!(
 impl<T: IntervalBound> Iterator for Interval<T> {
     type Item = T;
 
+    #[inline]
     fn next(&mut self) -> Option<T> {
         let current = self.start;
         if current > self.end {
@@ -233,6 +253,7 @@ impl<T: IntervalBound> Iterator for Interval<T> {
 }
 
 impl<T: IntervalBound> DoubleEndedIterator for Interval<T> {
+    #[inline]
     fn next_back(&mut self) -> Option<T> {
         let current = self.end;
         if current < self.start {
@@ -271,19 +292,23 @@ pub trait IntervalBound: Copy + Ord + Sized {
 macro_rules! integer_bounds {
     ($type:ident) => {
         impl IntervalBound for $type {
+            #[inline]
             fn step_up(self) -> Option<Self> {
                 self.checked_add(1)
             }
 
+            #[inline]
             fn step_down(self) -> Option<Self> {
                 self.checked_sub(1)
             }
 
+            #[inline]
             fn steps_between(&self, upper: &Self) -> usize {
                 use core::convert::TryInto;
                 (upper - self).try_into().unwrap_or(core::usize::MAX)
             }
 
+            #[inline]
             fn steps_between_len(&self, len: usize) -> Self {
                 use core::convert::TryInto;
                 let len: Self = (len - 1).try_into().unwrap();
@@ -309,40 +334,48 @@ integer_bounds!(isize);
 use s2n_quic_core::{packet::number::PacketNumber, varint::VarInt};
 
 impl IntervalBound for VarInt {
+    #[inline]
     fn step_up(self) -> Option<Self> {
         self.checked_add(Self::from_u8(1))
     }
 
+    #[inline]
     fn step_down(self) -> Option<Self> {
         self.checked_sub(Self::from_u8(1))
     }
 
+    #[inline]
     fn steps_between(&self, upper: &Self) -> usize {
         <u64 as IntervalBound>::steps_between(&*self, &*upper)
     }
 
+    #[inline]
     fn steps_between_len(&self, len: usize) -> Self {
         *self + (len - 1)
     }
 }
 
 impl IntervalBound for PacketNumber {
+    #[inline]
     fn step_up(self) -> Option<Self> {
         self.next()
     }
 
+    #[inline]
     fn step_down(self) -> Option<Self> {
         let space = self.space();
         let value = PacketNumber::as_varint(self);
         Some(space.new_packet_number(value.step_down()?))
     }
 
+    #[inline]
     fn steps_between(&self, upper: &Self) -> usize {
         let lower = PacketNumber::as_varint(*self);
         let upper = PacketNumber::as_varint(*upper);
         lower.steps_between(&upper)
     }
 
+    #[inline]
     fn steps_between_len(&self, len: usize) -> Self {
         let start = PacketNumber::as_varint(*self);
         let end = start.steps_between_len(len);

--- a/quic/s2n-quic-transport/src/interval_set/mod.rs
+++ b/quic/s2n-quic-transport/src/interval_set/mod.rs
@@ -295,6 +295,7 @@ impl<T: IntervalBound> IntervalSet<T> {
     /// assert!(set.contains(&3));
     /// assert!(!set.contains(&5));
     /// ```
+    #[inline]
     pub fn insert<R: RangeBounds<T>>(&mut self, interval: R) -> Result<(), IntervalSetError> {
         let interval = Interval::from_range_bounds(interval)?;
 
@@ -324,6 +325,7 @@ impl<T: IntervalBound> IntervalSet<T> {
     /// assert!(set.contains(&3));
     /// assert!(!set.contains(&5));
     /// ```
+    #[inline]
     pub fn insert_front<R: RangeBounds<T>>(&mut self, interval: R) -> Result<(), IntervalSetError> {
         let interval = Interval::from_range_bounds(interval)?;
 
@@ -351,6 +353,7 @@ impl<T: IntervalBound> IntervalSet<T> {
     /// assert!(!set.contains(&0));
     /// assert!(!set.contains(&2));
     /// ```
+    #[inline]
     pub fn insert_value(&mut self, value: T) -> Result<(), IntervalSetError> {
         self.insert((Bound::Included(value), Bound::Included(value)))
     }
@@ -369,6 +372,7 @@ impl<T: IntervalBound> IntervalSet<T> {
     /// a.union(&b);
     /// assert_eq!(a.iter().collect::<Vec<_>>(), (0..8).collect::<Vec<_>>());
     /// ```
+    #[inline]
     pub fn union(&mut self, other: &Self) -> Result<(), IntervalSetError> {
         if self.intervals.is_empty() {
             self.intervals = other.intervals.clone();
@@ -389,6 +393,7 @@ impl<T: IntervalBound> IntervalSet<T> {
     /// assert!(set.remove(0..4).is_ok());
     /// assert!(set.is_empty());
     /// ```
+    #[inline]
     pub fn remove<R: RangeBounds<T>>(&mut self, interval: R) -> Result<(), IntervalSetError> {
         let interval = Interval::from_range_bounds(interval)?;
 
@@ -415,6 +420,7 @@ impl<T: IntervalBound> IntervalSet<T> {
     /// assert!(set.remove_value(1).is_ok());
     /// assert!(!set.contains(&1));
     /// ```
+    #[inline]
     pub fn remove_value(&mut self, value: T) -> Result<(), IntervalSetError> {
         self.remove((Bound::Included(value), Bound::Included(value)))
     }
@@ -433,6 +439,7 @@ impl<T: IntervalBound> IntervalSet<T> {
     /// assert!(set_a.difference(&set_b).is_ok());
     /// assert_eq!(set_a.iter().collect::<Vec<_>>(), vec![0, 1, 2, 3, 9, 10]);
     /// ```
+    #[inline]
     pub fn difference(&mut self, other: &Self) -> Result<(), IntervalSetError> {
         if self.intervals.is_empty() {
             return Ok(());
@@ -455,6 +462,7 @@ impl<T: IntervalBound> IntervalSet<T> {
     /// assert!(set_a.intersection(&set_b).is_ok());
     /// assert_eq!(set_a.iter().collect::<Vec<_>>(), vec![4, 5, 6, 7, 8]);
     /// ```
+    #[inline]
     pub fn intersection(&mut self, other: &Self) -> Result<(), IntervalSetError> {
         if self.is_empty() {
             return Ok(());
@@ -486,6 +494,7 @@ impl<T: IntervalBound> IntervalSet<T> {
     /// let intersection = set_a.intersection_iter(&set_b).flatten();
     /// assert_eq!(intersection.collect::<Vec<_>>(), vec![4, 5, 6, 7, 8]);
     /// ```
+    #[inline]
     pub fn intersection_iter<'a>(&'a self, other: &'a Self) -> Intersection<'a, T> {
         Intersection::new(&self.intervals, &other.intervals)
     }
@@ -558,11 +567,13 @@ impl<T: IntervalBound> IntervalSet<T> {
     /// assert!(set.insert(0..5).is_ok());
     /// assert_eq!(set.contains(&1), true);
     /// ```
+    #[inline]
     pub fn contains(&self, value: &T) -> bool {
         self.binary_search_with(value, |_index| true, |_index| false, |_index| false)
     }
 
     /// Internal function for applying set operations
+    #[inline]
     fn set_operation<
         F: Fn(
             &mut VecDeque<Interval<T>>,
@@ -603,6 +614,7 @@ impl<T: IntervalBound> IntervalSet<T> {
 
     /// Internal function for locating the optimal starting index for
     /// interval comparison
+    #[inline]
     fn index_for(&self, interval: &Interval<T>) -> usize {
         // it's faster just to iterate through the set for smaller lengths
         if self.interval_len() < 16 {
@@ -755,6 +767,7 @@ pub struct Iter<'a, T> {
 impl<'a, T: IntervalBound> Iterator for Iter<'a, T> {
     type Item = T;
 
+    #[inline]
     fn next(&mut self) -> Option<T> {
         loop {
             if let Some(item) = self.head.as_mut().and_then(Iterator::next) {
@@ -765,6 +778,7 @@ impl<'a, T: IntervalBound> Iterator for Iter<'a, T> {
         }
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let (lower, _) = self.iter.size_hint();
         // Computing the upper length would require iterating through all of the ranges
@@ -774,6 +788,7 @@ impl<'a, T: IntervalBound> Iterator for Iter<'a, T> {
 }
 
 impl<'a, T: IntervalBound> DoubleEndedIterator for Iter<'a, T> {
+    #[inline]
     fn next_back(&mut self) -> Option<T> {
         loop {
             if let Some(item) = self.tail.as_mut().and_then(DoubleEndedIterator::next_back) {
@@ -800,16 +815,19 @@ macro_rules! impl_iterator_conversions {
         impl<'a, T: IntervalBound> Iterator for $iter<'a, T> {
             type Item = $item<T>;
 
+            #[inline]
             fn next(&mut self) -> Option<Self::Item> {
                 self.iter.next().map(|interval| interval.into())
             }
 
+            #[inline]
             fn size_hint(&self) -> (usize, Option<usize>) {
                 self.iter.size_hint()
             }
         }
 
         impl<'a, T: IntervalBound> DoubleEndedIterator for $iter<'a, T> {
+            #[inline]
             fn next_back(&mut self) -> Option<Self::Item> {
                 self.iter.next_back().map(|interval| interval.into())
             }
@@ -821,6 +839,7 @@ macro_rules! impl_iterator_conversions {
         }
 
         impl<T: IntervalBound> FromIterator<$item<T>> for IntervalSet<T> {
+            #[inline]
             fn from_iter<I: IntoIterator<Item = $item<T>>>(intervals: I) -> Self {
                 let intervals = intervals.into_iter();
                 let mut set = Self::with_capacity(intervals.size_hint().0);
@@ -830,6 +849,7 @@ macro_rules! impl_iterator_conversions {
         }
 
         impl<'a, T: 'a + IntervalBound> FromIterator<&'a $item<T>> for IntervalSet<T> {
+            #[inline]
             fn from_iter<I: IntoIterator<Item = &'a $item<T>>>(intervals: I) -> Self {
                 let intervals = intervals.into_iter();
                 let mut set = Self::with_capacity(intervals.size_hint().0);
@@ -839,6 +859,7 @@ macro_rules! impl_iterator_conversions {
         }
 
         impl<T: IntervalBound> Extend<$item<T>> for IntervalSet<T> {
+            #[inline]
             fn extend<I: IntoIterator<Item = $item<T>>>(&mut self, intervals: I) {
                 for interval in intervals {
                     if self.insert(interval).is_err() {
@@ -849,6 +870,7 @@ macro_rules! impl_iterator_conversions {
         }
 
         impl<'a, T: 'a + IntervalBound> Extend<&'a $item<T>> for IntervalSet<T> {
+            #[inline]
             fn extend<I: IntoIterator<Item = &'a $item<T>>>(&mut self, intervals: I) {
                 for interval in intervals {
                     let interval: Interval<T> = interval.into();
@@ -860,6 +882,7 @@ macro_rules! impl_iterator_conversions {
         }
 
         impl<T: IntervalBound> From<$item<T>> for IntervalSet<T> {
+            #[inline]
             fn from(interval: $item<T>) -> Self {
                 let mut set = Self::with_capacity(1);
                 let _ = set.insert(interval);
@@ -874,6 +897,7 @@ impl_iterator_conversions!(Range, RangeIter);
 impl_iterator_conversions!(RangeInclusive, RangeInclusiveIter);
 
 impl<T: IntervalBound> FromIterator<T> for IntervalSet<T> {
+    #[inline]
     fn from_iter<I: IntoIterator<Item = T>>(values: I) -> Self {
         let values = values.into_iter();
         let mut set = Self::with_capacity(values.size_hint().0);
@@ -887,6 +911,7 @@ impl<T: IntervalBound> FromIterator<T> for IntervalSet<T> {
 }
 
 impl<'a, T: 'a + IntervalBound> FromIterator<&'a T> for IntervalSet<T> {
+    #[inline]
     fn from_iter<I: IntoIterator<Item = &'a T>>(values: I) -> Self {
         values.into_iter().cloned().collect()
     }


### PR DESCRIPTION
The current data sender transmission set always puts transmission information into the slab and stores a mapping from packet number to slab index. This is because there can be multiple transmissions per packet number, depending on stream fragmentation. However, most of the time it will just be a single transmission so interacting with the slab can result in additional overhead.

This change changes the packet number map to a transmission that can chain additional slab indexes on it.

I've also added `#[inline]` on a bunch of additional methods :smile:.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
