### PR TITLE
datagram_sent event and amend packet_sent event

### DIFF
--- a/quic/s2n-quic-core/src/event.rs
+++ b/quic/s2n-quic-core/src/event.rs
@@ -331,6 +331,13 @@ events!(
         pub error: common::DuplicatePacketError,
     }
 
+    #[name = "transport:datagram_sent"]
+    //= https://tools.ietf.org/id/draft-marx-qlog-event-definitions-quic-h3-02.txt#5.3.10
+    /// Datagram sent
+    struct DatagramSent {
+        pub len: u16,
+    }
+
     #[name = "transport:datagram_received"]
     //= https://tools.ietf.org/id/draft-marx-qlog-event-definitions-quic-h3-02.txt#5.3.11
     /// Datagram received

--- a/quic/s2n-quic-core/src/event/macros.rs
+++ b/quic/s2n-quic-core/src/event/macros.rs
@@ -305,6 +305,23 @@ macro_rules! common {
                     }
                 }
             )*
+
+            // TODO: find a more automated way to create and maintain these and other enum
+            // variants.
+            //
+            // The following functions exist since PacketType is a non_exhaustive enum
+            // and therefore its variants cannot be created outside this crate.
+            pub fn version_packet_type() -> common::PacketType {
+                common::PacketType::VersionNegotiation
+            }
+
+            pub fn retry_packet_type() -> common::PacketType {
+                common::PacketType::Retry
+            }
+
+            pub fn stateless_reset_packet_type() -> common::PacketType {
+                common::PacketType::StatelessReset
+            }
         }
     };
 }

--- a/quic/s2n-quic-core/src/io/tx.rs
+++ b/quic/s2n-quic-core/src/io/tx.rs
@@ -22,7 +22,7 @@ pub trait Queue {
     ///
     /// The index of the message is returned to enable further operations to be
     /// performed, e.g. encryption.
-    fn push<M: Message<Handle = Self::Handle>>(&mut self, message: M) -> Result<usize, Error>;
+    fn push<M: Message<Handle = Self::Handle>>(&mut self, message: M) -> Result<Outcome, Error>;
 
     /// Returns the pending messages as a mutable slice
     fn as_slice_mut(&mut self) -> &mut [Self::Entry];
@@ -42,6 +42,11 @@ pub trait Queue {
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+}
+
+pub struct Outcome {
+    pub len: usize,
+    pub index: usize,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq)]

--- a/quic/s2n-quic-core/src/transmission/mod.rs
+++ b/quic/s2n-quic-core/src/transmission/mod.rs
@@ -5,7 +5,6 @@ use crate::{
     frame::ack_elicitation::{AckElicitable, AckElicitation},
     packet::number,
 };
-use core::ops;
 
 pub mod constraint;
 pub mod mode;
@@ -35,14 +34,5 @@ impl Outcome {
 impl AckElicitable for Outcome {
     fn ack_elicitation(&self) -> AckElicitation {
         self.ack_elicitation
-    }
-}
-
-impl ops::AddAssign for Outcome {
-    fn add_assign(&mut self, rhs: Self) {
-        self.ack_elicitation |= rhs.ack_elicitation;
-        self.is_congestion_controlled |= rhs.is_congestion_controlled;
-        self.bytes_sent += rhs.bytes_sent;
-        self.packet_number = rhs.packet_number;
     }
 }

--- a/quic/s2n-quic-transport/src/connection/close_sender.rs
+++ b/quic/s2n-quic-transport/src/connection/close_sender.rs
@@ -11,6 +11,7 @@ use bytes::Bytes;
 use core::{task::Poll, time::Duration};
 use s2n_quic_core::{
     counter::{self, Counter},
+    event,
     inet::ExplicitCongestionNotification,
     io::tx,
     time::{timer, Timer, Timestamp},
@@ -44,10 +45,11 @@ impl CloseSender {
         self.state.on_datagram_received(rtt, now);
     }
 
-    pub fn transmission<'a, Config: endpoint::Config>(
+    pub fn transmission<'a, Config: endpoint::Config, Pub: event::Publisher>(
         &'a mut self,
         path: &'a mut Path<Config>,
-    ) -> Transmission<'a, Config> {
+        publisher: &'a mut Pub,
+    ) -> Transmission<'a, Config, Pub> {
         debug_assert!(
             self.has_transmission_interest(),
             "transmission should only be called when transmission interest is expressed"
@@ -63,6 +65,7 @@ impl CloseSender {
                 packet,
                 transmission,
                 path,
+                publisher,
             }
         } else {
             unreachable!(
@@ -116,13 +119,16 @@ impl transmission::interest::Provider for CloseSender {
     }
 }
 
-pub struct Transmission<'a, Config: endpoint::Config> {
+pub struct Transmission<'a, Config: endpoint::Config, Pub: event::Publisher> {
     packet: &'a Bytes,
     transmission: &'a mut TransmissionState,
     path: &'a mut Path<Config>,
+    publisher: &'a mut Pub,
 }
 
-impl<'a, Config: endpoint::Config> tx::Message for Transmission<'a, Config> {
+impl<'a, Config: endpoint::Config, Pub: event::Publisher> tx::Message
+    for Transmission<'a, Config, Pub>
+{
     type Handle = Config::PathHandle;
 
     #[inline]
@@ -165,6 +171,9 @@ impl<'a, Config: endpoint::Config> tx::Message for Transmission<'a, Config> {
 
         self.path.on_bytes_transmitted(len);
         *self.transmission = TransmissionState::Idle;
+
+        self.publisher
+            .on_datagram_sent(event::builders::DatagramSent { len: len as u16 });
 
         len
     }
@@ -299,6 +308,7 @@ mod tests {
     use super::*;
     use crate::path::testing::helper_path;
     use s2n_quic_core::{
+        event::testing::Publisher,
         io::tx::Message as _,
         path::MINIMUM_MTU,
         time::{testing::Clock, timer::Provider as _, Clock as _},
@@ -340,7 +350,9 @@ mod tests {
 
                 // transmit an initial packet
                 assert!(sender.can_transmit(path.transmission_constraint()));
-                sender.transmission(&mut path).write_payload(&mut buffer);
+                sender
+                    .transmission(&mut path, &mut Publisher)
+                    .write_payload(&mut buffer);
 
                 for (gap, packet_size) in events {
                     // get the next timer event
@@ -360,7 +372,9 @@ mod tests {
                     for _ in 0..3 {
                         let interest = sender.get_transmission_interest();
                         if interest.can_transmit(path.transmission_constraint()) {
-                            sender.transmission(&mut path).write_payload(&mut buffer);
+                            sender
+                                .transmission(&mut path, &mut Publisher)
+                                .write_payload(&mut buffer);
                             transmission_count += 1;
                         }
                     }

--- a/quic/s2n-quic-transport/src/endpoint/retry.rs
+++ b/quic/s2n-quic-transport/src/endpoint/retry.rs
@@ -7,6 +7,7 @@ use core::ops::Range;
 use s2n_quic_core::{
     connection,
     crypto::RetryKey,
+    event,
     inet::ExplicitCongestionNotification,
     io::tx,
     packet,
@@ -54,11 +55,28 @@ impl<Path: path::Handle> Dispatch<Path> {
         }
     }
 
-    pub fn on_transmit<Tx: tx::Queue<Handle = Path>>(&mut self, queue: &mut Tx) {
+    pub fn on_transmit<Tx: tx::Queue<Handle = Path>, Pub: event::Publisher>(
+        &mut self,
+        queue: &mut Tx,
+        publisher: &mut Pub,
+    ) {
         while let Some(transmission) = self.transmissions.pop_front() {
-            if queue.push(&transmission).is_err() {
-                self.transmissions.push_front(transmission);
-                return;
+            match queue.push(&transmission) {
+                Ok(tx::Outcome { len, .. }) => {
+                    publisher.on_packet_sent(event::builders::PacketSent {
+                        packet_header: event::builders::PacketHeader {
+                            packet_type: event::builders::retry_packet_type(),
+                            version: publisher.quic_version(),
+                        }
+                        .into(),
+                    });
+
+                    publisher.on_datagram_sent(event::builders::DatagramSent { len: len as u16 });
+                }
+                Err(_) => {
+                    self.transmissions.push_front(transmission);
+                    return;
+                }
             }
         }
     }

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -233,12 +233,12 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         Ok((outcome, buffer))
     }
 
-    pub fn on_transmit_close<'a>(
+    pub(super) fn on_transmit_close<'a>(
         &mut self,
         context: &mut ConnectionTransmissionContext<Config>,
         connection_close: &ConnectionClose,
         buffer: EncoderBuffer<'a>,
-    ) -> Result<EncoderBuffer<'a>, PacketEncodingError<'a>> {
+    ) -> Result<(transmission::Outcome, EncoderBuffer<'a>), PacketEncodingError<'a>> {
         let packet_number = self.tx_packet_numbers.next();
 
         let packet_number_encoder = self.packet_number_encoder();
@@ -284,7 +284,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
                     )
                 })?;
 
-        Ok(buffer)
+        Ok((outcome, buffer))
     }
 
     /// Signals the connection was previously blocked by anti-amplification limits

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -170,12 +170,12 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
         Ok((outcome, buffer))
     }
 
-    pub fn on_transmit_close<'a>(
+    pub(super) fn on_transmit_close<'a>(
         &mut self,
         context: &mut ConnectionTransmissionContext<Config>,
         connection_close: &ConnectionClose,
         buffer: EncoderBuffer<'a>,
-    ) -> Result<EncoderBuffer<'a>, PacketEncodingError<'a>> {
+    ) -> Result<(transmission::Outcome, EncoderBuffer<'a>), PacketEncodingError<'a>> {
         let packet_number = self.tx_packet_numbers.next();
 
         let packet_number_encoder = self.packet_number_encoder();
@@ -214,7 +214,7 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
             buffer,
         )?;
 
-        Ok(buffer)
+        Ok((outcome, buffer))
     }
 
     /// Signals the connection was previously blocked by anti-amplification limits

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -172,12 +172,12 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
         Ok((outcome, buffer))
     }
 
-    pub fn on_transmit_close<'a>(
+    pub(super) fn on_transmit_close<'a>(
         &mut self,
         context: &mut ConnectionTransmissionContext<Config>,
         connection_close: &ConnectionClose,
         buffer: EncoderBuffer<'a>,
-    ) -> Result<EncoderBuffer<'a>, PacketEncodingError<'a>> {
+    ) -> Result<(transmission::Outcome, EncoderBuffer<'a>), PacketEncodingError<'a>> {
         let packet_number = self.tx_packet_numbers.next();
 
         let packet_number_encoder = self.packet_number_encoder();
@@ -217,7 +217,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
             buffer,
         )?;
 
-        Ok(buffer)
+        Ok((outcome, buffer))
     }
 
     /// Signals the connection was previously blocked by anti-amplification limits


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Datagrams/packets are sent as part of the normal connection establishment and use. These typically include transfer from the Initial, Handshake and Application space.

In addition to the normal use, datagram/packets are also sent as for Retry, StatelessReset, VersionNegotiation and ConnectionClose. These usecase are captured separately from the normal transmission path. This helps with type safety and also efficiency (close_sender only stores the bytes which it needs to transfer rather than needing to store additional context).

This PR adds the datagram_sent event for all the usecases. It also adds the packet_sent event for all these usecases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
