### PR TITLE
Add ghcr.io to tag name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Compute tags
         id: tags
         run: |
-          DOCKER_IMAGE=awslabs/s2n-quic/s2n-quic-qns
+          DOCKER_IMAGE=ghcr.io/awslabs/s2n-quic/s2n-quic-qns
           VERSION=main
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}


### PR DESCRIPTION
*Description of changes:*

GitHub support said they found there is an issue with how the tag is being passed (not exactly sure what that means), but they suggested we make this change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
