### PR TITLE
Track ECN markings on sent packets

### DIFF
--- a/quic/s2n-quic-core/src/inet/ecn.rs
+++ b/quic/s2n-quic-core/src/inet/ecn.rs
@@ -49,7 +49,7 @@ use bolero_generator::*;
 
 /// Explicit Congestion Notification
 #[repr(u8)]
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(feature = "generator", derive(TypeGenerator))]
 pub enum ExplicitCongestionNotification {
     /// The not-ECT codepoint '00' indicates a packet that is not using ECN.

--- a/quic/s2n-quic-transport/src/recovery/sent_packets.rs
+++ b/quic/s2n-quic-transport/src/recovery/sent_packets.rs
@@ -4,7 +4,8 @@
 use crate::path;
 use core::convert::TryInto;
 use s2n_quic_core::{
-    frame::ack_elicitation::AckElicitation, packet::number::Map as PacketNumberMap, time::Timestamp,
+    frame::ack_elicitation::AckElicitation, inet::ExplicitCongestionNotification,
+    packet::number::Map as PacketNumberMap, time::Timestamp,
 };
 
 //= https://tools.ietf.org/id/draft-ietf-quic-recovery-32.txt#A.1
@@ -26,6 +27,8 @@ pub struct SentPacketInfo {
     pub ack_elicitation: AckElicitation,
     /// The ID of the Path the packet was sent on
     pub path_id: path::Id,
+    /// The ECN marker (if any) sent on the datagram that contained this packet
+    pub ecn: ExplicitCongestionNotification,
 }
 
 impl SentPacketInfo {
@@ -35,6 +38,7 @@ impl SentPacketInfo {
         time_sent: Timestamp,
         ack_elicitation: AckElicitation,
         path_id: path::Id,
+        ecn: ExplicitCongestionNotification,
     ) -> Self {
         debug_assert_eq!(
             sent_bytes > 0,
@@ -50,6 +54,7 @@ impl SentPacketInfo {
             time_sent,
             ack_elicitation,
             path_id,
+            ecn,
         }
     }
 }
@@ -57,7 +62,9 @@ impl SentPacketInfo {
 #[cfg(test)]
 mod test {
     use crate::{path, recovery::SentPacketInfo};
-    use s2n_quic_core::frame::ack_elicitation::AckElicitation;
+    use s2n_quic_core::{
+        frame::ack_elicitation::AckElicitation, inet::ExplicitCongestionNotification,
+    };
 
     #[test]
     #[should_panic]
@@ -68,6 +75,7 @@ mod test {
             s2n_quic_platform::time::now(),
             AckElicitation::Eliciting,
             path::Id::new(0),
+            ExplicitCongestionNotification::default(),
         );
     }
 

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -227,6 +227,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
             packet_number,
             outcome,
             context.timestamp,
+            context.ecn,
             &mut recovery_context,
         );
 

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -165,7 +165,13 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
         let path_id = context.path_id;
         let (recovery_manager, mut recovery_context) =
             self.recovery(handshake_status, path_id, context.path_manager);
-        recovery_manager.on_packet_sent(packet_number, outcome, time_sent, &mut recovery_context);
+        recovery_manager.on_packet_sent(
+            packet_number,
+            outcome,
+            time_sent,
+            context.ecn,
+            &mut recovery_context,
+        );
 
         Ok((outcome, buffer))
     }

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -167,7 +167,13 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
         let path_id = context.path_id;
         let (recovery_manager, mut recovery_context) =
             self.recovery(handshake_status, path_id, context.path_manager);
-        recovery_manager.on_packet_sent(packet_number, outcome, time_sent, &mut recovery_context);
+        recovery_manager.on_packet_sent(
+            packet_number,
+            outcome,
+            time_sent,
+            context.ecn,
+            &mut recovery_context,
+        );
 
         Ok((outcome, buffer))
     }


### PR DESCRIPTION
*Issue #, if available:* #802

*Description of changes:*

ECN counts received in Ack frames must be validated against the number of packets we sent that contained a given ECN marker. For example, if we sent 10 packets with the Ect0 marker, but the peer sends us an Ack frame that acknowledges those 10 packets, but only increases the Ect0 count in the Ack frame by 9 (or less), we know that something is messing with the ECN markings and we cannot use ECN on this path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
