### PR TITLE
dont emit datagram event if its len 0

### DIFF
--- a/quic/s2n-quic-transport/src/connection/transmission.rs
+++ b/quic/s2n-quic-transport/src/connection/transmission.rs
@@ -369,11 +369,13 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
         let datagram_len = initial_capacity - encoder.capacity();
         self.context.path_mut().on_bytes_transmitted(datagram_len);
 
-        self.context
-            .publisher
-            .on_datagram_sent(event::builders::DatagramSent {
-                len: datagram_len as u16,
-            });
+        if datagram_len > 0 {
+            self.context
+                .publisher
+                .on_datagram_sent(event::builders::DatagramSent {
+                    len: datagram_len as u16,
+                });
+        }
 
         datagram_len
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The io layer doesnt send a datagram if the length of the queue is 0 == there is nothing to send. This matches the events to the implementation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
