### PR TITLE
ci: pin cargo-chef

### DIFF
--- a/quic/s2n-quic-qns/benchmark/client/Dockerfile.build
+++ b/quic/s2n-quic-qns/benchmark/client/Dockerfile.build
@@ -1,6 +1,6 @@
 FROM rust:latest as planner
 WORKDIR app
-RUN cargo install cargo-chef
+RUN cargo install cargo-chef --version 0.1.23
 
 #Install git
 RUN apt-get update; \
@@ -12,7 +12,7 @@ RUN cargo chef prepare  --recipe-path recipe.json
 
 FROM rust:latest as cacher
 WORKDIR app
-RUN cargo install cargo-chef
+RUN cargo install cargo-chef --version 0.1.23
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --recipe-path recipe.json
 

--- a/quic/s2n-quic-qns/etc/Dockerfile.build
+++ b/quic/s2n-quic-qns/etc/Dockerfile.build
@@ -1,6 +1,6 @@
 FROM rust:latest as planner
 WORKDIR app
-RUN cargo install cargo-chef
+RUN cargo install cargo-chef --version 0.1.23
 COPY Cargo.toml /app
 COPY common /app/common
 COPY tls /app/tls
@@ -9,7 +9,7 @@ RUN cargo chef prepare  --recipe-path recipe.json
 
 FROM rust:latest as cacher
 WORKDIR app
-RUN cargo install cargo-chef
+RUN cargo install cargo-chef --version 0.1.23
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --recipe-path recipe.json
 


### PR DESCRIPTION
cargo-chef seems to have pushed a change that broke our builds recently. By pinning to a specific version it fixes the issue and prevents us from getting future random breakage. I will open an issue with them to get it resolved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
