### PR TITLE
emit sni and alpn events

### DIFF
--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -7,9 +7,13 @@
 //# protocols and versions thereof they support.
 /// Application level protocol
 struct AlpnInformation<'a> {
-    server_alpns: &'a [&'a [u8]],
-    client_alpns: &'a [&'a [u8]],
     chosen_alpn: &'a [u8],
+}
+
+#[event("transport:sni_information")]
+/// Server Name Indication
+struct SniInformation<'a> {
+    chosen_sni: &'a [u8],
 }
 
 #[event("transport:packet_sent")]

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -177,6 +177,13 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
         let sni = application_parameters.sni.map(Bytes::copy_from_slice);
         let alpn = Bytes::copy_from_slice(application_parameters.alpn_protocol);
 
+        self.publisher
+            .on_alpn_information(event::builder::AlpnInformation { chosen_alpn: &alpn });
+        if let Some(chosen_sni) = &sni {
+            self.publisher
+                .on_sni_information(event::builder::SniInformation { chosen_sni });
+        };
+
         *self.application = Some(Box::new(ApplicationSpace::new(
             key,
             header_key,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This pr add emition of the alpn and sni events.

I chose to remove server_alpn and client_alpn fields since we dont have a nice way to expose those at the moment. Since all events are non-exhaustive it will be trivial to add them back if we want.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
