### PR TITLE
connection/endpoint publisher specific Meta

### DIFF
--- a/quic/s2n-quic-core/src/event.rs
+++ b/quic/s2n-quic-core/src/event.rs
@@ -70,9 +70,9 @@ impl Timestamp {
     ///
     /// let start_time = std::time::SystemTime::now();
     /// // `meta` is included as part of each event
-    /// # let meta: event::api::Meta = event::builder::Meta {
+    /// # let meta: event::api::ConnectionMeta = event::builder::ConnectionMeta {
     /// #     endpoint_type: endpoint::Type::Server,
-    /// #     subject: event::builder::Subject::Connection { id: 0 },
+    /// #     id: 0,
     /// #     timestamp: unsafe { Timestamp::from_duration(Duration::from_secs(1) )},
     /// # }.into_event();
     /// let event_time = start_time + meta.timestamp.duration_since_start();

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -1,11 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-struct Meta {
+struct ConnectionMeta {
     #[builder(crate::endpoint::Type)]
     endpoint_type: EndpointType,
 
-    subject: Subject,
+    id: u64,
+
+    #[builder(crate::time::Timestamp)]
+    timestamp: crate::event::Timestamp,
+}
+
+struct EndpointMeta {
+    #[builder(crate::endpoint::Type)]
+    endpoint_type: EndpointType,
 
     #[builder(crate::time::Timestamp)]
     timestamp: crate::event::Timestamp,

--- a/quic/s2n-quic-events/src/parser.rs
+++ b/quic/s2n-quic-events/src/parser.rs
@@ -136,7 +136,7 @@ impl Struct {
                     output.subscriber.extend(quote!(
                         #[doc = #subscriber_doc]
                         #[inline]
-                        fn #function(&mut self, meta: &Meta, event: &#ident) {
+                        fn #function(&mut self, meta: &EndpointMeta, event: &#ident) {
                             let _ = meta;
                             let _ = event;
                         }
@@ -144,7 +144,7 @@ impl Struct {
 
                     output.tuple_subscriber.extend(quote!(
                         #[inline]
-                        fn #function(&mut self, meta: &Meta, event: &#ident) {
+                        fn #function(&mut self, meta: &EndpointMeta, event: &#ident) {
                             (self.0).#function(meta, event);
                             (self.1).#function(meta, event);
                         }
@@ -165,7 +165,7 @@ impl Struct {
                     ));
 
                     output.subscriber_testing.extend(quote!(
-                        fn #function(&mut self, _meta: &api::Meta, _event: &api::#ident) {
+                        fn #function(&mut self, _meta: &api::EndpointMeta, _event: &api::#ident) {
                             self.#counter += 1;
                         }
                     ));
@@ -180,7 +180,7 @@ impl Struct {
                     output.subscriber.extend(quote!(
                         #[doc = #subscriber_doc]
                         #[inline]
-                        fn #function(&mut self, context: &mut Self::ConnectionContext, meta: &Meta, event: &#ident) {
+                        fn #function(&mut self, context: &mut Self::ConnectionContext, meta: &ConnectionMeta, event: &#ident) {
                             let _ = context;
                             let _ = meta;
                             let _ = event;
@@ -189,7 +189,7 @@ impl Struct {
 
                     output.tuple_subscriber.extend(quote!(
                         #[inline]
-                        fn #function(&mut self, context: &mut Self::ConnectionContext, meta: &Meta, event: &#ident) {
+                        fn #function(&mut self, context: &mut Self::ConnectionContext, meta: &ConnectionMeta, event: &#ident) {
                             (self.0).#function(&mut context.0, meta, event);
                             (self.1).#function(&mut context.1, meta, event);
                         }
@@ -211,7 +211,7 @@ impl Struct {
                     ));
 
                     output.subscriber_testing.extend(quote!(
-                        fn #function(&mut self, _context: &mut Self::ConnectionContext, _meta: &api::Meta, _event: &api::#ident) {
+                        fn #function(&mut self, _context: &mut Self::ConnectionContext, _meta: &api::ConnectionMeta, _event: &api::#ident) {
                             self.#counter += 1;
                         }
                     ));

--- a/quic/s2n-quic-qns/src/server/interop.rs
+++ b/quic/s2n-quic-qns/src/server/interop.rs
@@ -257,10 +257,10 @@ impl Subscriber for EventSubscriber {
     fn on_active_path_updated(
         &mut self,
         _context: &mut Self::ConnectionContext,
-        meta: &events::Meta,
+        meta: &events::ConnectionMeta,
         event: &events::ActivePathUpdated,
     ) {
-        info!("{:?} {:?}", meta.subject, event);
+        info!("{:?} {:?}", meta.id, event);
     }
 }
 

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -188,11 +188,9 @@ impl<Config: endpoint::Config> EventContext<Config> {
         subscriber: &'a mut Config::EventSubscriber,
     ) -> event::ConnectionPublisherSubscriber<'a, Config::EventSubscriber> {
         event::ConnectionPublisherSubscriber::new(
-            event::builder::Meta {
+            event::builder::ConnectionMeta {
                 endpoint_type: Config::ENDPOINT_TYPE,
-                subject: event::builder::Subject::Connection {
-                    id: self.internal_connection_id.into(),
-                },
+                id: self.internal_connection_id.into(),
                 timestamp,
             },
             self.quic_version,

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -221,11 +221,9 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             .create_connection_context();
 
         let mut publisher = event::ConnectionPublisherSubscriber::new(
-            event::builder::Meta {
+            event::builder::ConnectionMeta {
                 endpoint_type: Config::ENDPOINT_TYPE,
-                subject: event::builder::Subject::Connection {
-                    id: internal_connection_id.into(),
-                },
+                id: internal_connection_id.into(),
                 timestamp: datagram.timestamp,
             },
             quic_version,

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -133,9 +133,8 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
 
         if transmit_result.is_ok() {
             let mut publisher = event::EndpointPublisherSubscriber::new(
-                event::builder::Meta {
+                event::builder::EndpointMeta {
                     endpoint_type: Cfg::ENDPOINT_TYPE,
-                    subject: event::builder::Subject::Endpoint,
                     timestamp,
                 },
                 None,
@@ -336,9 +335,8 @@ impl<Cfg: Config> Endpoint<Cfg> {
             if internal_connection_id.is_none() {
                 // The packet didn't contain a valid stateless token
                 let mut publisher = event::EndpointPublisherSubscriber::new(
-                    event::builder::Meta {
+                    event::builder::EndpointMeta {
                         endpoint_type: Cfg::ENDPOINT_TYPE,
-                        subject: event::builder::Subject::Endpoint,
                         timestamp,
                     },
                     None,
@@ -354,9 +352,8 @@ impl<Cfg: Config> Endpoint<Cfg> {
         };
 
         let mut publisher = event::EndpointPublisherSubscriber::new(
-            event::builder::Meta {
+            event::builder::EndpointMeta {
                 endpoint_type: Cfg::ENDPOINT_TYPE,
-                subject: event::builder::Subject::Endpoint,
                 timestamp,
             },
             packet.version(),
@@ -588,9 +585,8 @@ impl<Cfg: Config> Endpoint<Cfg> {
                         //# containing a token.
                         if self.connection_allowed(header, &packet).is_none() {
                             let mut publisher = event::EndpointPublisherSubscriber::new(
-                                event::builder::Meta {
+                                event::builder::EndpointMeta {
                                     endpoint_type: Cfg::ENDPOINT_TYPE,
-                                    subject: event::builder::Subject::Endpoint,
                                     timestamp,
                                 },
                                 None,
@@ -723,16 +719,14 @@ impl<Cfg: Config> Endpoint<Cfg> {
             .remove_internal_connection_id_by_stateless_reset_token(&token)?;
 
         let mut publisher = event::EndpointPublisherSubscriber::new(
-            event::builder::Meta {
+            event::builder::EndpointMeta {
                 endpoint_type: Cfg::ENDPOINT_TYPE,
-                subject: event::builder::Subject::Connection {
-                    id: internal_id.into(),
-                },
                 timestamp,
             },
             None,
             endpoint_context.event_subscriber,
         );
+
         publisher.on_endpoint_packet_received(event::builder::EndpointPacketReceived {
             packet_header: event::builder::PacketHeader {
                 packet_type: event::builder::PacketType::StatelessReset {},

--- a/quic/s2n-quic/src/provider/event/mod.rs
+++ b/quic/s2n-quic/src/provider/event/mod.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use cfg_if::cfg_if;
-pub use s2n_quic_core::event::{api as events, Event, Subscriber, Timestamp};
+pub use s2n_quic_core::event::{api as events, Event, Meta, Subscriber, Timestamp};
 
 /// Provides logging support for an endpoint
 pub trait Provider {

--- a/quic/s2n-quic/src/provider/event/tracing.rs
+++ b/quic/s2n-quic/src/provider/event/tracing.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::provider::event::{events, Event};
+use crate::provider::event::{Event, Meta};
 use tracing::debug;
 
 #[derive(Debug, Default)]
@@ -24,12 +24,12 @@ impl super::Subscriber for Subscriber {
 
     fn create_connection_context(&mut self) -> Self::ConnectionContext {}
 
-    fn on_event<E: Event>(&mut self, meta: &events::Meta, event: &E) {
+    fn on_event<M: Meta, E: Event>(&mut self, meta: &M, event: &E) {
         debug!(
             "{:?} {:?} {:?}",
-            meta.subject,
-            meta.timestamp.duration_since_start(),
-            event
+            meta.subject(),
+            meta.timestamp().duration_since_start(),
+            event,
         );
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* 
There are now two types of Publishers: `Connection` and `Endpoint`. The `ConnectionPublisher` is instantiated within a connection and is guaranteeded to have an `internal_connection_id` (field named id), while the `EndpointPublisher` does not have a connection_id. The enum `Subject`, which is exposed as part of Meta captured these two variants.

However since all events are either connection or endpoint specific, we can be smart and expose `id: u64` rather than the enum for connection events.

- Introduce specific meta types: `ConnectionMeta` vs `EndpointMeta`
- convert Meta to a trait
- expose specific meta types depending on type of event: connection vs endpoint

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
