### PR TITLE
add local address and cid to events

### DIFF
--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -31,6 +31,8 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct Path<'a> {
+        pub local_addr: SocketAddress<'a>,
+        pub local_cid: ConnectionId<'a>,
         pub remote_addr: SocketAddress<'a>,
         pub remote_cid: ConnectionId<'a>,
         pub id: u64,
@@ -716,6 +718,8 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct Path<'a> {
+        pub local_addr: SocketAddress<'a>,
+        pub local_cid: ConnectionId<'a>,
         pub remote_addr: SocketAddress<'a>,
         pub remote_cid: ConnectionId<'a>,
         pub id: u64,
@@ -724,11 +728,15 @@ pub mod builder {
         #[inline]
         fn into_event(self) -> api::Path<'a> {
             let Path {
+                local_addr,
+                local_cid,
                 remote_addr,
                 remote_cid,
                 id,
             } = self;
             api::Path {
+                local_addr: local_addr.into_event(),
+                local_cid: local_cid.into_event(),
                 remote_addr: remote_addr.into_event(),
                 remote_cid: remote_cid.into_event(),
                 id: id.into_event(),

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -26,9 +26,8 @@ struct PacketHeader {
 }
 
 struct Path<'a> {
-    // TODO uncomment once we record the local Address/CID
-    // pub local_addr: SocketAddress<'a>,
-    // pub local_cid: ConnectionId<'a>,
+    local_addr: SocketAddress<'a>,
+    local_cid: ConnectionId<'a>,
     remote_addr: SocketAddress<'a>,
     remote_cid: ConnectionId<'a>,
     id: u64,

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -420,6 +420,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
 
         publisher.on_connection_started(event::builder::ConnectionStarted {
             path: event::builder::Path {
+                local_addr: parameters.path_handle.local_address().into_event(),
+                local_cid: parameters.local_connection_id.into_event(),
                 remote_addr: parameters.path_handle.remote_address().into_event(),
                 remote_cid: parameters.peer_connection_id.into_event(),
                 id: path_manager.active_path_id().into_event(),

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -106,11 +106,15 @@ impl<Config: endpoint::Config> Manager<Config> {
 
         publisher.on_active_path_updated(event::builder::ActivePathUpdated {
             previous: event::builder::Path {
+                local_addr: self[prev_path_id].local_address().into_event(),
+                local_cid: self[prev_path_id].local_connection_id.into_event(),
                 remote_addr: self[prev_path_id].remote_address().into_event(),
                 remote_cid: self[prev_path_id].peer_connection_id.into_event(),
                 id: prev_path_id.into_event(),
             },
             active: event::builder::Path {
+                local_addr: self.active_path().local_address().into_event(),
+                local_cid: self.active_path().local_connection_id.into_event(),
                 remote_addr: self.active_path().remote_address().into_event(),
                 remote_cid: self.active_path().peer_connection_id.into_event(),
                 id: new_path_id.into_event(),
@@ -319,11 +323,15 @@ impl<Config: endpoint::Config> Manager<Config> {
 
         publisher.on_path_created(event::builder::PathCreated {
             active: event::builder::Path {
+                local_addr: self.active_path().local_address().into_event(),
+                local_cid: self.active_path().local_connection_id.into_event(),
                 remote_addr: self.active_path().remote_address().into_event(),
                 remote_cid: self.active_path().peer_connection_id.into_event(),
                 id: self.active_path_id().into_event(),
             },
             new: event::builder::Path {
+                local_addr: path.local_address().into_event(),
+                local_cid: path.local_connection_id.into_event(),
                 remote_addr: path.remote_address().into_event(),
                 remote_cid: path.peer_connection_id.into_event(),
                 id: new_path_idx as u64,

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -766,6 +766,8 @@ impl<Config: endpoint::Config> Manager<Config> {
                     version: Some(publisher.quic_version()),
                 },
                 path: event::builder::Path {
+                    local_addr: path.local_address().into_event(),
+                    local_cid: path.local_connection_id.into_event(),
                     remote_addr: path.remote_address().into_event(),
                     remote_cid: path.peer_connection_id.into_event(),
                     id: current_path_id.into_event(),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
With this change local_address and local_connection_id are recorded as part of the `event::Path`, along with the remote data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
