### PR TITLE
provide Meta info when creating the connection Context

### DIFF
--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -1444,7 +1444,7 @@ mod traits {
     pub trait Subscriber: 'static + Send {
         type ConnectionContext: 'static + Send;
         #[doc = r" Creates a context to be passed to each connection-related event"]
-        fn create_connection_context(&mut self) -> Self::ConnectionContext;
+        fn create_connection_context(&mut self, meta: &ConnectionMeta) -> Self::ConnectionContext;
         #[doc = "Called when the `AlpnInformation` event is triggered"]
         #[inline]
         fn on_alpn_information(
@@ -1737,10 +1737,10 @@ mod traits {
     {
         type ConnectionContext = (A::ConnectionContext, B::ConnectionContext);
         #[inline]
-        fn create_connection_context(&mut self) -> Self::ConnectionContext {
+        fn create_connection_context(&mut self, meta: &ConnectionMeta) -> Self::ConnectionContext {
             (
-                self.0.create_connection_context(),
-                self.1.create_connection_context(),
+                self.0.create_connection_context(meta),
+                self.1.create_connection_context(meta),
             )
         }
         #[inline]
@@ -2341,7 +2341,11 @@ pub mod testing {
     }
     impl super::Subscriber for Subscriber {
         type ConnectionContext = ();
-        fn create_connection_context(&mut self) -> Self::ConnectionContext {}
+        fn create_connection_context(
+            &mut self,
+            _meta: &api::ConnectionMeta,
+        ) -> Self::ConnectionContext {
+        }
         fn on_alpn_information(
             &mut self,
             _context: &mut Self::ConnectionContext,

--- a/quic/s2n-quic-events/src/main.rs
+++ b/quic/s2n-quic-events/src/main.rs
@@ -109,7 +109,7 @@ impl ToTokens for Output {
                     type ConnectionContext: 'static + Send;
 
                     /// Creates a context to be passed to each connection-related event
-                    fn create_connection_context(&mut self) -> Self::ConnectionContext;
+                    fn create_connection_context(&mut self, meta: &ConnectionMeta) -> Self::ConnectionContext;
 
                     #subscriber
 
@@ -139,8 +139,8 @@ impl ToTokens for Output {
                     type ConnectionContext = (A::ConnectionContext, B::ConnectionContext);
 
                     #[inline]
-                    fn create_connection_context(&mut self) -> Self::ConnectionContext {
-                        (self.0.create_connection_context(), self.1.create_connection_context())
+                    fn create_connection_context(&mut self, meta: &ConnectionMeta) -> Self::ConnectionContext {
+                        (self.0.create_connection_context(meta), self.1.create_connection_context(meta))
                     }
 
                     #tuple_subscriber
@@ -266,7 +266,7 @@ impl ToTokens for Output {
                 impl super::Subscriber for Subscriber {
                     type ConnectionContext = ();
 
-                    fn create_connection_context(&mut self) -> Self::ConnectionContext {}
+                    fn create_connection_context(&mut self, _meta: &api::ConnectionMeta) -> Self::ConnectionContext {}
 
                     #subscriber_testing
                 }

--- a/quic/s2n-quic-qns/src/server/interop.rs
+++ b/quic/s2n-quic-qns/src/server/interop.rs
@@ -252,7 +252,11 @@ pub struct EventSubscriber;
 impl Subscriber for EventSubscriber {
     type ConnectionContext = ();
 
-    fn create_connection_context(&mut self) -> Self::ConnectionContext {}
+    fn create_connection_context(
+        &mut self,
+        _meta: &events::ConnectionMeta,
+    ) -> Self::ConnectionContext {
+    }
 
     fn on_active_path_updated(
         &mut self,

--- a/quic/s2n-quic/src/provider/event/disabled.rs
+++ b/quic/s2n-quic/src/provider/event/disabled.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::provider::event::ConnectionMeta;
+
 #[derive(Debug, Default)]
 pub struct Provider;
 
@@ -18,5 +20,5 @@ pub struct Subscriber;
 impl super::Subscriber for Subscriber {
     type ConnectionContext = ();
 
-    fn create_connection_context(&mut self) -> Self::ConnectionContext {}
+    fn create_connection_context(&mut self, _meta: &ConnectionMeta) -> Self::ConnectionContext {}
 }

--- a/quic/s2n-quic/src/provider/event/mod.rs
+++ b/quic/s2n-quic/src/provider/event/mod.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use cfg_if::cfg_if;
-pub use s2n_quic_core::event::{api as events, Event, Meta, Subscriber, Timestamp};
+pub use s2n_quic_core::event::{
+    api as events, api::ConnectionMeta, Event, Meta, Subscriber, Timestamp,
+};
 
 /// Provides logging support for an endpoint
 pub trait Provider {

--- a/quic/s2n-quic/src/provider/event/tracing.rs
+++ b/quic/s2n-quic/src/provider/event/tracing.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::provider::event::{Event, Meta};
+use crate::provider::event::{ConnectionMeta, Event, Meta};
 use tracing::debug;
 
 #[derive(Debug, Default)]
@@ -22,7 +22,7 @@ pub struct Subscriber;
 impl super::Subscriber for Subscriber {
     type ConnectionContext = ();
 
-    fn create_connection_context(&mut self) -> Self::ConnectionContext {}
+    fn create_connection_context(&mut self, _meta: &ConnectionMeta) -> Self::ConnectionContext {}
 
     fn on_event<M: Meta, E: Event>(&mut self, meta: &M, event: &E) {
         debug!(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Information such as connection_id and timestamp can be useful for logging when creating the connection context. events::Meta contains this info.

With this PR we provide access to Meta info when creating the event_connection_context.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
