### PR TITLE
api: implement connection handle function

### DIFF
--- a/quic/s2n-quic-transport/src/connection/api.rs
+++ b/quic/s2n-quic-transport/src/connection/api.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     connection::{self, ConnectionApi},
-    stream::Stream,
+    stream::{ops, Stream, StreamError, StreamId},
 };
 use bytes::Bytes;
 use core::{
@@ -56,6 +56,7 @@ impl Connection {
     ///   For this purpose the method will save the [`Waker`]
     ///   which is provided as part of the [`Context`] parameter, and notify it
     ///   as soon as retrying the method will yield a different result.
+    #[inline]
     pub fn poll_accept(
         &mut self,
         stream_type: Option<StreamType>,
@@ -64,6 +65,7 @@ impl Connection {
         self.api.poll_accept(&self.api, stream_type, context)
     }
 
+    #[inline]
     pub fn poll_open_stream(
         &mut self,
         stream_type: StreamType,
@@ -72,33 +74,50 @@ impl Connection {
         self.api.poll_open_stream(&self.api, stream_type, context)
     }
 
+    #[inline]
+    pub fn poll_request(
+        &self,
+        stream_id: StreamId,
+        request: &mut ops::Request,
+        context: Option<&Context>,
+    ) -> Result<ops::Response, StreamError> {
+        self.api.poll_request(stream_id, request, context)
+    }
+
     /// Closes the Connection with the provided error code
     ///
     /// This will immediatly terminate all outstanding streams.
+    #[inline]
     pub fn close(&self, error_code: application::Error) {
         self.api.close_connection(Some(error_code));
     }
 
+    #[inline]
     pub fn sni(&self) -> Result<Option<Bytes>, connection::Error> {
         self.api.sni()
     }
 
+    #[inline]
     pub fn alpn(&self) -> Result<Bytes, connection::Error> {
         self.api.alpn()
     }
 
+    #[inline]
     pub fn id(&self) -> u64 {
         self.api.id()
     }
 
+    #[inline]
     pub fn ping(&self) -> Result<(), connection::Error> {
         self.api.ping()
     }
 
+    #[inline]
     pub fn local_address(&self) -> Result<SocketAddress, connection::Error> {
         self.api.local_address()
     }
 
+    #[inline]
     pub fn remote_address(&self) -> Result<SocketAddress, connection::Error> {
         self.api.remote_address()
     }

--- a/quic/s2n-quic-transport/src/connection/connection_container.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container.rs
@@ -205,7 +205,9 @@ impl<C: connection::Trait, L: connection::Lock<C>> ConnectionApiProvider for Con
             Poll::Ready(Err(e)) => Err(e).into(),
             Poll::Ready(Ok(None)) => Ok(None).into(),
             Poll::Ready(Ok(Some(stream_id))) => {
-                let stream = stream::Stream::new(arc_self.clone(), stream_id);
+                let connection = arc_self.clone();
+                let connection = Connection::new(connection);
+                let stream = stream::Stream::new(connection, stream_id);
 
                 Ok(Some(stream)).into()
             }
@@ -224,7 +226,9 @@ impl<C: connection::Trait, L: connection::Lock<C>> ConnectionApiProvider for Con
             Poll::Pending => Poll::Pending,
             Poll::Ready(Err(e)) => Err(e).into(),
             Poll::Ready(Ok(stream_id)) => {
-                let stream = stream::Stream::new(arc_self.clone(), stream_id);
+                let connection = arc_self.clone();
+                let connection = Connection::new(connection);
+                let stream = stream::Stream::new(connection, stream_id);
 
                 Ok(stream).into()
             }

--- a/quic/s2n-quic-transport/src/stream/api.rs
+++ b/quic/s2n-quic-transport/src/stream/api.rs
@@ -3,7 +3,7 @@
 
 //! Defines the Stream objects that applications are interacting with
 
-use crate::connection::ConnectionApi;
+use crate::connection::Connection;
 use bytes::Bytes;
 use core::{
     fmt,
@@ -18,14 +18,14 @@ pub use s2n_quic_core::{
 
 #[derive(Clone)]
 struct State {
-    connection: ConnectionApi,
+    connection: Connection,
     stream_id: StreamId,
     is_rx_open: bool,
     is_tx_open: bool,
 }
 
 impl State {
-    fn new(connection: ConnectionApi, stream_id: StreamId) -> Self {
+    fn new(connection: Connection, stream_id: StreamId) -> Self {
         Self {
             connection,
             stream_id,
@@ -321,12 +321,16 @@ impl Stream {
     /// Creates a `Stream` instance, which represents a QUIC stream with the
     /// given ID. All interactions with the `Stream` will be performed through
     /// the provided [`SynchronizedSharedConnectionState`].
-    pub(crate) fn new(shared_state: ConnectionApi, stream_id: StreamId) -> Self {
-        Self(State::new(shared_state, stream_id))
+    pub(crate) fn new(connection: Connection, stream_id: StreamId) -> Self {
+        Self(State::new(connection, stream_id))
     }
 
     pub fn id(&self) -> StreamId {
         self.0.stream_id
+    }
+
+    pub fn connection(&self) -> &Connection {
+        &self.0.connection
     }
 
     pub fn request(&mut self) -> Request {
@@ -390,6 +394,10 @@ impl SendStream {
         self.0.stream_id
     }
 
+    pub fn connection(&self) -> &Connection {
+        &self.0.connection
+    }
+
     pub fn tx_request(&mut self) -> Result<TxRequest, StreamError> {
         Ok(TxRequest {
             state: &mut self.0,
@@ -428,6 +436,10 @@ impl fmt::Debug for ReceiveStream {
 impl ReceiveStream {
     pub fn id(&self) -> StreamId {
         self.0.stream_id
+    }
+
+    pub fn connection(&self) -> &Connection {
+        &self.0.connection
     }
 
     pub fn rx_request(&mut self) -> Result<RxRequest, StreamError> {

--- a/quic/s2n-quic/src/connection/acceptor.rs
+++ b/quic/s2n-quic/src/connection/acceptor.rs
@@ -15,6 +15,7 @@ macro_rules! impl_accept_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub async fn accept(
             &mut self,
         ) -> crate::connection::Result<Option<crate::stream::PeerStream>> {
@@ -28,6 +29,7 @@ macro_rules! impl_accept_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn poll_accept(
             &mut self,
             cx: &mut core::task::Context,
@@ -60,6 +62,7 @@ macro_rules! impl_accept_bidirectional_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub async fn accept_bidirectional_stream(
             &mut self,
         ) -> $crate::connection::Result<Option<$crate::stream::BidirectionalStream>> {
@@ -73,6 +76,7 @@ macro_rules! impl_accept_bidirectional_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn poll_accept_bidirectional_stream(
             &mut self,
             cx: &mut core::task::Context,
@@ -96,6 +100,7 @@ macro_rules! impl_accept_receive_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub async fn accept_receive_stream(
             &mut self,
         ) -> $crate::connection::Result<Option<$crate::stream::ReceiveStream>> {
@@ -109,6 +114,7 @@ macro_rules! impl_accept_receive_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn poll_accept_receive_stream(
             &mut self,
             cx: &mut core::task::Context,
@@ -135,6 +141,7 @@ impl StreamAcceptor {
     /// ```rust
     /// // TODO
     /// ```
+    #[inline]
     pub fn split(self) -> (BidirectionalStreamAcceptor, ReceiveStreamAcceptor) {
         let bidi = BidirectionalStreamAcceptor(self.0.clone());
         let recv = ReceiveStreamAcceptor(self.0);
@@ -145,6 +152,7 @@ impl StreamAcceptor {
 impl futures::stream::Stream for StreamAcceptor {
     type Item = connection::Result<PeerStream>;
 
+    #[inline]
     fn poll_next(
         mut self: core::pin::Pin<&mut Self>,
         cx: &mut core::task::Context<'_>,
@@ -168,6 +176,7 @@ impl BidirectionalStreamAcceptor {
 impl futures::stream::Stream for BidirectionalStreamAcceptor {
     type Item = connection::Result<BidirectionalStream>;
 
+    #[inline]
     fn poll_next(
         mut self: core::pin::Pin<&mut Self>,
         cx: &mut core::task::Context<'_>,
@@ -191,6 +200,7 @@ impl ReceiveStreamAcceptor {
 impl futures::stream::Stream for ReceiveStreamAcceptor {
     type Item = connection::Result<ReceiveStream>;
 
+    #[inline]
     fn poll_next(
         mut self: core::pin::Pin<&mut Self>,
         cx: &mut core::task::Context<'_>,

--- a/quic/s2n-quic/src/connection/handle.rs
+++ b/quic/s2n-quic/src/connection/handle.rs
@@ -10,6 +10,7 @@ macro_rules! impl_handle_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub async fn open_stream(
             &mut self,
             stream_type: $crate::stream::Type,
@@ -24,6 +25,7 @@ macro_rules! impl_handle_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn poll_open_stream(
             &mut self,
             stream_type: $crate::stream::Type,
@@ -50,6 +52,7 @@ macro_rules! impl_handle_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub async fn open_bidirectional_stream(
             &mut self,
         ) -> $crate::connection::Result<$crate::stream::BidirectionalStream> {
@@ -63,6 +66,7 @@ macro_rules! impl_handle_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn poll_open_bidirectional_stream(
             &mut self,
             cx: &mut core::task::Context,
@@ -82,6 +86,7 @@ macro_rules! impl_handle_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub async fn open_send_stream(
             &mut self,
         ) -> $crate::connection::Result<$crate::stream::SendStream> {
@@ -95,6 +100,7 @@ macro_rules! impl_handle_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn poll_open_send_stream(
             &mut self,
             cx: &mut core::task::Context,
@@ -115,6 +121,7 @@ macro_rules! impl_handle_api {
         /// // TODO
         /// ```
         #[cfg(feature = "std")]
+        #[inline]
         pub fn local_addr(&self) -> $crate::connection::Result<std::net::SocketAddr> {
             self.0.local_address().map(std::net::SocketAddr::from)
         }
@@ -127,6 +134,7 @@ macro_rules! impl_handle_api {
         /// // TODO
         /// ```
         #[cfg(feature = "std")]
+        #[inline]
         pub fn remote_addr(&self) -> $crate::connection::Result<std::net::SocketAddr> {
             self.0.remote_address().map(std::net::SocketAddr::from)
         }
@@ -138,6 +146,7 @@ macro_rules! impl_handle_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn sni(&self) -> $crate::connection::Result<Option<::bytes::Bytes>> {
             self.0.sni()
         }
@@ -149,6 +158,7 @@ macro_rules! impl_handle_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn alpn(&self) -> $crate::connection::Result<::bytes::Bytes> {
             self.0.alpn()
         }
@@ -160,6 +170,7 @@ macro_rules! impl_handle_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn id(&self) -> u64 {
             self.0.id()
         }
@@ -171,6 +182,7 @@ macro_rules! impl_handle_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn ping(&mut self) -> $crate::connection::Result<()> {
             self.0.ping()
         }
@@ -182,6 +194,7 @@ macro_rules! impl_handle_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn close(&self, error_code: $crate::application::Error) {
             self.0.close(error_code)
         }

--- a/quic/s2n-quic/src/connection/mod.rs
+++ b/quic/s2n-quic/src/connection/mod.rs
@@ -13,7 +13,7 @@ pub use acceptor::*;
 pub use handle::*;
 pub use s2n_quic_core::connection::Error;
 
-pub type Result<T> = core::result::Result<T, Error>;
+pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 pub struct Connection(Inner);
 
@@ -24,6 +24,7 @@ impl fmt::Debug for Connection {
 }
 
 impl Connection {
+    #[inline]
     pub(crate) const fn new(inner: Inner) -> Self {
         Self(inner)
     }
@@ -38,6 +39,7 @@ impl Connection {
     /// ```rust
     /// // TODO
     /// ```
+    #[inline]
     pub fn split(self) -> (Handle, StreamAcceptor) {
         let handle = Handle(self.0.clone());
         let acceptor = StreamAcceptor(self.0);

--- a/quic/s2n-quic/src/provider/congestion_controller.rs
+++ b/quic/s2n-quic/src/provider/congestion_controller.rs
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-pub use s2n_quic_core::recovery::{
-    congestion_controller::{CongestionController, Endpoint, PathInfo},
-    CubicCongestionController,
+pub use s2n_quic_core::recovery::congestion_controller::{
+    CongestionController, Endpoint, PathInfo,
 };
 
 /// Provides congestion controller support for an endpoint
@@ -14,15 +13,16 @@ pub trait Provider {
     fn start(self) -> Result<Self::Endpoint, Self::Error>;
 }
 
+pub use cubic as default;
 pub use default::Provider as Default;
 
 impl_provider_utils!();
 
-pub mod default {
+pub mod cubic {
     use s2n_quic_core::recovery::cubic::Endpoint;
 
     #[derive(Debug, Default)]
-    pub struct Provider;
+    pub struct Provider(());
 
     impl super::Provider for Provider {
         type Endpoint = Endpoint;

--- a/quic/s2n-quic/src/provider/connection_id.rs
+++ b/quic/s2n-quic/src/provider/connection_id.rs
@@ -13,13 +13,23 @@ pub trait Provider: 'static {
 
 cfg_if::cfg_if! {
     if #[cfg(feature = "rand")] {
-        pub use random::Provider as Default;
+        pub use random as default;
     } else {
         // TODO implement stub that panics
     }
 }
+pub use default::Provider as Default;
 
 impl_provider_utils!();
+
+impl<T: 'static + Format> Provider for T {
+    type Format = T;
+    type Error = core::convert::Infallible;
+
+    fn start(self) -> Result<Self::Format, Self::Error> {
+        Ok(self)
+    }
+}
 
 #[cfg(feature = "rand")]
 pub mod random {
@@ -42,15 +52,6 @@ pub mod random {
 
         fn start(self) -> Result<Self::Format, Self::Error> {
             Ok(self.0)
-        }
-    }
-
-    impl super::TryInto for Format {
-        type Provider = Provider;
-        type Error = Infallible;
-
-        fn try_into(self) -> Result<Self::Provider, Self::Error> {
-            Ok(Provider(self))
         }
     }
 

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -48,16 +48,16 @@ impl<Providers: ServerProviders> Builder<Providers> {
         ///
         /// # Examples
         ///
-        /// Sets the congestion controller to `Reno` with the default configuration.
+        /// Sets the congestion controller to `Cubic` with the default configuration.
         ///
-        /// ```rust,ignore
+        /// ```rust,no_run
         /// # use std::error::Error;
         /// use s2n_quic::{Server, provider::congestion_controller};
         ///
         /// # #[tokio::main]
         /// # async fn main() -> Result<(), Box<dyn Error>> {
         /// let server = Server::builder()
-        ///     .with_congestion_controller(congestion_controller::Reno::default())?
+        ///     .with_congestion_controller(congestion_controller::cubic::Provider::default())?
         ///     .start()?;
         /// #
         /// #    Ok(())
@@ -72,16 +72,50 @@ impl<Providers: ServerProviders> Builder<Providers> {
         ///
         /// # Examples
         ///
-        /// Sets a custom connection ID provider for the server
+        /// Uses the default connection ID provider with the default configuration.
         ///
-        /// ```rust,ignore
+        /// ```rust,no_run
         /// # use std::{error::Error, time::Duration};
-        /// use s2n_quic::Server;
+        /// use s2n_quic::{Server, provider::connection_id};
         /// #
         /// # #[tokio::main]
         /// # async fn main() -> Result<(), Box<dyn Error>> {
         /// let server = Server::builder()
-        ///     .with_connection_id(MyConnectionIDFormat::new())?
+        ///     .with_connection_id(connection_id::Default::default())?
+        ///     .start()?;
+        /// #
+        /// #    Ok(())
+        /// # }
+        /// ```
+        ///
+        /// Sets a custom connection ID provider for the server
+        ///
+        /// ```rust,no_run
+        /// # use std::{error::Error, time::Duration};
+        /// use s2n_quic::{Server, provider::connection_id};
+        /// use rand::prelude::*;
+        /// #
+        /// # #[tokio::main]
+        /// # async fn main() -> Result<(), Box<dyn Error>> {
+        /// struct MyConnectionIdFormat;
+        ///
+        /// impl connection_id::Generator for MyConnectionIdFormat {
+        ///     fn generate(&mut self, _conn_info: &connection_id::ConnectionInfo) -> connection_id::LocalId {
+        ///         let mut id = [0u8; 16];
+        ///         rand::thread_rng().fill_bytes(&mut id);
+        ///         connection_id::LocalId::try_from_bytes(&id[..]).unwrap()
+        ///     }
+        /// }
+        ///
+        /// impl connection_id::Validator for MyConnectionIdFormat {
+        ///     fn validate(&self, _conn_info: &connection_id::ConnectionInfo, packet: &[u8]) -> Option<usize> {
+        ///         // this connection id format is always 16 bytes
+        ///         Some(16)
+        ///     }
+        /// }
+        ///
+        /// let server = Server::builder()
+        ///     .with_connection_id(MyConnectionIdFormat)?
         ///     .start()?;
         /// #
         /// #    Ok(())

--- a/quic/s2n-quic/src/stream/connection.rs
+++ b/quic/s2n-quic/src/stream/connection.rs
@@ -3,13 +3,18 @@
 
 macro_rules! impl_connection_api {
     (| $self:ident | $convert:expr) => {
-        /// Returns the [`Handle`] associated with the [`Stream`]
+        /// Returns the [`connection::Handle`](crate::connection::Handle) associated with the stream.
         ///
         /// # Examples
         ///
-        /// ```rust
-        /// // TODO
+        /// ```rust,no_run
+        /// # let stream: s2n_quic::stream::Stream = todo!();
+        /// #
+        /// let connection = stream.connection();
+        ///
+        /// println!("The stream's connection id is: {}", connection.id());
         /// ```
+        #[inline]
         pub fn connection(&self) -> $crate::connection::Handle {
             let $self = self;
             $convert

--- a/quic/s2n-quic/src/stream/local.rs
+++ b/quic/s2n-quic/src/stream/local.rs
@@ -24,6 +24,7 @@ impl LocalStream {
         LocalStream::Send(stream) => dispatch!(stream),
     });
 
+    #[inline]
     pub fn id(&self) -> u64 {
         match self {
             Self::Bidirectional(stream) => stream.id(),
@@ -53,12 +54,14 @@ impl_splittable_stream_trait!(LocalStream, |stream| match stream {
 });
 
 impl From<SendStream> for LocalStream {
+    #[inline]
     fn from(stream: SendStream) -> Self {
         Self::Send(stream)
     }
 }
 
 impl From<BidirectionalStream> for LocalStream {
+    #[inline]
     fn from(stream: BidirectionalStream) -> Self {
         Self::Bidirectional(stream)
     }

--- a/quic/s2n-quic/src/stream/mod.rs
+++ b/quic/s2n-quic/src/stream/mod.rs
@@ -24,7 +24,7 @@ pub use receive::*;
 pub use send::*;
 pub use splittable::*;
 
-pub type Result<T> = core::result::Result<T, Error>;
+pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 /// An enum of all the possible types of QUIC streams.
 ///
@@ -50,6 +50,7 @@ impl Stream {
         Stream::Send(stream) => dispatch!(stream),
     });
 
+    #[inline]
     pub fn id(&self) -> u64 {
         match self {
             Self::Bidirectional(stream) => stream.id(),

--- a/quic/s2n-quic/src/stream/peer.rs
+++ b/quic/s2n-quic/src/stream/peer.rs
@@ -46,12 +46,14 @@ impl_splittable_stream_trait!(PeerStream, |stream| match stream {
 });
 
 impl From<ReceiveStream> for PeerStream {
+    #[inline]
     fn from(stream: ReceiveStream) -> Self {
         Self::Receive(stream)
     }
 }
 
 impl From<BidirectionalStream> for PeerStream {
+    #[inline]
     fn from(stream: BidirectionalStream) -> Self {
         Self::Bidirectional(stream)
     }

--- a/quic/s2n-quic/src/stream/receive.rs
+++ b/quic/s2n-quic/src/stream/receive.rs
@@ -19,6 +19,7 @@ macro_rules! impl_receive_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub async fn receive(&mut self) -> $crate::stream::Result<Option<bytes::Bytes>> {
             ::futures::future::poll_fn(|cx| self.poll_receive(cx)).await
         }
@@ -30,6 +31,7 @@ macro_rules! impl_receive_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn poll_receive(
             &mut self,
             cx: &mut core::task::Context,
@@ -54,6 +56,7 @@ macro_rules! impl_receive_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub async fn receive_vectored(
             &mut self,
             chunks: &mut [bytes::Bytes],
@@ -68,6 +71,7 @@ macro_rules! impl_receive_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn poll_receive_vectored(
             &mut self,
             chunks: &mut [bytes::Bytes],
@@ -102,6 +106,7 @@ macro_rules! impl_receive_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn stop_sending(
             &mut self,
             error_code: $crate::application::Error,
@@ -120,6 +125,7 @@ macro_rules! impl_receive_stream_api {
         }
 
         /// Create a batch request for receiving data
+        #[inline]
         pub(crate) fn rx_request(
             &mut self,
         ) -> $crate::stream::Result<s2n_quic_transport::stream::RxRequest> {
@@ -143,6 +149,7 @@ macro_rules! impl_receive_stream_trait {
         impl futures::stream::Stream for $name {
             type Item = $crate::stream::Result<bytes::Bytes>;
 
+            #[inline]
             fn poll_next(
                 mut self: core::pin::Pin<&mut Self>,
                 cx: &mut core::task::Context<'_>,
@@ -293,17 +300,19 @@ macro_rules! impl_receive_stream_trait {
 }
 
 impl ReceiveStream {
+    #[inline]
     pub(crate) const fn new(stream: stream::ReceiveStream) -> Self {
         Self(stream)
     }
 
     impl_receive_stream_api!(|stream, dispatch| dispatch!(stream.0));
 
+    #[inline]
     pub fn id(&self) -> u64 {
         self.0.id().into()
     }
 
-    impl_connection_api!(|_stream| todo!());
+    impl_connection_api!(|stream| crate::connection::Handle(stream.0.connection().clone()));
 }
 
 impl_splittable_stream_trait!(ReceiveStream, |stream| (Some(stream), None));

--- a/quic/s2n-quic/src/stream/send.rs
+++ b/quic/s2n-quic/src/stream/send.rs
@@ -19,6 +19,7 @@ macro_rules! impl_send_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub async fn send(&mut self, mut data: bytes::Bytes) -> $crate::stream::Result<()> {
             ::futures::future::poll_fn(|cx| self.poll_send(&mut data, cx)).await
         }
@@ -30,6 +31,7 @@ macro_rules! impl_send_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn poll_send(
             &mut self,
             chunk: &mut bytes::Bytes,
@@ -55,6 +57,7 @@ macro_rules! impl_send_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub async fn send_vectored(
             &mut self,
             chunks: &mut [bytes::Bytes],
@@ -79,6 +82,7 @@ macro_rules! impl_send_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn poll_send_vectored(
             &mut self,
             chunks: &mut [bytes::Bytes],
@@ -106,6 +110,7 @@ macro_rules! impl_send_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn poll_send_ready(
             &mut self,
             cx: &mut core::task::Context,
@@ -132,6 +137,7 @@ macro_rules! impl_send_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn send_data(&mut self, data: bytes::Bytes) -> $crate::stream::Result<()> {
             macro_rules! $dispatch {
                 () => {
@@ -153,6 +159,7 @@ macro_rules! impl_send_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub async fn flush(&mut self) -> $crate::stream::Result<()> {
             ::futures::future::poll_fn(|cx| self.poll_flush(cx)).await
         }
@@ -164,6 +171,7 @@ macro_rules! impl_send_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn poll_flush(
             &mut self,
             cx: &mut core::task::Context,
@@ -191,6 +199,7 @@ macro_rules! impl_send_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn finish(&mut self) -> $crate::stream::Result<()> {
             macro_rules! $dispatch {
                 () => {
@@ -212,6 +221,7 @@ macro_rules! impl_send_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub async fn close(&mut self) -> $crate::stream::Result<()> {
             ::futures::future::poll_fn(|cx| self.poll_close(cx)).await
         }
@@ -223,6 +233,7 @@ macro_rules! impl_send_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn poll_close(
             &mut self,
             cx: &mut core::task::Context,
@@ -250,6 +261,7 @@ macro_rules! impl_send_stream_api {
         /// ```rust
         /// // TODO
         /// ```
+        #[inline]
         pub fn reset(
             &mut self,
             error_code: $crate::application::Error,
@@ -274,6 +286,7 @@ macro_rules! impl_send_stream_trait {
         impl futures::sink::Sink<bytes::Bytes> for $name {
             type Error = $crate::stream::Error;
 
+            #[inline]
             fn poll_ready(
                 mut self: core::pin::Pin<&mut Self>,
                 cx: &mut core::task::Context<'_>,
@@ -282,6 +295,7 @@ macro_rules! impl_send_stream_trait {
                 Ok(()).into()
             }
 
+            #[inline]
             fn start_send(
                 mut self: core::pin::Pin<&mut Self>,
                 data: bytes::Bytes,
@@ -289,6 +303,7 @@ macro_rules! impl_send_stream_trait {
                 self.send_data(data)
             }
 
+            #[inline]
             fn poll_flush(
                 mut self: core::pin::Pin<&mut Self>,
                 cx: &mut core::task::Context<'_>,
@@ -296,6 +311,7 @@ macro_rules! impl_send_stream_trait {
                 Self::poll_flush(&mut self, cx)
             }
 
+            #[inline]
             fn poll_close(
                 mut self: core::pin::Pin<&mut Self>,
                 cx: &mut core::task::Context<'_>,
@@ -351,6 +367,7 @@ macro_rules! impl_send_stream_trait {
                 Ok(len).into()
             }
 
+            #[inline]
             fn poll_flush(
                 mut self: core::pin::Pin<&mut Self>,
                 cx: &mut core::task::Context<'_>,
@@ -359,6 +376,7 @@ macro_rules! impl_send_stream_trait {
                 Ok(()).into()
             }
 
+            #[inline]
             fn poll_close(
                 mut self: core::pin::Pin<&mut Self>,
                 cx: &mut core::task::Context<'_>,
@@ -370,6 +388,7 @@ macro_rules! impl_send_stream_trait {
 
         #[cfg(all(feature = "std", feature = "tokio"))]
         impl tokio::io::AsyncWrite for $name {
+            #[inline]
             fn poll_write(
                 self: core::pin::Pin<&mut Self>,
                 cx: &mut core::task::Context<'_>,
@@ -408,10 +427,12 @@ macro_rules! impl_send_stream_trait {
                 Ok(len).into()
             }
 
+            #[inline]
             fn is_write_vectored(&self) -> bool {
                 true
             }
 
+            #[inline]
             fn poll_flush(
                 self: core::pin::Pin<&mut Self>,
                 cx: &mut core::task::Context<'_>,
@@ -419,6 +440,7 @@ macro_rules! impl_send_stream_trait {
                 futures::io::AsyncWrite::poll_flush(self, cx)
             }
 
+            #[inline]
             fn poll_shutdown(
                 mut self: core::pin::Pin<&mut Self>,
                 cx: &mut core::task::Context<'_>,
@@ -431,17 +453,19 @@ macro_rules! impl_send_stream_trait {
 }
 
 impl SendStream {
+    #[inline]
     pub(crate) const fn new(stream: stream::SendStream) -> Self {
         Self(stream)
     }
 
     impl_send_stream_api!(|stream, dispatch| dispatch!(stream.0));
 
+    #[inline]
     pub fn id(&self) -> u64 {
         self.0.id().into()
     }
 
-    impl_connection_api!(|_stream| todo!());
+    impl_connection_api!(|stream| crate::connection::Handle(stream.0.connection().clone()));
 }
 
 impl_splittable_stream_trait!(SendStream, |stream| (None, Some(stream)));


### PR DESCRIPTION
I noticed the stream `connection() -> Handle` function wasn't entirely implemented so I've done that here. I've also added `#[inline]` on a bunch of the small functions in the public API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
