### PR TITLE
docs: fix links

### DIFF
--- a/quic/s2n-quic-core/src/crypto/initial.rs
+++ b/quic/s2n-quic-core/src/crypto/initial.rs
@@ -88,7 +88,7 @@ pub const EXAMPLE_SERVER_INITIAL_SECRET: [u8; 32] = hex!(
 //# a500320408ffffffffffffffff050480 00ffff07048000ffff08011001048000
 //# 75300901100f088394c8f03e51570806 048000ffff
 
-/// Example payload from https://tools.ietf.org/id/draft-ietf-quic-tls-32.txt#A.2
+/// Example payload from <https://tools.ietf.org/id/draft-ietf-quic-tls-32.txt#A.2>
 pub const EXAMPLE_CLIENT_INITIAL_PAYLOAD: [u8; 245] = hex!(
     "
    060040f1010000ed0303ebf8fa56f129 39b9584a3896472ec40bb863cfd3e868
@@ -181,7 +181,7 @@ fn client_initial_protection_test() {
 //# b5a464ca5b62df3be35ee0d0a2ec68f3
 
 /// Example protected packet from
-/// https://tools.ietf.org/id/draft-ietf-quic-tls-32.txt#A.2
+/// <https://tools.ietf.org/id/draft-ietf-quic-tls-32.txt#A.2>
 pub const EXAMPLE_CLIENT_INITIAL_PROTECTED_PACKET: [u8; 1200] = hex!(
     "
    cdff000020088394c8f03e5157080000 449e9cdb990bfb66bc6a93032b50dd89
@@ -234,7 +234,7 @@ pub const EXAMPLE_CLIENT_INITIAL_PROTECTED_PACKET: [u8; 1200] = hex!(
 //# 0d89690b84d08a60993c144eca684d10 81287c834d5311bcf32bb9da1a002b00
 //# 020304
 
-/// Example payload from https://tools.ietf.org/id/draft-ietf-quic-tls-32.txt#A.3
+/// Example payload from <https://tools.ietf.org/id/draft-ietf-quic-tls-32.txt#A.3>
 pub const EXAMPLE_SERVER_INITIAL_PAYLOAD: [u8; 99] = hex!(
     "
    02000000000600405a020000560303ee fce7f7b37ba1d1632e96677825ddf739
@@ -284,7 +284,7 @@ fn server_initial_protection_test() {
 //# fd8142fafc0f76
 
 /// Example protected packet from
-/// https://tools.ietf.org/id/draft-ietf-quic-tls-32.txt#A.3
+/// <https://tools.ietf.org/id/draft-ietf-quic-tls-32.txt#A.3>
 pub const EXAMPLE_SERVER_INITIAL_PROTECTED_PACKET: [u8; 135] = hex!(
     "
    c7ff0000200008f067a5502a4262b500 4075fb12ff07823a5d24534d906ce4c7

--- a/quic/s2n-quic-core/src/inet/unspecified.rs
+++ b/quic/s2n-quic-core/src/inet/unspecified.rs
@@ -4,7 +4,7 @@
 /// A trait to determine if the value is left unspecified,
 /// usually containing the default value.
 ///
-/// See: https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address
+/// See: <https://en.wikipedia.org/wiki/IPv6_address#Unspecified_address>
 pub trait Unspecified: Sized {
     /// Returns true if the value is unspecified
     fn is_unspecified(&self) -> bool;

--- a/quic/s2n-quic-core/src/io/tx.rs
+++ b/quic/s2n-quic-core/src/io/tx.rs
@@ -77,7 +77,7 @@ pub trait Entry {
 /// Instead of a concrete struct with eagerly evaluted fields,
 /// using trait callbacks ensure messages only need to compute what
 /// the actual transmission queue requires. For example, if the transmission
-/// queue cannot set ECN markings, it will not call the [`ecn`] function.
+/// queue cannot set ECN markings, it will not call the [`Message::ecn`] function.
 pub trait Message {
     type Handle: path::Handle;
 

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -57,7 +57,7 @@ enum FastRetransmission {
 }
 
 /// A congestion controller that implements "CUBIC for Fast Long-Distance Networks"
-/// as specified in https://tools.ietf.org/html/rfc8312. The Hybrid Slow Start algorithm
+/// as specified in <https://tools.ietf.org/html/rfc8312>. The Hybrid Slow Start algorithm
 /// is used for determining the slow start threshold.
 #[derive(Clone, Debug)]
 pub struct CubicCongestionController {

--- a/quic/s2n-quic-core/src/stream/id.rs
+++ b/quic/s2n-quic-core/src/stream/id.rs
@@ -81,7 +81,7 @@ impl StreamId {
     /// Returns the n-th `StreamId` for a certain type of `Stream`.
     ///
     /// The 0th `StreamId` thereby represents the `StreamId` which is returned
-    /// by the [`initial`] method. All further `StreamId`s of a certain type
+    /// by the [`Self::initial`] method. All further `StreamId`s of a certain type
     /// will be spaced apart by 4.
     ///
     /// nth() will return `None` if the resulting `StreamId` would not be valid.

--- a/quic/s2n-quic-platform/src/message/queue.rs
+++ b/quic/s2n-quic-platform/src/message/queue.rs
@@ -22,9 +22,9 @@ use core::fmt;
 /// it will be moved to the other.
 ///
 /// The payloads of the messages are backed by a parameterized
-/// [`Ring`] to reduce allocations.
+/// [`message::Ring`] to reduce allocations.
 ///
-/// The queue uses a `Vec` of [`Message`]s double the length of the payload buffer.
+/// The queue uses a [`Vec`] of [`message::Message`]s double the length of the payload buffer.
 /// The messages in the second half point to the same payloads as the first half, which
 /// enables contiguous slices with arbitrary indexes. For example:
 ///

--- a/quic/s2n-quic-platform/src/time/mod.rs
+++ b/quic/s2n-quic-platform/src/time/mod.rs
@@ -220,7 +220,7 @@ mod if_testing {
             }
 
             /// Sets the current time to the given [`Timestamp`].
-            /// Follow-up calls to [`get_time`] will return this [`Timestamp`]
+            /// Follow-up calls to [`Self::get_time`] will return this [`Timestamp`]
             /// until the time had been adjusted again.
             pub fn set_time(&self, timestamp: Timestamp) {
                 let mut guard = self.timestamp.lock().unwrap();

--- a/quic/s2n-quic-ring/src/negotiated.rs
+++ b/quic/s2n-quic-ring/src/negotiated.rs
@@ -40,7 +40,7 @@ impl KeyPair {
     }
 
     /// Update the ciphersuite as defined in
-    /// https://tools.ietf.org/id/draft-ietf-quic-tls-32.txt#6
+    /// <https://tools.ietf.org/id/draft-ietf-quic-tls-32.txt#6>
     #[inline]
     pub fn update(&self) -> Self {
         Self {
@@ -124,7 +124,7 @@ macro_rules! negotiated_crypto {
             }
 
             /// Update the ciphersuite as defined in
-            /// https://tools.ietf.org/id/draft-ietf-quic-tls-32.txt#6
+            /// <https://tools.ietf.org/id/draft-ietf-quic-tls-32.txt#6>
             #[inline]
             pub fn update(&self) -> Self {
                 Self(self.0.update())

--- a/quic/s2n-quic-transport/src/acceptor.rs
+++ b/quic/s2n-quic-transport/src/acceptor.rs
@@ -26,7 +26,7 @@ impl Acceptor {
     ///   In this case the caller must retry polling as soon as a client
     ///   establishes a connection.
     ///   In order to notify the application of this condition,
-    ///   the method will save the [`Waker`] which is provided as part of the
+    ///   the method will save the [`core::task::Waker`] which is provided as part of the
     ///   [`Context`] parameter, and notify it as soon as retrying
     ///   the method will yield a different result.
     pub fn poll_accept(&mut self, context: &Context) -> Poll<Option<Connection>> {

--- a/quic/s2n-quic-transport/src/connection/api.rs
+++ b/quic/s2n-quic-transport/src/connection/api.rs
@@ -52,8 +52,8 @@ impl Connection {
     /// - `Poll::Ready(Ok(None))` if the connection was closed without an error
     /// - `Poll::Ready(Err(stream_error))` if no could be accepted due to an error
     /// - `Poll::Pending` if no new [`Stream`] of the given type was accepted by the connection yet.
-    ///   In this case the caller must retry calling [`poll_accept`].
-    ///   For this purpose the method will save the [`Waker`]
+    ///   In this case the caller must retry calling [`Self::poll_accept`].
+    ///   For this purpose the method will save the [`core::task::Waker`]
     ///   which is provided as part of the [`Context`] parameter, and notify it
     ///   as soon as retrying the method will yield a different result.
     #[inline]

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -59,7 +59,7 @@ pub struct Endpoint<Cfg: Config> {
     /// Allows to wakeup the endpoint task which might be blocked on waiting for packets
     /// from application tasks (which e.g. enqueued new data to send).
     wakeup_queue: WakeupQueue<InternalConnectionId>,
-    /// This queue contains wakeups we retrieved from the [`wakeup_queue`] earlier.
+    /// This queue contains wakeups we retrieved from the [`Self::wakeup_queue`] earlier.
     /// This is not a local variable in order to reuse the allocated queue capacity in between
     /// [`Endpoint`] interactions.
     dequeued_wakeups: VecDeque<InternalConnectionId>,

--- a/quic/s2n-quic-transport/src/stream/stream_events.rs
+++ b/quic/s2n-quic-transport/src/stream/stream_events.rs
@@ -49,7 +49,7 @@ impl StreamEvents {
     }
 
     /// Wakes all [`Waker`] instances that have been stored via `add_waker`.
-    /// Waking the [`Waker`]s will remove them from the [`DataEvent`]s struct.
+    /// Waking the [`Waker`]s will remove them from the [`StreamEvents`]s struct.
     pub fn wake_all(&mut self) {
         if let Some(waker) = self.read_wake.take() {
             waker.wake();

--- a/quic/s2n-quic-transport/src/stream/stream_manager.rs
+++ b/quic/s2n-quic-transport/src/stream/stream_manager.rs
@@ -628,7 +628,7 @@ impl<S: StreamTrait> AbstractStreamManager<S> {
     }
 
     /// Closes the [`AbstractStreamManager`] and resets all streams with the
-    /// given error. The current implementation of [`StreamManager`] will still
+    /// given error. The current implementation will still
     /// allow to forward frames to the contained Streams as well as to query them
     /// for data. However new Streams can not be created.
     pub fn close(&mut self, error: connection::Error) {

--- a/quic/s2n-quic/src/connection/handle.rs
+++ b/quic/s2n-quic/src/connection/handle.rs
@@ -163,7 +163,7 @@ macro_rules! impl_handle_api {
             self.0.alpn()
         }
 
-        /// Returns the identifier for the [`Connection`]
+        /// Returns the identifier for the [`crate::Connection`]
         ///
         /// # Examples
         ///

--- a/quic/s2n-quic/src/stream/receive.rs
+++ b/quic/s2n-quic/src/stream/receive.rs
@@ -12,7 +12,7 @@ pub struct ReceiveStream(stream::ReceiveStream);
 
 macro_rules! impl_receive_stream_api {
     (| $stream:ident, $dispatch:ident | $dispatch_body:expr) => {
-        /// Reads the next chunk of data from the [`Stream`]
+        /// Reads the next chunk of data from the stream.
         ///
         /// # Examples
         ///
@@ -49,7 +49,7 @@ macro_rules! impl_receive_stream_api {
             $dispatch_body
         }
 
-        /// Reads the next slice of chunked data from the [`Stream`]
+        /// Reads the next slice of chunked data from the stream.
         ///
         /// # Examples
         ///

--- a/quic/s2n-quic/src/stream/splittable.rs
+++ b/quic/s2n-quic/src/stream/splittable.rs
@@ -20,7 +20,7 @@ pub trait SplittableStream {
 
 macro_rules! impl_splittable_stream_api {
     () => {
-        /// Splits the stream into [`ReceiveStream`] and [`SendStream`] halves
+        /// Splits the stream into [`crate::stream::ReceiveStream`] and [`crate::stream::SendStream`] halves
         ///
         /// # Examples
         ///


### PR DESCRIPTION
We have quite a few warnings from `cargo doc` and this fixes most of them. The ones left are due to empty examples in the public API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
