### PR TITLE
new type around sni to expose it as str or Bytes

### DIFF
--- a/quic/s2n-quic-core/src/application/mod.rs
+++ b/quic/s2n-quic-core/src/application/mod.rs
@@ -2,5 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod error;
+mod sni;
 
 pub use error::Error;
+pub use sni::Sni;

--- a/quic/s2n-quic-core/src/application/sni.rs
+++ b/quic/s2n-quic-core/src/application/sni.rs
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use bytes::Bytes;
+
+#[derive(Clone)]
+/// Sni holds a negotiated
+/// [Server Name Indication](https://en.wikipedia.org/wiki/Server_Name_Indication)
+/// value, encoded as UTF-8.
+///
+/// SNI should be a valid UTF-8 string, therfore this struct can only be
+/// constructed from a `&str` or `String`.
+///
+/// ```rust
+/// # use s2n_quic_core::application::Sni;
+/// let string: String = String::from("a valid utf-8 string");
+/// let sni: Sni = string.into();
+///
+/// let str_arr: &str = &"a valid utf-8 str array";
+/// let sni: Sni = str_arr.into();
+/// ```
+///
+/// `Sni` serves a dual purpose:
+/// - It can be converted into [`Bytes`] which supports zero-copy slicing and
+/// reference counting.
+/// - It can be accessed as `&str` so that applications can reason about the string value.
+pub struct Sni(Bytes);
+
+impl Sni {
+    #[inline]
+    pub fn into_bytes(self) -> Bytes {
+        self.0
+    }
+
+    #[inline]
+    fn as_str(&self) -> &str {
+        // Safety: the byte array is validated as a valid UTF-8 string
+        // before creating an instance of Sni.
+        unsafe { core::str::from_utf8_unchecked(&self.0) }
+    }
+}
+
+impl From<&str> for Sni {
+    #[inline]
+    fn from(data: &str) -> Self {
+        Sni(Bytes::copy_from_slice(data.as_bytes()))
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl From<alloc::string::String> for Sni {
+    #[inline]
+    fn from(data: alloc::string::String) -> Self {
+        Sni(data.into_bytes().into())
+    }
+}
+
+impl core::fmt::Debug for Sni {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        self.as_str().fmt(f)
+    }
+}
+
+impl core::ops::Deref for Sni {
+    type Target = str;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        self.as_str()
+    }
+}

--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -15,7 +15,7 @@ pub struct ApplicationParameters<'a> {
     /// The negotiated Application Layer Protocol
     pub alpn_protocol: &'a [u8],
     /// Server Name Indication
-    pub sni: Option<&'a [u8]>,
+    pub sni: Option<crate::application::Sni>,
     /// Encoded transport parameters
     pub transport_parameters: &'a [u8],
 }

--- a/quic/s2n-quic-core/src/crypto/tls/testing.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/testing.rs
@@ -247,7 +247,7 @@ impl<C: CryptoSuite> Context<C> {
 
     fn on_application_params(&mut self, params: tls::ApplicationParameters) {
         self.alpn = Some(Bytes::copy_from_slice(params.alpn_protocol));
-        self.sni = params.sni.map(Bytes::copy_from_slice);
+        self.sni = params.sni.map(|sni| sni.into_bytes());
         self.transport_parameters = Some(Bytes::copy_from_slice(params.transport_parameters));
     }
 }

--- a/quic/s2n-quic-core/src/event.rs
+++ b/quic/s2n-quic-core/src/event.rs
@@ -52,6 +52,13 @@ impl<T: IntoEvent<U>, U> IntoEvent<Option<U>> for Option<T> {
     }
 }
 
+impl<'a> IntoEvent<&'a str> for &'a str {
+    #[inline]
+    fn into_event(self) -> Self {
+        self
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Timestamp(crate::time::Timestamp);
 

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -194,7 +194,7 @@ pub mod api {
     #[non_exhaustive]
     #[doc = " Server Name Indication"]
     pub struct SniInformation<'a> {
-        pub chosen_sni: &'a [u8],
+        pub chosen_sni: &'a str,
     }
     impl<'a> Event for SniInformation<'a> {
         const NAME: &'static str = "transport:sni_information";
@@ -1028,7 +1028,7 @@ pub mod builder {
     #[derive(Clone, Debug)]
     #[doc = " Server Name Indication"]
     pub struct SniInformation<'a> {
-        pub chosen_sni: &'a [u8],
+        pub chosen_sni: &'a str,
     }
     impl<'a> IntoEvent<api::SniInformation<'a>> for SniInformation<'a> {
         #[inline]

--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -13,7 +13,7 @@ struct AlpnInformation<'a> {
 #[event("transport:sni_information")]
 /// Server Name Indication
 struct SniInformation<'a> {
-    chosen_sni: &'a [u8],
+    chosen_sni: &'a str,
 }
 
 #[event("transport:packet_sent")]

--- a/quic/s2n-quic-rustls/src/lib.rs
+++ b/quic/s2n-quic-rustls/src/lib.rs
@@ -12,6 +12,7 @@ use rustls::{
 use s2n_codec::{EncoderBuffer, EncoderValue};
 use s2n_quic_core::{
     self,
+    application::Sni,
     crypto::{tls, CryptoError, CryptoSuite},
     transport,
 };
@@ -473,8 +474,8 @@ pub mod server {
     }
 
     impl Session {
-        fn sni(&self) -> Option<&[u8]> {
-            self.0.session.get_sni_hostname().map(|sni| sni.as_bytes())
+        fn sni(&self) -> Option<Sni> {
+            self.0.session.get_sni_hostname().map(|sni| sni.into())
         }
     }
 }
@@ -587,7 +588,7 @@ pub mod client {
     }
 
     impl Session {
-        fn sni(&self) -> Option<&[u8]> {
+        fn sni(&self) -> Option<Sni> {
             // TODO return the specified sni value
             None
         }

--- a/quic/s2n-quic-transport/src/connection/api.rs
+++ b/quic/s2n-quic-transport/src/connection/api.rs
@@ -14,6 +14,7 @@ use core::{
 };
 use s2n_quic_core::{
     application,
+    application::Sni,
     event::query::{Query, QueryMut},
     inet::SocketAddress,
     stream::StreamType,
@@ -98,7 +99,7 @@ impl Connection {
     }
 
     #[inline]
-    pub fn sni(&self) -> Result<Option<Bytes>, connection::Error> {
+    pub fn sni(&self) -> Result<Option<Sni>, connection::Error> {
         self.api.sni()
     }
 

--- a/quic/s2n-quic-transport/src/connection/api_provider.rs
+++ b/quic/s2n-quic-transport/src/connection/api_provider.rs
@@ -13,6 +13,7 @@ use bytes::Bytes;
 use core::task::{Context, Poll};
 use s2n_quic_core::{
     application,
+    application::Sni,
     event::query::{Query, QueryMut},
     inet::SocketAddress,
     stream::{ops, StreamId, StreamType},
@@ -47,7 +48,7 @@ pub(crate) trait ConnectionApiProvider: Sync + Send {
 
     fn close_connection(&self, code: Option<application::Error>);
 
-    fn sni(&self) -> Result<Option<Bytes>, connection::Error>;
+    fn sni(&self) -> Result<Option<Sni>, connection::Error>;
 
     fn alpn(&self) -> Result<Bytes, connection::Error>;
 

--- a/quic/s2n-quic-transport/src/connection/connection_container.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container.rs
@@ -22,6 +22,7 @@ use intrusive_collections::{
 };
 use s2n_quic_core::{
     application,
+    application::Sni,
     event::query::{Query, QueryMut},
     inet::SocketAddress,
     recovery::K_GRANULARITY,
@@ -248,7 +249,7 @@ impl<C: connection::Trait, L: connection::Lock<C>> ConnectionApiProvider for Con
         });
     }
 
-    fn sni(&self) -> Result<Option<Bytes>, connection::Error> {
+    fn sni(&self) -> Result<Option<Sni>, connection::Error> {
         self.api_read_call(|conn| Ok(conn.sni()))
     }
 

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -248,7 +248,7 @@ impl connection::Trait for TestConnection {
         // no-op
     }
 
-    fn sni(&self) -> Option<Bytes> {
+    fn sni(&self) -> Option<Sni> {
         todo!()
     }
 

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -30,6 +30,7 @@ use core::{
 };
 use s2n_quic_core::{
     application,
+    application::Sni,
     event::{self, ConnectionPublisher as _, IntoEvent as _},
     inet::{DatagramInfo, SocketAddress},
     io::tx,
@@ -1325,7 +1326,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         });
     }
 
-    fn sni(&self) -> Option<Bytes> {
+    fn sni(&self) -> Option<Sni> {
         // TODO move SNI to connection
         self.space_manager.application()?.sni.clone()
     }

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -16,7 +16,9 @@ use bytes::Bytes;
 use core::task::{Context, Poll};
 use s2n_codec::DecoderBufferMut;
 use s2n_quic_core::{
-    application, event,
+    application,
+    application::Sni,
+    event,
     inet::{DatagramInfo, SocketAddress},
     io::tx,
     packet::{
@@ -324,7 +326,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
 
     fn application_close(&mut self, error: Option<application::Error>);
 
-    fn sni(&self) -> Option<Bytes>;
+    fn sni(&self) -> Option<Sni>;
 
     fn alpn(&self) -> Bytes;
 

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -16,6 +16,7 @@ use bytes::Bytes;
 use core::{convert::TryInto, fmt, marker::PhantomData};
 use s2n_codec::EncoderBuffer;
 use s2n_quic_core::{
+    application::Sni,
     crypto::{application::KeySet, tls, CryptoSuite},
     event::{self, IntoEvent},
     frame::{
@@ -65,7 +66,7 @@ pub struct ApplicationSpace<Config: endpoint::Config> {
     //# another mechanism is used for agreeing on an application protocol,
     //# endpoints MUST use ALPN for this purpose.
     pub alpn: Bytes,
-    pub sni: Option<Bytes>,
+    pub sni: Option<Sni>,
     ping: flag::Ping,
     processed_packet_numbers: SlidingWindow,
     recovery_manager: recovery::Manager<Config>,
@@ -93,7 +94,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         now: Timestamp,
         stream_manager: AbstractStreamManager<Config::Stream>,
         ack_manager: AckManager,
-        sni: Option<Bytes>,
+        sni: Option<Sni>,
         alpn: Bytes,
     ) -> Self {
         let key_set = KeySet::new(key);

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -174,7 +174,7 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
 
         // TODO use interning for these values
         // issue: https://github.com/awslabs/s2n-quic/issues/248
-        let sni = application_parameters.sni.map(Bytes::copy_from_slice);
+        let sni = application_parameters.sni;
         let alpn = Bytes::copy_from_slice(application_parameters.alpn_protocol);
 
         self.publisher

--- a/quic/s2n-quic/src/connection/handle.rs
+++ b/quic/s2n-quic/src/connection/handle.rs
@@ -147,7 +147,7 @@ macro_rules! impl_handle_api {
         /// // TODO
         /// ```
         #[inline]
-        pub fn sni(&self) -> $crate::connection::Result<Option<::bytes::Bytes>> {
+        pub fn sni(&self) -> $crate::connection::Result<Option<$crate::application::Sni>> {
             self.0.sni()
         }
 

--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -49,7 +49,7 @@ pub mod server;
 pub mod stream;
 
 pub mod application {
-    pub use s2n_quic_core::application::Error;
+    pub use s2n_quic_core::application::{Error, Sni};
 }
 
 pub use connection::Connection;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*l
Sni is required to be a valid utf-8 string, which the tls layer should validate. Previously we were converting back to an `&[u8]` instead of returning `&str`. This mean library users would need to do the conversion which is unsafe or deal with `Result`.

With this change we return a new type around Bytes, `Sni`, which also allows for a conversion to &str. Since the byte array is validated as a valid string when constructing `Sni`, the conversion can happen without error handling.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
