### PR TITLE
core: fix clippy warning

### DIFF
--- a/quic/s2n-quic-core/src/frame/connection_close.rs
+++ b/quic/s2n-quic-core/src/frame/connection_close.rs
@@ -129,11 +129,9 @@ impl<'a> EncoderValue for ConnectionClose<'a> {
     fn encode<E: Encoder>(&self, buffer: &mut E) {
         buffer.encode(&self.tag());
 
+        buffer.encode(&self.error_code);
         if let Some(frame_type) = &self.frame_type {
-            buffer.encode(&self.error_code);
             buffer.encode(frame_type);
-        } else {
-            buffer.encode(&self.error_code);
         }
 
         if let Some(reason) = &self.reason {


### PR DESCRIPTION
Clippy beta added a new lint. This PR fixes our warnings.

https://github.com/awslabs/s2n-quic/pull/850/checks?check_run_id=3547267654

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
