### PR TITLE
events: extra args for create_connection_context 

### DIFF
--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -19,6 +19,8 @@ struct EndpointMeta {
     timestamp: crate::event::Timestamp,
 }
 
+struct ConnectionInfo {}
+
 //= https://tools.ietf.org/id/draft-marx-qlog-event-definitions-quic-h3-02.txt#A.4
 struct PacketHeader {
     packet_type: PacketType,

--- a/quic/s2n-quic-events/src/main.rs
+++ b/quic/s2n-quic-events/src/main.rs
@@ -117,10 +117,10 @@ impl ToTokens for Output {
                     ///
                     /// ```no_run
                     /// # mod s2n_quic { pub mod provider { pub mod event {
-                    /// #     pub use s2n_quic_core::event::{api as events, api::ConnectionMeta, Subscriber};
+                    /// #     pub use s2n_quic_core::event::{api as events, api::ConnectionInfo, api::ConnectionMeta, Subscriber};
                     /// # }}}
                     /// use s2n_quic::provider::event::{
-                    ///     ConnectionMeta, Subscriber, events::PacketSent
+                    ///     ConnectionInfo, ConnectionMeta, Subscriber, events::PacketSent
                     /// };
                     ///
                     /// pub struct MyEventSubscriber;
@@ -134,6 +134,7 @@ impl ToTokens for Output {
                     ///
                     ///     fn create_connection_context(
                     ///         &mut self, _meta: &ConnectionMeta,
+                    ///         _info: &ConnectionInfo,
                     ///     ) -> Self::ConnectionContext {
                     ///         MyEventContext { packet_sent: 0 }
                     ///     }
@@ -151,7 +152,7 @@ impl ToTokens for Output {
                     type ConnectionContext: 'static + Send;
 
                     /// Creates a context to be passed to each connection-related event
-                    fn create_connection_context(&mut self, meta: &ConnectionMeta) -> Self::ConnectionContext;
+                    fn create_connection_context(&mut self, meta: &ConnectionMeta, info: &ConnectionInfo) -> Self::ConnectionContext;
 
                     #subscriber
 
@@ -191,8 +192,8 @@ impl ToTokens for Output {
                     type ConnectionContext = (A::ConnectionContext, B::ConnectionContext);
 
                     #[inline]
-                    fn create_connection_context(&mut self, meta: &ConnectionMeta) -> Self::ConnectionContext {
-                        (self.0.create_connection_context(meta), self.1.create_connection_context(meta))
+                    fn create_connection_context(&mut self, meta: &ConnectionMeta, info: &ConnectionInfo) -> Self::ConnectionContext {
+                        (self.0.create_connection_context(meta, info), self.1.create_connection_context(meta, info))
                     }
 
                     #tuple_subscriber
@@ -332,7 +333,7 @@ impl ToTokens for Output {
                 impl super::Subscriber for Subscriber {
                     type ConnectionContext = ();
 
-                    fn create_connection_context(&mut self, _meta: &api::ConnectionMeta) -> Self::ConnectionContext {}
+                    fn create_connection_context(&mut self, _meta: &api::ConnectionMeta, _info: &api::ConnectionInfo) -> Self::ConnectionContext {}
 
                     #subscriber_testing
                 }

--- a/quic/s2n-quic-qns/src/server/interop.rs
+++ b/quic/s2n-quic-qns/src/server/interop.rs
@@ -274,6 +274,7 @@ impl Subscriber for EventSubscriber {
     fn create_connection_context(
         &mut self,
         _meta: &events::ConnectionMeta,
+        _info: &events::ConnectionInfo,
     ) -> Self::ConnectionContext {
         MyConnectionContext {
             id: self.0,

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -221,9 +221,11 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             id: internal_connection_id.into(),
             timestamp: datagram.timestamp,
         };
-        let mut event_context = endpoint_context
-            .event_subscriber
-            .create_connection_context(&meta.clone().into_event());
+
+        let mut event_context = endpoint_context.event_subscriber.create_connection_context(
+            &meta.clone().into_event(),
+            &event::builder::ConnectionInfo {}.into_event(),
+        );
 
         let mut publisher = event::ConnectionPublisherSubscriber::new(
             meta,

--- a/quic/s2n-quic/src/connection/handle.rs
+++ b/quic/s2n-quic/src/connection/handle.rs
@@ -228,6 +228,7 @@ macro_rules! impl_handle_api {
         ///     type ConnectionContext = MyEventContext;
         ///     fn create_connection_context(
         ///        &mut self, _meta: &events::ConnectionMeta,
+        ///        _info: &events::ConnectionInfo,
         ///     ) -> Self::ConnectionContext {
         ///         MyEventContext { request: 0 }
         ///     }
@@ -293,6 +294,7 @@ macro_rules! impl_handle_api {
         ///    type ConnectionContext = u64;
         ///    fn create_connection_context(
         ///        &mut self, _meta: &events::ConnectionMeta,
+        ///        _info: &events::ConnectionInfo,
         ///    ) -> Self::ConnectionContext { 0 }
         /// }
         ///
@@ -302,6 +304,7 @@ macro_rules! impl_handle_api {
         ///    type ConnectionContext = u64;
         ///    fn create_connection_context(
         ///        &mut self, _meta: &events::ConnectionMeta,
+        ///        _info: &events::ConnectionInfo,
         ///    ) -> Self::ConnectionContext { 0 }
         /// }
         ///

--- a/quic/s2n-quic/src/provider/event/disabled.rs
+++ b/quic/s2n-quic/src/provider/event/disabled.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::provider::event::ConnectionMeta;
+use crate::provider::event::{ConnectionInfo, ConnectionMeta};
 
 #[derive(Debug, Default)]
 pub struct Provider;
@@ -20,5 +20,10 @@ pub struct Subscriber;
 impl super::Subscriber for Subscriber {
     type ConnectionContext = ();
 
-    fn create_connection_context(&mut self, _meta: &ConnectionMeta) -> Self::ConnectionContext {}
+    fn create_connection_context(
+        &mut self,
+        _meta: &ConnectionMeta,
+        _info: &ConnectionInfo,
+    ) -> Self::ConnectionContext {
+    }
 }

--- a/quic/s2n-quic/src/provider/event/mod.rs
+++ b/quic/s2n-quic/src/provider/event/mod.rs
@@ -3,7 +3,9 @@
 
 use cfg_if::cfg_if;
 pub use s2n_quic_core::event::{
-    api as events, api::ConnectionMeta, query, Event, Meta, Subscriber, Timestamp,
+    api as events,
+    api::{ConnectionInfo, ConnectionMeta},
+    query, Event, Meta, Subscriber, Timestamp,
 };
 
 /// Provides logging support for an endpoint

--- a/quic/s2n-quic/src/provider/event/tracing.rs
+++ b/quic/s2n-quic/src/provider/event/tracing.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::provider::event::{ConnectionMeta, Event, Meta};
+use crate::provider::event::{ConnectionInfo, ConnectionMeta, Event, Meta};
 use tracing::debug;
 
 #[derive(Debug, Default)]
@@ -22,7 +22,12 @@ pub struct Subscriber;
 impl super::Subscriber for Subscriber {
     type ConnectionContext = ();
 
-    fn create_connection_context(&mut self, _meta: &ConnectionMeta) -> Self::ConnectionContext {}
+    fn create_connection_context(
+        &mut self,
+        _meta: &ConnectionMeta,
+        _info: &ConnectionInfo,
+    ) -> Self::ConnectionContext {
+    }
 
     fn on_event<M: Meta, E: Event>(&mut self, meta: &M, event: &E) {
         debug!(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR includes an additional parameter to the `fn create_connection_context` (called when the connection is created and the connection event context is created) so that more information regarding connection createing can be included in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
