### PR TITLE
typo fix feature flag 'connection-migration'

### DIFF
--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -240,7 +240,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         // TODO: This would be better handled as a stateless reset so the peer can terminate the
         //       connection immediately. https://github.com/awslabs/s2n-quic/issues/317
         // We only enable connection migration for testing
-        #[cfg(not(any(feature = "connection_migration", feature = "testing", test)))]
+        #[cfg(not(any(feature = "connection-migration", feature = "testing", test)))]
         return Err(
             transport::Error::INTERNAL_ERROR.with_reason("Connection Migration is not supported")
         );


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fix typo for connection-migration flag 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
