### PR TITLE
fix path_validation probing usage around connection migration

### DIFF
--- a/quic/s2n-quic-core/src/frame/path_validation.rs
+++ b/quic/s2n-quic-core/src/frame/path_validation.rs
@@ -17,6 +17,18 @@ impl Probe {
     }
 }
 
+impl Default for Probe {
+    /// A packet is Probing only if all frames within the packet are
+    /// also Probing.
+    ///
+    /// This coupled with the Bit-Or logic makes `Probing` a good default:
+    /// Probing | Probing = Probing
+    /// Probing | NonProbing = NonProbing
+    fn default() -> Self {
+        Self::Probing
+    }
+}
+
 //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#9.1
 //# A packet containing only probing frames is a "probing packet", and a
 //# packet containing any other frame is a "non-probing packet".

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/tests/endpoint.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/tests/endpoint.rs
@@ -65,6 +65,7 @@ impl Endpoint {
             packet_number: packet.packet_number,
             path_challenge_on_active_path: false,
             frames: 1,
+            path_validation_probing: Default::default(),
         };
 
         self.ack_manager.on_processed_packet(&packet);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Receiving a non-path_validation-probing (`path_validation::Probing::NonProbing`) packet updates the path to an active path. This can happend intentionally, or as a result of a NAT rebind.

The logic around this was broken, which resulted in connection migration tests (rebind-addr and rebind-port, which essentially simulate a NAT rebind) not working. This PR fixes that logic and adds unit tests + compliance around it.

![image](https://user-images.githubusercontent.com/4350690/132905125-e9f336ee-0fc0-4d4b-831e-799acd081a95.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
