### PR TITLE
ci: remove xquic amplificationlimit requirement

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -193,7 +193,7 @@
     "quic-go": ["client"],
     "quiche": [],
     "quicly": ["client"],
-    "xquic": ["client"]
+    "xquic": []
   },
   "handshakeloss": {
     "aioquic": [],


### PR DESCRIPTION
The xquic amplicationlimit test isn't reliable enough to be in `required.json` so this change removes it.

See this failed job with completely unrelated changes: https://github.com/awslabs/s2n-quic/runs/3592742622#step:12:22

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
