### PR TITLE
deps: update msrv-blocked dependencies

### DIFF
--- a/common/compliance/cargo-compliance/Cargo.toml
+++ b/common/compliance/cargo-compliance/Cargo.toml
@@ -8,7 +8,6 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "1"
 fnv = { version = "1", default-features = false }
-goblin = "0.3"
 glob = "0.3"
 lazy_static = "1"
 pathdiff = "0.2"

--- a/common/compliance/cargo-compliance/src/main.rs
+++ b/common/compliance/cargo-compliance/src/main.rs
@@ -5,7 +5,6 @@ use structopt::StructOpt;
 
 mod annotation;
 mod extract;
-mod object;
 mod parser;
 mod pattern;
 mod project;

--- a/common/compliance/cargo-compliance/src/project.rs
+++ b/common/compliance/cargo-compliance/src/project.rs
@@ -1,15 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{pattern::Pattern, source::SourceFile, sourcemap::LinesIter, Error};
-use anyhow::anyhow;
+use crate::{pattern::Pattern, source::SourceFile, Error};
 use glob::glob;
-use serde::Deserialize;
-use std::{
-    collections::HashSet,
-    path::PathBuf,
-    process::{Command, Stdio},
-};
+use std::collections::HashSet;
 use structopt::StructOpt;
 
 #[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Hash, StructOpt)]
@@ -63,27 +57,9 @@ pub struct Project {
     spec_patterns: Vec<String>,
 }
 
-macro_rules! arg {
-    ($cmd:ident, $name:expr, $value:expr) => {
-        if let Some(value) = $value {
-            $cmd.arg($name).arg(value);
-        }
-    };
-}
-
-macro_rules! flag {
-    ($cmd:ident, $name:expr, $value:expr) => {
-        if $value {
-            $cmd.arg($name);
-        }
-    };
-}
-
 impl Project {
     pub fn sources(&self) -> Result<HashSet<SourceFile>, Error> {
         let mut sources = HashSet::new();
-
-        self.executables(&mut sources)?;
 
         self.cargo_files(&mut sources)?;
 
@@ -96,63 +72,6 @@ impl Project {
         }
 
         Ok(sources)
-    }
-
-    fn executables(&self, sources: &mut HashSet<SourceFile>) -> Result<(), Error> {
-        if self.no_cargo {
-            return Ok(());
-        }
-
-        let mut cmd = Command::new("cargo");
-
-        cmd.stdout(Stdio::piped())
-            .env("RUSTFLAGS", "--cfg compliance")
-            .env("RUSTDOCFLAGS", "--cfg compliance")
-            .arg("test")
-            .arg("--no-run")
-            .arg("--message-format")
-            .arg("json-render-diagnostics");
-
-        arg!(cmd, "--package", self.package.as_ref());
-        arg!(
-            cmd,
-            "--features",
-            Some(&self.features)
-                .filter(|f| !f.is_empty())
-                .map(|f| f.join(","))
-        );
-        flag!(cmd, "--workspace", self.workspace);
-        flag!(cmd, "--all-features", self.all_features);
-        flag!(cmd, "--no-default-features", self.no_default_features);
-        arg!(cmd, "--target", self.target.as_ref());
-        arg!(cmd, "--target-dir", Some(&self.target_dir));
-        arg!(cmd, "--manifest-path", self.manifest_path.as_ref());
-        for exclude in &self.excludes {
-            arg!(cmd, "--exclude", Some(exclude));
-        }
-
-        let child = cmd.spawn()?;
-
-        let output = child.wait_with_output()?;
-
-        if !output.status.success() {
-            return Err(anyhow!(format!(
-                "`cargo test` exited with status {}",
-                output.status
-            )));
-        }
-
-        let stdout = core::str::from_utf8(&output.stdout)?;
-
-        for line in LinesIter::new(stdout) {
-            if let Ok(event) = serde_json::from_str::<Event>(line.value) {
-                if let Some(executable) = event.executable {
-                    sources.insert(SourceFile::Object(PathBuf::from(executable)));
-                }
-            }
-        }
-
-        Ok(())
     }
 
     #[allow(clippy::unnecessary_wraps)] // this function will eventually return something
@@ -201,9 +120,4 @@ impl Project {
 
         Ok(())
     }
-}
-
-#[derive(Deserialize)]
-struct Event<'a> {
-    executable: Option<&'a str>,
 }

--- a/common/compliance/cargo-compliance/src/source.rs
+++ b/common/compliance/cargo-compliance/src/source.rs
@@ -13,7 +13,6 @@ use std::{collections::BTreeSet, path::PathBuf};
 
 #[derive(Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub enum SourceFile<'a> {
-    Object(PathBuf),
     Text(Pattern<'a>, PathBuf),
     Spec(PathBuf),
 }
@@ -22,12 +21,6 @@ impl<'a> SourceFile<'a> {
     pub fn annotations(&self) -> Result<AnnotationSet, Error> {
         let mut annotations = AnnotationSet::new();
         match self {
-            Self::Object(file) => {
-                let bytes = std::fs::read(file)?;
-                crate::object::extract(&bytes, &mut annotations)
-                    .with_context(|| file.display().to_string())?;
-                Ok(annotations)
-            }
             Self::Text(pattern, file) => {
                 let text = std::fs::read_to_string(file)?;
                 pattern

--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -15,5 +15,5 @@ generator = ["bolero-generator"]
 [dependencies]
 bolero-generator = { version = "0.6", default-features = false, optional = true }
 byteorder = { version = "1.1", default-features = false }
-zerocopy = "0.3"
-zerocopy-derive = "=0.2.0"
+zerocopy = "0.6"
+zerocopy-derive = "0.3"

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -23,8 +23,8 @@ num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features = false }
 subtle = { version = "2", default-features = false }
 thiserror = { version = "1", optional = true }
-zerocopy = "0.3"
-zerocopy-derive = "=0.2.0"
+zerocopy = "0.6"
+zerocopy-derive = "0.3"
 
 [dev-dependencies]
 bolero = "0.6"

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -50,8 +50,8 @@ s2n-quic-tls-default = { version = "0.1", path = "../s2n-quic-tls-default", opti
 s2n-quic-transport = { version = "0.1", path = "../s2n-quic-transport", default-features = false }
 thiserror = { version = "1.0", optional = true }
 tokio = { version = "1", optional = true, default-features = false }
-zerocopy = { version = "0.3", optional = true }
-zerocopy-derive = { version = "=0.2.0", optional = true }
+zerocopy = { version = "0.6", optional = true }
+zerocopy-derive = { version = "0.3", optional = true }
 zeroize = { version = "=1.2", default-features = false }
 tracing = { version = "0.1", optional = true }
 


### PR DESCRIPTION
We have several dependencies blocked on our previous MSRV (1.46). After upgrading to 1.51 in #870, we can finally apply these updates.

The goblin dependency was showing some usage warnings and I realized it hasn't even been used since #640. So that's been removed here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
