### PR TITLE
ci: remove lsquic interop requirements

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -58,7 +58,7 @@
   "longrtt": {
     "aioquic": ["client"],
     "kwik": [],
-    "lsquic": ["client"],
+    "lsquic": [],
     "msquic": [],
     "mvfst": [],
     "neqo": ["client"],
@@ -86,7 +86,7 @@
   "multiplexing": {
     "aioquic": ["client"],
     "kwik": [],
-    "lsquic": ["client"],
+    "lsquic": [],
     "msquic": [],
     "mvfst": [],
     "neqo": [],

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,11 +236,6 @@ jobs:
           override: true
           components: miri, rust-src
 
-      - name: Install xargo
-        uses: camshaft/install@v1
-        with:
-          crate: xargo
-
       - uses: camshaft/rust-cache@v1
         with:
           key: ${{ matrix.crate }}


### PR DESCRIPTION
lsquic had a random failure in the [longrtt and multiplexing tests](https://github.com/awslabs/s2n-quic/runs/3593503136?check_suite_focus=true#step:12:24) ([Report](https://dnglbrstg7yg.cloudfront.net/366480f45d424f211dfb1d47305ea6cdaed106b0/interop/index.html)) so that is being marked as not required until we have time to investigate.

I'm also removing the `xargo` install from the miri task as that seems to break the install processed after it's been cached: https://github.com/awslabs/s2n-quic/pull/871/checks?check_run_id=3601499345

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
