### PR TITLE
Update README to reflect #850

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,4 +64,4 @@ You can verify most tests run in the CI locally:
 
  * Simulate interop tests locally by following the instructions [here](scripts/interop/README.md).
  * Run a compliance report: `./scripts/compliance`
- * Run rustfmt, clippy, and all of the tests: `./scripts/test`
+ * Run rustfmt, clippy, and all of the tests: `./scripts/local_test`


### PR DESCRIPTION
After https://github.com/awslabs/s2n-quic/commit/85b9b8b5274a4b9d644801aff750e800b927858b, ./scripts/test no longer exists. The right script is ./scripts/local_test.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
