### PR TITLE
deps: update additional dependencies

### DIFF
--- a/common/compliance/cargo-compliance/Cargo.toml
+++ b/common/compliance/cargo-compliance/Cargo.toml
@@ -18,9 +18,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 structopt = "0.3"
 toml = "0.5"
-triple_accel = "0.3"
+triple_accel = "0.4"
 url = "2"
 v_jsonescape = "0.5"
 
 [dev-dependencies]
-insta = "1.0"
+insta = "1"

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -15,7 +15,7 @@ checked-counters = []
 
 [dependencies]
 bolero-generator = { version = "0.6", default-features = false, optional = true }
-byteorder = { version = "1.1", default-features = false }
+byteorder = { version = "1", default-features = false }
 bytes = { version = "1", default-features = false }
 displaydoc = { version = "0.1", default-features = false }
 hex-literal = "0.3"
@@ -30,7 +30,7 @@ zerocopy-derive = "0.3"
 bolero = "0.6"
 bolero-generator = { version = "0.6", default-features = false }
 criterion = { version = "0.3", features = ["html_reports"] }
-insta = "1.0"
+insta = "1"
 plotters = { version = "0.3", default-features = false, features = ["svg_backend", "line_series"] }
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", features = ["testing"] }
 

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -14,14 +14,14 @@ tokio-runtime = ["futures", "pin-project", "tokio"]
 wipe = ["zeroize"]
 
 [dependencies]
-cfg-if = "1.0"
+cfg-if = "1"
 futures = { version = "0.3", optional = true }
-lazy_static = { version = "1.4", optional = true }
+lazy_static = { version = "1", optional = true }
 pin-project = { version = "1", optional = true }
 s2n-quic-core = { version = "0.1.0", path = "../s2n-quic-core", default-features = false }
 socket2 = { version = "0.4", features = ["all"], optional = true }
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt", "time"], optional = true }
-zeroize = { version = "=1.2", default-features = false, optional = true }
+zeroize = { version = "1", default-features = false, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/quic/s2n-quic-ring/Cargo.toml
+++ b/quic/s2n-quic-ring/Cargo.toml
@@ -7,15 +7,15 @@ license = "Apache-2.0"
 
 [dependencies]
 hex-literal = "0.3"
-lazy_static = { version = "1.3", default-features = false }
+lazy_static = { version = "1", default-features = false }
 s2n-codec = { version = "0.1.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "0.1.0", path = "../s2n-quic-core", default-features = false }
 ring = { version = "0.16", default-features = false }
-zeroize = { version = "=1.2", default-features = false }
+zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
 bolero = "0.6"
-insta = "1.0"
+insta = "1"
 s2n-quic-core = { version = "0.1.0", path = "../s2n-quic-core", features = ["testing"] }
 
 [[test]]

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -15,6 +15,6 @@ s2n-quic-ring = { version = "0.1", path = "../s2n-quic-ring", default-features =
 s2n-tls = { version = "0.1", path = "../../tls/s2n-tls", features = ["quic"] }
 
 [dev-dependencies]
-checkers = "0.5"
+checkers = "0.6"
 s2n-quic-core = { version = "0.1", path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-rustls = { version = "0.1", path = "../s2n-quic-rustls" }

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -17,12 +17,12 @@ intrusive-collections = "0.9"
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "0.1", path = "../s2n-quic-core", default-features = false }
 siphasher = "0.3"
-smallvec = { version = "1.3", default-features = false }
+smallvec = { version = "1", default-features = false }
 
 [dev-dependencies]
 bolero = "0.6"
 futures-test = "0.3" # For testing Waker interactions
-insta = "1.0"
+insta = "1"
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
 s2n-quic-core = { version = "0.1", path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -34,10 +34,10 @@ tracing-provider = ["tracing"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-cfg-if = "1.0"
+cfg-if = "1"
 cuckoofilter = "0.5"
 futures = { version = "0.3", default-features = false, features = ["async-await"] }
-hash_hasher = "2.0"
+hash_hasher = "2"
 rand = { version = "0.8", optional = true }
 rand_chacha = { version = "0.3", optional = true }
 ring = { version = "0.16", optional = true, default-features = false }
@@ -48,11 +48,11 @@ s2n-quic-rustls = { version = "0.1", path = "../s2n-quic-rustls", optional = tru
 s2n-quic-tls = { version = "0.1", path = "../s2n-quic-tls", optional = true }
 s2n-quic-tls-default = { version = "0.1", path = "../s2n-quic-tls-default", optional = true }
 s2n-quic-transport = { version = "0.1", path = "../s2n-quic-transport", default-features = false }
-thiserror = { version = "1.0", optional = true }
+thiserror = { version = "1", optional = true }
 tokio = { version = "1", optional = true, default-features = false }
 zerocopy = { version = "0.6", optional = true }
 zerocopy-derive = { version = "0.3", optional = true }
-zeroize = { version = "=1.2", default-features = false }
+zeroize = { version = "1", default-features = false }
 tracing = { version = "0.1", optional = true }
 
 [dev-dependencies]

--- a/tls/s2n-tls-sys/Cargo.toml
+++ b/tls/s2n-tls-sys/Cargo.toml
@@ -14,7 +14,7 @@ libc = "0.2"
 openssl-sys = { version = "0.9" }
 
 [build-dependencies]
-bindgen = "0.58"
+bindgen = "0.59"
 cmake = "0.1"
 heck = "0.3"
 


### PR DESCRIPTION
Running `cargo outdated` highlighted a few other dependencies that needed to be updated in addition to #871.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
