### PR TITLE
api: enable ipv6 by default

### DIFF
--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 default = [
     "default-tls-provider",
     "default-token-provider",
+    "ipv6",
     "rand-provider",
     "std",
     "tokio-runtime",
@@ -18,6 +19,8 @@ connection-close-debug = []
 connection-migration = ["s2n-quic-transport/connection-migration"]
 default-token-provider = ["ring", "zerocopy", "zerocopy-derive"]
 default-tls-provider = ["s2n-quic-tls-default"]
+ipv6 = ["s2n-quic-platform/ipv6"]
+packet-wipe = ["s2n-quic-platform/wipe"]
 rand-provider = ["rand", "rand_chacha"]
 rustls = ["s2n-quic-rustls"]
 s2n-tls = ["s2n-quic-tls"]


### PR DESCRIPTION
IPv6 support is currently disabled by default in the public API, since the `s2n-quic-platform` dependency sets `default-features = false`. This change fixes the `ipv6` feature to be part of the public feature set and a part of `default`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
