### PR TITLE
Set socket option to get ECN information from RX socket

### DIFF
--- a/quic/s2n-quic-platform/build.rs
+++ b/quic/s2n-quic-platform/build.rs
@@ -20,9 +20,11 @@ fn main() -> Result<(), Error> {
         "linux" => {
             supports("gso");
             supports("pktinfo");
+            supports("tos");
         }
         "macos" => {
             supports("pktinfo");
+            supports("tos");
         }
         _ => {
             // TODO others

--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -169,7 +169,7 @@ impl Io {
         }
 
         // Set up the RX socket to pass ECN information
-        #[cfg(target_os = "linux")]
+        #[cfg(s2n_quic_platform_tos)]
         {
             use std::os::unix::io::AsRawFd;
             let enabled: libc::c_int = 1;


### PR DESCRIPTION
*Issue #, if available:* #802

*Description of changes:* This change sets the required socket options so the operating system will return the ECN related cmsgs on the RX socket.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
