### PR TITLE
platform: remove ipv6 feature flag

### DIFF
--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [features]
-default = ["ipv6", "std", "tokio-runtime", "wipe"]
-ipv6 = []
+default = ["std", "tokio-runtime", "wipe"]
 std = ["s2n-quic-core/std", "socket2", "lazy_static"]
 testing = ["std"] # Testing allows to overwrite the system time
 tokio-runtime = ["futures", "pin-project", "tokio"]

--- a/quic/s2n-quic-platform/build.rs
+++ b/quic/s2n-quic-platform/build.rs
@@ -19,6 +19,7 @@ fn main() -> Result<(), Error> {
     match env.target_os.as_str() {
         "linux" => {
             supports("gso");
+            supports("mtu_disc");
             supports("pktinfo");
             supports("tos");
         }

--- a/quic/s2n-quic-platform/src/message/cmsg.rs
+++ b/quic/s2n-quic-platform/src/message/cmsg.rs
@@ -113,7 +113,6 @@ pub fn decode(msghdr: &libc::msghdr) -> AncillaryData {
             (libc::IPPROTO_IP, libc::IP_TOS) | (libc::IPPROTO_IP, libc::IP_RECVTOS) => unsafe {
                 result.ecn = ExplicitCongestionNotification::new(decode_value::<u8>(cmsg));
             },
-            #[cfg(feature = "ipv6")]
             (libc::IPPROTO_IPV6, libc::IPV6_TCLASS) => unsafe {
                 result.ecn =
                     ExplicitCongestionNotification::new(decode_value::<libc::c_int>(cmsg) as u8);
@@ -129,7 +128,7 @@ pub fn decode(msghdr: &libc::msghdr) -> AncillaryData {
                 result.local_address = local_address.into();
                 result.local_interface = Some(pkt_info.ipi_ifindex as _);
             },
-            #[cfg(all(s2n_quic_platform_pktinfo, feature = "ipv6"))]
+            #[cfg(s2n_quic_platform_pktinfo)]
             (libc::IPPROTO_IPV6, libc::IPV6_PKTINFO) => unsafe {
                 let pkt_info = decode_value::<libc::in6_pktinfo>(cmsg);
                 let local_address = pkt_info.ipi6_addr.s6_addr;

--- a/quic/s2n-quic-platform/src/message/queue.rs
+++ b/quic/s2n-quic-platform/src/message/queue.rs
@@ -188,13 +188,7 @@ mod tests {
     }
 
     fn gen_address() -> impl ValueGenerator<Output = inet::SocketAddress> {
-        #[cfg(feature = "ipv6")]
-        let generator = gen();
-
-        #[cfg(not(feature = "ipv6"))]
-        let generator = gen::<inet::SocketAddressV4>().map(|addr| addr.into());
-
-        generator
+        gen()
     }
 
     #[derive(Clone, Copy, Debug, TypeGenerator)]
@@ -280,9 +274,6 @@ mod tests {
 
             for (message, (address, len, value)) in occupied.iter().zip(oracle.iter()) {
                 let address = *address;
-
-                #[cfg(all(target_os = "macos", feature = "ipv6"))]
-                let address = address.to_ipv6_mapped().into();
 
                 assert_eq!(message.remote_address(), Some(address));
                 assert_eq!(message.payload_len(), *len);

--- a/quic/s2n-quic-platform/src/message/simple.rs
+++ b/quic/s2n-quic-platform/src/message/simple.rs
@@ -42,10 +42,6 @@ impl MessageTrait for Message {
     fn set_remote_address(&mut self, remote_address: &SocketAddress) {
         let remote_address = *remote_address;
 
-        // macos doesn't like sending ipv4 addresses on ipv6 sockets
-        #[cfg(all(target_os = "macos", feature = "ipv6"))]
-        let remote_address = remote_address.to_ipv6_mapped().into();
-
         self.address = remote_address;
     }
 

--- a/quic/s2n-quic-qns/src/server/interop.rs
+++ b/quic/s2n-quic-qns/src/server/interop.rs
@@ -24,6 +24,9 @@ use tracing::info;
 
 #[derive(Debug, StructOpt)]
 pub struct Interop {
+    #[structopt(short, long, default_value = "::")]
+    ip: std::net::IpAddr,
+
     #[structopt(short, long, default_value = "443")]
     port: u16,
 
@@ -202,7 +205,7 @@ impl Interop {
             .build()?;
 
         let server = Server::builder()
-            .with_io(("::", self.port))?
+            .with_io((self.ip, self.port))?
             .with_tls(tls)?
             .with_endpoint_limits(limits)?
             .with_event(EventSubscriber(1))?

--- a/quic/s2n-quic-qns/src/server/perf.rs
+++ b/quic/s2n-quic-qns/src/server/perf.rs
@@ -18,6 +18,9 @@ use tokio::spawn;
 
 #[derive(Debug, StructOpt)]
 pub struct Perf {
+    #[structopt(short, long, default_value = "::")]
+    ip: std::net::IpAddr,
+
     #[structopt(short, long, default_value = "443")]
     port: u16,
 
@@ -242,7 +245,7 @@ impl Perf {
             .build()?;
 
         let server = Server::builder()
-            .with_io(("::", self.port))?
+            .with_io((self.ip, self.port))?
             .with_tls(tls)?
             .with_event(event::disabled::Provider)?
             .start()

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -9,7 +9,6 @@ license = "Apache-2.0"
 default = [
     "default-tls-provider",
     "default-token-provider",
-    "ipv6",
     "rand-provider",
     "std",
     "tokio-runtime",
@@ -19,7 +18,6 @@ connection-close-debug = []
 connection-migration = ["s2n-quic-transport/connection-migration"]
 default-token-provider = ["ring", "zerocopy", "zerocopy-derive"]
 default-tls-provider = ["s2n-quic-tls-default"]
-ipv6 = ["s2n-quic-platform/ipv6"]
 packet-wipe = ["s2n-quic-platform/wipe"]
 rand-provider = ["rand", "rand_chacha"]
 rustls = ["s2n-quic-rustls"]

--- a/quic/s2n-quic/src/provider/io.rs
+++ b/quic/s2n-quic/src/provider/io.rs
@@ -33,7 +33,7 @@ impl TryInto for u16 {
     type Provider = Default;
 
     fn try_into(self) -> io::Result<Self::Provider> {
-        Default::new(("0.0.0.0", self))
+        Default::new(("::", self))
     }
 }
 
@@ -51,6 +51,9 @@ macro_rules! impl_socket_addrs {
 }
 
 impl_socket_addrs!((&str, u16));
+impl_socket_addrs!((std::net::IpAddr, u16));
+impl_socket_addrs!((std::net::Ipv4Addr, u16));
+impl_socket_addrs!((std::net::Ipv6Addr, u16));
 impl_socket_addrs!(&str);
 impl_socket_addrs!(std::net::SocketAddr);
 impl_socket_addrs!(std::net::SocketAddrV4);


### PR DESCRIPTION
As part of testing the changes made in #880, I think the best path forward is to remove the ipv6 feature entirely and determine what kind of socket to create and configure at runtime. This should be much easier to maintain as well since we don't have to build the library multiple times to test each variant.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
