### PR TITLE
integration: update flume

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -11,19 +11,12 @@ multiple-versions = "deny"
 skip-tree = [
     { name = "cargo-compliance" },
     { name = "criterion" }, # criterion is always going to be just a test dependency
+    { name = "s2n-quic-integration" }, # s2n-quic-integration is a private crate
 ]
 
 [sources]
 unknown-registry = "deny"
 unknown-git = "deny"
-
-allow-git = [
-    # The main flume has dependencies which don't have a rolling 6-month MSRV
-    #
-    # This fork uses `parking_lot` instead, which does. Since this is only a dev-dependency, it
-    # shouldn't prevent us from publishing to crates.io.
-    "https://github.com/camshaft/flume",
-]
 
 [licenses]
 unlicensed = "deny"

--- a/quic/s2n-quic-integration/Cargo.toml
+++ b/quic/s2n-quic-integration/Cargo.toml
@@ -22,8 +22,4 @@ tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 bolero = "0.6"
-# The main flume has dependencies which don't have a rolling 6-month MSRV
-#
-# This fork uses `parking_lot` instead, which does. Since this is only a dev-dependency, it
-# shouldn't prevent us from publishing to crates.io.
-flume = { git = "https://github.com/camshaft/flume", default-features = false, features = ["async"] }
+flume = { version = "0.10", features = ["async"] }


### PR DESCRIPTION
After bumping our MSRV in #870, we can update our flume dependency to the latest version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
