### PR TITLE
core: emit gso offset with datagram sent event

### DIFF
--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -334,6 +334,13 @@ pub mod api {
     #[doc = " Datagram sent by a connection"]
     pub struct DatagramSent {
         pub len: u16,
+        #[doc = " The GSO offset at which this datagram was written"]
+        #[doc = ""]
+        #[doc = " If this value is greater than 0, it indicates that this datagram has been sent with other"]
+        #[doc = " segments in a single buffer."]
+        #[doc = ""]
+        #[doc = " See the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/segmentation-offloads.html#generic-segmentation-offload) for more details."]
+        pub gso_offset: usize,
     }
     impl Event for DatagramSent {
         const NAME: &'static str = "transport:datagram_sent";
@@ -362,6 +369,7 @@ pub mod api {
     #[doc = " ConnectionId updated"]
     pub struct ConnectionIdUpdated<'a> {
         pub path_id: u64,
+        #[doc = " The endpoint that updated its connection id"]
         pub cid_consumer: Location,
         pub previous: ConnectionId<'a>,
         pub current: ConnectionId<'a>,
@@ -403,6 +411,13 @@ pub mod api {
     #[doc = " Datagram sent by the endpoint"]
     pub struct EndpointDatagramSent {
         pub len: u16,
+        #[doc = " The GSO offset at which this datagram was written"]
+        #[doc = ""]
+        #[doc = " If this value is greater than 0, it indicates that this datagram has been sent with other"]
+        #[doc = " segments in a single buffer."]
+        #[doc = ""]
+        #[doc = " See the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/segmentation-offloads.html#generic-segmentation-offload) for more details."]
+        pub gso_offset: usize,
     }
     impl Event for EndpointDatagramSent {
         const NAME: &'static str = "transport:datagram_sent";
@@ -1288,13 +1303,21 @@ pub mod builder {
     #[doc = " Datagram sent by a connection"]
     pub struct DatagramSent {
         pub len: u16,
+        #[doc = " The GSO offset at which this datagram was written"]
+        #[doc = ""]
+        #[doc = " If this value is greater than 0, it indicates that this datagram has been sent with other"]
+        #[doc = " segments in a single buffer."]
+        #[doc = ""]
+        #[doc = " See the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/segmentation-offloads.html#generic-segmentation-offload) for more details."]
+        pub gso_offset: usize,
     }
     impl IntoEvent<api::DatagramSent> for DatagramSent {
         #[inline]
         fn into_event(self) -> api::DatagramSent {
-            let DatagramSent { len } = self;
+            let DatagramSent { len, gso_offset } = self;
             api::DatagramSent {
                 len: len.into_event(),
+                gso_offset: gso_offset.into_event(),
             }
         }
     }
@@ -1332,6 +1355,7 @@ pub mod builder {
     #[doc = " ConnectionId updated"]
     pub struct ConnectionIdUpdated<'a> {
         pub path_id: u64,
+        #[doc = " The endpoint that updated its connection id"]
         pub cid_consumer: crate::endpoint::Location,
         pub previous: ConnectionId<'a>,
         pub current: ConnectionId<'a>,
@@ -1407,13 +1431,21 @@ pub mod builder {
     #[doc = " Datagram sent by the endpoint"]
     pub struct EndpointDatagramSent {
         pub len: u16,
+        #[doc = " The GSO offset at which this datagram was written"]
+        #[doc = ""]
+        #[doc = " If this value is greater than 0, it indicates that this datagram has been sent with other"]
+        #[doc = " segments in a single buffer."]
+        #[doc = ""]
+        #[doc = " See the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/segmentation-offloads.html#generic-segmentation-offload) for more details."]
+        pub gso_offset: usize,
     }
     impl IntoEvent<api::EndpointDatagramSent> for EndpointDatagramSent {
         #[inline]
         fn into_event(self) -> api::EndpointDatagramSent {
-            let EndpointDatagramSent { len } = self;
+            let EndpointDatagramSent { len, gso_offset } = self;
             api::EndpointDatagramSent {
                 len: len.into_event(),
+                gso_offset: gso_offset.into_event(),
             }
         }
     }

--- a/quic/s2n-quic-core/src/io/tx.rs
+++ b/quic/s2n-quic-core/src/io/tx.rs
@@ -99,7 +99,7 @@ pub trait Message {
     fn can_gso(&self) -> bool;
 
     /// Writes the payload of the message to an output buffer
-    fn write_payload(&mut self, buffer: &mut [u8]) -> usize;
+    fn write_payload(&mut self, buffer: &mut [u8], gso_offset: usize) -> usize;
 }
 
 impl<Handle: path::Handle, Payload: AsRef<[u8]>> Message for (Handle, Payload) {
@@ -125,7 +125,7 @@ impl<Handle: path::Handle, Payload: AsRef<[u8]>> Message for (Handle, Payload) {
         true
     }
 
-    fn write_payload(&mut self, buffer: &mut [u8]) -> usize {
+    fn write_payload(&mut self, buffer: &mut [u8], _gso_offset: usize) -> usize {
         let payload = self.1.as_ref();
         let len = payload.len();
         if let Some(buffer) = buffer.get_mut(..len) {
@@ -158,9 +158,9 @@ mod tests {
         assert_eq!(message.ecn(), Default::default());
         assert_eq!(message.delay(), Default::default());
         assert_eq!(message.ipv6_flow_label(), 0);
-        assert_eq!(message.write_payload(&mut buffer[..]), 3);
+        assert_eq!(message.write_payload(&mut buffer[..], 0), 3);
 
         // assert an empty buffer doesn't panic
-        assert_eq!(message.write_payload(&mut [][..]), 0);
+        assert_eq!(message.write_payload(&mut [][..], 0), 0);
     }
 }

--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -129,6 +129,13 @@ struct DuplicatePacket {
 /// Datagram sent by a connection
 struct DatagramSent {
     len: u16,
+    /// The GSO offset at which this datagram was written
+    ///
+    /// If this value is greater than 0, it indicates that this datagram has been sent with other
+    /// segments in a single buffer.
+    ///
+    /// See the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/segmentation-offloads.html#generic-segmentation-offload) for more details.
+    gso_offset: usize,
 }
 
 #[event("transport:datagram_received")]

--- a/quic/s2n-quic-events/events/endpoint.rs
+++ b/quic/s2n-quic-events/events/endpoint.rs
@@ -35,6 +35,13 @@ struct EndpointPacketReceived {
 /// Datagram sent by the endpoint
 struct EndpointDatagramSent {
     len: u16,
+    /// The GSO offset at which this datagram was written
+    ///
+    /// If this value is greater than 0, it indicates that this datagram has been sent with other
+    /// segments in a single buffer.
+    ///
+    /// See the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/segmentation-offloads.html#generic-segmentation-offload) for more details.
+    gso_offset: usize,
 }
 
 #[event("transport:datagram_received")]

--- a/quic/s2n-quic-events/src/parser.rs
+++ b/quic/s2n-quic-events/src/parser.rs
@@ -371,24 +371,30 @@ impl Field {
     }
 
     fn api(&self) -> TokenStream {
-        let Self { ident, ty, .. } = self;
+        let Self { attrs, ident, ty } = self;
+        let attrs = &attrs.extra;
         if let Some(name) = ident {
             quote!(
+                #attrs
                 pub #name: #ty,
             )
         } else {
-            quote!(pub #ty,)
+            quote!(#attrs pub #ty,)
         }
     }
 
     fn enum_api(&self) -> TokenStream {
-        let Self { ident, ty, .. } = self;
+        let Self {
+            attrs, ident, ty, ..
+        } = self;
+        let attrs = &attrs.extra;
         if let Some(name) = ident {
             quote!(
+                #attrs
                 #name: #ty,
             )
         } else {
-            quote!(#ty,)
+            quote!(#attrs #ty,)
         }
     }
 
@@ -398,22 +404,24 @@ impl Field {
     }
 
     fn builder(&self) -> TokenStream {
-        let Self { ident, .. } = self;
+        let Self { attrs, ident, .. } = self;
+        let attrs = &attrs.extra;
         let ty = self.builder_type();
         if let Some(name) = ident {
-            quote!(pub #name: #ty,)
+            quote!(#attrs pub #name: #ty,)
         } else {
-            quote!(pub #ty,)
+            quote!(#attrs pub #ty,)
         }
     }
 
     fn enum_builder(&self) -> TokenStream {
-        let Self { ident, .. } = self;
+        let Self { attrs, ident, .. } = self;
+        let attrs = &attrs.extra;
         let ty = self.builder_type();
         if let Some(name) = ident {
-            quote!(#name: #ty,)
+            quote!(#attrs #name: #ty,)
         } else {
-            quote!(#ty,)
+            quote!(#attrs #ty,)
         }
     }
 

--- a/quic/s2n-quic-integration/src/packet.rs
+++ b/quic/s2n-quic-integration/src/packet.rs
@@ -31,7 +31,7 @@ impl tx::Entry for Packet {
         self.ecn = message.ecn();
         self.ipv6_flow_label = message.ipv6_flow_label();
 
-        let len = message.write_payload(&mut self.payload[..]);
+        let len = message.write_payload(&mut self.payload[..], 0);
 
         if len == 0 {
             return Err(tx::Error::EmptyPayload);

--- a/quic/s2n-quic-platform/src/message/mmsg.rs
+++ b/quic/s2n-quic-platform/src/message/mmsg.rs
@@ -186,7 +186,7 @@ impl tx::Entry for Message {
     ) -> Result<usize, tx::Error> {
         let payload = MessageTrait::payload_mut(self);
 
-        let len = message.write_payload(payload);
+        let len = message.write_payload(payload, 0);
 
         // don't send empty payloads
         if len == 0 {

--- a/quic/s2n-quic-platform/src/message/msg.rs
+++ b/quic/s2n-quic-platform/src/message/msg.rs
@@ -514,7 +514,7 @@ impl tx::Entry for Message {
     ) -> Result<usize, tx::Error> {
         let payload = MessageTrait::payload_mut(self);
 
-        let len = message.write_payload(payload);
+        let len = message.write_payload(payload, 0);
 
         // don't send empty payloads
         if len == 0 {

--- a/quic/s2n-quic-platform/src/message/queue/slice.rs
+++ b/quic/s2n-quic-platform/src/message/queue/slice.rs
@@ -182,7 +182,7 @@ impl<'a, Message: message::Message, B> Slice<'a, Message, B> {
         // allow the message to write up to `gso.size` bytes
         let buffer = &mut message::Message::payload_mut(prev_message)[payload_len..];
 
-        match message.write_payload(buffer) {
+        match message.write_payload(buffer, gso.count) {
             0 => {
                 unsafe {
                     // revert the len to what it was before

--- a/quic/s2n-quic-platform/src/message/simple.rs
+++ b/quic/s2n-quic-platform/src/message/simple.rs
@@ -176,7 +176,7 @@ impl tx::Entry for Message {
     ) -> Result<usize, tx::Error> {
         let payload = MessageTrait::payload_mut(self);
 
-        let len = message.write_payload(payload);
+        let len = message.write_payload(payload, 0);
 
         // don't send empty payloads
         if len == 0 {

--- a/quic/s2n-quic-transport/src/connection/transmission.rs
+++ b/quic/s2n-quic-transport/src/connection/transmission.rs
@@ -79,7 +79,7 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
         !self.context.transmission_mode.is_mtu_probing()
     }
 
-    fn write_payload(&mut self, buffer: &mut [u8]) -> usize {
+    fn write_payload(&mut self, buffer: &mut [u8], gso_offset: usize) -> usize {
         let space_manager = &mut self.space_manager;
 
         let mtu = self
@@ -367,6 +367,7 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
                 .publisher
                 .on_datagram_sent(event::builder::DatagramSent {
                     len: datagram_len as u16,
+                    gso_offset,
                 });
         }
 

--- a/quic/s2n-quic-transport/src/endpoint/retry.rs
+++ b/quic/s2n-quic-transport/src/endpoint/retry.rs
@@ -72,6 +72,7 @@ impl<Path: path::Handle> Dispatch<Path> {
 
                     publisher.on_endpoint_datagram_sent(event::builder::EndpointDatagramSent {
                         len: len as u16,
+                        gso_offset: 0,
                     });
                 }
                 Err(_) => {
@@ -160,7 +161,7 @@ impl<Path: path::Handle> tx::Message for &Transmission<Path> {
     }
 
     #[inline]
-    fn write_payload(&mut self, buffer: &mut [u8]) -> usize {
+    fn write_payload(&mut self, buffer: &mut [u8], _gso_offset: usize) -> usize {
         let packet = self.as_ref();
         buffer[..packet.len()].copy_from_slice(packet);
         packet.len()

--- a/quic/s2n-quic-transport/src/endpoint/stateless_reset.rs
+++ b/quic/s2n-quic-transport/src/endpoint/stateless_reset.rs
@@ -62,6 +62,7 @@ impl<Path: path::Handle> Dispatch<Path> {
 
                     publisher.on_endpoint_datagram_sent(event::builder::EndpointDatagramSent {
                         len: len as u16,
+                        gso_offset: 0,
                     });
                 }
                 Err(_) => {
@@ -151,7 +152,7 @@ impl<Path: path::Handle> tx::Message for &Transmission<Path> {
     }
 
     #[inline]
-    fn write_payload(&mut self, buffer: &mut [u8]) -> usize {
+    fn write_payload(&mut self, buffer: &mut [u8], _gso_offset: usize) -> usize {
         let packet = self.as_ref();
         buffer[..packet.len()].copy_from_slice(packet);
         packet.len()

--- a/quic/s2n-quic-transport/src/endpoint/version.rs
+++ b/quic/s2n-quic-transport/src/endpoint/version.rs
@@ -186,6 +186,7 @@ impl<Config: endpoint::Config> Negotiator<Config> {
 
                     publisher.on_endpoint_datagram_sent(event::builder::EndpointDatagramSent {
                         len: len as u16,
+                        gso_offset: 0,
                     });
                 }
                 Err(_) => {
@@ -269,7 +270,7 @@ impl<Path: path::Handle> tx::Message for &Transmission<Path> {
     }
 
     #[inline]
-    fn write_payload(&mut self, buffer: &mut [u8]) -> usize {
+    fn write_payload(&mut self, buffer: &mut [u8], _gso_offset: usize) -> usize {
         let packet = self.as_ref();
         buffer[..packet.len()].copy_from_slice(packet);
         packet.len()


### PR DESCRIPTION
Our current `DatagramSent` events do indicate whether or not it is part of a GSO packet. This makes it difficult to debug if GSO is actually enabled and working. This change adds a `gso_offset` to indicate the offset at which the datagram was written. If it's `>0` then it can be considered as offloaded.

I also noticed that field-level documentation wasn't being added to the generated events so I fixed that as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
