### PR TITLE
ci: fix interop comparisons

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -297,7 +297,7 @@ jobs:
         if: github.event.pull_request
         run: |
           curl \
-          --url "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/workflows/interop.yml/runs?branch=main&status=success&per_page=1" \
+          --url "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/workflows/qns.yml/runs?branch=main&status=success&per_page=1" \
           --header "authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
           --header "Accept: application/vnd.github.v3+json" > latest_workflow_run.json
           MAIN_SHA=$(jq --raw-output '.workflow_runs[0] | .head_sha' latest_workflow_run.json)


### PR DESCRIPTION
I noticed that our interop comparisons were stuck on d21a4924915b058039dd2c845d0b7172c812d9fa. This is due to #837 renaming the `interop.yml` to `qns.yml`, but the script not being updated.

The [report from this PR](https://dnglbrstg7yg.cloudfront.net/475681d307f547f305d6b953f9d00e05017036cc/interop/index.html) shows the latest commit to main.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
