### PR TITLE
event: replace path_id with Path event object

### DIFF
--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -262,12 +262,12 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     #[doc = " Frame was received"]
-    pub struct FrameReceived {
+    pub struct FrameReceived<'a> {
         pub packet_header: PacketHeader,
-        pub path_id: u64,
+        pub path: Path<'a>,
         pub frame: Frame,
     }
-    impl Event for FrameReceived {
+    impl<'a> Event for FrameReceived<'a> {
         const NAME: &'static str = "transport:frame_received";
     }
     #[derive(Clone, Debug)]
@@ -285,8 +285,8 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     #[doc = " Recovery metrics updated"]
-    pub struct RecoveryMetrics {
-        pub path_id: u64,
+    pub struct RecoveryMetrics<'a> {
+        pub path: Path<'a>,
         pub min_rtt: Duration,
         pub smoothed_rtt: Duration,
         pub latest_rtt: Duration,
@@ -296,7 +296,7 @@ pub mod api {
         pub congestion_window: u32,
         pub bytes_in_flight: u32,
     }
-    impl Event for RecoveryMetrics {
+    impl<'a> Event for RecoveryMetrics<'a> {
         const NAME: &'static str = "recovery:metrics_updated";
     }
     #[derive(Clone, Debug)]
@@ -329,12 +329,12 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     #[doc = " Duplicate packet received"]
-    pub struct DuplicatePacket {
+    pub struct DuplicatePacket<'a> {
         pub packet_header: PacketHeader,
-        pub path_id: u64,
+        pub path: Path<'a>,
         pub error: DuplicatePacketError,
     }
-    impl Event for DuplicatePacket {
+    impl<'a> Event for DuplicatePacket<'a> {
         const NAME: &'static str = "transport:duplicate_packet";
     }
     #[derive(Clone, Debug)]
@@ -1285,22 +1285,22 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     #[doc = " Frame was received"]
-    pub struct FrameReceived {
+    pub struct FrameReceived<'a> {
         pub packet_header: PacketHeader,
-        pub path_id: u64,
+        pub path: Path<'a>,
         pub frame: Frame,
     }
-    impl IntoEvent<api::FrameReceived> for FrameReceived {
+    impl<'a> IntoEvent<api::FrameReceived<'a>> for FrameReceived<'a> {
         #[inline]
-        fn into_event(self) -> api::FrameReceived {
+        fn into_event(self) -> api::FrameReceived<'a> {
             let FrameReceived {
                 packet_header,
-                path_id,
+                path,
                 frame,
             } = self;
             api::FrameReceived {
                 packet_header: packet_header.into_event(),
-                path_id: path_id.into_event(),
+                path: path.into_event(),
                 frame: frame.into_event(),
             }
         }
@@ -1332,8 +1332,8 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     #[doc = " Recovery metrics updated"]
-    pub struct RecoveryMetrics {
-        pub path_id: u64,
+    pub struct RecoveryMetrics<'a> {
+        pub path: Path<'a>,
         pub min_rtt: Duration,
         pub smoothed_rtt: Duration,
         pub latest_rtt: Duration,
@@ -1343,11 +1343,11 @@ pub mod builder {
         pub congestion_window: u32,
         pub bytes_in_flight: u32,
     }
-    impl IntoEvent<api::RecoveryMetrics> for RecoveryMetrics {
+    impl<'a> IntoEvent<api::RecoveryMetrics<'a>> for RecoveryMetrics<'a> {
         #[inline]
-        fn into_event(self) -> api::RecoveryMetrics {
+        fn into_event(self) -> api::RecoveryMetrics<'a> {
             let RecoveryMetrics {
-                path_id,
+                path,
                 min_rtt,
                 smoothed_rtt,
                 latest_rtt,
@@ -1358,7 +1358,7 @@ pub mod builder {
                 bytes_in_flight,
             } = self;
             api::RecoveryMetrics {
-                path_id: path_id.into_event(),
+                path: path.into_event(),
                 min_rtt: min_rtt.into_event(),
                 smoothed_rtt: smoothed_rtt.into_event(),
                 latest_rtt: latest_rtt.into_event(),
@@ -1414,22 +1414,22 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     #[doc = " Duplicate packet received"]
-    pub struct DuplicatePacket {
+    pub struct DuplicatePacket<'a> {
         pub packet_header: PacketHeader,
-        pub path_id: u64,
+        pub path: Path<'a>,
         pub error: DuplicatePacketError,
     }
-    impl IntoEvent<api::DuplicatePacket> for DuplicatePacket {
+    impl<'a> IntoEvent<api::DuplicatePacket<'a>> for DuplicatePacket<'a> {
         #[inline]
-        fn into_event(self) -> api::DuplicatePacket {
+        fn into_event(self) -> api::DuplicatePacket<'a> {
             let DuplicatePacket {
                 packet_header,
-                path_id,
+                path,
                 error,
             } = self;
             api::DuplicatePacket {
                 packet_header: packet_header.into_event(),
-                path_id: path_id.into_event(),
+                path: path.into_event(),
                 error: error.into_event(),
             }
         }

--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -64,9 +64,9 @@ struct FrameSent {
 // This diverges a bit from the qlog spec, which prefers to log data as part of the
 // packet events.
 /// Frame was received
-struct FrameReceived {
+struct FrameReceived<'a> {
     packet_header: PacketHeader,
-    path_id: u64,
+    path: Path<'a>,
     frame: Frame,
 }
 
@@ -83,8 +83,8 @@ struct PacketLost<'a> {
 #[event("recovery:metrics_updated")]
 //= https://tools.ietf.org/id/draft-marx-qlog-event-definitions-quic-h3-02.txt#5.4.2
 /// Recovery metrics updated
-struct RecoveryMetrics {
-    path_id: u64,
+struct RecoveryMetrics<'a> {
+    path: Path<'a>,
     min_rtt: Duration,
     smoothed_rtt: Duration,
     latest_rtt: Duration,
@@ -118,9 +118,9 @@ struct ConnectionClosed {
 
 #[event("transport:duplicate_packet")]
 /// Duplicate packet received
-struct DuplicatePacket {
+struct DuplicatePacket<'a> {
     packet_header: PacketHeader,
-    path_id: u64,
+    path: Path<'a>,
     error: DuplicatePacketError,
 }
 

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -846,7 +846,12 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         if let Some((space, _status)) = self.space_manager.initial_mut() {
             let mut publisher = self.event_context.publisher(datagram.timestamp, subscriber);
 
-            let packet = space.validate_and_decrypt_packet(packet, path_id, &mut publisher)?;
+            let packet = space.validate_and_decrypt_packet(
+                packet,
+                path_id,
+                &self.path_manager[path_id],
+                &mut publisher,
+            )?;
 
             publisher.on_packet_received(event::builder::PacketReceived {
                 packet_header: event::builder::PacketHeader {
@@ -943,7 +948,12 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         if let Some((space, handshake_status)) = self.space_manager.handshake_mut() {
             let mut publisher = self.event_context.publisher(datagram.timestamp, subscriber);
 
-            let packet = space.validate_and_decrypt_packet(packet, path_id, &mut publisher)?;
+            let packet = space.validate_and_decrypt_packet(
+                packet,
+                path_id,
+                &self.path_manager[path_id],
+                &mut publisher,
+            )?;
 
             publisher.on_packet_received(event::builder::PacketReceived {
                 packet_header: event::builder::PacketHeader {
@@ -1043,8 +1053,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             let packet = space.validate_and_decrypt_packet(
                 packet,
                 datagram,
-                &self.path_manager.active_path().rtt_estimator,
                 path_id,
+                &self.path_manager[path_id],
                 &mut publisher,
             )?;
 

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -4,7 +4,7 @@
 use crate::{
     connection::{self, ConnectionTransmissionContext, ProcessingError},
     endpoint, path,
-    path::Path,
+    path::{path_event, Path},
     processed_packet::ProcessedPacket,
     recovery,
     space::{
@@ -81,6 +81,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
         &self,
         packet_number: PacketNumber,
         path_id: path::Id,
+        path: &path::Path<Config>,
         publisher: &mut Pub,
     ) -> bool {
         let packet_check = self.processed_packet_numbers.check(packet_number);
@@ -90,7 +91,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
                     packet_type: packet_number.into_event(),
                     version: Some(publisher.quic_version()),
                 },
-                path_id: path_id.into_event(),
+                path: path_event!(path, path_id),
                 error: error.into_event(),
             });
         }
@@ -314,12 +315,13 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
         &self,
         protected: ProtectedInitial<'a>,
         path_id: path::Id,
+        path: &path::Path<Config>,
         publisher: &mut Pub,
     ) -> Result<CleartextInitial<'a>, ProcessingError> {
         let packet_number_decoder = self.packet_number_decoder();
         let packet = protected.unprotect(&self.header_key, packet_number_decoder)?;
 
-        if self.is_duplicate(packet.packet_number, path_id, publisher) {
+        if self.is_duplicate(packet.packet_number, path_id, path, publisher) {
             return Err(ProcessingError::DuplicatePacket);
         }
 

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -2,8 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    connection, endpoint, path, path::Path, processed_packet::ProcessedPacket,
-    space::rx_packet_numbers::AckManager, transmission,
+    connection, endpoint, path,
+    path::{path_event, Path},
+    processed_packet::ProcessedPacket,
+    space::rx_packet_numbers::AckManager,
+    transmission,
 };
 use bytes::Bytes;
 use core::fmt;
@@ -594,12 +597,13 @@ pub trait PacketSpace<Config: endpoint::Config> {
                 .decode::<FrameMut>()
                 .map_err(transport::Error::from)?;
 
+            let path = &path_manager[path_id];
             publisher.on_frame_received(event::builder::FrameReceived {
                 packet_header: event::builder::PacketHeader {
                     packet_type: packet_number.into_event(),
                     version: Some(publisher.quic_version()),
                 },
-                path_id: path_id.into_event(),
+                path: path_event!(path, path_id),
                 frame: frame.into_event(),
             });
             match frame {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This pr replaces `path_id` with `Path`, which exposes more information about the Path such as connection_id and SocketAddress.

Note there are still two events: `FrameSent` and `ConnectionIdUpdated` that use path_id. There were too difficult to thread the path_manager into without a bigger refactor so I might tackel them in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
