### PR TITLE
Handle 4 byte IP_TOS ecn cmsgs

### DIFF
--- a/quic/s2n-quic-core/src/inet/ecn.rs
+++ b/quic/s2n-quic-core/src/inet/ecn.rs
@@ -77,6 +77,12 @@ impl Default for ExplicitCongestionNotification {
 impl ExplicitCongestionNotification {
     /// Create a ExplicitCongestionNotification from the ECN field in the IP header
     pub fn new(ecn_field: u8) -> Self {
+        debug_assert!(
+            ecn_field >> 2 == 0,
+            "{:#b} is not a valid ECN marking",
+            ecn_field
+        );
+
         match ecn_field & 0b11 {
             0b00 => ExplicitCongestionNotification::NotEct,
             0b01 => ExplicitCongestionNotification::Ect1,
@@ -89,5 +95,28 @@ impl ExplicitCongestionNotification {
     /// Returns true if congestion was experienced by the peer
     pub fn congestion_experienced(self) -> bool {
         self == Self::Ce
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn new() {
+        for ecn in &[
+            ExplicitCongestionNotification::NotEct,
+            ExplicitCongestionNotification::Ect1,
+            ExplicitCongestionNotification::Ect0,
+            ExplicitCongestionNotification::Ce,
+        ] {
+            assert_eq!(*ecn, ExplicitCongestionNotification::new(*ecn as u8));
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn invalid_ecn() {
+        ExplicitCongestionNotification::new(4);
     }
 }


### PR DESCRIPTION
*Issue #, if available:* #802

*Description of changes:* IP_TOS cmsgs, which contain the Explicit Congestion Notification marking from an IP header, are typically 1 byte in size, resulting in a `cmsg_len` of 17 bytes (16 bytes for the header and 1 byte for the data). In testing, however, occasionally the operating system would return a `cmsg_len` of 20 bytes, with a valid ECN marking contained within 4 bytes of data. To handle this case, this change will decode the ECN marking based on if the indicated `cmsg_len` is 17 or 20 (calculated using the `CMSG_LEN` macro.  A debug assertion is also added to `ExplicitCongestionNotification` to ensure we aren't trying to parse garbage data.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
