### PR TITLE
core: use sni new type for TLS trait

### DIFF
--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{crypto::CryptoSuite, transport};
+use crate::{application::Sni, crypto::CryptoSuite, transport};
 pub use bytes::{Bytes, BytesMut};
 use core::fmt::Debug;
 use s2n_codec::EncoderValue;
@@ -89,7 +89,7 @@ pub trait Endpoint: 'static + Sized + Send {
     fn new_client_session<Params: EncoderValue>(
         &mut self,
         transport_parameters: &Params,
-        sni: &[u8],
+        sni: Sni,
     ) -> Self::Session;
 
     /// The maximum length of a tag for any algorithm that may be negotiated

--- a/quic/s2n-quic-rustls/src/lib.rs
+++ b/quic/s2n-quic-rustls/src/lib.rs
@@ -463,7 +463,7 @@ pub mod server {
         fn new_client_session<Params: EncoderValue>(
             &mut self,
             _transport_parameters: &Params,
-            _sni: &[u8],
+            _sni: Sni,
         ) -> Self::Session {
             panic!("cannot create a client session from a server config");
         }
@@ -519,10 +519,10 @@ pub mod client {
         fn new_client_session<Params: EncoderValue>(
             &mut self,
             params: &Params,
-            sni: &[u8],
+            sni: Sni,
         ) -> Self::Session {
             let params = encode_transport_params(params);
-            let sni = DNSNameRef::try_from_ascii(sni).expect("sni hostname should be valid");
+            let sni = DNSNameRef::try_from_ascii_str(&*sni).expect("sni hostname should be valid");
             let session = rustls::ClientSession::new_quic(&self.config, sni, params);
             Self::Session::new(session)
         }
@@ -679,7 +679,7 @@ fn client_server_test() {
         .build()
         .unwrap();
 
-    let mut pair = tls::testing::Pair::new(&mut server, &mut client, b"localhost");
+    let mut pair = tls::testing::Pair::new(&mut server, &mut client, "localhost".into());
 
     while pair.is_handshaking() {
         pair.poll().unwrap();

--- a/quic/s2n-quic-tls/src/client.rs
+++ b/quic/s2n-quic-tls/src/client.rs
@@ -3,7 +3,7 @@
 
 use crate::{certificate::IntoCertificate, keylog::KeyLogHandle, params::Params, session::Session};
 use s2n_codec::EncoderValue;
-use s2n_quic_core::{crypto::tls, endpoint};
+use s2n_quic_core::{application::Sni, crypto::tls, endpoint};
 use s2n_tls::{
     config::{self, Config},
     error::Error,
@@ -109,12 +109,15 @@ impl tls::Endpoint for Client {
     fn new_client_session<Params: EncoderValue>(
         &mut self,
         params: &Params,
-        sni: &[u8],
+        sni: Sni,
     ) -> Self::Session {
         let config = self.config.clone();
         self.params.with(params, |params| {
             let mut session = Session::new(endpoint::Type::Client, config, params).unwrap();
-            session.connection.set_sni(sni).expect("invalid sni value");
+            session
+                .connection
+                .set_sni(sni.as_bytes())
+                .expect("invalid sni value");
             session
         })
     }

--- a/quic/s2n-quic-tls/src/server.rs
+++ b/quic/s2n-quic-tls/src/server.rs
@@ -8,7 +8,7 @@ use crate::{
     session::Session,
 };
 use s2n_codec::EncoderValue;
-use s2n_quic_core::{crypto::tls, endpoint};
+use s2n_quic_core::{application::Sni, crypto::tls, endpoint};
 use s2n_tls::{
     config::{self, Config},
     error::Error,
@@ -127,7 +127,7 @@ impl tls::Endpoint for Server {
     fn new_client_session<Params: EncoderValue>(
         &mut self,
         _transport_parameters: &Params,
-        _sni: &[u8],
+        _sni: Sni,
     ) -> Self::Session {
         panic!("cannot create a client session from a server config");
     }

--- a/quic/s2n-quic-tls/src/tests.rs
+++ b/quic/s2n-quic-tls/src/tests.rs
@@ -61,7 +61,7 @@ fn s2n_client_rustls_server_test() {
 
 /// Executes the handshake to completion
 fn run<S: Endpoint, C: Endpoint>(server: &mut S, client: &mut C) {
-    let mut pair = tls::testing::Pair::new(server, client, b"localhost");
+    let mut pair = tls::testing::Pair::new(server, client, "localhost".into());
 
     while pair.is_handshaking() {
         pair.poll().unwrap();


### PR DESCRIPTION
#849 added a SNI new type. This change changes the TLS trait to use it instead of `&[u8]`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
