### PR TITLE
Start paths on the client in the Validated state

### DIFF
--- a/quic/s2n-quic-transport/src/connection/close_sender.rs
+++ b/quic/s2n-quic-transport/src/connection/close_sender.rs
@@ -309,7 +309,7 @@ impl timer::Provider for Limiter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::path::testing::helper_path;
+    use crate::path::testing::helper_path_server;
     use s2n_quic_core::{
         event::testing::Publisher,
         io::tx::Message as _,
@@ -336,7 +336,7 @@ mod tests {
             .for_each(|(close_time, rtt, events, is_validated)| {
                 let mut sender = CloseSender::default();
                 let mut clock = Clock::default();
-                let mut path = helper_path();
+                let mut path = helper_path_server();
                 let mut buffer = [0; MINIMUM_MTU as usize];
                 let mut transmission_count = 0usize;
 

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -524,7 +524,7 @@ pub mod testing {
     use core::time::Duration;
     use s2n_quic_core::{connection, recovery::RttEstimator};
 
-    pub fn helper_path() -> Path<endpoint::testing::Server> {
+    pub fn helper_path_server() -> Path<endpoint::testing::Server> {
         Path::new(
             Default::default(),
             connection::PeerId::try_from_bytes(&[]).unwrap(),
@@ -572,7 +572,7 @@ mod tests {
     #[test]
     fn response_data_should_only_be_sent_once() {
         // Setup:
-        let mut path = testing::helper_path();
+        let mut path = testing::helper_path_server();
         let now = NoopClock {}.get_time();
 
         let mut frame_buffer = OutgoingFrameBuffer::new();
@@ -610,7 +610,7 @@ mod tests {
     #[test]
     fn on_timeout_should_set_challenge_to_none_on_challenge_abandonment() {
         // Setup:
-        let mut path = testing::helper_path();
+        let mut path = testing::helper_path_server();
         let helper_challenge = helper_challenge();
         let expiration_time = helper_challenge.now + helper_challenge.abandon_duration;
         path.set_challenge(helper_challenge.challenge);
@@ -645,7 +645,7 @@ mod tests {
     #[test]
     fn is_challenge_pending_should_return_false_if_challenge_is_not_set() {
         // Setup:
-        let mut path = testing::helper_path();
+        let mut path = testing::helper_path_server();
         let helper_challenge = helper_challenge();
 
         // Expectation:
@@ -663,7 +663,7 @@ mod tests {
     #[test]
     fn first_path_in_disabled_state_cant_fail_validation() {
         // Setup:
-        let path = testing::helper_path();
+        let path = testing::helper_path_server();
 
         // Expectation:
         assert!(path.challenge.is_disabled());
@@ -676,7 +676,7 @@ mod tests {
     #[test]
     fn failed_validation() {
         // Setup:
-        let mut path = testing::helper_path();
+        let mut path = testing::helper_path_server();
         let helper_challenge = helper_challenge();
 
         path.set_challenge(helper_challenge.challenge);
@@ -711,7 +711,7 @@ mod tests {
     #[test]
     fn abandon_challenge() {
         // Setup:
-        let mut path = testing::helper_path();
+        let mut path = testing::helper_path_server();
         let helper_challenge = helper_challenge();
         path.set_challenge(helper_challenge.challenge);
 
@@ -725,7 +725,7 @@ mod tests {
     #[test]
     fn on_path_challenge_should_set_reponse_data() {
         // Setup:
-        let mut path = testing::helper_path();
+        let mut path = testing::helper_path_server();
 
         // Expectation:
         assert!(!path.response_data.is_some());
@@ -746,7 +746,7 @@ mod tests {
     #[test]
     fn on_path_challenge_should_replace_reponse_data() {
         // Setup:
-        let mut path = testing::helper_path();
+        let mut path = testing::helper_path_server();
         let expected_data: [u8; 8] = [0; 8];
 
         // Trigger 1:
@@ -767,7 +767,7 @@ mod tests {
     #[test]
     fn validate_path_response_should_only_validate_if_challenge_is_set() {
         // Setup:
-        let mut path = testing::helper_path();
+        let mut path = testing::helper_path_server();
         let helper_challenge = helper_challenge();
 
         // Expectation:
@@ -784,7 +784,7 @@ mod tests {
     #[test]
     fn on_validated_should_change_state_to_validated_and_clear_challenge() {
         // Setup:
-        let mut path = testing::helper_path();
+        let mut path = testing::helper_path_server();
         let helper_challenge = helper_challenge();
         path.set_challenge(helper_challenge.challenge);
 
@@ -802,7 +802,7 @@ mod tests {
     #[test]
     fn on_validated_when_already_validated_does_nothing() {
         // Setup:
-        let mut path = testing::helper_path();
+        let mut path = testing::helper_path_server();
         path.set_challenge(helper_challenge().challenge);
         path.on_validated();
 
@@ -835,7 +835,7 @@ mod tests {
         //# adhere to the anti-amplification limits found in Section 8.1.
         // This tests the IP change because a new path is created when a new peer_address is
         // detected. This new path should always start in State::Pending.
-        let mut path = testing::helper_path();
+        let mut path = testing::helper_path_server();
 
         // Verify we enforce the amplification limit if we can't send
         // at least 1 minimum sized packet
@@ -922,7 +922,7 @@ mod tests {
             Mode::MtuProbing,
             Mode::LossRecoveryProbing,
         ] {
-            let mut path = testing::helper_path();
+            let mut path = testing::helper_path_server();
             // Verify we can transmit up to the mtu
             let mtu = path.mtu(transmission_mode);
 
@@ -952,7 +952,7 @@ mod tests {
 
     #[test]
     fn clamp_mtu_for_validated_path() {
-        let mut path = testing::helper_path();
+        let mut path = testing::helper_path_server();
         path.on_validated();
         let mtu = 1472;
         let probed_size = 1500;
@@ -978,7 +978,7 @@ mod tests {
 
     #[test]
     fn path_mtu() {
-        let mut path = testing::helper_path();
+        let mut path = testing::helper_path_server();
         path.on_bytes_received(1);
         let mtu = 1472;
         let probed_size = 1500;
@@ -1004,7 +1004,7 @@ mod tests {
 
     #[test]
     fn clamp_mtu_when_tx_more_than_rx() {
-        let mut path = testing::helper_path();
+        let mut path = testing::helper_path_server();
         let mtu = 1472;
         let probed_size = 1500;
         path.mtu_controller = mtu::testing::test_controller(mtu, probed_size);


### PR DESCRIPTION
*Issue #, if available:* #922

*Description of changes:* Since clients are not subject to anti-amplification limits, this change starts new paths on the client in the `Validated` state. Since validation also triggers the `mtu::Controller` to start probing (via the `on_validated` and `on_handshake_packet`) functions, and `on_handshake_packet` would be too early for the client to start probing, I added an `on_fully_validated` function that will start probing when both sides have validated the path. `on_validated` would presumably not be called for new paths the client creates during connection migration, so the `on_peer_validated` function also calls `on_fully_validated`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
