### PR TITLE
testing: add fuzz testing for path manager (connection migration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,13 @@ You'll need to have `cargo-bolero` installed first.
 See Bolero's [instructions](https://camshaft.github.io/bolero/cli-installation.html) to install.
 
 ```bash
-$ cargo bolero test varint -p s2n-quic-core -s address
+$ cargo bolero test varint -p s2n-quic-core -s address -T 30sec
 ```
 
 Test targets can be executed on stable by disabling the sanitzer:
 
 ```bash
-$ cargo bolero test varint -p s2n-quic-core -s NONE
+$ cargo bolero test varint -p s2n-quic-core -s NONE -T 30sec
 ```
 
 ### Testing all the things

--- a/quic/s2n-quic-core/src/connection/id.rs
+++ b/quic/s2n-quic-core/src/connection/id.rs
@@ -13,6 +13,9 @@ use core::{
 };
 use s2n_codec::{decoder_value, Encoder, EncoderValue};
 
+#[cfg(any(test, feature = "generator"))]
+use bolero_generator::*;
+
 //= https://tools.ietf.org/id/draft-ietf-quic-transport-32.txt#5.1
 //# Each connection possesses a set of connection identifiers, or
 //# connection IDs, each of which can identify the connection.
@@ -33,8 +36,10 @@ macro_rules! id {
     ($type:ident, $min_len:expr) => {
         /// Uniquely identifies a QUIC connection between 2 peers
         #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+        #[cfg_attr(any(feature = "generator", test), derive(TypeGenerator))]
         pub struct $type {
             bytes: [u8; MAX_LEN],
+            #[cfg_attr(any(feature = "generator", test), generator($min_len..=(MAX_LEN as u8)))]
             len: u8,
         }
 

--- a/quic/s2n-quic-core/src/frame/path_validation.rs
+++ b/quic/s2n-quic-core/src/frame/path_validation.rs
@@ -3,8 +3,12 @@
 
 use core::ops::{BitOr, BitOrAssign};
 
+#[cfg(any(test, feature = "generator"))]
+use bolero_generator::*;
+
 /// Describes if a frame is probing
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(any(feature = "generator", test), derive(TypeGenerator))]
 pub enum Probe {
     NonProbing,
     Probing,

--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -65,7 +65,7 @@ pub trait Handle: 'static + Copy + Send + fmt::Debug {
 
 macro_rules! impl_addr {
     ($name:ident) => {
-        #[derive(Clone, Copy, Debug, Default, Eq)]
+        #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
         #[cfg_attr(any(test, feature = "generator"), derive(TypeGenerator))]
         pub struct $name(pub SocketAddress);
 
@@ -87,13 +87,6 @@ macro_rules! impl_addr {
             #[inline]
             fn from(value: SocketAddressV6) -> Self {
                 Self(value.into())
-            }
-        }
-
-        impl PartialEq for $name {
-            #[inline]
-            fn eq(&self, other: &Self) -> bool {
-                self.0.eq(&other.0)
             }
         }
 

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -801,3 +801,6 @@ pub(crate) use path_event;
 
 #[cfg(test)]
 mod tests;
+
+#[cfg(test)]
+mod fuzz_target;

--- a/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
@@ -1,0 +1,336 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{tests::helper_path, *};
+use crate::{
+    connection::{ConnectionIdMapper, InternalConnectionIdGenerator},
+    endpoint::testing::Server as Config,
+    path,
+};
+use bolero::{check, generator::*};
+use core::time::Duration;
+use s2n_quic_core::{
+    connection::LocalId,
+    event::testing::Publisher,
+    frame::path_validation,
+    inet::{DatagramInfo, ExplicitCongestionNotification},
+    random,
+    random::testing::Generator,
+    time::{testing::Clock, Clock as _},
+};
+use std::collections::HashMap;
+
+type Manager = super::Manager<Config>;
+type Handle = path::RemoteAddress;
+
+/// Path information stored for modeling the path::Manager
+#[derive(Debug)]
+struct PathInfo {
+    state: path::State,
+    handle: Handle,
+}
+
+impl PathInfo {
+    pub fn new(path: Path<Config>) -> PathInfo {
+        PathInfo {
+            handle: path.handle,
+            state: path.state,
+        }
+    }
+
+    fn remote_address(&self) -> Handle {
+        self.handle
+    }
+
+    fn is_validated(&self) -> bool {
+        self.state == path::State::Validated
+    }
+}
+
+#[derive(Debug)]
+struct Oracle {
+    paths: HashMap<Handle, PathInfo>,
+    active: Handle,
+    last_known_validated_path: Option<u8>,
+}
+
+impl Oracle {
+    fn new(handle: Handle, path: PathInfo) -> Oracle {
+        let mut paths = HashMap::new();
+        paths.insert(handle, path);
+
+        Oracle {
+            paths,
+            active: handle,
+            last_known_validated_path: None,
+        }
+    }
+
+    fn get_active_path(&self) -> &PathInfo {
+        self.paths.get(&self.active).unwrap()
+    }
+
+    fn path(&mut self, handle: &Handle) -> Option<(&Handle, &mut PathInfo)> {
+        self.paths
+            .iter_mut()
+            .find(|(path_handle, _path)| path_handle == &handle)
+    }
+
+    /// Insert a new path while adhering to limits
+    fn insert_new_path(&mut self, new_handle: Handle, new_path: PathInfo) {
+        // We only store max of 4 paths because of limits imposed by Active cid limits
+        if self.paths.len() < 4 {
+            self.paths.insert(new_handle, new_path);
+        }
+    }
+
+    /// Insert new path if the remote address doesnt match any existing path
+    fn on_datagram_received(&mut self, handle: &Handle) {
+        match self.path(handle) {
+            Some(_path) => (),
+            None => {
+                let new_path = PathInfo {
+                    handle: *handle,
+                    state: path::State::Validated,
+                };
+
+                self.insert_new_path(*handle, new_path);
+            }
+        }
+    }
+
+    fn on_timeout(&self, _millis: &u16) {
+        // TODO implement
+        // call timeout on each Path
+        //
+        // if active path is not validated and validation failed
+        //   set the last_known_validated_path as active path
+    }
+
+    fn on_processed_packet(&mut self, handle: &Handle, probe: &path_validation::Probe) {
+        if !probe.is_probing() {
+            self.active = *handle;
+        }
+    }
+}
+
+#[derive(Debug, TypeGenerator)]
+enum Operation {
+    // on_datagram_received
+    // on_processed_packet
+    OnDatagramReceived {
+        /// Used for calling on_processed_packet
+        ///
+        /// `Some` implies that the packet was successfully processed
+        /// and that `on_processed_packet` should be called.
+        probing: Option<path_validation::Probe>,
+
+        /// The remote address from which the datagram was sent
+        handle: Handle,
+
+        /// The peer may switch the cid on the connection
+        local_id: LocalId,
+        // TODO enable
+        // ecn: ExplicitCongestionNotification,
+        // payload_len: u8,
+    },
+
+    // on_timeout
+    IncrementTime {
+        /// The milli-second value by which to increase the timestamp
+        millis: u16,
+    },
+}
+
+#[derive(Debug)]
+struct Model {
+    oracle: Oracle,
+    subject: Manager,
+
+    /// A monotonically increasing timestamp
+    timestamp: Timestamp,
+}
+
+impl Model {
+    pub fn new() -> Model {
+        let zero_conn_id = connection::PeerId::try_from_bytes(&[0]).unwrap();
+        let new_addr = Handle::default();
+        let oracle = {
+            let zero_path = PathInfo::new(helper_path(zero_conn_id));
+            Oracle::new(new_addr, zero_path)
+        };
+
+        let manager = {
+            let zero_path = helper_path(zero_conn_id);
+            let mut random_generator = random::testing::Generator(123);
+            let mut peer_id_registry =
+                ConnectionIdMapper::new(&mut random_generator, endpoint::Type::Server)
+                    .create_peer_id_registry(
+                        InternalConnectionIdGenerator::new().generate_id(),
+                        zero_path.peer_connection_id,
+                        None,
+                    );
+
+            // register 3 more ids which means a total of 4 paths. cid 0 is retired as part of
+            // on_new_connection_id call
+            for i in 1..=3 {
+                let cid = connection::PeerId::try_from_bytes(&[i]).unwrap();
+                let token = &[i; 16].into();
+                peer_id_registry
+                    .on_new_connection_id(&cid, i.into(), 0, token)
+                    .unwrap();
+            }
+
+            Manager::new(zero_path, peer_id_registry)
+        };
+
+        let clock = Clock::default();
+        Model {
+            oracle,
+            subject: manager,
+            timestamp: clock.get_time(),
+        }
+    }
+
+    pub fn apply(&mut self, operation: &Operation) {
+        match operation {
+            Operation::IncrementTime { millis } => self.on_timeout(millis),
+            Operation::OnDatagramReceived {
+                probing,
+                handle,
+                local_id,
+            } => self.on_datagram_received(handle, probing, *local_id),
+        }
+    }
+
+    fn on_timeout(&mut self, millis: &u16) {
+        // timestamp should be monotonically increasing
+        self.timestamp += Duration::from_millis(*millis as u64);
+
+        self.oracle.on_timeout(millis);
+
+        self.subject
+            .on_timeout(
+                self.timestamp,
+                &mut Generator::default(),
+                &mut Publisher::default(),
+            )
+            .unwrap();
+    }
+
+    fn on_datagram_received(
+        &mut self,
+        handle: &Handle,
+        probing: &Option<path_validation::Probe>,
+        local_id: LocalId,
+    ) {
+        let datagram = DatagramInfo {
+            timestamp: self.timestamp,
+            payload_len: 2000,
+            ecn: ExplicitCongestionNotification::NotEct,
+            destination_connection_id: local_id,
+        };
+        let mut migration_validator = path::migration::default::Validator;
+        let mut random_generator = Generator::default();
+        let mut publisher = Publisher::default();
+
+        match self.subject.on_datagram_received(
+            handle,
+            &datagram,
+            true,
+            &mut Default::default(),
+            &mut migration_validator,
+            MaxMtu::default(),
+            &mut publisher,
+        ) {
+            Ok(_) => {
+                self.oracle.on_datagram_received(handle);
+
+                if let Some(probe) = probing {
+                    self.oracle.on_processed_packet(handle, probe);
+
+                    let (path_id, _path) = self.subject.path(handle).unwrap();
+                    self.subject
+                        .on_processed_packet(path_id, *probe, &mut random_generator, &mut publisher)
+                        .unwrap();
+                }
+            }
+            Err(err) => {
+                // Ignore errors emitted by the migration::validator and peer_id_registry
+                let ignore_err = err.reason == "insufficient connection ids"
+                    || err.reason == "migration attempt denied";
+                if !ignore_err {
+                    panic!("{}", err)
+                }
+            }
+        }
+    }
+
+    /// Check that the subject and oracle match.
+    pub fn invariants(&self) {
+        // compare total paths
+        assert_eq!(self.oracle.paths.len(), self.subject.paths.len());
+
+        // compare active path
+        assert_eq!(
+            self.oracle.get_active_path().remote_address(),
+            self.subject.active_path().remote_address()
+        );
+
+        // compare last known valid path
+        assert_eq!(
+            self.oracle.last_known_validated_path,
+            self.subject.last_known_validated_path
+        );
+
+        // compare path properties
+        for (path_id, s_path) in self.subject.paths.iter().enumerate() {
+            let o_path = self.oracle.paths.get(&s_path.remote_address()).unwrap();
+
+            assert_eq!(
+                o_path.remote_address(),
+                s_path.remote_address(),
+                "path_id: {}",
+                path_id
+            );
+            assert_eq!(
+                o_path.is_validated(),
+                s_path.is_validated(),
+                "path_id: {}",
+                path_id
+            );
+
+            // TODO Enable other checks
+            // assert_eq!(o_path.state, s_path.state, "path_id: {}", path_id);
+            //
+            // assert_eq!(
+            //     o_path.is_challenge_pending(),
+            //     s_path.is_challenge_pending(),
+            //     "path_id: {}, {:?}",
+            //     path_id,
+            //     s_path
+            // );
+            //
+            // assert_eq!(
+            //     o_path.is_response_pending(),
+            //     s_path.is_response_pending(),
+            //     "path_id: {}",
+            //     path_id
+            // );
+        }
+    }
+}
+
+#[test]
+fn cm_model_test() {
+    check!()
+        .with_type::<Vec<Operation>>()
+        .for_each(|operations| {
+            let mut model = Model::new();
+            for operation in operations.iter() {
+                model.apply(operation);
+            }
+
+            model.invariants();
+        })
+}

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -1419,7 +1419,7 @@ fn temporary_until_authenticated() {
 
 // creates a test path_manager. also check out `helper_manager_with_paths`
 // which calls this helper with preset options
-fn helper_manager_with_paths_base(
+pub fn helper_manager_with_paths_base(
     register_second_conn_id: bool,
     validate_path_zero: bool,
 ) -> Helper {
@@ -1429,16 +1429,7 @@ fn helper_manager_with_paths_base(
     let zero_path_id = Id(0);
     let first_path_id = Id(1);
     let second_path_id = Id(2);
-    let local_conn_id = connection::LocalId::TEST_ID;
-    let mut zero_path = Path::new(
-        Default::default(),
-        zero_conn_id,
-        local_conn_id,
-        RttEstimator::new(Duration::from_millis(30)),
-        Default::default(),
-        false,
-        DEFAULT_MAX_MTU,
-    );
+    let mut zero_path = helper_path(zero_conn_id);
     if validate_path_zero {
         // simulate receiving a handshake packet to force path validation
         zero_path.on_handshake_packet();
@@ -1450,29 +1441,13 @@ fn helper_manager_with_paths_base(
     let expected_data = [0; 8];
     let challenge = challenge::Challenge::new(challenge_expiration, expected_data);
 
-    let mut first_path = Path::new(
-        Default::default(),
-        first_conn_id,
-        local_conn_id,
-        RttEstimator::new(Duration::from_millis(30)),
-        Default::default(),
-        false,
-        DEFAULT_MAX_MTU,
-    );
+    let mut first_path = helper_path(first_conn_id);
     first_path.set_challenge(challenge);
 
     // Create a challenge that will expire in 100ms
     let expected_data = [1; 8];
     let challenge = challenge::Challenge::new(challenge_expiration, expected_data);
-    let mut second_path = Path::new(
-        Default::default(),
-        second_conn_id,
-        local_conn_id,
-        RttEstimator::new(Duration::from_millis(30)),
-        Default::default(),
-        false,
-        DEFAULT_MAX_MTU,
-    );
+    let mut second_path = helper_path(second_conn_id);
     second_path.set_challenge(challenge);
 
     let mut random_generator = random::testing::Generator(123);
@@ -1542,11 +1517,24 @@ fn helper_manager_with_paths_base(
     }
 }
 
-fn helper_manager_with_paths() -> Helper {
+pub fn helper_path(peer_id: connection::PeerId) -> Path {
+    let local_conn_id = connection::LocalId::TEST_ID;
+    Path::new(
+        Default::default(),
+        peer_id,
+        local_conn_id,
+        RttEstimator::new(Duration::from_millis(30)),
+        Default::default(),
+        false,
+        DEFAULT_MAX_MTU,
+    )
+}
+
+pub fn helper_manager_with_paths() -> Helper {
     helper_manager_with_paths_base(true, true)
 }
 
-struct Helper {
+pub struct Helper {
     pub now: Timestamp,
     pub expected_data: challenge::Data,
     pub challenge_expiration: Duration,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a harness for fuzz testing the `path::Manager` (specifially logic around connection migration). This is not a comprehensive test of the path Manager but a good starting point. Take a look at the **Future testing** section below to see examples of other things we should add to this testing.

The fuzzer was run for approx 1hr locally without any errors.

**Future testing:**
- Sending and challenges validating
- Path state transitions (amplification limited/not limited and validated)
- Failing path validation
- etc

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
