### PR TITLE
codec: specialize on writing Bytes

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [features]
-default = ["std"]
+default = ["std", "bytes"]
 std = []
 testing = ["std", "generator"]
 checked_range_unsafe = []
@@ -15,5 +15,6 @@ generator = ["bolero-generator"]
 [dependencies]
 bolero-generator = { version = "0.6", default-features = false, optional = true }
 byteorder = { version = "1.1", default-features = false }
+bytes = { version = "1", default-features = false, optional = true }
 zerocopy = "0.6"
 zerocopy-derive = "0.3"

--- a/common/s2n-codec/src/encoder/mod.rs
+++ b/common/s2n-codec/src/encoder/mod.rs
@@ -12,6 +12,10 @@ pub use value::*;
 use core::convert::TryFrom;
 
 pub trait Encoder: Sized {
+    /// Set to `true` if the particular encoder specializes on the bytes implementation
+    #[cfg(feature = "bytes")]
+    const SPECIALIZES_BYTES: bool = false;
+
     /// Encode the given `EncoderValue` into the buffer
     #[inline]
     fn encode<T: EncoderValue>(&mut self, value: &T) {
@@ -34,6 +38,12 @@ pub trait Encoder: Sized {
 
     /// Copies the slice into the buffer
     fn write_slice(&mut self, slice: &[u8]);
+
+    #[cfg(feature = "bytes")]
+    #[inline]
+    fn write_bytes(&mut self, bytes: bytes::Bytes) {
+        self.write_slice(&bytes)
+    }
 
     /// Repeatedly write a byte `value` for a given `count`
     ///

--- a/common/s2n-codec/src/encoder/value.rs
+++ b/common/s2n-codec/src/encoder/value.rs
@@ -168,3 +168,47 @@ impl<T: EncoderValue> EncoderValue for Option<T> {
         }
     }
 }
+
+#[cfg(feature = "bytes")]
+impl EncoderValue for bytes::Bytes {
+    #[inline]
+    fn encode<E: Encoder>(&self, encoder: &mut E) {
+        if E::SPECIALIZES_BYTES {
+            encoder.write_bytes(self.clone())
+        } else {
+            encoder.write_slice(self)
+        }
+    }
+
+    #[inline]
+    fn encoding_size(&self) -> usize {
+        self.len()
+    }
+
+    #[inline]
+    fn encoding_size_for_encoder<E: Encoder>(&self, _encoder: &E) -> usize {
+        self.len()
+    }
+}
+
+#[cfg(feature = "bytes")]
+impl EncoderValue for &bytes::Bytes {
+    #[inline]
+    fn encode<E: Encoder>(&self, encoder: &mut E) {
+        if E::SPECIALIZES_BYTES {
+            encoder.write_bytes((*self).clone())
+        } else {
+            encoder.write_slice(self)
+        }
+    }
+
+    #[inline]
+    fn encoding_size(&self) -> usize {
+        self.len()
+    }
+
+    #[inline]
+    fn encoding_size_for_encoder<E: Encoder>(&self, _encoder: &E) -> usize {
+        self.len()
+    }
+}

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -15,7 +15,7 @@ futures-channel = { version = "0.3", default-features = false, features = ["allo
 futures-core = { version = "0.3", default-features = false, features = ["alloc"] }
 hashbrown = "0.11"
 intrusive-collections = "0.9"
-s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features = false }
+s2n-codec = { version = "0.1", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
 s2n-quic-core = { version = "0.1", path = "../s2n-quic-core", default-features = false }
 siphasher = "0.3"
 smallvec = { version = "1", default-features = false }


### PR DESCRIPTION
A large portion of our packets end with STREAM frames which always end in at least one `Bytes` slice. This means we're copying data out of this value into the target encoder buffer. A lot of time, this ends up being the large majority of the actual packet payload.

This PR adds some specialization to the codec crate. Instead of only having a `write_slice` method, we now have a `write_bytes` which allows the buffer to potentially take the slice without doing a deep copy.

In a later PR, I plan on adding a packet encoder that will store a single Bytes at the end. This encoder will be passed to the AEAD encrypt method, allowing implementations to avoid paying for the copy. Unfortunately ring only allows for a single contiguous slice so we will have to perform the copy anyway. But for the `s2n-quic-crypto` crate, we can take advantage of it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
