### PR TITLE
create a PathHandle from a RemoteAddress

### DIFF
--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -46,6 +46,9 @@ pub const INITIAL_PTO_BACKOFF: u32 = 1;
 
 /// An interface for an object that represents a unique path between two endpoints
 pub trait Handle: 'static + Copy + Send + fmt::Debug {
+    /// Creates a Handle from a RemoteAddress
+    fn from_remote_address(remote_addr: RemoteAddress) -> Self;
+
     /// Returns the remote address for the given handle
     fn remote_address(&self) -> RemoteAddress;
 
@@ -104,14 +107,12 @@ impl_addr!(LocalAddress);
 
 impl_addr!(RemoteAddress);
 
-impl RemoteAddress {
-    #[inline]
-    pub fn from_remote_address(remote_address: SocketAddress) -> Self {
-        Self(remote_address)
-    }
-}
-
 impl Handle for RemoteAddress {
+    #[inline]
+    fn from_remote_address(remote_address: RemoteAddress) -> Self {
+        remote_address
+    }
+
     #[inline]
     fn remote_address(&self) -> RemoteAddress {
         *self
@@ -140,17 +141,6 @@ pub struct Tuple {
     pub local_address: LocalAddress,
 }
 
-impl Tuple {
-    #[inline]
-    pub fn from_remote_address(remote_address: RemoteAddress) -> Self {
-        let local_address = SocketAddressV4::UNSPECIFIED.into();
-        Self {
-            remote_address,
-            local_address,
-        }
-    }
-}
-
 impl PartialEq for Tuple {
     #[inline]
     fn eq(&self, other: &Self) -> bool {
@@ -160,6 +150,15 @@ impl PartialEq for Tuple {
 }
 
 impl Handle for Tuple {
+    #[inline]
+    fn from_remote_address(remote_address: RemoteAddress) -> Self {
+        let local_address = SocketAddressV4::UNSPECIFIED.into();
+        Self {
+            remote_address,
+            local_address,
+        }
+    }
+
     #[inline]
     fn remote_address(&self) -> RemoteAddress {
         self.remote_address

--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -736,6 +736,7 @@ mod tests {
             rx::{self, Entry as _},
             tx,
         },
+        path::Handle as _,
         time::{Clock, Timestamp},
     };
     use std::collections::BTreeMap;

--- a/quic/s2n-quic-platform/src/message/msg.rs
+++ b/quic/s2n-quic-platform/src/message/msg.rs
@@ -34,15 +34,6 @@ pub struct Handle {
 
 impl Handle {
     #[inline]
-    pub fn from_remote_address(remote_address: RemoteAddress) -> Self {
-        Self {
-            remote_address,
-            #[cfg(s2n_quic_platform_pktinfo)]
-            local_address: SocketAddressV4::UNSPECIFIED.into(),
-        }
-    }
-
-    #[inline]
     fn with_ancillary_data(&mut self, ancillary_data: AncillaryData) {
         #[cfg(s2n_quic_platform_pktinfo)]
         {
@@ -92,6 +83,15 @@ impl Handle {
 }
 
 impl path::Handle for Handle {
+    #[inline]
+    fn from_remote_address(remote_address: RemoteAddress) -> Self {
+        Self {
+            remote_address,
+            #[cfg(s2n_quic_platform_pktinfo)]
+            local_address: SocketAddressV4::UNSPECIFIED.into(),
+        }
+    }
+
     #[inline]
     fn remote_address(&self) -> RemoteAddress {
         self.remote_address


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a `from_remote_address` fn to the path::Handle. This PR enables creation of a client Connection.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
