### PR TITLE
peg to openssl 1.1.1

### DIFF
--- a/tls/s2n-tls-sys/Cargo.toml
+++ b/tls/s2n-tls-sys/Cargo.toml
@@ -11,7 +11,7 @@ vendored = ["openssl-sys/vendored"]
 
 [dependencies]
 libc = "0.2"
-openssl-sys = { version = "0.9.68" } # Pin to this version until s2n-tls supports OpenSSL 3.0
+openssl-sys = { version = "<= 0.9.68" } # Pin to this version until s2n-tls supports OpenSSL 3.0
 
 [build-dependencies]
 bindgen = "0.59"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
s2n-quic depends on a vendored copy of openssl (openssl-src): `vendored = ["openssl-sys/vendored"]`

openssl-src just [bumped their version from 1.x to 3.x](https://github.com/sfackler/rust-openssl/commit/e5999ccf4a203fcbe41723923334ba18eaf1e159) and since s2n-tls is not compatible with 3.x we not break when attempting to build s2n-tls. 

This PR pegs the verison of openssl-sys

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
