### PR TITLE
Export rustls

### DIFF
--- a/quic/s2n-quic-rustls/src/lib.rs
+++ b/quic/s2n-quic-rustls/src/lib.rs
@@ -3,6 +3,8 @@
 
 #![forbid(unsafe_code)]
 
+pub use rustls::{self, Certificate, PrivateKey};
+
 mod ciphersuite;
 mod error;
 mod session;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change adds back the rustls export that was removed in #888


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
