### PR TITLE
ci: use source-based coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,6 +344,12 @@ jobs:
           command: llvm-cov
           args: --html --no-fail-fast --workspace --exclude s2n-quic-qns --exclude s2n-quic-events --exclude cargo-compliance --all-features
 
+      - uses: aws-actions/configure-aws-credentials@v1.5.11
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-1
+
       - name: Upload results
         id: s3
         run: |


### PR DESCRIPTION
We're currently not doing anything with our coverage reports. It's also using the gcov format which isn't as accurate as source-based coverage. 

This change uses the cargo-llvm-cov crate to generate coverage reports. Here's an example report:

https://dnglbrstg7yg.cloudfront.net/cc4aa41e7d4ca178496a7f28778122e9e0192f03/coverage/index.html

Eventually it would be nice to diff what's in main but that can be done later.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
