### PR TITLE
Use zero as the default error code in STOP_SENDING frames

### DIFF
--- a/quic/s2n-quic-core/src/application/error.rs
+++ b/quic/s2n-quic-core/src/application/error.rs
@@ -27,7 +27,7 @@ impl core::fmt::Debug for Error {
 impl Error {
     /// An error code that can be used when the application cannot provide
     /// a more meaningful code.
-    pub const UNKNOWN: Self = Self(VarInt::MAX);
+    pub const UNKNOWN: Self = Self(VarInt::from_u8(0));
 
     /// Creates an `ApplicationErrorCode` from an unsigned integer.
     ///


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* To improve interopability, this change uses 0 as the error code when a STOP_SENDING frame is automatically sent from s2n-quic, rather than VarInt::MAX. Some client implementations (such as Kwik) are not able to parse errors of the size VarInt::MAX (see https://github.com/ptrd/kwik/issues/4)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
