### PR TITLE
Remove kwik from required interop tests

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -211,7 +211,7 @@
   },
   "transferloss": {
     "aioquic": ["client"],
-    "kwik": ["client"],
+    "kwik": [],
     "lsquic": ["client"],
     "msquic": [],
     "mvfst": ["client"],
@@ -239,7 +239,7 @@
   },
   "transfercorruption": {
     "aioquic": ["client"],
-    "kwik": ["client"],
+    "kwik": [],
     "lsquic": ["client"],
     "msquic": [],
     "mvfst": ["client"],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The Kwik client sends invalid `RETIRE_CONNECTION_ID` frames (see https://github.com/ptrd/kwik/issues/13) during interop testing. This change removes Kwik from the list of required successful interop tests. Once Kwik fixes this, it can be re-added.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
