### PR TITLE
qns: resolve full requests with DNS

### DIFF
--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -19,3 +19,4 @@ structopt = "0.3"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+url = "2"

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1100,8 +1100,10 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 &mut publisher,
             )?;
 
-            // Currently, the application space does not have any crypto state.
-            // If, at some point, we decide to add it, we need to call `update_crypto_state` here.
+            // Make progress on the handshake if we're the client
+            if Config::ENDPOINT_TYPE.is_client() && self.is_handshaking() {
+                self.update_crypto_state(datagram.timestamp, subscriber)?;
+            }
 
             // notify the connection a packet was processed
             self.on_processed_packet(datagram.timestamp);


### PR DESCRIPTION
The interop runner passes full URLs and not just paths. This change implements URL parsing and resolves DNS hosts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
