### PR TITLE
qns: fix multiconnect server tests

### DIFF
--- a/quic/s2n-quic-qns/src/server/interop.rs
+++ b/quic/s2n-quic-qns/src/server/interop.rs
@@ -213,8 +213,7 @@ fn is_supported_testcase(testcase: Testcase) -> bool {
         ZeroRtt => false,
         // TODO integrate a H3 implementation
         Http3 => false,
-        // Multiconnect is client only
-        Multiconnect => false,
+        Multiconnect => true,
         Ecn => true,
         ConnectionMigration => true,
     }


### PR DESCRIPTION
In #956 I misread the quic-interop-runner code and assumed `multiconnect` was never passed to the server. This is incorrect [as seen in the CI](https://github.com/awslabs/s2n-quic/runs/4148281841?check_suite_focus=true#step:14:3112). This change fixes this mistake and returns `true` for the test case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
