### PR TITLE
crypto: optimize block ct_eq

### DIFF
--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -17,7 +17,6 @@ cfg-if = "1"
 lazy_static = "1"
 ghash = { version = "0.4", optional = true }
 ring = { version = "0.16", default-features = false, optional = true }
-subtle = { version = "2", default-features = false }
 
 [dev-dependencies]
 aes = "0.7"

--- a/quic/s2n-quic-crypto/src/block.rs
+++ b/quic/s2n-quic-crypto/src/block.rs
@@ -10,6 +10,7 @@ pub trait Block: Copy + Zeroed {
     fn from_array(array: [u8; LEN]) -> Self;
     fn into_array(self) -> [u8; LEN];
     fn xor(self, other: Self) -> Self;
+    fn ct_ensure_eq(self, b: Self) -> Result<(), ()>;
 }
 
 pub trait Batch {


### PR DESCRIPTION
In the AES-GCM implementation, we are currently using subtle to perform the tag check after decrypting a payload. The [generated code for this](https://gist.github.com/camshaft/ab08bf814f7dda3175c55eddd11988b5) is _very_ slow, unfortunately.

I talked to @SalusaSecondus, @Shay-Gueron, and @dkostic and played around a bit with a few implementations and came up with this new implementation, which results in a 20% increase in throughput over the subtle usage for 96 block-sized payloads, which puts us at the same level of efficiency as the encryption side of things.

### Benchmark comparison

![new-ct](https://user-images.githubusercontent.com/799311/141097342-6c95b4eb-ac31-42b5-b5a8-74e0a71d850b.png)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
