### PR TITLE
platform: fix sending messages with empty cmsg buffers

### DIFF
--- a/quic/s2n-quic-platform/src/message/cmsg.rs
+++ b/quic/s2n-quic-platform/src/message/cmsg.rs
@@ -49,10 +49,10 @@ pub trait Encoder {
 impl Encoder for libc::msghdr {
     fn encode_cmsg<T: Copy + ?Sized>(&mut self, level: libc::c_int, ty: libc::c_int, value: T) {
         unsafe {
-            // If it's equal to the max len it means it's empty so reset it to 0
-            if self.msg_controllen as usize == MAX_LEN {
-                self.msg_controllen = 0;
-            }
+            debug_assert_ne!(
+                self.msg_controllen as usize, MAX_LEN,
+                "msg_controllen should be reset when encoding a msg"
+            );
 
             let cmsg =
                 // Safety: the msg_control buffer should always be allocated to MAX_LEN

--- a/quic/s2n-quic-platform/src/message/msg.rs
+++ b/quic/s2n-quic-platform/src/message/msg.rs
@@ -45,6 +45,9 @@ impl Handle {
 
     #[inline]
     pub(crate) fn update_msg_hdr(self, msghdr: &mut msghdr) {
+        // when sending a packet, we start out with no cmsg items
+        msghdr.msg_controllen = 0;
+
         msghdr.set_remote_address(&self.remote_address.0);
 
         #[cfg(s2n_quic_platform_pktinfo)]


### PR DESCRIPTION
In the platform crate, we use the same message type for both sending and receiving datagrams. This means that we don't know how a message is going to be used until it is either written to in user space or passed to the kernel for writing. When we write to a cmsg buffer in the user space, we want to start with `msg_controllen = 0`. When we pass it to the kernel it should be `msg_controllen = cmsg::MAX_LEN`.

Today we have a bug where if we don't write any cmsg data when sending a packet, then we don't set the `msg_controllen = 0`, which means the kernel sees a bunch of garbage data and doesn't know what to do with it.

This change adds a debug assert to catch this in the future and moves the `msg_controllen = 0` to a common function to ensure when we start writing to a packet it's correctly initialized.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
