### PR TITLE
interop: fix interop diff report for client

### DIFF
--- a/.github/interop/merge.py
+++ b/.github/interop/merge.py
@@ -233,9 +233,8 @@ if args.prev_version:
             break
 
     for impl in out['all_impls']:
-        pair_results = []
-
         if 'server' in out["results_diff"]:
+            pair_results = []
             for test in sorted(tests.keys()):
                 server_diff = results_diff.get(impl, {}).get(S2N_QUIC, {}).get(test)
                 if server_diff:
@@ -249,6 +248,7 @@ if args.prev_version:
             out["results_diff"]["server"].append(pair_results)
 
         if 'client' in out["results_diff"]:
+            pair_results = []
             for test in sorted(tests.keys()):
                 client_diff = results_diff.get(S2N_QUIC, {}).get(impl, {}).get(test)
                 if client_diff:

--- a/.github/interop/script.js
+++ b/.github/interop/script.js
@@ -394,7 +394,7 @@
         $("#client").append(result.clients.map(e => makeButton("client", e)));
         $("#server").append(result.servers.map(e => makeButton("server", e)));
         if (result.hasOwnProperty("tests"))
-            $("#test").append(Object.keys(result.tests).map(e => makeButton("test", e, makeTooltip(result.tests[e].name, result.tests[e].desc))));
+        $("#test").append(Object.keys(result.tests).map(e => makeButton("test", e, makeTooltip(result.tests[e].name, result.tests[e].desc))));
         else {
             // TODO: this else can eventually be removed, when all past runs have the test descriptions in the json
             const tcases = result.results.concat(result.measurements).flat().map(x => [x.abbr, x.name]).filter((e, i, a) => a.map(x => x[0]).indexOf(e[0]) === i);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change fixes the interop diff report to show the correct diff for the client

<img width="568" alt="Screen Shot 2021-11-12 at 9 44 26 AM" src="https://user-images.githubusercontent.com/55108558/141511465-e72c25f2-a2a7-4035-a6f1-134ea3631050.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
