### PR TITLE
qns: bump cert chain depth limits

### DIFF
--- a/quic/s2n-quic-qns/src/client/interop.rs
+++ b/quic/s2n-quic-qns/src/client/interop.rs
@@ -155,6 +155,8 @@ impl Interop {
 
         let tls = s2n_quic::provider::tls::default::Client::builder()
             .with_certificate(ca)?
+            // the "amplificationlimit" tests generates a very large chain so bump the limit
+            .with_max_cert_chain_depth(10)?
             .with_alpn_protocols(self.alpn_protocols.iter().map(String::as_bytes))?
             .with_key_logging()?
             .build()?;

--- a/quic/s2n-quic-rustls/src/client.rs
+++ b/quic/s2n-quic-rustls/src/client.rs
@@ -113,6 +113,12 @@ impl Builder {
         Ok(self)
     }
 
+    pub fn with_max_cert_chain_depth(self, len: u16) -> Result<Self, rustls::Error> {
+        // TODO is there a way to configure this?
+        let _ = len;
+        Ok(self)
+    }
+
     pub fn with_alpn_protocols<P: Iterator<Item = I>, I: AsRef<[u8]>>(
         mut self,
         protocols: P,

--- a/quic/s2n-quic-tls/src/client.rs
+++ b/quic/s2n-quic-tls/src/client.rs
@@ -70,6 +70,11 @@ impl Builder {
         Ok(self)
     }
 
+    pub fn with_max_cert_chain_depth(mut self, len: u16) -> Result<Self, Error> {
+        self.config.set_max_cert_chain_depth(len)?;
+        Ok(self)
+    }
+
     pub fn with_key_logging(mut self) -> Result<Self, Error> {
         use crate::keylog::KeyLog;
 

--- a/scripts/interop/run
+++ b/scripts/interop/run
@@ -63,4 +63,4 @@ case "$@" in
      ;;
 esac
 
-python3 run.py --server s2n-quic --debug "$@"
+python3 run.py --debug "$@"

--- a/tls/s2n-tls/src/config.rs
+++ b/tls/s2n-tls/src/config.rs
@@ -66,6 +66,14 @@ impl Builder {
         Ok(self)
     }
 
+    pub fn set_max_cert_chain_depth(&mut self, depth: u16) -> Result<&mut Self, Error> {
+        call!(s2n_config_set_max_cert_chain_depth(
+            self.as_mut_ptr(),
+            depth
+        ))?;
+        Ok(self)
+    }
+
     pub fn set_cipher_preference(&mut self, name: &str) -> Result<&mut Self, Error> {
         let name = CString::new(name).map_err(|_| Error::InvalidInput)?;
         call!(s2n_config_set_cipher_preferences(


### PR DESCRIPTION
The interop runner generates a cert chain of 9 when testing amplification limits. This becomes a problem with s2n-tls defaulting to only allow a depth of 7.

This change adds a method to configure the max cert chain depth and calls it in the interop qns app.

https://dnglbrstg7yg.cloudfront.net/6e9bb7351f4d445aad3e5e8369748533019507e4/interop/index.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
