### PR TITLE
ci: dedupe and sort interop pairs

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -67,7 +67,7 @@ jobs:
             | jq -c '[. | to_entries[] | select(.value.role == "both" or .value.role == "server") | {"client": "s2n-quic", "server": .key}] | sort'
           )
           echo "Servers: $SERVERS"
-          MATRIX=$(echo "[$CLIENTS, $SERVERS]" | jq -c '{"include": . | flatten}')
+          MATRIX=$(echo "[$CLIENTS, $SERVERS]" | jq -c '{"include": . | flatten | sort | unique}')
           echo "Matrix: $MATRIX"
           echo "::set-output name=matrix::$MATRIX"
 


### PR DESCRIPTION
After adding s2n-quic tests, we actually run the s2n-quic <> s2n-quic [tests twice in interop](https://github.com/awslabs/s2n-quic/runs/4194371227?check_suite_focus=true#step:7:29). This change sorts and de-duplicates all of the pairs, instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
