### PR TITLE
platform: check if the cmsg returned by CMSG_NXTHDR points to the previous cmsg

### DIFF
--- a/quic/s2n-quic-platform/src/message/cmsg.rs
+++ b/quic/s2n-quic-platform/src/message/cmsg.rs
@@ -242,8 +242,10 @@ impl<'a> Iterator for Iter<'a> {
         // in the buffer.
         self.cmsghdr =
             unsafe { libc::CMSG_NXTHDR(self.msghdr, current).as_ref() }.filter(|cmsghdr| {
-                // make sure we have a length, otherwise it'll loop forever
-                cmsghdr.cmsg_len > 0
+                // CMSG_NXTHDR on some operating systems returns the previous pointer when its
+                // length is zero, so check if the previous pointer is the same as
+                // the current one. Also check if the length is zero, otherwise it'll loop forever.
+                cmsghdr.cmsg_len > 0 && !core::ptr::eq(*cmsghdr, current)
             });
         Some(current)
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* According to [rust-lang](https://github.com/rust-lang/rust/blob/68b554e6af18726fe6fa8de2134c59c441e0b019/library/std/src/os/unix/net/ancillary.rs#L125-L130), on some operating systems, `CMSG_NXTHDR` returns the previous pointer when the cmsg length is zero. While this doesn't actually seem to effect Rust as `libc::CMSG_NXTHDR` is just [implemented](https://github.com/rust-lang/libc/blob/8c6b63463f02d7fa6f410ded2bf600329053796e/src/unix/bsd/apple/mod.rs#L4631-L4645) as a Rust function and does not call the operating system, we can still add a check just in case this changes in the future.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
