### PR TITLE
interop: print the file path when a file cannot be opened

### DIFF
--- a/quic/s2n-quic-qns/src/server/interop.rs
+++ b/quic/s2n-quic-qns/src/server/interop.rs
@@ -123,6 +123,7 @@ impl Interop {
                 match file.next().await {
                     Some(Ok(chunk)) => tx_stream.send(chunk).await?,
                     Some(Err(err)) => {
+                        eprintln!("error opening {:?}", abs_path);
                         tx_stream.reset(1u32.try_into()?)?;
                         return Err(err.into());
                     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* When the interop test fails to open a file, it does not currently log which file it was attempting to open. This change adds a message when a file fails to open to assist with debugging interop failures.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
