### PR TITLE
Remove prompt from README commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ rustup toolchain install nightly
 
 ```sh
 # Initialize the project's submodules
-$ git submodule update --init
+git submodule update --init
 ```
 
 ### Running a fuzz target
@@ -49,13 +49,13 @@ You'll need to have `cargo-bolero` installed first.
 See Bolero's [instructions](https://camshaft.github.io/bolero/cli-installation.html) to install.
 
 ```bash
-$ cargo bolero test varint -p s2n-quic-core -T 30sec --toolchain nightly-2021-09-12 -s address
+cargo bolero test varint -p s2n-quic-core -T 30sec --toolchain nightly-2021-09-12 -s address
 ```
 
 Test targets can be executed on stable by disabling the sanitzer:
 
 ```bash
-$ cargo bolero test varint -p s2n-quic-core -s NONE -T 30sec
+cargo bolero test varint -p s2n-quic-core -s NONE -T 30sec
 ```
 
 ```bash


### PR DESCRIPTION
*Description of changes:*
Most commands in QUIC READMEs don't include the prompt, but these do. If you're just copy/pasting commands to set up a new environment, it's annoying.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
