### PR TITLE
transport: drop packets when non-zero length retry token is received by client

### DIFF
--- a/quic/s2n-quic-core/src/connection/error.rs
+++ b/quic/s2n-quic-core/src/connection/error.rs
@@ -255,6 +255,7 @@ pub enum ProcessingError {
     DuplicatePacket,
     ConnectionError(Error),
     CryptoError(CryptoError),
+    NonEmptyRetryToken,
 }
 
 impl From<Error> for ProcessingError {

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -222,6 +222,8 @@ pub mod api {
         },
         #[non_exhaustive]
         DecodingFailed { path: Path<'a> },
+        #[non_exhaustive]
+        NonEmptyRetryToken { path: Path<'a> },
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
@@ -1873,6 +1875,9 @@ pub mod builder {
         DecodingFailed {
             path: Path<'a>,
         },
+        NonEmptyRetryToken {
+            path: Path<'a>,
+        },
     }
     impl<'a> IntoEvent<api::PacketDropReason<'a>> for PacketDropReason<'a> {
         #[inline]
@@ -1905,6 +1910,9 @@ pub mod builder {
                     packet_header: packet_header.into_event(),
                 },
                 Self::DecodingFailed { path } => DecodingFailed {
+                    path: path.into_event(),
+                },
+                Self::NonEmptyRetryToken { path } => NonEmptyRetryToken {
                     path: path.into_event(),
                 },
             }

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -548,10 +548,7 @@ enum PacketDropReason<'a> {
         path: Path<'a>,
     },
     /// There was a failure when attempting to remove header protection.
-    UnprotectFailed {
-        space: KeySpace,
-        path: Path<'a>,
-    },
+    UnprotectFailed { space: KeySpace, path: Path<'a> },
     /// There was a failure when attempting to decrypt the packet.
     DecryptionFailed {
         path: Path<'a>,
@@ -562,6 +559,8 @@ enum PacketDropReason<'a> {
     /// The payload is decoded one packet at a time. If decoding fails
     /// then the remaining packets are also discarded.
     DecodingFailed { path: Path<'a> },
+    /// The client received a non-empty retry token.
+    NonEmptyRetryToken { path: Path<'a> },
 }
 
 enum MigrationDenyReason {

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -294,6 +294,11 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                         debug_assert!(false, "got duplicate packet error on first packet");
                         transport::Error::INTERNAL_ERROR.into()
                     }
+                    // this error is only raised by the client
+                    ProcessingError::NonEmptyRetryToken => {
+                        debug_assert!(false, "got non empty retry token error on server");
+                        transport::Error::INTERNAL_ERROR.into()
+                    }
                 }
             })?;
 

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -545,6 +545,16 @@ impl<Cfg: Config> Endpoint<Cfg> {
                         ProcessingError::DuplicatePacket => {
                             // We discard duplicate packets
                         }
+                        ProcessingError::NonEmptyRetryToken => {
+                            //= https://www.rfc-editor.org/rfc/rfc9000.txt#17.2.2
+                            //# Initial packets sent by the server MUST set the Token Length field
+                            //# to 0; clients that receive an Initial packet with a non-zero Token
+                            //# Length field MUST either discard the packet or generate a
+                            //# connection error of type PROTOCOL_VIOLATION.
+                            // We discard server initials with non empty retry tokens instead of closing
+                            // the connection to prevent an attacker that can spoof initial packets
+                            // from gaining the ability to close a connection by setting a retry token.
+                        }
                         ProcessingError::ConnectionError(err) => {
                             conn.close(
                                 err,

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -358,11 +358,12 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
             //# to 0; clients that receive an Initial packet with a non-zero Token
             //# Length field MUST either discard the packet or generate a
             //# connection error of type PROTOCOL_VIOLATION.
-            return Err(transport::Error::PROTOCOL_VIOLATION
-                .with_reason(
-                    "initial packets sent by the server MUST set the Token Length field to 0",
-                )
-                .into());
+            publisher.on_packet_dropped(event::builder::PacketDropped {
+                reason: event::builder::PacketDropReason::NonEmptyRetryToken {
+                    path: path_event!(path, path_id),
+                },
+            });
+            return Err(ProcessingError::NonEmptyRetryToken);
         }
 
         Ok(decrypted)


### PR DESCRIPTION
*Issue #, if available:* #1009

*Description of changes:*  

> Initial packets sent by the server MUST set the Token Length field to 0; clients that receive an Initial packet with a non-zero Token Length field MUST either discard the packet or generate a connection error of type PROTOCOL_VIOLATION.
 
This change will validate the retry token is empty after the initial packet is decrypted.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
