### PR TITLE
client: store and process the first Retry Packet

### DIFF
--- a/quic/s2n-quic-core/src/connection/error.rs
+++ b/quic/s2n-quic-core/src/connection/error.rs
@@ -253,6 +253,8 @@ impl From<Error> for std::io::ErrorKind {
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ProcessingError {
     DuplicatePacket,
+    /// Received a Retry packet with SCID field equal to DCID field.
+    RetryScidEqualsDcid,
     ConnectionError(Error),
     CryptoError(CryptoError),
     NonEmptyRetryToken,

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -214,6 +214,8 @@ pub mod api {
             path: Path<'a>,
         },
         #[non_exhaustive]
+        RetryScidEqualsDcid { path: Path<'a>, cid: &'a [u8] },
+        #[non_exhaustive]
         UnprotectFailed { space: KeySpace, path: Path<'a> },
         #[non_exhaustive]
         DecryptionFailed {
@@ -1864,6 +1866,10 @@ pub mod builder {
             packet_cid: &'a [u8],
             path: Path<'a>,
         },
+        RetryScidEqualsDcid {
+            path: Path<'a>,
+            cid: &'a [u8],
+        },
         UnprotectFailed {
             space: KeySpace,
             path: Path<'a>,
@@ -1897,6 +1903,10 @@ pub mod builder {
                 Self::ConnectionIdMismatch { packet_cid, path } => ConnectionIdMismatch {
                     packet_cid: packet_cid.into_event(),
                     path: path.into_event(),
+                },
+                Self::RetryScidEqualsDcid { path, cid } => RetryScidEqualsDcid {
+                    path: path.into_event(),
+                    cid: cid.into_event(),
                 },
                 Self::UnprotectFailed { space, path } => UnprotectFailed {
                     space: space.into_event(),

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -547,6 +547,8 @@ enum PacketDropReason<'a> {
         packet_cid: &'a [u8],
         path: Path<'a>,
     },
+    /// Received a Retry packet with SCID field equal to DCID field.
+    RetryScidEqualsDcid { path: Path<'a>, cid: &'a [u8] },
     /// There was a failure when attempting to remove header protection.
     UnprotectFailed { space: KeySpace, path: Path<'a> },
     /// There was a failure when attempting to decrypt the packet.

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -299,6 +299,14 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                         debug_assert!(false, "got non empty retry token error on server");
                         transport::Error::INTERNAL_ERROR.into()
                     }
+                    // this error is only emitted when processing a Retry packet
+                    ProcessingError::RetryScidEqualsDcid => {
+                        debug_assert!(
+                            false,
+                            "got a Retry packet error while processing an Initial packet"
+                        );
+                        transport::Error::INTERNAL_ERROR.into()
+                    }
                 }
             })?;
 

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -551,9 +551,17 @@ impl<Cfg: Config> Endpoint<Cfg> {
                             //# to 0; clients that receive an Initial packet with a non-zero Token
                             //# Length field MUST either discard the packet or generate a
                             //# connection error of type PROTOCOL_VIOLATION.
+                            //
                             // We discard server initials with non empty retry tokens instead of closing
                             // the connection to prevent an attacker that can spoof initial packets
                             // from gaining the ability to close a connection by setting a retry token.
+                        }
+                        ProcessingError::RetryScidEqualsDcid => {
+                            //= https://www.rfc-editor.org/rfc/rfc9000.txt#17.2.5.1
+                            //# A client MUST
+                            //# discard a Retry packet that contains a Source Connection ID field
+                            //# that is identical to the Destination Connection ID field of its
+                            //# Initial packet.
                         }
                         ProcessingError::ConnectionError(err) => {
                             conn.close(

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -541,6 +541,11 @@ impl<Config: endpoint::Config> Manager<Config> {
         random_generator: &mut Config::RandomGenerator,
         publisher: &mut Pub,
     ) -> Result<(), transport::Error> {
+        //= https://www.rfc-editor.org/rfc/rfc9000.txt#7.2
+        //# A client MUST change the Destination Connection ID it uses for
+        //# sending packets in response to only the first received Initial or
+        //# Retry packet.
+        //
         // A QUIC client uses a randomly generated value as the Initial Connection Id
         // until it receives a packet from the Server. Upon receiving a Server packet,
         // the Client switches to using the new Destination Connection Id. The


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
> Computing the server's first flight for a full handshake is
   potentially expensive, requiring both a signature and a key exchange
   computation.  In order to prevent computational DoS attacks, the
   Retry packet provides a cheap token exchange mechanism that allows
   servers to validate a client's IP address prior to doing any
   expensive computations at the cost of a single round trip.

This PR adds Client-side handling for Retry packets.

Specifically this PR does the following:
- Store Retry info, which can then be used for validation and sending.
- Change DCID used to send Initial packets
- Validate that only one Retry packet is processed
- Check that SCID field is not equal to DCID field
  - Adds a packet drop event for this scenario
- Updates TLS keys using the new DCID

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
