### PR TITLE
ci: ignore clippy failures on other toolchains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         toolchain: [stable, beta]
     steps:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR sets `fail-fast` to false for the Clippy CI job

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
