### PR TITLE
transport: drop datagrams when the source connection ID has changed from the Initial packet

### DIFF
--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -219,13 +219,11 @@ impl<Config: endpoint::Config> Manager<Config> {
         let valid_initial_received = self.valid_initial_received();
 
         if let Some((id, path)) = self.path_mut(path_handle) {
-            let source_cid_changed =
-                |scid| scid != path.peer_connection_id && valid_initial_received;
+            let source_cid_changed = datagram.source_connection_id.map_or(false, |scid| {
+                scid != path.peer_connection_id && valid_initial_received
+            });
 
-            if datagram
-                .source_connection_id
-                .map_or(false, source_cid_changed)
-            {
+            if source_cid_changed {
                 //= https://www.rfc-editor.org/rfc/rfc9000.txt#7.2
                 //# Once a client has received a valid Initial packet from the server, it MUST
                 //# discard any subsequent packet it receives on that connection with a


### PR DESCRIPTION
*Issue #, if available:* #1009

*Description of changes:* From https://www.rfc-editor.org/rfc/rfc9000.txt#7.2:

>  Once a client has received a valid Initial packet from the server, it MUST discard any subsequent packet it receives on that connection with a different Source Connection ID.

> Any further changes to the Destination Connection ID are only permitted if the values are taken from NEW_CONNECTION_ID frames; if subsequent Initial packets include a different Source Connection ID, they MUST be discarded.

This change will drop datagrams when any packet received after a valid Initial packet has changed the Source Connection ID. 

*Call outs:* The second RFC requirement above mentions **Initial** packets with a different Source Connection ID, whereas this change will drop **any** packet with a different Source Connection ID, since I don't believe a Handshake packet could change Source Connection IDs either. Short packets do not have a Source Connection IDs, so they are not effected.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
