### PR TITLE
client: discard Retry packets after a valid Initial has been processed

### DIFF
--- a/quic/s2n-quic-core/src/packet/retry.rs
+++ b/quic/s2n-quic-core/src/packet/retry.rs
@@ -248,7 +248,7 @@ impl<'a> Retry<'a> {
     }
 
     #[inline]
-    pub fn pseudo_packet(&self, odcid: &'a [u8]) -> PseudoRetry {
+    fn pseudo_packet(&self, odcid: &'a [u8]) -> PseudoRetry {
         PseudoRetry {
             original_destination_connection_id: odcid,
             tag: self.tag,

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -531,7 +531,7 @@ enum KeySpace {
 }
 
 enum PacketDropReason<'a> {
-    /// A connection error occured and is no longer able to process packets.
+    /// A connection error occurred and is no longer able to process packets.
     ConnectionError { path: Path<'a> },
     /// The handshake needed to be complete before processing the packet.
     ///
@@ -542,13 +542,11 @@ enum PacketDropReason<'a> {
     /// during the handshake.
     VersionMismatch { version: u32, path: Path<'a> },
     /// A datagram contained more than one destination connection ID, which is
-    /// unallowed.
+    /// not allowed.
     ConnectionIdMismatch {
         packet_cid: &'a [u8],
         path: Path<'a>,
     },
-    /// Received a Retry packet with SCID field equal to DCID field.
-    RetryScidEqualsDcid { path: Path<'a>, cid: &'a [u8] },
     /// There was a failure when attempting to remove header protection.
     UnprotectFailed { space: KeySpace, path: Path<'a> },
     /// There was a failure when attempting to decrypt the packet.
@@ -563,6 +561,21 @@ enum PacketDropReason<'a> {
     DecodingFailed { path: Path<'a> },
     /// The client received a non-empty retry token.
     NonEmptyRetryToken { path: Path<'a> },
+    /// A Retry packet was discarded.
+    RetryDiscarded {
+        reason: RetryDiscardReason<'a>,
+        path: Path<'a>,
+    },
+}
+
+enum RetryDiscardReason<'a> {
+    /// Received a Retry packet with SCID field equal to DCID field.
+    ScidEqualsDcid { cid: &'a [u8] },
+    /// A client only processes at most one Retry packet.
+    RetryAlreadyProcessed,
+    /// The client discards Retry packets if a valid Initial packet
+    /// has been received and processed.
+    InitialAlreadyProcessed,
 }
 
 enum MigrationDenyReason {

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -62,7 +62,7 @@ pub struct Manager<Config: endpoint::Config> {
     /// appending another to the list. This is used to prevent an off-path attacker from
     /// creating new paths with garbage data and preventing the peer to migrate paths.
     ///
-    /// Note that it doesn't prevent an on-path attacker from observering/forwarding
+    /// Note that it doesn't prevent an on-path attacker from observing/forwarding
     /// authenticated packets from bogus addresses. Because of the current hard limit
     /// of `MAX_ALLOWED_PATHS`, this will prevent the peer from migrating, if it needs to.
     /// The `paths` data structure will need to be enhanced to include garbage collection


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR discards Retry packets if a valid Initial has already been received.

> //= https://www.rfc-editor.org/rfc/rfc9000.txt#17.2.5.2
//# After the client has received and processed an
//# Initial or Retry packet from the server, it MUST discard any
//# subsequent Retry packets that it receives.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
