### PR TITLE
interop: remove unnecessary interop test packet captures from s3 upload

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -284,8 +284,9 @@ jobs:
           done
           # remove files we don't do anything with to reduce the artifact size
           find results -name '*.qlog' -exec rm {} \;
-          # remove cross traffic packet captures as they are large and not useful
+          # remove cross traffic and goodput packet captures as they are large and not useful
           find results -maxdepth 7 -type d -path "**/crosstraffic/*/sim" | xargs rm -rf \;
+          find results -maxdepth 7 -type d -path "**/goodput/*/sim" | xargs rm -rf \;
 
           # Add index files for easy browsing
           find results -maxdepth 3 -type d -path "*/logs/*/*" | while read from; do


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The packet captures from the cross traffic and goodput interop tests are responsible for more than 50% of the artifact size for each CI run. This change will remove those packet captures before uploading the results, as they are not particularly useful for analysis. The resulting artifacts size decreases from 22.5GB to 10.5GB


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
