### PR TITLE
client: include RetryToken as part of subsequent Initial packets

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1233,8 +1233,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         });
 
         if Self::Config::ENDPOINT_TYPE.is_client() {
-            match self.space_manager.retry_info() {
-                Some(_retry_token) => {
+            match self.space_manager.retry_cid() {
+                Some(_retry_cid) => {
                     //= https://www.rfc-editor.org/rfc/rfc9000.txt#17.2.5.2
                     //# A client MUST accept and process at most one Retry packet for each
                     //# connection attempt.
@@ -1296,10 +1296,10 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                     path.peer_connection_id = retry_source_connection_id;
 
                     self.space_manager
-                        .on_retry_packet(retry_source_connection_id, packet.retry_token);
+                        .on_retry_packet(retry_source_connection_id);
 
                     if let Some((space, _handshake_status)) = self.space_manager.initial_mut() {
-                        space.on_retry_packet(&retry_source_connection_id);
+                        space.on_retry_packet(&retry_source_connection_id, packet.retry_token);
                     }
                 }
             }
@@ -1358,6 +1358,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 let constraint = self.path_manager.transmission_constraint();
 
                 interests.transmission = self.can_transmit(constraint);
+
                 interests.new_connection_id =
                     // Only issue new Connection Ids to the peer when we know they won't be used
                     // for Initial or Handshake packets.

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -33,8 +33,8 @@ use s2n_quic_core::{
 
 pub struct SessionContext<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher> {
     pub now: Timestamp,
-    pub initial_id: &'a InitialId,
-    pub retry_id: Option<&'a PeerId>,
+    pub initial_cid: &'a InitialId,
+    pub retry_cid: Option<&'a PeerId>,
     pub path: &'a Path<Config>,
     pub initial: &'a mut Option<Box<InitialSpace<Config>>>,
     pub handshake: &'a mut Option<Box<HandshakeSpace<Config>>>,
@@ -81,7 +81,7 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
             self.path.peer_connection_id.as_bytes(),
         )?;
 
-        match (self.retry_id, peer_parameters.retry_source_connection_id) {
+        match (self.retry_cid, peer_parameters.retry_source_connection_id) {
             (Some(retry_packet_value), Some(transport_params_value)) => {
                 if retry_packet_value
                     .as_bytes()
@@ -123,7 +123,7 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
             //# parameters match received connection ID values.
             if peer_value
                 .as_bytes()
-                .ct_eq(self.initial_id.as_bytes())
+                .ct_eq(self.initial_cid.as_bytes())
                 .not()
                 .into()
             {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The RetryToken is used by the Server to validate the Clients ip address prior to committing to an expensive handshake. 

With this PR the Client will include the RetryToken, which it got from the server, in subsequent Initial packets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
