### PR TITLE
transport: allow handshake CID to be used until it expires

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_id_mapper.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_id_mapper.rs
@@ -7,7 +7,7 @@ use crate::connection::{local_id_registry::LocalIdRegistry, InternalConnectionId
 use alloc::rc::Rc;
 use core::{cell::RefCell, convert::TryFrom as _, hash::BuildHasher};
 use hashbrown::hash_map::{Entry, HashMap};
-use s2n_quic_core::{connection, endpoint, random, stateless_reset};
+use s2n_quic_core::{connection, endpoint, random, stateless_reset, time::Timestamp};
 use siphasher::sip::SipHasher13;
 
 // Since the input to the hash function (stateless reset token) come from the peer, we need to
@@ -300,12 +300,14 @@ impl ConnectionIdMapper {
         &mut self,
         internal_id: InternalConnectionId,
         initial_connection_id: &connection::LocalId,
+        initial_connection_id_expiration_time: Option<Timestamp>,
         local_stateless_reset_token: stateless_reset::Token,
     ) -> LocalIdRegistry {
         LocalIdRegistry::new(
             internal_id,
             self.state.clone(),
             initial_connection_id,
+            initial_connection_id_expiration_time,
             local_stateless_reset_token,
         )
     }

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -116,6 +116,13 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
 
         let internal_connection_id = self.connection_id_generator.generate_id();
 
+        let initial_connection_id_expiration_time = self
+            .config
+            .context()
+            .connection_id_format
+            .lifetime()
+            .map(|duration| datagram.timestamp + duration);
+
         let stateless_reset_token = self
             .config
             .context()
@@ -125,6 +132,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
         let local_id_registry = self.connection_id_mapper.create_local_id_registry(
             internal_connection_id,
             &initial_connection_id,
+            initial_connection_id_expiration_time,
             stateless_reset_token,
         );
 

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -913,6 +913,13 @@ impl<Cfg: Config> Endpoint<Cfg> {
             .connection_id_format
             .generate(&ConnectionInfo::new(&remote_address));
 
+        let local_connection_id_expiration_time = self
+            .config
+            .context()
+            .connection_id_format
+            .lifetime()
+            .map(|duration| timestamp + duration);
+
         let local_id_registry = {
             // TODO: the client currently generates a random stateless_reset_token but doesnt
             // transmit it. Refactor `create_local_id_registry` to instead accept None for
@@ -925,6 +932,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
             self.connection_id_mapper.create_local_id_registry(
                 internal_connection_id,
                 &local_connection_id,
+                local_connection_id_expiration_time,
                 stateless_reset_token,
             )
         };

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -312,7 +312,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         timestamp: Timestamp,
     ) {
         // Retire the local connection ID used during the handshake to reduce linkability
-        local_id_registry.retire_handshake_connection_id(timestamp);
+        local_id_registry.retire_handshake_connection_id();
 
         //= https://www.rfc-editor.org/rfc/rfc9002.txt#6.2.1
         //# A sender SHOULD restart its PTO timer every time an ack-eliciting


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Some QUIC implementations (see https://github.com/mozilla/neqo/issues/1290) do not allow retiring the handshake connection ID, causing the connection to fail after we remove the handshake connection ID 30 seconds after the handshake. This change will allow the handshake CID to be used until the time specified by the connection ID generator is passed, while still signaling to the peer to retire it immediately if possible. If no CID lifetime is specified, the handshake CID is allowed to be used forever, or until it is successfully retired by the peer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
