### PR TITLE
transport: wire up the default pacer

### DIFF
--- a/quic/s2n-quic-core/src/recovery/pacing.rs
+++ b/quic/s2n-quic-core/src/recovery/pacing.rs
@@ -35,7 +35,7 @@ const SLOW_START_N: Fraction = Fraction(2, 1); // 2/1 = 2.00
 const MAX_BURST_PACKETS: u16 = 10;
 
 /// A packet pacer that returns departure times that evenly distribute bursts of packets over time
-#[derive(Default)]
+#[derive(Clone, Debug, Default)]
 pub struct Pacer {
     // The capacity of the current departure time slot
     capacity: Counter<u32, Saturating>,

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -1097,8 +1097,11 @@ mod tests {
         );
 
         // Fill up the congestion controller
-        path.congestion_controller
-            .on_packet_sent(now, path.congestion_controller.congestion_window() as usize);
+        path.congestion_controller.on_packet_sent(
+            now,
+            path.congestion_controller.congestion_window() as usize,
+            &path.rtt_estimator,
+        );
 
         assert_eq!(
             path.transmission_constraint(),

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -202,8 +202,11 @@ impl<Config: endpoint::Config> Manager<Config> {
             let is_handshake_confirmed = context.is_handshake_confirmed();
             let path = context.path_mut_by_id(context.path_id());
             self.update_pto_timer(path, time_sent, is_handshake_confirmed);
-            path.congestion_controller
-                .on_packet_sent(time_sent, congestion_controlled_bytes);
+            path.congestion_controller.on_packet_sent(
+                time_sent,
+                congestion_controlled_bytes,
+                &path.rtt_estimator,
+            );
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:* #146

*Description of changes:* This change wires up the default packet pacer into the Cubic congestion controller. I've also added a `earliest_departure_time` method to the CongestionController trait.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
