### PR TITLE
platform: fix GSO path handle comparison

### DIFF
--- a/quic/s2n-quic-platform/src/message/msg.rs
+++ b/quic/s2n-quic-platform/src/message/msg.rs
@@ -283,8 +283,14 @@ impl MessageTrait for msghdr {
     #[inline]
     fn can_gso<M: tx::Message<Handle = Self::Handle>>(&self, other: &mut M) -> bool {
         if let Some(header) = Message::header(self) {
+            let mut other_handle = *other.path_handle();
+
+            // when reading the header back from the msghdr, we don't know the port
+            // so set the other port to 0 as well.
+            other_handle.local_address.set_port(0);
+
             // check the path handles match
-            header.path.strict_eq(other.path_handle()) &&
+            header.path.strict_eq(&other_handle) &&
                 // check the ECN markings match
                 header.ecn == other.ecn()
         } else {


### PR DESCRIPTION
In #1030 I fixed the issue of threading the correct port in the path handle. This had the side-effect of the `can_gso` comparison to fail, since after reading back the local address sets the port to `0`.

This change sets the comparison handle also to `0` as a workaround.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
