### PR TITLE
clippy: fix warnings for 1.57, current beta, and nightly

### DIFF
--- a/common/compliance/cargo-compliance/src/sourcemap.rs
+++ b/common/compliance/cargo-compliance/src/sourcemap.rs
@@ -33,7 +33,8 @@ impl<'a> Iterator for LinesIter<'a> {
             return None;
         }
 
-        let rel_offset = content.find('\n').unwrap_or_else(|| content.len());
+        let len = content.len();
+        let rel_offset = content.find('\n').unwrap_or(len);
 
         let value = Str {
             value: content[..rel_offset].trim_end_matches('\r'),

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -283,7 +283,7 @@ pub mod api {
     #[doc = " The source that caused a congestion event"]
     pub enum CongestionSource {
         #[non_exhaustive]
-        ECN {},
+        Ecn {},
         #[non_exhaustive]
         PacketLoss {},
     }
@@ -2021,7 +2021,7 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub enum CongestionSource {
-        ECN,
+        Ecn,
         PacketLoss,
     }
     impl IntoEvent<api::CongestionSource> for CongestionSource {
@@ -2029,7 +2029,7 @@ pub mod builder {
         fn into_event(self) -> api::CongestionSource {
             use api::CongestionSource::*;
             match self {
-                Self::ECN => ECN {},
+                Self::Ecn => Ecn {},
                 Self::PacketLoss => PacketLoss {},
             }
         }

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -621,7 +621,7 @@ enum HandshakeStatus {
 /// The source that caused a congestion event
 enum CongestionSource {
     /// Explicit Congestion Notification
-    ECN,
+    Ecn,
     /// One or more packets were detected lost
     PacketLoss,
 }

--- a/quic/s2n-quic-platform/src/message/mmsg.rs
+++ b/quic/s2n-quic-platform/src/message/mmsg.rs
@@ -123,6 +123,7 @@ pub struct Ring<Payloads> {
 
 /// Even though `Ring` contains raw pointers, it owns all of the data
 /// and can be sent across threads safely.
+#[allow(unknown_lints, clippy::non_send_fields_in_send_ty)]
 unsafe impl<Payloads: Send> Send for Ring<Payloads> {}
 
 impl<Payloads: crate::buffer::Buffer + Default> Default for Ring<Payloads> {

--- a/quic/s2n-quic-platform/src/message/msg.rs
+++ b/quic/s2n-quic-platform/src/message/msg.rs
@@ -420,6 +420,7 @@ impl<Payloads: crate::buffer::Buffer> Storage<Payloads> {
 
 /// Even though `Ring` contains raw pointers, it owns all of the data
 /// and can be sent across threads safely.
+#[allow(unknown_lints, clippy::non_send_fields_in_send_ty)]
 unsafe impl<Payloads: Send> Send for Ring<Payloads> {}
 
 impl<Payloads: crate::buffer::Buffer + Default> Default for Ring<Payloads> {

--- a/quic/s2n-quic-platform/src/message/simple.rs
+++ b/quic/s2n-quic-platform/src/message/simple.rs
@@ -93,6 +93,7 @@ pub struct Ring<Payloads> {
 
 /// Even though `Ring` contains raw pointers, it owns all of the data
 /// and can be sent across threads safely.
+#[allow(unknown_lints, clippy::non_send_fields_in_send_ty)]
 unsafe impl<Payloads: Send> Send for Ring<Payloads> {}
 
 impl<Payloads: crate::buffer::Buffer + Default> Default for Ring<Payloads> {

--- a/quic/s2n-quic-transport/src/connection/connection_container.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container.rs
@@ -4,6 +4,9 @@
 //! `ConnectionContainer` is a container for all Connections. It manages the permanent
 //! map of all active Connections, as well as a variety of dynamic Connection lists.
 
+// hide warnings from the intrusive_collections crate
+#![allow(unknown_lints, clippy::non_send_fields_in_send_ty)]
+
 use super::{ConnectionApi, ConnectionApiProvider};
 use crate::{
     connection::{self, Connection, ConnectionInterests, InternalConnectionId},

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -205,7 +205,8 @@ impl<Config: endpoint::Config> EventContext<Config> {
 }
 
 /// Safety: we use some `Rc<RefCell<T>>` inside of the connection but these values
-/// never leave the API boundary and will be all sent together
+/// never leave the API boundary and will be all sent across threads together
+#[allow(unknown_lints, clippy::non_send_fields_in_send_ty)]
 unsafe impl<Config: endpoint::Config> Send for ConnectionImpl<Config> {}
 
 #[cfg(debug_assertions)]

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -82,6 +82,7 @@ pub struct Endpoint<Cfg: Config> {
 /// Safety: The endpoint is marked as `!Send`, because the struct contains `Rc`s.
 /// However those `Rcs` are only referenced by other objects within the `Endpoint`
 /// and which also get moved.
+#[allow(unknown_lints, clippy::non_send_fields_in_send_ty)]
 unsafe impl<Cfg: Config> Send for Endpoint<Cfg> {}
 
 impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
@@ -478,8 +479,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
 
         let source_connection_id = packet
             .source_connection_id()
-            .map(PeerId::try_from_bytes)
-            .flatten();
+            .and_then(PeerId::try_from_bytes);
 
         let datagram = &DatagramInfo {
             timestamp,

--- a/quic/s2n-quic-transport/src/path/ecn.rs
+++ b/quic/s2n-quic-transport/src/path/ecn.rs
@@ -234,9 +234,7 @@ impl Controller {
             }
         }
 
-        let congestion_experienced;
-
-        if let Some(incremental_ecn_counts) = ack_frame_ecn_counts
+        let congestion_experienced = if let Some(incremental_ecn_counts) = ack_frame_ecn_counts
             .unwrap_or_default()
             .checked_sub(baseline_ecn_counts)
         {
@@ -248,13 +246,12 @@ impl Controller {
                 return ValidationOutcome::Failed;
             }
 
-            congestion_experienced =
-                incremental_ecn_counts.ce_count > newly_acked_ecn_counts.ce_count;
+            incremental_ecn_counts.ce_count > newly_acked_ecn_counts.ce_count
         } else {
             // ECN counts decreased from the baseline
             self.fail(now, path, publisher);
             return ValidationOutcome::Failed;
-        }
+        };
 
         //= https://www.rfc-editor.org/rfc/rfc9000.txt#A.4
         //# From the "unknown" state, successful validation of the ECN counts in an ACK frame

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -887,6 +887,7 @@ macro_rules! path_event {
         }
     }};
 }
+
 pub(crate) use path_event;
 
 #[cfg(test)]

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -623,7 +623,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             let path = context.path();
             publisher.on_congestion(event::builder::Congestion {
                 path: path_event!(path, path_id),
-                source: CongestionSource::ECN,
+                source: CongestionSource::Ecn,
             })
         }
 

--- a/quic/s2n-quic-transport/src/stream/stream_container.rs
+++ b/quic/s2n-quic-transport/src/stream/stream_container.rs
@@ -4,6 +4,9 @@
 //! `StreamContainer` is a container for all Streams. It manages the permanent
 //! map of all active Streams, as well as a variety of dynamic Stream lists.
 
+// hide warnings from the intrusive_collections crate
+#![allow(unknown_lints, clippy::non_send_fields_in_send_ty)]
+
 use crate::{
     stream,
     stream::{stream_impl::StreamTrait, stream_interests::StreamInterests},

--- a/quic/s2n-quic-transport/src/stream/stream_manager.rs
+++ b/quic/s2n-quic-transport/src/stream/stream_manager.rs
@@ -380,6 +380,7 @@ pub struct AbstractStreamManager<S> {
 
 // Sending the `AbstractStreamManager` between threads is safe, since we never expose the `Rc`s
 // outside of the container
+#[allow(unknown_lints, clippy::non_send_fields_in_send_ty)]
 unsafe impl<S> Send for AbstractStreamManager<S> {}
 
 impl<S: StreamTrait> AbstractStreamManager<S> {

--- a/tls/s2n-tls/src/config.rs
+++ b/tls/s2n-tls/src/config.rs
@@ -9,6 +9,9 @@ use std::ffi::CString;
 
 struct Owned(*mut s2n_config);
 
+/// Safety: s2n_config objects can be sent across threads
+unsafe impl Send for Owned {}
+
 impl Default for Owned {
     fn default() -> Self {
         Self::new()
@@ -37,6 +40,7 @@ impl Drop for Owned {
 pub struct Config(Arc<Owned>);
 
 /// Safety: s2n_config objects can be sent across threads
+#[allow(unknown_lints, clippy::non_send_fields_in_send_ty)]
 unsafe impl Send for Config {}
 
 impl Config {


### PR DESCRIPTION
The latest beta clippy has a bunch of false positives regarding our `Send` implementations being unsound. In a general sense, they are unsound but the way they get used they are not, since all connections under a endpoint are migrated together. Since these are not public APIs, this PR suppresses those warnings.

I've also fixed some of the other smaller suggestions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
