### PR TITLE
transport: enable additional event snapshot tests

### DIFF
--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__do_not_add_new_path_if_client.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__do_not_add_new_path_if_client.snap
@@ -1,0 +1,6 @@
+---
+source: quic/s2n-quic-transport/src/path/manager/tests.rs
+expression: ""
+
+---
+

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__last_known_validated_path_should_update_on_path_response.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__last_known_validated_path_should_update_on_path_response.snap
@@ -1,0 +1,7 @@
+---
+source: quic/s2n-quic-transport/src/path/manager/tests.rs
+expression: ""
+
+---
+ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0 }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1 } }
+ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1 }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x02, id: 2 } }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__switch_destination_connection_id_after_first_server_response.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__switch_destination_connection_id_after_first_server_response.snap
@@ -1,0 +1,6 @@
+---
+source: quic/s2n-quic-transport/src/path/manager/tests.rs
+expression: ""
+
+---
+

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -822,7 +822,7 @@ fn do_not_add_new_path_if_client() {
         true,
     );
     let mut manager = manager_client(first_path);
-    let mut publisher = Publisher::default();
+    let mut publisher = Publisher::snapshot();
 
     // verify we have one path
     let new_addr: SocketAddr = "127.0.0.1:8001".parse().unwrap();
@@ -880,7 +880,7 @@ fn switch_destination_connection_id_after_first_server_response() {
 
     // Trigger:
     let server_destination_cid = connection::PeerId::try_from_bytes(&[1, 1]).unwrap();
-    let mut publisher = Publisher::default();
+    let mut publisher = Publisher::snapshot();
     let processed_packet = manager.on_processed_packet(
         zero_path_id,
         Some(server_destination_cid),
@@ -1551,6 +1551,7 @@ fn temporary_until_authenticated() {
 #[test]
 fn last_known_validated_path_should_update_on_path_response() {
     // Setup:
+    let mut publisher = Publisher::snapshot();
     let zero_conn_id = connection::PeerId::try_from_bytes(&[0]).unwrap();
     let first_conn_id = connection::PeerId::try_from_bytes(&[1]).unwrap();
     let second_conn_id = connection::PeerId::try_from_bytes(&[2]).unwrap();
@@ -1595,7 +1596,7 @@ fn last_known_validated_path_should_update_on_path_response() {
         .update_active_path(
             first_path_id,
             &mut random::testing::Generator(123),
-            &mut Publisher::default(),
+            &mut publisher
         )
         .is_ok());
 
@@ -1631,7 +1632,7 @@ fn last_known_validated_path_should_update_on_path_response() {
         .update_active_path(
             second_path_id,
             &mut random::testing::Generator(123),
-            &mut Publisher::default(),
+            &mut publisher,
         )
         .is_ok());
 
@@ -1675,7 +1676,7 @@ fn last_known_validated_path_should_update_on_path_response() {
         .on_timeout(
             now + challenge_expiration + Duration::from_millis(100),
             &mut random::testing::Generator(123),
-            &mut Publisher::default(),
+            &mut publisher,
         )
         .unwrap();
 

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -1570,7 +1570,7 @@ fn detect_lost_packets_persistent_cogestion_path_aware() {
     assert_eq!(bytes_in_flight, 9);
 
     let (max_persistent_congestion_period, _sent_packets_to_remove) =
-        manager.detect_lost_packets(now, &mut context, &mut Publisher::default());
+        manager.detect_lost_packets(now, &mut context, &mut publisher);
 
     // Expectation:
     assert_eq!(max_persistent_congestion_period, Duration::from_secs(2));

--- a/quic/s2n-quic-transport/src/space/handshake_status.rs
+++ b/quic/s2n-quic-transport/src/space/handshake_status.rs
@@ -218,6 +218,7 @@ mod tests {
 
     #[test]
     fn server_test() {
+        let mut publisher = Publisher::snapshot();
         let mut frame_buffer = OutgoingFrameBuffer::new();
         let mut context = MockWriteContext::new(
             time::now(),
@@ -247,7 +248,7 @@ mod tests {
         //= type=test
         //# the TLS handshake is considered confirmed at the
         //# server when the handshake completes.
-        status.on_handshake_complete(endpoint::Type::Server, &mut Publisher::default());
+        status.on_handshake_complete(endpoint::Type::Server, &mut publisher);
         assert!(status.is_confirmed());
         assert!(status.is_complete());
 
@@ -265,7 +266,7 @@ mod tests {
             .expect("status should write HANDSHAKE_DONE frames")
             .packet_nr;
 
-        status.on_packet_ack(&packet_number, &mut Publisher::default());
+        status.on_packet_ack(&packet_number, &mut publisher);
         assert!(status.is_confirmed());
 
         assert!(
@@ -282,6 +283,7 @@ mod tests {
 
     #[test]
     fn client_test() {
+        let mut publisher = Publisher::snapshot();
         let mut frame_buffer = OutgoingFrameBuffer::new();
         let mut context = MockWriteContext::new(
             time::now(),
@@ -308,11 +310,11 @@ mod tests {
         );
 
         // the handshake must be complete prior to being confirmed
-        status.on_handshake_done_received(&mut Publisher::default());
+        status.on_handshake_done_received(&mut publisher);
         assert!(!status.is_complete());
         assert!(!status.is_confirmed());
 
-        status.on_handshake_complete(endpoint::Type::Client, &mut Publisher::default());
+        status.on_handshake_complete(endpoint::Type::Client, &mut publisher);
         assert!(status.is_complete());
 
         assert!(
@@ -327,11 +329,11 @@ mod tests {
         );
 
         // confirm the client handshake
-        status.on_handshake_done_received(&mut Publisher::default());
+        status.on_handshake_done_received(&mut publisher);
         assert!(status.is_confirmed());
 
         // try calling it multiple times
-        status.on_handshake_done_received(&mut Publisher::default());
+        status.on_handshake_done_received(&mut publisher);
         assert!(status.is_confirmed());
     }
 }

--- a/quic/s2n-quic-transport/src/space/snapshots/quic__s2n-quic-transport__src__space__handshake_status__events__client_test.snap
+++ b/quic/s2n-quic-transport/src/space/snapshots/quic__s2n-quic-transport__src__space__handshake_status__events__client_test.snap
@@ -1,0 +1,8 @@
+---
+source: quic/s2n-quic-transport/src/space/handshake_status.rs
+expression: ""
+
+---
+HandshakeStatusUpdated { status: Complete }
+HandshakeStatusUpdated { status: HandshakeDoneAcked }
+HandshakeStatusUpdated { status: Confirmed }

--- a/quic/s2n-quic-transport/src/space/snapshots/quic__s2n-quic-transport__src__space__handshake_status__events__server_test.snap
+++ b/quic/s2n-quic-transport/src/space/snapshots/quic__s2n-quic-transport__src__space__handshake_status__events__server_test.snap
@@ -1,0 +1,8 @@
+---
+source: quic/s2n-quic-transport/src/space/handshake_status.rs
+expression: ""
+
+---
+HandshakeStatusUpdated { status: Complete }
+HandshakeStatusUpdated { status: Confirmed }
+HandshakeStatusUpdated { status: HandshakeDoneAcked }


### PR DESCRIPTION
After merging #920, I noticed there were a few tests that were missed. This change includes them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
