### PR TITLE
transport: wait to send MTU probes until after the handshake completes

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -636,10 +636,11 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 let mut outcome = transmission::Outcome::new(PacketNumber::default());
                 let path_id = self.path_manager.active_path_id();
 
-                // Send an MTU probe if necessary
+                // Send an MTU probe if necessary and the handshake has completed
                 // MTU probes are prioritized over other data so they are not blocked by the
                 // congestion controller, as they are critical to achieving maximum throughput.
-                if self.path_manager.active_path().can_transmit(timestamp)
+                if self.state == ConnectionState::Active
+                    && self.path_manager.active_path().can_transmit(timestamp)
                     && self
                         .path_manager
                         .active_path()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Currently, MTU probes are sent as soon as both the peer and local endpoint have had their address validated. In the case of the server, this happens as soon as a handshake packet is received. For handshakes that can complete in 1RT, this is fine, as the client will have the keys necessary to process the MTU probe short packet. However, if the handshake takes more than 1RT (because the crypto stream is larger than the amplification limit), this can result in the MTU probe being sent before all handshake crypto data has been transmitted. Clients that do not retain 1RT data before completing the handshake will drop this MTU probe, delaying the increase in MTU until the probe can be declared lost. 

This change will only send MTU probes if the handshake has been completed. We may be able to optimize this further in the future, that work is tracked in #1045.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
