### PR TITLE
deps: pin zerocopy and zerocopy-derive

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -16,5 +16,5 @@ generator = ["bolero-generator"]
 bolero-generator = { version = "0.6", default-features = false, optional = true }
 byteorder = { version = "1.1", default-features = false }
 bytes = { version = "1", default-features = false, optional = true }
-zerocopy = "0.6"
+zerocopy = "=0.6.0"
 zerocopy-derive = "=0.3.0"

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -25,7 +25,7 @@ s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features
 subtle = { version = "2", default-features = false }
 thiserror = { version = "1", optional = true }
 tracing = { version = "0.1", default-features = false, optional = true }
-zerocopy = "0.6"
+zerocopy = "=0.6.0"
 zerocopy-derive = "=0.3.0"
 
 [dev-dependencies]

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -51,7 +51,7 @@ s2n-quic-tls-default = { version = "0.1", path = "../s2n-quic-tls-default", opti
 s2n-quic-transport = { version = "0.1", path = "../s2n-quic-transport", default-features = false }
 thiserror = { version = "1", optional = true }
 tokio = { version = "1", optional = true, default-features = false }
-zerocopy = { version = "0.6", optional = true }
+zerocopy = { version = "=0.6.0", optional = true }
 zerocopy-derive = { version = "=0.3.0", optional = true }
 zeroize = { version = "1", default-features = false }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The latest versions of zerocopy and zerocopy-derive started using a non-standard license, so we'll pin these until they go back to BSD 3-Clause or another standard license.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
