### PR TITLE
client: confirm handshake if a 1-rtt packet was acknowledged

### DIFF
--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -277,6 +277,8 @@ pub mod api {
         HandshakeDoneAcked {},
         #[non_exhaustive]
         HandshakeDoneLost {},
+        #[non_exhaustive]
+        OneRttAcked {},
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
@@ -2006,6 +2008,7 @@ pub mod builder {
         Confirmed,
         HandshakeDoneAcked,
         HandshakeDoneLost,
+        OneRttAcked,
     }
     impl IntoEvent<api::HandshakeStatus> for HandshakeStatus {
         #[inline]
@@ -2016,6 +2019,7 @@ pub mod builder {
                 Self::Confirmed => Confirmed {},
                 Self::HandshakeDoneAcked => HandshakeDoneAcked {},
                 Self::HandshakeDoneLost => HandshakeDoneLost {},
+                Self::OneRttAcked => OneRttAcked {},
             }
         }
     }

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -610,12 +610,13 @@ enum HandshakeStatus {
     /// only a Server is allowed to send the HANDSHAKE_DONE
     /// frame.
     HandshakeDoneAcked,
-
     /// A HANDSHAKE_DONE frame was declared lost.
     ///
     /// The Server is responsible for re-transmitting the
     /// HANDSHAKE_DONE frame until it is acked by the peer.
     HandshakeDoneLost,
+    /// A 1-Rtt packet was acked.
+    OneRttAcked,
 }
 
 /// The source that caused a congestion event

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -399,7 +399,7 @@ impl<Config: endpoint::Config> Manager<Config> {
 
             context.validate_packet_ack(datagram, &acked_packets)?;
             // notify components of packets acked
-            context.on_packet_ack(datagram, &acked_packets);
+            context.on_packet_ack(datagram, &acked_packets, publisher);
 
             let mut newly_acked_range: Option<(PacketNumber, PacketNumber)> = None;
 
@@ -1007,7 +1007,12 @@ pub trait Context<Config: endpoint::Config> {
         packet_number_range: &PacketNumberRange,
         publisher: &mut Pub,
     );
-    fn on_packet_ack(&mut self, datagram: &DatagramInfo, packet_number_range: &PacketNumberRange);
+    fn on_packet_ack<Pub: event::ConnectionPublisher>(
+        &mut self,
+        datagram: &DatagramInfo,
+        packet_number_range: &PacketNumberRange,
+        publisher: &mut Pub,
+    );
     fn on_packet_loss<Pub: event::ConnectionPublisher>(
         &mut self,
         packet_number_range: &PacketNumberRange,

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -2992,10 +2992,11 @@ impl<'a> recovery::Context<Config> for MockContext<'a> {
         self.on_new_packet_ack_count += 1;
     }
 
-    fn on_packet_ack(
+    fn on_packet_ack<Pub: event::ConnectionPublisher>(
         &mut self,
         _datagram: &DatagramInfo,
         _packet_number_range: &PacketNumberRange,
+        _publisher: &mut Pub,
     ) {
         self.on_packet_ack_count += 1;
     }

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -563,7 +563,13 @@ impl<'a, Config: endpoint::Config> recovery::Context<Config> for RecoveryContext
         self.path_manager.on_packet_ack(packet_number_range);
     }
 
-    fn on_packet_ack(&mut self, datagram: &DatagramInfo, packet_number_range: &PacketNumberRange) {
+    fn on_packet_ack<Pub: event::ConnectionPublisher>(
+        &mut self,
+        datagram: &DatagramInfo,
+        packet_number_range: &PacketNumberRange,
+        publisher: &mut Pub,
+    ) {
+        self.handshake_status.on_1rtt_ack(publisher);
         self.ack_manager
             .on_packet_ack(datagram, packet_number_range);
     }

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -434,7 +434,12 @@ impl<'a, Config: endpoint::Config> recovery::Context<Config> for RecoveryContext
         self.crypto_stream.on_packet_ack(packet_number_range);
     }
 
-    fn on_packet_ack(&mut self, datagram: &DatagramInfo, packet_number_range: &PacketNumberRange) {
+    fn on_packet_ack<Pub: event::ConnectionPublisher>(
+        &mut self,
+        datagram: &DatagramInfo,
+        packet_number_range: &PacketNumberRange,
+        _publisher: &mut Pub,
+    ) {
         self.ack_manager
             .on_packet_ack(datagram, packet_number_range);
     }

--- a/quic/s2n-quic-transport/src/space/handshake_status.rs
+++ b/quic/s2n-quic-transport/src/space/handshake_status.rs
@@ -85,7 +85,7 @@ impl HandshakeStatus {
     }
 
     /// This method is called on the client when the HANDSHAKE_DONE
-    /// frame has been received
+    /// frame has been received.
     pub fn on_handshake_done_received<Pub: ConnectionPublisher>(&mut self, publisher: &mut Pub) {
         if let HandshakeStatus::ClientComplete = self {
             publisher.on_handshake_status_updated(event::builder::HandshakeStatusUpdated {
@@ -97,6 +97,23 @@ impl HandshakeStatus {
             //= https://www.rfc-editor.org/rfc/rfc9001.txt#4.1.2
             //# At the client, the handshake is
             //# considered confirmed when a HANDSHAKE_DONE frame is received.
+            *self = HandshakeStatus::Confirmed;
+        }
+    }
+
+    /// The delivery of a 1-Rtt packet was acknowledged by the peer.
+    #[inline]
+    pub fn on_1rtt_ack<Pub: ConnectionPublisher>(&mut self, publisher: &mut Pub) {
+        if let HandshakeStatus::ClientComplete = self {
+            publisher.on_handshake_status_updated(event::builder::HandshakeStatusUpdated {
+                status: event::builder::HandshakeStatus::OneRttAcked,
+            });
+            publisher.on_handshake_status_updated(event::builder::HandshakeStatusUpdated {
+                status: event::builder::HandshakeStatus::Confirmed,
+            });
+            //= https://www.rfc-editor.org/rfc/rfc9001.txt#4.1.2
+            //# Additionally, a client MAY consider the handshake to be confirmed
+            //# when it receives an acknowledgment for a 1-RTT packet.
             *self = HandshakeStatus::Confirmed;
         }
     }

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -572,7 +572,12 @@ impl<'a, Config: endpoint::Config> recovery::Context<Config> for RecoveryContext
         self.crypto_stream.on_packet_ack(packet_number_range);
     }
 
-    fn on_packet_ack(&mut self, datagram: &DatagramInfo, packet_number_range: &PacketNumberRange) {
+    fn on_packet_ack<Pub: event::ConnectionPublisher>(
+        &mut self,
+        datagram: &DatagramInfo,
+        packet_number_range: &PacketNumberRange,
+        _publisher: &mut Pub,
+    ) {
         self.ack_manager
             .on_packet_ack(datagram, packet_number_range);
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR implements the optional [requirement](https://datatracker.ietf.org/doc/html/rfc9001#section-4.1.2):

> Additionally, a client MAY consider the handshake to be confirmed
   when it receives an acknowledgment for a 1-RTT packet.

### Callout:
- We are calling `handshake_status.on_packet_ack` each time we receive an Ack frame in the 1-rtt space. The function has been inlined but is possibly too expensive.

- [x] compare perf results to confirm this implementation doesnt affect performance
  - perf: [pr](https://dnglbrstg7yg.cloudfront.net/07440b315c656dced868b1e404947478e5f0acf1/perf/quinn-client-s2n-quic-server/1000MB-down-0MB-up.server.svg) vs [main](https://dnglbrstg7yg.cloudfront.net/71db03e77e99716d3b3c02aa03da75b41a44c76d/perf/quinn-client-s2n-quic-server/1000MB-down-0MB-up.server.svg) shows negligible difference. on_packet_ack goes form 1.9% to 2.2%
  - interop: goodput transfer test shows comparable performance https://dnglbrstg7yg.cloudfront.net/07440b315c656dced868b1e404947478e5f0acf1/interop/index.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
