### PR TITLE
client: poll crypto if the handshake is not complete

### DIFF
--- a/quic/s2n-quic-rustls/src/session.rs
+++ b/quic/s2n-quic-rustls/src/session.rs
@@ -130,7 +130,7 @@ impl Session {
     /// Check and process TLS handshake complete.
     ///
     /// Upon TLS handshake complete, emit an event to notify the transport layer.
-    fn process_handshake_complete<C: tls::Context<Self>>(
+    fn try_complete_handshake<C: tls::Context<Self>>(
         &mut self,
         context: &mut C,
     ) -> Result<(), transport::Error> {
@@ -176,13 +176,13 @@ impl tls::Session for Session {
             if let Some(crypto_data) = crypto_data {
                 self.receive(&crypto_data)?;
             } else if has_tried_receive {
-                self.process_handshake_complete(context)?;
+                self.try_complete_handshake(context)?;
 
                 // If there's nothing to receive then we're done for now
                 return Ok(());
             }
 
-            self.process_handshake_complete(context)?;
+            self.try_complete_handshake(context)?;
             if self.emitted_handshake_complete {
                 return Ok(());
             }

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -267,6 +267,25 @@ impl<Config: endpoint::Config> ConnectionImpl<Config> {
             &mut publisher,
         )?;
 
+        //= https://www.rfc-editor.org/rfc/rfc9000.txt#7.1
+        //#
+        //#   Client                                                  Server
+        //#
+        //#   Initial[0]: CRYPTO[CH] ->
+        //#
+        //#                                    Initial[0]: CRYPTO[SH] ACK[0]
+        //#                          Handshake[0]: CRYPTO[EE, CERT, CV, FIN]
+        //#                                    <- 1-RTT[0]: STREAM[1, "..."]
+        //#
+        //#   Initial[1]: ACK[0]
+        //#   Handshake[0]: CRYPTO[FIN], ACK[0]
+        //#   1-RTT[0]: STREAM[0, "..."], ACK[0] ->
+        //#
+        //#                                             Handshake[1]: ACK[0]
+        //#            <- 1-RTT[1]: HANDSHAKE_DONE, STREAM[3, "..."], ACK[0]
+        //#
+        //#                     Figure 5: Example 1-RTT Handshake
+        //
         // The application is allowed to send and receive 1-RTT data once the
         // handshake is complete so update the connection state and prepare
         // to hand it over to the application.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Prior to this PR we were returning from the `rustls/src/session.rs poll()` method before checking and marking the handshake as complete. With this PR we update the handshake state and also allow the connection to transition to active sooner on handshake complete.  

**Changes:**
- check if handshake is complete prior to exiting the crypto poll method
- mark connection as ready to accept when handshake is complete (prior we waited for handshake confirm)
- since we mark the connection state on handshake_complete, it allows for removing calls to `update_crypto_state` from the 1-rtt space

#### Testing:
[rustls interop (main branch)](https://dnglbrstg7yg.cloudfront.net/0d3a6f11b10c37dddad28fd7a954ed8cacb55cae/interop/index.html) (Taken from https://github.com/awslabs/s2n-quic/pull/1060)
<img src="https://user-images.githubusercontent.com/4350690/148134367-6c141e89-873b-4f6c-be20-0127d88661bc.png" height="400">


[s2n-tls interop (PR)](https://dnglbrstg7yg.cloudfront.net/8c57716fc420b6563aef7c1cf784532555341424/interop/index.html)
<img src="https://user-images.githubusercontent.com/4350690/148134375-d570a245-433c-4fde-9697-8c806e9114c8.png" height="400">

[rustls interop (PR)](https://dnglbrstg7yg.cloudfront.net/082320680a913e13623b40fd13e8955e6d8b71ed/interop/index.html)
<img src="https://user-images.githubusercontent.com/4350690/148134383-1f1dd8b5-670f-4d32-9bd1-1f8199a47f14.png" height="400">


#### CALLOUT:
There are currently two sources of truth for handshake status `connection.accept_status` and `spacemanager.handshake_status`. We should attempt to combine these two states if possible (this might be quite complex and so out of scope for this PR).


#### Background:
We primarily run tests against s2n-tls. Due to api difference between the two TLS providers the integration code is difference, which resulted in a bug with the rustls client impl. 

s2n-tls [emits a signal](https://github.com/awslabs/s2n-quic/blob/71db03e77e99716d3b3c02aa03da75b41a44c76d/quic/s2n-quic-tls/src/session.rs#L97-L108) when the handshake is complete.

rustls doesn't emit a signal. The implementation instead has to track state [tx_phase](https://github.com/awslabs/s2n-quic/blob/71db03e77e99716d3b3c02aa03da75b41a44c76d/quic/s2n-quic-rustls/src/session.rs#L168-L172) and use [key_change](https://github.com/awslabs/s2n-quic/blob/71db03e77e99716d3b3c02aa03da75b41a44c76d/quic/s2n-quic-rustls/src/session.rs#L227-L231) to decide when the handshake has completed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
