### PR TITLE
ci: remove xquic from interop required checklist

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -10,7 +10,7 @@
     "picoquic": ["client"],
     "quic-go": ["client"],
     "quiche": ["client"],
-    "xquic": ["client"]
+    "xquic": []
   },
   "handshake": {
     "aioquic": ["client"],
@@ -75,7 +75,7 @@
     "picoquic": ["client"],
     "quic-go": ["client"],
     "quiche": ["client"],
-    "xquic": ["client"]
+    "xquic": []
   },
   "retry": {
     "aioquic": ["client"],
@@ -101,7 +101,7 @@
     "picoquic": ["client"],
     "quic-go": ["client"],
     "quiche": ["client"],
-    "xquic": ["client"]
+    "xquic": []
   },
   "keyupdate": {
     "aioquic": [],
@@ -166,7 +166,7 @@
     "picoquic": [],
     "quic-go": ["client"],
     "quiche": ["client"],
-    "xquic": ["client"]
+    "xquic": []
   },
   "handshakecorruption": {
     "aioquic": [],
@@ -192,7 +192,7 @@
     "picoquic": ["client"],
     "quic-go": ["client"],
     "quiche": ["client"],
-    "xquic": ["client"]
+    "xquic": []
   },
   "rebind-addr": {
     "aioquic": [],


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
xquic is closed source and the project tends to do releases after long periods. the last release broke out interoperability.

Being closed source it is not trivial to try and resolve the interop failures so this removes xquic from the required CI tests to unblock other PRs.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
