### PR TITLE
api: track application_handle_count to decide when to close the connection

### DIFF
--- a/quic/s2n-quic-transport/src/connection/api.rs
+++ b/quic/s2n-quic-transport/src/connection/api.rs
@@ -67,12 +67,13 @@ impl Drop for Connection {
             .api
             .application_handle_count()
             .fetch_sub(1, Ordering::Release)
-            == 1
+            != 1
         {
-            self.api.close_connection(None)
+            return;
         }
 
-        atomic::fence(Ordering::Acquire)
+        atomic::fence(Ordering::Acquire);
+        self.api.close_connection(None);
     }
 }
 

--- a/quic/s2n-quic-transport/src/connection/api_provider.rs
+++ b/quic/s2n-quic-transport/src/connection/api_provider.rs
@@ -10,7 +10,10 @@ use crate::{
 };
 use alloc::sync::Arc;
 use bytes::Bytes;
-use core::task::{Context, Poll};
+use core::{
+    sync::atomic::AtomicUsize,
+    task::{Context, Poll},
+};
 use s2n_quic_core::{
     application,
     application::Sni,
@@ -18,7 +21,6 @@ use s2n_quic_core::{
     inet::SocketAddress,
     stream::{ops, StreamId, StreamType},
 };
-use std::sync::atomic::AtomicUsize;
 
 /// A dynamically dispatched connection API
 pub(crate) type ConnectionApi = Arc<dyn ConnectionApiProvider>;

--- a/quic/s2n-quic-transport/src/connection/connection_container.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container.rs
@@ -24,6 +24,7 @@ use core::{
     marker::PhantomData,
     ops::Deref,
     pin::Pin,
+    sync::atomic::AtomicUsize,
     task::{Context, Poll},
 };
 use intrusive_collections::{
@@ -38,7 +39,6 @@ use s2n_quic_core::{
     time::Timestamp,
     transport,
 };
-use std::sync::atomic::AtomicUsize;
 
 // Intrusive list adapter for managing the list of `done` connections
 intrusive_adapter!(DoneConnectionsAdapter<C, L> = Arc<ConnectionNode<C, L>>: ConnectionNode<C, L> {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The [current mechanism](https://github.com/awslabs/s2n-quic/blob/d380be490579b4e5bf2cadc39c6a0d24f7cf598b/quic/s2n-quic-transport/src/connection/api.rs#L49) of detecting is a sharp edge since the connection could be part of multiple interest lists and cause the count to be wrong. This is true now since we have 3 handles to the connections:

- (transmit interest) https://github.com/awslabs/s2n-quic/blob/9ca8358bdbf4a7d671d7835ddd2a10fc88b5644b/quic/s2n-quic-transport/src/connection/connection_container.rs#L395
- (timeout interest) https://github.com/awslabs/s2n-quic/blob/9ca8358bdbf4a7d671d7835ddd2a10fc88b5644b/quic/s2n-quic-transport/src/connection/connection_container.rs#L417
- (application handle) https://github.com/awslabs/s2n-quic/blob/9ca8358bdbf4a7d671d7835ddd2a10fc88b5644b/quic/s2n-quic-transport/src/connection/connection_container.rs#L445

### Changes
This PR uses a `application_handle_count` AtomicUsize which explicitly tracks the number of application handles. Once this count hits 0 then we know it is safe to close the connection.

### Testing
Local testing was done to confirm the counter increments and and decrements as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
