### PR TITLE
ci: fix inferno install

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -562,6 +562,13 @@ jobs:
         with:
           submodules: true
 
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
       - uses: camshaft/gha-perf@v0.1
 
       - name: Install inferno


### PR DESCRIPTION
Inferno needs to be built on rust stable. This change enables that in the workflow.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
