### PR TITLE
interop: log only to the log file

### DIFF
--- a/quic/s2n-quic-qns/etc/run_endpoint.sh
+++ b/quic/s2n-quic-qns/etc/run_endpoint.sh
@@ -58,9 +58,9 @@ if [ "$ROLE" == "client" ]; then
     /wait-for-it.sh sim:57832 -s -t 30
     $QNS_BIN $QNS_MODE client \
         $CLIENT_PARAMS \
-        $REQUESTS 2>&1 | tee $LOG
+        $REQUESTS > $LOG
 elif [ "$ROLE" == "server" ]; then
     $QNS_BIN $QNS_MODE server \
-        $SERVER_PARAMS 2>&1 | tee $LOG
+        $SERVER_PARAMS > $LOG
 fi
 

--- a/quic/s2n-quic-qns/src/server/interop.rs
+++ b/quic/s2n-quic-qns/src/server/interop.rs
@@ -122,7 +122,16 @@ impl Interop {
             let mut file = File::open(&abs_path).await?;
             loop {
                 match timeout(Duration::from_secs(1), file.next()).await {
-                    Ok(Some(Ok(chunk))) => tx_stream.send(chunk).await?,
+                    Ok(Some(Ok(chunk))) => {
+                        let len = chunk.len();
+                        debug!(
+                            "{:?} bytes ready to send on Stream({:?})",
+                            len,
+                            tx_stream.id()
+                        );
+                        tx_stream.send(chunk).await?;
+                        debug!("{:?} bytes sent on Stream({:?})", len, tx_stream.id());
+                    }
                     Ok(Some(Err(err))) => {
                         eprintln!("error opening {:?}", abs_path);
                         tx_stream.reset(1u32.try_into()?)?;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* After enabling verbose Interop logging in #998, we have started to see sporadic failures interoping with Picoquic. These failures involve long periods of time where s2n-quic does not send on any Stream. The first of these failures can be seen [here]( https://dnglbrstg7yg.cloudfront.net/d28eec56c275a9d7c53b171a6a8e5f3e3ca1a5ad/interop/logs/latest/s2n-quic_picoquic/transfer/index.html), on a commit that was committed immediately after #998. This would seem to indicate some issue reading from files in the Docker container while a large amount of writes are occuring. To reduce the amount of file IO in Interop, this change removes writing of log output to standard out (which was written to output.txt), leaving the log output only in logs.txt. I've also added some additional debug messages around the `tx_stream.send` call to help with future debugging. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
