### PR TITLE
transport: send appropriate ECN codepoint on ConnectionClose frame

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -742,7 +742,10 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 let path = self.path_manager.active_path_mut();
 
                 if queue
-                    .push(self.close_sender.transmission(path, &mut publisher))
+                    .push(
+                        self.close_sender
+                            .transmission(path, timestamp, &mut publisher),
+                    )
                     .is_ok()
                 {
                     count += 1;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds the proper ECN codepoint to the `ConnectionClose frame` rather. This change is necessary for implementing the Endpoint Close api, when the endpoint `awaits` sending the ConnectionClose frame prior to terminating the process.

- interop [before ecn fix](https://dnglbrstg7yg.cloudfront.net/94df4f6ae5bf6e8dcd421c9d802b691d6f5b86cc/interop/index.html)
- interop [after ecn fix](https://dnglbrstg7yg.cloudfront.net/7edeb882ee9e0e0caa3bd534554ae7dde069500a/interop/index.html). Test performed along with the [Endpoint close api changes](https://github.com/awslabs/s2n-quic/pull/1081)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
