### PR TITLE
transport: aggregate transmission::Outcome

### DIFF
--- a/quic/s2n-quic-core/src/transmission/mod.rs
+++ b/quic/s2n-quic-core/src/transmission/mod.rs
@@ -1,10 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    frame::ack_elicitation::{AckElicitable, AckElicitation},
-    packet::number,
-};
+use crate::frame::ack_elicitation::{AckElicitable, AckElicitation};
+use core::ops::AddAssign;
 
 pub mod constraint;
 pub mod mode;
@@ -12,27 +10,23 @@ pub mod mode;
 pub use constraint::Constraint;
 pub use mode::Mode;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub struct Outcome {
     pub ack_elicitation: AckElicitation,
     pub is_congestion_controlled: bool,
     pub bytes_sent: usize,
-    pub packet_number: number::PacketNumber,
-}
-
-impl Outcome {
-    pub fn new(packet_number: number::PacketNumber) -> Outcome {
-        Outcome {
-            ack_elicitation: AckElicitation::NonEliciting,
-            is_congestion_controlled: false,
-            bytes_sent: 0,
-            packet_number,
-        }
-    }
 }
 
 impl AckElicitable for Outcome {
     fn ack_elicitation(&self) -> AckElicitation {
         self.ack_elicitation
+    }
+}
+
+impl AddAssign for Outcome {
+    fn add_assign(&mut self, rhs: Self) {
+        self.ack_elicitation |= rhs.ack_elicitation;
+        self.is_congestion_controlled |= rhs.is_congestion_controlled;
+        self.bytes_sent += rhs.bytes_sent;
     }
 }

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -40,7 +40,7 @@ use s2n_quic_core::{
     packet::{
         handshake::ProtectedHandshake,
         initial::{CleartextInitial, ProtectedInitial},
-        number::{PacketNumber, PacketNumberSpace},
+        number::PacketNumberSpace,
         retry::ProtectedRetry,
         short::ProtectedShort,
         version_negotiation::ProtectedVersionNegotiation,
@@ -540,7 +540,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         if let Some((early_connection_close, connection_close)) =
             s2n_quic_core::connection::error::as_frame(error, close_formatter, &close_context)
         {
-            let mut outcome = transmission::Outcome::new(PacketNumber::default());
+            let mut outcome = transmission::Outcome::default();
             let mut context = transmission_context!(
                 self,
                 &mut outcome,
@@ -655,7 +655,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
 
         match self.state {
             ConnectionState::Handshaking | ConnectionState::Active => {
-                let mut outcome = transmission::Outcome::new(PacketNumber::default());
+                let mut outcome = transmission::Outcome::default();
                 let path_id = self.path_manager.active_path_id();
 
                 // Send an MTU probe if necessary and the handshake has completed

--- a/quic/s2n-quic-transport/src/connection/transmission.rs
+++ b/quic/s2n-quic-transport/src/connection/transmission.rs
@@ -184,15 +184,6 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
                 encoder,
             ) {
                 Ok((outcome, encoder)) => {
-                    self.context
-                        .publisher
-                        .on_packet_sent(event::builder::PacketSent {
-                            packet_header: event::builder::PacketHeader::new(
-                                outcome.packet_number,
-                                self.context.publisher.quic_version(),
-                            ),
-                        });
-
                     if Config::ENDPOINT_TYPE.is_server()
                         && !outcome.ack_elicitation().is_ack_eliciting()
                     {
@@ -205,6 +196,7 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
                         // The Initial packet was not ack eliciting so there is no need to pad
                         pn_space_to_pad = None;
                     }
+                    *self.context.outcome += outcome;
                     encoder
                 }
                 Err(PacketEncodingError::PacketNumberTruncationError(encoder)) => {
@@ -244,15 +236,6 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
                 encoder,
             ) {
                 Ok((outcome, encoder)) => {
-                    self.context
-                        .publisher
-                        .on_packet_sent(event::builder::PacketSent {
-                            packet_header: event::builder::PacketHeader::new(
-                                outcome.packet_number,
-                                self.context.publisher.quic_version(),
-                            ),
-                        });
-
                     //= https://www.rfc-editor.org/rfc/rfc9001.txt#4.9.1
                     //# a client MUST discard Initial keys when it first sends a
                     //# Handshake packet
@@ -266,6 +249,7 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
                         );
                     }
 
+                    *self.context.outcome += outcome;
                     encoder
                 }
                 Err(PacketEncodingError::PacketNumberTruncationError(encoder)) => {
@@ -342,14 +326,7 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
                 encoder,
             ) {
                 Ok((outcome, encoder)) => {
-                    self.context
-                        .publisher
-                        .on_packet_sent(event::builder::PacketSent {
-                            packet_header: event::builder::PacketHeader::new(
-                                outcome.packet_number,
-                                self.context.publisher.quic_version(),
-                            ),
-                        });
+                    *self.context.outcome += outcome;
                     encoder
                 }
                 Err(PacketEncodingError::PacketNumberTruncationError(encoder)) => {

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -108,7 +108,6 @@ fn on_packet_sent() {
             ack_elicitation,
             is_congestion_controlled: i % 3 == 0,
             bytes_sent: (2 * i) as usize,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         };
 
         manager.on_packet_sent(
@@ -234,7 +233,6 @@ fn on_packet_sent_across_multiple_paths() {
         ack_elicitation,
         is_congestion_controlled: true,
         bytes_sent: packet_bytes,
-        packet_number: space.new_packet_number(VarInt::from_u8(1)),
     };
 
     manager.on_packet_sent(
@@ -274,7 +272,6 @@ fn on_packet_sent_across_multiple_paths() {
         ack_elicitation,
         is_congestion_controlled: true,
         bytes_sent: packet_bytes,
-        packet_number: space.new_packet_number(VarInt::from_u8(2)),
     };
 
     // Reset the timer so we can confirm it was set correctly
@@ -337,7 +334,6 @@ fn on_ack_frame() {
                 ack_elicitation: AckElicitation::Eliciting,
                 is_congestion_controlled: true,
                 bytes_sent: packet_bytes,
-                packet_number: space.new_packet_number(VarInt::from_u8(1)),
             },
             time_sent,
             ecn,
@@ -475,7 +471,6 @@ fn on_ack_frame() {
             ack_elicitation: AckElicitation::NonEliciting,
             is_congestion_controlled: true,
             bytes_sent: packet_bytes,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         time_sent,
         ecn,
@@ -544,7 +539,6 @@ fn process_new_acked_packets_update_pto_timer() {
             ack_elicitation: AckElicitation::Eliciting,
             is_congestion_controlled: true,
             bytes_sent: packet_bytes,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         time_sent,
         ecn,
@@ -559,7 +553,6 @@ fn process_new_acked_packets_update_pto_timer() {
             ack_elicitation: AckElicitation::Eliciting,
             is_congestion_controlled: true,
             bytes_sent: packet_bytes,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         time_sent,
         ecn,
@@ -657,7 +650,6 @@ fn process_new_acked_packets_congestion_controller() {
             ack_elicitation: AckElicitation::Eliciting,
             is_congestion_controlled: true,
             bytes_sent: packet_bytes,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         time_sent,
         ecn,
@@ -672,7 +664,6 @@ fn process_new_acked_packets_congestion_controller() {
             ack_elicitation: AckElicitation::Eliciting,
             is_congestion_controlled: true,
             bytes_sent: packet_bytes,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         time_sent,
         ecn,
@@ -781,7 +772,6 @@ fn process_new_acked_packets_pto_timer() {
             ack_elicitation: AckElicitation::Eliciting,
             is_congestion_controlled: true,
             bytes_sent: packet_bytes,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         time_sent,
         ecn,
@@ -796,7 +786,6 @@ fn process_new_acked_packets_pto_timer() {
             ack_elicitation: AckElicitation::Eliciting,
             is_congestion_controlled: true,
             bytes_sent: packet_bytes,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         time_sent,
         ecn,
@@ -831,7 +820,6 @@ fn process_new_acked_packets_pto_timer() {
             ack_elicitation: AckElicitation::Eliciting,
             is_congestion_controlled: true,
             bytes_sent: packet_bytes,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         time_sent,
         ecn,
@@ -893,7 +881,6 @@ fn process_new_acked_packets_process_ecn() {
                 ack_elicitation: AckElicitation::Eliciting,
                 is_congestion_controlled: true,
                 bytes_sent: packet_bytes,
-                packet_number: space.new_packet_number(VarInt::from_u8(i)),
             },
             time_sent,
             ExplicitCongestionNotification::Ect0,
@@ -993,7 +980,6 @@ fn process_new_acked_packets_failed_ecn_validation_does_not_cause_congestion_eve
                 ack_elicitation: AckElicitation::Eliciting,
                 is_congestion_controlled: true,
                 bytes_sent: packet_bytes,
-                packet_number: space.new_packet_number(VarInt::from_u8(i)),
             },
             time_sent,
             ExplicitCongestionNotification::Ect0,
@@ -1049,7 +1035,6 @@ fn no_rtt_update_when_not_acknowledging_the_largest_acknowledged_packet() {
             ack_elicitation: AckElicitation::Eliciting,
             is_congestion_controlled: true,
             bytes_sent: packet_bytes,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         time_sent,
         ecn,
@@ -1062,7 +1047,6 @@ fn no_rtt_update_when_not_acknowledging_the_largest_acknowledged_packet() {
             ack_elicitation: AckElicitation::Eliciting,
             is_congestion_controlled: true,
             bytes_sent: packet_bytes,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         time_sent,
         ecn,
@@ -1138,7 +1122,6 @@ fn no_rtt_update_when_receiving_packet_on_different_path() {
             ack_elicitation: AckElicitation::Eliciting,
             is_congestion_controlled: true,
             bytes_sent: packet_bytes,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         time_sent,
         ecn,
@@ -1151,7 +1134,6 @@ fn no_rtt_update_when_receiving_packet_on_different_path() {
             ack_elicitation: AckElicitation::Eliciting,
             is_congestion_controlled: true,
             bytes_sent: packet_bytes,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         time_sent,
         ecn,
@@ -1252,7 +1234,6 @@ fn rtt_update_when_receiving_ack_from_multiple_paths() {
             ack_elicitation: AckElicitation::Eliciting,
             is_congestion_controlled: true,
             bytes_sent: packet_bytes,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         sent_time,
         ecn,
@@ -1268,7 +1249,6 @@ fn rtt_update_when_receiving_ack_from_multiple_paths() {
             ack_elicitation: AckElicitation::Eliciting,
             is_congestion_controlled: true,
             bytes_sent: packet_bytes,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         sent_time,
         ecn,
@@ -1334,7 +1314,6 @@ fn detect_and_remove_lost_packets() {
         ack_elicitation: AckElicitation::Eliciting,
         is_congestion_controlled: true,
         bytes_sent: 1,
-        packet_number: space.new_packet_number(VarInt::from_u8(1)),
     };
 
     // Send a packet that was sent too long ago (lost)
@@ -1508,7 +1487,6 @@ fn detect_lost_packets_persistent_congestion_path_aware() {
         ack_elicitation: AckElicitation::Eliciting,
         is_congestion_controlled: true,
         bytes_sent: 1,
-        packet_number: space.new_packet_number(VarInt::from_u8(1)),
     };
 
     // Send a packet that was sent too long ago (lost)
@@ -1726,7 +1704,6 @@ fn detect_and_remove_lost_packets_nothing_lost() {
         ack_elicitation: AckElicitation::Eliciting,
         is_congestion_controlled: true,
         bytes_sent: 1,
-        packet_number: space.new_packet_number(VarInt::from_u8(1)),
     };
 
     // Send a packet that is less than the largest acked but not lost
@@ -1776,7 +1753,6 @@ fn detect_and_remove_lost_packets_mtu_probe() {
         ack_elicitation: AckElicitation::Eliciting,
         is_congestion_controlled: true,
         bytes_sent: MINIMUM_MTU as usize + 1,
-        packet_number: space.new_packet_number(VarInt::from_u8(1)),
     };
 
     // Send an MTU probe packet
@@ -1835,7 +1811,6 @@ fn persistent_congestion() {
         ack_elicitation: AckElicitation::Eliciting,
         is_congestion_controlled: true,
         bytes_sent: 1,
-        packet_number: space.new_packet_number(VarInt::from_u8(1)),
     };
 
     // t=0: Send packet #1 (app data)
@@ -1985,7 +1960,6 @@ fn persistent_congestion_multiple_periods() {
         ack_elicitation: AckElicitation::Eliciting,
         is_congestion_controlled: true,
         bytes_sent: 1,
-        packet_number: space.new_packet_number(VarInt::from_u8(1)),
     };
 
     // t=0: Send packet #1 (app data)
@@ -2107,7 +2081,6 @@ fn persistent_congestion_period_does_not_start_until_rtt_sample() {
         ack_elicitation: AckElicitation::Eliciting,
         is_congestion_controlled: true,
         bytes_sent: 1,
-        packet_number: space.new_packet_number(VarInt::from_u8(1)),
     };
 
     // t=0: Send packet #1 (app data)
@@ -2187,7 +2160,6 @@ fn persistent_congestion_not_ack_eliciting() {
         ack_elicitation: AckElicitation::NonEliciting,
         is_congestion_controlled: true,
         bytes_sent: 1,
-        packet_number: space.new_packet_number(VarInt::from_u8(1)),
     };
 
     // t=0: Send packet #1 (app data)
@@ -2331,7 +2303,6 @@ fn update_pto_timer() {
             ack_elicitation: AckElicitation::Eliciting,
             is_congestion_controlled: true,
             bytes_sent: 1,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         now,
         ecn,
@@ -2467,7 +2438,6 @@ fn on_timeout() {
             ack_elicitation: AckElicitation::Eliciting,
             is_congestion_controlled: true,
             bytes_sent: 1,
-            packet_number: space.new_packet_number(VarInt::from_u8(1)),
         },
         now - Duration::from_secs(5),
         ecn,
@@ -2768,7 +2738,6 @@ fn probe_packets_count_towards_bytes_in_flight() {
         ack_elicitation: AckElicitation::Eliciting,
         is_congestion_controlled: true,
         bytes_sent: 100,
-        packet_number: space.new_packet_number(VarInt::from_u8(1)),
     };
     manager.on_packet_sent(
         space.new_packet_number(VarInt::from_u8(1)),
@@ -2858,7 +2827,6 @@ fn packet_declared_lost_less_than_1_ms_from_loss_threshold() {
         ack_elicitation: AckElicitation::Eliciting,
         is_congestion_controlled: true,
         bytes_sent: 100,
-        packet_number: space.new_packet_number(VarInt::from_u8(1)),
     };
     manager.on_packet_sent(
         space.new_packet_number(VarInt::from_u8(1)),

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -15,7 +15,7 @@ use s2n_quic_core::{
     ack,
     connection::{limits::Limits, InitialId, PeerId},
     crypto::{tls, tls::Session, CryptoSuite},
-    event::{self, ConnectionPublisher as _, IntoEvent},
+    event::{self, IntoEvent},
     frame::{
         ack::AckRanges, crypto::CryptoRef, stream::StreamRef, Ack, ConnectionClose, DataBlocked,
         HandshakeDone, MaxData, MaxStreamData, MaxStreams, NewConnectionId, NewToken,
@@ -351,14 +351,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
 
                         match result {
                             Ok((outcome, buffer)) => {
-                                context
-                                    .publisher
-                                    .on_packet_sent(event::builder::PacketSent {
-                                        packet_header: event::builder::PacketHeader::new(
-                                            outcome.packet_number,
-                                            context.publisher.quic_version(),
-                                        ),
-                                    });
+                                *context.outcome += outcome;
                                 buffer
                             }
                             Err(err) => err.take_buffer(),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change aggregates each individual transmission::Outcome into the transmission::Outcome in ConnectionTransmissionContext, to allow for the aggregate outcome to be used as intended in ConnectionImpl. 

*Call-outs*: I've removed `packet_number` from the Outcome, as that cannot be aggregated. Alternatively I could define a different type for the aggregated outcome, but that felt like overkill since I was able to refactor things to remove usage of it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
