### PR TITLE
limits: max handshake duration

### DIFF
--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -16,6 +16,8 @@ use core::{convert::TryInto, time::Duration};
 
 pub use crate::transport::parameters::ValidationError;
 
+const MAX_HANDSHAKE_DURATION_DEFAULT: Duration = Duration::from_secs(10);
+
 #[non_exhaustive]
 #[derive(Debug)]
 pub struct ConnectionInfo<'a> {
@@ -49,6 +51,7 @@ pub struct Limits {
     pub(crate) ack_ranges_limit: u8,
     pub(crate) max_send_buffer_size: u32,
     pub(crate) min_transfer_bytes_per_second: u32,
+    pub(crate) max_handshake_duration: Duration,
 }
 
 impl Default for Limits {
@@ -84,6 +87,7 @@ impl Limits {
             ack_ranges_limit: ack::Settings::RECOMMENDED.ack_ranges_limit,
             max_send_buffer_size: stream::Limits::RECOMMENDED.max_send_buffer_size,
             min_transfer_bytes_per_second: 0,
+            max_handshake_duration: MAX_HANDSHAKE_DURATION_DEFAULT,
         }
     }
 
@@ -133,6 +137,11 @@ impl Limits {
         min_transfer_bytes_per_second,
         u32
     );
+    setter!(
+        with_max_handshake_duration,
+        max_handshake_duration,
+        Duration
+    );
 
     pub fn load_peer<A, B, C, D>(&mut self, peer_parameters: &TransportParameters<A, B, C, D>) {
         self.max_idle_timeout
@@ -180,6 +189,10 @@ impl Limits {
 
     pub fn min_transfer_bytes_per_second(&self) -> u32 {
         self.min_transfer_bytes_per_second
+    }
+
+    pub fn max_handshake_duration(&self) -> Duration {
+        self.max_handshake_duration
     }
 }
 

--- a/quic/s2n-quic-transport/src/connection/connection_timers.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_timers.rs
@@ -29,8 +29,10 @@ pub struct ConnectionTimers {
     pub initial_id_expiration_timer: Timer,
     /// The timer for pacing transmission of packets
     pub pacing_timer: Timer,
-    /// Timer for evaluating if the transfer rate is below the min transfer rate
+    /// The timer for evaluating if the transfer rate is below the min transfer rate
     pub min_transfer_rate_timer: Timer,
+    /// The timer for closing the connection if the handshake is still in progress
+    pub max_handshake_duration_timer: Timer,
 }
 
 impl ConnectionTimers {
@@ -40,6 +42,7 @@ impl ConnectionTimers {
         self.initial_id_expiration_timer.cancel();
         self.pacing_timer.cancel();
         self.min_transfer_rate_timer.cancel();
+        self.max_handshake_duration_timer.cancel();
     }
 }
 
@@ -51,6 +54,7 @@ impl timer::Provider for ConnectionTimers {
         self.initial_id_expiration_timer.timers(query)?;
         self.pacing_timer.timers(query)?;
         self.min_transfer_rate_timer.timers(query)?;
+        self.max_handshake_duration_timer.timers(query)?;
 
         Ok(())
     }


### PR DESCRIPTION
*Issue #, if available:* #1056

*Description of changes:* This change allows customers to configure a `max_handshake_duration` in the Connection limits, as a mitigation for the SlowLoris attack. If the handshake takes longer than the configured value (10 seconds by default), the connection will be closed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
