### PR TITLE
s2n-tls: remove s2n-tls method not relevant for TLS1.3

### DIFF
--- a/tls/s2n-tls/src/config.rs
+++ b/tls/s2n-tls/src/config.rs
@@ -65,11 +65,6 @@ impl Builder {
         Default::default()
     }
 
-    pub fn set_alert_behavior(&mut self, value: s2n_alert_behavior) -> Result<&mut Self, Error> {
-        call!(s2n_config_set_alert_behavior(self.as_mut_ptr(), value))?;
-        Ok(self)
-    }
-
     pub fn set_max_cert_chain_depth(&mut self, depth: u16) -> Result<&mut Self, Error> {
         call!(s2n_config_set_max_cert_chain_depth(
             self.as_mut_ptr(),


### PR DESCRIPTION
Very small fix.

TLS1.3 deprecated the "severity level" field of alerts, meaning
that there are no longer separate "warnings" and "errors". Most
alerts are errors, except "close_notify" which is special cased.
See https://datatracker.ietf.org/doc/html/rfc8446#section-6

Basically, in TLS1.3 the "alert behavior" is always considered
"S2N_ALERT_FAIL_ON_WARNINGS".

I'd like to remove the wrapper method to avoid future confusion.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
