### PR TITLE
ci: bypass pyshark build failure

### DIFF
--- a/.github/interop/runner.patch
+++ b/.github/interop/runner.patch
@@ -146,6 +146,17 @@ index c2d6d1f..844bbd5 100644
  
  print("\nPulling the iperf endpoint...")
  os.system("docker pull martenseemann/quic-interop-iperf-endpoint")
+diff --git a/requirements.txt b/requirements.txt
+index fff6217..a22ef1f 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,4 +1,4 @@
+ pycrypto
+ termcolor
+ prettytable
+-pyshark
+\ No newline at end of file
++pyshark==0.4.3
 diff --git a/testcases.py b/testcases.py
 index 1d81d25..7260408 100644
 --- a/testcases.py

--- a/scripts/interop/README.md
+++ b/scripts/interop/README.md
@@ -28,11 +28,10 @@
 ```
 git clone git@github.com:marten-seemann/quic-interop-runner.git
 cd quic-interop-runner
-gco cd62367f7cf98d16854551fdd8ef6a48ad89d53d
+git checkout 37c7eb05402c43ad1d7daa0e1c903db80f6478b9 # check run script in this dir
 
-cp <s2n-quic_proj_dir>.runner.patch .
+cp <s2n-quic_proj_dir>/.github/interop/runner.patch .
 git apply --3way runner.patch # apply the current patch
-git add . # add the current changes
 ```
 
 Make changes to the quic-interop-runner repo and run the following command to sync the changes


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
pyshark forgot to upload source when releasing `0.4.4` and breaks interop. This pins the version to `0.4.3`.

**Btw there are instructions on how to update the patch script in `scripts/interop/README.md` if you ever need to do that!**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
