### PR TITLE
core: add checks to ensure tls handshake behavior

### DIFF
--- a/quic/s2n-quic-core/src/crypto/tls/testing.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/testing.rs
@@ -169,7 +169,7 @@ impl<S: tls::Session, C: tls::Session> Pair<S, C> {
                 );
                 assert!(
                     self.client.1.application.crypto.is_some(),
-                    "server should have application keys after reading the ServerFinished"
+                    "client should have application keys after reading the ServerHello"
                 );
                 assert!(
                     self.client.1.handshake_complete,


### PR DESCRIPTION
Currently, our TLS tests just ensure that the handshake completes in less than 10 iterations and that we ended up with all of the keys. This change makes additional assertions about when keys become available and reduces the maximum iterations to 4.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
