### PR TITLE
tls: simplify check of transport param decode function

### DIFF
--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -68,7 +68,7 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
                     .with_reason("Invalid transport parameters")
             })?;
 
-        assert_eq!(remaining.len(), 0);
+        debug_assert_eq!(remaining.len(), 0);
         self.publisher.on_transport_parameters_received(
             event::builder::TransportParametersReceived {
                 transport_parameters: peer_parameters.into_event(),
@@ -185,7 +185,7 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
                     .with_reason("Invalid transport parameters")
             })?;
 
-        assert_eq!(remaining.len(), 0);
+        debug_assert_eq!(remaining.len(), 0);
         self.publisher.on_transport_parameters_received(
             event::builder::TransportParametersReceived {
                 transport_parameters: peer_parameters.into_event(),


### PR DESCRIPTION

*Issue #, if available:*
Currently we do a map on an error rather than a map_err, which hides the error.

However we can do better. The remaining byes should always be 0 since the [transport param decode function drains](https://github.com/awslabs/s2n-quic/blob/acf6492a12567f810804027c13db91792c046005/quic/s2n-quic-core/src/transport/parameters/mod.rs#L135-L136) the entire length of the buffer. Therefore this PR removes the error mapping and replaces it with an assert.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
