### PR TITLE
transport: flush finished receive stream buffers on errors

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1576,7 +1576,9 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         request: &mut stream::ops::Request,
         context: Option<&Context>,
     ) -> Result<stream::ops::Response, stream::StreamError> {
-        self.error?;
+        // Don't check the `self.error` here so streams can handle errors individually. This is especially
+        // important for receive streams that may have buffered stream data that haven't been
+        // consumed by the application.
 
         let (space, _) = self
             .space_manager

--- a/quic/s2n-quic-transport/src/stream/contract.rs
+++ b/quic/s2n-quic-transport/src/stream/contract.rs
@@ -107,7 +107,7 @@ pub mod tx {
             }
 
             // resetting takes priority
-            if self.reset.is_some() {
+            if self.reset.is_some() || response.map_or(false, |res| res.is_reset()) {
                 let response = response.expect("reset should never fail");
 
                 assert_eq!(
@@ -141,13 +141,6 @@ pub mod tx {
 
                 // none of the other checks apply so return early
                 return;
-            }
-
-            if let Ok(response) = response {
-                assert!(
-                    !response.is_reset() && !response.is_resetting(),
-                    "is_reset should only be set on a reset request"
-                );
             }
 
             // the request is interested in push availability


### PR DESCRIPTION
Consider the following scenario:

```
client_stream.send(...);
client_stream.finish();
client_conn.close();

                 ---------------------------->
                   STREAM { fin: true, ... }
                   CONNECTION_CLOSE { ... }
                 ---------------------------->

                                           let data = server_stream.recv().await?;
```

The client sends some data and finishes the stream, then immediately closes the connection afterward. Even though the server's connection is technically closed immediately after receiving a CONNECTION_CLOSE frame, the application should still be able to drain completed streams. Most of the stream logic already handled this scenario. However, the `ConnectionImpl::poll_stream_request` incorrectly gated stream operations with `self.error?`, which caused the server to be unable to flush the outstanding stream buffer.

This change fixes that issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
