### PR TITLE
platform: turn off SO_REUSEPORT by default

### DIFF
--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -358,7 +358,7 @@ fn bind<A: std::net::ToSocketAddrs>(addr: A, reuse_port: bool) -> io::Result<soc
 
     #[cfg(unix)]
     socket.set_reuse_port(reuse_port)?;
-    
+
     // mark the variable as "used" regardless of platform support
     let _ = reuse_port;
 
@@ -466,7 +466,10 @@ impl Builder {
     /// Enables the port reuse (SO_REUSEPORT) socket option
     pub fn with_reuse_port(mut self) -> io::Result<Self> {
         if !cfg!(unix) {
-            return Err(io::Error::new(io::ErrorKind::InvalidInput, "reuse_port is not supported on the current platform"));
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "reuse_port is not supported on the current platform",
+            ));
         }
         self.reuse_port = true;
         Ok(self)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Setting SO_REUSEPORT to true causes failures in our perf CI runs. This happens if the previous server is not killed before the next test and the client ends up connection to the previous server.

This PR sets SO_REUSEPORT to `false` by default. An option is exposed to the application to turn this on if desired.

Some more info about SO_REUSEPORT: https://lwn.net/Articles/542629/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
