### PR TITLE
ci: add rustls tls provider to interop report

### DIFF
--- a/.github/interop/Dockerfile
+++ b/.github/interop/Dockerfile
@@ -28,3 +28,6 @@ RUN set -eux; \
 
 # help with debugging
 ENV RUST_BACKTRACE=1
+
+ARG tls
+ENV TLS="${tls}"

--- a/.github/interop/runner.patch
+++ b/.github/interop/runner.patch
@@ -38,13 +38,18 @@ index 7541cae..ba1b4da 100644
        - VERSION=$VERSION
      depends_on:
 diff --git a/implementations.json b/implementations.json
-index 3df16da..7ed4f6e 100644
+index 3df16da..70ff578 100644
 --- a/implementations.json
 +++ b/implementations.json
-@@ -1,24 +1,19 @@
+@@ -1,24 +1,24 @@
  {
 +  "s2n-quic": {
 +    "image": "awslabs/s2n-quic-qns:latest",
++    "url": "https://github.com/awslabs/s2n-quic",
++    "role": "both"
++  },
++  "s2n-quic-rustls": {
++    "image": "awslabs/s2n-quic-qns-rustls:latest",
 +    "url": "https://github.com/awslabs/s2n-quic",
 +    "role": "both"
 +  },

--- a/.github/interop/script.js
+++ b/.github/interop/script.js
@@ -34,12 +34,11 @@
             log_url_pattern = log_dir;
         }
 
-        // Use original s2n-quic names
-        if (server.startsWith('s2n-quic')) {
+        // Use original s2n-quic names.
+        if (server.startsWith('s2n-quic') && (server != 's2n-quic-rustls')) {
             server = 's2n-quic';
         }
-
-        if (client.startsWith('s2n-quic')) {
+        if (client.startsWith('s2n-quic') && (server != 's2n-quic-rustls')) {
             client = 's2n-quic';
         }
 

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -222,7 +222,8 @@ jobs:
       - name: Run docker build
         working-directory: s2n-quic-qns
         run: |
-          docker build . --file Dockerfile --tag awslabs/s2n-quic-qns
+          docker build . --file Dockerfile --tag awslabs/s2n-quic-qns --build-arg tls=s2n-tls
+          docker build . --file Dockerfile --tag awslabs/s2n-quic-qns-rustls --build-arg tls=rustls
 
       - uses: actions/checkout@v2
         with:

--- a/quic/s2n-quic-qns/etc/Dockerfile.build
+++ b/quic/s2n-quic-qns/etc/Dockerfile.build
@@ -68,3 +68,6 @@ RUN set -eux; \
   # ensure the binary works \
   s2n-quic-qns --help; \
   echo done
+
+ARG tls
+ENV TLS="${tls}"

--- a/quic/s2n-quic-qns/etc/run_endpoint.sh
+++ b/quic/s2n-quic-qns/etc/run_endpoint.sh
@@ -23,6 +23,7 @@ LOG=$LOG_DIR/logs.txt
 
 QNS_BIN="s2n-quic-qns"
 QNS_MODE=${QNS_MODE:-interop}
+TLS=${TLS:-s2n-tls}
 
 # Disable GSO as it does not work with Docker
 SERVER_PARAMS+=" --disable-gso"
@@ -35,6 +36,9 @@ if [ "$QNS_MODE" == "interop" ]; then
         CLIENT_PARAMS+=" --download-dir /downloads"
     fi
 fi
+
+SERVER_PARAMS+=" --tls $TLS"
+CLIENT_PARAMS+=" --tls $TLS"
 
 if [ "$TEST_TYPE" == "MEASUREMENT" ] && [ -x "$(command -v s2n-quic-qns-release)" ]; then
     echo "using optimized build"

--- a/scripts/interop/run
+++ b/scripts/interop/run
@@ -10,7 +10,8 @@ set -e
 INTEROP_DIR=target/quic-interop-runner
 
 # Setup the s2n-quic docker image
-sudo docker build . --file quic/s2n-quic-qns/etc/Dockerfile.build --tag awslabs/s2n-quic-qns
+sudo docker build . --file quic/s2n-quic-qns/etc/Dockerfile.build --tag awslabs/s2n-quic-qns --build-arg tls=s2n-tls
+sudo docker build . --file quic/s2n-quic-qns/etc/Dockerfile.build --tag awslabs/s2n-quic-qns-rustls --build-arg tls=rustls
 
 if [ ! -d $INTEROP_DIR ]; then
   git clone https://github.com/marten-seemann/quic-interop-runner $INTEROP_DIR


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a single interop test between client(s2n-quic) <-> server(s2n-quic)

Only a single test is added so that CI test time doesnt increase.

[report](https://dnglbrstg7yg.cloudfront.net/dbd97251eca6f2039d7a67496287d43ea06dad26/interop/index.html)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
