### PR TITLE
netbench: initial commit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     "common/s2n-*",
+    "netbench/netbench*",
     "quic/s2n-*",
 ]
 resolver = "2"

--- a/netbench/Cargo.toml
+++ b/netbench/Cargo.toml
@@ -1,7 +1,6 @@
 [workspace]
 members = [
-    "common/s2n-*",
-    "quic/s2n-*",
+    "netbench*",
 ]
 resolver = "2"
 

--- a/netbench/netbench/Cargo.toml
+++ b/netbench/netbench/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "netbench"
+version = "0.1.0"
+authors = ["Cameron Bytheway <bythewc@amazon.com>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[features]
+default = ["s2n-quic"]
+
+[dependencies]
+bytes = "1"
+enum-primitive-derive = "0.2"
+futures = "0.3"
+num-traits = "0.2"
+s2n-quic-core = { version = "0.1", path = "../../quic/s2n-quic-core", features = ["testing"] }
+s2n-quic = { version = "0.1", path = "../../quic/s2n-quic", optional = true }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+tokio = { version = "1", features = ["net", "time"] }
+
+[dev-dependencies]
+insta = "1"

--- a/netbench/netbench/Cargo.toml
+++ b/netbench/netbench/Cargo.toml
@@ -14,7 +14,7 @@ enum-primitive-derive = "0.2"
 futures = "0.3"
 num-traits = "0.2"
 s2n-quic-core = { version = "0.1", path = "../../quic/s2n-quic-core", features = ["testing"] }
-s2n-quic = { version = "0.1", path = "../../quic/s2n-quic", optional = true }
+s2n-quic = { version = "1", path = "../../quic/s2n-quic", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"
@@ -22,3 +22,4 @@ tokio = { version = "1", features = ["net", "time"] }
 
 [dev-dependencies]
 insta = "1"
+tokio = { version = "1", features = ["io-util", "net", "time"] }

--- a/netbench/netbench/Cargo.toml
+++ b/netbench/netbench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "netbench"
 version = "0.1.0"
-authors = ["Cameron Bytheway <bythewc@amazon.com>"]
+authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"
 

--- a/netbench/netbench/Cargo.toml
+++ b/netbench/netbench/Cargo.toml
@@ -21,5 +21,6 @@ sha2 = "0.10"
 tokio = { version = "1", features = ["net", "time"] }
 
 [dev-dependencies]
+futures-test = "0.3"
 insta = "1"
 tokio = { version = "1", features = ["io-util", "net", "time"] }

--- a/netbench/netbench/src/checkpoints.rs
+++ b/netbench/netbench/src/checkpoints.rs
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use core::task::Poll;
+use core::task::{Context, Poll};
 use std::collections::HashSet;
 
 pub trait Checkpoints {
     fn park(&mut self, id: u64) -> Poll<()>;
-    fn unpark(&mut self, id: u64);
+    fn unpark(&mut self, id: u64, cx: &mut Context);
 }
 
 impl Checkpoints for HashSet<u64> {
@@ -18,7 +18,9 @@ impl Checkpoints for HashSet<u64> {
         }
     }
 
-    fn unpark(&mut self, id: u64) {
+    fn unpark(&mut self, id: u64, cx: &mut Context) {
         self.insert(id);
+        // notify the task to make more progress
+        cx.waker().wake_by_ref();
     }
 }

--- a/netbench/netbench/src/checkpoints.rs
+++ b/netbench/netbench/src/checkpoints.rs
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::task::Poll;
+use std::collections::HashSet;
+
+pub trait Checkpoints {
+    fn park(&mut self, id: u64) -> Poll<()>;
+    fn unpark(&mut self, id: u64);
+}
+
+impl Checkpoints for HashSet<u64> {
+    fn park(&mut self, id: u64) -> Poll<()> {
+        if self.remove(&id) {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn unpark(&mut self, id: u64) {
+        self.insert(id);
+    }
+}

--- a/netbench/netbench/src/connection.rs
+++ b/netbench/netbench/src/connection.rs
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Result;
+use core::task::{Context, Poll};
+
+pub trait Connection {
+    fn poll_open_bidirectional_stream(&mut self, id: u64, cx: &mut Context) -> Poll<Result<()>>;
+    fn poll_open_send_stream(&mut self, id: u64, cx: &mut Context) -> Poll<Result<()>>;
+    fn poll_accept_stream(&mut self, cx: &mut Context) -> Poll<Result<Option<u64>>>;
+    fn poll_send(
+        &mut self,
+        owner: Owner,
+        id: u64,
+        bytes: u64,
+        cx: &mut Context,
+    ) -> Poll<Result<u64>>;
+    fn poll_receive(
+        &mut self,
+        owner: Owner,
+        id: u64,
+        bytes: u64,
+        cx: &mut Context,
+    ) -> Poll<Result<u64>>;
+    fn poll_send_finish(&mut self, owner: Owner, id: u64, cx: &mut Context) -> Poll<Result<()>>;
+    fn poll_receive_finish(&mut self, owner: Owner, id: u64, cx: &mut Context) -> Poll<Result<()>>;
+    fn poll_progress(&mut self, cx: &mut Context) -> Poll<Result<()>> {
+        let _ = cx;
+        Ok(()).into()
+    }
+    fn poll_finish(&mut self, cx: &mut Context) -> Poll<Result<()>> {
+        let _ = cx;
+        Ok(()).into()
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum Owner {
+    Local,
+    Remote,
+}
+
+impl<T> core::ops::Index<Owner> for [T; 2] {
+    type Output = T;
+
+    fn index(&self, index: Owner) -> &Self::Output {
+        match index {
+            Owner::Local => &self[0],
+            Owner::Remote => &self[1],
+        }
+    }
+}
+
+impl<T> core::ops::IndexMut<Owner> for [T; 2] {
+    fn index_mut(&mut self, index: Owner) -> &mut Self::Output {
+        match index {
+            Owner::Local => &mut self[0],
+            Owner::Remote => &mut self[1],
+        }
+    }
+}
+
+impl core::ops::Not for Owner {
+    type Output = Self;
+
+    fn not(self) -> Self::Output {
+        match self {
+            Self::Local => Self::Remote,
+            Self::Remote => Self::Local,
+        }
+    }
+}

--- a/netbench/netbench/src/driver.rs
+++ b/netbench/netbench/src/driver.rs
@@ -10,6 +10,7 @@ mod timer;
 
 use thread::Thread;
 
+#[derive(Debug)]
 pub struct Driver<'a, C: Connection> {
     pub connection: C,
     local_thread: Thread<'a>,

--- a/netbench/netbench/src/driver/thread.rs
+++ b/netbench/netbench/src/driver/thread.rs
@@ -1,0 +1,242 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::timer::Timer;
+use crate::{
+    connection::Owner,
+    operation::ConnectionOperation,
+    units::{Byte, Rate, Rates},
+    Checkpoints, Connection, Result, Trace,
+};
+use core::task::{Context, Poll};
+use futures::ready;
+
+#[derive(Debug)]
+pub struct Thread<'a> {
+    ops: &'a [ConnectionOperation],
+    index: usize,
+    op: Option<Op<'a>>,
+    timer: Timer,
+    owner: Owner,
+}
+
+impl<'a> Thread<'a> {
+    pub fn new(ops: &'a [ConnectionOperation], owner: Owner) -> Self {
+        Self {
+            ops,
+            index: 0,
+            op: None,
+            timer: Timer::default(),
+            owner,
+        }
+    }
+
+    pub(crate) fn poll<C: Connection, T: Trace, Ch: Checkpoints>(
+        &mut self,
+        conn: &mut C,
+        trace: &mut T,
+        checkpoints: &mut Ch,
+        rates: &mut Rates,
+        cx: &mut Context,
+    ) -> Poll<Result<()>> {
+        loop {
+            while self.op.is_none() {
+                if let Some(op) = self.ops.get(self.index) {
+                    self.index += 1;
+                    self.on_op(op, trace, checkpoints, rates, cx);
+                } else {
+                    // we are all done processing the operations
+                    return Poll::Ready(Ok(()));
+                }
+            }
+
+            ready!(self.poll_op(conn, trace, checkpoints, rates, cx))?;
+            self.op = None;
+        }
+    }
+
+    fn on_op<T: Trace, Ch: Checkpoints>(
+        &mut self,
+        op: &'a ConnectionOperation,
+        trace: &mut T,
+        checkpoints: &mut Ch,
+        rates: &mut Rates,
+        cx: &mut Context,
+    ) {
+        trace.exec(op);
+        match op {
+            ConnectionOperation::Sleep { amount } => {
+                self.timer.sleep(*amount);
+                self.op = Some(Op::Sleep);
+            }
+            ConnectionOperation::OpenBidirectionalStream { stream_id } => {
+                self.op = Some(Op::OpenBidirectionalStream { id: *stream_id });
+            }
+            ConnectionOperation::OpenSendStream { stream_id } => {
+                self.op = Some(Op::OpenSendStream { id: *stream_id });
+            }
+            ConnectionOperation::Send { stream_id, bytes } => {
+                self.op = Some(Op::Send {
+                    id: *stream_id,
+                    remaining: *bytes,
+                    rate: rates.send.get(stream_id).cloned(),
+                });
+            }
+            ConnectionOperation::SendFinish { stream_id } => {
+                self.op = Some(Op::SendFinish { id: *stream_id });
+            }
+            ConnectionOperation::SendRate { stream_id, rate } => {
+                rates.send.insert(*stream_id, *rate);
+            }
+            ConnectionOperation::Receive { stream_id, bytes } => {
+                self.op = Some(Op::Receive {
+                    id: *stream_id,
+                    remaining: *bytes,
+                    rate: rates.receive.get(stream_id).cloned(),
+                });
+            }
+            ConnectionOperation::ReceiveAll { stream_id } => {
+                self.op = Some(Op::ReceiveAll {
+                    id: *stream_id,
+                    rate: rates.receive.get(stream_id).cloned(),
+                });
+            }
+            ConnectionOperation::ReceiveFinish { stream_id } => {
+                self.op = Some(Op::ReceiveFinish { id: *stream_id });
+            }
+            ConnectionOperation::ReceiveRate { stream_id, rate } => {
+                rates.receive.insert(*stream_id, *rate);
+            }
+            ConnectionOperation::Trace { trace_id } => {
+                trace.trace(*trace_id);
+            }
+            ConnectionOperation::Park { checkpoint } => {
+                self.op = Some(Op::Wait {
+                    checkpoint: *checkpoint,
+                });
+            }
+            ConnectionOperation::Unpark { checkpoint } => {
+                // notify the checkpoint that it can make progress
+                checkpoints.unpark(*checkpoint);
+                // re-poll the operations since we may be unblocking another task
+                cx.waker().wake_by_ref();
+            }
+            ConnectionOperation::Scope { threads } => {
+                if !threads.is_empty() {
+                    let threads = threads
+                        .iter()
+                        .map(|thread| Thread::new(thread, self.owner))
+                        .collect();
+                    self.op = Some(Op::Scope { threads });
+                }
+            }
+        }
+    }
+
+    fn poll_op<C: Connection, T: Trace, Ch: Checkpoints>(
+        &mut self,
+        conn: &mut C,
+        trace: &mut T,
+        checkpoints: &mut Ch,
+        rates: &mut Rates,
+        cx: &mut Context,
+    ) -> Poll<Result<()>> {
+        let owner = self.owner;
+        match self.op.as_mut().unwrap() {
+            Op::Sleep => {
+                ready!(self.timer.poll(cx));
+                Poll::Ready(Ok(()))
+            }
+            Op::OpenBidirectionalStream { id } => conn.poll_open_bidirectional_stream(*id, cx),
+            Op::OpenSendStream { id } => conn.poll_open_send_stream(*id, cx),
+            Op::Send {
+                id,
+                remaining,
+                rate,
+            } => self.timer.transfer(remaining, rate, cx, |bytes, cx| {
+                let amount = ready!(conn.poll_send(owner, *id, *bytes, cx))?;
+                trace.send(*id, amount);
+                Ok(amount).into()
+            }),
+            Op::SendFinish { id } => conn.poll_send_finish(owner, *id, cx),
+            Op::Receive {
+                id,
+                remaining,
+                rate,
+            } => self.timer.transfer(remaining, rate, cx, |bytes, cx| {
+                let amount = ready!(conn.poll_receive(owner, *id, *bytes, cx))?;
+                trace.receive(*id, amount);
+                Ok(amount).into()
+            }),
+            Op::ReceiveAll { id, rate } => {
+                let mut remaining = Byte::MAX;
+                self.timer.transfer(&mut remaining, rate, cx, |bytes, cx| {
+                    let amount = ready!(conn.poll_receive(owner, *id, *bytes, cx))?;
+                    trace.receive(*id, amount);
+                    Ok(amount).into()
+                })
+            }
+            Op::ReceiveFinish { id } => conn.poll_receive_finish(owner, *id, cx),
+            Op::Wait { checkpoint } => {
+                ready!(checkpoints.park(*checkpoint));
+                Ok(()).into()
+            }
+            Op::Scope { threads } => {
+                let mut all_ready = true;
+                let op_idx = self.index;
+                for (idx, thread) in threads.iter_mut().enumerate() {
+                    trace.enter(op_idx, idx);
+                    let result = thread.poll(conn, trace, checkpoints, rates, cx);
+                    trace.exit();
+                    match result {
+                        Poll::Ready(Ok(_)) => {}
+                        Poll::Ready(Err(err)) => return Err(err).into(),
+                        Poll::Pending => all_ready = false,
+                    }
+                }
+                if all_ready {
+                    Poll::Ready(Ok(()))
+                } else {
+                    Poll::Pending
+                }
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum Op<'a> {
+    Sleep,
+    OpenBidirectionalStream {
+        id: u64,
+    },
+    OpenSendStream {
+        id: u64,
+    },
+    Send {
+        id: u64,
+        remaining: Byte,
+        rate: Option<Rate>,
+    },
+    SendFinish {
+        id: u64,
+    },
+    Receive {
+        id: u64,
+        remaining: Byte,
+        rate: Option<Rate>,
+    },
+    ReceiveAll {
+        id: u64,
+        rate: Option<Rate>,
+    },
+    ReceiveFinish {
+        id: u64,
+    },
+    Wait {
+        checkpoint: u64,
+    },
+    Scope {
+        threads: Vec<Thread<'a>>,
+    },
+}

--- a/netbench/netbench/src/driver/timer.rs
+++ b/netbench/netbench/src/driver/timer.rs
@@ -1,0 +1,88 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    units::{Byte, Rate},
+    Result,
+};
+use core::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+use futures::ready;
+use tokio::time::{sleep_until, Instant, Sleep};
+
+#[derive(Debug, Default)]
+pub struct Timer {
+    sleep: Option<Pin<Box<Sleep>>>,
+    is_armed: bool,
+    window: Byte,
+}
+
+impl Timer {
+    pub fn poll(&mut self, cx: &mut Context) -> Poll<()> {
+        if !self.is_armed {
+            return Poll::Ready(());
+        }
+
+        if let Some(timer) = self.sleep.as_mut() {
+            ready!(timer.as_mut().poll(cx));
+            self.is_armed = false;
+        }
+
+        Poll::Ready(())
+    }
+
+    pub fn sleep(&mut self, duration: Duration) {
+        let deadline = Instant::now() + duration;
+        if let Some(timer) = self.sleep.as_mut() {
+            Sleep::reset(timer.as_mut(), deadline);
+        } else {
+            self.sleep = Some(Box::pin(sleep_until(deadline)));
+        }
+        self.is_armed = true;
+    }
+
+    pub fn transfer<F: FnMut(Byte, &mut Context) -> Poll<Result<u64>>>(
+        &mut self,
+        remaining: &mut Byte,
+        rate: &Option<Rate>,
+        cx: &mut Context,
+        mut f: F,
+    ) -> Poll<Result<()>> {
+        loop {
+            let amount = if let Some(Rate { bytes, period }) = rate.as_ref() {
+                if self.poll(cx).is_ready() {
+                    self.window = *bytes.min(remaining);
+                    self.sleep(*period);
+                }
+
+                if self.window == Byte::default() {
+                    return Poll::Pending;
+                }
+
+                let amount = ready!(f(self.window, cx))?;
+
+                self.window -= amount;
+
+                amount
+            } else {
+                ready!(f(*remaining, cx))?
+            };
+
+            // if the transfer returned 0 bytes that means it's done
+            if amount == 0 {
+                *remaining = Byte::default();
+            } else {
+                *remaining -= amount;
+            }
+
+            if *remaining == Byte::default() {
+                self.window = Byte::default();
+                return Poll::Ready(Ok(()));
+            }
+        }
+    }
+}

--- a/netbench/netbench/src/driver/timer.rs
+++ b/netbench/netbench/src/driver/timer.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::units::{Byte, Rate};
+use crate::units::{Byte, ByteExt, Rate};
 use core::{
     task::{Context, Poll},
     time::Duration,
@@ -57,20 +57,20 @@ impl Timer {
                     return Poll::Pending;
                 }
 
-                let amount = ready!(f(self.window, cx))?;
+                let amount = ready!(f(self.window, cx))?.bytes();
 
                 self.window -= amount;
 
                 amount
             } else {
-                ready!(f(*remaining, cx))?
+                ready!(f(*remaining, cx))?.bytes()
             };
 
             // if the transfer returned 0 bytes that means it's done
-            if amount == 0 {
+            if amount == 0.bytes() {
                 *remaining = Byte::default();
             } else {
-                *remaining -= amount;
+                *remaining -= amount.bytes();
             }
 
             if *remaining == Byte::default() {

--- a/netbench/netbench/src/driver/timer.rs
+++ b/netbench/netbench/src/driver/timer.rs
@@ -34,6 +34,10 @@ impl Timer {
         }
     }
 
+    pub fn cancel(&mut self) {
+        self.sleep.cancel();
+    }
+
     pub fn sleep(&mut self, now: Timestamp, duration: Duration) {
         self.sleep.set(now + duration);
     }

--- a/netbench/netbench/src/helper.rs
+++ b/netbench/netbench/src/helper.rs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::task::Poll;
+
+#[derive(Clone, Debug, Default)]
+pub struct IdPrefixReader {
+    bytes: [u8; core::mem::size_of::<u64>()],
+    cursor: u8,
+}
+
+impl IdPrefixReader {
+    pub fn remaining(&mut self) -> &mut [u8] {
+        &mut self.bytes[self.cursor as usize..]
+    }
+
+    pub fn on_read(&mut self, len: usize) -> Poll<u64> {
+        let cursor = self.cursor as usize + len;
+        if cursor >= self.bytes.len() {
+            Poll::Ready(u64::from_be_bytes(self.bytes))
+        } else {
+            self.cursor = cursor as u8;
+            Poll::Pending
+        }
+    }
+}

--- a/netbench/netbench/src/lib.rs
+++ b/netbench/netbench/src/lib.rs
@@ -7,16 +7,21 @@ pub type Error = Box<dyn std::error::Error>;
 mod checkpoints;
 mod connection;
 mod driver;
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;
+
 pub mod helper;
 pub mod multiplex;
 pub mod operation;
 #[cfg(feature = "s2n-quic")]
 pub mod s2n_quic;
 pub mod scenario;
+pub mod timer;
 pub mod trace;
 pub mod units;
 
 pub use checkpoints::Checkpoints;
 pub use connection::Connection;
 pub use driver::Driver;
+pub use timer::Timer;
 pub use trace::Trace;

--- a/netbench/netbench/src/lib.rs
+++ b/netbench/netbench/src/lib.rs
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub type Result<T, E = Error> = core::result::Result<T, E>;
+pub type Error = Box<dyn std::error::Error>;
+
+mod checkpoints;
+mod connection;
+mod driver;
+pub mod helper;
+pub mod multiplex;
+pub mod operation;
+#[cfg(feature = "s2n-quic")]
+pub mod s2n_quic;
+pub mod scenario;
+pub mod trace;
+pub mod units;
+
+pub use checkpoints::Checkpoints;
+pub use connection::Connection;
+pub use driver::Driver;
+pub use trace::Trace;

--- a/netbench/netbench/src/multiplex.rs
+++ b/netbench/netbench/src/multiplex.rs
@@ -1,0 +1,441 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{connection::Owner, Result};
+use bytes::Buf;
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use futures::ready;
+use std::collections::{hash_map::Entry, HashMap, HashSet, VecDeque};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+mod buffer;
+mod frame;
+mod stream;
+
+use buffer::{ReadBuffer, WriteBuffer};
+use frame::Frame;
+use stream::{ReceiveStream, SendStream, Stream};
+
+const DEFUALT_STREAM_WINDOW: u64 = 256000;
+const DEFAULT_MAX_STREAMS: u64 = 100;
+
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub stream_window: u64,
+    pub max_streams: u64,
+    pub max_stream_data_thresh: u64,
+    pub max_stream_frame_len: u32,
+    pub max_write_queue_len: usize,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            stream_window: DEFUALT_STREAM_WINDOW,
+            max_streams: DEFAULT_MAX_STREAMS,
+            max_stream_data_thresh: DEFUALT_STREAM_WINDOW / 2,
+            max_stream_frame_len: (1 << 15),
+            max_write_queue_len: 250,
+        }
+    }
+}
+
+pub struct Connection<T: AsyncRead + AsyncWrite> {
+    inner: Pin<Box<T>>,
+    rx_open: bool,
+    tx_open: bool,
+    frame: Option<frame::Frame>,
+    read_buf: ReadBuffer,
+    decoder: frame::Decoder,
+    write_buf: WriteBuffer,
+    stream_controllers: [stream::Controller; 2],
+    streams: [HashMap<u64, Stream>; 2],
+    max_stream_data: HashSet<(Owner, u64)>,
+    pending_accept: VecDeque<u64>,
+    peer_initial_max_stream_data: u64,
+    config: Config,
+}
+
+impl<T: AsyncRead + AsyncWrite> Connection<T> {
+    pub fn new(inner: Pin<Box<T>>, config: Config) -> Self {
+        let mut write_buf = WriteBuffer::default();
+
+        if config.stream_window != DEFUALT_STREAM_WINDOW {
+            write_buf.push(Frame::InitialMaxStreamData {
+                up_to: config.stream_window,
+            });
+        }
+
+        Self {
+            inner,
+            rx_open: true,
+            tx_open: true,
+            frame: None,
+            read_buf: Default::default(),
+            decoder: Default::default(),
+            write_buf,
+            stream_controllers: [
+                stream::Controller::new(config.max_streams),
+                stream::Controller::new(100),
+            ],
+            streams: [Default::default(), Default::default()],
+            max_stream_data: Default::default(),
+            pending_accept: Default::default(),
+            peer_initial_max_stream_data: DEFUALT_STREAM_WINDOW,
+            config,
+        }
+    }
+
+    fn flush_write_buffer(&mut self, cx: &mut Context) -> Result<()> {
+        if !self.tx_open {
+            return if self.write_buf.is_empty() {
+                Ok(())
+            } else {
+                Err("stream was closed with pending data".into())
+            };
+        }
+
+        if self.write_buf.is_empty() {
+            return Ok(());
+        }
+
+        if self.inner.as_ref().is_write_vectored() {
+            let chunks = self.write_buf.chunks();
+
+            return match self.inner.as_mut().poll_write_vectored(cx, &chunks) {
+                Poll::Ready(result) => {
+                    let len = result?;
+                    self.write_buf.advance(len);
+                    self.write_buf.notify(cx);
+                    Ok(())
+                }
+                Poll::Pending => Ok(()),
+            };
+        }
+
+        while let Some(mut chunk) = self.write_buf.pop_front() {
+            match self.inner.as_mut().poll_write(cx, &chunk) {
+                Poll::Ready(result) => {
+                    let len = result?;
+                    chunk.advance(len);
+
+                    if !chunk.is_empty() {
+                        self.write_buf.push_front(chunk);
+                    }
+
+                    if len == 0 {
+                        return if self.write_buf.is_empty() {
+                            self.tx_open = false;
+                            Ok(())
+                        } else {
+                            Err("stream was closed with pending data".into())
+                        };
+                    }
+                }
+                Poll::Pending => {
+                    self.write_buf.push_front(chunk);
+                    break;
+                }
+            }
+        }
+
+        self.write_buf.notify(cx);
+
+        Ok(())
+    }
+
+    fn flush_read_buffer(&mut self, cx: &mut Context) -> Result<()> {
+        loop {
+            if self.frame.is_none() {
+                if let Some(frame) = self.decoder.decode(&mut self.read_buf)? {
+                    self.frame = Some(frame);
+                }
+            }
+
+            match self.dispatch_frame(cx) {
+                Poll::Ready(result) => result?,
+                Poll::Pending => return Ok(()),
+            }
+        }
+    }
+
+    fn dispatch_frame(&mut self, cx: &mut Context) -> Poll<Result<()>> {
+        use frame::Frame::*;
+
+        match self.frame.take() {
+            Some(StreamOpen { id, bidirectional }) => {
+                // TODO make sure the peer hasn't opened too many
+                let mut stream = Stream {
+                    rx: Some(ReceiveStream::new(self.config.stream_window)),
+                    tx: None,
+                };
+                if bidirectional {
+                    stream.tx = Some(SendStream::new(self.peer_initial_max_stream_data));
+                };
+                self.streams[Owner::Remote].insert(id, stream);
+                self.pending_accept.push_back(id);
+                cx.waker().wake_by_ref();
+            }
+            Some(StreamData {
+                id,
+                owner,
+                mut data,
+            }) => {
+                if let Some(rx) = self.streams[owner]
+                    .get_mut(&id)
+                    .and_then(|stream| stream.rx.as_mut())
+                {
+                    let len = data.len() as u64;
+                    let len = rx.buffer(len, cx)?;
+                    data.advance(len as _);
+
+                    if !data.is_empty() {
+                        self.frame = Some(StreamData { id, owner, data });
+                        return Poll::Pending;
+                    }
+                }
+            }
+            Some(MaxStreams { up_to }) => {
+                self.stream_controllers[Owner::Remote].max_streams(up_to, cx);
+            }
+            Some(MaxStreamData { id, owner, up_to }) => {
+                if let Some(tx) = self.streams[owner]
+                    .get_mut(&id)
+                    .and_then(|stream| stream.tx.as_mut())
+                {
+                    tx.max_data(up_to, cx);
+                }
+            }
+            Some(StreamFinish { id, owner }) => {
+                if let Some(rx) = self.streams[owner]
+                    .get_mut(&id)
+                    .ok_or("invalid stream")?
+                    .rx
+                    .as_mut()
+                {
+                    rx.finish(cx);
+                }
+            }
+            Some(InitialMaxStreamData { up_to }) => {
+                self.peer_initial_max_stream_data = up_to;
+            }
+            None => return Poll::Pending,
+        }
+
+        Ok(()).into()
+    }
+}
+
+impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
+    fn poll_open_bidirectional_stream(&mut self, id: u64, _cx: &mut Context) -> Poll<Result<()>> {
+        ready!(self.stream_controllers[Owner::Local].open());
+
+        self.write_buf.push(Frame::StreamOpen {
+            id,
+            bidirectional: true,
+        });
+
+        let stream = Stream {
+            rx: Some(ReceiveStream::new(self.config.stream_window)),
+            tx: Some(SendStream::new(self.peer_initial_max_stream_data)),
+        };
+        self.streams[Owner::Local].insert(id, stream);
+
+        Ok(()).into()
+    }
+
+    fn poll_open_send_stream(&mut self, id: u64, _cx: &mut Context) -> Poll<Result<()>> {
+        ready!(self.stream_controllers[Owner::Local].open());
+
+        self.write_buf.push(Frame::StreamOpen {
+            id,
+            bidirectional: false,
+        });
+
+        let stream = Stream {
+            rx: None,
+            tx: Some(SendStream::new(self.peer_initial_max_stream_data)),
+        };
+        self.streams[Owner::Local].insert(id, stream);
+
+        Ok(()).into()
+    }
+
+    fn poll_accept_stream(&mut self, _cx: &mut Context) -> Poll<Result<Option<u64>>> {
+        if !self.rx_open {
+            return Ok(None).into();
+        }
+
+        if let Some(id) = self.pending_accept.pop_front() {
+            Ok(Some(id)).into()
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn poll_send(
+        &mut self,
+        owner: Owner,
+        id: u64,
+        bytes: u64,
+        _cx: &mut Context,
+    ) -> Poll<Result<u64>> {
+        if !self.write_buf.request_push(self.config.max_write_queue_len) {
+            return Poll::Pending;
+        }
+
+        let stream = self.streams[owner]
+            .get_mut(&id)
+            .ok_or("missing stream")?
+            .tx
+            .as_mut()
+            .ok_or("missing tx stream")?;
+
+        let allowed_bytes = bytes.min(self.config.max_stream_frame_len as _);
+
+        if let Some(data) = stream.send(allowed_bytes) {
+            let len = data.len() as u64;
+            self.write_buf.push(frame::Frame::StreamData {
+                id,
+                owner: !owner,
+                data,
+            });
+            Ok(len).into()
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn poll_receive(
+        &mut self,
+        owner: Owner,
+        id: u64,
+        bytes: u64,
+        _cx: &mut Context,
+    ) -> Poll<Result<u64>> {
+        let stream = self.streams[owner]
+            .get_mut(&id)
+            .ok_or("missing stream")?
+            .rx
+            .as_mut()
+            .ok_or("missing rx stream")?;
+
+        let len = ready!(stream.receive(bytes))?;
+
+        if stream.receive_window() < self.config.stream_window / 2 {
+            self.max_stream_data.insert((owner, id));
+        }
+
+        Ok(len).into()
+    }
+
+    fn poll_send_finish(&mut self, owner: Owner, id: u64, _cx: &mut Context) -> Poll<Result<()>> {
+        if !self.write_buf.request_push(self.config.max_write_queue_len) {
+            return Poll::Pending;
+        }
+
+        if let Entry::Occupied(mut entry) = self.streams[owner].entry(id) {
+            let stream = entry.get_mut();
+
+            if stream.tx.take().is_some() {
+                self.write_buf
+                    .push(frame::Frame::StreamFinish { id, owner: !owner });
+            }
+
+            if stream.rx.is_none() {
+                entry.remove();
+            }
+        }
+
+        Ok(()).into()
+    }
+
+    fn poll_receive_finish(
+        &mut self,
+        owner: Owner,
+        id: u64,
+        _cx: &mut Context,
+    ) -> Poll<Result<()>> {
+        if let Entry::Occupied(mut entry) = self.streams[owner].entry(id) {
+            let stream = entry.get_mut();
+            stream.rx = None;
+            if stream.tx.is_none() {
+                entry.remove();
+            }
+        }
+
+        Ok(()).into()
+    }
+
+    fn poll_progress(&mut self, cx: &mut Context) -> Poll<Result<()>> {
+        loop {
+            for (owner, id) in self.max_stream_data.drain() {
+                let stream = self.streams[owner]
+                    .get_mut(&id)
+                    .unwrap()
+                    .rx
+                    .as_mut()
+                    .unwrap();
+                let up_to = stream.credit(self.config.stream_window);
+                self.write_buf.push_priority(Frame::MaxStreamData {
+                    id,
+                    owner: !owner,
+                    up_to,
+                });
+            }
+
+            self.flush_write_buffer(cx)?;
+
+            self.flush_read_buffer(cx)?;
+
+            // only read from the socket if it's open and we don't have a pending frame
+            if !(self.rx_open && self.frame.is_none()) {
+                return Ok(()).into();
+            }
+
+            let rx_open = &mut self.rx_open;
+            let inner = self.inner.as_mut();
+
+            ready!(self.read_buf.read(|buf| {
+                ready!(inner.poll_read(cx, buf))?;
+
+                // the socket returned a 0 write
+                if buf.filled().is_empty() {
+                    *rx_open = false;
+                }
+
+                Ok(()).into()
+            }))?;
+        }
+    }
+
+    fn poll_finish(&mut self, cx: &mut Context) -> Poll<Result<()>> {
+        self.flush_write_buffer(cx)?;
+
+        if !self.write_buf.is_empty() {
+            return Poll::Pending;
+        }
+
+        ready!(self.inner.as_mut().poll_flush(cx))?;
+        Ok(()).into()
+    }
+}
+
+#[derive(Debug, Default)]
+struct Blocked(bool);
+
+impl Blocked {
+    pub fn block(&mut self) {
+        self.0 = true;
+    }
+
+    pub fn unblock(&mut self, cx: &mut Context) {
+        if self.0 {
+            self.0 = false;
+            cx.waker().wake_by_ref();
+        }
+    }
+}

--- a/netbench/netbench/src/multiplex/buffer.rs
+++ b/netbench/netbench/src/multiplex/buffer.rs
@@ -1,0 +1,227 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Frame;
+use crate::Result;
+use bytes::{Buf, BufMut, Bytes, BytesMut};
+use core::{
+    mem::MaybeUninit,
+    task::{Context, Poll},
+};
+use futures::ready;
+use std::{collections::VecDeque, io::IoSlice};
+use tokio::io::ReadBuf;
+
+#[derive(Debug, Default)]
+pub struct ReadBuffer {
+    len: usize,
+    tail: BytesMut,
+    head: VecDeque<BytesMut>,
+}
+
+impl ReadBuffer {
+    pub fn read<F: FnOnce(&mut ReadBuf) -> Poll<Result<()>>>(
+        &mut self,
+        read: F,
+    ) -> Poll<Result<()>> {
+        let capacity = self.tail.capacity();
+
+        const CAPACITY: usize = 2 << 12;
+
+        if capacity == 0 {
+            self.tail.reserve(CAPACITY);
+        } else if capacity < 32 {
+            let tail = core::mem::replace(&mut self.tail, BytesMut::with_capacity(CAPACITY));
+            self.head.push_back(tail);
+        }
+
+        let buf = self.tail.chunk_mut();
+        let buf = unsafe { &mut *(buf as *mut _ as *mut [MaybeUninit<u8>]) };
+        let mut buf = ReadBuf::uninit(buf);
+        ready!(read(&mut buf))?;
+        let len = buf.filled().len();
+
+        if len == 0 {
+            return Ok(()).into();
+        }
+
+        unsafe {
+            self.tail.advance_mut(len);
+            self.len += len;
+        }
+
+        Ok(()).into()
+    }
+
+    fn check_consistency(&self) {
+        if cfg!(debug_assertions) {
+            let mut actual_len = self.tail.len();
+            for chunk in self.head.iter() {
+                actual_len += chunk.len();
+            }
+            assert_eq!(actual_len, self.remaining(), "{:?}", self);
+        }
+    }
+}
+
+impl Buf for ReadBuffer {
+    fn remaining(&self) -> usize {
+        self.len
+    }
+
+    fn chunk(&self) -> &[u8] {
+        for chunk in self.head.iter() {
+            if !chunk.is_empty() {
+                return chunk.chunk();
+            }
+        }
+
+        self.tail.chunk()
+    }
+
+    fn advance(&mut self, mut cnt: usize) {
+        while cnt > 0 {
+            let len = if let Some(front) = self.head.front_mut() {
+                let len = front.len().min(cnt);
+                front.advance(len);
+                if front.is_empty() {
+                    let _ = self.head.pop_front();
+                }
+                len
+            } else {
+                self.tail.advance(cnt);
+                cnt
+            };
+
+            cnt -= len;
+            self.len -= len;
+        }
+
+        self.check_consistency();
+    }
+
+    fn copy_to_bytes(&mut self, len: usize) -> Bytes {
+        while let Some(mut front) = self.head.pop_front() {
+            if front.is_empty() {
+                continue;
+            }
+
+            self.len -= len;
+
+            if front.len() == len {
+                self.check_consistency();
+                return front.freeze();
+            }
+
+            let out = front.split_to(len);
+            self.head.push_front(front);
+
+            self.check_consistency();
+            return out.freeze();
+        }
+
+        let out = self.tail.split_to(len).freeze();
+
+        self.len -= len;
+        self.check_consistency();
+
+        out
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct WriteBuffer {
+    unfilled: BytesMut,
+    queue: VecDeque<Bytes>,
+    push_interest: bool,
+}
+
+impl WriteBuffer {
+    pub fn request_push(&mut self, max_queue_len: usize) -> bool {
+        let can_push = max_queue_len > self.queue.len();
+        self.push_interest |= !can_push;
+        can_push
+    }
+
+    pub fn push(&mut self, frame: Frame) {
+        let capacity = self.unfilled.capacity();
+
+        const CAPACITY: usize = 4096;
+
+        if capacity == 0 {
+            self.unfilled.reserve(CAPACITY);
+        } else if capacity < 32 {
+            self.unfilled = BytesMut::with_capacity(CAPACITY);
+        }
+
+        frame.write_header(&mut self.unfilled);
+        self.queue.push_back(self.unfilled.split().freeze());
+
+        if let Some(data) = frame.body() {
+            self.queue.push_back(data);
+        }
+    }
+
+    pub fn push_priority(&mut self, frame: Frame) {
+        let capacity = self.unfilled.capacity();
+
+        const CAPACITY: usize = 4096;
+
+        if capacity == 0 {
+            self.unfilled.reserve(CAPACITY);
+        } else if capacity < 32 {
+            self.unfilled = BytesMut::with_capacity(CAPACITY);
+        }
+
+        frame.write_header(&mut self.unfilled);
+        let header = self.unfilled.split().freeze();
+
+        // push the body first
+        if let Some(data) = frame.body() {
+            self.queue.push_front(data);
+        }
+
+        self.queue.push_front(header);
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    pub fn pop_front(&mut self) -> Option<Bytes> {
+        self.queue.pop_front()
+    }
+
+    pub fn push_front(&mut self, chunk: Bytes) {
+        self.queue.push_front(chunk);
+    }
+
+    pub fn notify(&mut self, cx: &mut Context) {
+        if self.push_interest {
+            self.push_interest = false;
+            cx.waker().wake_by_ref();
+        }
+    }
+
+    pub fn advance(&mut self, mut len: usize) {
+        while let Some(mut chunk) = self.queue.pop_front() {
+            let next_len = len.saturating_sub(chunk.len());
+
+            if next_len > 0 {
+                len = next_len;
+                continue;
+            }
+
+            if chunk.len() > len {
+                chunk.advance(len);
+                self.queue.push_front(chunk);
+            }
+
+            return;
+        }
+    }
+
+    pub fn chunks(&self) -> Vec<IoSlice> {
+        self.queue.iter().map(|v| IoSlice::new(v)).collect()
+    }
+}

--- a/netbench/netbench/src/multiplex/frame.rs
+++ b/netbench/netbench/src/multiplex/frame.rs
@@ -1,0 +1,209 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{connection::Owner, Result};
+use bytes::{Buf, BufMut, Bytes};
+use core::mem::size_of;
+use enum_primitive_derive::Primitive;
+use num_traits::FromPrimitive;
+use std::io;
+
+#[derive(Clone, Copy, Debug, Primitive)]
+#[repr(u8)]
+enum Tag {
+    StreamOpen = 0,
+    StreamData = 1,
+    StreamFinish = 2,
+    MaxStreams = 3,
+    MaxStreamData = 4,
+    InitialMaxStreamData = 5,
+}
+
+#[derive(Clone, Debug)]
+pub enum Frame {
+    StreamOpen { id: u64, bidirectional: bool },
+    StreamData { id: u64, owner: Owner, data: Bytes },
+    StreamFinish { id: u64, owner: Owner },
+    MaxStreams { up_to: u64 },
+    MaxStreamData { id: u64, owner: Owner, up_to: u64 },
+    InitialMaxStreamData { up_to: u64 },
+}
+
+impl Frame {
+    pub fn write_header<B: BufMut>(&self, buf: &mut B) {
+        match self {
+            Self::StreamOpen { id, bidirectional } => {
+                buf.put_u8(Tag::StreamOpen as _);
+                buf.put_u64(*id);
+                buf.put_u8(*bidirectional as u8);
+            }
+            Self::StreamData { id, owner, data } => {
+                buf.put_u8(Tag::StreamData as _);
+                buf.put_u64(*id);
+                buf.put_u8(*owner as _);
+                buf.put_u32(data.len() as _);
+            }
+            Self::StreamFinish { id, owner } => {
+                buf.put_u8(Tag::StreamFinish as _);
+                buf.put_u64(*id);
+                buf.put_u8(*owner as _);
+            }
+            Self::MaxStreams { up_to } => {
+                buf.put_u8(Tag::MaxStreams as _);
+                buf.put_u64(*up_to);
+            }
+            Self::MaxStreamData { id, owner, up_to } => {
+                buf.put_u8(Tag::MaxStreamData as _);
+                buf.put_u64(*id);
+                buf.put_u8(*owner as _);
+                buf.put_u64(*up_to);
+            }
+            Self::InitialMaxStreamData { up_to } => {
+                buf.put_u8(Tag::InitialMaxStreamData as _);
+                buf.put_u64(*up_to);
+            }
+        }
+    }
+
+    pub fn body(self) -> Option<Bytes> {
+        if let Self::StreamData { data, .. } = self {
+            Some(data)
+        } else {
+            None
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Decoder {
+    tag: Option<Tag>,
+    stream: Option<(u64, Owner, usize)>,
+}
+
+impl Decoder {
+    pub fn decode<B: Buf>(&mut self, buf: &mut B) -> Result<Option<Frame>> {
+        if let Some((id, owner, len)) = self.stream.take() {
+            return self.decode_stream(buf, id, owner, len);
+        }
+
+        if let Some(tag) = self.tag.take() {
+            return self.decode_frame(buf, tag);
+        }
+
+        if buf.remaining() == 0 {
+            return Ok(None);
+        }
+
+        let tag = Tag::from_u8(buf.get_u8())
+            .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "invalid frame tag"))?;
+
+        self.decode_frame(buf, tag)
+    }
+
+    fn decode_frame<B: Buf>(&mut self, buf: &mut B, tag: Tag) -> Result<Option<Frame>> {
+        match tag {
+            Tag::StreamOpen => {
+                if buf.remaining() < (size_of::<u64>() + size_of::<u8>()) {
+                    self.tag = Some(tag);
+                    return Ok(None);
+                }
+
+                let id = buf.get_u64();
+                let bidirectional = buf.get_u8() != 0;
+
+                Ok(Some(Frame::StreamOpen { id, bidirectional }))
+            }
+            Tag::StreamData => {
+                if buf.remaining() < (size_of::<u64>() + size_of::<u8>() + size_of::<u32>()) {
+                    self.tag = Some(tag);
+                    return Ok(None);
+                }
+
+                let id = buf.get_u64();
+                let owner = Self::decode_owner(buf)?;
+                let len = buf.get_u32();
+                self.decode_stream(buf, id, owner, len as _)
+            }
+            Tag::StreamFinish => {
+                if buf.remaining() < (size_of::<u64>() + size_of::<u8>()) {
+                    self.tag = Some(tag);
+                    return Ok(None);
+                }
+
+                let id = buf.get_u64();
+                let owner = Self::decode_owner(buf)?;
+
+                Ok(Some(Frame::StreamFinish { id, owner }))
+            }
+            Tag::MaxStreams => {
+                if buf.remaining() < size_of::<u64>() {
+                    self.tag = Some(tag);
+                    return Ok(None);
+                }
+
+                let up_to = buf.get_u64();
+
+                Ok(Some(Frame::MaxStreams { up_to }))
+            }
+            Tag::MaxStreamData => {
+                if buf.remaining() < (size_of::<u64>() + size_of::<u8>() + size_of::<u64>()) {
+                    self.tag = Some(tag);
+                    return Ok(None);
+                }
+
+                let id = buf.get_u64();
+                let owner = Self::decode_owner(buf)?;
+                let up_to = buf.get_u64();
+
+                Ok(Some(Frame::MaxStreamData { id, owner, up_to }))
+            }
+            Tag::InitialMaxStreamData => {
+                if buf.remaining() < (size_of::<u64>()) {
+                    self.tag = Some(tag);
+                    return Ok(None);
+                }
+
+                let up_to = buf.get_u64();
+
+                Ok(Some(Frame::InitialMaxStreamData { up_to }))
+            }
+        }
+    }
+
+    fn decode_owner<B: Buf>(buf: &mut B) -> Result<Owner> {
+        let owner = buf.get_u8();
+        Ok(match owner {
+            0 => Owner::Local,
+            1 => Owner::Remote,
+            _ => return Err(io::Error::new(io::ErrorKind::InvalidData, "invalid owner id").into()),
+        })
+    }
+
+    fn decode_stream<B: Buf>(
+        &mut self,
+        buf: &mut B,
+        id: u64,
+        owner: Owner,
+        len: usize,
+    ) -> Result<Option<Frame>> {
+        if len == 0 {
+            return self.decode(buf);
+        }
+
+        let chunk_len = buf.chunk().len();
+
+        if chunk_len == 0 {
+            self.stream = Some((id, owner, len));
+            return Ok(None);
+        }
+
+        Ok(if chunk_len >= len {
+            let data = buf.copy_to_bytes(len);
+            Some(Frame::StreamData { id, owner, data })
+        } else {
+            let data = buf.copy_to_bytes(chunk_len);
+            self.stream = Some((id, owner, len - chunk_len));
+            Some(Frame::StreamData { id, owner, data })
+        })
+    }
+}

--- a/netbench/netbench/src/multiplex/stream.rs
+++ b/netbench/netbench/src/multiplex/stream.rs
@@ -1,0 +1,155 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Blocked;
+use crate::Result;
+use bytes::Bytes;
+use core::task::{Context, Poll};
+use s2n_quic_core::stream::testing::Data;
+
+#[derive(Debug)]
+pub struct Stream {
+    pub rx: Option<ReceiveStream>,
+    pub tx: Option<SendStream>,
+}
+
+#[derive(Debug)]
+pub struct ReceiveStream {
+    received_offset: u64,
+    buffered_offset: u64,
+    window_offset: u64,
+    is_finished: bool,
+    blocked: Blocked,
+}
+
+impl ReceiveStream {
+    pub fn new(window_offset: u64) -> Self {
+        Self {
+            received_offset: 0,
+            buffered_offset: 0,
+            window_offset,
+            is_finished: false,
+            blocked: Default::default(),
+        }
+    }
+
+    pub fn buffer(&mut self, len: u64, cx: &mut Context) -> Result<u64> {
+        if self.is_finished {
+            return Err("stream is already finished".into());
+        }
+
+        let len = (self.window_offset - self.buffered_offset).min(len);
+
+        if len == 0 {
+            return Ok(0);
+        }
+
+        self.buffered_offset += len;
+
+        self.blocked.unblock(cx);
+
+        Ok(len)
+    }
+
+    pub fn receive(&mut self, len: u64) -> Poll<Result<u64>> {
+        let len = (self.buffered_offset - self.received_offset).min(len);
+
+        if len == 0 {
+            return if self.is_finished {
+                Ok(0).into()
+            } else {
+                self.blocked.block();
+                Poll::Pending
+            };
+        }
+
+        self.received_offset += len;
+
+        Ok(len).into()
+    }
+
+    pub fn finish(&mut self, cx: &mut Context) {
+        self.is_finished = true;
+        self.blocked.unblock(cx);
+    }
+
+    pub fn receive_window(&self) -> u64 {
+        self.window_offset - self.received_offset
+    }
+
+    pub fn credit(&mut self, credits: u64) -> u64 {
+        self.window_offset += credits;
+        self.window_offset
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct SendStream {
+    max_data: u64,
+    data: Data,
+    blocked: Blocked,
+}
+
+impl SendStream {
+    pub fn new(max_data: u64) -> Self {
+        Self {
+            max_data,
+            data: Data::new(u64::MAX),
+            blocked: Default::default(),
+        }
+    }
+
+    pub fn max_data(&mut self, max_data: u64, cx: &mut Context) {
+        self.max_data = max_data.max(self.max_data);
+        self.blocked.unblock(cx)
+    }
+
+    pub fn send(&mut self, len: u64) -> Option<Bytes> {
+        let window = self.max_data - self.data.offset();
+        let len = len.min(window) as usize;
+
+        if len == 0 {
+            self.blocked.block();
+            return None;
+        }
+
+        self.data.send_one(len)
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Controller {
+    open_offset: u64,
+    window_offset: u64,
+    blocked: Blocked,
+}
+
+impl Controller {
+    pub fn new(window_offset: u64) -> Self {
+        Self {
+            open_offset: 0,
+            window_offset,
+            blocked: Default::default(),
+        }
+    }
+
+    pub fn open(&mut self) -> Poll<()> {
+        if self.capacity() == 0 {
+            self.blocked.block();
+            return Poll::Pending;
+        }
+
+        self.open_offset += 1;
+
+        Poll::Ready(())
+    }
+
+    pub fn max_streams(&mut self, up_to: u64, cx: &mut Context) {
+        self.window_offset = up_to;
+        self.blocked.unblock(cx)
+    }
+
+    pub fn capacity(&self) -> u64 {
+        self.window_offset - self.open_offset
+    }
+}

--- a/netbench/netbench/src/multiplex/stream.rs
+++ b/netbench/netbench/src/multiplex/stream.rs
@@ -145,8 +145,10 @@ impl Controller {
     }
 
     pub fn max_streams(&mut self, up_to: u64, cx: &mut Context) {
-        self.window_offset = up_to;
-        self.blocked.unblock(cx)
+        self.window_offset = self.window_offset.max(up_to);
+        if self.capacity() > 0 {
+            self.blocked.unblock(cx)
+        }
     }
 
     pub fn capacity(&self) -> u64 {

--- a/netbench/netbench/src/operation.rs
+++ b/netbench/netbench/src/operation.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "snake_case")]
-pub enum ConnectionOperation {
+pub enum Connection {
     /// Pause for the specified duration before processing the next op
     Sleep {
         #[serde(with = "duration_format", rename = "amount_ms")]
@@ -45,14 +45,12 @@ pub enum ConnectionOperation {
     /// Emit a trace event
     Trace { trace_id: u64 },
     /// Perform operations concurrently
-    Scope {
-        threads: Vec<Vec<ConnectionOperation>>,
-    },
+    Scope { threads: Vec<Vec<Connection>> },
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "snake_case")]
-pub enum ClientOperation {
+pub enum Client {
     /// Pause for the specified duration before processing the next op
     Sleep {
         #[serde(with = "duration_format", rename = "timeout_ms")]
@@ -71,12 +69,12 @@ pub enum ClientOperation {
     /// Emit a trace event
     Trace { trace_id: u64 },
     /// Perform operations concurrently
-    Scope { threads: Vec<Vec<ClientOperation>> },
+    Scope { threads: Vec<Vec<Client>> },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "snake_case")]
-pub enum RouterOperation {
+pub enum Router {
     /// Pause for the specified duration before processing the next op
     Sleep {
         #[serde(with = "duration_format", rename = "amount_ms")]

--- a/netbench/netbench/src/operation.rs
+++ b/netbench/netbench/src/operation.rs
@@ -1,0 +1,138 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::units::{duration_format, Byte, Duration, Rate};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum ConnectionOperation {
+    /// Pause for the specified duration before processing the next op
+    Sleep {
+        #[serde(with = "duration_format", rename = "amount_ms")]
+        amount: Duration,
+    },
+    /// Open a bidirectional stream with an identifier
+    OpenBidirectionalStream { stream_id: u64 },
+    /// Open a unidirectional stream with an identifier
+    OpenSendStream { stream_id: u64 },
+    /// Send a specific amount of data over the stream id
+    Send { stream_id: u64, bytes: Byte },
+    /// Finish sending data on the stream
+    SendFinish { stream_id: u64 },
+    /// Sets the send rate for a stream
+    SendRate {
+        stream_id: u64,
+        #[serde(flatten)]
+        rate: Rate,
+    },
+    /// Send a specific amount of data over the stream id
+    Receive { stream_id: u64, bytes: Byte },
+    /// Receives all of the data on the stream until it is finished
+    ReceiveAll { stream_id: u64 },
+    /// Finish receiving data on the stream
+    ReceiveFinish { stream_id: u64 },
+    /// Sets the receive rate for a stream
+    ReceiveRate {
+        stream_id: u64,
+        #[serde(flatten)]
+        rate: Rate,
+    },
+    /// Parks the current thread and waits for the checkpoint to be unparked
+    Park { checkpoint: u64 },
+    /// Notifies the parked checkpoint that it can continue
+    Unpark { checkpoint: u64 },
+    /// Emit a trace event
+    Trace { trace_id: u64 },
+    /// Perform operations concurrently
+    Scope {
+        threads: Vec<Vec<ConnectionOperation>>,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum ClientOperation {
+    /// Pause for the specified duration before processing the next op
+    Sleep {
+        #[serde(with = "duration_format", rename = "timeout_ms")]
+        timeout: Duration,
+    },
+    /// Open a connection with an identifier
+    Connect {
+        server_id: u64,
+        #[serde(skip_serializing_if = "Option::is_none", default)]
+        router_id: Option<u64>,
+        server_connection_id: u64,
+        client_connection_id: u64,
+    },
+    /// Synchronizes two checkpoints across different threads
+    Sync { checkpoint: u64 },
+    /// Emit a trace event
+    Trace { trace_id: u64 },
+    /// Perform operations concurrently
+    Scope { threads: Vec<Vec<ClientOperation>> },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum RouterOperation {
+    /// Pause for the specified duration before processing the next op
+    Sleep {
+        #[serde(with = "duration_format", rename = "amount_ms")]
+        amount: Duration,
+    },
+
+    /// Set the number of packets that can be buffered server->client
+    ServerBufferCount { packet_count: u32 },
+    /// Set the chance of a server->client packet being dropped
+    ServerDropRate { packet_count: u32 },
+    /// Set the chance of a server->client packet being reordered
+    ServerReorderRate { packet_count: u32 },
+    /// Set the chance of a server->client packet being corrupted
+    ServerCorruptRate { packet_count: u32 },
+    /// Set the amount of delay for server->client packets
+    ServerDelay {
+        #[serde(with = "duration_format", rename = "amount_ms")]
+        amount: Duration,
+    },
+    /// Set the amount of jitter for server->client packets
+    ServerJitter {
+        #[serde(with = "duration_format", rename = "amount_ms")]
+        amount: Duration,
+    },
+    /// Set the server->client MTU
+    ServerMtu { mtu: u16 },
+
+    /// Set the number of packets that can be buffered server->client
+    ClientBufferCount { packet_count: u32 },
+    /// Set the chance of a client->server packet being dropped
+    ClientDropRate { packet_count: u32 },
+    /// Set the chance of a client->server packet being reordered
+    ClientReorderRate { packet_count: u32 },
+    /// Set the chance of a client->server packet being corrupted
+    ClientCorruptRate { packet_count: u32 },
+    /// Set the amount of delay for client->server packets
+    ClientDelay {
+        #[serde(with = "duration_format", rename = "amount_ms")]
+        amount: Duration,
+    },
+    /// Set the amount of jitter for client->server packets
+    ClientJitter {
+        #[serde(with = "duration_format", rename = "amount_ms")]
+        amount: Duration,
+    },
+    /// Set the client->server MTU
+    ClientMtu { mtu: u16 },
+
+    /// Set the chance of a port being rebound
+    ClientRebindPortRate { packet_count: u32 },
+    /// Set the chance of an IP being rebound
+    ClientRebindAddressRate { packet_count: u32 },
+
+    /// Rebinds all of the ports and/or addresses currently being used
+    RebindAll { ports: bool, addresses: bool },
+
+    /// Emit a trace event
+    Trace { trace_id: u64 },
+}

--- a/netbench/netbench/src/s2n_quic.rs
+++ b/netbench/netbench/src/s2n_quic.rs
@@ -1,0 +1,323 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{connection::Owner, helper::IdPrefixReader, Result};
+use bytes::Bytes;
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use futures::ready;
+use s2n_quic::{
+    connection,
+    stream::{LocalStream, PeerStream, SplittableStream},
+};
+use s2n_quic_core::stream::testing::Data;
+use std::collections::{hash_map::Entry, HashMap};
+
+pub struct Connection {
+    conn: s2n_quic::Connection,
+    streams: [HashMap<u64, Stream>; 2],
+    opened_streams: HashMap<u64, (Bytes, LocalStream)>,
+    unidentified_peer_stream: Option<(IdPrefixReader, PeerStream)>,
+}
+
+impl From<s2n_quic::Connection> for Connection {
+    fn from(conn: s2n_quic::Connection) -> Self {
+        Self::new(conn)
+    }
+}
+
+impl Connection {
+    pub fn new(connection: s2n_quic::Connection) -> Self {
+        Self {
+            conn: connection,
+            streams: [HashMap::new(), HashMap::new()],
+            opened_streams: HashMap::new(),
+            unidentified_peer_stream: Default::default(),
+        }
+    }
+
+    pub fn into_inner(self) -> s2n_quic::Connection {
+        self.conn
+    }
+
+    fn open_local_stream<
+        F: FnOnce(&mut s2n_quic::Connection, &mut Context) -> Poll<Result<S, connection::Error>>,
+        S: Into<LocalStream>,
+    >(
+        &mut self,
+        id: u64,
+        open: F,
+        cx: &mut Context,
+    ) -> Poll<Result<()>> {
+        // the stream has already been opened and is waiting to send the prefix
+        if let Entry::Occupied(mut entry) = self.opened_streams.entry(id) {
+            let (prefix, stream) = entry.get_mut();
+            return match stream.poll_send(prefix, cx) {
+                Poll::Ready(Ok(_)) => {
+                    let (_, stream) = entry.remove();
+                    let stream = Stream::new(stream);
+                    self.streams[Owner::Local].insert(id, stream);
+                    Poll::Ready(Ok(()))
+                }
+                Poll::Ready(Err(err)) => {
+                    entry.remove();
+                    Poll::Ready(Err(err.into()))
+                }
+                Poll::Pending => Poll::Pending,
+            };
+        }
+
+        let mut stream = ready!(open(&mut self.conn, cx))?.into();
+
+        let mut prefix = Bytes::copy_from_slice(&id.to_be_bytes());
+
+        match stream.poll_send(&mut prefix, cx) {
+            Poll::Ready(Ok(_)) => {
+                let stream = Stream::new(stream);
+                self.streams[Owner::Local].insert(id, stream);
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(err)) => Poll::Ready(Err(err.into())),
+            Poll::Pending => {
+                self.opened_streams.insert(id, (prefix, stream));
+                Poll::Pending
+            }
+        }
+    }
+}
+
+impl super::Connection for Connection {
+    fn poll_open_bidirectional_stream(&mut self, id: u64, cx: &mut Context) -> Poll<Result<()>> {
+        self.open_local_stream(id, |conn, cx| conn.poll_open_bidirectional_stream(cx), cx)
+    }
+
+    fn poll_open_send_stream(&mut self, id: u64, cx: &mut Context) -> Poll<Result<()>> {
+        self.open_local_stream(id, |conn, cx| conn.poll_open_send_stream(cx), cx)
+    }
+
+    fn poll_accept_stream(&mut self, cx: &mut Context) -> Poll<Result<Option<u64>>> {
+        loop {
+            if let Some((id, stream)) = self.unidentified_peer_stream.as_mut() {
+                let len = ready!(futures::io::AsyncRead::poll_read(
+                    Pin::new(stream),
+                    cx,
+                    id.remaining()
+                ))?;
+                let id = ready!(id.on_read(len));
+
+                let (_, stream) = self.unidentified_peer_stream.take().unwrap();
+                let stream = Stream::new(stream);
+                self.streams[Owner::Remote].insert(id, stream);
+                return Poll::Ready(Ok(Some(id)));
+            }
+
+            let stream = ready!(self.conn.poll_accept(cx));
+
+            if let Ok(Some(stream)) = stream {
+                self.unidentified_peer_stream = Some((Default::default(), stream));
+            } else {
+                return Poll::Ready(Ok(None));
+            };
+        }
+    }
+
+    fn poll_send(
+        &mut self,
+        owner: Owner,
+        id: u64,
+        bytes: u64,
+        cx: &mut Context,
+    ) -> Poll<Result<u64>> {
+        self.streams[owner]
+            .get_mut(&id)
+            .unwrap()
+            .tx
+            .as_mut()
+            .unwrap()
+            .poll_send(bytes, cx)
+    }
+
+    fn poll_receive(
+        &mut self,
+        owner: Owner,
+        id: u64,
+        bytes: u64,
+        cx: &mut Context,
+    ) -> Poll<Result<u64>> {
+        self.streams[owner]
+            .get_mut(&id)
+            .unwrap()
+            .rx
+            .as_mut()
+            .unwrap()
+            .poll_receive(bytes, cx)
+    }
+
+    fn poll_send_finish(&mut self, owner: Owner, id: u64, _cx: &mut Context) -> Poll<Result<()>> {
+        if let Entry::Occupied(mut entry) = self.streams[owner].entry(id) {
+            let stream = entry.get_mut();
+            if let Some(stream) = stream.tx.as_mut() {
+                stream.inner.finish()?;
+            }
+
+            if stream.rx.is_none() {
+                entry.remove();
+            }
+        }
+
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_receive_finish(
+        &mut self,
+        owner: Owner,
+        id: u64,
+        _cx: &mut Context,
+    ) -> Poll<Result<()>> {
+        if let Entry::Occupied(mut entry) = self.streams[owner].entry(id) {
+            let stream = entry.get_mut();
+            if let Some(mut stream) = stream.rx.take() {
+                let _ = stream.inner.stop_sending(0u8.into());
+            }
+
+            if stream.tx.is_none() {
+                entry.remove();
+            }
+        }
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+macro_rules! chunks {
+    () => {
+        [
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+            Bytes::new(),
+        ]
+    };
+}
+
+struct Stream {
+    rx: Option<ReceiveStream>,
+    tx: Option<SendStream>,
+}
+
+impl Stream {
+    fn new(stream: impl SplittableStream) -> Self {
+        let (rx, tx) = stream.split();
+        let rx = rx.map(ReceiveStream::new);
+        let tx = tx.map(SendStream::new);
+        Self { rx, tx }
+    }
+}
+
+struct ReceiveStream {
+    inner: s2n_quic::stream::ReceiveStream,
+    buffered: u64,
+    is_open: bool,
+}
+
+impl ReceiveStream {
+    fn new(inner: s2n_quic::stream::ReceiveStream) -> Self {
+        Self {
+            inner,
+            buffered: 0,
+            is_open: true,
+        }
+    }
+
+    fn poll_receive(&mut self, bytes: u64, cx: &mut Context) -> Poll<Result<u64>> {
+        if !self.is_open && self.buffered == 0 {
+            return Ok(0).into();
+        }
+
+        if self.buffered <= bytes {
+            let mut chunks = chunks!();
+
+            if let Poll::Ready(res) = self.inner.poll_receive_vectored(&mut chunks, cx) {
+                let (count, is_open) = res?;
+                self.is_open &= is_open;
+
+                for chunk in &chunks[..count] {
+                    self.buffered += chunk.len() as u64;
+                }
+            }
+        }
+
+        let received_len = bytes.min(self.buffered);
+        self.buffered -= received_len;
+
+        if !self.is_open && received_len == 0 {
+            return Ok(0).into();
+        }
+
+        if received_len == 0 {
+            Poll::Pending
+        } else {
+            Ok(received_len).into()
+        }
+    }
+}
+
+struct SendStream {
+    inner: s2n_quic::stream::SendStream,
+    data: Data,
+}
+
+impl SendStream {
+    fn new(inner: s2n_quic::stream::SendStream) -> Self {
+        Self {
+            inner,
+            data: Data::new(u64::MAX),
+        }
+    }
+
+    fn poll_send(&mut self, bytes: u64, cx: &mut Context) -> Poll<Result<u64>> {
+        let mut chunks = chunks!();
+
+        let count = self.data.clone().send(bytes as usize, &mut chunks).unwrap();
+        let initial_len: u64 = chunks.iter().map(|chunk| chunk.len() as u64).sum();
+
+        let count = ready!(self.inner.poll_send_vectored(&mut chunks[..count], cx))?;
+        let remaining_len: u64 = chunks[count..].iter().map(|chunk| chunk.len() as u64).sum();
+
+        let len = initial_len - remaining_len;
+
+        self.data.seek_forward(len as usize);
+
+        Poll::Ready(Ok(len))
+    }
+}

--- a/netbench/netbench/src/scenario.rs
+++ b/netbench/netbench/src/scenario.rs
@@ -1,10 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    operation::{ClientOperation, ConnectionOperation, RouterOperation},
-    Result,
-};
+use crate::{operation as op, Result};
 use serde::{Deserialize, Serialize};
 use std::{collections::BTreeMap, path::Path};
 
@@ -44,7 +41,7 @@ impl Scenario {
 pub struct Client {
     #[serde(skip_serializing_if = "String::is_empty", default)]
     pub name: String,
-    pub scenario: Vec<ClientOperation>,
+    pub scenario: Vec<op::Client>,
     pub connections: Vec<Connection>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub configuration: BTreeMap<String, String>,
@@ -62,16 +59,16 @@ pub struct Server {
 #[derive(Clone, Debug, Deserialize, Serialize, Hash)]
 pub struct Connection {
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub ops: Vec<ConnectionOperation>,
+    pub ops: Vec<op::Connection>,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
-    pub peer_streams: Vec<Vec<ConnectionOperation>>,
+    pub peer_streams: Vec<Vec<op::Connection>>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize, Hash)]
 pub struct Router {
     #[serde(skip_serializing_if = "String::is_empty", default)]
     pub name: String,
-    pub scenario: Vec<RouterOperation>,
+    pub scenario: Vec<op::Router>,
     #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
     pub configuration: BTreeMap<String, String>,
 }

--- a/netbench/netbench/src/scenario.rs
+++ b/netbench/netbench/src/scenario.rs
@@ -1,0 +1,77 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    operation::{ClientOperation, ConnectionOperation, RouterOperation},
+    Result,
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, path::Path};
+
+pub mod builder;
+mod id;
+
+pub use builder::Builder;
+pub use id::Id;
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Hash)]
+pub struct Scenario {
+    pub id: Id,
+    pub clients: Vec<Client>,
+    pub servers: Vec<Server>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub routers: Vec<Router>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub traces: Vec<String>,
+}
+
+impl Scenario {
+    pub fn build<F: FnOnce(&mut builder::Builder)>(f: F) -> Self {
+        let mut builder = builder::Builder::new();
+        f(&mut builder);
+        builder.finish()
+    }
+
+    pub fn open(path: &Path) -> Result<Self> {
+        let file = std::fs::File::open(path)?;
+        let mut file = std::io::BufReader::new(file);
+        let scenario = serde_json::from_reader(&mut file)?;
+        Ok(scenario)
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Hash)]
+pub struct Client {
+    #[serde(skip_serializing_if = "String::is_empty", default)]
+    pub name: String,
+    pub scenario: Vec<ClientOperation>,
+    pub connections: Vec<Connection>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub configuration: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Serialize, Hash)]
+pub struct Server {
+    #[serde(skip_serializing_if = "String::is_empty", default)]
+    pub name: String,
+    pub connections: Vec<Connection>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub configuration: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Hash)]
+pub struct Connection {
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub ops: Vec<ConnectionOperation>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub peer_streams: Vec<Vec<ConnectionOperation>>,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, Hash)]
+pub struct Router {
+    #[serde(skip_serializing_if = "String::is_empty", default)]
+    pub name: String,
+    pub scenario: Vec<RouterOperation>,
+    #[serde(skip_serializing_if = "BTreeMap::is_empty", default)]
+    pub configuration: BTreeMap<String, String>,
+}

--- a/netbench/netbench/src/scenario/builder.rs
+++ b/netbench/netbench/src/scenario/builder.rs
@@ -4,7 +4,8 @@
 macro_rules! sleep {
     () => {
         pub fn sleep(&mut self, amount: core::time::Duration) -> &mut Self {
-            self.ops.push(ConnectionOperation::Sleep { amount });
+            self.ops
+                .push(crate::operation::Connection::Sleep { amount });
             self
         }
     };
@@ -14,7 +15,8 @@ macro_rules! trace {
     () => {
         pub fn trace(&mut self, name: &str) -> &mut Self {
             let trace_id = self.state.trace(name);
-            self.ops.push(ConnectionOperation::Trace { trace_id });
+            self.ops
+                .push(crate::operation::Connection::Trace { trace_id });
             self
         }
     };

--- a/netbench/netbench/src/scenario/builder.rs
+++ b/netbench/netbench/src/scenario/builder.rs
@@ -1,0 +1,114 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+macro_rules! sleep {
+    () => {
+        pub fn sleep(&mut self, amount: core::time::Duration) -> &mut Self {
+            self.ops.push(ConnectionOperation::Sleep { amount });
+            self
+        }
+    };
+}
+
+macro_rules! trace {
+    () => {
+        pub fn trace(&mut self, name: &str) -> &mut Self {
+            let trace_id = self.state.trace(name);
+            self.ops.push(ConnectionOperation::Trace { trace_id });
+            self
+        }
+    };
+}
+
+#[macro_use]
+pub mod checkpoint;
+
+pub mod client;
+pub mod connection;
+pub mod scope;
+pub mod server;
+mod state;
+pub mod stream;
+
+pub use client::Client;
+pub use connection::Connection;
+pub use scope::Scope;
+pub use server::Server;
+pub use stream::Stream;
+
+use state::State;
+
+#[derive(Debug)]
+pub struct Builder {
+    state: State,
+}
+
+impl Builder {
+    pub(super) fn new() -> Self {
+        Self {
+            state: Default::default(),
+        }
+    }
+
+    pub fn create_server(&mut self) -> Server {
+        Server::new(self.state.clone())
+    }
+
+    pub fn create_client<F: FnOnce(&mut client::Builder)>(&mut self, f: F) {
+        let id = self.state.clients.push(super::Client {
+            name: String::new(),
+            scenario: vec![],
+            connections: vec![],
+            configuration: Default::default(),
+        }) as u64;
+
+        let mut builder = client::Builder::new(id, self.state.clone());
+        f(&mut builder);
+
+        self.state.clients.borrow_mut()[id as usize].scenario = builder.finish();
+    }
+
+    pub(super) fn finish(self) -> super::Scenario {
+        let clients = self.state.clients.take();
+        let servers = self.state.servers.take();
+        let mut traces = self.state.trace.take().into_iter().collect::<Vec<_>>();
+        traces.sort_by(|(_, a), (_, b)| a.cmp(b));
+        let traces = traces.into_iter().map(|(value, _)| value).collect();
+
+        let mut scenario = super::Scenario {
+            id: Default::default(),
+            clients,
+            servers,
+            // TODO implement router builder
+            routers: vec![],
+            traces,
+        };
+
+        let mut hash = crate::scenario::Id::hasher();
+        core::hash::Hash::hash(&scenario, &mut hash);
+        scenario.id = hash.finish();
+
+        scenario
+    }
+}
+
+pub trait Endpoint {
+    type Peer: Endpoint;
+}
+
+impl Endpoint for Client {
+    type Peer = Server;
+}
+
+impl Endpoint for Server {
+    type Peer = Client;
+}
+
+#[derive(Debug)]
+pub struct Local;
+
+#[derive(Debug)]
+pub struct Remote;
+
+#[cfg(test)]
+mod tests;

--- a/netbench/netbench/src/scenario/builder/checkpoint.rs
+++ b/netbench/netbench/src/scenario/builder/checkpoint.rs
@@ -38,7 +38,7 @@ macro_rules! sync {
                 crate::scenario::builder::checkpoint::Park,
             >,
         ) -> &mut Self {
-            self.ops.push(crate::operation::ConnectionOperation::Park {
+            self.ops.push(crate::operation::Connection::Park {
                 checkpoint: checkpoint.id,
             });
             self
@@ -52,10 +52,9 @@ macro_rules! sync {
                 crate::scenario::builder::checkpoint::Unpark,
             >,
         ) -> &mut Self {
-            self.ops
-                .push(crate::operation::ConnectionOperation::Unpark {
-                    checkpoint: checkpoint.id,
-                });
+            self.ops.push(crate::operation::Connection::Unpark {
+                checkpoint: checkpoint.id,
+            });
             self
         }
     };

--- a/netbench/netbench/src/scenario/builder/checkpoint.rs
+++ b/netbench/netbench/src/scenario/builder/checkpoint.rs
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::marker::PhantomData;
+
+#[derive(Debug)]
+pub struct Checkpoint<Endpoint, Location, Op> {
+    pub(crate) id: u64,
+    endpoint: PhantomData<Endpoint>,
+    location: PhantomData<Location>,
+    op: PhantomData<Op>,
+}
+
+impl<Endpoint, Location, Op> Checkpoint<Endpoint, Location, Op> {
+    pub(crate) fn new(id: u64) -> Self {
+        Self {
+            id,
+            endpoint: PhantomData,
+            location: PhantomData,
+            op: PhantomData,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Park;
+
+#[derive(Debug)]
+pub struct Unpark;
+
+macro_rules! sync {
+    ($endpoint:ty, $location:ty) => {
+        pub fn park(
+            &mut self,
+            checkpoint: crate::scenario::builder::checkpoint::Checkpoint<
+                $endpoint,
+                $location,
+                crate::scenario::builder::checkpoint::Park,
+            >,
+        ) -> &mut Self {
+            self.ops.push(crate::operation::ConnectionOperation::Park {
+                checkpoint: checkpoint.id,
+            });
+            self
+        }
+
+        pub fn unpark(
+            &mut self,
+            checkpoint: crate::scenario::builder::checkpoint::Checkpoint<
+                $endpoint,
+                $location,
+                crate::scenario::builder::checkpoint::Unpark,
+            >,
+        ) -> &mut Self {
+            self.ops
+                .push(crate::operation::ConnectionOperation::Unpark {
+                    checkpoint: checkpoint.id,
+                });
+            self
+        }
+    };
+}

--- a/netbench/netbench/src/scenario/builder/client.rs
+++ b/netbench/netbench/src/scenario/builder/client.rs
@@ -1,0 +1,65 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    checkpoint::{Checkpoint, Park, Unpark},
+    connection::{self, Connect, Connection},
+    Local,
+};
+use crate::scenario::ClientOperation;
+use core::marker::PhantomData;
+
+#[derive(Debug)]
+pub struct Builder {
+    id: u64,
+    state: super::State,
+    ops: Vec<ClientOperation>,
+}
+
+impl Builder {
+    pub(crate) fn new(id: u64, state: super::State) -> Self {
+        Self {
+            id,
+            state,
+            ops: vec![],
+        }
+    }
+
+    pub fn connect_to<F: FnOnce(&mut connection::Builder<Client>), To: Connect<Client>>(
+        &mut self,
+        to: To,
+        f: F,
+    ) -> Connection<Client> {
+        let mut builder = connection::Builder::new(self.state.connection());
+        f(&mut builder);
+
+        let template = builder.finish();
+        let connection = Connection {
+            endpoint_id: self.id,
+            state: self.state.clone(),
+            template,
+            endpoint: PhantomData,
+        };
+
+        let op = to.connect_to(&connection);
+        self.ops.push(op);
+
+        connection
+    }
+
+    pub fn checkpoint(
+        &mut self,
+    ) -> (
+        Checkpoint<Client, Local, Park>,
+        Checkpoint<Client, Local, Unpark>,
+    ) {
+        self.state.checkpoint()
+    }
+
+    pub(crate) fn finish(self) -> Vec<ClientOperation> {
+        self.ops
+    }
+}
+
+#[derive(Debug)]
+pub struct Client {}

--- a/netbench/netbench/src/scenario/builder/client.rs
+++ b/netbench/netbench/src/scenario/builder/client.rs
@@ -6,14 +6,14 @@ use super::{
     connection::{self, Connect, Connection},
     Local,
 };
-use crate::scenario::ClientOperation;
+use crate::operation as op;
 use core::marker::PhantomData;
 
 #[derive(Debug)]
 pub struct Builder {
     id: u64,
     state: super::State,
-    ops: Vec<ClientOperation>,
+    ops: Vec<op::Client>,
 }
 
 impl Builder {
@@ -56,7 +56,7 @@ impl Builder {
         self.state.checkpoint()
     }
 
-    pub(crate) fn finish(self) -> Vec<ClientOperation> {
+    pub(crate) fn finish(self) -> Vec<op::Client> {
         self.ops
     }
 }

--- a/netbench/netbench/src/scenario/builder/connection.rs
+++ b/netbench/netbench/src/scenario/builder/connection.rs
@@ -1,0 +1,201 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    checkpoint::{Checkpoint, Park, Unpark},
+    state::{IdPool, RefVec},
+    stream::{ReceiveStream, SendStream, Stream},
+    Client, Endpoint, Local, Remote, Scope, Server,
+};
+use crate::operation::{ClientOperation, ConnectionOperation};
+use core::marker::PhantomData;
+
+#[derive(Clone, Debug, Default)]
+pub struct State {
+    peer_streams: RefVec<Vec<ConnectionOperation>>,
+    stream: IdPool,
+    scenario: super::State,
+}
+
+impl State {
+    pub(crate) fn new(scenario: super::State) -> Self {
+        Self {
+            scenario,
+            ..Default::default()
+        }
+    }
+}
+
+impl core::ops::Deref for State {
+    type Target = super::State;
+
+    fn deref(&self) -> &Self::Target {
+        &self.scenario
+    }
+}
+
+#[derive(Debug)]
+pub struct Builder<Endpoint> {
+    ops: Vec<ConnectionOperation>,
+    state: State,
+    endpoint: PhantomData<Endpoint>,
+}
+
+impl<E: Endpoint> Builder<E> {
+    pub(crate) fn new(state: State) -> Self {
+        Self {
+            ops: vec![],
+            state,
+            endpoint: PhantomData,
+        }
+    }
+
+    pub fn checkpoint<Location>(
+        &self,
+    ) -> (
+        Checkpoint<E, Location, Park>,
+        Checkpoint<E, Location, Unpark>,
+    ) {
+        self.state.checkpoint()
+    }
+
+    sync!(E, Local);
+    sleep!();
+    trace!();
+
+    pub fn scope<F: FnOnce(&mut Scope<E>)>(&mut self, f: F) -> &mut Self {
+        let mut scope = Scope::new(self.state.clone());
+        f(&mut scope);
+
+        let threads = scope.finish();
+
+        if threads.is_empty() {
+            // no-op
+        } else if threads.len() == 1 {
+            // only a single thread was spawned, which is the same as not spawning it
+            self.ops.extend(threads.into_iter().flatten());
+        } else {
+            self.ops.push(ConnectionOperation::Scope { threads });
+        }
+
+        self
+    }
+
+    pub fn concurrently<A: FnOnce(&mut Builder<E>), B: FnOnce(&mut Builder<E>)>(
+        &mut self,
+        a: A,
+        b: B,
+    ) -> &mut Self {
+        self.scope(|scope| {
+            scope.spawn(a);
+            scope.spawn(b);
+        })
+    }
+
+    pub fn open_bidirectional_stream<
+        L: FnOnce(&mut Stream<E, Local>),
+        R: FnOnce(&mut Stream<E::Peer, Remote>),
+    >(
+        &mut self,
+        local: L,
+        remote: R,
+    ) -> &mut Self {
+        let id = self.state.stream.next_id();
+        let mut local_stream = Stream::new(id, self.state.clone());
+        let mut remote_stream = Stream::new(id, self.state.clone());
+
+        local(&mut local_stream);
+        remote(&mut remote_stream);
+
+        self.ops
+            .push(ConnectionOperation::OpenBidirectionalStream { stream_id: id });
+        self.ops.extend(local_stream.finish());
+
+        debug_assert_eq!(id, self.state.peer_streams.len() as u64);
+        self.state.peer_streams.push(remote_stream.finish());
+
+        self
+    }
+
+    pub fn open_send_stream<
+        L: FnOnce(&mut SendStream<E, Local>),
+        R: FnOnce(&mut ReceiveStream<E::Peer, Remote>),
+    >(
+        &mut self,
+        local: L,
+        remote: R,
+    ) -> &mut Self {
+        let id = self.state.stream.next_id();
+        let mut local_stream = SendStream::new(id, self.state.clone());
+        let mut remote_stream = ReceiveStream::new(id, self.state.clone());
+
+        local(&mut local_stream);
+        remote(&mut remote_stream);
+
+        self.ops
+            .push(ConnectionOperation::OpenSendStream { stream_id: id });
+        self.ops.extend(local_stream.finish());
+
+        debug_assert_eq!(id, self.state.peer_streams.len() as u64);
+        self.state.peer_streams.push(remote_stream.finish());
+
+        self
+    }
+
+    pub(crate) fn finish(self) -> crate::scenario::Connection {
+        let peer_streams = self.state.peer_streams.take();
+        let ops = self.ops;
+        crate::scenario::Connection { ops, peer_streams }
+    }
+
+    pub(crate) fn finish_scope(self) -> Vec<ConnectionOperation> {
+        self.ops
+    }
+}
+
+#[derive(Debug)]
+pub struct Connection<Endpoint> {
+    pub(crate) state: super::State,
+    pub(crate) endpoint_id: u64,
+    pub(crate) template: crate::scenario::Connection,
+    pub(crate) endpoint: PhantomData<Endpoint>,
+}
+
+pub trait Connect<Endpoint> {
+    fn connect_to(&self, handle: &Connection<Endpoint>) -> ClientOperation;
+}
+
+impl Connect<Client> for Connection<Server> {
+    fn connect_to(&self, handle: &Connection<Client>) -> ClientOperation {
+        let server_id = self.endpoint_id;
+        let server = &mut self.state.servers.borrow_mut()[server_id as usize];
+        let server_connection_id = server.connections.len() as u64;
+        server.connections.push(crate::scenario::Connection {
+            ops: self.template.ops.clone(),
+            peer_streams: handle.template.peer_streams.clone(),
+        });
+
+        let client = &mut self.state.clients.borrow_mut()[handle.endpoint_id as usize];
+        let client_connection_id = client.connections.len() as u64;
+        client.connections.push(crate::scenario::Connection {
+            ops: handle.template.ops.clone(),
+            peer_streams: self.template.peer_streams.clone(),
+        });
+
+        ClientOperation::Connect {
+            server_id,
+            router_id: None,
+            server_connection_id,
+            client_connection_id,
+        }
+    }
+}
+
+impl Connect<Client> for Server {
+    fn connect_to(&self, handle: &Connection<Client>) -> ClientOperation {
+        self.with(|_| {
+            // empty instructions
+        })
+        .connect_to(handle)
+    }
+}

--- a/netbench/netbench/src/scenario/builder/scope.rs
+++ b/netbench/netbench/src/scenario/builder/scope.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{connection, Endpoint};
-use crate::operation::ConnectionOperation;
+use crate::operation as op;
 use core::marker::PhantomData;
 
 pub struct Scope<Endpoint> {
     state: connection::State,
-    threads: Vec<Vec<ConnectionOperation>>,
+    threads: Vec<Vec<op::Connection>>,
     endpoint: PhantomData<Endpoint>,
 }
 
@@ -27,7 +27,7 @@ impl<E: Endpoint> Scope<E> {
         self
     }
 
-    pub(crate) fn finish(self) -> Vec<Vec<ConnectionOperation>> {
+    pub(crate) fn finish(self) -> Vec<Vec<op::Connection>> {
         self.threads
     }
 }

--- a/netbench/netbench/src/scenario/builder/scope.rs
+++ b/netbench/netbench/src/scenario/builder/scope.rs
@@ -1,0 +1,33 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{connection, Endpoint};
+use crate::operation::ConnectionOperation;
+use core::marker::PhantomData;
+
+pub struct Scope<Endpoint> {
+    state: connection::State,
+    threads: Vec<Vec<ConnectionOperation>>,
+    endpoint: PhantomData<Endpoint>,
+}
+
+impl<E: Endpoint> Scope<E> {
+    pub(crate) fn new(state: connection::State) -> Self {
+        Self {
+            state,
+            threads: vec![],
+            endpoint: PhantomData,
+        }
+    }
+
+    pub fn spawn<F: FnOnce(&mut connection::Builder<E>)>(&mut self, f: F) -> &mut Self {
+        let mut builder = connection::Builder::new(self.state.clone());
+        f(&mut builder);
+        self.threads.push(builder.finish_scope());
+        self
+    }
+
+    pub(crate) fn finish(self) -> Vec<Vec<ConnectionOperation>> {
+        self.threads
+    }
+}

--- a/netbench/netbench/src/scenario/builder/server.rs
+++ b/netbench/netbench/src/scenario/builder/server.rs
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::connection::{self, Connection};
+use core::marker::PhantomData;
+
+#[derive(Debug)]
+pub struct Server {
+    id: u64,
+    state: super::State,
+}
+
+impl Server {
+    pub(crate) fn new(state: super::State) -> Self {
+        let id = state.servers.push(crate::scenario::Server::default()) as u64;
+
+        Self { id, state }
+    }
+
+    pub fn with<F: FnOnce(&mut connection::Builder<Server>)>(&self, f: F) -> Connection<Server> {
+        let mut builder = connection::Builder::new(self.state.connection());
+        f(&mut builder);
+
+        Connection {
+            endpoint_id: self.id,
+            state: self.state.clone(),
+            template: builder.finish(),
+            endpoint: PhantomData,
+        }
+    }
+}

--- a/netbench/netbench/src/scenario/builder/snapshots/netbench__scenario__builder__tests__conn_checkpoints.snap
+++ b/netbench/netbench/src/scenario/builder/snapshots/netbench__scenario__builder__tests__conn_checkpoints.snap
@@ -1,0 +1,130 @@
+---
+source: netbench/netbench/src/scenario/builder/tests.rs
+assertion_line: 46
+expression: "scenario(|scenario|\n             {\n                 let server = scenario.create_server();\n                 scenario.create_client(|client|\n                                            {\n                                                client.connect_to(server,\n                                                                  |conn|\n                                                                      {\n                                                                          let (cp1_rx,\n                                                                               cp1_tx) =\n                                                                              conn.checkpoint();\n                                                                          conn.concurrently(|conn|\n                                                                                                {\n                                                                                                    conn.open_send_stream(|local|\n                                                                                                                              {\n                                                                                                                                  local.set_send_rate(10.kilobytes()\n                                                                                                                                                          /\n                                                                                                                                                          50.millis());\n                                                                                                                                  local.send(1.megabytes()\n                                                                                                                                                 /\n                                                                                                                                                 2);\n                                                                                                                                  local.unpark(cp1_tx);\n                                                                                                                                  local.send(1.megabytes()\n                                                                                                                                                 /\n                                                                                                                                                 2);\n                                                                                                                              },\n                                                                                                                          |peer|\n                                                                                                                              {\n                                                                                                                                  peer.set_receive_rate(10.kilobytes()\n                                                                                                                                                            /\n                                                                                                                                                            50.millis());\n                                                                                                                                  peer.receive(1.megabytes());\n                                                                                                                              });\n                                                                                                },\n                                                                                            |conn|\n                                                                                                {\n                                                                                                    conn.open_send_stream(|local|\n                                                                                                                              {\n                                                                                                                                  local.park(cp1_rx);\n                                                                                                                                  local.set_send_rate(1024.bytes()\n                                                                                                                                                          /\n                                                                                                                                                          50.millis());\n                                                                                                                                  local.send(1.megabytes());\n                                                                                                                              },\n                                                                                                                          |peer|\n                                                                                                                              {\n                                                                                                                                  peer.set_receive_rate(1024.bytes()\n                                                                                                                                                            /\n                                                                                                                                                            50.millis());\n                                                                                                                                  peer.receive(1.megabytes());\n                                                                                                                              });\n                                                                                                });\n                                                                      });\n                                            });\n             })"
+
+---
+{
+  "id": "",
+  "clients": [
+    {
+      "scenario": [
+        {
+          "connect": {
+            "server_id": 0,
+            "server_connection_id": 0,
+            "client_connection_id": 0
+          }
+        }
+      ],
+      "connections": [
+        {
+          "ops": [
+            {
+              "scope": {
+                "threads": [
+                  [
+                    {
+                      "open_send_stream": {
+                        "stream_id": 0
+                      }
+                    },
+                    {
+                      "send_rate": {
+                        "stream_id": 0,
+                        "bytes": 10000,
+                        "period_ms": 50
+                      }
+                    },
+                    {
+                      "send": {
+                        "stream_id": 0,
+                        "bytes": 500000
+                      }
+                    },
+                    {
+                      "unpark": {
+                        "checkpoint": 0
+                      }
+                    },
+                    {
+                      "send": {
+                        "stream_id": 0,
+                        "bytes": 500000
+                      }
+                    }
+                  ],
+                  [
+                    {
+                      "open_send_stream": {
+                        "stream_id": 1
+                      }
+                    },
+                    {
+                      "park": {
+                        "checkpoint": 0
+                      }
+                    },
+                    {
+                      "send_rate": {
+                        "stream_id": 1,
+                        "bytes": 1024,
+                        "period_ms": 50
+                      }
+                    },
+                    {
+                      "send": {
+                        "stream_id": 1,
+                        "bytes": 1000000
+                      }
+                    }
+                  ]
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "servers": [
+    {
+      "connections": [
+        {
+          "peer_streams": [
+            [
+              {
+                "receive_rate": {
+                  "stream_id": 0,
+                  "bytes": 10000,
+                  "period_ms": 50
+                }
+              },
+              {
+                "receive": {
+                  "stream_id": 0,
+                  "bytes": 1000000
+                }
+              }
+            ],
+            [
+              {
+                "receive_rate": {
+                  "stream_id": 1,
+                  "bytes": 1024,
+                  "period_ms": 50
+                }
+              },
+              {
+                "receive": {
+                  "stream_id": 1,
+                  "bytes": 1000000
+                }
+              }
+            ]
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/netbench/netbench/src/scenario/builder/snapshots/netbench__scenario__builder__tests__conn_checkpoints.snap
+++ b/netbench/netbench/src/scenario/builder/snapshots/netbench__scenario__builder__tests__conn_checkpoints.snap
@@ -1,5 +1,5 @@
 ---
-source: netbench/netbench/src/scenario/builder/tests.rs
+source: netbench/src/scenario/builder/tests.rs
 assertion_line: 46
 expression: "scenario(|scenario|\n             {\n                 let server = scenario.create_server();\n                 scenario.create_client(|client|\n                                            {\n                                                client.connect_to(server,\n                                                                  |conn|\n                                                                      {\n                                                                          let (cp1_rx,\n                                                                               cp1_tx) =\n                                                                              conn.checkpoint();\n                                                                          conn.concurrently(|conn|\n                                                                                                {\n                                                                                                    conn.open_send_stream(|local|\n                                                                                                                              {\n                                                                                                                                  local.set_send_rate(10.kilobytes()\n                                                                                                                                                          /\n                                                                                                                                                          50.millis());\n                                                                                                                                  local.send(1.megabytes()\n                                                                                                                                                 /\n                                                                                                                                                 2);\n                                                                                                                                  local.unpark(cp1_tx);\n                                                                                                                                  local.send(1.megabytes()\n                                                                                                                                                 /\n                                                                                                                                                 2);\n                                                                                                                              },\n                                                                                                                          |peer|\n                                                                                                                              {\n                                                                                                                                  peer.set_receive_rate(10.kilobytes()\n                                                                                                                                                            /\n                                                                                                                                                            50.millis());\n                                                                                                                                  peer.receive(1.megabytes());\n                                                                                                                              });\n                                                                                                },\n                                                                                            |conn|\n                                                                                                {\n                                                                                                    conn.open_send_stream(|local|\n                                                                                                                              {\n                                                                                                                                  local.park(cp1_rx);\n                                                                                                                                  local.set_send_rate(1024.bytes()\n                                                                                                                                                          /\n                                                                                                                                                          50.millis());\n                                                                                                                                  local.send(1.megabytes());\n                                                                                                                              },\n                                                                                                                          |peer|\n                                                                                                                              {\n                                                                                                                                  peer.set_receive_rate(1024.bytes()\n                                                                                                                                                            /\n                                                                                                                                                            50.millis());\n                                                                                                                                  peer.receive(1.megabytes());\n                                                                                                                              });\n                                                                                                });\n                                                                      });\n                                            });\n             })"
 
@@ -52,6 +52,11 @@ expression: "scenario(|scenario|\n             {\n                 let server = 
                         "stream_id": 0,
                         "bytes": 500000
                       }
+                    },
+                    {
+                      "send_finish": {
+                        "stream_id": 0
+                      }
                     }
                   ],
                   [
@@ -76,6 +81,11 @@ expression: "scenario(|scenario|\n             {\n                 let server = 
                       "send": {
                         "stream_id": 1,
                         "bytes": 1000000
+                      }
+                    },
+                    {
+                      "send_finish": {
+                        "stream_id": 1
                       }
                     }
                   ]
@@ -105,6 +115,11 @@ expression: "scenario(|scenario|\n             {\n                 let server = 
                   "stream_id": 0,
                   "bytes": 1000000
                 }
+              },
+              {
+                "receive_finish": {
+                  "stream_id": 0
+                }
               }
             ],
             [
@@ -119,6 +134,11 @@ expression: "scenario(|scenario|\n             {\n                 let server = 
                 "receive": {
                   "stream_id": 1,
                   "bytes": 1000000
+                }
+              },
+              {
+                "receive_finish": {
+                  "stream_id": 1
                 }
               }
             ]

--- a/netbench/netbench/src/scenario/builder/snapshots/netbench__scenario__builder__tests__linked_streams.snap
+++ b/netbench/netbench/src/scenario/builder/snapshots/netbench__scenario__builder__tests__linked_streams.snap
@@ -1,0 +1,148 @@
+---
+source: netbench/netbench/src/scenario/builder/tests.rs
+assertion_line: 86
+expression: "scenario(|scenario|\n             {\n                 let server = scenario.create_server();\n                 scenario.create_client(|client|\n                                            {\n                                                client.connect_to(server,\n                                                                  |conn|\n                                                                      {\n                                                                          let (b_park,\n                                                                               b_unpark) =\n                                                                              conn.checkpoint();\n                                                                          conn.concurrently(|conn|\n                                                                                                {\n                                                                                                    conn.open_bidirectional_stream(|local|\n                                                                                                                                       {\n                                                                                                                                           local.concurrently(|sender|\n                                                                                                                                                                  {\n                                                                                                                                                                      sender.set_send_rate(1024.bytes()\n                                                                                                                                                                                               /\n                                                                                                                                                                                               50.millis());\n                                                                                                                                                                      sender.send(1.megabytes());\n                                                                                                                                                                  },\n                                                                                                                                                              |receiver|\n                                                                                                                                                                  {\n                                                                                                                                                                      receiver.receive_all();\n                                                                                                                                                                  });\n                                                                                                                                           local.unpark(b_unpark);\n                                                                                                                                       },\n                                                                                                                                   |peer|\n                                                                                                                                       {\n                                                                                                                                           peer.sleep(100.millis());\n                                                                                                                                           peer.set_receive_rate(1024.bytes()\n                                                                                                                                                                     /\n                                                                                                                                                                     50.millis());\n                                                                                                                                           peer.receive(100.kilobytes());\n                                                                                                                                           peer.set_receive_rate(10.bytes()\n                                                                                                                                                                     /\n                                                                                                                                                                     50.millis());\n                                                                                                                                           peer.receive_all();\n                                                                                                                                           peer.send(2.megabytes());\n                                                                                                                                       });\n                                                                                                },\n                                                                                            |conn|\n                                                                                                {\n                                                                                                    conn.open_send_stream(|local|\n                                                                                                                              {\n                                                                                                                                  local.park(b_park);\n                                                                                                                                  local.send(1.megabytes());\n                                                                                                                              },\n                                                                                                                          |peer|\n                                                                                                                              {\n                                                                                                                                  peer.receive(1.megabytes());\n                                                                                                                              });\n                                                                                                });\n                                                                      });\n                                            });\n             })"
+
+---
+{
+  "id": "",
+  "clients": [
+    {
+      "scenario": [
+        {
+          "connect": {
+            "server_id": 0,
+            "server_connection_id": 0,
+            "client_connection_id": 0
+          }
+        }
+      ],
+      "connections": [
+        {
+          "ops": [
+            {
+              "scope": {
+                "threads": [
+                  [
+                    {
+                      "open_bidirectional_stream": {
+                        "stream_id": 0
+                      }
+                    },
+                    {
+                      "scope": {
+                        "threads": [
+                          [
+                            {
+                              "send_rate": {
+                                "stream_id": 0,
+                                "bytes": 1024,
+                                "period_ms": 50
+                              }
+                            },
+                            {
+                              "send": {
+                                "stream_id": 0,
+                                "bytes": 1000000
+                              }
+                            }
+                          ],
+                          [
+                            {
+                              "receive_all": {
+                                "stream_id": 0
+                              }
+                            }
+                          ]
+                        ]
+                      }
+                    },
+                    {
+                      "unpark": {
+                        "checkpoint": 0
+                      }
+                    }
+                  ],
+                  [
+                    {
+                      "open_send_stream": {
+                        "stream_id": 1
+                      }
+                    },
+                    {
+                      "park": {
+                        "checkpoint": 0
+                      }
+                    },
+                    {
+                      "send": {
+                        "stream_id": 1,
+                        "bytes": 1000000
+                      }
+                    }
+                  ]
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "servers": [
+    {
+      "connections": [
+        {
+          "peer_streams": [
+            [
+              {
+                "sleep": {
+                  "amount_ms": 100
+                }
+              },
+              {
+                "receive_rate": {
+                  "stream_id": 0,
+                  "bytes": 1024,
+                  "period_ms": 50
+                }
+              },
+              {
+                "receive": {
+                  "stream_id": 0,
+                  "bytes": 100000
+                }
+              },
+              {
+                "receive_rate": {
+                  "stream_id": 0,
+                  "bytes": 10,
+                  "period_ms": 50
+                }
+              },
+              {
+                "receive_all": {
+                  "stream_id": 0
+                }
+              },
+              {
+                "send": {
+                  "stream_id": 0,
+                  "bytes": 2000000
+                }
+              }
+            ],
+            [
+              {
+                "receive": {
+                  "stream_id": 1,
+                  "bytes": 1000000
+                }
+              }
+            ]
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/netbench/netbench/src/scenario/builder/snapshots/netbench__scenario__builder__tests__linked_streams.snap
+++ b/netbench/netbench/src/scenario/builder/snapshots/netbench__scenario__builder__tests__linked_streams.snap
@@ -1,5 +1,5 @@
 ---
-source: netbench/netbench/src/scenario/builder/tests.rs
+source: netbench/src/scenario/builder/tests.rs
 assertion_line: 86
 expression: "scenario(|scenario|\n             {\n                 let server = scenario.create_server();\n                 scenario.create_client(|client|\n                                            {\n                                                client.connect_to(server,\n                                                                  |conn|\n                                                                      {\n                                                                          let (b_park,\n                                                                               b_unpark) =\n                                                                              conn.checkpoint();\n                                                                          conn.concurrently(|conn|\n                                                                                                {\n                                                                                                    conn.open_bidirectional_stream(|local|\n                                                                                                                                       {\n                                                                                                                                           local.concurrently(|sender|\n                                                                                                                                                                  {\n                                                                                                                                                                      sender.set_send_rate(1024.bytes()\n                                                                                                                                                                                               /\n                                                                                                                                                                                               50.millis());\n                                                                                                                                                                      sender.send(1.megabytes());\n                                                                                                                                                                  },\n                                                                                                                                                              |receiver|\n                                                                                                                                                                  {\n                                                                                                                                                                      receiver.receive_all();\n                                                                                                                                                                  });\n                                                                                                                                           local.unpark(b_unpark);\n                                                                                                                                       },\n                                                                                                                                   |peer|\n                                                                                                                                       {\n                                                                                                                                           peer.sleep(100.millis());\n                                                                                                                                           peer.set_receive_rate(1024.bytes()\n                                                                                                                                                                     /\n                                                                                                                                                                     50.millis());\n                                                                                                                                           peer.receive(100.kilobytes());\n                                                                                                                                           peer.set_receive_rate(10.bytes()\n                                                                                                                                                                     /\n                                                                                                                                                                     50.millis());\n                                                                                                                                           peer.receive_all();\n                                                                                                                                           peer.send(2.megabytes());\n                                                                                                                                       });\n                                                                                                },\n                                                                                            |conn|\n                                                                                                {\n                                                                                                    conn.open_send_stream(|local|\n                                                                                                                              {\n                                                                                                                                  local.park(b_park);\n                                                                                                                                  local.send(1.megabytes());\n                                                                                                                              },\n                                                                                                                          |peer|\n                                                                                                                              {\n                                                                                                                                  peer.receive(1.megabytes());\n                                                                                                                              });\n                                                                                                });\n                                                                      });\n                                            });\n             })"
 
@@ -61,6 +61,16 @@ expression: "scenario(|scenario|\n             {\n                 let server = 
                       "unpark": {
                         "checkpoint": 0
                       }
+                    },
+                    {
+                      "send_finish": {
+                        "stream_id": 0
+                      }
+                    },
+                    {
+                      "receive_finish": {
+                        "stream_id": 0
+                      }
                     }
                   ],
                   [
@@ -78,6 +88,11 @@ expression: "scenario(|scenario|\n             {\n                 let server = 
                       "send": {
                         "stream_id": 1,
                         "bytes": 1000000
+                      }
+                    },
+                    {
+                      "send_finish": {
+                        "stream_id": 1
                       }
                     }
                   ]
@@ -130,6 +145,16 @@ expression: "scenario(|scenario|\n             {\n                 let server = 
                   "stream_id": 0,
                   "bytes": 2000000
                 }
+              },
+              {
+                "send_finish": {
+                  "stream_id": 0
+                }
+              },
+              {
+                "receive_finish": {
+                  "stream_id": 0
+                }
               }
             ],
             [
@@ -137,6 +162,11 @@ expression: "scenario(|scenario|\n             {\n                 let server = 
                 "receive": {
                   "stream_id": 1,
                   "bytes": 1000000
+                }
+              },
+              {
+                "receive_finish": {
+                  "stream_id": 1
                 }
               }
             ]

--- a/netbench/netbench/src/scenario/builder/snapshots/netbench__scenario__builder__tests__simple.snap
+++ b/netbench/netbench/src/scenario/builder/snapshots/netbench__scenario__builder__tests__simple.snap
@@ -1,0 +1,71 @@
+---
+source: netbench/netbench/src/scenario/builder/tests.rs
+assertion_line: 27
+expression: "scenario(|scenario|\n             {\n                 let server = scenario.create_server();\n                 scenario.create_client(|client|\n                                            {\n                                                client.connect_to(server,\n                                                                  |conn|\n                                                                      {\n                                                                          conn.open_send_stream(|local|\n                                                                                                    {\n                                                                                                        local.set_send_rate(1024.bytes()\n                                                                                                                                /\n                                                                                                                                50.millis());\n                                                                                                        local.send(1.megabytes());\n                                                                                                    },\n                                                                                                |peer|\n                                                                                                    {\n                                                                                                        peer.set_receive_rate(1024.bytes()\n                                                                                                                                  /\n                                                                                                                                  50.millis());\n                                                                                                        peer.receive(1.megabytes());\n                                                                                                    });\n                                                                      });\n                                            });\n             })"
+
+---
+{
+  "id": "",
+  "clients": [
+    {
+      "scenario": [
+        {
+          "connect": {
+            "server_id": 0,
+            "server_connection_id": 0,
+            "client_connection_id": 0
+          }
+        }
+      ],
+      "connections": [
+        {
+          "ops": [
+            {
+              "open_send_stream": {
+                "stream_id": 0
+              }
+            },
+            {
+              "send_rate": {
+                "stream_id": 0,
+                "bytes": 1024,
+                "period_ms": 50
+              }
+            },
+            {
+              "send": {
+                "stream_id": 0,
+                "bytes": 1000000
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "servers": [
+    {
+      "connections": [
+        {
+          "peer_streams": [
+            [
+              {
+                "receive_rate": {
+                  "stream_id": 0,
+                  "bytes": 1024,
+                  "period_ms": 50
+                }
+              },
+              {
+                "receive": {
+                  "stream_id": 0,
+                  "bytes": 1000000
+                }
+              }
+            ]
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/netbench/netbench/src/scenario/builder/snapshots/netbench__scenario__builder__tests__simple.snap
+++ b/netbench/netbench/src/scenario/builder/snapshots/netbench__scenario__builder__tests__simple.snap
@@ -1,5 +1,5 @@
 ---
-source: netbench/netbench/src/scenario/builder/tests.rs
+source: netbench/src/scenario/builder/tests.rs
 assertion_line: 27
 expression: "scenario(|scenario|\n             {\n                 let server = scenario.create_server();\n                 scenario.create_client(|client|\n                                            {\n                                                client.connect_to(server,\n                                                                  |conn|\n                                                                      {\n                                                                          conn.open_send_stream(|local|\n                                                                                                    {\n                                                                                                        local.set_send_rate(1024.bytes()\n                                                                                                                                /\n                                                                                                                                50.millis());\n                                                                                                        local.send(1.megabytes());\n                                                                                                    },\n                                                                                                |peer|\n                                                                                                    {\n                                                                                                        peer.set_receive_rate(1024.bytes()\n                                                                                                                                  /\n                                                                                                                                  50.millis());\n                                                                                                        peer.receive(1.megabytes());\n                                                                                                    });\n                                                                      });\n                                            });\n             })"
 
@@ -37,6 +37,11 @@ expression: "scenario(|scenario|\n             {\n                 let server = 
                 "stream_id": 0,
                 "bytes": 1000000
               }
+            },
+            {
+              "send_finish": {
+                "stream_id": 0
+              }
             }
           ]
         }
@@ -60,6 +65,11 @@ expression: "scenario(|scenario|\n             {\n                 let server = 
                 "receive": {
                   "stream_id": 0,
                   "bytes": 1000000
+                }
+              },
+              {
+                "receive_finish": {
+                  "stream_id": 0
                 }
               }
             ]

--- a/netbench/netbench/src/scenario/builder/state.rs
+++ b/netbench/netbench/src/scenario/builder/state.rs
@@ -1,0 +1,122 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    checkpoint::{Checkpoint, Park, Unpark},
+    connection,
+};
+use crate::scenario::{Client, Server};
+use core::fmt;
+use std::{
+    cell::{RefCell, RefMut},
+    collections::HashMap,
+    rc::Rc,
+};
+
+#[derive(Clone, Debug, Default)]
+pub struct State {
+    pub checkpoint: IdPool,
+    pub servers: RefVec<Server>,
+    pub clients: RefVec<Client>,
+    pub trace: RefMap<String, u64>,
+}
+
+impl State {
+    pub fn checkpoint<Endpoint, Location>(
+        &self,
+    ) -> (
+        Checkpoint<Endpoint, Location, Park>,
+        Checkpoint<Endpoint, Location, Unpark>,
+    ) {
+        let id = self.checkpoint.next_id();
+        (Checkpoint::new(id), Checkpoint::new(id))
+    }
+
+    pub fn connection(&self) -> connection::State {
+        connection::State::new(self.clone())
+    }
+
+    pub fn trace(&self, name: &str) -> u64 {
+        if let Some(v) = self.trace.0.borrow().get(name) {
+            return *v;
+        }
+
+        let mut map = self.trace.0.borrow_mut();
+
+        let id = map.len() as u64;
+        map.insert(name.to_string(), id);
+        id
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct IdPool(Rc<RefCell<u64>>);
+
+impl fmt::Debug for IdPool {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "IdPool({})", *self.0.borrow())
+    }
+}
+
+impl IdPool {
+    pub fn next_id(&self) -> u64 {
+        let mut next_id = self.0.borrow_mut();
+        let id = *next_id;
+        *next_id += 1;
+        id
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RefMap<Key, Value>(Rc<RefCell<HashMap<Key, Value>>>);
+
+impl<Key, Value> Default for RefMap<Key, Value> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<Key: core::hash::Hash + Eq, Value> RefMap<Key, Value> {
+    #[allow(dead_code)]
+    pub fn insert(&self, key: Key, value: Value) {
+        self.0.borrow_mut().insert(key, value);
+    }
+
+    pub fn take(&self) -> HashMap<Key, Value> {
+        core::mem::take(&mut self.0.borrow_mut())
+    }
+
+    pub fn borrow_mut(&self) -> RefMut<HashMap<Key, Value>> {
+        self.0.borrow_mut()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RefVec<Value>(Rc<RefCell<Vec<Value>>>);
+
+impl<Value> Default for RefVec<Value> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<Value> RefVec<Value> {
+    pub fn len(&self) -> usize {
+        self.0.borrow().len()
+    }
+
+    pub fn push(&self, value: Value) -> usize {
+        let mut v = self.0.borrow_mut();
+        let len = v.len();
+        v.push(value);
+        len
+    }
+
+    pub fn take(&self) -> Vec<Value> {
+        core::mem::take(&mut self.0.borrow_mut())
+    }
+
+    pub fn borrow_mut(&self) -> RefMut<Vec<Value>> {
+        self.0.borrow_mut()
+    }
+}

--- a/netbench/netbench/src/scenario/builder/stream.rs
+++ b/netbench/netbench/src/scenario/builder/stream.rs
@@ -1,0 +1,160 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::connection;
+use crate::{
+    operation::ConnectionOperation,
+    units::{Byte, Rate},
+};
+use core::marker::PhantomData;
+
+macro_rules! send_stream {
+    () => {
+        pub fn send(&mut self, bytes: Byte) -> &mut Self {
+            self.ops.push(ConnectionOperation::Send {
+                stream_id: self.id,
+                bytes,
+            });
+            self
+        }
+
+        pub fn set_send_rate(&mut self, rate: Rate) -> &mut Self {
+            self.ops.push(ConnectionOperation::SendRate {
+                stream_id: self.id,
+                rate,
+            });
+            self
+        }
+    };
+}
+
+macro_rules! receive_stream {
+    () => {
+        pub fn receive(&mut self, bytes: Byte) -> &mut Self {
+            self.ops.push(ConnectionOperation::Receive {
+                stream_id: self.id,
+                bytes,
+            });
+            self
+        }
+
+        pub fn set_receive_rate(&mut self, rate: Rate) -> &mut Self {
+            self.ops.push(ConnectionOperation::ReceiveRate {
+                stream_id: self.id,
+                rate,
+            });
+            self
+        }
+
+        pub fn receive_all(&mut self) -> &mut Self {
+            self.ops
+                .push(ConnectionOperation::ReceiveAll { stream_id: self.id });
+            self
+        }
+    };
+}
+
+pub struct Stream<Endpoint, Location> {
+    id: u64,
+    ops: Vec<ConnectionOperation>,
+    state: connection::State,
+    endpoint: PhantomData<Endpoint>,
+    location: PhantomData<Location>,
+}
+
+impl<Endpoint, Location> Stream<Endpoint, Location> {
+    send_stream!();
+    receive_stream!();
+    sync!(Endpoint, Location);
+    sleep!();
+    trace!();
+
+    pub(crate) fn new(id: u64, state: connection::State) -> Self {
+        Self {
+            id,
+            ops: vec![],
+            state,
+            endpoint: PhantomData,
+            location: PhantomData,
+        }
+    }
+
+    pub fn concurrently<
+        S: FnOnce(&mut SendStream<Endpoint, Location>),
+        R: FnOnce(&mut ReceiveStream<Endpoint, Location>),
+    >(
+        &mut self,
+        send: S,
+        receive: R,
+    ) -> &mut Self {
+        let mut send_stream = SendStream::new(self.id, self.state.clone());
+        let mut receive_stream = ReceiveStream::new(self.id, self.state.clone());
+        send(&mut send_stream);
+        receive(&mut receive_stream);
+        let threads = vec![send_stream.ops, receive_stream.ops];
+        self.ops.push(ConnectionOperation::Scope { threads });
+        self
+    }
+
+    pub(crate) fn finish(self) -> Vec<ConnectionOperation> {
+        self.ops
+    }
+}
+
+pub struct SendStream<Endpoint, Location> {
+    id: u64,
+    ops: Vec<ConnectionOperation>,
+    state: connection::State,
+    endpoint: PhantomData<Endpoint>,
+    location: PhantomData<Location>,
+}
+
+impl<Endpoint, Location> SendStream<Endpoint, Location> {
+    send_stream!();
+    sync!(Endpoint, Location);
+    sleep!();
+    trace!();
+
+    pub(crate) fn new(id: u64, state: connection::State) -> Self {
+        Self {
+            id,
+            ops: vec![],
+            state,
+            endpoint: PhantomData,
+            location: PhantomData,
+        }
+    }
+
+    pub(crate) fn finish(self) -> Vec<ConnectionOperation> {
+        self.ops
+    }
+}
+
+pub struct ReceiveStream<Endpoint, Location> {
+    id: u64,
+    ops: Vec<ConnectionOperation>,
+    state: connection::State,
+    endpoint: PhantomData<Endpoint>,
+    location: PhantomData<Location>,
+}
+
+impl<Endpoint, Location> ReceiveStream<Endpoint, Location> {
+    receive_stream!();
+    sync!(Endpoint, Location);
+    sleep!();
+    trace!();
+
+    pub(crate) fn new(id: u64, state: connection::State) -> Self {
+        Self {
+            id,
+            ops: vec![],
+            state,
+            endpoint: PhantomData,
+            location: PhantomData,
+        }
+    }
+
+    pub(crate) fn finish(self) -> Vec<ConnectionOperation> {
+        self.ops
+    }
+}

--- a/netbench/netbench/src/scenario/builder/stream.rs
+++ b/netbench/netbench/src/scenario/builder/stream.rs
@@ -96,7 +96,10 @@ impl<Endpoint, Location> Stream<Endpoint, Location> {
         self
     }
 
-    pub(crate) fn finish(self) -> Vec<op::Connection> {
+    pub(crate) fn finish(mut self) -> Vec<op::Connection> {
+        let stream_id = self.id;
+        self.ops.push(op::Connection::SendFinish { stream_id });
+        self.ops.push(op::Connection::ReceiveFinish { stream_id });
         self.ops
     }
 }
@@ -125,7 +128,9 @@ impl<Endpoint, Location> SendStream<Endpoint, Location> {
         }
     }
 
-    pub(crate) fn finish(self) -> Vec<op::Connection> {
+    pub(crate) fn finish(mut self) -> Vec<op::Connection> {
+        let stream_id = self.id;
+        self.ops.push(op::Connection::SendFinish { stream_id });
         self.ops
     }
 }
@@ -154,7 +159,9 @@ impl<Endpoint, Location> ReceiveStream<Endpoint, Location> {
         }
     }
 
-    pub(crate) fn finish(self) -> Vec<op::Connection> {
+    pub(crate) fn finish(mut self) -> Vec<op::Connection> {
+        let stream_id = self.id;
+        self.ops.push(op::Connection::ReceiveFinish { stream_id });
         self.ops
     }
 }

--- a/netbench/netbench/src/scenario/builder/tests.rs
+++ b/netbench/netbench/src/scenario/builder/tests.rs
@@ -1,0 +1,136 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    scenario::{Builder, Scenario},
+    units::*,
+};
+use insta::assert_json_snapshot;
+
+fn scenario<F: FnOnce(&mut Builder)>(f: F) -> Scenario {
+    let mut scenario = Scenario::build(f);
+    // hash traversal order was changed somewhere between 1.53 and 1.58 so
+    // we won't compare the id for now
+    scenario.id = Default::default();
+    scenario
+}
+
+macro_rules! scenario_test {
+    ($name:ident, $builder:expr) => {
+        #[test]
+        fn $name() {
+            assert_json_snapshot!(scenario($builder));
+        }
+    };
+}
+
+scenario_test!(simple, |scenario| {
+    let server = scenario.create_server();
+
+    scenario.create_client(|client| {
+        client.connect_to(server, |conn| {
+            conn.open_send_stream(
+                |local| {
+                    local.set_send_rate(1024.bytes() / 50.millis());
+                    local.send(1.megabytes());
+                },
+                |peer| {
+                    peer.set_receive_rate(1024.bytes() / 50.millis());
+                    peer.receive(1.megabytes());
+                },
+            );
+        });
+    });
+});
+
+scenario_test!(conn_checkpoints, |scenario| {
+    let server = scenario.create_server();
+
+    scenario.create_client(|client| {
+        client.connect_to(server, |conn| {
+            let (cp1_rx, cp1_tx) = conn.checkpoint();
+
+            conn.concurrently(
+                |conn| {
+                    conn.open_send_stream(
+                        |local| {
+                            local.set_send_rate(10.kilobytes() / 50.millis());
+                            local.send(1.megabytes() / 2);
+                            local.unpark(cp1_tx);
+                            local.send(1.megabytes() / 2);
+                        },
+                        |peer| {
+                            peer.set_receive_rate(10.kilobytes() / 50.millis());
+                            peer.receive(1.megabytes());
+                        },
+                    );
+                },
+                |conn| {
+                    conn.open_send_stream(
+                        |local| {
+                            local.park(cp1_rx);
+                            local.set_send_rate(1024.bytes() / 50.millis());
+                            local.send(1.megabytes());
+                        },
+                        |peer| {
+                            peer.set_receive_rate(1024.bytes() / 50.millis());
+                            peer.receive(1.megabytes());
+                        },
+                    );
+                },
+            );
+        });
+    });
+});
+
+scenario_test!(linked_streams, |scenario| {
+    let server = scenario.create_server();
+
+    scenario.create_client(|client| {
+        client.connect_to(server, |conn| {
+            let (b_park, b_unpark) = conn.checkpoint();
+
+            conn.concurrently(
+                |conn| {
+                    conn.open_bidirectional_stream(
+                        |local| {
+                            local.concurrently(
+                                |sender| {
+                                    sender.set_send_rate(1024.bytes() / 50.millis());
+                                    sender.send(1.megabytes());
+                                },
+                                |receiver| {
+                                    receiver.receive_all();
+                                },
+                            );
+
+                            local.unpark(b_unpark);
+                        },
+                        |peer| {
+                            peer.sleep(100.millis());
+
+                            peer.set_receive_rate(1024.bytes() / 50.millis());
+                            peer.receive(100.kilobytes());
+
+                            peer.set_receive_rate(10.bytes() / 50.millis());
+                            peer.receive_all();
+
+                            peer.send(2.megabytes());
+                        },
+                    );
+                },
+                |conn| {
+                    conn.open_send_stream(
+                        |local| {
+                            local.park(b_park);
+                            local.send(1.megabytes());
+                        },
+                        |peer| {
+                            peer.receive(1.megabytes());
+                        },
+                    );
+                },
+            );
+        });
+    });
+});

--- a/netbench/netbench/src/scenario/id.rs
+++ b/netbench/netbench/src/scenario/id.rs
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::fmt::Write;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Hash)]
+pub struct Id(String);
+
+impl Id {
+    pub(crate) fn hasher() -> Hasher {
+        Hasher::default()
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Hasher {
+    hash: sha2::Sha256,
+}
+
+impl Hasher {
+    pub fn finish(self) -> Id {
+        use sha2::Digest;
+        let hash = self.hash.finalize();
+        let mut out = String::new();
+        for byte in hash.iter() {
+            write!(out, "{:02x}", byte).unwrap();
+        }
+        Id(out)
+    }
+}
+
+impl core::hash::Hasher for Hasher {
+    fn write(&mut self, bytes: &[u8]) {
+        use sha2::Digest;
+        self.hash.update(bytes)
+    }
+
+    fn finish(&self) -> u64 {
+        unimplemented!()
+    }
+}

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__checkpoint__client.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__checkpoint__client.snap
@@ -1,15 +1,17 @@
 ---
-source: netbench/netbench/src/multiplex.rs
-assertion_line: 584
+source: netbench/src/multiplex.rs
+assertion_line: 635
 expression: (client_trace.1).as_str().unwrap()
 
 ---
-0:00:00.000001: 0:0.0:exec: Scope { threads: [[OpenSendStream { stream_id: 0 }, SendRate { stream_id: 0, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 0, bytes: Byte(1000) }, Unpark { checkpoint: 0 }, Send { stream_id: 0, bytes: Byte(1000) }], [OpenSendStream { stream_id: 1 }, Park { checkpoint: 0 }, SendRate { stream_id: 1, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 1, bytes: Byte(1000) }]] }
+0:00:00.000001: 0:0.0:exec: Scope { threads: [[OpenSendStream { stream_id: 0 }, SendRate { stream_id: 0, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 0, bytes: Byte(1000) }, Unpark { checkpoint: 0 }, Send { stream_id: 0, bytes: Byte(1000) }, SendFinish { stream_id: 0 }], [OpenSendStream { stream_id: 1 }, Park { checkpoint: 0 }, SendRate { stream_id: 1, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 1, bytes: Byte(1000) }, SendFinish { stream_id: 1 }]] }
 0:00:00.000001: 0:0.0:1.0:exec: OpenSendStream { stream_id: 0 }
+0:00:00.000001: 0:0.0:1.0:open: stream=0
 0:00:00.000001: 0:0.0:1.0:exec: SendRate { stream_id: 0, rate: Rate { bytes: Byte(100), period: 50ms } }
 0:00:00.000001: 0:0.0:1.0:exec: Send { stream_id: 0, bytes: Byte(1000) }
 0:00:00.000001: 0:0.0:1.0:send: stream=0, len=100
 0:00:00.000001: 0:0.0:1.1:exec: OpenSendStream { stream_id: 1 }
+0:00:00.000001: 0:0.0:1.1:open: stream=1
 0:00:00.000001: 0:0.0:1.1:exec: Park { checkpoint: 0 }
 0:00:00.050001: 0:0.0:1.0:send: stream=0, len=100
 0:00:00.100001: 0:0.0:1.0:send: stream=0, len=100
@@ -22,6 +24,7 @@ expression: (client_trace.1).as_str().unwrap()
 0:00:00.450001: 0:0.0:1.0:send: stream=0, len=100
 0:00:00.450001: 0:0.0:1.0:exec: Unpark { checkpoint: 0 }
 0:00:00.450001: 0:0.0:1.0:exec: Send { stream_id: 0, bytes: Byte(1000) }
+0:00:00.450001: 0:0.0:1.1:unpark: 0
 0:00:00.450001: 0:0.0:1.1:exec: SendRate { stream_id: 1, rate: Rate { bytes: Byte(100), period: 50ms } }
 0:00:00.450001: 0:0.0:1.1:exec: Send { stream_id: 1, bytes: Byte(1000) }
 0:00:00.450001: 0:0.0:1.1:send: stream=1, len=100
@@ -43,5 +46,9 @@ expression: (client_trace.1).as_str().unwrap()
 0:00:00.850001: 0:0.0:1.1:send: stream=1, len=100
 0:00:00.900001: 0:0.0:1.0:send: stream=0, len=100
 0:00:00.900001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.900001: 0:0.0:1.1:exec: SendFinish { stream_id: 1 }
+0:00:00.900001: 0:0.0:1.1:send finish: stream=1
 0:00:00.950001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.950001: 0:0.0:1.0:exec: SendFinish { stream_id: 0 }
+0:00:00.950001: 0:0.0:1.0:send finish: stream=0
 

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__checkpoint__client.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__checkpoint__client.snap
@@ -1,0 +1,47 @@
+---
+source: netbench/netbench/src/multiplex.rs
+assertion_line: 584
+expression: (client_trace.1).as_str().unwrap()
+
+---
+0:00:00.000001: 0:0.0:exec: Scope { threads: [[OpenSendStream { stream_id: 0 }, SendRate { stream_id: 0, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 0, bytes: Byte(1000) }, Unpark { checkpoint: 0 }, Send { stream_id: 0, bytes: Byte(1000) }], [OpenSendStream { stream_id: 1 }, Park { checkpoint: 0 }, SendRate { stream_id: 1, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 1, bytes: Byte(1000) }]] }
+0:00:00.000001: 0:0.0:1.0:exec: OpenSendStream { stream_id: 0 }
+0:00:00.000001: 0:0.0:1.0:exec: SendRate { stream_id: 0, rate: Rate { bytes: Byte(100), period: 50ms } }
+0:00:00.000001: 0:0.0:1.0:exec: Send { stream_id: 0, bytes: Byte(1000) }
+0:00:00.000001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.000001: 0:0.0:1.1:exec: OpenSendStream { stream_id: 1 }
+0:00:00.000001: 0:0.0:1.1:exec: Park { checkpoint: 0 }
+0:00:00.050001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.100001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.150001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.200001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.250001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.300001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.350001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.400001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.450001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.450001: 0:0.0:1.0:exec: Unpark { checkpoint: 0 }
+0:00:00.450001: 0:0.0:1.0:exec: Send { stream_id: 0, bytes: Byte(1000) }
+0:00:00.450001: 0:0.0:1.1:exec: SendRate { stream_id: 1, rate: Rate { bytes: Byte(100), period: 50ms } }
+0:00:00.450001: 0:0.0:1.1:exec: Send { stream_id: 1, bytes: Byte(1000) }
+0:00:00.450001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.500001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.500001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.550001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.550001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.600001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.600001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.650001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.650001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.700001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.700001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.750001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.750001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.800001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.800001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.850001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.850001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.900001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.900001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.950001: 0:0.0:1.0:send: stream=0, len=100
+

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__checkpoint__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__checkpoint__server.snap
@@ -1,6 +1,6 @@
 ---
-source: netbench/netbench/src/multiplex.rs
-assertion_line: 584
+source: netbench/src/multiplex.rs
+assertion_line: 637
 expression: (server_trace.1).as_str().unwrap()
 
 ---
@@ -37,5 +37,9 @@ expression: (server_trace.1).as_str().unwrap()
 0:00:00.850001: 1:1.1:recv: stream=1, len=100
 0:00:00.900001: 1:1.0:recv: stream=0, len=100
 0:00:00.900001: 1:1.1:recv: stream=1, len=100
+0:00:00.900001: 1:1.1:exec: ReceiveFinish { stream_id: 1 }
+0:00:00.900001: 1:1.1:recv finish: stream=1
 0:00:00.950001: 1:1.0:recv: stream=0, len=100
+0:00:00.950001: 1:1.0:exec: ReceiveFinish { stream_id: 0 }
+0:00:00.950001: 1:1.0:recv finish: stream=0
 

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__checkpoint__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__checkpoint__server.snap
@@ -1,0 +1,41 @@
+---
+source: netbench/netbench/src/multiplex.rs
+assertion_line: 584
+expression: (server_trace.1).as_str().unwrap()
+
+---
+0:00:00.000001: 1:accept: stream=0
+0:00:00.000001: 1:1.0:exec: Receive { stream_id: 0, bytes: Byte(2000) }
+0:00:00.000001: 1:1.0:recv: stream=0, len=100
+0:00:00.000001: 1:accept: stream=1
+0:00:00.000001: 1:1.1:exec: Receive { stream_id: 1, bytes: Byte(1000) }
+0:00:00.050001: 1:1.0:recv: stream=0, len=100
+0:00:00.100001: 1:1.0:recv: stream=0, len=100
+0:00:00.150001: 1:1.0:recv: stream=0, len=100
+0:00:00.200001: 1:1.0:recv: stream=0, len=100
+0:00:00.250001: 1:1.0:recv: stream=0, len=100
+0:00:00.300001: 1:1.0:recv: stream=0, len=100
+0:00:00.350001: 1:1.0:recv: stream=0, len=100
+0:00:00.400001: 1:1.0:recv: stream=0, len=100
+0:00:00.450001: 1:1.0:recv: stream=0, len=100
+0:00:00.450001: 1:1.1:recv: stream=1, len=100
+0:00:00.500001: 1:1.0:recv: stream=0, len=100
+0:00:00.500001: 1:1.1:recv: stream=1, len=100
+0:00:00.550001: 1:1.0:recv: stream=0, len=100
+0:00:00.550001: 1:1.1:recv: stream=1, len=100
+0:00:00.600001: 1:1.0:recv: stream=0, len=100
+0:00:00.600001: 1:1.1:recv: stream=1, len=100
+0:00:00.650001: 1:1.0:recv: stream=0, len=100
+0:00:00.650001: 1:1.1:recv: stream=1, len=100
+0:00:00.700001: 1:1.0:recv: stream=0, len=100
+0:00:00.700001: 1:1.1:recv: stream=1, len=100
+0:00:00.750001: 1:1.0:recv: stream=0, len=100
+0:00:00.750001: 1:1.1:recv: stream=1, len=100
+0:00:00.800001: 1:1.0:recv: stream=0, len=100
+0:00:00.800001: 1:1.1:recv: stream=1, len=100
+0:00:00.850001: 1:1.0:recv: stream=0, len=100
+0:00:00.850001: 1:1.1:recv: stream=1, len=100
+0:00:00.900001: 1:1.0:recv: stream=0, len=100
+0:00:00.900001: 1:1.1:recv: stream=1, len=100
+0:00:00.950001: 1:1.0:recv: stream=0, len=100
+

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_max_streams__client.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_max_streams__client.snap
@@ -1,0 +1,40 @@
+---
+source: netbench/src/multiplex.rs
+assertion_line: 598
+expression: client_trace.as_str().unwrap()
+
+---
+0:00:00.000001: 0:0.0:exec: Scope { threads: [[OpenSendStream { stream_id: 0 }, SendRate { stream_id: 0, rate: Rate { bytes: Byte(500), period: 50ms } }, Send { stream_id: 0, bytes: Byte(1000) }, SendFinish { stream_id: 0 }], [OpenSendStream { stream_id: 1 }, SendRate { stream_id: 1, rate: Rate { bytes: Byte(500), period: 50ms } }, Send { stream_id: 1, bytes: Byte(1000) }, SendFinish { stream_id: 1 }], [OpenSendStream { stream_id: 2 }, SendRate { stream_id: 2, rate: Rate { bytes: Byte(500), period: 50ms } }, Send { stream_id: 2, bytes: Byte(1000) }, SendFinish { stream_id: 2 }], [OpenSendStream { stream_id: 3 }, SendRate { stream_id: 3, rate: Rate { bytes: Byte(500), period: 50ms } }, Send { stream_id: 3, bytes: Byte(1000) }, SendFinish { stream_id: 3 }]] }
+0:00:00.000001: 0:0.0:1.0:exec: OpenSendStream { stream_id: 0 }
+0:00:00.000001: 0:0.0:1.0:open: stream=0
+0:00:00.000001: 0:0.0:1.0:exec: SendRate { stream_id: 0, rate: Rate { bytes: Byte(500), period: 50ms } }
+0:00:00.000001: 0:0.0:1.0:exec: Send { stream_id: 0, bytes: Byte(1000) }
+0:00:00.000001: 0:0.0:1.0:send: stream=0, len=500
+0:00:00.000001: 0:0.0:1.1:exec: OpenSendStream { stream_id: 1 }
+0:00:00.000001: 0:0.0:1.1:open: stream=1
+0:00:00.000001: 0:0.0:1.1:exec: SendRate { stream_id: 1, rate: Rate { bytes: Byte(500), period: 50ms } }
+0:00:00.000001: 0:0.0:1.1:exec: Send { stream_id: 1, bytes: Byte(1000) }
+0:00:00.000001: 0:0.0:1.1:send: stream=1, len=500
+0:00:00.000001: 0:0.0:1.2:exec: OpenSendStream { stream_id: 2 }
+0:00:00.000001: 0:0.0:1.3:exec: OpenSendStream { stream_id: 3 }
+0:00:00.050001: 0:0.0:1.0:send: stream=0, len=500
+0:00:00.050001: 0:0.0:1.0:exec: SendFinish { stream_id: 0 }
+0:00:00.050001: 0:0.0:1.0:send finish: stream=0
+0:00:00.050001: 0:0.0:1.1:send: stream=1, len=500
+0:00:00.050001: 0:0.0:1.1:exec: SendFinish { stream_id: 1 }
+0:00:00.050001: 0:0.0:1.1:send finish: stream=1
+0:00:00.050001: 0:0.0:1.2:open: stream=2
+0:00:00.050001: 0:0.0:1.2:exec: SendRate { stream_id: 2, rate: Rate { bytes: Byte(500), period: 50ms } }
+0:00:00.050001: 0:0.0:1.2:exec: Send { stream_id: 2, bytes: Byte(1000) }
+0:00:00.050001: 0:0.0:1.2:send: stream=2, len=500
+0:00:00.050001: 0:0.0:1.3:open: stream=3
+0:00:00.050001: 0:0.0:1.3:exec: SendRate { stream_id: 3, rate: Rate { bytes: Byte(500), period: 50ms } }
+0:00:00.050001: 0:0.0:1.3:exec: Send { stream_id: 3, bytes: Byte(1000) }
+0:00:00.050001: 0:0.0:1.3:send: stream=3, len=500
+0:00:00.100001: 0:0.0:1.2:send: stream=2, len=500
+0:00:00.100001: 0:0.0:1.2:exec: SendFinish { stream_id: 2 }
+0:00:00.100001: 0:0.0:1.2:send finish: stream=2
+0:00:00.100001: 0:0.0:1.3:send: stream=3, len=500
+0:00:00.100001: 0:0.0:1.3:exec: SendFinish { stream_id: 3 }
+0:00:00.100001: 0:0.0:1.3:send finish: stream=3
+

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_max_streams__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_max_streams__server.snap
@@ -1,0 +1,31 @@
+---
+source: netbench/src/multiplex.rs
+assertion_line: 598
+expression: server_trace.as_str().unwrap()
+
+---
+0:00:00.000001: 1:accept: stream=0
+0:00:00.000001: 1:1.0:exec: Receive { stream_id: 0, bytes: Byte(1000) }
+0:00:00.000001: 1:1.0:recv: stream=0, len=500
+0:00:00.000001: 1:accept: stream=1
+0:00:00.000001: 1:1.1:exec: Receive { stream_id: 1, bytes: Byte(1000) }
+0:00:00.000001: 1:1.1:recv: stream=1, len=500
+0:00:00.050001: 1:1.0:recv: stream=0, len=500
+0:00:00.050001: 1:1.0:exec: ReceiveFinish { stream_id: 0 }
+0:00:00.050001: 1:1.0:recv finish: stream=0
+0:00:00.050001: 1:1.1:recv: stream=1, len=500
+0:00:00.050001: 1:1.1:exec: ReceiveFinish { stream_id: 1 }
+0:00:00.050001: 1:1.1:recv finish: stream=1
+0:00:00.050001: 1:accept: stream=2
+0:00:00.050001: 1:1.2:exec: Receive { stream_id: 2, bytes: Byte(1000) }
+0:00:00.050001: 1:1.2:recv: stream=2, len=500
+0:00:00.050001: 1:accept: stream=3
+0:00:00.050001: 1:1.3:exec: Receive { stream_id: 3, bytes: Byte(1000) }
+0:00:00.050001: 1:1.3:recv: stream=3, len=500
+0:00:00.100001: 1:1.2:recv: stream=2, len=500
+0:00:00.100001: 1:1.2:exec: ReceiveFinish { stream_id: 2 }
+0:00:00.100001: 1:1.2:recv finish: stream=2
+0:00:00.100001: 1:1.3:recv: stream=3, len=500
+0:00:00.100001: 1:1.3:exec: ReceiveFinish { stream_id: 3 }
+0:00:00.100001: 1:1.3:recv finish: stream=3
+

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_stream_window__client.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_stream_window__client.snap
@@ -1,7 +1,7 @@
 ---
 source: netbench/src/multiplex.rs
-assertion_line: 560
-expression: (client_trace.1).as_str().unwrap()
+assertion_line: 596
+expression: client_trace.as_str().unwrap()
 
 ---
 0:00:00.000001: 0:0.0:exec: OpenSendStream { stream_id: 0 }

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_stream_window__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_stream_window__server.snap
@@ -1,0 +1,31 @@
+---
+source: netbench/src/multiplex.rs
+assertion_line: 596
+expression: server_trace.as_str().unwrap()
+
+---
+0:00:00.000001: 1:accept: stream=0
+0:00:00.000001: 1:1.0:exec: Receive { stream_id: 0, bytes: Byte(1000) }
+0:00:00.000001: 1:1.0:recv: stream=0, len=50
+0:00:00.000001: 1:1.0:recv: stream=0, len=50
+0:00:00.050001: 1:1.0:recv: stream=0, len=50
+0:00:00.050001: 1:1.0:recv: stream=0, len=50
+0:00:00.100001: 1:1.0:recv: stream=0, len=50
+0:00:00.100001: 1:1.0:recv: stream=0, len=50
+0:00:00.150001: 1:1.0:recv: stream=0, len=50
+0:00:00.150001: 1:1.0:recv: stream=0, len=50
+0:00:00.200001: 1:1.0:recv: stream=0, len=50
+0:00:00.200001: 1:1.0:recv: stream=0, len=50
+0:00:00.250001: 1:1.0:recv: stream=0, len=50
+0:00:00.250001: 1:1.0:recv: stream=0, len=50
+0:00:00.300001: 1:1.0:recv: stream=0, len=50
+0:00:00.300001: 1:1.0:recv: stream=0, len=50
+0:00:00.350001: 1:1.0:recv: stream=0, len=50
+0:00:00.350001: 1:1.0:recv: stream=0, len=50
+0:00:00.400001: 1:1.0:recv: stream=0, len=50
+0:00:00.400001: 1:1.0:recv: stream=0, len=50
+0:00:00.450001: 1:1.0:recv: stream=0, len=50
+0:00:00.450001: 1:1.0:recv: stream=0, len=50
+0:00:00.450001: 1:1.0:exec: ReceiveFinish { stream_id: 0 }
+0:00:00.450001: 1:1.0:recv finish: stream=0
+

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__multiple_streams__client.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__multiple_streams__client.snap
@@ -1,0 +1,47 @@
+---
+source: netbench/netbench/src/multiplex.rs
+assertion_line: 566
+expression: (client_trace.1).as_str().unwrap()
+
+---
+0:00:00.000001: 0:0.0:exec: Scope { threads: [[OpenSendStream { stream_id: 0 }, SendRate { stream_id: 0, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 0, bytes: Byte(1000) }], [OpenSendStream { stream_id: 1 }, SendRate { stream_id: 1, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 1, bytes: Byte(1000) }], [OpenSendStream { stream_id: 2 }, SendRate { stream_id: 2, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 2, bytes: Byte(1000) }]] }
+0:00:00.000001: 0:0.0:1.0:exec: OpenSendStream { stream_id: 0 }
+0:00:00.000001: 0:0.0:1.0:exec: SendRate { stream_id: 0, rate: Rate { bytes: Byte(100), period: 50ms } }
+0:00:00.000001: 0:0.0:1.0:exec: Send { stream_id: 0, bytes: Byte(1000) }
+0:00:00.000001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.000001: 0:0.0:1.1:exec: OpenSendStream { stream_id: 1 }
+0:00:00.000001: 0:0.0:1.1:exec: SendRate { stream_id: 1, rate: Rate { bytes: Byte(100), period: 50ms } }
+0:00:00.000001: 0:0.0:1.1:exec: Send { stream_id: 1, bytes: Byte(1000) }
+0:00:00.000001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.000001: 0:0.0:1.2:exec: OpenSendStream { stream_id: 2 }
+0:00:00.000001: 0:0.0:1.2:exec: SendRate { stream_id: 2, rate: Rate { bytes: Byte(100), period: 50ms } }
+0:00:00.000001: 0:0.0:1.2:exec: Send { stream_id: 2, bytes: Byte(1000) }
+0:00:00.000001: 0:0.0:1.2:send: stream=2, len=100
+0:00:00.050001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.050001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.050001: 0:0.0:1.2:send: stream=2, len=100
+0:00:00.100001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.100001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.100001: 0:0.0:1.2:send: stream=2, len=100
+0:00:00.150001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.150001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.150001: 0:0.0:1.2:send: stream=2, len=100
+0:00:00.200001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.200001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.200001: 0:0.0:1.2:send: stream=2, len=100
+0:00:00.250001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.250001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.250001: 0:0.0:1.2:send: stream=2, len=100
+0:00:00.300001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.300001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.300001: 0:0.0:1.2:send: stream=2, len=100
+0:00:00.350001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.350001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.350001: 0:0.0:1.2:send: stream=2, len=100
+0:00:00.400001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.400001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.400001: 0:0.0:1.2:send: stream=2, len=100
+0:00:00.450001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.450001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.450001: 0:0.0:1.2:send: stream=2, len=100
+

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__multiple_streams__client.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__multiple_streams__client.snap
@@ -1,19 +1,22 @@
 ---
-source: netbench/netbench/src/multiplex.rs
-assertion_line: 566
+source: netbench/src/multiplex.rs
+assertion_line: 617
 expression: (client_trace.1).as_str().unwrap()
 
 ---
-0:00:00.000001: 0:0.0:exec: Scope { threads: [[OpenSendStream { stream_id: 0 }, SendRate { stream_id: 0, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 0, bytes: Byte(1000) }], [OpenSendStream { stream_id: 1 }, SendRate { stream_id: 1, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 1, bytes: Byte(1000) }], [OpenSendStream { stream_id: 2 }, SendRate { stream_id: 2, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 2, bytes: Byte(1000) }]] }
+0:00:00.000001: 0:0.0:exec: Scope { threads: [[OpenSendStream { stream_id: 0 }, SendRate { stream_id: 0, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 0, bytes: Byte(1000) }, SendFinish { stream_id: 0 }], [OpenSendStream { stream_id: 1 }, SendRate { stream_id: 1, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 1, bytes: Byte(1000) }, SendFinish { stream_id: 1 }], [OpenSendStream { stream_id: 2 }, SendRate { stream_id: 2, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 2, bytes: Byte(1000) }, SendFinish { stream_id: 2 }]] }
 0:00:00.000001: 0:0.0:1.0:exec: OpenSendStream { stream_id: 0 }
+0:00:00.000001: 0:0.0:1.0:open: stream=0
 0:00:00.000001: 0:0.0:1.0:exec: SendRate { stream_id: 0, rate: Rate { bytes: Byte(100), period: 50ms } }
 0:00:00.000001: 0:0.0:1.0:exec: Send { stream_id: 0, bytes: Byte(1000) }
 0:00:00.000001: 0:0.0:1.0:send: stream=0, len=100
 0:00:00.000001: 0:0.0:1.1:exec: OpenSendStream { stream_id: 1 }
+0:00:00.000001: 0:0.0:1.1:open: stream=1
 0:00:00.000001: 0:0.0:1.1:exec: SendRate { stream_id: 1, rate: Rate { bytes: Byte(100), period: 50ms } }
 0:00:00.000001: 0:0.0:1.1:exec: Send { stream_id: 1, bytes: Byte(1000) }
 0:00:00.000001: 0:0.0:1.1:send: stream=1, len=100
 0:00:00.000001: 0:0.0:1.2:exec: OpenSendStream { stream_id: 2 }
+0:00:00.000001: 0:0.0:1.2:open: stream=2
 0:00:00.000001: 0:0.0:1.2:exec: SendRate { stream_id: 2, rate: Rate { bytes: Byte(100), period: 50ms } }
 0:00:00.000001: 0:0.0:1.2:exec: Send { stream_id: 2, bytes: Byte(1000) }
 0:00:00.000001: 0:0.0:1.2:send: stream=2, len=100
@@ -42,6 +45,12 @@ expression: (client_trace.1).as_str().unwrap()
 0:00:00.400001: 0:0.0:1.1:send: stream=1, len=100
 0:00:00.400001: 0:0.0:1.2:send: stream=2, len=100
 0:00:00.450001: 0:0.0:1.0:send: stream=0, len=100
+0:00:00.450001: 0:0.0:1.0:exec: SendFinish { stream_id: 0 }
+0:00:00.450001: 0:0.0:1.0:send finish: stream=0
 0:00:00.450001: 0:0.0:1.1:send: stream=1, len=100
+0:00:00.450001: 0:0.0:1.1:exec: SendFinish { stream_id: 1 }
+0:00:00.450001: 0:0.0:1.1:send finish: stream=1
 0:00:00.450001: 0:0.0:1.2:send: stream=2, len=100
+0:00:00.450001: 0:0.0:1.2:exec: SendFinish { stream_id: 2 }
+0:00:00.450001: 0:0.0:1.2:send finish: stream=2
 

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__multiple_streams__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__multiple_streams__server.snap
@@ -1,0 +1,43 @@
+---
+source: netbench/netbench/src/multiplex.rs
+assertion_line: 566
+expression: (server_trace.1).as_str().unwrap()
+
+---
+0:00:00.000001: 1:accept: stream=0
+0:00:00.000001: 1:1.0:exec: Receive { stream_id: 0, bytes: Byte(1000) }
+0:00:00.000001: 1:1.0:recv: stream=0, len=100
+0:00:00.000001: 1:accept: stream=1
+0:00:00.000001: 1:1.1:exec: Receive { stream_id: 1, bytes: Byte(1000) }
+0:00:00.000001: 1:1.1:recv: stream=1, len=100
+0:00:00.000001: 1:accept: stream=2
+0:00:00.000001: 1:1.2:exec: Receive { stream_id: 2, bytes: Byte(1000) }
+0:00:00.000001: 1:1.2:recv: stream=2, len=100
+0:00:00.050001: 1:1.0:recv: stream=0, len=100
+0:00:00.050001: 1:1.1:recv: stream=1, len=100
+0:00:00.050001: 1:1.2:recv: stream=2, len=100
+0:00:00.100001: 1:1.0:recv: stream=0, len=100
+0:00:00.100001: 1:1.1:recv: stream=1, len=100
+0:00:00.100001: 1:1.2:recv: stream=2, len=100
+0:00:00.150001: 1:1.0:recv: stream=0, len=100
+0:00:00.150001: 1:1.1:recv: stream=1, len=100
+0:00:00.150001: 1:1.2:recv: stream=2, len=100
+0:00:00.200001: 1:1.0:recv: stream=0, len=100
+0:00:00.200001: 1:1.1:recv: stream=1, len=100
+0:00:00.200001: 1:1.2:recv: stream=2, len=100
+0:00:00.250001: 1:1.0:recv: stream=0, len=100
+0:00:00.250001: 1:1.1:recv: stream=1, len=100
+0:00:00.250001: 1:1.2:recv: stream=2, len=100
+0:00:00.300001: 1:1.0:recv: stream=0, len=100
+0:00:00.300001: 1:1.1:recv: stream=1, len=100
+0:00:00.300001: 1:1.2:recv: stream=2, len=100
+0:00:00.350001: 1:1.0:recv: stream=0, len=100
+0:00:00.350001: 1:1.1:recv: stream=1, len=100
+0:00:00.350001: 1:1.2:recv: stream=2, len=100
+0:00:00.400001: 1:1.0:recv: stream=0, len=100
+0:00:00.400001: 1:1.1:recv: stream=1, len=100
+0:00:00.400001: 1:1.2:recv: stream=2, len=100
+0:00:00.450001: 1:1.0:recv: stream=0, len=100
+0:00:00.450001: 1:1.1:recv: stream=1, len=100
+0:00:00.450001: 1:1.2:recv: stream=2, len=100
+

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__multiple_streams__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__multiple_streams__server.snap
@@ -1,6 +1,6 @@
 ---
-source: netbench/netbench/src/multiplex.rs
-assertion_line: 566
+source: netbench/src/multiplex.rs
+assertion_line: 619
 expression: (server_trace.1).as_str().unwrap()
 
 ---
@@ -38,6 +38,12 @@ expression: (server_trace.1).as_str().unwrap()
 0:00:00.400001: 1:1.1:recv: stream=1, len=100
 0:00:00.400001: 1:1.2:recv: stream=2, len=100
 0:00:00.450001: 1:1.0:recv: stream=0, len=100
+0:00:00.450001: 1:1.0:exec: ReceiveFinish { stream_id: 0 }
+0:00:00.450001: 1:1.0:recv finish: stream=0
 0:00:00.450001: 1:1.1:recv: stream=1, len=100
+0:00:00.450001: 1:1.1:exec: ReceiveFinish { stream_id: 1 }
+0:00:00.450001: 1:1.1:recv finish: stream=1
 0:00:00.450001: 1:1.2:recv: stream=2, len=100
+0:00:00.450001: 1:1.2:exec: ReceiveFinish { stream_id: 2 }
+0:00:00.450001: 1:1.2:recv finish: stream=2
 

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_slow_stream__client.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_slow_stream__client.snap
@@ -1,0 +1,20 @@
+---
+source: netbench/netbench/src/multiplex.rs
+assertion_line: 554
+expression: (client_trace.1).as_str().unwrap()
+
+---
+0:00:00.000001: 0:0.0:exec: OpenSendStream { stream_id: 0 }
+0:00:00.000001: 0:0.0:exec: SendRate { stream_id: 0, rate: Rate { bytes: Byte(100), period: 50ms } }
+0:00:00.000001: 0:0.0:exec: Send { stream_id: 0, bytes: Byte(1000) }
+0:00:00.000001: 0:0.0:send: stream=0, len=100
+0:00:00.050001: 0:0.0:send: stream=0, len=100
+0:00:00.100001: 0:0.0:send: stream=0, len=100
+0:00:00.150001: 0:0.0:send: stream=0, len=100
+0:00:00.200001: 0:0.0:send: stream=0, len=100
+0:00:00.250001: 0:0.0:send: stream=0, len=100
+0:00:00.300001: 0:0.0:send: stream=0, len=100
+0:00:00.350001: 0:0.0:send: stream=0, len=100
+0:00:00.400001: 0:0.0:send: stream=0, len=100
+0:00:00.450001: 0:0.0:send: stream=0, len=100
+

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_slow_stream__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_slow_stream__server.snap
@@ -1,0 +1,19 @@
+---
+source: netbench/netbench/src/multiplex.rs
+assertion_line: 554
+expression: (server_trace.1).as_str().unwrap()
+
+---
+0:00:00.000001: 1:accept: stream=0
+0:00:00.000001: 1:1.0:exec: Receive { stream_id: 0, bytes: Byte(1000) }
+0:00:00.000001: 1:1.0:recv: stream=0, len=100
+0:00:00.050001: 1:1.0:recv: stream=0, len=100
+0:00:00.100001: 1:1.0:recv: stream=0, len=100
+0:00:00.150001: 1:1.0:recv: stream=0, len=100
+0:00:00.200001: 1:1.0:recv: stream=0, len=100
+0:00:00.250001: 1:1.0:recv: stream=0, len=100
+0:00:00.300001: 1:1.0:recv: stream=0, len=100
+0:00:00.350001: 1:1.0:recv: stream=0, len=100
+0:00:00.400001: 1:1.0:recv: stream=0, len=100
+0:00:00.450001: 1:1.0:recv: stream=0, len=100
+

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_slow_stream__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_slow_stream__server.snap
@@ -1,6 +1,6 @@
 ---
-source: netbench/netbench/src/multiplex.rs
-assertion_line: 554
+source: netbench/src/multiplex.rs
+assertion_line: 560
 expression: (server_trace.1).as_str().unwrap()
 
 ---
@@ -16,4 +16,6 @@ expression: (server_trace.1).as_str().unwrap()
 0:00:00.350001: 1:1.0:recv: stream=0, len=100
 0:00:00.400001: 1:1.0:recv: stream=0, len=100
 0:00:00.450001: 1:1.0:recv: stream=0, len=100
+0:00:00.450001: 1:1.0:exec: ReceiveFinish { stream_id: 0 }
+0:00:00.450001: 1:1.0:recv finish: stream=0
 

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_stream__client.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_stream__client.snap
@@ -1,10 +1,13 @@
 ---
-source: netbench/netbench/src/multiplex.rs
-assertion_line: 543
+source: netbench/src/multiplex.rs
+assertion_line: 549
 expression: (client_trace.1).as_str().unwrap()
 
 ---
 0:00:00.000001: 0:0.0:exec: OpenSendStream { stream_id: 0 }
+0:00:00.000001: 0:0.0:open: stream=0
 0:00:00.000001: 0:0.0:exec: Send { stream_id: 0, bytes: Byte(1000) }
 0:00:00.000001: 0:0.0:send: stream=0, len=1000
+0:00:00.000001: 0:0.0:exec: SendFinish { stream_id: 0 }
+0:00:00.000001: 0:0.0:send finish: stream=0
 

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_stream__client.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_stream__client.snap
@@ -1,0 +1,10 @@
+---
+source: netbench/netbench/src/multiplex.rs
+assertion_line: 543
+expression: (client_trace.1).as_str().unwrap()
+
+---
+0:00:00.000001: 0:0.0:exec: OpenSendStream { stream_id: 0 }
+0:00:00.000001: 0:0.0:exec: Send { stream_id: 0, bytes: Byte(1000) }
+0:00:00.000001: 0:0.0:send: stream=0, len=1000
+

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_stream__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_stream__server.snap
@@ -1,0 +1,10 @@
+---
+source: netbench/netbench/src/multiplex.rs
+assertion_line: 543
+expression: (server_trace.1).as_str().unwrap()
+
+---
+0:00:00.000001: 1:accept: stream=0
+0:00:00.000001: 1:1.0:exec: Receive { stream_id: 0, bytes: Byte(1000) }
+0:00:00.000001: 1:1.0:recv: stream=0, len=1000
+

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_stream__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_stream__server.snap
@@ -1,10 +1,12 @@
 ---
-source: netbench/netbench/src/multiplex.rs
-assertion_line: 543
+source: netbench/src/multiplex.rs
+assertion_line: 549
 expression: (server_trace.1).as_str().unwrap()
 
 ---
 0:00:00.000001: 1:accept: stream=0
 0:00:00.000001: 1:1.0:exec: Receive { stream_id: 0, bytes: Byte(1000) }
 0:00:00.000001: 1:1.0:recv: stream=0, len=1000
+0:00:00.000001: 1:1.0:exec: ReceiveFinish { stream_id: 0 }
+0:00:00.000001: 1:1.0:recv finish: stream=0
 

--- a/netbench/netbench/src/testing.rs
+++ b/netbench/netbench/src/testing.rs
@@ -1,0 +1,241 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    io,
+    pin::Pin,
+    sync::{Arc, Mutex},
+    task::{Context, Poll, Waker},
+};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+/// Simple testing connection with a single bidirectional stream
+pub struct Connection {
+    local: Arc<Mutex<Stream>>,
+    peer: Arc<Mutex<Stream>>,
+}
+
+impl Connection {
+    /// Creates a pair of connections with the specified buffer limit
+    pub fn pair(max_buffer: usize) -> (Connection, Connection) {
+        let client: Arc<Mutex<Stream>> = Arc::new(Mutex::new(Stream::new(max_buffer)));
+        let server: Arc<Mutex<Stream>> = Arc::new(Mutex::new(Stream::new(max_buffer)));
+        let client_conn = Connection {
+            local: client.clone(),
+            peer: server.clone(),
+        };
+        let server_conn = Connection {
+            local: server,
+            peer: client,
+        };
+        (client_conn, server_conn)
+    }
+}
+
+impl Drop for Connection {
+    fn drop(&mut self) {
+        if let Ok(mut stream) = self.local.lock() {
+            stream.close();
+        }
+        if let Ok(mut stream) = self.peer.lock() {
+            stream.close();
+        }
+    }
+}
+
+impl AsyncRead for Connection {
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let mut stream = self.local.lock().unwrap();
+        Pin::new(&mut *stream).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for Connection {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        let mut stream = self.peer.lock().unwrap();
+        Pin::new(&mut *stream).poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        let mut stream = self.peer.lock().unwrap();
+        Pin::new(&mut *stream).poll_flush(cx)
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        let mut stream = self.peer.lock().unwrap();
+        Pin::new(&mut *stream).poll_shutdown(cx)
+    }
+}
+
+#[derive(Debug, Default)]
+struct Stream {
+    buffer: Vec<u8>,
+    read_waker: Option<Waker>,
+    write_waker: Option<Waker>,
+    is_closed: bool,
+    max_buffer: usize,
+}
+
+impl Stream {
+    fn new(max_buffer: usize) -> Self {
+        Self {
+            max_buffer,
+            ..Default::default()
+        }
+    }
+
+    fn close(&mut self) {
+        self.is_closed = true;
+        self.wake_writer();
+        self.wake_reader();
+    }
+
+    fn wake_reader(&mut self) {
+        if let Some(waker) = self.read_waker.take() {
+            waker.wake();
+        }
+    }
+
+    fn wake_writer(&mut self) {
+        if let Some(waker) = self.write_waker.take() {
+            waker.wake();
+        }
+    }
+
+    fn ensure_open(&self) -> io::Result<()> {
+        if self.is_closed {
+            Err(io::Error::new(io::ErrorKind::ConnectionReset, "closed"))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl AsyncRead for Stream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        context: &mut Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        if self.buffer.is_empty() {
+            // do an empty write
+            if self.is_closed {
+                return Ok(()).into();
+            }
+
+            self.read_waker = Some(context.waker().clone());
+            return Poll::Pending;
+        }
+
+        let len = self.buffer.len().min(buf.remaining());
+        buf.put_slice(&self.buffer[..len]);
+        self.buffer.drain(..len);
+
+        // let the peer know it can write more
+        self.wake_writer();
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl AsyncWrite for Stream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        self.ensure_open()?;
+
+        let len = (self.max_buffer - self.buffer.len()).min(buf.len());
+
+        if len == 0 {
+            self.write_waker = Some(cx.waker().clone());
+            return Poll::Pending;
+        }
+
+        self.buffer.extend_from_slice(&buf[..len]);
+
+        // let the peer know it can read more
+        self.wake_reader();
+
+        Poll::Ready(Ok(len))
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        self.ensure_open()?;
+
+        if self.buffer.is_empty() {
+            Poll::Ready(Ok(()))
+        } else {
+            self.write_waker = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+
+    fn poll_shutdown(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), io::Error>> {
+        if !self.buffer.is_empty() {
+            self.write_waker = Some(cx.waker().clone());
+            return Poll::Pending;
+        }
+
+        self.is_closed = true;
+
+        // let the peer know we're closed now
+        self.wake_reader();
+
+        Poll::Ready(Ok(()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    #[tokio::test]
+    async fn read_write_shutdown() -> io::Result<()> {
+        let (mut client, mut server) = Connection::pair(100);
+
+        tokio::spawn(async move {
+            client.write_all(b"hello!").await?;
+            client.shutdown().await?;
+            io::Result::Ok(())
+        });
+
+        let mut buf = vec![];
+        server.read_to_end(&mut buf).await?;
+
+        assert_eq!(buf, b"hello!");
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn read_write_drop() -> io::Result<()> {
+        let (mut client, mut server) = Connection::pair(100);
+
+        tokio::spawn(async move {
+            client.write_all(b"hello!").await?;
+            // let the drop handle the connection shutdown
+            io::Result::Ok(())
+        });
+
+        let mut buf = vec![];
+        server.read_to_end(&mut buf).await?;
+
+        assert_eq!(buf, b"hello!");
+
+        Ok(())
+    }
+}

--- a/netbench/netbench/src/testing.rs
+++ b/netbench/netbench/src/testing.rs
@@ -10,6 +10,7 @@ use std::{
 use tokio::io::{AsyncRead, AsyncWrite};
 
 /// Simple testing connection with a single bidirectional stream
+#[derive(Debug)]
 pub struct Connection {
     local: Arc<Mutex<Stream>>,
     peer: Arc<Mutex<Stream>>,

--- a/netbench/netbench/src/timer.rs
+++ b/netbench/netbench/src/timer.rs
@@ -30,7 +30,7 @@ impl Default for Testing {
 }
 
 impl Testing {
-    pub fn advance_pair(&mut self, other: &mut Self) {
+    pub fn advance_pair(&mut self, other: &mut Self) -> Option<Timestamp> {
         let target = self.target.map(|target| {
             if let Some(other) = other.target {
                 target.min(other)
@@ -42,6 +42,9 @@ impl Testing {
         if let Some(target) = target {
             self.set(target);
             other.set(target);
+            Some(self.now)
+        } else {
+            None
         }
     }
 

--- a/netbench/netbench/src/timer.rs
+++ b/netbench/netbench/src/timer.rs
@@ -1,0 +1,71 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::{
+    task::{Context, Poll, Waker},
+    time::Duration,
+};
+pub use s2n_quic_core::time::Timestamp;
+
+pub trait Timer {
+    fn now(&self) -> Timestamp;
+    fn poll(&mut self, target: Timestamp, cx: &mut Context) -> Poll<()>;
+}
+
+#[derive(Debug)]
+pub struct Testing {
+    now: Timestamp,
+    target: Option<Timestamp>,
+    waker: Option<Waker>,
+}
+
+impl Default for Testing {
+    fn default() -> Self {
+        Self {
+            now: unsafe { Timestamp::from_duration(Duration::ZERO) },
+            target: None,
+            waker: None,
+        }
+    }
+}
+
+impl Testing {
+    pub fn advance_pair(&mut self, other: &mut Self) {
+        let target = self.target.map(|target| {
+            if let Some(other) = other.target {
+                target.min(other)
+            } else {
+                target
+            }
+        });
+
+        if let Some(target) = target {
+            self.set(target);
+            other.set(target);
+        }
+    }
+
+    fn set(&mut self, target: Timestamp) {
+        self.now = target;
+        self.target = None;
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
+    }
+}
+
+impl Timer for Testing {
+    fn now(&self) -> s2n_quic_core::time::Timestamp {
+        self.now
+    }
+
+    fn poll(&mut self, target: Timestamp, cx: &mut Context<'_>) -> Poll<()> {
+        if target == self.now {
+            Poll::Ready(())
+        } else {
+            self.target = Some(target);
+            self.waker = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}

--- a/netbench/netbench/src/trace.rs
+++ b/netbench/netbench/src/trace.rs
@@ -1,0 +1,171 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::operation::ConnectionOperation;
+use core::{fmt, time::Duration};
+use std::sync::{
+    atomic::{AtomicBool, AtomicU64, Ordering},
+    Arc,
+};
+
+pub trait Trace {
+    #[inline(always)]
+    fn exec(&mut self, op: &ConnectionOperation) {
+        let _ = op;
+    }
+
+    #[inline(always)]
+    fn enter(&mut self, scope: usize, thread: usize) {
+        let _ = scope;
+        let _ = thread;
+    }
+
+    #[inline(always)]
+    fn exit(&mut self) {}
+
+    #[inline(always)]
+    fn send(&mut self, stream_id: u64, len: u64) {
+        let _ = stream_id;
+        let _ = len;
+    }
+
+    #[inline(always)]
+    fn receive(&mut self, stream_id: u64, len: u64) {
+        let _ = stream_id;
+        let _ = len;
+    }
+
+    #[inline(always)]
+    fn accept(&mut self, stream_id: u64) {
+        let _ = stream_id;
+    }
+
+    #[inline(always)]
+    fn trace(&mut self, id: u64) {
+        let _ = id;
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Disabled(());
+
+impl Trace for Disabled {}
+
+#[derive(Clone, Debug)]
+pub struct Logger<'a> {
+    id: u64,
+    traces: &'a [String],
+    scope: Vec<(usize, usize)>,
+}
+
+impl<'a> Logger<'a> {
+    pub fn new(id: u64, traces: &'a [String]) -> Self {
+        Self {
+            id,
+            traces,
+            scope: vec![],
+        }
+    }
+
+    fn log(&self, v: impl fmt::Display) {
+        use std::io::Write;
+
+        let out = std::io::stdout();
+        let mut out = out.lock();
+        let _ = write!(out, "{}:", self.id);
+        for (scope, thread) in self.scope.iter() {
+            let _ = write!(out, "{}.{}:", scope, thread);
+        }
+        let _ = writeln!(out, "{}", v);
+    }
+}
+
+impl Trace for Logger<'_> {
+    #[inline(always)]
+    fn exec(&mut self, op: &ConnectionOperation) {
+        self.log(format_args!("exec: {:?}", op));
+    }
+
+    #[inline(always)]
+    fn enter(&mut self, scope: usize, thread: usize) {
+        self.scope.push((scope, thread));
+    }
+
+    #[inline(always)]
+    fn exit(&mut self) {
+        self.scope.pop();
+    }
+
+    #[inline(always)]
+    fn send(&mut self, stream_id: u64, len: u64) {
+        self.log(format_args!("send: stream={}, len={}", stream_id, len));
+    }
+
+    #[inline(always)]
+    fn receive(&mut self, stream_id: u64, len: u64) {
+        self.log(format_args!("recv: stream={}, len={}", stream_id, len));
+    }
+
+    #[inline(always)]
+    fn accept(&mut self, stream_id: u64) {
+        self.log(format_args!("accept: stream={}", stream_id));
+    }
+
+    #[inline(always)]
+    fn trace(&mut self, id: u64) {
+        if let Some(msg) = self.traces.get(id as usize) {
+            self.log(format_args!("trace: {}", msg));
+        } else {
+            self.log(format_args!("trace: id={}", id));
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct Throughput<Counter> {
+    rx: Counter,
+    tx: Counter,
+}
+
+impl Throughput<Arc<AtomicU64>> {
+    pub fn take(&self) -> Throughput<u64> {
+        Throughput {
+            rx: self.rx.swap(0, Ordering::Relaxed),
+            tx: self.tx.swap(0, Ordering::Relaxed),
+        }
+    }
+
+    pub fn reporter(&self, freq: Duration) -> ReporterHandle {
+        let handle = ReporterHandle::default();
+        let values = self.clone();
+        let r_handle = handle.clone();
+        tokio::spawn(async move {
+            while !r_handle.0.fetch_or(false, Ordering::Relaxed) {
+                tokio::time::sleep(freq).await;
+                let v = values.take();
+                eprintln!("{:?}", v);
+            }
+        });
+
+        handle
+    }
+}
+
+impl Trace for Throughput<Arc<AtomicU64>> {
+    fn send(&mut self, _stream_id: u64, len: u64) {
+        self.tx.fetch_add(len, Ordering::Relaxed);
+    }
+
+    fn receive(&mut self, _stream_id: u64, len: u64) {
+        self.rx.fetch_add(len, Ordering::Relaxed);
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ReporterHandle(Arc<AtomicBool>);
+
+impl Drop for ReporterHandle {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Relaxed);
+    }
+}

--- a/netbench/netbench/src/trace.rs
+++ b/netbench/netbench/src/trace.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::operation::ConnectionOperation;
+use crate::{operation as op, timer::Timestamp};
 use core::{fmt, time::Duration};
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
@@ -10,39 +10,91 @@ use std::sync::{
 
 pub trait Trace {
     #[inline(always)]
-    fn exec(&mut self, op: &ConnectionOperation) {
+    fn exec(&mut self, now: Timestamp, op: &op::Connection) {
+        let _ = now;
         let _ = op;
     }
 
     #[inline(always)]
-    fn enter(&mut self, scope: usize, thread: usize) {
+    fn enter(&mut self, now: Timestamp, scope: usize, thread: usize) {
+        let _ = now;
         let _ = scope;
         let _ = thread;
     }
 
     #[inline(always)]
-    fn exit(&mut self) {}
+    fn exit(&mut self, now: Timestamp) {
+        let _ = now;
+    }
 
     #[inline(always)]
-    fn send(&mut self, stream_id: u64, len: u64) {
+    fn send(&mut self, now: Timestamp, stream_id: u64, len: u64) {
+        let _ = now;
         let _ = stream_id;
         let _ = len;
     }
 
     #[inline(always)]
-    fn receive(&mut self, stream_id: u64, len: u64) {
+    fn receive(&mut self, now: Timestamp, stream_id: u64, len: u64) {
+        let _ = now;
         let _ = stream_id;
         let _ = len;
     }
 
     #[inline(always)]
-    fn accept(&mut self, stream_id: u64) {
+    fn accept(&mut self, now: Timestamp, stream_id: u64) {
+        let _ = now;
         let _ = stream_id;
     }
 
     #[inline(always)]
-    fn trace(&mut self, id: u64) {
+    fn trace(&mut self, now: Timestamp, id: u64) {
+        let _ = now;
         let _ = id;
+    }
+}
+
+impl<A: Trace, B: Trace> Trace for (A, B) {
+    #[inline(always)]
+    fn exec(&mut self, now: Timestamp, op: &op::Connection) {
+        self.0.exec(now, op);
+        self.1.exec(now, op);
+    }
+
+    #[inline(always)]
+    fn enter(&mut self, now: Timestamp, scope: usize, thread: usize) {
+        self.0.enter(now, scope, thread);
+        self.1.enter(now, scope, thread);
+    }
+
+    #[inline(always)]
+    fn exit(&mut self, now: Timestamp) {
+        self.0.exit(now);
+        self.1.exit(now);
+    }
+
+    #[inline(always)]
+    fn send(&mut self, now: Timestamp, stream_id: u64, len: u64) {
+        self.0.send(now, stream_id, len);
+        self.1.send(now, stream_id, len);
+    }
+
+    #[inline(always)]
+    fn receive(&mut self, now: Timestamp, stream_id: u64, len: u64) {
+        self.0.receive(now, stream_id, len);
+        self.1.receive(now, stream_id, len);
+    }
+
+    #[inline(always)]
+    fn accept(&mut self, now: Timestamp, stream_id: u64) {
+        self.0.accept(now, stream_id);
+        self.1.accept(now, stream_id)
+    }
+
+    #[inline(always)]
+    fn trace(&mut self, now: Timestamp, id: u64) {
+        self.0.trace(now, id);
+        self.1.trace(now, id)
     }
 }
 
@@ -52,71 +104,129 @@ pub struct Disabled(());
 impl Trace for Disabled {}
 
 #[derive(Clone, Debug)]
-pub struct Logger<'a> {
+pub struct Logger<'a, O: Output> {
     id: u64,
     traces: &'a [String],
     scope: Vec<(usize, usize)>,
+    output: O,
 }
 
-impl<'a> Logger<'a> {
+pub type MemoryLogger<'a> = Logger<'a, std::io::Cursor<Vec<u8>>>;
+pub type StdioLogger<'a> = Logger<'a, std::io::BufWriter<std::io::Stdout>>;
+
+impl<'a, O: Output> Logger<'a, O> {
     pub fn new(id: u64, traces: &'a [String]) -> Self {
         Self {
             id,
             traces,
             scope: vec![],
+            output: O::new(),
         }
     }
 
-    fn log(&self, v: impl fmt::Display) {
-        use std::io::Write;
-
-        let out = std::io::stdout();
-        let mut out = out.lock();
-        let _ = write!(out, "{}:", self.id);
-        for (scope, thread) in self.scope.iter() {
-            let _ = write!(out, "{}.{}:", scope, thread);
-        }
-        let _ = writeln!(out, "{}", v);
+    fn log(&mut self, now: Timestamp, v: impl fmt::Display) {
+        let id = self.id;
+        let scope = &self.scope;
+        let _ = self.output.write(|out| {
+            use std::io::Write;
+            write!(out, "{}: ", now)?;
+            write!(out, "{}:", id)?;
+            for (scope, thread) in scope.iter() {
+                write!(out, "{}.{}:", scope, thread)?;
+            }
+            writeln!(out, "{}", v)?;
+            Ok(())
+        });
     }
 }
 
-impl Trace for Logger<'_> {
+impl<'a> Logger<'a, std::io::Cursor<Vec<u8>>> {
+    pub fn as_str(&self) -> Option<&str> {
+        core::str::from_utf8(self.output.get_ref()).ok()
+    }
+}
+
+pub trait Output {
+    type Io: std::io::Write;
+
+    fn new() -> Self;
+    fn write<F: FnOnce(&mut Self::Io) -> std::io::Result<()>>(
+        &mut self,
+        f: F,
+    ) -> std::io::Result<()>;
+}
+
+impl Output for std::io::BufWriter<std::io::Stdout> {
+    type Io = Self;
+
+    fn new() -> Self {
+        std::io::BufWriter::new(std::io::stdout())
+    }
+
+    fn write<F: FnOnce(&mut Self::Io) -> std::io::Result<()>>(
+        &mut self,
+        f: F,
+    ) -> std::io::Result<()> {
+        f(self)?;
+        use std::io::Write;
+        self.flush()?;
+        Ok(())
+    }
+}
+
+impl Output for std::io::Cursor<Vec<u8>> {
+    type Io = Self;
+
+    fn new() -> Self {
+        std::io::Cursor::new(vec![])
+    }
+
+    fn write<F: FnOnce(&mut Self::Io) -> std::io::Result<()>>(
+        &mut self,
+        f: F,
+    ) -> std::io::Result<()> {
+        f(self)?;
+        Ok(())
+    }
+}
+
+impl<O: Output> Trace for Logger<'_, O> {
     #[inline(always)]
-    fn exec(&mut self, op: &ConnectionOperation) {
-        self.log(format_args!("exec: {:?}", op));
+    fn exec(&mut self, now: Timestamp, op: &op::Connection) {
+        self.log(now, format_args!("exec: {:?}", op));
     }
 
     #[inline(always)]
-    fn enter(&mut self, scope: usize, thread: usize) {
+    fn enter(&mut self, _now: Timestamp, scope: usize, thread: usize) {
         self.scope.push((scope, thread));
     }
 
     #[inline(always)]
-    fn exit(&mut self) {
+    fn exit(&mut self, _now: Timestamp) {
         self.scope.pop();
     }
 
     #[inline(always)]
-    fn send(&mut self, stream_id: u64, len: u64) {
-        self.log(format_args!("send: stream={}, len={}", stream_id, len));
+    fn send(&mut self, now: Timestamp, stream_id: u64, len: u64) {
+        self.log(now, format_args!("send: stream={}, len={}", stream_id, len));
     }
 
     #[inline(always)]
-    fn receive(&mut self, stream_id: u64, len: u64) {
-        self.log(format_args!("recv: stream={}, len={}", stream_id, len));
+    fn receive(&mut self, now: Timestamp, stream_id: u64, len: u64) {
+        self.log(now, format_args!("recv: stream={}, len={}", stream_id, len));
     }
 
     #[inline(always)]
-    fn accept(&mut self, stream_id: u64) {
-        self.log(format_args!("accept: stream={}", stream_id));
+    fn accept(&mut self, now: Timestamp, stream_id: u64) {
+        self.log(now, format_args!("accept: stream={}", stream_id));
     }
 
     #[inline(always)]
-    fn trace(&mut self, id: u64) {
+    fn trace(&mut self, now: Timestamp, id: u64) {
         if let Some(msg) = self.traces.get(id as usize) {
-            self.log(format_args!("trace: {}", msg));
+            self.log(now, format_args!("trace: {}", msg));
         } else {
-            self.log(format_args!("trace: id={}", id));
+            self.log(now, format_args!("trace: id={}", id));
         }
     }
 }
@@ -152,11 +262,11 @@ impl Throughput<Arc<AtomicU64>> {
 }
 
 impl Trace for Throughput<Arc<AtomicU64>> {
-    fn send(&mut self, _stream_id: u64, len: u64) {
+    fn send(&mut self, _now: Timestamp, _stream_id: u64, len: u64) {
         self.tx.fetch_add(len, Ordering::Relaxed);
     }
 
-    fn receive(&mut self, _stream_id: u64, len: u64) {
+    fn receive(&mut self, _now: Timestamp, _stream_id: u64, len: u64) {
         self.rx.fetch_add(len, Ordering::Relaxed);
     }
 }
@@ -167,5 +277,42 @@ pub struct ReporterHandle(Arc<AtomicBool>);
 impl Drop for ReporterHandle {
     fn drop(&mut self) {
         self.0.store(true, Ordering::Relaxed);
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Tracker {
+    pub had_traces: bool,
+}
+
+impl Tracker {
+    pub fn reset(&mut self) -> bool {
+        core::mem::replace(&mut self.had_traces, false)
+    }
+}
+
+impl Trace for Tracker {
+    fn exec(&mut self, _now: Timestamp, _op: &op::Connection) {
+        self.had_traces = true;
+    }
+
+    fn enter(&mut self, _now: Timestamp, _scope: usize, _thread: usize) {}
+
+    fn exit(&mut self, _now: Timestamp) {}
+
+    fn send(&mut self, _now: Timestamp, _stream_id: u64, _len: u64) {
+        self.had_traces = true;
+    }
+
+    fn receive(&mut self, _now: Timestamp, _stream_id: u64, _len: u64) {
+        self.had_traces = true;
+    }
+
+    fn accept(&mut self, _now: Timestamp, _stream_id: u64) {
+        self.had_traces = true;
+    }
+
+    fn trace(&mut self, _now: Timestamp, _id: u64) {
+        self.had_traces = true;
     }
 }

--- a/netbench/netbench/src/units.rs
+++ b/netbench/netbench/src/units.rs
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+mod byte;
+mod duration;
+mod rate;
+
+pub use byte::*;
+pub use duration::*;
+pub use rate::*;

--- a/netbench/netbench/src/units/byte.rs
+++ b/netbench/netbench/src/units/byte.rs
@@ -15,31 +15,31 @@ impl Byte {
     pub const MIN: Self = Self(u64::MIN);
 }
 
-impl ops::Add<u64> for Byte {
+impl ops::Add for Byte {
     type Output = Self;
 
-    fn add(self, rhs: u64) -> Self::Output {
-        Self(self.0 + rhs)
+    fn add(self, rhs: Self) -> Self::Output {
+        Self(self.0 + rhs.0)
     }
 }
 
-impl ops::AddAssign<u64> for Byte {
-    fn add_assign(&mut self, rhs: u64) {
-        self.0 += rhs;
+impl ops::AddAssign for Byte {
+    fn add_assign(&mut self, rhs: Self) {
+        self.0 += rhs.0;
     }
 }
 
-impl ops::Sub<u64> for Byte {
+impl ops::Sub for Byte {
     type Output = Self;
 
-    fn sub(self, rhs: u64) -> Self::Output {
-        Self(self.0 - rhs)
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self(self.0 - rhs.0)
     }
 }
 
-impl ops::SubAssign<u64> for Byte {
-    fn sub_assign(&mut self, rhs: u64) {
-        self.0 -= rhs;
+impl ops::SubAssign for Byte {
+    fn sub_assign(&mut self, rhs: Self) {
+        self.0 -= rhs.0;
     }
 }
 
@@ -83,22 +83,45 @@ pub trait ByteExt {
     fn kilobytes(&self) -> Byte {
         self.bytes() * 1000
     }
+    fn kibibytes(&self) -> Byte {
+        self.bytes() * 1024
+    }
     fn megabytes(&self) -> Byte {
         self.kilobytes() * 1000
+    }
+    fn mebibytes(&self) -> Byte {
+        self.kibibytes() * 1024
     }
     fn gigabytes(&self) -> Byte {
         self.megabytes() * 1000
     }
-}
-
-impl ByteExt for i32 {
-    fn bytes(&self) -> Byte {
-        Byte(*self as _)
+    fn gibibytes(&self) -> Byte {
+        self.mebibytes() * 1024
     }
 }
 
 impl ByteExt for u64 {
     fn bytes(&self) -> Byte {
         Byte(*self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_debug_snapshot;
+
+    #[test]
+    fn ext_test() {
+        assert_debug_snapshot!([
+            42.bytes(),
+            42.kilobytes(),
+            42.kibibytes(),
+            42.megabytes(),
+            42.mebibytes(),
+            42.gigabytes(),
+            42.gibibytes(),
+            42.kibibytes() + 42.bytes()
+        ]);
     }
 }

--- a/netbench/netbench/src/units/byte.rs
+++ b/netbench/netbench/src/units/byte.rs
@@ -1,0 +1,104 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::units::{Duration, Rate};
+use core::ops;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize,
+)]
+pub struct Byte(u64);
+
+impl Byte {
+    pub const MAX: Self = Self(u64::MAX);
+    pub const MIN: Self = Self(u64::MIN);
+}
+
+impl ops::Add<u64> for Byte {
+    type Output = Self;
+
+    fn add(self, rhs: u64) -> Self::Output {
+        Self(self.0 + rhs)
+    }
+}
+
+impl ops::AddAssign<u64> for Byte {
+    fn add_assign(&mut self, rhs: u64) {
+        self.0 += rhs;
+    }
+}
+
+impl ops::Sub<u64> for Byte {
+    type Output = Self;
+
+    fn sub(self, rhs: u64) -> Self::Output {
+        Self(self.0 - rhs)
+    }
+}
+
+impl ops::SubAssign<u64> for Byte {
+    fn sub_assign(&mut self, rhs: u64) {
+        self.0 -= rhs;
+    }
+}
+
+impl ops::Mul<u64> for Byte {
+    type Output = Self;
+
+    fn mul(self, rhs: u64) -> Self::Output {
+        Self(self.0 * rhs)
+    }
+}
+
+impl ops::Div<u64> for Byte {
+    type Output = Self;
+
+    fn div(self, rhs: u64) -> Self::Output {
+        Self(self.0 / rhs)
+    }
+}
+
+impl ops::Div<Duration> for Byte {
+    type Output = Rate;
+
+    fn div(self, period: Duration) -> Self::Output {
+        Rate {
+            bytes: self,
+            period,
+        }
+    }
+}
+
+impl ops::Deref for Byte {
+    type Target = u64;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+pub trait ByteExt {
+    fn bytes(&self) -> Byte;
+    fn kilobytes(&self) -> Byte {
+        self.bytes() * 1000
+    }
+    fn megabytes(&self) -> Byte {
+        self.kilobytes() * 1000
+    }
+    fn gigabytes(&self) -> Byte {
+        self.megabytes() * 1000
+    }
+}
+
+impl ByteExt for i32 {
+    fn bytes(&self) -> Byte {
+        Byte(*self as _)
+    }
+}
+
+impl ByteExt for u64 {
+    fn bytes(&self) -> Byte {
+        Byte(*self)
+    }
+}

--- a/netbench/netbench/src/units/duration.rs
+++ b/netbench/netbench/src/units/duration.rs
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub use core::time::Duration;
+
+pub trait DurationExt {
+    fn millis(&self) -> Duration;
+    fn seconds(&self) -> Duration {
+        self.millis() * 1000
+    }
+    fn minutes(&self) -> Duration {
+        self.seconds() * 60
+    }
+}
+
+impl DurationExt for i32 {
+    fn millis(&self) -> Duration {
+        Duration::from_millis(*self as _)
+    }
+}
+
+impl DurationExt for u64 {
+    fn millis(&self) -> Duration {
+        Duration::from_millis(*self)
+    }
+}
+
+pub(crate) mod duration_format {
+    use core::time::Duration;
+    use serde::{self, Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u64(duration.as_millis() as u64)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let millis = u64::deserialize(deserializer)?;
+        Ok(Duration::from_millis(millis))
+    }
+}

--- a/netbench/netbench/src/units/duration.rs
+++ b/netbench/netbench/src/units/duration.rs
@@ -13,9 +13,12 @@ pub trait DurationExt {
     }
 }
 
-impl DurationExt for i32 {
+impl DurationExt for f32 {
     fn millis(&self) -> Duration {
-        Duration::from_millis(*self as _)
+        Duration::from_secs_f32(*self / 1000.0)
+    }
+    fn seconds(&self) -> Duration {
+        Duration::from_secs_f32(*self)
     }
 }
 
@@ -42,5 +45,25 @@ pub(crate) mod duration_format {
     {
         let millis = u64::deserialize(deserializer)?;
         Ok(Duration::from_millis(millis))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_debug_snapshot;
+
+    #[test]
+    fn ext_test() {
+        assert_debug_snapshot!([
+            42.millis(),
+            42.seconds(),
+            42.minutes(),
+            42.minutes() + 42.seconds(),
+            4.2.millis(),
+            4.2.seconds(),
+            4.2.minutes(),
+            4.2.minutes() + 4.2.seconds(),
+        ]);
     }
 }

--- a/netbench/netbench/src/units/rate.rs
+++ b/netbench/netbench/src/units/rate.rs
@@ -1,0 +1,19 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::units::{duration_format, Byte, Duration};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Hash, Deserialize, Serialize)]
+pub struct Rate {
+    pub bytes: Byte,
+    #[serde(with = "duration_format", rename = "period_ms")]
+    pub period: Duration,
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct Rates {
+    pub send: HashMap<u64, Rate>,
+    pub receive: HashMap<u64, Rate>,
+}

--- a/netbench/netbench/src/units/rate.rs
+++ b/netbench/netbench/src/units/rate.rs
@@ -17,3 +17,18 @@ pub(crate) struct Rates {
     pub send: HashMap<u64, Rate>,
     pub receive: HashMap<u64, Rate>,
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::units::*;
+    use insta::assert_debug_snapshot;
+
+    #[test]
+    fn ext_test() {
+        assert_debug_snapshot!([
+            42.bytes() / 42.millis(),
+            42.mebibytes() / 42.seconds(),
+            42.gigabytes() / 42.minutes()
+        ]);
+    }
+}

--- a/netbench/netbench/src/units/snapshots/netbench__units__byte__tests__ext_test.snap
+++ b/netbench/netbench/src/units/snapshots/netbench__units__byte__tests__ext_test.snap
@@ -1,0 +1,32 @@
+---
+source: netbench/netbench/src/units/byte.rs
+assertion_line: 116
+expression: "[42.bytes(), 42.kilobytes(), 42.kibibytes(), 42.megabytes(), 42.mebibytes(),\n 42.gigabytes(), 42.gibibytes(), 42.kibibytes() + 42.bytes()]"
+
+---
+[
+    Byte(
+        42,
+    ),
+    Byte(
+        42000,
+    ),
+    Byte(
+        43008,
+    ),
+    Byte(
+        42000000,
+    ),
+    Byte(
+        44040192,
+    ),
+    Byte(
+        42000000000,
+    ),
+    Byte(
+        45097156608,
+    ),
+    Byte(
+        43050,
+    ),
+]

--- a/netbench/netbench/src/units/snapshots/netbench__units__duration__tests__ext_test.snap
+++ b/netbench/netbench/src/units/snapshots/netbench__units__duration__tests__ext_test.snap
@@ -1,0 +1,16 @@
+---
+source: netbench/netbench/src/units/duration.rs
+assertion_line: 58
+expression: "[42.millis(), 42.seconds(), 42.minutes(), 42.minutes() + 42.seconds(),\n 4.2.millis(), 4.2.seconds(), 4.2.minutes(), 4.2.minutes() + 4.2.seconds()]"
+
+---
+[
+    42ms,
+    42s,
+    2520s,
+    2562s,
+    4.2ms,
+    4.199999744s,
+    251.99998464s,
+    256.199984384s,
+]

--- a/netbench/netbench/src/units/snapshots/netbench__units__rate__tests__ext_test.snap
+++ b/netbench/netbench/src/units/snapshots/netbench__units__rate__tests__ext_test.snap
@@ -1,0 +1,26 @@
+---
+source: netbench/src/units/rate.rs
+assertion_line: 28
+expression: "[42.bytes() / 42.millis(), 42.mebibytes() / 42.seconds(),\n 42.gigabytes() / 42.minutes()]"
+
+---
+[
+    Rate {
+        bytes: Byte(
+            42,
+        ),
+        period: 42ms,
+    },
+    Rate {
+        bytes: Byte(
+            44040192,
+        ),
+        period: 42s,
+    },
+    Rate {
+        bytes: Byte(
+            42000000000,
+        ),
+        period: 2520s,
+    },
+]


### PR DESCRIPTION
This is the first commit of our new `netbench` library. Here's an overview:

`netbench`'s goal is to enable benchmarking of streaming transport protocols. This includes TCP, TLS, and QUIC. It accomplishes this by using a JSON scenario format of instructions that implementations read and execute. This has a major advantage that drivers can be written once and execute an endless number of scenarios. Scenarios can be built with the builder:

```rust
Scenario::builder(|scenario| {
    let server = scenario.create_server();

    scenario.create_client(|client| {
        client.connect_to(server, |conn| {
            conn.open_send_stream(
                |local| {
                    local.set_send_rate(1024.bytes() / 50.millis());
                    local.send(1.megabytes());
                },
                |peer| {
                    peer.set_receive_rate(512.bytes() / 50.millis());
                    peer.receive(1.megabytes());
                }
            )
        });
    })
})
```

This scenario, when written to JSON will look like this:


<details>
  <summary>Click to expand!</summary>

    {
      "id": "103c9a6685d18b8d41852dbb5c427caab9181d9e93ba5e4df9ed50021dad935d",
      "clients": [
        {
          "scenario": [
            {
              "connect": {
                "server_id": 0,
                "server_connection_id": 0,
                "client_connection_id": 0
              }
            }
          ],
          "connections": [
            {
              "ops": [
                {
                  "open_send_stream": {
                    "stream_id": 0
                  }
                },
                {
                  "send_rate": {
                    "stream_id": 0,
                    "bytes": 1024,
                    "period_ms": 50
                  }
                },
                {
                  "send": {
                    "stream_id": 0,
                    "bytes": 1000000
                  }
                }
              ]
            }
          ]
        }
      ],
      "servers": [
        {
          "connections": [
            {
              "peer_streams": [
                [
                  {
                    "receive_rate": {
                      "stream_id": 0,
                      "bytes": 512,
                      "period_ms": 50
                    }
                  },
                  {
                    "receive": {
                      "stream_id": 0,
                      "bytes": 1000000
                    }
                  }
                ]
              ]
            }
          ]
        }
      ]
    }

</details>

Each endpoint can now read this file and execute the instructions with the `netbench::Driver`.

### Features of this PR

* [Generic Driver implementation](https://github.com/awslabs/s2n-quic/blob/camshaft/netbench-init/netbench/netbench/src/driver.rs)
* [Connection trait for pluggable drivers](https://github.com/awslabs/s2n-quic/blob/camshaft/netbench-init/netbench/netbench/src/connection.rs)
* [Stream multiplexer](https://github.com/awslabs/s2n-quic/blob/camshaft/netbench-init/netbench/netbench/src/multiplex.rs) for protocols that only feature a single duplex stream, e.g. TCP. This design was inspired by [HTTP/2](https://datatracker.ietf.org/doc/html/rfc7540#section-5), [QUIC](https://datatracker.ietf.org/doc/html/rfc9000#section-4), and [yamux](https://github.com/hashicorp/yamux/blob/master/spec.md).
* [s2n-quic driver](https://github.com/awslabs/s2n-quic/blob/camshaft/netbench-init/netbench/netbench/src/s2n_quic.rs)
* [Scenario builder](https://github.com/awslabs/s2n-quic/blob/camshaft/netbench-init/netbench/netbench/src/scenario/builder.rs) for writing and generating scenarios in rust

### Future additions

* A driver CLI to execute client and server operations
* A router that will interpret operations for packet loss, buffer sizes, MTU, etc
* A CLI that will spin up a docker swarm cluster and execute the tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
