### PR TITLE
transport: emit connection close event for initial connections

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -285,7 +285,7 @@ impl connection::Trait for TestConnection {
     fn with_event_publisher<F>(
         &mut self,
         _timestamp: Timestamp,
-        _path_id: path::Id,
+        _path_id: Option<path::Id>,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         _f: F,
     ) where

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -203,7 +203,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
             if version != self.quic_version() {
                 self.with_event_publisher(
                     datagram.timestamp,
-                    path_id,
+                    Some(path_id),
                     subscriber,
                     |publisher, path| {
                         publisher.on_packet_dropped(event::builder::PacketDropped {
@@ -283,7 +283,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 {
                     self.with_event_publisher(
                         datagram.timestamp,
-                        path_id,
+                        Some(path_id),
                         subscriber,
                         |publisher, path| {
                             publisher.on_packet_dropped(event::builder::PacketDropped {
@@ -308,7 +308,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                     if !payload.is_empty() {
                         self.with_event_publisher(
                             datagram.timestamp,
-                            path_id,
+                            Some(path_id),
                             subscriber,
                             |publisher, path| {
                                 publisher.on_packet_dropped(event::builder::PacketDropped {
@@ -336,7 +336,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 // would be difficult to recover from an invalid packet.
                 self.with_event_publisher(
                     datagram.timestamp,
-                    path_id,
+                    Some(path_id),
                     subscriber,
                     |publisher, path| {
                         publisher.on_packet_dropped(event::builder::PacketDropped {
@@ -396,7 +396,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     fn with_event_publisher<F>(
         &mut self,
         timestamp: Timestamp,
-        path_id: path::Id,
+        path_id: Option<path::Id>,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         f: F,
     ) where


### PR DESCRIPTION
We're currently not emitting a connection close event when the connection is closed right after creating it. This makes determining why connections failed difficult.

This PR adds the connection close events on failure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
