### PR TITLE
examples: add rustls provider example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,7 +372,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        example: [examples/echo]
+        example: [examples/echo, examples/rustls-provider]
     steps:
       - uses: actions/checkout@v2
         with:

--- a/examples/rustls-provider/Cargo.toml
+++ b/examples/rustls-provider/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rustls-provider"
+version = "0.1.0"
+authors = ["AWS s2n"]
+edition = "2018"
+
+[dependencies]
+# Remove the `default-tls-provider` feature and add `rustls`
+s2n-quic = { version = "0.1", path = "../../quic/s2n-quic", default-features = false, features = ["default-token-provider", "rand-provider", "std", "tokio-runtime", "rustls"] }
+tokio = { version = "1", features = ["full"] }
+
+[workspace]
+members = ["."]

--- a/examples/rustls-provider/src/bin/quic_echo_client.rs
+++ b/examples/rustls-provider/src/bin/quic_echo_client.rs
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_quic::{client::Connect, Client};
+use std::{error::Error, net::SocketAddr};
+
+/// NOTE: this certificate is to be used for demonstration purposes only!
+pub static CERT_PEM: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../quic/s2n-quic-core/certs/cert.pem"
+));
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let client = Client::builder()
+        .with_tls(CERT_PEM)?
+        .with_io("0.0.0.0:0")?
+        .start()?;
+
+    let addr: SocketAddr = "127.0.0.1:4433".parse()?;
+    let connect = Connect::new(addr).with_server_name("localhost");
+    let mut connection = client.connect(connect).await?;
+
+    // ensure the connection doesn't time out with inactivity
+    connection.keep_alive(true)?;
+
+    // open a new stream and split the receiving and sending sides
+    let stream = connection.open_bidirectional_stream().await?;
+    let (mut receive_stream, mut send_stream) = stream.split();
+
+    // spawn a task that copies responses from the server to stdout
+    tokio::spawn(async move {
+        let mut stdout = tokio::io::stdout();
+        let _ = tokio::io::copy(&mut receive_stream, &mut stdout).await;
+    });
+
+    // copy data from stdin and send it to the server
+    let mut stdin = tokio::io::stdin();
+    tokio::io::copy(&mut stdin, &mut send_stream).await?;
+
+    Ok(())
+}

--- a/examples/rustls-provider/src/bin/quic_echo_server.rs
+++ b/examples/rustls-provider/src/bin/quic_echo_server.rs
@@ -1,0 +1,45 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_quic::Server;
+use std::error::Error;
+
+/// NOTE: this certificate is to be used for demonstration purposes only!
+pub static CERT_PEM: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../quic/s2n-quic-core/certs/cert.pem"
+));
+/// NOTE: this certificate is to be used for demonstration purposes only!
+pub static KEY_PEM: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../quic/s2n-quic-core/certs/key.pem"
+));
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let mut server = Server::builder()
+        .with_tls((CERT_PEM, KEY_PEM))?
+        .with_io("127.0.0.1:4433")?
+        .start()?;
+
+    while let Some(mut connection) = server.accept().await {
+        // spawn a new task for the connection
+        tokio::spawn(async move {
+            eprintln!("Connection accepted from {:?}", connection.remote_addr());
+
+            while let Ok(Some(mut stream)) = connection.accept_bidirectional_stream().await {
+                // spawn a new task for the stream
+                tokio::spawn(async move {
+                    eprintln!("Stream opened from {:?}", stream.connection().remote_addr());
+
+                    // echo any data back to the stream
+                    while let Ok(Some(data)) = stream.receive().await {
+                        stream.send(data).await.expect("stream should be open");
+                    }
+                });
+            }
+        });
+    }
+
+    Ok(())
+}

--- a/quic/s2n-quic/src/provider/tls.rs
+++ b/quic/s2n-quic/src/provider/tls.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use cfg_if::cfg_if;
 use s2n_quic_core::crypto;
 
 /// Provides TLS support for an endpoint
@@ -17,6 +18,22 @@ pub trait Provider {
 }
 
 impl_provider_utils!();
+
+cfg_if! {
+    if #[cfg(feature = "default-tls-provider")] {
+        pub mod default {
+            pub use super::default_tls::*;
+        }
+    } else if #[cfg(feature = "s2n-tls")] {
+        pub use s2n_tls as default;
+    } else if #[cfg(feature = "rustls")] {
+        pub use rustls as default;
+    } else {
+        pub mod default {
+            pub use super::default_tls::*;
+        }
+    }
+}
 
 #[derive(Debug, Default)]
 pub struct Default;
@@ -168,7 +185,7 @@ impl Provider for &str {
 }
 
 #[cfg(feature = "default-tls-provider")]
-pub mod default {
+mod default_tls {
     pub use s2n_quic_tls_default::*;
 
     // We need to implement the provider trait for whatever the default is as long as it's
@@ -214,7 +231,7 @@ pub mod default {
     }
 }
 #[cfg(not(feature = "default-tls-provider"))]
-pub mod default {
+mod default_tls {
     // TODO stub out default that fails with error when started
 }
 


### PR DESCRIPTION
This change adds an example of how to modify the default TLS provider to rustls.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
