### PR TITLE
api: remove Congestion Controller from Builders

### DIFF
--- a/quic/s2n-quic/src/client/builder.rs
+++ b/quic/s2n-quic/src/client/builder.rs
@@ -18,31 +18,6 @@ impl Default for Builder<DefaultProviders> {
 
 impl<Providers: ClientProviders> Builder<Providers> {
     impl_provider_method!(
-        /// Sets the congestion controller provider for the [`Client`]
-        ///
-        /// # Examples
-        ///
-        /// Sets the congestion controller to `Cubic` with the default configuration.
-        ///
-        /// ```rust,no_run
-        /// # use std::error::Error;
-        /// use s2n_quic::{Client, provider::congestion_controller};
-        ///
-        /// # #[tokio::main]
-        /// # async fn main() -> Result<(), Box<dyn Error>> {
-        /// let client = Client::builder()
-        ///     .with_congestion_controller(congestion_controller::cubic::Provider::default())?
-        ///     .start()?;
-        /// #
-        /// #    Ok(())
-        /// # }
-        /// ```
-        with_congestion_controller,
-        congestion_controller,
-        ClientProviders
-    );
-
-    impl_provider_method!(
         /// Sets the connection ID provider for the [`Client`]
         ///
         /// # Examples

--- a/quic/s2n-quic/src/provider.rs
+++ b/quic/s2n-quic/src/provider.rs
@@ -6,7 +6,6 @@ use core::fmt;
 #[macro_use]
 mod macros;
 
-pub mod congestion_controller;
 pub mod connection_id;
 pub mod endpoint_limits;
 pub mod event;
@@ -17,6 +16,7 @@ pub mod tls;
 pub mod token;
 
 // These providers are not currently exposed to applications
+pub(crate) mod congestion_controller;
 pub(crate) mod connection_close_formatter;
 pub(crate) mod path_migration;
 pub(crate) mod random;

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -18,31 +18,6 @@ impl Default for Builder<DefaultProviders> {
 
 impl<Providers: ServerProviders> Builder<Providers> {
     impl_provider_method!(
-        /// Sets the congestion controller provider for the [`Server`]
-        ///
-        /// # Examples
-        ///
-        /// Sets the congestion controller to `Cubic` with the default configuration.
-        ///
-        /// ```rust,no_run
-        /// # use std::error::Error;
-        /// use s2n_quic::{Server, provider::congestion_controller};
-        ///
-        /// # #[tokio::main]
-        /// # async fn main() -> Result<(), Box<dyn Error>> {
-        /// let server = Server::builder()
-        ///     .with_congestion_controller(congestion_controller::cubic::Provider::default())?
-        ///     .start()?;
-        /// #
-        /// #    Ok(())
-        /// # }
-        /// ```
-        with_congestion_controller,
-        congestion_controller,
-        ServerProviders
-    );
-
-    impl_provider_method!(
         /// Sets the connection ID provider for the [`Server`]
         ///
         /// # Examples


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change removes the `with_congestion_controller` methods from the Server and Client builders, and makes the CongestionController module private, as the CongestionController API is not stable yet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
