### PR TITLE
api: make default token provider deps optional

### DIFF
--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -15,7 +15,14 @@ default = [
 ]
 # Sends debug information in CONNECTION_CLOSE frames
 connection-close-debug = []
-default-token-provider = ["ring", "zerocopy", "zerocopy-derive"]
+default-token-provider = [
+    "cuckoofilter",
+    "hash_hasher",
+    "ring",
+    "zerocopy",
+    "zerocopy-derive",
+    "zeroize",
+]
 default-tls-provider = ["s2n-quic-tls-default"]
 packet-wipe = ["s2n-quic-platform/wipe"]
 rand-provider = ["rand", "rand_chacha"]
@@ -27,7 +34,7 @@ std = [
     "s2n-quic-core/std",
     "s2n-quic-platform/std",
     "s2n-quic-transport/std",
-    "thiserror"
+    "thiserror",
 ]
 tokio-runtime = ["tokio", "s2n-quic-platform/tokio-runtime"]
 tracing-provider = ["s2n-quic-core/event-tracing"]
@@ -35,9 +42,9 @@ tracing-provider = ["s2n-quic-core/event-tracing"]
 [dependencies]
 bytes = { version = "1", default-features = false }
 cfg-if = "1"
-cuckoofilter = "0.5"
-futures = { version = "0.3", default-features = false, features = ["async-await"] }
-hash_hasher = "2"
+cuckoofilter = { version = "0.5", optional = true }
+futures = { version = "0.3", default-features = false }
+hash_hasher = { version = "2", optional = true }
 rand = { version = "0.8", optional = true }
 rand_chacha = { version = "0.3", optional = true }
 ring = { version = "0.16", optional = true, default-features = false }
@@ -52,7 +59,7 @@ thiserror = { version = "1", optional = true }
 tokio = { version = "1", optional = true, default-features = false }
 zerocopy = { version = "=0.6.0", optional = true }
 zerocopy-derive = { version = "=0.3.0", optional = true }
-zeroize = { version = "1", default-features = false }
+zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 bolero = { version = "0.6" }


### PR DESCRIPTION
Some of the crates in the main `s2n-quic` crate were only required if the `default-token-provider` feature is enabled. This change makes those optional.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
