### PR TITLE
api: set version to 1.0.0

### DIFF
--- a/docs/dev-guide/setup.md
+++ b/docs/dev-guide/setup.md
@@ -1,10 +1,8 @@
 # Setup
 
-
 ### Prerequisites
 
-- GCC / CLang (some CC), Make, and CMake. Installation of these
-  items depends on your package manager.
+- GCC / clang (some CC). Installation of these items depends on your package manager.
 - Install [rustup](https://rustup.rs/)
 
 ```sh
@@ -13,11 +11,4 @@ rustup component add rustfmt clippy rust-analysis
 
 # Install the nightly toolchain for testing
 rustup toolchain install nightly
-```
-
-### Initialization
-
-```sh
-# Initialize the project's submodules and tell cargo to rebuild it
-git submodule update --init && touch tls/s2n-tls-sys/build.rs
 ```

--- a/examples/echo/Cargo.toml
+++ b/examples/echo/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["AWS s2n"]
 edition = "2018"
 
 [dependencies]
-s2n-quic = { version = "0.1", path = "../../quic/s2n-quic" }
+s2n-quic = { version = "1", path = "../../quic/s2n-quic" }
 tokio = { version = "1", features = ["full"] }
 
 [workspace]

--- a/examples/rustls-provider/Cargo.toml
+++ b/examples/rustls-provider/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 # Remove the `provider-tls-default` feature and add `provider-tls-rustls`
-s2n-quic = { version = "0.1", path = "../../quic/s2n-quic", default-features = false, features = ["provider-address-token-default", "provider-tls-rustls"] }
+s2n-quic = { version = "1", path = "../../quic/s2n-quic", default-features = false, features = ["provider-address-token-default", "provider-tls-rustls"] }
 tokio = { version = "1", features = ["full"] }
 
 [workspace]

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic"
-version = "0.1.0"
+version = "1.0.0"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
This change sets the public API version to 1.0. By doing so, we commit to the following:

* We will not make backward-incompatible changes
* `s2n-quic` is ready to be used in production by applications

See [Semantic Versioning - How do I know when to release 1.0.0?](https://semver.org/#how-do-i-know-when-to-release-100)

> If your software is being used in production, it should probably already be 1.0.0. If you have a stable API on which users have come to depend, you should be 1.0.0. If you’re worrying a lot about backwards compatibility, you should probably already be 1.0.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
