### PR TITLE
api: remove delay from endpoint limit retry and close outcomes

### DIFF
--- a/quic/s2n-quic-core/src/endpoint/limits.rs
+++ b/quic/s2n-quic-core/src/endpoint/limits.rs
@@ -13,6 +13,9 @@ use crate::{
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Outcome {
     /// Allow the connection to continue
+    ///
+    /// Use `Outcome::allow()` to construct this variant
+    #[non_exhaustive]
     Allow,
 
     /// Defer the connection by sending a Retry packet
@@ -22,6 +25,9 @@ pub enum Outcome {
     Retry,
 
     /// Silently drop the connection attempt
+    ///
+    /// Use `Outcome::drop()` to construct this variant
+    #[non_exhaustive]
     Drop,
 
     /// Cleanly close the connection
@@ -32,9 +38,19 @@ pub enum Outcome {
 }
 
 impl Outcome {
+    /// Allow the connection to continue
+    pub fn allow() -> Self {
+        Self::Allow
+    }
+
     /// Defer the connection by sending a Retry packet
     pub fn retry() -> Self {
         Self::Retry
+    }
+
+    /// Silently drop the connection attempt
+    pub fn drop() -> Self {
+        Self::Drop
     }
 
     /// Cleanly close the connection
@@ -94,7 +110,7 @@ pub trait Limiter: 'static + Send {
     ///        if info.inflight_handshakes > self.handshake_limit {
     ///            Outcome::retry()
     ///        } else {
-    ///            Outcome::Allow
+    ///            Outcome::allow()
     ///        }
     ///    }
     /// }

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -347,7 +347,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
         );
 
         match outcome {
-            Outcome::Allow => Some(()),
+            Outcome::Allow { .. } => Some(()),
             Outcome::Retry { .. } => {
                 //= https://www.rfc-editor.org/rfc/rfc9000#section-8.1.2
                 //# A server can also use a Retry packet to defer the state and
@@ -391,7 +391,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
 
                 None
             }
-            Outcome::Drop => {
+            Outcome::Drop { .. } => {
                 publisher.on_endpoint_datagram_dropped(event::builder::EndpointDatagramDropped {
                     len: payload_len as u16,
                     reason: event::builder::DatagramDropReason::RejectedConnectionAttempt,
@@ -1178,7 +1178,7 @@ pub mod testing {
             &mut self,
             _attempt: &endpoint::limits::ConnectionAttempt,
         ) -> endpoint::limits::Outcome {
-            endpoint::limits::Outcome::Allow
+            endpoint::limits::Outcome::allow()
         }
     }
 }

--- a/quic/s2n-quic/src/provider/endpoint_limits.rs
+++ b/quic/s2n-quic/src/provider/endpoint_limits.rs
@@ -94,7 +94,7 @@ pub mod default {
                 }
             }
 
-            Outcome::Allow
+            Outcome::allow()
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This change removes delay from the endpoint limit `Outcome::Retry` and `Outcome::Close` as #280 is not yet implemented. All Outcome variants are made `#[non_exhaustive]` so we can add this functionality (or other functionality) later on without breaking existing usage.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
