### PR TITLE
tests: remove spaces from snapshot names

### DIFF
--- a/quic/s2n-quic-core/src/crypto/tls/testing.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/testing.rs
@@ -171,7 +171,7 @@ impl<S: tls::Session, C: tls::Session> Pair<S, C> {
                 );
 
                 // TODO remove this when s2n-tls fixes its key schedule
-                if !core::any::type_name::<S>().starts_with("s2n_quic_tls") {
+                if !core::any::type_name::<S>().contains("s2n_quic_tls") {
                     assert!(
                         self.server.1.application.crypto.is_some(),
                         "server should have application keys after reading the ClientHello"

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -1428,7 +1428,7 @@ mod snapshot_tests {
 
             #[cfg(not(miri))] // snapshot tests don't work on miri
             insta::assert_debug_snapshot!(
-                concat!(stringify!($endpoint_params), " default"),
+                concat!(stringify!($endpoint_params), "__default"),
                 default_value
             );
 

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__ClientTransportParameters__default.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__ClientTransportParameters__default.snap
@@ -1,6 +1,8 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/mod.rs
+assertion_line: 1452
 expression: default_value
+
 ---
 TransportParameters {
     max_idle_timeout: MaxIdleTimeout(
@@ -57,9 +59,17 @@ TransportParameters {
             2,
         ),
     ),
-    original_destination_connection_id: None,
-    stateless_reset_token: None,
-    preferred_address: None,
+    original_destination_connection_id: DisabledParameter(
+        PhantomData,
+    ),
+    stateless_reset_token: DisabledParameter(
+        PhantomData,
+    ),
+    preferred_address: DisabledParameter(
+        PhantomData,
+    ),
     initial_source_connection_id: None,
-    retry_source_connection_id: None,
+    retry_source_connection_id: DisabledParameter(
+        PhantomData,
+    ),
 }

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__ServerTransportParameters__default.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__ServerTransportParameters__default.snap
@@ -1,6 +1,8 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/mod.rs
+assertion_line: 1447
 expression: default_value
+
 ---
 TransportParameters {
     max_idle_timeout: MaxIdleTimeout(
@@ -57,17 +59,9 @@ TransportParameters {
             2,
         ),
     ),
-    original_destination_connection_id: DisabledParameter(
-        PhantomData,
-    ),
-    stateless_reset_token: DisabledParameter(
-        PhantomData,
-    ),
-    preferred_address: DisabledParameter(
-        PhantomData,
-    ),
+    original_destination_connection_id: None,
+    stateless_reset_token: None,
+    preferred_address: None,
     initial_source_connection_id: None,
-    retry_source_connection_id: DisabledParameter(
-        PhantomData,
-    ),
+    retry_source_connection_id: None,
 }

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__client_snapshot_test.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__client_snapshot_test.snap
@@ -1,6 +1,8 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/mod.rs
+assertion_line: 1529
 expression: encoded_output
+
 ---
 [
     1,

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__server_snapshot_test.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__server_snapshot_test.snap
@@ -1,6 +1,8 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/mod.rs
+assertion_line: 1493
 expression: encoded_output
+
 ---
 [
     1,

--- a/quic/s2n-quic-core/tests/recovery/simulation.rs
+++ b/quic/s2n-quic-core/tests/recovery/simulation.rs
@@ -17,6 +17,10 @@ use std::{
 
 const CHART_DIMENSIONS: (u32, u32) = (1024, 768);
 
+fn type_name<T>() -> &'static str {
+    core::any::type_name::<T>().split("::").last().unwrap()
+}
+
 // These simulations are too slow for Miri
 #[test]
 #[cfg_attr(miri, ignore)]
@@ -165,7 +169,7 @@ fn slow_start_unlimited<CC: CongestionController>(
     Simulation {
         name: "Slow Start Unlimited",
         description: "Full congestion window utilization with no congestion experienced",
-        cc: core::any::type_name::<CC>(),
+        cc: type_name::<CC>(),
         rounds: simulate_constant_rtt(&mut congestion_controller, &[], None, num_rounds),
     }
 }
@@ -178,7 +182,7 @@ fn loss_at_3mb<CC: CongestionController>(
     Simulation {
         name: "Loss at 3MB",
         description: "Full congestion window utilization with loss encountered at ~3MB",
-        cc: core::any::type_name::<CC>(),
+        cc: type_name::<CC>(),
         rounds: simulate_constant_rtt(&mut congestion_controller, &[3_000_000], None, num_rounds),
     }
 }
@@ -194,7 +198,7 @@ fn app_limited_1mb<CC: CongestionController>(
     Simulation {
         name: "App Limited 1MB",
         description: "App limited to 1MB per round with loss encountered at ~750KB",
-        cc: core::any::type_name::<CC>(),
+        cc: type_name::<CC>(),
         rounds: simulate_constant_rtt(
             &mut congestion_controller,
             &[750_000],
@@ -222,7 +226,7 @@ fn minimum_window<CC: CongestionController>(
     Simulation {
         name: "Minimum Window",
         description: "Full congestion window utilization after starting from the minimum window",
-        cc: core::any::type_name::<CC>(),
+        cc: type_name::<CC>(),
         rounds: simulate_constant_rtt(&mut congestion_controller, &[], None, num_rounds),
     }
 }
@@ -236,7 +240,7 @@ fn loss_at_3mb_and_2_75mb<CC: CongestionController>(
     Simulation {
         name: "Loss at 3MB and 2.75MB",
         description: "Loss encountered at ~3MB and ~2.75MB",
-        cc: core::any::type_name::<CC>(),
+        cc: type_name::<CC>(),
         rounds: simulate_constant_rtt(
             &mut congestion_controller,
             &[3_000_000, 2_750_000],

--- a/quic/s2n-quic-core/tests/recovery/snapshots/recovery_simulation__AppLimited1MB-CubicCongestionController.snap
+++ b/quic/s2n-quic-core/tests/recovery/snapshots/recovery_simulation__AppLimited1MB-CubicCongestionController.snap
@@ -1,12 +1,13 @@
 ---
 source: quic/s2n-quic-core/tests/recovery/simulation.rs
+assertion_line: 148
 expression: self
 
 ---
 Simulation {
     name: "App Limited 1MB",
     description: "App limited to 1MB per round with loss encountered at ~750KB",
-    cc: "s2n_quic_core::recovery::cubic::CubicCongestionController",
+    cc: "CubicCongestionController",
     rounds: [
           0: pkts: 10,
           1: pkts: 20,

--- a/quic/s2n-quic-core/tests/recovery/snapshots/recovery_simulation__Lossat3MB-CubicCongestionController.snap
+++ b/quic/s2n-quic-core/tests/recovery/snapshots/recovery_simulation__Lossat3MB-CubicCongestionController.snap
@@ -1,12 +1,13 @@
 ---
 source: quic/s2n-quic-core/tests/recovery/simulation.rs
+assertion_line: 148
 expression: self
 
 ---
 Simulation {
     name: "Loss at 3MB",
     description: "Full congestion window utilization with loss encountered at ~3MB",
-    cc: "s2n_quic_core::recovery::cubic::CubicCongestionController",
+    cc: "CubicCongestionController",
     rounds: [
           0: pkts: 10,
           1: pkts: 20,

--- a/quic/s2n-quic-core/tests/recovery/snapshots/recovery_simulation__Lossat3MBand2_75MB-CubicCongestionController.snap
+++ b/quic/s2n-quic-core/tests/recovery/snapshots/recovery_simulation__Lossat3MBand2_75MB-CubicCongestionController.snap
@@ -1,12 +1,13 @@
 ---
 source: quic/s2n-quic-core/tests/recovery/simulation.rs
+assertion_line: 148
 expression: self
 
 ---
 Simulation {
     name: "Loss at 3MB and 2.75MB",
     description: "Loss encountered at ~3MB and ~2.75MB",
-    cc: "s2n_quic_core::recovery::cubic::CubicCongestionController",
+    cc: "CubicCongestionController",
     rounds: [
           0: pkts: 10,
           1: pkts: 20,

--- a/quic/s2n-quic-core/tests/recovery/snapshots/recovery_simulation__MinimumWindow-CubicCongestionController.snap
+++ b/quic/s2n-quic-core/tests/recovery/snapshots/recovery_simulation__MinimumWindow-CubicCongestionController.snap
@@ -1,12 +1,13 @@
 ---
 source: quic/s2n-quic-core/tests/recovery/simulation.rs
+assertion_line: 148
 expression: self
 
 ---
 Simulation {
     name: "Minimum Window",
     description: "Full congestion window utilization after starting from the minimum window",
-    cc: "s2n_quic_core::recovery::cubic::CubicCongestionController",
+    cc: "CubicCongestionController",
     rounds: [
           0: pkts: 2,
           1: pkts: 2,

--- a/quic/s2n-quic-core/tests/recovery/snapshots/recovery_simulation__SlowStartUnlimited-CubicCongestionController.snap
+++ b/quic/s2n-quic-core/tests/recovery/snapshots/recovery_simulation__SlowStartUnlimited-CubicCongestionController.snap
@@ -1,12 +1,13 @@
 ---
 source: quic/s2n-quic-core/tests/recovery/simulation.rs
+assertion_line: 148
 expression: self
 
 ---
 Simulation {
     name: "Slow Start Unlimited",
     description: "Full congestion window utilization with no congestion experienced",
-    cc: "s2n_quic_core::recovery::cubic::CubicCongestionController",
+    cc: "CubicCongestionController",
     rounds: [
           0: pkts: 10,
           1: pkts: 20,

--- a/quic/s2n-quic-transport/src/sync/data_sender/snapshots/s2n_quic_transport__sync__data_sender__transmissions__tests__transmission_entry_size.snap
+++ b/quic/s2n-quic-transport/src/sync/data_sender/snapshots/s2n_quic_transport__sync__data_sender__transmissions__tests__transmission_entry_size.snap
@@ -1,5 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/sync/data_sender/transmissions.rs
+assertion_line: 519
 expression: "size_of::<TransmissionSlabEntry>()"
 
 ---

--- a/quic/s2n-quic-transport/src/sync/data_sender/transmissions.rs
+++ b/quic/s2n-quic-transport/src/sync/data_sender/transmissions.rs
@@ -517,7 +517,7 @@ mod tests {
     #[test]
     fn size_test() {
         assert_debug_snapshot!(
-            "transmission entry size",
+            "transmission_entry_size",
             size_of::<TransmissionSlabEntry>()
         );
         assert_eq!(


### PR DESCRIPTION
Spaces in file names are annoying to work with. This change removes them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
