### PR TITLE
api: clean up errors

### DIFF
--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 [features]
 default = ["alloc", "std"]
 alloc = []
-std = ["alloc", "thiserror"]
+std = ["alloc"]
 testing = ["std", "generator", "s2n-codec/testing", "checked-counters", "insta", "futures-test"]
 generator = ["bolero-generator"]
 checked-counters = []
@@ -24,7 +24,6 @@ insta = { version = ">=1.12", optional = true }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features = false }
 subtle = { version = "2", default-features = false }
-thiserror = { version = "1", optional = true }
 tracing = { version = "0.1", default-features = false, optional = true }
 zerocopy = "=0.6.0"
 zerocopy-derive = "=0.3.0"

--- a/quic/s2n-quic-core/src/connection/close.rs
+++ b/quic/s2n-quic-core/src/connection/close.rs
@@ -121,7 +121,7 @@ impl Formatter for Production {
         }
 
         // only preserve the error code
-        transport::Error::new(*error.code).into()
+        transport::Error::new(error.code.as_varint()).into()
     }
 
     fn format_application_error(

--- a/quic/s2n-quic-core/src/connection/error.rs
+++ b/quic/s2n-quic-core/src/connection/error.rs
@@ -4,24 +4,31 @@
 use crate::{
     application, connection, crypto::CryptoError, endpoint, frame::ConnectionClose, transport,
 };
-use core::{fmt, time::Duration};
+use core::{convert::TryInto, fmt, panic, time::Duration};
 
 /// Errors that a connection can encounter.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
 #[non_exhaustive]
-#[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 pub enum Error {
     /// The connection was closed without an error
-    Closed { initiator: endpoint::Location },
+    #[non_exhaustive]
+    Closed {
+        initiator: endpoint::Location,
+        source: &'static panic::Location<'static>,
+    },
 
     /// The connection was closed on the transport level
     ///
     /// This can occur either locally or by the peer. The argument contains
     /// the error code which the transport provided in order to close the
     /// connection.
+    #[non_exhaustive]
     Transport {
-        error: transport::Error,
+        code: transport::error::Code,
+        frame_type: u64,
+        reason: &'static str,
         initiator: endpoint::Location,
+        source: &'static panic::Location<'static>,
     },
 
     /// The connection was closed on the application level
@@ -29,85 +36,123 @@ pub enum Error {
     /// This can occur either locally or by the peer. The argument contains
     /// the error code which the application/ supplied in order to close the
     /// connection.
+    #[non_exhaustive]
     Application {
         error: application::Error,
         initiator: endpoint::Location,
+        source: &'static panic::Location<'static>,
     },
 
     /// The connection was reset by a stateless reset from the peer
-    StatelessReset,
+    #[non_exhaustive]
+    StatelessReset {
+        source: &'static panic::Location<'static>,
+    },
 
     /// The connection was closed because the local connection's idle timer expired
-    IdleTimerExpired,
+    #[non_exhaustive]
+    IdleTimerExpired {
+        source: &'static panic::Location<'static>,
+    },
 
     /// The connection was closed because there are no valid paths
-    NoValidPath,
+    #[non_exhaustive]
+    NoValidPath {
+        source: &'static panic::Location<'static>,
+    },
 
     /// All Stream IDs for Streams on the given connection had been exhausted
-    StreamIdExhausted,
+    #[non_exhaustive]
+    StreamIdExhausted {
+        source: &'static panic::Location<'static>,
+    },
 
     /// The handshake has taken longer to complete than the configured max handshake duration
-    MaxHandshakeDurationExceeded { max_handshake_duration: Duration },
+    #[non_exhaustive]
+    MaxHandshakeDurationExceeded {
+        max_handshake_duration: Duration,
+        source: &'static panic::Location<'static>,
+    },
 
     /// The connection should be closed immediately without notifying the peer
-    ImmediateClose { reason: &'static str },
+    #[non_exhaustive]
+    ImmediateClose {
+        reason: &'static str,
+        source: &'static panic::Location<'static>,
+    },
 
     /// The connection attempt was rejected because the endpoint is closing
-    EndpointClosing,
+    #[non_exhaustive]
+    EndpointClosing {
+        source: &'static panic::Location<'static>,
+    },
 
     /// The connection was closed due to an unspecified reason
-    Unspecified,
+    #[non_exhaustive]
+    Unspecified {
+        source: &'static panic::Location<'static>,
+    },
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::Closed { initiator } => write!(
+            Self::Closed { initiator, .. } => write!(
                 f,
                 "The connection was closed without an error by {}",
                 initiator
             ),
-            Self::Transport { error, initiator } => write!(
-                f,
-                "The connection was closed on the transport level with error {} by {}",
-                error, initiator
-            ),
-            Self::Application { error, initiator } => write!(
+            Self::Transport { code, frame_type, reason, initiator, .. } => {
+                let error = transport::Error {
+                    code: *code,
+                    frame_type: (*frame_type).try_into().ok().unwrap_or_default(),
+                    reason,
+                };
+                write!(
+                    f,
+                    "The connection was closed on the transport level with error {} by {}",
+                    error, initiator
+                )
+            },
+            Self::Application { error, initiator, .. } => write!(
                 f,
                 "The connection was closed on the application level with error {:?} by {}",
                 error, initiator
             ),
-            Self::StatelessReset => write!(
+            Self::StatelessReset { .. } => write!(
                 f,
                 "The connection was reset by a stateless reset by {}",
                 endpoint::Location::Remote
             ),
-            Self::IdleTimerExpired => write!(
+            Self::IdleTimerExpired {.. } => write!(
                 f,
                 "The connection was closed because the connection's idle timer expired by {}",
                 endpoint::Location::Local
             ),
-            Self::NoValidPath => write!(
+            Self::NoValidPath { .. } => write!(
                 f,
                 "The connection was closed because there are no valid paths"
             ),
-            Self::StreamIdExhausted => write!(
+            Self::StreamIdExhausted { .. } => write!(
                 f,
                 "All Stream IDs for Streams on the given connection had been exhausted"
             ),
-            Self::MaxHandshakeDurationExceeded { max_handshake_duration } => write!(
+            Self::MaxHandshakeDurationExceeded { max_handshake_duration, .. } => write!(
               f,
                 "The connection was closed because the handshake took longer than the max handshake \
                 duration of {:?}", max_handshake_duration
             ),
-            Self::ImmediateClose { reason } => write!(
+            Self::ImmediateClose { reason, .. } => write!(
                 f,
                 "The connection was closed due to: {}", reason
             ),
-            Self::EndpointClosing => {
+            Self::EndpointClosing { .. } => {
                 write!(f, "The connection attempt was rejected because the endpoint is closing")
             }
-            Self::Unspecified => {
+            Self::Unspecified { .. } => {
                 write!(f, "The connection was closed due to an unspecified reason")
             }
         }
@@ -115,17 +160,129 @@ impl fmt::Display for Error {
 }
 
 impl Error {
+    /// Returns the [`panic::Location`] for the error
+    pub fn source(&self) -> &'static panic::Location<'static> {
+        match self {
+            Error::Closed { source, .. } => source,
+            Error::Transport { source, .. } => source,
+            Error::Application { source, .. } => source,
+            Error::StatelessReset { source } => source,
+            Error::IdleTimerExpired { source } => source,
+            Error::NoValidPath { source } => source,
+            Error::StreamIdExhausted { source } => source,
+            Error::MaxHandshakeDurationExceeded { source, .. } => source,
+            Error::ImmediateClose { source, .. } => source,
+            Error::EndpointClosing { source } => source,
+            Error::Unspecified { source } => source,
+        }
+    }
+
+    #[track_caller]
     fn from_transport_error(error: transport::Error, initiator: endpoint::Location) -> Self {
+        let source = panic::Location::caller();
         match error.code {
             // The connection closed without an error
-            code if code == transport::Error::NO_ERROR.code => Self::Closed { initiator },
+            code if code == transport::Error::NO_ERROR.code => Self::Closed { initiator, source },
             // The connection closed without an error at the application layer
             code if code == transport::Error::APPLICATION_ERROR.code && initiator.is_remote() => {
-                Self::Closed { initiator }
+                Self::Closed { initiator, source }
             }
             // The connection closed with an actual error
-            _ => Self::Transport { error, initiator },
+            _ => Self::Transport {
+                code: error.code,
+                frame_type: error.frame_type.into(),
+                reason: error.reason,
+                initiator,
+                source,
+            },
         }
+    }
+
+    #[inline]
+    #[track_caller]
+    #[doc(hidden)]
+    pub fn closed(initiator: endpoint::Location) -> Error {
+        let source = panic::Location::caller();
+        Error::Closed { initiator, source }
+    }
+
+    #[inline]
+    #[track_caller]
+    #[doc(hidden)]
+    pub fn immediate_close(reason: &'static str) -> Error {
+        let source = panic::Location::caller();
+        Error::ImmediateClose { reason, source }
+    }
+
+    #[inline]
+    #[track_caller]
+    #[doc(hidden)]
+    pub fn idle_timer_expired() -> Error {
+        let source = panic::Location::caller();
+        Error::IdleTimerExpired { source }
+    }
+
+    #[inline]
+    #[track_caller]
+    #[doc(hidden)]
+    pub fn stream_id_exhausted() -> Error {
+        let source = panic::Location::caller();
+        Error::StreamIdExhausted { source }
+    }
+
+    #[inline]
+    #[track_caller]
+    #[doc(hidden)]
+    pub fn no_valid_path() -> Error {
+        let source = panic::Location::caller();
+        Error::NoValidPath { source }
+    }
+
+    #[inline]
+    #[track_caller]
+    #[doc(hidden)]
+    pub fn stateless_reset() -> Error {
+        let source = panic::Location::caller();
+        Error::StatelessReset { source }
+    }
+
+    #[inline]
+    #[track_caller]
+    #[doc(hidden)]
+    pub fn max_handshake_duration_exceeded(max_handshake_duration: Duration) -> Error {
+        let source = panic::Location::caller();
+        Error::MaxHandshakeDurationExceeded {
+            max_handshake_duration,
+            source,
+        }
+    }
+
+    #[inline]
+    #[track_caller]
+    #[doc(hidden)]
+    pub fn application(error: application::Error) -> Error {
+        let source = panic::Location::caller();
+        Error::Application {
+            error,
+            initiator: endpoint::Location::Local,
+            source,
+        }
+    }
+
+    #[inline]
+    #[track_caller]
+    #[doc(hidden)]
+    pub fn endpoint_closing() -> Error {
+        let source = panic::Location::caller();
+        Error::EndpointClosing { source }
+    }
+
+    #[inline]
+    #[track_caller]
+    #[doc(hidden)]
+    pub fn unspecified() -> Error {
+        let source = panic::Location::caller();
+        Error::Unspecified { source }
     }
 }
 
@@ -139,7 +296,7 @@ pub fn as_frame<'a, F: connection::close::Formatter>(
     context: &'a connection::close::Context<'a>,
 ) -> Option<(ConnectionClose<'a>, ConnectionClose<'a>)> {
     match error {
-        Error::Closed { initiator } => {
+        Error::Closed { initiator, .. } => {
             // don't send CONNECTION_CLOSE frames on remote-initiated errors
             if initiator.is_remote() {
                 return None;
@@ -151,17 +308,31 @@ pub fn as_frame<'a, F: connection::close::Formatter>(
 
             Some((early, one_rtt))
         }
-        Error::Transport { error, initiator } => {
+        Error::Transport {
+            code,
+            frame_type,
+            reason,
+            initiator,
+            ..
+        } => {
             // don't send CONNECTION_CLOSE frames on remote-initiated errors
             if initiator.is_remote() {
                 return None;
             }
 
+            let error = transport::Error {
+                code,
+                frame_type: frame_type.try_into().unwrap_or_default(),
+                reason,
+            };
+
             let early = formatter.format_early_transport_error(context, error);
             let one_rtt = formatter.format_transport_error(context, error);
             Some((early, one_rtt))
         }
-        Error::Application { error, initiator } => {
+        Error::Application {
+            error, initiator, ..
+        } => {
             // don't send CONNECTION_CLOSE frames on remote-initiated errors
             if initiator.is_remote() {
                 return None;
@@ -172,11 +343,11 @@ pub fn as_frame<'a, F: connection::close::Formatter>(
             Some((early, one_rtt))
         }
         // This error comes from the peer so we don't respond with a CONNECTION_CLOSE
-        Error::StatelessReset => None,
+        Error::StatelessReset { .. } => None,
         // Nothing gets sent on idle timeouts
-        Error::IdleTimerExpired => None,
-        Error::NoValidPath => None,
-        Error::StreamIdExhausted => {
+        Error::IdleTimerExpired { .. } => None,
+        Error::NoValidPath { .. } => None,
+        Error::StreamIdExhausted { .. } => {
             let error =
                 transport::Error::PROTOCOL_VIOLATION.with_reason("stream IDs have been exhausted");
 
@@ -187,8 +358,8 @@ pub fn as_frame<'a, F: connection::close::Formatter>(
         }
         Error::MaxHandshakeDurationExceeded { .. } => None,
         Error::ImmediateClose { .. } => None,
-        Error::EndpointClosing => None,
-        Error::Unspecified => {
+        Error::EndpointClosing { .. } => None,
+        Error::Unspecified { .. } => {
             let error =
                 transport::Error::INTERNAL_ERROR.with_reason("an unspecified error occurred");
 
@@ -211,22 +382,25 @@ impl application::error::TryInto for Error {
 }
 
 impl From<transport::Error> for Error {
+    #[track_caller]
     fn from(error: transport::Error) -> Self {
         Self::from_transport_error(error, endpoint::Location::Local)
     }
 }
 
 impl From<CryptoError> for Error {
+    #[track_caller]
     fn from(error: CryptoError) -> Self {
         transport::Error::from(error).into()
     }
 }
 
 impl<'a> From<ConnectionClose<'a>> for Error {
+    #[track_caller]
     fn from(error: ConnectionClose) -> Self {
         if let Some(frame_type) = error.frame_type {
             let error = transport::Error {
-                code: error.error_code.into(),
+                code: transport::error::Code::new(error.error_code),
                 // we use an empty `&'static str` so we don't allocate anything
                 // in the event of an error
                 reason: "",
@@ -234,9 +408,11 @@ impl<'a> From<ConnectionClose<'a>> for Error {
             };
             Self::from_transport_error(error, endpoint::Location::Remote)
         } else {
+            let source = panic::Location::caller();
             Self::Application {
                 error: error.error_code.into(),
                 initiator: endpoint::Location::Remote,
+                source,
             }
         }
     }
@@ -256,21 +432,19 @@ impl From<Error> for std::io::ErrorKind {
         use std::io::ErrorKind;
         match error {
             Error::Closed { .. } => ErrorKind::ConnectionAborted,
-            Error::Transport { error, .. }
-                if error.code == transport::Error::CONNECTION_REFUSED.code =>
-            {
+            Error::Transport { code, .. } if code == transport::Error::CONNECTION_REFUSED.code => {
                 ErrorKind::ConnectionRefused
             }
             Error::Transport { .. } => ErrorKind::ConnectionReset,
             Error::Application { .. } => ErrorKind::ConnectionReset,
-            Error::StatelessReset => ErrorKind::ConnectionReset,
-            Error::IdleTimerExpired => ErrorKind::TimedOut,
-            Error::NoValidPath => ErrorKind::Other,
-            Error::StreamIdExhausted => ErrorKind::Other,
-            Error::MaxHandshakeDurationExceeded { .. } => ErrorKind::Other,
+            Error::StatelessReset { .. } => ErrorKind::ConnectionReset,
+            Error::IdleTimerExpired { .. } => ErrorKind::TimedOut,
+            Error::NoValidPath { .. } => ErrorKind::Other,
+            Error::StreamIdExhausted { .. } => ErrorKind::Other,
+            Error::MaxHandshakeDurationExceeded { .. } => ErrorKind::TimedOut,
             Error::ImmediateClose { .. } => ErrorKind::Other,
             Error::EndpointClosing { .. } => ErrorKind::Other,
-            Error::Unspecified => ErrorKind::Other,
+            Error::Unspecified { .. } => ErrorKind::Other,
         }
     }
 }
@@ -294,6 +468,7 @@ impl From<Error> for ProcessingError {
 }
 
 impl From<crate::transport::Error> for ProcessingError {
+    #[track_caller]
     fn from(inner_error: crate::transport::Error) -> Self {
         // Try extracting out the crypto error from other transport errors
         if let Some(error) = inner_error.try_into_crypto_error() {

--- a/quic/s2n-quic-core/src/stream/error.rs
+++ b/quic/s2n-quic-core/src/stream/error.rs
@@ -2,69 +2,99 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{application, connection, frame::ConnectionClose, transport};
-use core::fmt;
+use core::{fmt, panic};
 
 /// Errors that a stream can encounter.
 #[derive(PartialEq, Eq, Debug, Copy, Clone)]
-#[cfg_attr(feature = "thiserror", derive(thiserror::Error))]
 #[non_exhaustive]
 pub enum StreamError {
     /// The Stream ID which was referenced is invalid
     ///
     /// This could mean the ID is no longer tracked by the Connection.
-    InvalidStream,
+    #[non_exhaustive]
+    InvalidStream {
+        source: &'static panic::Location<'static>,
+    },
     /// The Stream had been reset by the peer via a `RESET_STREAM` frame.
     ///
     /// Inside this frame the peer will deliver an error code, which will be
     /// provided by the parameter.
-    StreamReset(application::Error),
+    #[non_exhaustive]
+    StreamReset {
+        error: application::Error,
+        source: &'static panic::Location<'static>,
+    },
     /// A send attempt had been performed on a Stream after it was closed
-    SendAfterFinish,
+    #[non_exhaustive]
+    SendAfterFinish {
+        source: &'static panic::Location<'static>,
+    },
     /// Attempting to write data would exceed the stream limit
     ///
     /// This is caused because the maximum possible amount
     /// of data (2^62-1 bytes) had already been written to the
     /// Stream.
-    MaxStreamDataSizeExceeded,
+    #[non_exhaustive]
+    MaxStreamDataSizeExceeded {
+        source: &'static panic::Location<'static>,
+    },
     /// The Stream was reset due to a Connection Error
-    ConnectionError(connection::Error),
+    #[non_exhaustive]
+    ConnectionError { error: connection::Error },
     /// The stream is not readable
-    NonReadable,
+    #[non_exhaustive]
+    NonReadable {
+        source: &'static panic::Location<'static>,
+    },
     /// The stream is not writable
-    NonWritable,
+    #[non_exhaustive]
+    NonWritable {
+        source: &'static panic::Location<'static>,
+    },
     /// The stream is blocked on writing data
     ///
     /// This is caused by trying to send data before polling readiness
-    SendingBlocked,
+    #[non_exhaustive]
+    SendingBlocked {
+        source: &'static panic::Location<'static>,
+    },
     /// The stream was provided a non-empty placeholder buffer for receiving data.
     ///
     /// The application should ensure only empty buffers are provided to receive calls,
     /// otherwise it can lead to data loss on the stream.
-    NonEmptyOutput,
+    #[non_exhaustive]
+    NonEmptyOutput {
+        source: &'static panic::Location<'static>,
+    },
 }
+
+#[cfg(feature = "std")]
+impl std::error::Error for StreamError {}
 
 impl fmt::Display for StreamError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::InvalidStream => write!(f, "The Stream ID which was referenced is invalid"),
-            Self::StreamReset(error) => write!(
+            Self::InvalidStream { .. } => {
+                write!(f, "The Stream ID which was referenced is invalid")
+            }
+            Self::StreamReset { error, .. } => write!(
                 f,
                 "The Stream had been reset with the error {:?} by {}",
                 error,
                 crate::endpoint::Location::Remote,
             ),
-            Self::SendAfterFinish => write!(
+            Self::SendAfterFinish { .. } => write!(
                 f,
                 "A send attempt had been performed on a Stream after it was closed"
             ),
-            Self::MaxStreamDataSizeExceeded => {
+            Self::MaxStreamDataSizeExceeded { .. } => {
                 write!(f, "Attempting to write data would exceed the stream limit")
             }
-            Self::ConnectionError(error) => error.fmt(f),
-            Self::NonReadable => write!(f, "The stream is not readable"),
-            Self::NonWritable => write!(f, "The stream is not writable"),
-            Self::SendingBlocked => write!(f, "The stream is blocked on writing data"),
-            Self::NonEmptyOutput => write!(
+            Self::ConnectionError { error, .. } => error.fmt(f),
+            Self::NonReadable { .. } => write!(f, "The stream is not readable"),
+            Self::NonWritable { .. } => write!(f, "The stream is not writable"),
+            Self::SendingBlocked { .. } => write!(f, "The stream is blocked on writing data"),
+            Self::NonEmptyOutput { .. } => write!(
                 f,
                 "The stream was provided a non-empty placeholder buffer for receiving data."
             ),
@@ -72,9 +102,90 @@ impl fmt::Display for StreamError {
     }
 }
 
+impl StreamError {
+    /// Returns the [`panic::Location`] for the error
+    pub fn source(&self) -> &'static panic::Location<'static> {
+        match self {
+            StreamError::InvalidStream { source } => source,
+            StreamError::StreamReset { source, .. } => source,
+            StreamError::SendAfterFinish { source } => source,
+            StreamError::MaxStreamDataSizeExceeded { source } => source,
+            StreamError::ConnectionError { error } => error.source(),
+            StreamError::NonReadable { source } => source,
+            StreamError::NonWritable { source } => source,
+            StreamError::SendingBlocked { source } => source,
+            StreamError::NonEmptyOutput { source } => source,
+        }
+    }
+
+    #[track_caller]
+    #[inline]
+    #[doc(hidden)]
+    pub fn invalid_stream() -> StreamError {
+        let source = panic::Location::caller();
+        StreamError::InvalidStream { source }
+    }
+
+    #[track_caller]
+    #[inline]
+    #[doc(hidden)]
+    pub fn stream_reset(error: application::Error) -> StreamError {
+        let source = panic::Location::caller();
+        StreamError::StreamReset { source, error }
+    }
+
+    #[track_caller]
+    #[inline]
+    #[doc(hidden)]
+    pub fn send_after_finish() -> StreamError {
+        let source = panic::Location::caller();
+        StreamError::SendAfterFinish { source }
+    }
+
+    #[track_caller]
+    #[inline]
+    #[doc(hidden)]
+    pub fn max_stream_data_size_exceeded() -> StreamError {
+        let source = panic::Location::caller();
+        StreamError::MaxStreamDataSizeExceeded { source }
+    }
+
+    #[track_caller]
+    #[inline]
+    #[doc(hidden)]
+    pub fn non_readable() -> StreamError {
+        let source = panic::Location::caller();
+        StreamError::NonReadable { source }
+    }
+
+    #[track_caller]
+    #[inline]
+    #[doc(hidden)]
+    pub fn non_writable() -> StreamError {
+        let source = panic::Location::caller();
+        StreamError::NonWritable { source }
+    }
+
+    #[track_caller]
+    #[inline]
+    #[doc(hidden)]
+    pub fn sending_blocked() -> StreamError {
+        let source = panic::Location::caller();
+        StreamError::SendingBlocked { source }
+    }
+
+    #[track_caller]
+    #[inline]
+    #[doc(hidden)]
+    pub fn non_empty_output() -> StreamError {
+        let source = panic::Location::caller();
+        StreamError::NonEmptyOutput { source }
+    }
+}
+
 impl application::error::TryInto for StreamError {
     fn application_error(&self) -> Option<application::Error> {
-        if let StreamError::ConnectionError(error) = self {
+        if let StreamError::ConnectionError { error, .. } = self {
             error.application_error()
         } else {
             None
@@ -84,19 +195,23 @@ impl application::error::TryInto for StreamError {
 
 impl From<connection::Error> for StreamError {
     fn from(error: connection::Error) -> Self {
-        Self::ConnectionError(error)
+        Self::ConnectionError { error }
     }
 }
 
 impl From<transport::Error> for StreamError {
+    #[track_caller]
     fn from(error: transport::Error) -> Self {
-        Self::ConnectionError(error.into())
+        let error: connection::Error = error.into();
+        error.into()
     }
 }
 
 impl<'a> From<ConnectionClose<'a>> for StreamError {
+    #[track_caller]
     fn from(error: ConnectionClose) -> Self {
-        Self::ConnectionError(error.into())
+        let error: connection::Error = error.into();
+        error.into()
     }
 }
 
@@ -113,15 +228,15 @@ impl From<StreamError> for std::io::ErrorKind {
     fn from(error: StreamError) -> Self {
         use std::io::ErrorKind;
         match error {
-            StreamError::InvalidStream => ErrorKind::NotFound,
-            StreamError::StreamReset(_) => ErrorKind::ConnectionReset,
-            StreamError::SendAfterFinish => ErrorKind::BrokenPipe,
-            StreamError::MaxStreamDataSizeExceeded => ErrorKind::Other,
-            StreamError::ConnectionError(error) => error.into(),
-            StreamError::NonReadable => ErrorKind::Other,
-            StreamError::NonWritable => ErrorKind::Other,
-            StreamError::SendingBlocked => ErrorKind::WouldBlock,
-            StreamError::NonEmptyOutput => ErrorKind::InvalidInput,
+            StreamError::InvalidStream { .. } => ErrorKind::NotFound,
+            StreamError::StreamReset { .. } => ErrorKind::ConnectionReset,
+            StreamError::SendAfterFinish { .. } => ErrorKind::BrokenPipe,
+            StreamError::MaxStreamDataSizeExceeded { .. } => ErrorKind::Other,
+            StreamError::ConnectionError { error, .. } => error.into(),
+            StreamError::NonReadable { .. } => ErrorKind::Other,
+            StreamError::NonWritable { .. } => ErrorKind::Other,
+            StreamError::SendingBlocked { .. } => ErrorKind::WouldBlock,
+            StreamError::NonEmptyOutput { .. } => ErrorKind::InvalidInput,
         }
     }
 }

--- a/quic/s2n-quic-transport/src/connection/connection_container.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container.rs
@@ -142,7 +142,7 @@ impl<C: connection::Trait, L: connection::Lock<C>> ConnectionNode<C, L> {
     ) -> Result<R, E> {
         match self.inner.write(|conn| f(conn)) {
             Ok(res) => res,
-            Err(_) => Err(connection::Error::Unspecified.into()),
+            Err(_) => Err(connection::Error::unspecified().into()),
         }
     }
 
@@ -153,7 +153,7 @@ impl<C: connection::Trait, L: connection::Lock<C>> ConnectionNode<C, L> {
     ) -> Result<R, E> {
         match self.inner.read(|conn| f(conn)) {
             Ok(res) => res,
-            Err(_) => Err(connection::Error::Unspecified.into()),
+            Err(_) => Err(connection::Error::unspecified().into()),
         }
     }
 
@@ -164,7 +164,7 @@ impl<C: connection::Trait, L: connection::Lock<C>> ConnectionNode<C, L> {
     ) -> Poll<Result<R, E>> {
         match self.inner.write(|conn| f(conn)) {
             Ok(res) => res,
-            Err(_) => Poll::Ready(Err(connection::Error::Unspecified.into())),
+            Err(_) => Poll::Ready(Err(connection::Error::unspecified().into())),
         }
     }
 }
@@ -668,7 +668,7 @@ impl<C: connection::Trait, L: connection::Lock<C>> ConnectionContainer<C, L> {
         while let Ok(Some(request)) = self.connector_receiver.try_next() {
             if request
                 .sender
-                .send(Err(connection::Error::EndpointClosing))
+                .send(Err(connection::Error::endpoint_closing()))
                 .is_err()
             {
                 // the application is no longer waiting so skip

--- a/quic/s2n-quic-transport/src/endpoint/connect.rs
+++ b/quic/s2n-quic-transport/src/endpoint/connect.rs
@@ -139,13 +139,13 @@ impl Future for Attempt {
                                 }
                                 Err(_) => {
                                     // The endpoint has closed
-                                    return Err(connection::Error::Unspecified).into();
+                                    return Err(connection::Error::unspecified()).into();
                                 }
                             }
                         }
                         Poll::Ready(Err(_)) => {
                             // The endpoint has closed
-                            return Err(connection::Error::Unspecified).into();
+                            return Err(connection::Error::unspecified()).into();
                         }
                         Poll::Pending => {
                             // reset to the original state
@@ -160,7 +160,7 @@ impl Future for Attempt {
                         Poll::Ready(Ok(res)) => Poll::Ready(res),
                         Poll::Ready(Err(_)) => {
                             // The endpoint has closed
-                            Err(connection::Error::Unspecified).into()
+                            Err(connection::Error::unspecified()).into()
                         }
                         Poll::Pending => {
                             self.state = AttemptState::Waiting(response);

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -300,7 +300,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                         false,
                         "on_datagram_received should not fail for a newly created connection"
                     );
-                    connection::Error::Unspecified
+                    connection::Error::unspecified()
                 })?;
 
                 connection

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -873,7 +873,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
         //# and not send any further packets on this connection.
         self.connections.with_connection(internal_id, |conn| {
             conn.close(
-                connection::Error::StatelessReset,
+                connection::Error::stateless_reset(),
                 endpoint_context.connection_close_formatter,
                 close_packet_buffer,
                 timestamp,

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -748,7 +748,7 @@ impl<Config: endpoint::Config> Manager<Config> {
                     //= https://www.rfc-editor.org/rfc/rfc9000#section-10
                     //# An endpoint MAY discard connection state if it does not have a
                     //# validated path on which it can send packets; see Section 8.2
-                    return Err(connection::Error::NoValidPath);
+                    return Err(connection::Error::no_valid_path());
                 }
             }
         }

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -514,7 +514,10 @@ fn silently_return_when_there_is_no_valid_path() {
 
     // Expectation:
     assert!(!manager[first_path_id].is_challenge_pending());
-    assert_eq!(res.unwrap_err(), connection::Error::NoValidPath);
+    assert!(matches!(
+        res.unwrap_err(),
+        connection::Error::NoValidPath { .. }
+    ));
 }
 
 #[test]

--- a/quic/s2n-quic-transport/src/stream/api.rs
+++ b/quic/s2n-quic-transport/src/stream/api.rs
@@ -176,7 +176,7 @@ macro_rules! tx_stream_apis {
 
             match self.tx_request()?.send(&mut [chunk]).poll(None)? {
                 response if response.tx().expect("invalid response").chunks.consumed == 1 => Ok(()),
-                _ => Err(StreamError::SendingBlocked),
+                _ => Err(StreamError::sending_blocked()),
             }
         }
 

--- a/quic/s2n-quic-transport/src/stream/contract.rs
+++ b/quic/s2n-quic-transport/src/stream/contract.rs
@@ -424,7 +424,7 @@ pub mod rx {
                 let should_error = chunks.iter().any(|chunk| !chunk.is_empty());
 
                 if should_error {
-                    assert_eq!(response, Err(&StreamError::NonEmptyOutput));
+                    assert!(matches!(response, Err(StreamError::NonEmptyOutput { .. })));
                     return;
                 }
 

--- a/quic/s2n-quic-transport/src/stream/receive_stream.rs
+++ b/quic/s2n-quic-transport/src/stream/receive_stream.rs
@@ -527,7 +527,7 @@ impl ReceiveStream {
         //# error code in any RESET_STREAM frames subsequently received for that
         //# stream.
 
-        let error = StreamError::StreamReset(frame.application_error_code.into());
+        let error = StreamError::stream_reset(frame.application_error_code.into());
         self.init_reset(error, Some(frame.final_size), Some(frame.tag()))?;
 
         // We don't have to send `STOP_SENDING` anymore since the stream was reset by the peer
@@ -695,7 +695,7 @@ impl ReceiveStream {
 
             // Mark the stream as reset. Note that the request doesn't have a flush so there's
             // currently no way to wait for the reset to be acknowledged.
-            response.status = ops::Status::Reset(StreamError::StreamReset(error_code));
+            response.status = ops::Status::Reset(StreamError::stream_reset(error_code));
 
             return Ok(response);
         }
@@ -734,7 +734,7 @@ impl ReceiveStream {
                 // We iterate over all of the chunks to make sure we don't do a partial write and
                 // return an error (which would result in losing data).
                 if chunks.iter().any(|chunk| !chunk.is_empty()) {
-                    return Err(StreamError::NonEmptyOutput);
+                    return Err(StreamError::non_empty_output());
                 }
 
                 while response.chunks.consumed < chunks.len() {

--- a/quic/s2n-quic-transport/src/stream/tests/mod.rs
+++ b/quic/s2n-quic-transport/src/stream/tests/mod.rs
@@ -9,6 +9,17 @@ pub use crate::contexts::testing::*;
 mod test_environment;
 pub use test_environment::*;
 
+macro_rules! assert_matches {
+    ($a:expr, $b:pat $(,)?) => {
+        match $a {
+            $b => {}
+            ref value => {
+                panic!("value {:?} did not match {}", value, stringify!($b))
+            }
+        }
+    };
+}
+
 /// Creates a `STREAM_DATA` frame
 pub fn stream_data<Data>(
     stream_id: StreamId,

--- a/quic/s2n-quic-transport/src/stream/tests/receive_stream_tests.rs
+++ b/quic/s2n-quic-transport/src/stream/tests/receive_stream_tests.rs
@@ -448,7 +448,7 @@ fn receive_fin_twice_at_different_positions() {
         events = StreamEvents::new();
         test_env
             .stream
-            .on_internal_reset(connection::Error::Unspecified.into(), &mut events);
+            .on_internal_reset(connection::Error::unspecified().into(), &mut events);
         assert_eq!(1, events.waker_count());
 
         test_env.assert_pop_error();
@@ -649,7 +649,7 @@ fn exceed_stream_flow_control_window() {
     events = StreamEvents::new();
     test_env
         .stream
-        .on_internal_reset(connection::Error::Unspecified.into(), &mut events);
+        .on_internal_reset(connection::Error::unspecified().into(), &mut events);
 
     assert_eq!(
         stream_interests(&[]),
@@ -697,7 +697,7 @@ fn exceed_connection_flow_control_window() {
     events = StreamEvents::new();
     test_env
         .stream
-        .on_internal_reset(connection::Error::Unspecified.into(), &mut events);
+        .on_internal_reset(connection::Error::unspecified().into(), &mut events);
 
     assert_eq!(
         stream_interests(&[]),
@@ -2531,18 +2531,16 @@ fn receiving_into_non_empty_buffers_returns_an_error() {
 
     test_env.feed_data(VarInt::from_u8(0), 32);
 
-    assert_eq!(
-        Poll::Ready(Err(StreamError::NonEmptyOutput)),
+    assert_matches!(
         test_env.poll_request(ops::Request::default().receive(&mut [Bytes::from(&[1][..])])),
-        "non-empty buffers should return an error",
+        Poll::Ready(Err(StreamError::NonEmptyOutput { .. })),
     );
 
-    assert_eq!(
-        Poll::Ready(Err(StreamError::NonEmptyOutput)),
+    assert_matches!(
         test_env.poll_request(
             ops::Request::default().receive(&mut [Bytes::new(), Bytes::from(&[1][..])])
         ),
-        "all buffers should be pre-scanned for contents"
+        Poll::Ready(Err(StreamError::NonEmptyOutput { .. })),
     );
 
     assert_eq!(

--- a/quic/s2n-quic/src/connection.rs
+++ b/quic/s2n-quic/src/connection.rs
@@ -13,6 +13,10 @@ pub use acceptor::*;
 pub use handle::*;
 pub use s2n_quic_core::connection::Error;
 
+pub mod error {
+    pub use s2n_quic_core::{endpoint::Location, transport::error::Code};
+}
+
 pub type Result<T, E = Error> = core::result::Result<T, E>;
 
 pub struct Connection(Inner);

--- a/quic/s2n-quic/src/stream/receive.rs
+++ b/quic/s2n-quic/src/stream/receive.rs
@@ -58,7 +58,7 @@ macro_rules! impl_receive_stream_api {
         ) -> core::task::Poll<$crate::stream::Result<Option<bytes::Bytes>>> {
             macro_rules! $dispatch {
                 () => {
-                    Err($crate::stream::Error::NonReadable).into()
+                    Err($crate::stream::Error::non_readable()).into()
                 };
                 ($variant: expr) => {
                     $variant.poll_receive(cx)
@@ -142,7 +142,7 @@ macro_rules! impl_receive_stream_api {
         ) -> core::task::Poll<$crate::stream::Result<(usize, bool)>> {
             macro_rules! $dispatch {
                 () => {
-                    Err($crate::stream::Error::NonReadable).into()
+                    Err($crate::stream::Error::non_readable()).into()
                 };
                 ($variant: expr) => {
                     $variant.poll_receive_vectored(chunks, cx)
@@ -193,7 +193,7 @@ macro_rules! impl_receive_stream_api {
         ) -> $crate::stream::Result<()> {
             macro_rules! $dispatch {
                 () => {
-                    Err($crate::stream::Error::NonReadable)
+                    Err($crate::stream::Error::non_readable())
                 };
                 ($variant: expr) => {
                     $variant.stop_sending(error_code)
@@ -211,7 +211,7 @@ macro_rules! impl_receive_stream_api {
         ) -> $crate::stream::Result<s2n_quic_transport::stream::RxRequest> {
             macro_rules! $dispatch {
                 () => {
-                    Err($crate::stream::Error::NonReadable)
+                    Err($crate::stream::Error::non_readable())
                 };
                 ($variant: expr) => {
                     $variant.rx_request()

--- a/quic/s2n-quic/src/stream/send.rs
+++ b/quic/s2n-quic/src/stream/send.rs
@@ -55,7 +55,7 @@ macro_rules! impl_send_stream_api {
         ) -> core::task::Poll<$crate::stream::Result<()>> {
             macro_rules! $dispatch {
                 () => {
-                    Err($crate::stream::Error::NonWritable).into()
+                    Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
                     $variant.poll_send(chunk, cx)
@@ -131,7 +131,7 @@ macro_rules! impl_send_stream_api {
         ) -> core::task::Poll<$crate::stream::Result<usize>> {
             macro_rules! $dispatch {
                 () => {
-                    Err($crate::stream::Error::NonWritable).into()
+                    Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
                     $variant.poll_send_vectored(chunks, cx)
@@ -162,7 +162,7 @@ macro_rules! impl_send_stream_api {
         ) -> core::task::Poll<$crate::stream::Result<usize>> {
             macro_rules! $dispatch {
                 () => {
-                    Err($crate::stream::Error::NonWritable).into()
+                    Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
                     $variant.poll_send_ready(cx)
@@ -188,7 +188,7 @@ macro_rules! impl_send_stream_api {
         pub fn send_data(&mut self, chunk: bytes::Bytes) -> $crate::stream::Result<()> {
             macro_rules! $dispatch {
                 () => {
-                    Err($crate::stream::Error::NonWritable)
+                    Err($crate::stream::Error::non_writable())
                 };
                 ($variant: expr) => {
                     $variant.send_data(chunk)
@@ -245,7 +245,7 @@ macro_rules! impl_send_stream_api {
         ) -> core::task::Poll<$crate::stream::Result<()>> {
             macro_rules! $dispatch {
                 () => {
-                    Err($crate::stream::Error::NonWritable).into()
+                    Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
                     $variant.poll_flush(cx)
@@ -274,7 +274,7 @@ macro_rules! impl_send_stream_api {
         pub fn finish(&mut self) -> $crate::stream::Result<()> {
             macro_rules! $dispatch {
                 () => {
-                    Err($crate::stream::Error::NonWritable).into()
+                    Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
                     $variant.finish()
@@ -336,7 +336,7 @@ macro_rules! impl_send_stream_api {
         ) -> core::task::Poll<$crate::stream::Result<()>> {
             macro_rules! $dispatch {
                 () => {
-                    Err($crate::stream::Error::NonWritable).into()
+                    Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
                     $variant.poll_close(cx)
@@ -366,7 +366,7 @@ macro_rules! impl_send_stream_api {
         ) -> $crate::stream::Result<()> {
             macro_rules! $dispatch {
                 () => {
-                    Err($crate::stream::Error::NonWritable)
+                    Err($crate::stream::Error::non_writable())
                 };
                 ($variant: expr) => {
                     $variant.reset(error_code)


### PR DESCRIPTION
I noticed that the error variants were non-exhaustive, which would prevent us from adding new fields. This change adds the non_exhaustive attribute and adds [`panic::Location`](https://doc.rust-lang.org/nightly/core/panic/struct.Location.html#)s to each variant to make it easier for applications to debug _why_ an error was encountered.

* [`connection::Error`](https://dnglbrstg7yg.cloudfront.net/b90b7b6851e6a8e6f02bba8cc15fd0e51345ae21/doc/s2n_quic/connection/enum.Error.html)
* [`stream::Error`](https://dnglbrstg7yg.cloudfront.net/b90b7b6851e6a8e6f02bba8cc15fd0e51345ae21/doc/s2n_quic/stream/enum.Error.html)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
