### PR TITLE
ci: gate authenticated steps to 1st-party branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,16 +36,6 @@ jobs:
           export VERSIONS=$(echo $RAW_VERSIONS | jq -scR 'rtrimstr("\n")|split(" ")|.')
           echo "::set-output name=versions::$VERSIONS"
 
-      - uses: ouzi-dev/commit-status-updater@v1.1.2
-        with:
-          name: 'compliance / report'
-          status: 'pending'
-
-      - uses: ouzi-dev/commit-status-updater@v1.1.2
-        with:
-          name: 'doc / report'
-          status: 'pending'
-
   rustfmt:
     runs-on: ubuntu-latest
     steps:
@@ -88,12 +78,12 @@ jobs:
 
       - uses: camshaft/rust-cache@v1
 
+      # TODO translate json reports to in-action warnings
       - name: Run cargo clippy
-        uses: actions-rs/clippy-check@v1.0.7
+        uses: actions-rs/cargo@v1.0.3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          command: clippy
           args: --all-features --all-targets -- -D warnings
-          name: clippy (${{ matrix.toolchain }}) / report
 
   udeps:
     runs-on: ubuntu-latest
@@ -118,7 +108,7 @@ jobs:
       - name: Run cargo udeps
         run: cargo udeps --workspace --all-targets
         env:
-          RUSTC_WRAPPER: ''
+          RUSTC_WRAPPER: ""
 
   doc:
     runs-on: ubuntu-latest
@@ -143,12 +133,14 @@ jobs:
           args: --all-features --no-deps --workspace --exclude duvet --exclude s2n-quic-qns
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload to S3
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET="${{ github.sha }}/doc"
@@ -157,9 +149,10 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
-          name: 'doc / report'
-          status: 'success'
+          name: "doc / report"
+          status: "success"
           url: "${{ steps.s3.outputs.URL }}"
 
   test:
@@ -299,12 +292,14 @@ jobs:
         run: ./scripts/compliance ${{ github.sha }}
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload to S3
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET="${{ github.sha }}/compliance.html"
@@ -313,9 +308,10 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
-          name: 'compliance / report'
-          status: 'success'
+          name: "compliance / report"
+          status: "success"
           url: "${{ steps.s3.outputs.URL }}"
 
   coverage:
@@ -349,12 +345,14 @@ jobs:
           args: --html --no-fail-fast --workspace --exclude s2n-quic-qns --exclude s2n-quic-events --exclude cargo-compliance --all-features
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload results
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET="${{ github.sha }}/coverage"
@@ -363,16 +361,22 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
-          name: 'coverage / report'
-          status: 'success'
+          name: "coverage / report"
+          status: "success"
           url: "${{ steps.s3.outputs.URL }}"
 
   examples:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        example: [examples/echo, examples/rustls-provider, examples/dos-mitigation, examples/event-framework]
+        example:
+          - examples/echo
+          - examples/rustls-provider
+          - examples/dos-mitigation
+          - examples/event-framework
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -414,12 +418,14 @@ jobs:
           ./scripts/recovery-sim
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload to S3
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET="${{ github.sha }}/recovery-simulations"
@@ -428,9 +434,10 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
-          name: 'recovery-simulations / report'
-          status: 'success'
+          name: "recovery-simulations / report"
+          status: "success"
           url: "${{ steps.s3.outputs.URL }}"
 
   copyright:
@@ -522,12 +529,14 @@ jobs:
           cargo build -Z timings --release
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload to S3
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET="${{ github.sha }}/timing/index.html"
@@ -536,9 +545,10 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
-          name: 'timing / report'
-          status: 'success'
+          name: "timing / report"
+          status: "success"
           url: "${{ steps.s3.outputs.URL }}"
 
   typos:

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -5,23 +5,23 @@ on:
     branches:
       - main
     paths:
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - '.github/config/cargo-deny.toml'
-      - '.github/workflows/dependencies.yml'
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/config/cargo-deny.toml"
+      - ".github/workflows/dependencies.yml"
 
   pull_request:
     branches:
       - main
     paths:
-      - '**/Cargo.toml'
-      - '**/Cargo.lock'
-      - '.github/config/cargo-deny.toml'
-      - '.github/workflows/dependencies.yml'
+      - "**/Cargo.toml"
+      - "**/Cargo.lock"
+      - ".github/config/cargo-deny.toml"
+      - ".github/workflows/dependencies.yml"
 
   schedule:
     # run every morning at 10am Pacific Time
-    - cron: '0 17 * * *'
+    - cron: "0 17 * * *"
 
 jobs:
   audit:
@@ -53,7 +53,7 @@ jobs:
         with:
           submodules: true
 
-      - name: 'Remove rust-toolchain'
+      - name: "Remove rust-toolchain"
         run: rm rust-toolchain
 
       - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -31,16 +31,6 @@ jobs:
     outputs:
       matrix: ${{ steps.implementations.outputs.matrix }}
     steps:
-      - uses: ouzi-dev/commit-status-updater@v1.1.2
-        with:
-          name: 'interop / report'
-          status: 'pending'
-
-      - uses: ouzi-dev/commit-status-updater@v1.1.2
-        with:
-          name: 'bench / report'
-          status: 'pending'
-
       - uses: actions/checkout@v2
         with:
           path: s2n-quic
@@ -303,12 +293,14 @@ jobs:
           done
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload to S3
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         id: s3
         working-directory: quic-interop-runner
         run: |
@@ -347,7 +339,7 @@ jobs:
 
       - name: Get latest successfull interop commit SHA on main branch
         id: mainsha
-        if: github.event.pull_request
+        if: github.event.pull_request && github.repository.name == github.pull_request.head.repo.full_name
         run: |
           curl \
           --url "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/workflows/qns.yml/runs?branch=main&status=success&per_page=1" \
@@ -358,14 +350,14 @@ jobs:
           echo "::set-output name=MAIN_SHA::$MAIN_SHA"
 
       - name: Download latest main interop result
-        if: github.event.pull_request
+        if: github.event.pull_request && github.repository.name == github.pull_request.head.repo.full_name
         run: |
           rm -f prev_result.json
           wget $CDN/${{ steps.mainsha.outputs.MAIN_SHA }}/interop/logs/latest/result.json || echo '{}' > result.json
           mv result.json prev_result.json
 
       - name: Generate report for pull request
-        if: github.event.pull_request
+        if: github.event.pull_request && github.repository.name == github.pull_request.head.repo.full_name
         run: |
           mkdir -p web/logs/latest
           MAIN_SHA=${{ steps.mainsha.outputs.MAIN_SHA }}
@@ -394,12 +386,14 @@ jobs:
               web/logs/latest/result.json
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload to S3
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         id: s3
         run: |
           cp .github/interop/*.html web/
@@ -410,8 +404,9 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
-          name: 'interop / report'
+          name: "interop / report"
           status: "success"
           url: "${{ steps.s3.outputs.URL }}"
 
@@ -496,12 +491,14 @@ jobs:
         run: sudo env "PATH=$PATH" "BUILD_S2N_QUIC=false" ./scripts/benchmark/run-all
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload results
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET="${{ github.sha }}/bench"
@@ -510,9 +507,10 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
-          name: 'bench / report'
-          status: 'success'
+          name: "bench / report"
+          status: "success"
           url: "${{ steps.s3.outputs.URL }}"
 
       - name: Assert no crashes
@@ -602,7 +600,6 @@ jobs:
             --skip "MUST send TRANSPORT_PARAMETER_ERROR if ack_delay_exponen > 20 [Transport 7.4 and 18.2]" \
             --skip "MUST send TRANSPORT_PARAMETER_ERROR if max_ack_delay >= 2^14 [Transport 7.4 and 18.2]" \
             --skip "MUST send no_application_protocol TLS alert if no application protocols are supported [TLS 8.1]" \
-
 
   perf:
     runs-on: ubuntu-latest
@@ -703,12 +700,14 @@ jobs:
           tree -H "." -T "Performance Results" --noreport --charset utf-8 > index.html
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload results
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET="${{ github.sha }}/perf"
@@ -717,8 +716,8 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
+        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
         with:
-          name: 'perf / report'
-          status: 'success'
+          name: "perf / report"
+          status: "success"
           url: "${{ steps.s3.outputs.URL }}"
-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
     paths:
-      - '.github/workflows/release.yml'
+      - ".github/workflows/release.yml"
 
   release:
     types: [published]


### PR DESCRIPTION
### Description of changes: 

We currently require the contributor to be pushing to the main repository for S3 and GitHub credentials. This isn't ideal, as 3rd party contributors won't be able to run workflows.

This change removes this requirement by gating authenticated steps to 1st-party branches. This means that 3rd party contributions won't have reports available, but it's better than not running the workflow at all. I'm working on a more permanent fix in #1178.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

