### PR TITLE
api: remove duplicate Location export

### DIFF
--- a/quic/s2n-quic/src/connection.rs
+++ b/quic/s2n-quic/src/connection.rs
@@ -14,7 +14,7 @@ pub use handle::*;
 pub use s2n_quic_core::connection::Error;
 
 pub mod error {
-    pub use s2n_quic_core::{endpoint::Location, transport::error::Code};
+    pub use s2n_quic_core::transport::error::Code;
 }
 
 pub type Result<T, E = Error> = core::result::Result<T, E>;


### PR DESCRIPTION
### Description of changes: 

In #1175 and #1174, the `Location` enum was exported. This results in it being available in 2 locations. I think the `event` provider module is probably a better place for it, so this removes it from `connection::error`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

