### PR TITLE
doc: Correct MSRV header size in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 }
 ```
 
-### Minimum Supported Rust Version (MSRV)
+## Minimum Supported Rust Version (MSRV)
 
 `s2n-quic` will maintain a rolling MSRV (minimum supported rust version) policy of at least 6 months. The current s2n-quic version is not guaranteed to build on Rust versions earlier than the MSRV.
 


### PR DESCRIPTION
### Description of changes:

This change fixes the MSRV header size in the readme to increase it by one level

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

