### PR TITLE
docs: add description and repository to Cargo.toml

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "s2n-codec"
 version = "0.1.0"
+description = "Internal crate used by s2n-quic"
+repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "s2n-quic-core"
 version = "0.1.0"
+description = "Internal crate used by s2n-quic"
+repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "s2n-quic-platform"
 version = "0.1.0"
+description = "Internal crate used by s2n-quic"
+repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"

--- a/quic/s2n-quic-ring/Cargo.toml
+++ b/quic/s2n-quic-ring/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "s2n-quic-ring"
 version = "0.1.0"
+description = "Internal crate used by s2n-quic"
+repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "s2n-quic-rustls"
 version = "0.1.0"
+description = "Internal crate used by s2n-quic"
+repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "s2n-quic-tls-default"
 version = "0.1.0"
+description = "Internal crate used by s2n-quic"
+repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "s2n-quic-tls"
 version = "0.1.0"
+description = "Internal crate used by s2n-quic"
+repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "s2n-quic-transport"
 version = "0.1.0"
+description = "Internal crate used by s2n-quic"
+repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"
@@ -16,7 +18,7 @@ futures-core = { version = "0.3", default-features = false, features = ["alloc"]
 hashbrown = "0.11"
 intrusive-collections = "0.9"
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
-s2n-quic-core = { version = "0.1", path = "../s2n-quic-core", default-features = false }
+s2n-quic-core = { version = "0.1", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
 siphasher = "0.3"
 smallvec = { version = "1", default-features = false }
 

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -1,6 +1,8 @@
 [package]
 name = "s2n-quic"
 version = "1.0.0"
+description = "A Rust implementation of the IETF QUIC protocol"
+repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"


### PR DESCRIPTION
### Description of changes: 

When publishing to crates, it likes you to have a `description` and `repository` field. This change adds those.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

