### PR TITLE
tools: add doc diff

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -11,6 +11,7 @@ ignore = [
 multiple-versions = "deny"
 
 skip-tree = [
+    { name = "docdiff" }, # docdiff is a private crate
     { name = "duvet" }, # duvet is a private crate
     { name = "criterion" }, # criterion is always going to be just a test dependency
     { name = "s2n-quic-integration" }, # s2n-quic-integration is a private crate
@@ -27,7 +28,9 @@ unknown-git = "deny"
 unlicensed = "deny"
 allow-osi-fsf-free = "neither"
 copyleft = "deny"
-confidence-threshold = 0.90
+confidence-threshold = 0.9
+# ignore licenses for private crates
+private = { ignore = true }
 allow = [
     "Apache-2.0",
     "BSD-2-Clause",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,48 @@ jobs:
           status: "success"
           url: "${{ steps.s3.outputs.URL }}"
 
+  docdiff:
+    runs-on: ubuntu-latest
+    needs: env
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          # pin to a specific version so we don't get breakage in the generated html
+          toolchain: ${{ needs.env.outputs.msrv }}
+          profile: minimal
+          override: true
+
+      - uses: camshaft/rust-cache@v1
+
+      - name: Clean up cache
+        run: |
+          rm -f target/release/docdiff
+          rm -f common/docdiff/target/release/docdiff
+
+      - name: Cache docdiff
+        uses: actions/cache@v2.1.7
+        continue-on-error: true
+        with:
+          path: target/release/docdiff
+          key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ github.job }}-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('common/docdiff/**') }}
+
+      - name: Build docdiff
+        working-directory: common/docdiff
+        run: |
+          if [ ! -f ../../target/release/docdiff ]; then
+            mkdir -p ../../target/release
+            cargo build --release
+            cp target/release/docdiff ../../target/release/docdiff
+          fi
+
+      - name: Run docdiff
+        run: ./target/release/docdiff s2n-quic
+
   test:
     runs-on: ${{ matrix.os }}
     needs: env
@@ -276,7 +318,9 @@ jobs:
       - uses: camshaft/rust-cache@v1
 
       - name: Clean up cache
-        run: rm -f target/release/duvet
+        run: |
+          rm -f target/release/duvet
+          rm -f common/duvet/target/release/duvet
 
       - name: Cache duvet
         uses: actions/cache@v2.1.7
@@ -286,7 +330,13 @@ jobs:
           key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ github.job }}-duvet-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('common/duvet/**') }}
 
       - name: Build duvet
-        run: test -f target/release/duvet || cargo build --bin duvet --release
+        working-directory: common/duvet
+        run: |
+          if [ ! -f ../../target/release/duvet ]; then
+            mkdir -p ../../target/release
+            cargo build --release
+            cp target/release/duvet ../../target/release/duvet
+          fi
 
       - name: Run duvet
         run: ./scripts/compliance ${{ github.sha }}
@@ -497,6 +547,14 @@ jobs:
           crate: cargo-insta
 
       - uses: camshaft/rust-cache@v1
+
+      - name: Remove api snapshots
+        run: |
+          rm quic/*/api.snap
+          git config --global user.email "ci@example.com"
+          git config --global user.name "CI"
+          git add .
+          git commit -m 'remove api.snap'
 
       - name: Run cargo insta test
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
 members = [
-    "common/duvet",
     "common/s2n-*",
     "quic/s2n-*",
 ]

--- a/common/docdiff/Cargo.toml
+++ b/common/docdiff/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "docdiff"
+version = "0.1.0"
+authors = ["AWS s2n"]
+edition = "2018"
+license = "Apache-2.0"
+publish = false
+
+[dependencies]
+anyhow = "1"
+duct = "0.13"
+glob = "0.3"
+insta = "1"
+once_cell = "1"
+rayon = "1"
+scraper = "0.12"
+selectors = "0.22"
+structopt = "0.3"
+
+[workspace]
+members = ["."]

--- a/common/docdiff/src/main.rs
+++ b/common/docdiff/src/main.rs
@@ -1,0 +1,490 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Context, Error, Result};
+use duct::cmd;
+use glob::glob;
+use once_cell::sync::OnceCell;
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use scraper::{ElementRef, Html, Selector};
+use selectors::attr::CaseSensitivity;
+use std::{
+    fmt,
+    path::{Path, PathBuf},
+    str::FromStr,
+    sync::Arc,
+};
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct Arguments {
+    #[structopt(short, long)]
+    output: Option<PathBuf>,
+
+    #[structopt(name = "CRATE")]
+    crate_name: String,
+}
+
+macro_rules! sel {
+    ($sel:expr) => {{
+        static SEL: OnceCell<Selector> = OnceCell::new();
+        SEL.get_or_init(|| Selector::parse($sel).unwrap())
+    }};
+}
+
+fn main() -> Result<()> {
+    let Arguments { output, crate_name } = Arguments::from_args();
+
+    let dump = Dump::new(&crate_name)?;
+
+    let path = cmd!("cargo", "pkgid", &crate_name).stdout_capture().run()?;
+    let path = String::from_utf8(path.stdout)?;
+    let path = path
+        .trim_start_matches("file://")
+        .split('#')
+        .next()
+        .unwrap();
+    let project = PathBuf::from_str(path)?;
+
+    let output = if let Some(output) = output {
+        output
+    } else {
+        project.clone()
+    };
+
+    let mut settings = insta::Settings::new();
+    settings.set_input_file(&project.join("src").join("lib.rs"));
+    settings.set_snapshot_path(output);
+    settings.set_prepend_module_to_snapshot(false);
+
+    settings.bind(|| {
+        insta::assert_display_snapshot!("api", dump);
+    });
+
+    Ok(())
+}
+
+struct Dump {
+    entries: Vec<Entry>,
+}
+
+impl fmt::Display for Dump {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for entry in &self.entries {
+            write!(f, "{}", entry)?;
+        }
+        Ok(())
+    }
+}
+
+impl Dump {
+    fn new(crate_name: &str) -> Result<Self> {
+        cmd!("cargo", "doc", "--all-features", "--workspace")
+            .stdout_path("/dev/null")
+            .run()?;
+
+        let paths = glob(&format!(
+            "target/doc/{}/**/*.html",
+            crate_name.replace('-', "_")
+        ))?
+        .collect::<Vec<_>>();
+
+        let paths: Vec<_> = paths
+            .into_par_iter()
+            .map(|path| {
+                let path = path?;
+                index_file(&path).with_context(|| format!("failed to parse: {}", path.display()))
+            })
+            .collect();
+
+        let mut entries = vec![];
+        let mut has_error = false;
+        for result in paths {
+            match result {
+                Ok(e) => entries.extend(e),
+                Err(err) => {
+                    has_error = true;
+                    eprintln!("error {:?}", err);
+                }
+            }
+        }
+
+        if has_error {
+            return Err(anyhow!("bailing due to errors"));
+        }
+
+        // make sure things are sorted for nicer diffs
+        entries.sort();
+        entries.dedup();
+
+        Ok(Self { entries })
+    }
+}
+
+#[derive(Debug, PartialEq, PartialOrd, Eq, Ord)]
+struct Entry {
+    context: Arc<Fqn>,
+    signature: String,
+    kind: Kind,
+}
+
+impl fmt::Display for Entry {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let action = match (self.context.kind, self.kind) {
+            (Kind::Struct, Kind::Trait) | (Kind::Enum, Kind::Trait) => "implements",
+            (Kind::Struct, Kind::NonExhaustive)
+            | (Kind::Enum, Kind::NonExhaustive)
+            | (Kind::Variant, Kind::NonExhaustive) => "is",
+            (Kind::Trait, Kind::Type) | (Kind::Trait, Kind::Constant) => "associates",
+            _ => "exports",
+        };
+
+        write!(
+            f,
+            "{} {} {} {}",
+            self.context.kind, self.context.path, action, self.kind
+        )?;
+
+        if !self.signature.is_empty() {
+            writeln!(f, ":")?;
+        } else {
+            writeln!(f)?;
+        }
+
+        for line in self.signature.split_terminator('\n') {
+            writeln!(f, "  {}", line.trim_end())?;
+        }
+
+        writeln!(f)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug, PartialEq, PartialOrd, Eq, Ord)]
+struct Fqn {
+    path: String,
+    kind: Kind,
+}
+
+impl FromStr for Fqn {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(sig) = s.strip_prefix("Type Definition ") {
+            return Ok(Self {
+                kind: Kind::Typedef,
+                path: sig.to_string(),
+            });
+        }
+
+        let (kind, path) = s
+            .trim()
+            .split_once(' ')
+            .ok_or_else(|| anyhow!("invalid fqn {}", s))?;
+        let kind = kind.parse()?;
+        let path = path.into();
+        Ok(Self { path, kind })
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord)]
+enum Kind {
+    Crate,
+    Module,
+    Struct,
+    Enum,
+    NonExhaustive,
+    Variant,
+    Field,
+    Function,
+    Type,
+    Typedef,
+    Static,
+    Constant,
+    Trait,
+    List,
+}
+
+impl fmt::Display for Kind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let s = match self {
+            Kind::Struct => "struct",
+            Kind::Enum => "enum",
+            Kind::Trait => "trait",
+            Kind::Function => "function",
+            Kind::Module => "module",
+            Kind::Crate => "crate",
+            Kind::Type => "type",
+            Kind::Typedef => "typedef",
+            Kind::Static => "static",
+            Kind::Constant => "constant",
+            Kind::List => "list",
+            Kind::Variant => "variant",
+            Kind::Field => "field",
+            Kind::NonExhaustive => "non-exhaustive",
+        };
+        write!(f, "{}", s)
+    }
+}
+
+impl FromStr for Kind {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Ok(match s {
+            "Struct" | "struct" => Self::Struct,
+            "Enum" | "enum" => Self::Enum,
+            "Trait" | "trait" => Self::Trait,
+            "Function" | "function" | "fn" => Self::Function,
+            "Module" | "mod" => Self::Module,
+            "Crate" | "crate" => Self::Crate,
+            "Type" | "type" => Self::Type,
+            "Static" | "static" => Self::Static,
+            "Constant" | "constant" => Self::Constant,
+            "List" => Self::List,
+            _ => return Err(anyhow!("Unsupported kind {}", s)),
+        })
+    }
+}
+
+fn index_file(path: &Path) -> Result<Vec<Entry>> {
+    let mut results = vec![];
+
+    let contents = std::fs::read_to_string(path)?;
+    let document = Html::parse_document(&contents);
+
+    let context: Fqn = if let Some(fqn) = document.select(sel!(".fqn")).next() {
+        el_to_string(fqn).parse()?
+    } else {
+        eprintln!("skipping {}", path.display());
+        return Ok(results);
+    };
+    let context = Arc::new(context);
+
+    for el in document
+        .select(sel!("#main .import-item a[title]"))
+        .chain(document.select(sel!("#main .module-item a[title]")))
+    {
+        let el = ElementRef::wrap(*el).unwrap();
+        let title = el.value().attr("title").unwrap();
+        if let Ok(entry) = parse_entry_title(title, &context) {
+            results.push(entry);
+        }
+    }
+
+    let items = [
+        (sel!(".impl-items .method:not(.trait-impl)"), Kind::Function),
+        (sel!(".impl-items .associatedconstant"), Kind::Constant),
+        (sel!(".methods .method[id^=tymethod]"), Kind::Function),
+        (sel!(".typedef"), Kind::Typedef),
+        (sel!("#synthetic-implementations-list .impl"), Kind::Trait),
+        (sel!(".structfield"), Kind::Field),
+    ];
+
+    for (sel, kind) in items.iter().copied() {
+        for el in document.select(sel) {
+            let signature = el_to_string(el);
+            results.push(Entry {
+                kind,
+                signature,
+                context: context.clone(),
+            })
+        }
+    }
+
+    for trait_impl in document.select(sel!("#trait-implementations-list details")) {
+        let types = trait_impl
+            .select(sel!(".impl-items .trait-impl.type:not(.hidden)"))
+            .map(|t| (t, Kind::Type));
+        let constants = trait_impl
+            .select(sel!(
+                ".impl-items .trait-impl.associatedconstant:not(.hidden)"
+            ))
+            .map(|t| (t, Kind::Constant));
+
+        let items = types.chain(constants);
+
+        let signature = el_to_string(trait_impl.select(sel!(".impl")).next().unwrap());
+
+        results.push(Entry {
+            kind: Kind::Trait,
+            signature: signature.clone(),
+            context: context.clone(),
+        });
+
+        let context = Arc::new(Fqn {
+            kind: Kind::Trait,
+            path: signature,
+        });
+
+        for (item, kind) in items {
+            let signature = el_to_string(item);
+            results.push(Entry {
+                kind,
+                signature,
+                context: context.clone(),
+            })
+        }
+    }
+
+    // search for variants
+    for variant in document.select(sel!("#main > .variant")) {
+        let name = el_to_string(variant)
+            .trim_start_matches("Fields of ")
+            .to_string();
+
+        results.push(Entry {
+            kind: Kind::Variant,
+            signature: name.clone(),
+            context: context.clone(),
+        });
+
+        // look for the non-exhaustive marker
+        for sibling in variant.next_siblings().flat_map(ElementRef::wrap) {
+            // we're on to the next section
+            if sibling.value().name() != "div"
+                || sibling
+                    .value()
+                    .has_class(".variant", CaseSensitivity::CaseSensitive)
+            {
+                break;
+            }
+
+            if sibling
+                .value()
+                .has_class("non-exhaustive-variant", CaseSensitivity::CaseSensitive)
+            {
+                let path = format!("{}::{}", context.path, name);
+                let context = Arc::new(Fqn {
+                    kind: Kind::Variant,
+                    path,
+                });
+                results.push(Entry {
+                    kind: Kind::NonExhaustive,
+                    signature: String::new(),
+                    context,
+                });
+            }
+        }
+    }
+
+    // search for variant fields
+    for variant in document.select(sel!(".sub-variant[id^=variant\\.]")) {
+        let name = variant
+            .value()
+            .id()
+            .unwrap()
+            .trim_start_matches("variant.")
+            .trim_end_matches(".fields");
+
+        let path = format!("{}::{}", context.path, name);
+        let context = Arc::new(Fqn {
+            kind: Kind::Variant,
+            path,
+        });
+
+        for field in variant.select(sel!(".variant")) {
+            let signature = el_to_string(field);
+            results.push(Entry {
+                kind: Kind::Field,
+                signature,
+                context: context.clone(),
+            })
+        }
+    }
+
+    for el in document
+        .select(sel!("#variants"))
+        .chain(document.select(sel!("#fields")))
+    {
+        if el_to_string(el).contains("(Non-exhaustive)") {
+            results.push(Entry {
+                kind: Kind::NonExhaustive,
+                signature: String::new(),
+                context: context.clone(),
+            })
+        }
+    }
+
+    Ok(results)
+}
+
+fn parse_entry_title(title: &str, context: &Arc<Fqn>) -> Result<Entry> {
+    let (kind, sig) = title
+        .trim()
+        .split_once(' ')
+        .ok_or_else(|| anyhow!("invalid entry title: {}", title))?;
+
+    if let Ok(kind) = kind.parse() {
+        let signature = sig.to_string();
+        let context = context.clone();
+        Ok(Entry {
+            context,
+            signature,
+            kind,
+        })
+    } else {
+        let kind_p = sig.parse()?;
+        let signature = kind.to_string();
+        let context = context.clone();
+        Ok(Entry {
+            context,
+            signature,
+            kind: kind_p,
+        })
+    }
+}
+
+fn el_to_string(el: ElementRef) -> String {
+    fn traverse(el: ElementRef, out: &mut String) {
+        for child in el.children() {
+            if let Some(text) = child.value().as_text() {
+                let mut has_ua0 = false;
+                out.extend(text.text.chars().filter_map(|c| {
+                    if c == '\u{a0}' {
+                        if core::mem::replace(&mut has_ua0, true) {
+                            None
+                        } else {
+                            Some('\n')
+                        }
+                    } else {
+                        has_ua0 = false;
+                        Some(c)
+                    }
+                }));
+            } else if let Some(el) = child.value().as_element() {
+                if el.name() == "button" {
+                    continue;
+                }
+
+                let case = CaseSensitivity::CaseSensitive;
+
+                if el.has_class("out-of-band", case)
+                    || el.has_class("srclink", case)
+                    || el.has_class("collapse-toggle", case)
+                    || el.has_class("since", case)
+                    || el.has_class("docblock", case)
+                {
+                    continue;
+                }
+
+                if let Some(Fqn { path, .. }) = el.attr("title").and_then(|v| v.parse().ok()) {
+                    out.push_str(&path);
+                    continue;
+                }
+
+                let child = ElementRef::wrap(child).unwrap();
+                traverse(child, out);
+
+                // put a newline after attributes
+                if el.has_class("code-attribute", case) {
+                    out.push('\n');
+                }
+            }
+        }
+    }
+
+    let mut out = String::new();
+    traverse(el, &mut out);
+    out
+}

--- a/common/duvet/Cargo.toml
+++ b/common/duvet/Cargo.toml
@@ -25,3 +25,6 @@ v_jsonescape = "0.6"
 
 [dev-dependencies]
 insta = "1"
+
+[workspace]
+members = ["."]

--- a/quic/s2n-quic/api.snap
+++ b/quic/s2n-quic/api.snap
@@ -1,0 +1,17483 @@
+---
+source: common/docdiff/src/main.rs
+assertion_line: 58
+expression: dump
+input_file: quic/s2n-quic/src/lib.rs
+
+---
+trait impl core::convert::TryFrom<s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message associates type:
+  type Error = s2n_quic::provider::tls::rustls::rustls::Error
+
+trait impl core::convert::TryFrom<u64> for s2n_quic::application::Error associates type:
+  type Error = s2n_quic_core::varint::VarIntError
+
+trait impl core::future::future::Future for s2n_quic::client::ConnectionAttempt associates type:
+  type Output = core::result::Result<s2n_quic::connection::Connection, s2n_quic::connection::Error>
+
+trait impl core::ops::deref::Deref for s2n_quic::application::Error associates type:
+  type Target = u64
+
+trait impl core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::ClientConnection associates type:
+  type Target = s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<s2n_quic::provider::tls::rustls::rustls::client::ClientConnectionData>
+
+trait impl core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::Connection associates type:
+  type Target = s2n_quic::provider::tls::rustls::rustls::CommonState
+
+trait impl core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::ServerConnection associates type:
+  type Target = s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<s2n_quic::provider::tls::rustls::rustls::server::ServerConnectionData>
+
+trait impl core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue associates type:
+  type Target = s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon
+
+trait impl core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue associates type:
+  type Target = s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon
+
+trait impl core::ops::deref::Deref for s2n_quic::server::Name associates type:
+  type Target = str
+
+trait impl futures_core::stream::Stream for s2n_quic::connection::BidirectionalStreamAcceptor associates type:
+  type Item = s2n_quic::connection::Result<s2n_quic::stream::BidirectionalStream>
+
+trait impl futures_core::stream::Stream for s2n_quic::connection::ReceiveStreamAcceptor associates type:
+  type Item = s2n_quic::connection::Result<s2n_quic::stream::ReceiveStream>
+
+trait impl futures_core::stream::Stream for s2n_quic::connection::StreamAcceptor associates type:
+  type Item = s2n_quic::connection::Result<s2n_quic::stream::PeerStream>
+
+trait impl futures_core::stream::Stream for s2n_quic::server::Server associates type:
+  type Item = s2n_quic::connection::Connection
+
+trait impl futures_core::stream::Stream for s2n_quic::stream::BidirectionalStream associates type:
+  type Item = s2n_quic::stream::Result<bytes::bytes::Bytes>
+
+trait impl futures_core::stream::Stream for s2n_quic::stream::LocalStream associates type:
+  type Item = s2n_quic::stream::Result<bytes::bytes::Bytes>
+
+trait impl futures_core::stream::Stream for s2n_quic::stream::PeerStream associates type:
+  type Item = s2n_quic::stream::Result<bytes::bytes::Bytes>
+
+trait impl futures_core::stream::Stream for s2n_quic::stream::ReceiveStream associates type:
+  type Item = s2n_quic::stream::Result<bytes::bytes::Bytes>
+
+trait impl futures_core::stream::Stream for s2n_quic::stream::Stream associates type:
+  type Item = s2n_quic::stream::Result<bytes::bytes::Bytes>
+
+trait impl futures_sink::Sink<bytes::bytes::Bytes> for s2n_quic::stream::BidirectionalStream associates type:
+  type Error = s2n_quic::stream::Error
+
+trait impl futures_sink::Sink<bytes::bytes::Bytes> for s2n_quic::stream::LocalStream associates type:
+  type Error = s2n_quic::stream::Error
+
+trait impl futures_sink::Sink<bytes::bytes::Bytes> for s2n_quic::stream::PeerStream associates type:
+  type Error = s2n_quic::stream::Error
+
+trait impl futures_sink::Sink<bytes::bytes::Bytes> for s2n_quic::stream::SendStream associates type:
+  type Error = s2n_quic::stream::Error
+
+trait impl futures_sink::Sink<bytes::bytes::Bytes> for s2n_quic::stream::Stream associates type:
+  type Error = s2n_quic::stream::Error
+
+trait impl s2n_quic::provider::address_token::Provider for s2n_quic::provider::address_token::default::Provider associates type:
+  type Error = core::convert::Infallible
+
+trait impl s2n_quic::provider::address_token::Provider for s2n_quic::provider::address_token::default::Provider associates type:
+  type Format = s2n_quic::provider::address_token::default::Format
+
+trait impl s2n_quic::provider::connection_id::Provider for s2n_quic::provider::connection_id::default::Provider associates type:
+  type Error = core::convert::Infallible
+
+trait impl s2n_quic::provider::connection_id::Provider for s2n_quic::provider::connection_id::default::Provider associates type:
+  type Format = s2n_quic::provider::connection_id::default::Format
+
+trait impl s2n_quic::provider::event::Provider for s2n_quic::provider::event::disabled::Provider associates type:
+  type Error = core::convert::Infallible
+
+trait impl s2n_quic::provider::event::Provider for s2n_quic::provider::event::disabled::Provider associates type:
+  type Subscriber = s2n_quic::provider::event::disabled::Subscriber
+
+trait impl s2n_quic::provider::event::Provider for s2n_quic::provider::event::tracing::Provider associates type:
+  type Error = core::convert::Infallible
+
+trait impl s2n_quic::provider::event::Provider for s2n_quic::provider::event::tracing::Provider associates type:
+  type Subscriber = s2n_quic::provider::event::tracing::Subscriber
+
+trait impl s2n_quic::provider::event::Subscriber for s2n_quic::provider::event::disabled::Subscriber associates type:
+  type ConnectionContext = ()
+
+trait impl s2n_quic::provider::event::Subscriber for s2n_quic::provider::event::tracing::Subscriber associates type:
+  type ConnectionContext = tracing::span::Span
+
+trait impl s2n_quic::provider::io::Provider for s2n_quic::provider::io::Default associates type:
+  type Error = std::io::error::Error
+
+trait impl s2n_quic::provider::io::Provider for s2n_quic::provider::io::Default associates type:
+  type PathHandle = s2n_quic_platform::io::tokio::PathHandle
+
+trait impl s2n_quic::provider::limits::Provider for s2n_quic::provider::limits::default::Provider associates type:
+  type Error = core::convert::Infallible
+
+trait impl s2n_quic::provider::limits::Provider for s2n_quic::provider::limits::default::Provider associates type:
+  type Limits = s2n_quic::provider::limits::Limits
+
+trait impl s2n_quic::provider::stateless_reset_token::Provider for s2n_quic::provider::stateless_reset_token::Default associates type:
+  type Error = core::convert::Infallible
+
+trait impl s2n_quic::provider::stateless_reset_token::Provider for s2n_quic::provider::stateless_reset_token::Default associates type:
+  type Generator = Generator
+
+trait impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::Default associates type:
+  type Client = s2n_quic::provider::tls::s2n_tls::Client
+
+trait impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::Default associates type:
+  type Error = core::convert::Infallible
+
+trait impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::Default associates type:
+  type Server = s2n_quic::provider::tls::s2n_tls::Server
+
+trait impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::rustls::Client associates type:
+  type Client = Self
+
+trait impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::rustls::Client associates type:
+  type Error = core::convert::Infallible
+
+trait impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::rustls::Client associates type:
+  type Server = s2n_quic::provider::tls::rustls::Server
+
+trait impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::rustls::Server associates type:
+  type Client = s2n_quic::provider::tls::rustls::Client
+
+trait impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::rustls::Server associates type:
+  type Error = core::convert::Infallible
+
+trait impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::rustls::Server associates type:
+  type Server = Self
+
+trait impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::s2n_tls::Client associates type:
+  type Client = Self
+
+trait impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::s2n_tls::Client associates type:
+  type Error = core::convert::Infallible
+
+trait impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::s2n_tls::Client associates type:
+  type Server = s2n_quic::provider::tls::s2n_tls::Server
+
+trait impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::s2n_tls::Server associates type:
+  type Client = s2n_quic::provider::tls::s2n_tls::Client
+
+trait impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::s2n_tls::Server associates type:
+  type Error = core::convert::Infallible
+
+trait impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::s2n_tls::Server associates type:
+  type Server = Self
+
+trait impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::rustls::Client associates type:
+  type Session = Session
+
+trait impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::rustls::Server associates type:
+  type Session = Session
+
+trait impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::s2n_tls::Client associates type:
+  type Session = Session
+
+trait impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::s2n_tls::Server associates type:
+  type Session = Session
+
+trait impl<'_> core::convert::TryFrom<&'_ [u8]> for s2n_quic::provider::connection_id::LocalId associates type:
+  type Error = s2n_quic_core::connection::id::Error
+
+trait impl<'_> core::convert::TryFrom<&'_ str> for s2n_quic::provider::tls::rustls::rustls::ServerName associates type:
+  type Error = s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError
+
+trait impl<T> core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<T> associates type:
+  type Target = s2n_quic::provider::tls::rustls::rustls::CommonState
+
+trait impl<T> core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved<T> associates type:
+  type Target = T
+
+crate s2n_quic exports module:
+  s2n_quic::application
+
+crate s2n_quic exports module:
+  s2n_quic::client
+
+crate s2n_quic exports struct:
+  s2n_quic::client::Client
+
+crate s2n_quic exports module:
+  s2n_quic::connection
+
+crate s2n_quic exports struct:
+  s2n_quic::connection::Connection
+
+crate s2n_quic exports module:
+  s2n_quic::provider
+
+crate s2n_quic exports module:
+  s2n_quic::server
+
+crate s2n_quic exports struct:
+  s2n_quic::server::Server
+
+crate s2n_quic exports module:
+  s2n_quic::stream
+
+module s2n_quic::application exports struct:
+  s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl core::clone::Clone for s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl core::cmp::PartialEq<s2n_quic::application::Error> for s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl core::convert::From<s2n_quic::application::Error> for u64
+
+struct s2n_quic::application::Error implements trait:
+  impl core::convert::From<s2n_quic_core::varint::VarInt> for s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl core::convert::From<u16> for s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl core::convert::From<u32> for s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl core::convert::From<u8> for s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl core::convert::TryFrom<u64> for s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl core::fmt::Debug for s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl core::marker::Send for s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl core::marker::Sync for s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl core::marker::Unpin for s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl core::ops::deref::Deref for s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl s2n_quic_core::application::error::TryInto for s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::application::Error
+
+struct s2n_quic::application::Error implements trait:
+  impl<'a> core::convert::From<s2n_quic::application::Error> for s2n_quic_core::frame::connection_close::ConnectionClose<'a>
+
+struct s2n_quic::application::Error exports constant:
+  pub const BITS: u32
+
+struct s2n_quic::application::Error exports constant:
+  pub const MAX: u64
+
+struct s2n_quic::application::Error exports constant:
+  pub const MIN: u64
+
+struct s2n_quic::application::Error exports constant:
+  pub const UNKNOWN: s2n_quic::application::Error
+
+struct s2n_quic::application::Error exports function:
+  pub fn as_ne_bytes(&self) -> &[u8; 8]
+
+struct s2n_quic::application::Error exports function:
+  pub fn new(value: u64) -> core::result::Result<s2n_quic::application::Error, s2n_quic_core::varint::VarIntError>
+
+module s2n_quic::client exports struct:
+  s2n_quic::client::Builder
+
+module s2n_quic::client exports struct:
+  s2n_quic::client::Client
+
+module s2n_quic::client exports trait:
+  s2n_quic::client::ClientProviders
+
+module s2n_quic::client exports struct:
+  s2n_quic::client::Connect
+
+module s2n_quic::client exports struct:
+  s2n_quic::client::ConnectionAttempt
+
+module s2n_quic::client exports struct:
+  s2n_quic::client::DefaultProviders
+
+struct s2n_quic::client::Builder implements trait:
+  impl core::default::Default for s2n_quic::client::Builder<s2n_quic::client::DefaultProviders>
+
+struct s2n_quic::client::Builder implements trait:
+  impl<Providers:
+  core::fmt::Debug> core::fmt::Debug for s2n_quic::client::Builder<Providers>
+
+struct s2n_quic::client::Builder implements trait:
+  impl<Providers> core::marker::Send for s2n_quic::client::Builder<Providers> where
+  Providers: core::marker::Send,
+
+struct s2n_quic::client::Builder implements trait:
+  impl<Providers> core::marker::Sync for s2n_quic::client::Builder<Providers> where
+  Providers: core::marker::Sync,
+
+struct s2n_quic::client::Builder implements trait:
+  impl<Providers> core::marker::Unpin for s2n_quic::client::Builder<Providers> where
+  Providers: core::marker::Unpin,
+
+struct s2n_quic::client::Builder implements trait:
+  impl<Providers> std::panic::RefUnwindSafe for s2n_quic::client::Builder<Providers> where
+  Providers: std::panic::RefUnwindSafe,
+
+struct s2n_quic::client::Builder implements trait:
+  impl<Providers> std::panic::UnwindSafe for s2n_quic::client::Builder<Providers> where
+  Providers: std::panic::UnwindSafe,
+
+struct s2n_quic::client::Builder exports function:
+  pub fn start(self) -> core::result::Result<s2n_quic::client::Client, s2n_quic::provider::StartError>
+
+struct s2n_quic::client::Builder exports function:
+  pub fn with_connection_id<T, U>(
+  self,
+  connection_id: T) -> core::result::Result<s2n_quic::client::Builder<impl s2n_quic::client::ClientProviders>, T::s2n_quic::provider::connection_id::TryInto::Error> where
+  T: s2n_quic::provider::connection_id::TryInto,
+  U: s2n_quic::client::ClientProviders,
+  Self: With<T::s2n_quic::provider::connection_id::TryInto::Provider, Output = s2n_quic::client::Builder<U>>,
+
+struct s2n_quic::client::Builder exports function:
+  pub fn with_event<T, U>(
+  self,
+  event: T) -> core::result::Result<s2n_quic::client::Builder<impl s2n_quic::client::ClientProviders>, T::s2n_quic::provider::event::TryInto::Error> where
+  T: s2n_quic::provider::event::TryInto,
+  U: s2n_quic::client::ClientProviders,
+  Self: With<T::s2n_quic::provider::event::TryInto::Provider, Output = s2n_quic::client::Builder<U>>,
+
+struct s2n_quic::client::Builder exports function:
+  pub fn with_io<T, U>(
+  self,
+  io: T) -> core::result::Result<s2n_quic::client::Builder<impl s2n_quic::client::ClientProviders>, T::s2n_quic::provider::io::TryInto::Error> where
+  T: s2n_quic::provider::io::TryInto,
+  U: s2n_quic::client::ClientProviders,
+  Self: With<T::s2n_quic::provider::io::TryInto::Provider, Output = s2n_quic::client::Builder<U>>,
+
+struct s2n_quic::client::Builder exports function:
+  pub fn with_limits<T, U>(
+  self,
+  limits: T) -> core::result::Result<s2n_quic::client::Builder<impl s2n_quic::client::ClientProviders>, T::s2n_quic::provider::limits::TryInto::Error> where
+  T: s2n_quic::provider::limits::TryInto,
+  U: s2n_quic::client::ClientProviders,
+  Self: With<T::s2n_quic::provider::limits::TryInto::Provider, Output = s2n_quic::client::Builder<U>>,
+
+struct s2n_quic::client::Builder exports function:
+  pub fn with_stateless_reset_token<T, U>(
+  self,
+  stateless_reset_token: T) -> core::result::Result<s2n_quic::client::Builder<impl s2n_quic::client::ClientProviders>, T::s2n_quic::provider::stateless_reset_token::TryInto::Error> where
+  T: s2n_quic::provider::stateless_reset_token::TryInto,
+  U: s2n_quic::client::ClientProviders,
+  Self: With<T::s2n_quic::provider::stateless_reset_token::TryInto::Provider, Output = s2n_quic::client::Builder<U>>,
+
+struct s2n_quic::client::Builder exports function:
+  pub fn with_tls<T, U>(
+  self,
+  tls: T) -> core::result::Result<s2n_quic::client::Builder<impl s2n_quic::client::ClientProviders>, T::s2n_quic::provider::tls::TryInto::Error> where
+  T: s2n_quic::provider::tls::TryInto,
+  U: s2n_quic::client::ClientProviders,
+  Self: With<T::s2n_quic::provider::tls::TryInto::Provider, Output = s2n_quic::client::Builder<U>>,
+
+struct s2n_quic::client::Client implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::client::Client
+
+struct s2n_quic::client::Client implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::client::Client
+
+struct s2n_quic::client::Client implements trait:
+  impl core::clone::Clone for s2n_quic::client::Client
+
+struct s2n_quic::client::Client implements trait:
+  impl core::fmt::Debug for s2n_quic::client::Client
+
+struct s2n_quic::client::Client implements trait:
+  impl core::marker::Send for s2n_quic::client::Client
+
+struct s2n_quic::client::Client implements trait:
+  impl core::marker::Sync for s2n_quic::client::Client
+
+struct s2n_quic::client::Client implements trait:
+  impl core::marker::Unpin for s2n_quic::client::Client
+
+struct s2n_quic::client::Client exports function:
+  pub async fn wait_idle(&mut self) -> core::result::Result<(), s2n_quic::connection::Error>
+
+struct s2n_quic::client::Client exports function:
+  pub fn bind<T>(socket: T) -> core::result::Result<Self, s2n_quic::provider::StartError> where
+  T: s2n_quic::provider::io::TryInto,
+
+struct s2n_quic::client::Client exports function:
+  pub fn builder() -> s2n_quic::client::Builder<impl s2n_quic::client::ClientProviders>
+
+struct s2n_quic::client::Client exports function:
+  pub fn connect(&self, connect: s2n_quic::client::Connect) -> s2n_quic::client::ConnectionAttemptⓘ
+
+struct s2n_quic::client::Client exports function:
+  pub fn local_addr(&self) -> core::result::Result<std::net::addr::SocketAddr, std::io::error::Error>
+
+struct s2n_quic::client::Connect exports function:
+  #[must_use]
+  pub fn with_server_name<Name>(self, server_name: Name) -> s2n_quic::client::Connect where
+  Name: core::convert::Into<s2n_quic::server::Name>,
+
+struct s2n_quic::client::Connect implements trait:
+  impl core::clone::Clone for s2n_quic::client::Connect
+
+struct s2n_quic::client::Connect implements trait:
+  impl core::fmt::Debug for s2n_quic::client::Connect
+
+struct s2n_quic::client::Connect implements trait:
+  impl core::fmt::Display for s2n_quic::client::Connect
+
+struct s2n_quic::client::Connect implements trait:
+  impl core::marker::Send for s2n_quic::client::Connect
+
+struct s2n_quic::client::Connect implements trait:
+  impl core::marker::Sync for s2n_quic::client::Connect
+
+struct s2n_quic::client::Connect implements trait:
+  impl core::marker::Unpin for s2n_quic::client::Connect
+
+struct s2n_quic::client::Connect implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::client::Connect
+
+struct s2n_quic::client::Connect implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::client::Connect
+
+struct s2n_quic::client::Connect implements trait:
+  impl<T> core::convert::From<T> for s2n_quic::client::Connect where
+  T: core::convert::Into<s2n_quic_core::inet::ip::SocketAddress>,
+
+struct s2n_quic::client::Connect exports function:
+  pub fn new<Addr>(addr: Addr) -> s2n_quic::client::Connect where
+  Addr: core::convert::Into<s2n_quic_core::inet::ip::SocketAddress>,
+
+struct s2n_quic::client::ConnectionAttempt implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::client::ConnectionAttempt
+
+struct s2n_quic::client::ConnectionAttempt implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::client::ConnectionAttempt
+
+struct s2n_quic::client::ConnectionAttempt implements trait:
+  impl core::future::future::Future for s2n_quic::client::ConnectionAttempt
+
+struct s2n_quic::client::ConnectionAttempt implements trait:
+  impl core::marker::Send for s2n_quic::client::ConnectionAttempt
+
+struct s2n_quic::client::ConnectionAttempt implements trait:
+  impl core::marker::Sync for s2n_quic::client::ConnectionAttempt
+
+struct s2n_quic::client::ConnectionAttempt implements trait:
+  impl core::marker::Unpin for s2n_quic::client::ConnectionAttempt
+
+struct s2n_quic::client::DefaultProviders implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::client::DefaultProviders
+
+struct s2n_quic::client::DefaultProviders implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::client::DefaultProviders
+
+struct s2n_quic::client::DefaultProviders implements trait:
+  impl core::default::Default for s2n_quic::client::DefaultProviders
+
+struct s2n_quic::client::DefaultProviders implements trait:
+  impl core::fmt::Debug for s2n_quic::client::DefaultProviders
+
+struct s2n_quic::client::DefaultProviders implements trait:
+  impl core::marker::Send for s2n_quic::client::DefaultProviders
+
+struct s2n_quic::client::DefaultProviders implements trait:
+  impl core::marker::Sync for s2n_quic::client::DefaultProviders
+
+struct s2n_quic::client::DefaultProviders implements trait:
+  impl core::marker::Unpin for s2n_quic::client::DefaultProviders
+
+module s2n_quic::connection exports struct:
+  s2n_quic::connection::BidirectionalStreamAcceptor
+
+module s2n_quic::connection exports struct:
+  s2n_quic::connection::Connection
+
+module s2n_quic::connection exports enum:
+  s2n_quic::connection::Error
+
+module s2n_quic::connection exports struct:
+  s2n_quic::connection::Handle
+
+module s2n_quic::connection exports struct:
+  s2n_quic::connection::ReceiveStreamAcceptor
+
+module s2n_quic::connection exports type:
+  s2n_quic::connection::Result
+
+module s2n_quic::connection exports struct:
+  s2n_quic::connection::StreamAcceptor
+
+module s2n_quic::connection exports module:
+  s2n_quic::connection::error
+
+struct s2n_quic::connection::BidirectionalStreamAcceptor implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::connection::BidirectionalStreamAcceptor
+
+struct s2n_quic::connection::BidirectionalStreamAcceptor implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::connection::BidirectionalStreamAcceptor
+
+struct s2n_quic::connection::BidirectionalStreamAcceptor implements trait:
+  impl core::fmt::Debug for s2n_quic::connection::BidirectionalStreamAcceptor
+
+struct s2n_quic::connection::BidirectionalStreamAcceptor implements trait:
+  impl core::marker::Send for s2n_quic::connection::BidirectionalStreamAcceptor
+
+struct s2n_quic::connection::BidirectionalStreamAcceptor implements trait:
+  impl core::marker::Sync for s2n_quic::connection::BidirectionalStreamAcceptor
+
+struct s2n_quic::connection::BidirectionalStreamAcceptor implements trait:
+  impl core::marker::Unpin for s2n_quic::connection::BidirectionalStreamAcceptor
+
+struct s2n_quic::connection::BidirectionalStreamAcceptor implements trait:
+  impl futures_core::stream::Stream for s2n_quic::connection::BidirectionalStreamAcceptor
+
+struct s2n_quic::connection::BidirectionalStreamAcceptor exports function:
+  pub async fn accept_bidirectional_stream(
+  &mut self) -> s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::BidirectionalStream>>
+
+struct s2n_quic::connection::BidirectionalStreamAcceptor exports function:
+  pub fn poll_accept_bidirectional_stream(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::BidirectionalStream>>>
+
+struct s2n_quic::connection::Connection implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::connection::Connection
+
+struct s2n_quic::connection::Connection implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::connection::Connection
+
+struct s2n_quic::connection::Connection implements trait:
+  impl core::fmt::Debug for s2n_quic::connection::Connection
+
+struct s2n_quic::connection::Connection implements trait:
+  impl core::marker::Send for s2n_quic::connection::Connection
+
+struct s2n_quic::connection::Connection implements trait:
+  impl core::marker::Sync for s2n_quic::connection::Connection
+
+struct s2n_quic::connection::Connection implements trait:
+  impl core::marker::Unpin for s2n_quic::connection::Connection
+
+struct s2n_quic::connection::Connection exports function:
+  pub async fn accept(&mut self) -> s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::PeerStream>>
+
+struct s2n_quic::connection::Connection exports function:
+  pub async fn accept_bidirectional_stream(
+  &mut self) -> s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::BidirectionalStream>>
+
+struct s2n_quic::connection::Connection exports function:
+  pub async fn accept_receive_stream(&mut self) -> s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::ReceiveStream>>
+
+struct s2n_quic::connection::Connection exports function:
+  pub async fn open_bidirectional_stream(&mut self) -> s2n_quic::connection::Result<s2n_quic::stream::BidirectionalStream>
+
+struct s2n_quic::connection::Connection exports function:
+  pub async fn open_send_stream(&mut self) -> s2n_quic::connection::Result<s2n_quic::stream::SendStream>
+
+struct s2n_quic::connection::Connection exports function:
+  pub async fn open_stream(&mut self, stream_type: s2n_quic::stream::Type) -> s2n_quic::connection::Result<s2n_quic::stream::LocalStream>
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn application_protocol(&self) -> s2n_quic::connection::Result<bytes::bytes::Bytes>
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn close(&self, error_code: s2n_quic::application::Error)
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn handle(&self) -> s2n_quic::connection::Handle
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn id(&self) -> u64
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn keep_alive(&mut self, enabled: bool) -> s2n_quic::connection::Result<()>
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn local_addr(&self) -> s2n_quic::connection::Result<std::net::addr::SocketAddr>
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn ping(&mut self) -> s2n_quic::connection::Result<()>
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn poll_accept(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::PeerStream>>>
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn poll_accept_bidirectional_stream(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::BidirectionalStream>>>
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn poll_accept_receive_stream(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::ReceiveStream>>>
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn poll_open_bidirectional_stream(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::connection::Result<s2n_quic::stream::BidirectionalStream>>
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn poll_open_send_stream(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::connection::Result<s2n_quic::stream::SendStream>>
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn poll_open_stream(
+  &mut self,
+  stream_type: s2n_quic::stream::Type,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::connection::Result<s2n_quic::stream::LocalStream>>
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn query_event_context<Query, EventContext, Outcome>(
+  &self,
+  query: Query) -> core::result::Result<Outcome, s2n_quic::provider::event::query::Error> where
+  Query: core::ops::function::FnOnce(&EventContext) -> Outcome,
+  EventContext: 'static,
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn query_event_context_mut<Query, EventContext, Outcome>(
+  &mut self,
+  query: Query) -> core::result::Result<Outcome, s2n_quic::provider::event::query::Error> where
+  Query: core::ops::function::FnOnce(&mut EventContext) -> Outcome,
+  EventContext: 'static,
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn remote_addr(&self) -> s2n_quic::connection::Result<std::net::addr::SocketAddr>
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn server_name(&self) -> s2n_quic::connection::Result<core::option::Option<s2n_quic::server::Name>>
+
+struct s2n_quic::connection::Connection exports function:
+  pub fn split(self) -> (s2n_quic::connection::Handle, s2n_quic::connection::StreamAcceptor)
+
+enum s2n_quic::connection::Error is non-exhaustive
+
+enum s2n_quic::connection::Error exports variant:
+  Application
+
+enum s2n_quic::connection::Error exports variant:
+  Closed
+
+enum s2n_quic::connection::Error exports variant:
+  EndpointClosing
+
+enum s2n_quic::connection::Error exports variant:
+  IdleTimerExpired
+
+enum s2n_quic::connection::Error exports variant:
+  ImmediateClose
+
+enum s2n_quic::connection::Error exports variant:
+  MaxHandshakeDurationExceeded
+
+enum s2n_quic::connection::Error exports variant:
+  NoValidPath
+
+enum s2n_quic::connection::Error exports variant:
+  StatelessReset
+
+enum s2n_quic::connection::Error exports variant:
+  StreamIdExhausted
+
+enum s2n_quic::connection::Error exports variant:
+  Transport
+
+enum s2n_quic::connection::Error exports variant:
+  Unspecified
+
+enum s2n_quic::connection::Error implements trait:
+  impl core::clone::Clone for s2n_quic::connection::Error
+
+enum s2n_quic::connection::Error implements trait:
+  impl core::cmp::PartialEq<s2n_quic::connection::Error> for s2n_quic::connection::Error
+
+enum s2n_quic::connection::Error implements trait:
+  impl core::convert::From<s2n_quic::connection::Error> for s2n_quic::stream::Error
+
+enum s2n_quic::connection::Error implements trait:
+  impl core::convert::From<s2n_quic_core::crypto::error::CryptoError> for s2n_quic::connection::Error
+
+enum s2n_quic::connection::Error implements trait:
+  impl core::convert::From<s2n_quic_core::transport::error::Error> for s2n_quic::connection::Error
+
+enum s2n_quic::connection::Error implements trait:
+  impl core::fmt::Debug for s2n_quic::connection::Error
+
+enum s2n_quic::connection::Error implements trait:
+  impl core::fmt::Display for s2n_quic::connection::Error
+
+enum s2n_quic::connection::Error implements trait:
+  impl core::marker::Send for s2n_quic::connection::Error
+
+enum s2n_quic::connection::Error implements trait:
+  impl core::marker::Sync for s2n_quic::connection::Error
+
+enum s2n_quic::connection::Error implements trait:
+  impl core::marker::Unpin for s2n_quic::connection::Error
+
+enum s2n_quic::connection::Error implements trait:
+  impl s2n_quic_core::application::error::TryInto for s2n_quic::connection::Error
+
+enum s2n_quic::connection::Error implements trait:
+  impl s2n_quic_core::event::IntoEvent<s2n_quic::connection::Error> for s2n_quic::connection::Error
+
+enum s2n_quic::connection::Error implements trait:
+  impl std::error::Error for s2n_quic::connection::Error
+
+enum s2n_quic::connection::Error implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::connection::Error
+
+enum s2n_quic::connection::Error implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::connection::Error
+
+enum s2n_quic::connection::Error implements trait:
+  impl<'a> core::convert::From<s2n_quic_core::frame::connection_close::ConnectionClose<'a>> for s2n_quic::connection::Error
+
+enum s2n_quic::connection::Error exports function:
+  pub fn source(&self) -> &'static core::panic::Location<'static>
+
+variant s2n_quic::connection::Error::Application is non-exhaustive
+
+variant s2n_quic::connection::Error::Application exports field:
+  error:
+  s2n_quic::application::Error
+
+variant s2n_quic::connection::Error::Application exports field:
+  initiator:
+  s2n_quic::provider::event::Location
+
+variant s2n_quic::connection::Error::Application exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::connection::Error::Closed is non-exhaustive
+
+variant s2n_quic::connection::Error::Closed exports field:
+  initiator:
+  s2n_quic::provider::event::Location
+
+variant s2n_quic::connection::Error::Closed exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::connection::Error::EndpointClosing is non-exhaustive
+
+variant s2n_quic::connection::Error::EndpointClosing exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::connection::Error::IdleTimerExpired is non-exhaustive
+
+variant s2n_quic::connection::Error::IdleTimerExpired exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::connection::Error::ImmediateClose is non-exhaustive
+
+variant s2n_quic::connection::Error::ImmediateClose exports field:
+  reason:
+  &'static str
+
+variant s2n_quic::connection::Error::ImmediateClose exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::connection::Error::MaxHandshakeDurationExceeded is non-exhaustive
+
+variant s2n_quic::connection::Error::MaxHandshakeDurationExceeded exports field:
+  max_handshake_duration:
+  core::time::Duration
+
+variant s2n_quic::connection::Error::MaxHandshakeDurationExceeded exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::connection::Error::NoValidPath is non-exhaustive
+
+variant s2n_quic::connection::Error::NoValidPath exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::connection::Error::StatelessReset is non-exhaustive
+
+variant s2n_quic::connection::Error::StatelessReset exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::connection::Error::StreamIdExhausted is non-exhaustive
+
+variant s2n_quic::connection::Error::StreamIdExhausted exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::connection::Error::Transport is non-exhaustive
+
+variant s2n_quic::connection::Error::Transport exports field:
+  code:
+  s2n_quic::connection::error::Code
+
+variant s2n_quic::connection::Error::Transport exports field:
+  frame_type:
+  u64
+
+variant s2n_quic::connection::Error::Transport exports field:
+  initiator:
+  s2n_quic::provider::event::Location
+
+variant s2n_quic::connection::Error::Transport exports field:
+  reason:
+  &'static str
+
+variant s2n_quic::connection::Error::Transport exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::connection::Error::Unspecified is non-exhaustive
+
+variant s2n_quic::connection::Error::Unspecified exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+struct s2n_quic::connection::Handle implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::connection::Handle
+
+struct s2n_quic::connection::Handle implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::connection::Handle
+
+struct s2n_quic::connection::Handle implements trait:
+  impl core::clone::Clone for s2n_quic::connection::Handle
+
+struct s2n_quic::connection::Handle implements trait:
+  impl core::fmt::Debug for s2n_quic::connection::Handle
+
+struct s2n_quic::connection::Handle implements trait:
+  impl core::marker::Send for s2n_quic::connection::Handle
+
+struct s2n_quic::connection::Handle implements trait:
+  impl core::marker::Sync for s2n_quic::connection::Handle
+
+struct s2n_quic::connection::Handle implements trait:
+  impl core::marker::Unpin for s2n_quic::connection::Handle
+
+struct s2n_quic::connection::Handle exports function:
+  pub async fn open_bidirectional_stream(&mut self) -> s2n_quic::connection::Result<s2n_quic::stream::BidirectionalStream>
+
+struct s2n_quic::connection::Handle exports function:
+  pub async fn open_send_stream(&mut self) -> s2n_quic::connection::Result<s2n_quic::stream::SendStream>
+
+struct s2n_quic::connection::Handle exports function:
+  pub async fn open_stream(&mut self, stream_type: s2n_quic::stream::Type) -> s2n_quic::connection::Result<s2n_quic::stream::LocalStream>
+
+struct s2n_quic::connection::Handle exports function:
+  pub fn application_protocol(&self) -> s2n_quic::connection::Result<bytes::bytes::Bytes>
+
+struct s2n_quic::connection::Handle exports function:
+  pub fn close(&self, error_code: s2n_quic::application::Error)
+
+struct s2n_quic::connection::Handle exports function:
+  pub fn id(&self) -> u64
+
+struct s2n_quic::connection::Handle exports function:
+  pub fn keep_alive(&mut self, enabled: bool) -> s2n_quic::connection::Result<()>
+
+struct s2n_quic::connection::Handle exports function:
+  pub fn local_addr(&self) -> s2n_quic::connection::Result<std::net::addr::SocketAddr>
+
+struct s2n_quic::connection::Handle exports function:
+  pub fn ping(&mut self) -> s2n_quic::connection::Result<()>
+
+struct s2n_quic::connection::Handle exports function:
+  pub fn poll_open_bidirectional_stream(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::connection::Result<s2n_quic::stream::BidirectionalStream>>
+
+struct s2n_quic::connection::Handle exports function:
+  pub fn poll_open_send_stream(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::connection::Result<s2n_quic::stream::SendStream>>
+
+struct s2n_quic::connection::Handle exports function:
+  pub fn poll_open_stream(
+  &mut self,
+  stream_type: s2n_quic::stream::Type,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::connection::Result<s2n_quic::stream::LocalStream>>
+
+struct s2n_quic::connection::Handle exports function:
+  pub fn query_event_context<Query, EventContext, Outcome>(
+  &self,
+  query: Query) -> core::result::Result<Outcome, s2n_quic::provider::event::query::Error> where
+  Query: core::ops::function::FnOnce(&EventContext) -> Outcome,
+  EventContext: 'static,
+
+struct s2n_quic::connection::Handle exports function:
+  pub fn query_event_context_mut<Query, EventContext, Outcome>(
+  &mut self,
+  query: Query) -> core::result::Result<Outcome, s2n_quic::provider::event::query::Error> where
+  Query: core::ops::function::FnOnce(&mut EventContext) -> Outcome,
+  EventContext: 'static,
+
+struct s2n_quic::connection::Handle exports function:
+  pub fn remote_addr(&self) -> s2n_quic::connection::Result<std::net::addr::SocketAddr>
+
+struct s2n_quic::connection::Handle exports function:
+  pub fn server_name(&self) -> s2n_quic::connection::Result<core::option::Option<s2n_quic::server::Name>>
+
+struct s2n_quic::connection::ReceiveStreamAcceptor implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::connection::ReceiveStreamAcceptor
+
+struct s2n_quic::connection::ReceiveStreamAcceptor implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::connection::ReceiveStreamAcceptor
+
+struct s2n_quic::connection::ReceiveStreamAcceptor implements trait:
+  impl core::fmt::Debug for s2n_quic::connection::ReceiveStreamAcceptor
+
+struct s2n_quic::connection::ReceiveStreamAcceptor implements trait:
+  impl core::marker::Send for s2n_quic::connection::ReceiveStreamAcceptor
+
+struct s2n_quic::connection::ReceiveStreamAcceptor implements trait:
+  impl core::marker::Sync for s2n_quic::connection::ReceiveStreamAcceptor
+
+struct s2n_quic::connection::ReceiveStreamAcceptor implements trait:
+  impl core::marker::Unpin for s2n_quic::connection::ReceiveStreamAcceptor
+
+struct s2n_quic::connection::ReceiveStreamAcceptor implements trait:
+  impl futures_core::stream::Stream for s2n_quic::connection::ReceiveStreamAcceptor
+
+struct s2n_quic::connection::ReceiveStreamAcceptor exports function:
+  pub async fn accept_receive_stream(&mut self) -> s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::ReceiveStream>>
+
+struct s2n_quic::connection::ReceiveStreamAcceptor exports function:
+  pub fn poll_accept_receive_stream(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::ReceiveStream>>>
+
+typedef s2n_quic::connection::Result exports typedef:
+  type Result<T, E
+  =
+  s2n_quic::connection::Error> = core::result::Result<T, E>;
+
+struct s2n_quic::connection::StreamAcceptor implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::connection::StreamAcceptor
+
+struct s2n_quic::connection::StreamAcceptor implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::connection::StreamAcceptor
+
+struct s2n_quic::connection::StreamAcceptor implements trait:
+  impl core::fmt::Debug for s2n_quic::connection::StreamAcceptor
+
+struct s2n_quic::connection::StreamAcceptor implements trait:
+  impl core::marker::Send for s2n_quic::connection::StreamAcceptor
+
+struct s2n_quic::connection::StreamAcceptor implements trait:
+  impl core::marker::Sync for s2n_quic::connection::StreamAcceptor
+
+struct s2n_quic::connection::StreamAcceptor implements trait:
+  impl core::marker::Unpin for s2n_quic::connection::StreamAcceptor
+
+struct s2n_quic::connection::StreamAcceptor implements trait:
+  impl futures_core::stream::Stream for s2n_quic::connection::StreamAcceptor
+
+struct s2n_quic::connection::StreamAcceptor exports function:
+  pub async fn accept(&mut self) -> s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::PeerStream>>
+
+struct s2n_quic::connection::StreamAcceptor exports function:
+  pub async fn accept_bidirectional_stream(
+  &mut self) -> s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::BidirectionalStream>>
+
+struct s2n_quic::connection::StreamAcceptor exports function:
+  pub async fn accept_receive_stream(&mut self) -> s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::ReceiveStream>>
+
+struct s2n_quic::connection::StreamAcceptor exports function:
+  pub fn poll_accept(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::PeerStream>>>
+
+struct s2n_quic::connection::StreamAcceptor exports function:
+  pub fn poll_accept_bidirectional_stream(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::BidirectionalStream>>>
+
+struct s2n_quic::connection::StreamAcceptor exports function:
+  pub fn poll_accept_receive_stream(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::connection::Result<core::option::Option<s2n_quic::stream::ReceiveStream>>>
+
+struct s2n_quic::connection::StreamAcceptor exports function:
+  pub fn split(self) -> (s2n_quic::connection::BidirectionalStreamAcceptor, s2n_quic::connection::ReceiveStreamAcceptor)
+
+module s2n_quic::connection::error exports struct:
+  s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code implements trait:
+  impl core::clone::Clone for s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code implements trait:
+  impl core::cmp::Ord for s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code implements trait:
+  impl core::cmp::PartialEq<s2n_quic::connection::error::Code> for s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code implements trait:
+  impl core::cmp::PartialOrd<s2n_quic::connection::error::Code> for s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code implements trait:
+  impl core::fmt::Debug for s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code implements trait:
+  impl core::fmt::Display for s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code implements trait:
+  impl core::marker::Send for s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code implements trait:
+  impl core::marker::Sync for s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code implements trait:
+  impl core::marker::Unpin for s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const AEAD_LIMIT_REACHED: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const APPLICATION_ERROR: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const CONNECTION_ID_LIMIT_ERROR: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const CONNECTION_REFUSED: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const CRYPTO_BUFFER_EXCEEDED: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const FINAL_SIZE_ERROR: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const FLOW_CONTROL_ERROR: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const FRAME_ENCODING_ERROR: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const INTERNAL_ERROR: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const INVALID_TOKEN: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const KEY_UPDATE_ERROR: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const NO_ERROR: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const PROTOCOL_VIOLATION: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const STREAM_LIMIT_ERROR: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const STREAM_STATE_ERROR: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports constant:
+  pub const TRANSPORT_PARAMETER_ERROR: s2n_quic::connection::error::Code
+
+struct s2n_quic::connection::error::Code exports function:
+  pub fn as_u64(self) -> u64
+
+struct s2n_quic::connection::error::Code exports function:
+  pub fn description(&self) -> core::option::Option<&'static str>
+
+module s2n_quic::provider exports struct:
+  s2n_quic::provider::StartError
+
+module s2n_quic::provider exports module:
+  s2n_quic::provider::address_token
+
+module s2n_quic::provider exports module:
+  s2n_quic::provider::connection_id
+
+module s2n_quic::provider exports module:
+  s2n_quic::provider::endpoint_limits
+
+module s2n_quic::provider exports module:
+  s2n_quic::provider::event
+
+module s2n_quic::provider exports module:
+  s2n_quic::provider::io
+
+module s2n_quic::provider exports module:
+  s2n_quic::provider::limits
+
+module s2n_quic::provider exports module:
+  s2n_quic::provider::stateless_reset_token
+
+module s2n_quic::provider exports module:
+  s2n_quic::provider::tls
+
+struct s2n_quic::provider::StartError implements trait:
+  impl !core::marker::Send for s2n_quic::provider::StartError
+
+struct s2n_quic::provider::StartError implements trait:
+  impl !core::marker::Sync for s2n_quic::provider::StartError
+
+struct s2n_quic::provider::StartError implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::StartError
+
+struct s2n_quic::provider::StartError implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::StartError
+
+struct s2n_quic::provider::StartError implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::StartError
+
+struct s2n_quic::provider::StartError implements trait:
+  impl core::fmt::Display for s2n_quic::provider::StartError
+
+struct s2n_quic::provider::StartError implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::StartError
+
+struct s2n_quic::provider::StartError implements trait:
+  impl std::error::Error for s2n_quic::provider::StartError
+
+module s2n_quic::provider::address_token exports struct:
+  s2n_quic::provider::address_token::Context
+
+module s2n_quic::provider::address_token exports trait:
+  s2n_quic::provider::address_token::Format
+
+module s2n_quic::provider::address_token exports trait:
+  s2n_quic::provider::address_token::Provider
+
+module s2n_quic::provider::address_token exports trait:
+  s2n_quic::provider::address_token::TryInto
+
+module s2n_quic::provider::address_token exports module:
+  s2n_quic::provider::address_token::default
+
+module s2n_quic::provider::address_token exports struct:
+  s2n_quic::provider::address_token::default::Provider
+
+struct s2n_quic::provider::address_token::Context is non-exhaustive
+
+struct s2n_quic::provider::address_token::Context implements trait:
+  impl<'a> !core::marker::Sync for s2n_quic::provider::address_token::Context<'a>
+
+struct s2n_quic::provider::address_token::Context implements trait:
+  impl<'a> !std::panic::RefUnwindSafe for s2n_quic::provider::address_token::Context<'a>
+
+struct s2n_quic::provider::address_token::Context implements trait:
+  impl<'a> !std::panic::UnwindSafe for s2n_quic::provider::address_token::Context<'a>
+
+struct s2n_quic::provider::address_token::Context implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::address_token::Context<'a>
+
+struct s2n_quic::provider::address_token::Context implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::address_token::Context<'a>
+
+struct s2n_quic::provider::address_token::Context exports field:
+  peer_connection_id: &'a [u8]
+
+struct s2n_quic::provider::address_token::Context exports field:
+  random: &'a mut (dyn s2n_quic_core::random::Generator + 'static)
+
+struct s2n_quic::provider::address_token::Context exports field:
+  remote_address: s2n_quic::provider::event::events::SocketAddress<'a>
+
+trait s2n_quic::provider::address_token::Format associates constant:
+  const TOKEN_LEN: usize
+
+trait s2n_quic::provider::address_token::Format associates constant:
+  pub const TOKEN_LEN: usize
+
+trait s2n_quic::provider::address_token::Format exports function:
+  pub fn generate_new_token(
+  &mut self,
+  context: &mut s2n_quic::provider::address_token::Context<'_>,
+  source_connection_id: &s2n_quic::provider::connection_id::LocalId,
+  output_buffer: &mut [u8]) -> core::option::Option<()>
+
+trait s2n_quic::provider::address_token::Format exports function:
+  pub fn generate_retry_token(
+  &mut self,
+  context: &mut s2n_quic::provider::address_token::Context<'_>,
+  original_destination_connection_id: &s2n_quic_core::connection::id::InitialId,
+  output_buffer: &mut [u8]) -> core::option::Option<()>
+
+trait s2n_quic::provider::address_token::Format exports function:
+  pub fn validate_token(
+  &mut self,
+  context: &mut s2n_quic::provider::address_token::Context<'_>,
+  token: &[u8]) -> core::option::Option<s2n_quic_core::connection::id::InitialId>
+
+trait s2n_quic::provider::address_token::Provider exports function:
+  fn start(self) -> core::result::Result<Self::s2n_quic::provider::address_token::Provider::Format, Self::s2n_quic::provider::address_token::Provider::Error>
+
+trait s2n_quic::provider::address_token::TryInto exports function:
+  fn try_into(self) -> core::result::Result<Self::s2n_quic::provider::address_token::TryInto::Provider, Self::s2n_quic::provider::address_token::TryInto::Error>
+
+module s2n_quic::provider::address_token::default exports struct:
+  s2n_quic::provider::address_token::default::Format
+
+module s2n_quic::provider::address_token::default exports struct:
+  s2n_quic::provider::address_token::default::Provider
+
+struct s2n_quic::provider::address_token::default::Format exports constant:
+  const TOKEN_LEN: usize
+
+struct s2n_quic::provider::address_token::default::Format implements trait:
+  impl core::marker::Send for s2n_quic::provider::address_token::default::Format
+
+struct s2n_quic::provider::address_token::default::Format implements trait:
+  impl core::marker::Sync for s2n_quic::provider::address_token::default::Format
+
+struct s2n_quic::provider::address_token::default::Format implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::address_token::default::Format
+
+struct s2n_quic::provider::address_token::default::Format implements trait:
+  impl s2n_quic::provider::address_token::Format for s2n_quic::provider::address_token::default::Format
+
+struct s2n_quic::provider::address_token::default::Format implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::address_token::default::Format
+
+struct s2n_quic::provider::address_token::default::Format implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::address_token::default::Format
+
+struct s2n_quic::provider::address_token::default::Provider implements trait:
+  impl core::default::Default for s2n_quic::provider::address_token::default::Provider
+
+struct s2n_quic::provider::address_token::default::Provider implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::address_token::default::Provider
+
+struct s2n_quic::provider::address_token::default::Provider implements trait:
+  impl core::marker::Send for s2n_quic::provider::address_token::default::Provider
+
+struct s2n_quic::provider::address_token::default::Provider implements trait:
+  impl core::marker::Sync for s2n_quic::provider::address_token::default::Provider
+
+struct s2n_quic::provider::address_token::default::Provider implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::address_token::default::Provider
+
+struct s2n_quic::provider::address_token::default::Provider implements trait:
+  impl s2n_quic::provider::address_token::Provider for s2n_quic::provider::address_token::default::Provider
+
+struct s2n_quic::provider::address_token::default::Provider implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::address_token::default::Provider
+
+struct s2n_quic::provider::address_token::default::Provider implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::address_token::default::Provider
+
+module s2n_quic::provider::connection_id exports struct:
+  s2n_quic::provider::connection_id::ConnectionInfo
+
+module s2n_quic::provider::connection_id exports trait:
+  s2n_quic::provider::connection_id::Format
+
+module s2n_quic::provider::connection_id exports trait:
+  s2n_quic::provider::connection_id::Generator
+
+module s2n_quic::provider::connection_id exports struct:
+  s2n_quic::provider::connection_id::LocalId
+
+module s2n_quic::provider::connection_id exports trait:
+  s2n_quic::provider::connection_id::Provider
+
+module s2n_quic::provider::connection_id exports trait:
+  s2n_quic::provider::connection_id::TryInto
+
+module s2n_quic::provider::connection_id exports trait:
+  s2n_quic::provider::connection_id::Validator
+
+module s2n_quic::provider::connection_id exports module:
+  s2n_quic::provider::connection_id::default
+
+module s2n_quic::provider::connection_id exports struct:
+  s2n_quic::provider::connection_id::default::Provider
+
+struct s2n_quic::provider::connection_id::ConnectionInfo is non-exhaustive
+
+struct s2n_quic::provider::connection_id::ConnectionInfo implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::connection_id::ConnectionInfo<'a>
+
+struct s2n_quic::provider::connection_id::ConnectionInfo implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::connection_id::ConnectionInfo<'a>
+
+struct s2n_quic::provider::connection_id::ConnectionInfo implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::connection_id::ConnectionInfo<'a>
+
+struct s2n_quic::provider::connection_id::ConnectionInfo implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::connection_id::ConnectionInfo<'a>
+
+struct s2n_quic::provider::connection_id::ConnectionInfo implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::connection_id::ConnectionInfo<'a>
+
+struct s2n_quic::provider::connection_id::ConnectionInfo implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::connection_id::ConnectionInfo<'a>
+
+struct s2n_quic::provider::connection_id::ConnectionInfo implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::connection_id::ConnectionInfo<'a>
+
+struct s2n_quic::provider::connection_id::ConnectionInfo exports field:
+  remote_address: s2n_quic::provider::event::events::SocketAddress<'a>
+
+trait s2n_quic::provider::connection_id::Generator exports function:
+  pub fn generate(&mut self, connection_info: &s2n_quic::provider::connection_id::ConnectionInfo<'_>) -> s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl bolero_generator::TypeGenerator for s2n_quic::provider::connection_id::LocalId where
+  [u8; 20]: bolero_generator::TypeGenerator,
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl core::clone::Clone for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl core::cmp::Ord for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::connection_id::LocalId> for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl core::cmp::PartialOrd<s2n_quic::provider::connection_id::LocalId> for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl core::convert::AsRef<[u8]> for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl core::convert::From<[u8; 20]> for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl core::default::Default for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl core::hash::Hash for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl core::marker::Send for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl core::marker::Sync for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl s2n_codec::encoder::value::EncoderValue for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl<'_> core::convert::TryFrom<&'_ [u8]> for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl<'a> s2n_codec::decoder::value::DecoderValue<'a> for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl<'a> s2n_codec::decoder::value::DecoderValueMut<'a> for s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId implements trait:
+  impl<'a> s2n_quic_core::event::IntoEvent<s2n_quic_core::event::generated::builder::ConnectionId<'a>> for &'a s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId exports constant:
+  pub const MIN_LEN: usize
+
+struct s2n_quic::provider::connection_id::LocalId exports constant:
+  pub const TEST_ID: s2n_quic::provider::connection_id::LocalId
+
+struct s2n_quic::provider::connection_id::LocalId exports function:
+  pub const fn len(&self) -> usize
+
+struct s2n_quic::provider::connection_id::LocalId exports function:
+  pub fn as_bytes(&self) -> &[u8]
+
+struct s2n_quic::provider::connection_id::LocalId exports function:
+  pub fn is_empty(&self) -> bool
+
+struct s2n_quic::provider::connection_id::LocalId exports function:
+  pub fn try_from_bytes(bytes: &[u8]) -> core::option::Option<s2n_quic::provider::connection_id::LocalId>
+
+trait s2n_quic::provider::connection_id::Provider exports function:
+  fn start(self) -> core::result::Result<Self::s2n_quic::provider::connection_id::Provider::Format, Self::s2n_quic::provider::connection_id::Provider::Error>
+
+trait s2n_quic::provider::connection_id::TryInto exports function:
+  fn try_into(self) -> core::result::Result<Self::s2n_quic::provider::connection_id::TryInto::Provider, Self::s2n_quic::provider::connection_id::TryInto::Error>
+
+trait s2n_quic::provider::connection_id::Validator exports function:
+  pub fn validate(
+  &self,
+  connection_info: &s2n_quic::provider::connection_id::ConnectionInfo<'_>,
+  buffer: &[u8]) -> core::option::Option<usize>
+
+module s2n_quic::provider::connection_id::default exports struct:
+  s2n_quic::provider::connection_id::default::Builder
+
+module s2n_quic::provider::connection_id::default exports struct:
+  s2n_quic::provider::connection_id::default::Format
+
+module s2n_quic::provider::connection_id::default exports struct:
+  s2n_quic::provider::connection_id::default::Provider
+
+struct s2n_quic::provider::connection_id::default::Builder implements trait:
+  impl core::default::Default for s2n_quic::provider::connection_id::default::Builder
+
+struct s2n_quic::provider::connection_id::default::Builder implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::connection_id::default::Builder
+
+struct s2n_quic::provider::connection_id::default::Builder implements trait:
+  impl core::marker::Send for s2n_quic::provider::connection_id::default::Builder
+
+struct s2n_quic::provider::connection_id::default::Builder implements trait:
+  impl core::marker::Sync for s2n_quic::provider::connection_id::default::Builder
+
+struct s2n_quic::provider::connection_id::default::Builder implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::connection_id::default::Builder
+
+struct s2n_quic::provider::connection_id::default::Builder implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::connection_id::default::Builder
+
+struct s2n_quic::provider::connection_id::default::Builder implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::connection_id::default::Builder
+
+struct s2n_quic::provider::connection_id::default::Builder exports function:
+  pub fn build(self) -> core::result::Result<s2n_quic::provider::connection_id::default::Format, core::convert::Infallible>
+
+struct s2n_quic::provider::connection_id::default::Builder exports function:
+  pub fn with_len(self, len: usize) -> core::result::Result<Self, s2n_quic_core::connection::id::Error>
+
+struct s2n_quic::provider::connection_id::default::Builder exports function:
+  pub fn with_lifetime(self, lifetime: core::time::Duration) -> core::result::Result<Self, s2n_quic_core::connection::id::Error>
+
+struct s2n_quic::provider::connection_id::default::Format implements trait:
+  impl core::default::Default for s2n_quic::provider::connection_id::default::Format
+
+struct s2n_quic::provider::connection_id::default::Format implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::connection_id::default::Format
+
+struct s2n_quic::provider::connection_id::default::Format implements trait:
+  impl core::marker::Send for s2n_quic::provider::connection_id::default::Format
+
+struct s2n_quic::provider::connection_id::default::Format implements trait:
+  impl core::marker::Sync for s2n_quic::provider::connection_id::default::Format
+
+struct s2n_quic::provider::connection_id::default::Format implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::connection_id::default::Format
+
+struct s2n_quic::provider::connection_id::default::Format implements trait:
+  impl s2n_quic::provider::connection_id::Generator for s2n_quic::provider::connection_id::default::Format
+
+struct s2n_quic::provider::connection_id::default::Format implements trait:
+  impl s2n_quic::provider::connection_id::Validator for s2n_quic::provider::connection_id::default::Format
+
+struct s2n_quic::provider::connection_id::default::Format implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::connection_id::default::Format
+
+struct s2n_quic::provider::connection_id::default::Format implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::connection_id::default::Format
+
+struct s2n_quic::provider::connection_id::default::Format exports function:
+  pub fn builder() -> s2n_quic::provider::connection_id::default::Builder
+
+struct s2n_quic::provider::connection_id::default::Provider implements trait:
+  impl core::default::Default for s2n_quic::provider::connection_id::default::Provider
+
+struct s2n_quic::provider::connection_id::default::Provider implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::connection_id::default::Provider
+
+struct s2n_quic::provider::connection_id::default::Provider implements trait:
+  impl core::marker::Send for s2n_quic::provider::connection_id::default::Provider
+
+struct s2n_quic::provider::connection_id::default::Provider implements trait:
+  impl core::marker::Sync for s2n_quic::provider::connection_id::default::Provider
+
+struct s2n_quic::provider::connection_id::default::Provider implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::connection_id::default::Provider
+
+struct s2n_quic::provider::connection_id::default::Provider implements trait:
+  impl s2n_quic::provider::connection_id::Provider for s2n_quic::provider::connection_id::default::Provider
+
+struct s2n_quic::provider::connection_id::default::Provider implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::connection_id::default::Provider
+
+struct s2n_quic::provider::connection_id::default::Provider implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::connection_id::default::Provider
+
+module s2n_quic::provider::endpoint_limits exports struct:
+  s2n_quic::provider::endpoint_limits::ConnectionAttempt
+
+module s2n_quic::provider::endpoint_limits exports trait:
+  s2n_quic::provider::endpoint_limits::Limiter
+
+module s2n_quic::provider::endpoint_limits exports enum:
+  s2n_quic::provider::endpoint_limits::Outcome
+
+module s2n_quic::provider::endpoint_limits exports trait:
+  s2n_quic::provider::endpoint_limits::Provider
+
+module s2n_quic::provider::endpoint_limits exports trait:
+  s2n_quic::provider::endpoint_limits::TryInto
+
+module s2n_quic::provider::endpoint_limits exports module:
+  s2n_quic::provider::endpoint_limits::default
+
+module s2n_quic::provider::endpoint_limits exports struct:
+  s2n_quic::provider::endpoint_limits::default::Limits
+
+struct s2n_quic::provider::endpoint_limits::ConnectionAttempt is non-exhaustive
+
+struct s2n_quic::provider::endpoint_limits::ConnectionAttempt exports field:
+  connection_count: usize
+
+struct s2n_quic::provider::endpoint_limits::ConnectionAttempt implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::endpoint_limits::ConnectionAttempt<'a>
+
+struct s2n_quic::provider::endpoint_limits::ConnectionAttempt implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::endpoint_limits::ConnectionAttempt<'a>
+
+struct s2n_quic::provider::endpoint_limits::ConnectionAttempt implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::endpoint_limits::ConnectionAttempt<'a>
+
+struct s2n_quic::provider::endpoint_limits::ConnectionAttempt implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::endpoint_limits::ConnectionAttempt<'a>
+
+struct s2n_quic::provider::endpoint_limits::ConnectionAttempt implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::endpoint_limits::ConnectionAttempt<'a>
+
+struct s2n_quic::provider::endpoint_limits::ConnectionAttempt implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::endpoint_limits::ConnectionAttempt<'a>
+
+struct s2n_quic::provider::endpoint_limits::ConnectionAttempt exports field:
+  inflight_handshakes: usize
+
+struct s2n_quic::provider::endpoint_limits::ConnectionAttempt exports field:
+  remote_address: s2n_quic::provider::event::events::SocketAddress<'a>
+
+trait s2n_quic::provider::endpoint_limits::Limiter exports function:
+  pub fn on_connection_attempt(&mut self, info: &s2n_quic::provider::endpoint_limits::ConnectionAttempt<'_>) -> s2n_quic::provider::endpoint_limits::Outcome
+
+enum s2n_quic::provider::endpoint_limits::Outcome is non-exhaustive
+
+enum s2n_quic::provider::endpoint_limits::Outcome exports variant:
+  Allow
+
+enum s2n_quic::provider::endpoint_limits::Outcome exports variant:
+  Close
+
+enum s2n_quic::provider::endpoint_limits::Outcome exports variant:
+  Drop
+
+enum s2n_quic::provider::endpoint_limits::Outcome exports variant:
+  Retry
+
+enum s2n_quic::provider::endpoint_limits::Outcome implements trait:
+  impl core::clone::Clone for s2n_quic::provider::endpoint_limits::Outcome
+
+enum s2n_quic::provider::endpoint_limits::Outcome implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::endpoint_limits::Outcome> for s2n_quic::provider::endpoint_limits::Outcome
+
+enum s2n_quic::provider::endpoint_limits::Outcome implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::endpoint_limits::Outcome
+
+enum s2n_quic::provider::endpoint_limits::Outcome implements trait:
+  impl core::marker::Send for s2n_quic::provider::endpoint_limits::Outcome
+
+enum s2n_quic::provider::endpoint_limits::Outcome implements trait:
+  impl core::marker::Sync for s2n_quic::provider::endpoint_limits::Outcome
+
+enum s2n_quic::provider::endpoint_limits::Outcome implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::endpoint_limits::Outcome
+
+enum s2n_quic::provider::endpoint_limits::Outcome implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::endpoint_limits::Outcome
+
+enum s2n_quic::provider::endpoint_limits::Outcome implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::endpoint_limits::Outcome
+
+enum s2n_quic::provider::endpoint_limits::Outcome exports function:
+  pub fn allow() -> s2n_quic::provider::endpoint_limits::Outcome
+
+enum s2n_quic::provider::endpoint_limits::Outcome exports function:
+  pub fn close() -> s2n_quic::provider::endpoint_limits::Outcome
+
+enum s2n_quic::provider::endpoint_limits::Outcome exports function:
+  pub fn drop() -> s2n_quic::provider::endpoint_limits::Outcome
+
+enum s2n_quic::provider::endpoint_limits::Outcome exports function:
+  pub fn retry() -> s2n_quic::provider::endpoint_limits::Outcome
+
+variant s2n_quic::provider::endpoint_limits::Outcome::Allow is non-exhaustive
+
+variant s2n_quic::provider::endpoint_limits::Outcome::Close is non-exhaustive
+
+variant s2n_quic::provider::endpoint_limits::Outcome::Drop is non-exhaustive
+
+variant s2n_quic::provider::endpoint_limits::Outcome::Retry is non-exhaustive
+
+trait s2n_quic::provider::endpoint_limits::Provider exports function:
+  fn start(self) -> core::result::Result<Self::s2n_quic::provider::endpoint_limits::Provider::Limits, Self::s2n_quic::provider::endpoint_limits::Provider::Error>
+
+trait s2n_quic::provider::endpoint_limits::TryInto exports function:
+  fn try_into(self) -> core::result::Result<Self::s2n_quic::provider::endpoint_limits::TryInto::Provider, Self::s2n_quic::provider::endpoint_limits::TryInto::Error>
+
+module s2n_quic::provider::endpoint_limits::default exports struct:
+  s2n_quic::provider::endpoint_limits::default::Builder
+
+module s2n_quic::provider::endpoint_limits::default exports struct:
+  s2n_quic::provider::endpoint_limits::default::Limits
+
+struct s2n_quic::provider::endpoint_limits::default::Builder implements trait:
+  impl core::default::Default for s2n_quic::provider::endpoint_limits::default::Builder
+
+struct s2n_quic::provider::endpoint_limits::default::Builder implements trait:
+  impl core::marker::Send for s2n_quic::provider::endpoint_limits::default::Builder
+
+struct s2n_quic::provider::endpoint_limits::default::Builder implements trait:
+  impl core::marker::Sync for s2n_quic::provider::endpoint_limits::default::Builder
+
+struct s2n_quic::provider::endpoint_limits::default::Builder implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::endpoint_limits::default::Builder
+
+struct s2n_quic::provider::endpoint_limits::default::Builder implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::endpoint_limits::default::Builder
+
+struct s2n_quic::provider::endpoint_limits::default::Builder implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::endpoint_limits::default::Builder
+
+struct s2n_quic::provider::endpoint_limits::default::Builder exports function:
+  pub fn build(self) -> core::result::Result<s2n_quic::provider::endpoint_limits::default::Limits, core::convert::Infallible>
+
+struct s2n_quic::provider::endpoint_limits::default::Builder exports function:
+  pub fn with_inflight_handshake_limit(
+  self,
+  limit: usize) -> core::result::Result<Self, core::convert::Infallible>
+
+struct s2n_quic::provider::endpoint_limits::default::Limits implements trait:
+  impl core::clone::Clone for s2n_quic::provider::endpoint_limits::default::Limits
+
+struct s2n_quic::provider::endpoint_limits::default::Limits implements trait:
+  impl core::default::Default for s2n_quic::provider::endpoint_limits::default::Limits
+
+struct s2n_quic::provider::endpoint_limits::default::Limits implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::endpoint_limits::default::Limits
+
+struct s2n_quic::provider::endpoint_limits::default::Limits implements trait:
+  impl core::marker::Send for s2n_quic::provider::endpoint_limits::default::Limits
+
+struct s2n_quic::provider::endpoint_limits::default::Limits implements trait:
+  impl core::marker::Sync for s2n_quic::provider::endpoint_limits::default::Limits
+
+struct s2n_quic::provider::endpoint_limits::default::Limits implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::endpoint_limits::default::Limits
+
+struct s2n_quic::provider::endpoint_limits::default::Limits implements trait:
+  impl s2n_quic::provider::endpoint_limits::Limiter for s2n_quic::provider::endpoint_limits::default::Limits
+
+struct s2n_quic::provider::endpoint_limits::default::Limits implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::endpoint_limits::default::Limits
+
+struct s2n_quic::provider::endpoint_limits::default::Limits implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::endpoint_limits::default::Limits
+
+struct s2n_quic::provider::endpoint_limits::default::Limits exports function:
+  pub fn builder() -> s2n_quic::provider::endpoint_limits::default::Builder
+
+module s2n_quic::provider::event exports struct:
+  s2n_quic::provider::event::ConnectionInfo
+
+module s2n_quic::provider::event exports struct:
+  s2n_quic::provider::event::ConnectionMeta
+
+module s2n_quic::provider::event exports trait:
+  s2n_quic::provider::event::Event
+
+module s2n_quic::provider::event exports enum:
+  s2n_quic::provider::event::Location
+
+module s2n_quic::provider::event exports trait:
+  s2n_quic::provider::event::Meta
+
+module s2n_quic::provider::event exports trait:
+  s2n_quic::provider::event::Provider
+
+module s2n_quic::provider::event exports trait:
+  s2n_quic::provider::event::Subscriber
+
+module s2n_quic::provider::event exports struct:
+  s2n_quic::provider::event::Timestamp
+
+module s2n_quic::provider::event exports trait:
+  s2n_quic::provider::event::TryInto
+
+module s2n_quic::provider::event exports module:
+  s2n_quic::provider::event::disabled
+
+module s2n_quic::provider::event exports module:
+  s2n_quic::provider::event::events
+
+module s2n_quic::provider::event exports module:
+  s2n_quic::provider::event::query
+
+module s2n_quic::provider::event exports module:
+  s2n_quic::provider::event::supervisor
+
+module s2n_quic::provider::event exports module:
+  s2n_quic::provider::event::tracing
+
+module s2n_quic::provider::event exports struct:
+  s2n_quic::provider::event::tracing::Provider
+
+struct s2n_quic::provider::event::ConnectionInfo implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::ConnectionInfo
+
+struct s2n_quic::provider::event::ConnectionInfo implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::ConnectionInfo
+
+struct s2n_quic::provider::event::ConnectionInfo implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::ConnectionInfo
+
+struct s2n_quic::provider::event::ConnectionInfo implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::ConnectionInfo
+
+struct s2n_quic::provider::event::ConnectionInfo implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::ConnectionInfo
+
+struct s2n_quic::provider::event::ConnectionInfo implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::ConnectionInfo
+
+struct s2n_quic::provider::event::ConnectionInfo implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::ConnectionInfo
+
+struct s2n_quic::provider::event::ConnectionMeta is non-exhaustive
+
+struct s2n_quic::provider::event::ConnectionMeta exports field:
+  endpoint_type: s2n_quic::provider::event::events::EndpointType
+
+struct s2n_quic::provider::event::ConnectionMeta exports field:
+  id: u64
+
+struct s2n_quic::provider::event::ConnectionMeta implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::ConnectionMeta implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::ConnectionMeta implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::ConnectionMeta implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::ConnectionMeta implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::ConnectionMeta implements trait:
+  impl s2n_quic::provider::event::Meta for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::ConnectionMeta implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::ConnectionMeta implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::ConnectionMeta exports field:
+  timestamp: s2n_quic::provider::event::Timestamp
+
+trait s2n_quic::provider::event::Event associates constant:
+  pub const NAME: &'static str
+
+enum s2n_quic::provider::event::Location exports function:
+  #[must_use]
+  pub fn peer_type(self) -> s2n_quic::provider::event::Location
+
+enum s2n_quic::provider::event::Location exports variant:
+  Local
+
+enum s2n_quic::provider::event::Location exports variant:
+  Remote
+
+enum s2n_quic::provider::event::Location implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::Location
+
+enum s2n_quic::provider::event::Location implements trait:
+  impl core::cmp::Ord for s2n_quic::provider::event::Location
+
+enum s2n_quic::provider::event::Location implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::event::Location> for s2n_quic::provider::event::Location
+
+enum s2n_quic::provider::event::Location implements trait:
+  impl core::cmp::PartialOrd<s2n_quic::provider::event::Location> for s2n_quic::provider::event::Location
+
+enum s2n_quic::provider::event::Location implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::Location
+
+enum s2n_quic::provider::event::Location implements trait:
+  impl core::fmt::Display for s2n_quic::provider::event::Location
+
+enum s2n_quic::provider::event::Location implements trait:
+  impl core::hash::Hash for s2n_quic::provider::event::Location
+
+enum s2n_quic::provider::event::Location implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::Location
+
+enum s2n_quic::provider::event::Location implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::Location
+
+enum s2n_quic::provider::event::Location implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::Location
+
+enum s2n_quic::provider::event::Location implements trait:
+  impl s2n_quic_core::event::IntoEvent<s2n_quic::provider::event::Location> for s2n_quic::provider::event::Location
+
+enum s2n_quic::provider::event::Location implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::Location
+
+enum s2n_quic::provider::event::Location implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::Location
+
+enum s2n_quic::provider::event::Location exports function:
+  pub fn is_local(self) -> bool
+
+enum s2n_quic::provider::event::Location exports function:
+  pub fn is_remote(self) -> bool
+
+trait s2n_quic::provider::event::Meta exports function:
+  pub fn endpoint_type(&self) -> &s2n_quic::provider::event::events::EndpointType
+
+trait s2n_quic::provider::event::Meta exports function:
+  pub fn subject(&self) -> s2n_quic::provider::event::events::Subject
+
+trait s2n_quic::provider::event::Meta exports function:
+  pub fn timestamp(&self) -> &s2n_quic::provider::event::Timestamp
+
+trait s2n_quic::provider::event::Provider exports function:
+  fn start(self) -> core::result::Result<Self::s2n_quic::provider::event::Provider::Subscriber, Self::s2n_quic::provider::event::Provider::Error>
+
+trait s2n_quic::provider::event::Subscriber exports function:
+  pub fn create_connection_context(
+  &mut self,
+  meta: &s2n_quic::provider::event::ConnectionMeta,
+  info: &s2n_quic::provider::event::ConnectionInfo) -> Self::s2n_quic::provider::event::Subscriber::ConnectionContext
+
+struct s2n_quic::provider::event::Timestamp implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::Timestamp
+
+struct s2n_quic::provider::event::Timestamp implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::Timestamp
+
+struct s2n_quic::provider::event::Timestamp implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::Timestamp
+
+struct s2n_quic::provider::event::Timestamp implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::Timestamp
+
+struct s2n_quic::provider::event::Timestamp implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::Timestamp
+
+struct s2n_quic::provider::event::Timestamp implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::Timestamp
+
+struct s2n_quic::provider::event::Timestamp implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::Timestamp
+
+struct s2n_quic::provider::event::Timestamp exports function:
+  pub fn duration_since_start(&self) -> core::time::Duration
+
+trait s2n_quic::provider::event::TryInto exports function:
+  fn try_into(self) -> core::result::Result<Self::s2n_quic::provider::event::TryInto::Provider, Self::s2n_quic::provider::event::TryInto::Error>
+
+module s2n_quic::provider::event::disabled exports struct:
+  s2n_quic::provider::event::disabled::Provider
+
+module s2n_quic::provider::event::disabled exports struct:
+  s2n_quic::provider::event::disabled::Subscriber
+
+struct s2n_quic::provider::event::disabled::Provider implements trait:
+  impl core::default::Default for s2n_quic::provider::event::disabled::Provider
+
+struct s2n_quic::provider::event::disabled::Provider implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::disabled::Provider
+
+struct s2n_quic::provider::event::disabled::Provider implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::disabled::Provider
+
+struct s2n_quic::provider::event::disabled::Provider implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::disabled::Provider
+
+struct s2n_quic::provider::event::disabled::Provider implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::disabled::Provider
+
+struct s2n_quic::provider::event::disabled::Provider implements trait:
+  impl s2n_quic::provider::event::Provider for s2n_quic::provider::event::disabled::Provider
+
+struct s2n_quic::provider::event::disabled::Provider implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::disabled::Provider
+
+struct s2n_quic::provider::event::disabled::Provider implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::disabled::Provider
+
+struct s2n_quic::provider::event::disabled::Subscriber implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::disabled::Subscriber
+
+struct s2n_quic::provider::event::disabled::Subscriber implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::disabled::Subscriber
+
+struct s2n_quic::provider::event::disabled::Subscriber implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::disabled::Subscriber
+
+struct s2n_quic::provider::event::disabled::Subscriber implements trait:
+  impl s2n_quic::provider::event::Subscriber for s2n_quic::provider::event::disabled::Subscriber
+
+struct s2n_quic::provider::event::disabled::Subscriber implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::disabled::Subscriber
+
+struct s2n_quic::provider::event::disabled::Subscriber implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::disabled::Subscriber
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::ActivePathUpdated
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::ApplicationProtocolInformation
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::CipherSuite
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::Congestion
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::CongestionSource
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::ConnectionClosed
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::ConnectionId
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::ConnectionIdUpdated
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::ConnectionInfo
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::ConnectionMeta
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::ConnectionMigrationDenied
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::ConnectionStarted
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::DatagramDropReason
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::DatagramDropped
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::DatagramReceived
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::DatagramSent
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::DuplicatePacket
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::DuplicatePacketError
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::EcnState
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::EcnStateChanged
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::EndpointConnectionAttemptFailed
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::EndpointDatagramDropped
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::EndpointDatagramReceived
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::EndpointDatagramSent
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::EndpointMeta
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::EndpointPacketReceived
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::EndpointPacketSent
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::EndpointType
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::Frame
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::FrameReceived
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::FrameSent
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::HandshakeStatus
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::HandshakeStatusUpdated
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::KeepAliveTimerExpired
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::KeySpace
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::KeySpaceDiscarded
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::KeyType
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::KeyUpdate
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::MigrationDenyReason
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::PacketDropReason
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::PacketDropped
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::PacketHeader
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::PacketLost
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::PacketReceived
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::PacketSent
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::Path
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::PathChallengeStatus
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::PathChallengeUpdated
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::PathCreated
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::PlatformEventLoopWakeup
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::PlatformFeatureConfiguration
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::PlatformFeatureConfigured
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::PlatformRx
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::PlatformRxError
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::PlatformTx
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::PlatformTxError
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::PreferredAddress
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::RecoveryMetrics
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::RetryDiscardReason
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::RxStreamProgress
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::ServerNameInformation
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::SocketAddress
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::StreamType
+
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::Subject
+
+module s2n_quic::provider::event::events exports trait:
+  s2n_quic::provider::event::events::Subscriber
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::TlsClientHello
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::TlsServerHello
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::TransportParameters
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::TransportParametersReceived
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::TxStreamProgress
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::VersionInformation
+
+struct s2n_quic::provider::event::events::ActivePathUpdated is non-exhaustive
+
+struct s2n_quic::provider::event::events::ActivePathUpdated exports field:
+  active: s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::ActivePathUpdated implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::ActivePathUpdated<'a>
+
+struct s2n_quic::provider::event::events::ActivePathUpdated implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::ActivePathUpdated<'a>
+
+struct s2n_quic::provider::event::events::ActivePathUpdated implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::ActivePathUpdated<'a>
+
+struct s2n_quic::provider::event::events::ActivePathUpdated implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::ActivePathUpdated<'a>
+
+struct s2n_quic::provider::event::events::ActivePathUpdated implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::ActivePathUpdated<'a>
+
+struct s2n_quic::provider::event::events::ActivePathUpdated implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::ActivePathUpdated<'a>
+
+struct s2n_quic::provider::event::events::ActivePathUpdated implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::ActivePathUpdated<'a>
+
+struct s2n_quic::provider::event::events::ActivePathUpdated implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::ActivePathUpdated<'a>
+
+struct s2n_quic::provider::event::events::ActivePathUpdated exports field:
+  previous: s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::ActivePathUpdated exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::ApplicationProtocolInformation is non-exhaustive
+
+struct s2n_quic::provider::event::events::ApplicationProtocolInformation exports field:
+  chosen_application_protocol: &'a [u8]
+
+struct s2n_quic::provider::event::events::ApplicationProtocolInformation implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::ApplicationProtocolInformation<'a>
+
+struct s2n_quic::provider::event::events::ApplicationProtocolInformation implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::ApplicationProtocolInformation<'a>
+
+struct s2n_quic::provider::event::events::ApplicationProtocolInformation implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::ApplicationProtocolInformation<'a>
+
+struct s2n_quic::provider::event::events::ApplicationProtocolInformation implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::ApplicationProtocolInformation<'a>
+
+struct s2n_quic::provider::event::events::ApplicationProtocolInformation implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::ApplicationProtocolInformation<'a>
+
+struct s2n_quic::provider::event::events::ApplicationProtocolInformation implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::ApplicationProtocolInformation<'a>
+
+struct s2n_quic::provider::event::events::ApplicationProtocolInformation implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::ApplicationProtocolInformation<'a>
+
+struct s2n_quic::provider::event::events::ApplicationProtocolInformation implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::ApplicationProtocolInformation<'a>
+
+struct s2n_quic::provider::event::events::ApplicationProtocolInformation exports constant:
+  pub const NAME: &'static str
+
+enum s2n_quic::provider::event::events::CipherSuite is non-exhaustive
+
+enum s2n_quic::provider::event::events::CipherSuite exports variant:
+  TLS_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::event::events::CipherSuite exports variant:
+  TLS_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::event::events::CipherSuite exports variant:
+  TLS_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::event::events::CipherSuite exports variant:
+  Unknown
+
+enum s2n_quic::provider::event::events::CipherSuite implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::CipherSuite
+
+enum s2n_quic::provider::event::events::CipherSuite implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::CipherSuite
+
+enum s2n_quic::provider::event::events::CipherSuite implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::CipherSuite
+
+enum s2n_quic::provider::event::events::CipherSuite implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::CipherSuite
+
+enum s2n_quic::provider::event::events::CipherSuite implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::CipherSuite
+
+enum s2n_quic::provider::event::events::CipherSuite implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::CipherSuite
+
+enum s2n_quic::provider::event::events::CipherSuite implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::CipherSuite
+
+enum s2n_quic::provider::event::events::CipherSuite exports function:
+  pub fn as_str(&self) -> &'static str
+
+variant s2n_quic::provider::event::events::CipherSuite::TLS_AES_128_GCM_SHA256 is non-exhaustive
+
+variant s2n_quic::provider::event::events::CipherSuite::TLS_AES_256_GCM_SHA384 is non-exhaustive
+
+variant s2n_quic::provider::event::events::CipherSuite::TLS_CHACHA20_POLY1305_SHA256 is non-exhaustive
+
+variant s2n_quic::provider::event::events::CipherSuite::Unknown is non-exhaustive
+
+struct s2n_quic::provider::event::events::Congestion is non-exhaustive
+
+struct s2n_quic::provider::event::events::Congestion implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::Congestion<'a>
+
+struct s2n_quic::provider::event::events::Congestion implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::Congestion<'a>
+
+struct s2n_quic::provider::event::events::Congestion implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::Congestion<'a>
+
+struct s2n_quic::provider::event::events::Congestion implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::Congestion<'a>
+
+struct s2n_quic::provider::event::events::Congestion implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::Congestion<'a>
+
+struct s2n_quic::provider::event::events::Congestion implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::Congestion<'a>
+
+struct s2n_quic::provider::event::events::Congestion implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::Congestion<'a>
+
+struct s2n_quic::provider::event::events::Congestion implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::Congestion<'a>
+
+struct s2n_quic::provider::event::events::Congestion exports field:
+  path: s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::Congestion exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::Congestion exports field:
+  source: s2n_quic::provider::event::events::CongestionSource
+
+enum s2n_quic::provider::event::events::CongestionSource is non-exhaustive
+
+enum s2n_quic::provider::event::events::CongestionSource exports variant:
+  Ecn
+
+enum s2n_quic::provider::event::events::CongestionSource exports variant:
+  PacketLoss
+
+enum s2n_quic::provider::event::events::CongestionSource implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::CongestionSource
+
+enum s2n_quic::provider::event::events::CongestionSource implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::CongestionSource
+
+enum s2n_quic::provider::event::events::CongestionSource implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::CongestionSource
+
+enum s2n_quic::provider::event::events::CongestionSource implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::CongestionSource
+
+enum s2n_quic::provider::event::events::CongestionSource implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::CongestionSource
+
+enum s2n_quic::provider::event::events::CongestionSource implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::CongestionSource
+
+enum s2n_quic::provider::event::events::CongestionSource implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::CongestionSource
+
+variant s2n_quic::provider::event::events::CongestionSource::Ecn is non-exhaustive
+
+variant s2n_quic::provider::event::events::CongestionSource::PacketLoss is non-exhaustive
+
+struct s2n_quic::provider::event::events::ConnectionClosed is non-exhaustive
+
+struct s2n_quic::provider::event::events::ConnectionClosed exports field:
+  error: s2n_quic::connection::Error
+
+struct s2n_quic::provider::event::events::ConnectionClosed implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::ConnectionClosed
+
+struct s2n_quic::provider::event::events::ConnectionClosed implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::ConnectionClosed
+
+struct s2n_quic::provider::event::events::ConnectionClosed implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::ConnectionClosed
+
+struct s2n_quic::provider::event::events::ConnectionClosed implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::ConnectionClosed
+
+struct s2n_quic::provider::event::events::ConnectionClosed implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::ConnectionClosed
+
+struct s2n_quic::provider::event::events::ConnectionClosed implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::ConnectionClosed
+
+struct s2n_quic::provider::event::events::ConnectionClosed implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::ConnectionClosed
+
+struct s2n_quic::provider::event::events::ConnectionClosed implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::ConnectionClosed
+
+struct s2n_quic::provider::event::events::ConnectionClosed exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::ConnectionId is non-exhaustive
+
+struct s2n_quic::provider::event::events::ConnectionId exports field:
+  bytes: &'a [u8]
+
+struct s2n_quic::provider::event::events::ConnectionId implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::ConnectionId<'a>
+
+struct s2n_quic::provider::event::events::ConnectionId implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::ConnectionId<'a>
+
+struct s2n_quic::provider::event::events::ConnectionId implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::ConnectionId<'a>
+
+struct s2n_quic::provider::event::events::ConnectionId implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::ConnectionId<'a>
+
+struct s2n_quic::provider::event::events::ConnectionId implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::ConnectionId<'a>
+
+struct s2n_quic::provider::event::events::ConnectionId implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::ConnectionId<'a>
+
+struct s2n_quic::provider::event::events::ConnectionId implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::ConnectionId<'a>
+
+struct s2n_quic::provider::event::events::ConnectionIdUpdated is non-exhaustive
+
+struct s2n_quic::provider::event::events::ConnectionIdUpdated exports field:
+  cid_consumer: s2n_quic::provider::event::Location
+
+struct s2n_quic::provider::event::events::ConnectionIdUpdated exports field:
+  current: s2n_quic::provider::event::events::ConnectionId<'a>
+
+struct s2n_quic::provider::event::events::ConnectionIdUpdated implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::ConnectionIdUpdated<'a>
+
+struct s2n_quic::provider::event::events::ConnectionIdUpdated implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::ConnectionIdUpdated<'a>
+
+struct s2n_quic::provider::event::events::ConnectionIdUpdated implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::ConnectionIdUpdated<'a>
+
+struct s2n_quic::provider::event::events::ConnectionIdUpdated implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::ConnectionIdUpdated<'a>
+
+struct s2n_quic::provider::event::events::ConnectionIdUpdated implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::ConnectionIdUpdated<'a>
+
+struct s2n_quic::provider::event::events::ConnectionIdUpdated implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::ConnectionIdUpdated<'a>
+
+struct s2n_quic::provider::event::events::ConnectionIdUpdated implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::ConnectionIdUpdated<'a>
+
+struct s2n_quic::provider::event::events::ConnectionIdUpdated implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::ConnectionIdUpdated<'a>
+
+struct s2n_quic::provider::event::events::ConnectionIdUpdated exports field:
+  path_id: u64
+
+struct s2n_quic::provider::event::events::ConnectionIdUpdated exports field:
+  previous: s2n_quic::provider::event::events::ConnectionId<'a>
+
+struct s2n_quic::provider::event::events::ConnectionIdUpdated exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::ConnectionInfo implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::ConnectionInfo
+
+struct s2n_quic::provider::event::events::ConnectionInfo implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::ConnectionInfo
+
+struct s2n_quic::provider::event::events::ConnectionInfo implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::ConnectionInfo
+
+struct s2n_quic::provider::event::events::ConnectionInfo implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::ConnectionInfo
+
+struct s2n_quic::provider::event::events::ConnectionInfo implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::ConnectionInfo
+
+struct s2n_quic::provider::event::events::ConnectionInfo implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::ConnectionInfo
+
+struct s2n_quic::provider::event::events::ConnectionInfo implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::ConnectionInfo
+
+struct s2n_quic::provider::event::events::ConnectionMeta is non-exhaustive
+
+struct s2n_quic::provider::event::events::ConnectionMeta exports field:
+  endpoint_type: s2n_quic::provider::event::events::EndpointType
+
+struct s2n_quic::provider::event::events::ConnectionMeta exports field:
+  id: u64
+
+struct s2n_quic::provider::event::events::ConnectionMeta implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::events::ConnectionMeta implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::events::ConnectionMeta implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::events::ConnectionMeta implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::events::ConnectionMeta implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::events::ConnectionMeta implements trait:
+  impl s2n_quic::provider::event::Meta for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::events::ConnectionMeta implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::events::ConnectionMeta implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::ConnectionMeta
+
+struct s2n_quic::provider::event::events::ConnectionMeta exports field:
+  timestamp: s2n_quic::provider::event::Timestamp
+
+struct s2n_quic::provider::event::events::ConnectionMigrationDenied is non-exhaustive
+
+struct s2n_quic::provider::event::events::ConnectionMigrationDenied implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::ConnectionMigrationDenied
+
+struct s2n_quic::provider::event::events::ConnectionMigrationDenied implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::ConnectionMigrationDenied
+
+struct s2n_quic::provider::event::events::ConnectionMigrationDenied implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::ConnectionMigrationDenied
+
+struct s2n_quic::provider::event::events::ConnectionMigrationDenied implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::ConnectionMigrationDenied
+
+struct s2n_quic::provider::event::events::ConnectionMigrationDenied implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::ConnectionMigrationDenied
+
+struct s2n_quic::provider::event::events::ConnectionMigrationDenied implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::ConnectionMigrationDenied
+
+struct s2n_quic::provider::event::events::ConnectionMigrationDenied implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::ConnectionMigrationDenied
+
+struct s2n_quic::provider::event::events::ConnectionMigrationDenied implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::ConnectionMigrationDenied
+
+struct s2n_quic::provider::event::events::ConnectionMigrationDenied exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::ConnectionMigrationDenied exports field:
+  reason: s2n_quic::provider::event::events::MigrationDenyReason
+
+struct s2n_quic::provider::event::events::ConnectionStarted is non-exhaustive
+
+struct s2n_quic::provider::event::events::ConnectionStarted implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::ConnectionStarted<'a>
+
+struct s2n_quic::provider::event::events::ConnectionStarted implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::ConnectionStarted<'a>
+
+struct s2n_quic::provider::event::events::ConnectionStarted implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::ConnectionStarted<'a>
+
+struct s2n_quic::provider::event::events::ConnectionStarted implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::ConnectionStarted<'a>
+
+struct s2n_quic::provider::event::events::ConnectionStarted implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::ConnectionStarted<'a>
+
+struct s2n_quic::provider::event::events::ConnectionStarted implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::ConnectionStarted<'a>
+
+struct s2n_quic::provider::event::events::ConnectionStarted implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::ConnectionStarted<'a>
+
+struct s2n_quic::provider::event::events::ConnectionStarted implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::ConnectionStarted<'a>
+
+struct s2n_quic::provider::event::events::ConnectionStarted exports field:
+  path: s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::ConnectionStarted exports constant:
+  pub const NAME: &'static str
+
+enum s2n_quic::provider::event::events::DatagramDropReason is non-exhaustive
+
+enum s2n_quic::provider::event::events::DatagramDropReason exports variant:
+  ConnectionMigrationDuringHandshake
+
+enum s2n_quic::provider::event::events::DatagramDropReason exports variant:
+  DecodingFailed
+
+enum s2n_quic::provider::event::events::DatagramDropReason exports variant:
+  InsufficientConnectionIds
+
+enum s2n_quic::provider::event::events::DatagramDropReason exports variant:
+  InvalidDestinationConnectionId
+
+enum s2n_quic::provider::event::events::DatagramDropReason exports variant:
+  InvalidRetryToken
+
+enum s2n_quic::provider::event::events::DatagramDropReason exports variant:
+  InvalidSourceConnectionId
+
+enum s2n_quic::provider::event::events::DatagramDropReason exports variant:
+  PathLimitExceeded
+
+enum s2n_quic::provider::event::events::DatagramDropReason exports variant:
+  RejectedConnectionAttempt
+
+enum s2n_quic::provider::event::events::DatagramDropReason exports variant:
+  RejectedConnectionMigration
+
+enum s2n_quic::provider::event::events::DatagramDropReason exports variant:
+  UnknownDestinationConnectionId
+
+enum s2n_quic::provider::event::events::DatagramDropReason exports variant:
+  UnknownServerAddress
+
+enum s2n_quic::provider::event::events::DatagramDropReason exports variant:
+  UnsupportedVersion
+
+enum s2n_quic::provider::event::events::DatagramDropReason implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::DatagramDropReason
+
+enum s2n_quic::provider::event::events::DatagramDropReason implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::DatagramDropReason
+
+enum s2n_quic::provider::event::events::DatagramDropReason implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::DatagramDropReason
+
+enum s2n_quic::provider::event::events::DatagramDropReason implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::DatagramDropReason
+
+enum s2n_quic::provider::event::events::DatagramDropReason implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::DatagramDropReason
+
+enum s2n_quic::provider::event::events::DatagramDropReason implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::DatagramDropReason
+
+enum s2n_quic::provider::event::events::DatagramDropReason implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::DatagramDropReason
+
+variant s2n_quic::provider::event::events::DatagramDropReason::ConnectionMigrationDuringHandshake is non-exhaustive
+
+variant s2n_quic::provider::event::events::DatagramDropReason::DecodingFailed is non-exhaustive
+
+variant s2n_quic::provider::event::events::DatagramDropReason::InsufficientConnectionIds is non-exhaustive
+
+variant s2n_quic::provider::event::events::DatagramDropReason::InvalidDestinationConnectionId is non-exhaustive
+
+variant s2n_quic::provider::event::events::DatagramDropReason::InvalidRetryToken is non-exhaustive
+
+variant s2n_quic::provider::event::events::DatagramDropReason::InvalidSourceConnectionId is non-exhaustive
+
+variant s2n_quic::provider::event::events::DatagramDropReason::PathLimitExceeded is non-exhaustive
+
+variant s2n_quic::provider::event::events::DatagramDropReason::RejectedConnectionAttempt is non-exhaustive
+
+variant s2n_quic::provider::event::events::DatagramDropReason::RejectedConnectionMigration is non-exhaustive
+
+variant s2n_quic::provider::event::events::DatagramDropReason::UnknownDestinationConnectionId is non-exhaustive
+
+variant s2n_quic::provider::event::events::DatagramDropReason::UnknownServerAddress is non-exhaustive
+
+variant s2n_quic::provider::event::events::DatagramDropReason::UnsupportedVersion is non-exhaustive
+
+struct s2n_quic::provider::event::events::DatagramDropped is non-exhaustive
+
+struct s2n_quic::provider::event::events::DatagramDropped implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::DatagramDropped
+
+struct s2n_quic::provider::event::events::DatagramDropped implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::DatagramDropped
+
+struct s2n_quic::provider::event::events::DatagramDropped implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::DatagramDropped
+
+struct s2n_quic::provider::event::events::DatagramDropped implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::DatagramDropped
+
+struct s2n_quic::provider::event::events::DatagramDropped implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::DatagramDropped
+
+struct s2n_quic::provider::event::events::DatagramDropped implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::DatagramDropped
+
+struct s2n_quic::provider::event::events::DatagramDropped implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::DatagramDropped
+
+struct s2n_quic::provider::event::events::DatagramDropped implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::DatagramDropped
+
+struct s2n_quic::provider::event::events::DatagramDropped exports field:
+  len: u16
+
+struct s2n_quic::provider::event::events::DatagramDropped exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::DatagramDropped exports field:
+  reason: s2n_quic::provider::event::events::DatagramDropReason
+
+struct s2n_quic::provider::event::events::DatagramReceived is non-exhaustive
+
+struct s2n_quic::provider::event::events::DatagramReceived implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::DatagramReceived
+
+struct s2n_quic::provider::event::events::DatagramReceived implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::DatagramReceived
+
+struct s2n_quic::provider::event::events::DatagramReceived implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::DatagramReceived
+
+struct s2n_quic::provider::event::events::DatagramReceived implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::DatagramReceived
+
+struct s2n_quic::provider::event::events::DatagramReceived implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::DatagramReceived
+
+struct s2n_quic::provider::event::events::DatagramReceived implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::DatagramReceived
+
+struct s2n_quic::provider::event::events::DatagramReceived implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::DatagramReceived
+
+struct s2n_quic::provider::event::events::DatagramReceived implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::DatagramReceived
+
+struct s2n_quic::provider::event::events::DatagramReceived exports field:
+  len: u16
+
+struct s2n_quic::provider::event::events::DatagramReceived exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::DatagramSent is non-exhaustive
+
+struct s2n_quic::provider::event::events::DatagramSent exports field:
+  gso_offset: usize
+
+struct s2n_quic::provider::event::events::DatagramSent implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::DatagramSent
+
+struct s2n_quic::provider::event::events::DatagramSent implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::DatagramSent
+
+struct s2n_quic::provider::event::events::DatagramSent implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::DatagramSent
+
+struct s2n_quic::provider::event::events::DatagramSent implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::DatagramSent
+
+struct s2n_quic::provider::event::events::DatagramSent implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::DatagramSent
+
+struct s2n_quic::provider::event::events::DatagramSent implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::DatagramSent
+
+struct s2n_quic::provider::event::events::DatagramSent implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::DatagramSent
+
+struct s2n_quic::provider::event::events::DatagramSent implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::DatagramSent
+
+struct s2n_quic::provider::event::events::DatagramSent exports field:
+  len: u16
+
+struct s2n_quic::provider::event::events::DatagramSent exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::DuplicatePacket is non-exhaustive
+
+struct s2n_quic::provider::event::events::DuplicatePacket exports field:
+  error: s2n_quic::provider::event::events::DuplicatePacketError
+
+struct s2n_quic::provider::event::events::DuplicatePacket implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::DuplicatePacket<'a>
+
+struct s2n_quic::provider::event::events::DuplicatePacket implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::DuplicatePacket<'a>
+
+struct s2n_quic::provider::event::events::DuplicatePacket implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::DuplicatePacket<'a>
+
+struct s2n_quic::provider::event::events::DuplicatePacket implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::DuplicatePacket<'a>
+
+struct s2n_quic::provider::event::events::DuplicatePacket implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::DuplicatePacket<'a>
+
+struct s2n_quic::provider::event::events::DuplicatePacket implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::DuplicatePacket<'a>
+
+struct s2n_quic::provider::event::events::DuplicatePacket implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::DuplicatePacket<'a>
+
+struct s2n_quic::provider::event::events::DuplicatePacket implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::DuplicatePacket<'a>
+
+struct s2n_quic::provider::event::events::DuplicatePacket exports field:
+  packet_header: s2n_quic::provider::event::events::PacketHeader
+
+struct s2n_quic::provider::event::events::DuplicatePacket exports field:
+  path: s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::DuplicatePacket exports constant:
+  pub const NAME: &'static str
+
+enum s2n_quic::provider::event::events::DuplicatePacketError is non-exhaustive
+
+enum s2n_quic::provider::event::events::DuplicatePacketError exports variant:
+  Duplicate
+
+enum s2n_quic::provider::event::events::DuplicatePacketError exports variant:
+  TooOld
+
+enum s2n_quic::provider::event::events::DuplicatePacketError implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::DuplicatePacketError
+
+enum s2n_quic::provider::event::events::DuplicatePacketError implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::DuplicatePacketError
+
+enum s2n_quic::provider::event::events::DuplicatePacketError implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::DuplicatePacketError
+
+enum s2n_quic::provider::event::events::DuplicatePacketError implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::DuplicatePacketError
+
+enum s2n_quic::provider::event::events::DuplicatePacketError implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::DuplicatePacketError
+
+enum s2n_quic::provider::event::events::DuplicatePacketError implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::DuplicatePacketError
+
+enum s2n_quic::provider::event::events::DuplicatePacketError implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::DuplicatePacketError
+
+variant s2n_quic::provider::event::events::DuplicatePacketError::Duplicate is non-exhaustive
+
+variant s2n_quic::provider::event::events::DuplicatePacketError::TooOld is non-exhaustive
+
+enum s2n_quic::provider::event::events::EcnState is non-exhaustive
+
+enum s2n_quic::provider::event::events::EcnState exports variant:
+  Capable
+
+enum s2n_quic::provider::event::events::EcnState exports variant:
+  Failed
+
+enum s2n_quic::provider::event::events::EcnState exports variant:
+  Testing
+
+enum s2n_quic::provider::event::events::EcnState exports variant:
+  Unknown
+
+enum s2n_quic::provider::event::events::EcnState implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::EcnState
+
+enum s2n_quic::provider::event::events::EcnState implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::EcnState
+
+enum s2n_quic::provider::event::events::EcnState implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::EcnState
+
+enum s2n_quic::provider::event::events::EcnState implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::EcnState
+
+enum s2n_quic::provider::event::events::EcnState implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::EcnState
+
+enum s2n_quic::provider::event::events::EcnState implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::EcnState
+
+enum s2n_quic::provider::event::events::EcnState implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::EcnState
+
+variant s2n_quic::provider::event::events::EcnState::Capable is non-exhaustive
+
+variant s2n_quic::provider::event::events::EcnState::Failed is non-exhaustive
+
+variant s2n_quic::provider::event::events::EcnState::Testing is non-exhaustive
+
+variant s2n_quic::provider::event::events::EcnState::Unknown is non-exhaustive
+
+struct s2n_quic::provider::event::events::EcnStateChanged is non-exhaustive
+
+struct s2n_quic::provider::event::events::EcnStateChanged implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::EcnStateChanged<'a>
+
+struct s2n_quic::provider::event::events::EcnStateChanged implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::EcnStateChanged<'a>
+
+struct s2n_quic::provider::event::events::EcnStateChanged implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::EcnStateChanged<'a>
+
+struct s2n_quic::provider::event::events::EcnStateChanged implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::EcnStateChanged<'a>
+
+struct s2n_quic::provider::event::events::EcnStateChanged implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::EcnStateChanged<'a>
+
+struct s2n_quic::provider::event::events::EcnStateChanged implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::EcnStateChanged<'a>
+
+struct s2n_quic::provider::event::events::EcnStateChanged implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::EcnStateChanged<'a>
+
+struct s2n_quic::provider::event::events::EcnStateChanged implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::EcnStateChanged<'a>
+
+struct s2n_quic::provider::event::events::EcnStateChanged exports field:
+  path: s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::EcnStateChanged exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::EcnStateChanged exports field:
+  state: s2n_quic::provider::event::events::EcnState
+
+struct s2n_quic::provider::event::events::EndpointConnectionAttemptFailed is non-exhaustive
+
+struct s2n_quic::provider::event::events::EndpointConnectionAttemptFailed exports field:
+  error: s2n_quic::connection::Error
+
+struct s2n_quic::provider::event::events::EndpointConnectionAttemptFailed implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::EndpointConnectionAttemptFailed
+
+struct s2n_quic::provider::event::events::EndpointConnectionAttemptFailed implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::EndpointConnectionAttemptFailed
+
+struct s2n_quic::provider::event::events::EndpointConnectionAttemptFailed implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::EndpointConnectionAttemptFailed
+
+struct s2n_quic::provider::event::events::EndpointConnectionAttemptFailed implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::EndpointConnectionAttemptFailed
+
+struct s2n_quic::provider::event::events::EndpointConnectionAttemptFailed implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::EndpointConnectionAttemptFailed
+
+struct s2n_quic::provider::event::events::EndpointConnectionAttemptFailed implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::EndpointConnectionAttemptFailed
+
+struct s2n_quic::provider::event::events::EndpointConnectionAttemptFailed implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::EndpointConnectionAttemptFailed
+
+struct s2n_quic::provider::event::events::EndpointConnectionAttemptFailed implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::EndpointConnectionAttemptFailed
+
+struct s2n_quic::provider::event::events::EndpointConnectionAttemptFailed exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::EndpointDatagramDropped is non-exhaustive
+
+struct s2n_quic::provider::event::events::EndpointDatagramDropped implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::EndpointDatagramDropped
+
+struct s2n_quic::provider::event::events::EndpointDatagramDropped implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::EndpointDatagramDropped
+
+struct s2n_quic::provider::event::events::EndpointDatagramDropped implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::EndpointDatagramDropped
+
+struct s2n_quic::provider::event::events::EndpointDatagramDropped implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::EndpointDatagramDropped
+
+struct s2n_quic::provider::event::events::EndpointDatagramDropped implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::EndpointDatagramDropped
+
+struct s2n_quic::provider::event::events::EndpointDatagramDropped implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::EndpointDatagramDropped
+
+struct s2n_quic::provider::event::events::EndpointDatagramDropped implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::EndpointDatagramDropped
+
+struct s2n_quic::provider::event::events::EndpointDatagramDropped implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::EndpointDatagramDropped
+
+struct s2n_quic::provider::event::events::EndpointDatagramDropped exports field:
+  len: u16
+
+struct s2n_quic::provider::event::events::EndpointDatagramDropped exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::EndpointDatagramDropped exports field:
+  reason: s2n_quic::provider::event::events::DatagramDropReason
+
+struct s2n_quic::provider::event::events::EndpointDatagramReceived is non-exhaustive
+
+struct s2n_quic::provider::event::events::EndpointDatagramReceived implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::EndpointDatagramReceived
+
+struct s2n_quic::provider::event::events::EndpointDatagramReceived implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::EndpointDatagramReceived
+
+struct s2n_quic::provider::event::events::EndpointDatagramReceived implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::EndpointDatagramReceived
+
+struct s2n_quic::provider::event::events::EndpointDatagramReceived implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::EndpointDatagramReceived
+
+struct s2n_quic::provider::event::events::EndpointDatagramReceived implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::EndpointDatagramReceived
+
+struct s2n_quic::provider::event::events::EndpointDatagramReceived implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::EndpointDatagramReceived
+
+struct s2n_quic::provider::event::events::EndpointDatagramReceived implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::EndpointDatagramReceived
+
+struct s2n_quic::provider::event::events::EndpointDatagramReceived implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::EndpointDatagramReceived
+
+struct s2n_quic::provider::event::events::EndpointDatagramReceived exports field:
+  len: u16
+
+struct s2n_quic::provider::event::events::EndpointDatagramReceived exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::EndpointDatagramSent is non-exhaustive
+
+struct s2n_quic::provider::event::events::EndpointDatagramSent exports field:
+  gso_offset: usize
+
+struct s2n_quic::provider::event::events::EndpointDatagramSent implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::EndpointDatagramSent
+
+struct s2n_quic::provider::event::events::EndpointDatagramSent implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::EndpointDatagramSent
+
+struct s2n_quic::provider::event::events::EndpointDatagramSent implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::EndpointDatagramSent
+
+struct s2n_quic::provider::event::events::EndpointDatagramSent implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::EndpointDatagramSent
+
+struct s2n_quic::provider::event::events::EndpointDatagramSent implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::EndpointDatagramSent
+
+struct s2n_quic::provider::event::events::EndpointDatagramSent implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::EndpointDatagramSent
+
+struct s2n_quic::provider::event::events::EndpointDatagramSent implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::EndpointDatagramSent
+
+struct s2n_quic::provider::event::events::EndpointDatagramSent implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::EndpointDatagramSent
+
+struct s2n_quic::provider::event::events::EndpointDatagramSent exports field:
+  len: u16
+
+struct s2n_quic::provider::event::events::EndpointDatagramSent exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::EndpointMeta is non-exhaustive
+
+struct s2n_quic::provider::event::events::EndpointMeta exports field:
+  endpoint_type: s2n_quic::provider::event::events::EndpointType
+
+struct s2n_quic::provider::event::events::EndpointMeta implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::EndpointMeta
+
+struct s2n_quic::provider::event::events::EndpointMeta implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::EndpointMeta
+
+struct s2n_quic::provider::event::events::EndpointMeta implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::EndpointMeta
+
+struct s2n_quic::provider::event::events::EndpointMeta implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::EndpointMeta
+
+struct s2n_quic::provider::event::events::EndpointMeta implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::EndpointMeta
+
+struct s2n_quic::provider::event::events::EndpointMeta implements trait:
+  impl s2n_quic::provider::event::Meta for s2n_quic::provider::event::events::EndpointMeta
+
+struct s2n_quic::provider::event::events::EndpointMeta implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::EndpointMeta
+
+struct s2n_quic::provider::event::events::EndpointMeta implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::EndpointMeta
+
+struct s2n_quic::provider::event::events::EndpointMeta exports field:
+  timestamp: s2n_quic::provider::event::Timestamp
+
+struct s2n_quic::provider::event::events::EndpointPacketReceived is non-exhaustive
+
+struct s2n_quic::provider::event::events::EndpointPacketReceived implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::EndpointPacketReceived
+
+struct s2n_quic::provider::event::events::EndpointPacketReceived implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::EndpointPacketReceived
+
+struct s2n_quic::provider::event::events::EndpointPacketReceived implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::EndpointPacketReceived
+
+struct s2n_quic::provider::event::events::EndpointPacketReceived implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::EndpointPacketReceived
+
+struct s2n_quic::provider::event::events::EndpointPacketReceived implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::EndpointPacketReceived
+
+struct s2n_quic::provider::event::events::EndpointPacketReceived implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::EndpointPacketReceived
+
+struct s2n_quic::provider::event::events::EndpointPacketReceived implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::EndpointPacketReceived
+
+struct s2n_quic::provider::event::events::EndpointPacketReceived implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::EndpointPacketReceived
+
+struct s2n_quic::provider::event::events::EndpointPacketReceived exports field:
+  packet_header: s2n_quic::provider::event::events::PacketHeader
+
+struct s2n_quic::provider::event::events::EndpointPacketReceived exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::EndpointPacketSent is non-exhaustive
+
+struct s2n_quic::provider::event::events::EndpointPacketSent implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::EndpointPacketSent
+
+struct s2n_quic::provider::event::events::EndpointPacketSent implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::EndpointPacketSent
+
+struct s2n_quic::provider::event::events::EndpointPacketSent implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::EndpointPacketSent
+
+struct s2n_quic::provider::event::events::EndpointPacketSent implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::EndpointPacketSent
+
+struct s2n_quic::provider::event::events::EndpointPacketSent implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::EndpointPacketSent
+
+struct s2n_quic::provider::event::events::EndpointPacketSent implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::EndpointPacketSent
+
+struct s2n_quic::provider::event::events::EndpointPacketSent implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::EndpointPacketSent
+
+struct s2n_quic::provider::event::events::EndpointPacketSent implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::EndpointPacketSent
+
+struct s2n_quic::provider::event::events::EndpointPacketSent exports field:
+  packet_header: s2n_quic::provider::event::events::PacketHeader
+
+struct s2n_quic::provider::event::events::EndpointPacketSent exports constant:
+  pub const NAME: &'static str
+
+enum s2n_quic::provider::event::events::EndpointType exports variant:
+  Client
+
+enum s2n_quic::provider::event::events::EndpointType exports variant:
+  Server
+
+enum s2n_quic::provider::event::events::EndpointType implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::EndpointType
+
+enum s2n_quic::provider::event::events::EndpointType implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::EndpointType
+
+enum s2n_quic::provider::event::events::EndpointType implements trait:
+  impl core::fmt::Display for s2n_quic::provider::event::events::EndpointType
+
+enum s2n_quic::provider::event::events::EndpointType implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::EndpointType
+
+enum s2n_quic::provider::event::events::EndpointType implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::EndpointType
+
+enum s2n_quic::provider::event::events::EndpointType implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::EndpointType
+
+enum s2n_quic::provider::event::events::EndpointType implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::EndpointType
+
+enum s2n_quic::provider::event::events::EndpointType implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::EndpointType
+
+variant s2n_quic::provider::event::events::EndpointType::Client is non-exhaustive
+
+variant s2n_quic::provider::event::events::EndpointType::Server is non-exhaustive
+
+enum s2n_quic::provider::event::events::Frame is non-exhaustive
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  Ack
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  ConnectionClose
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  Crypto
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  DataBlocked
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  HandshakeDone
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  MaxData
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  MaxStreamData
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  MaxStreams
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  NewConnectionId
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  NewToken
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  Padding
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  PathChallenge
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  PathResponse
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  Ping
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  ResetStream
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  RetireConnectionId
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  StopSending
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  Stream
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  StreamDataBlocked
+
+enum s2n_quic::provider::event::events::Frame exports variant:
+  StreamsBlocked
+
+enum s2n_quic::provider::event::events::Frame implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::Frame
+
+enum s2n_quic::provider::event::events::Frame implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::Frame
+
+enum s2n_quic::provider::event::events::Frame implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::Frame
+
+enum s2n_quic::provider::event::events::Frame implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::Frame
+
+enum s2n_quic::provider::event::events::Frame implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::Frame
+
+enum s2n_quic::provider::event::events::Frame implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::Frame
+
+enum s2n_quic::provider::event::events::Frame implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::Frame
+
+variant s2n_quic::provider::event::events::Frame::Ack is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::ConnectionClose is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::Crypto is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::Crypto exports field:
+  len:
+  u16
+
+variant s2n_quic::provider::event::events::Frame::Crypto exports field:
+  offset:
+  u64
+
+variant s2n_quic::provider::event::events::Frame::DataBlocked is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::HandshakeDone is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::MaxData is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::MaxStreamData is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::MaxStreams is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::MaxStreams exports field:
+  stream_type:
+  s2n_quic::provider::event::events::StreamType
+
+variant s2n_quic::provider::event::events::Frame::NewConnectionId is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::NewToken is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::Padding is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::PathChallenge is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::PathResponse is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::Ping is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::ResetStream is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::RetireConnectionId is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::StopSending is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::Stream is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::Stream exports field:
+  id:
+  u64
+
+variant s2n_quic::provider::event::events::Frame::Stream exports field:
+  is_fin:
+  bool
+
+variant s2n_quic::provider::event::events::Frame::Stream exports field:
+  len:
+  u16
+
+variant s2n_quic::provider::event::events::Frame::Stream exports field:
+  offset:
+  u64
+
+variant s2n_quic::provider::event::events::Frame::StreamDataBlocked is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::StreamsBlocked is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::StreamsBlocked exports field:
+  stream_type:
+  s2n_quic::provider::event::events::StreamType
+
+struct s2n_quic::provider::event::events::FrameReceived is non-exhaustive
+
+struct s2n_quic::provider::event::events::FrameReceived exports field:
+  frame: s2n_quic::provider::event::events::Frame
+
+struct s2n_quic::provider::event::events::FrameReceived implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::FrameReceived<'a>
+
+struct s2n_quic::provider::event::events::FrameReceived implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::FrameReceived<'a>
+
+struct s2n_quic::provider::event::events::FrameReceived implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::FrameReceived<'a>
+
+struct s2n_quic::provider::event::events::FrameReceived implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::FrameReceived<'a>
+
+struct s2n_quic::provider::event::events::FrameReceived implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::FrameReceived<'a>
+
+struct s2n_quic::provider::event::events::FrameReceived implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::FrameReceived<'a>
+
+struct s2n_quic::provider::event::events::FrameReceived implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::FrameReceived<'a>
+
+struct s2n_quic::provider::event::events::FrameReceived implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::FrameReceived<'a>
+
+struct s2n_quic::provider::event::events::FrameReceived exports field:
+  packet_header: s2n_quic::provider::event::events::PacketHeader
+
+struct s2n_quic::provider::event::events::FrameReceived exports field:
+  path: s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::FrameReceived exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::FrameSent is non-exhaustive
+
+struct s2n_quic::provider::event::events::FrameSent exports field:
+  frame: s2n_quic::provider::event::events::Frame
+
+struct s2n_quic::provider::event::events::FrameSent implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::FrameSent
+
+struct s2n_quic::provider::event::events::FrameSent implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::FrameSent
+
+struct s2n_quic::provider::event::events::FrameSent implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::FrameSent
+
+struct s2n_quic::provider::event::events::FrameSent implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::FrameSent
+
+struct s2n_quic::provider::event::events::FrameSent implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::FrameSent
+
+struct s2n_quic::provider::event::events::FrameSent implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::FrameSent
+
+struct s2n_quic::provider::event::events::FrameSent implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::FrameSent
+
+struct s2n_quic::provider::event::events::FrameSent implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::FrameSent
+
+struct s2n_quic::provider::event::events::FrameSent exports field:
+  packet_header: s2n_quic::provider::event::events::PacketHeader
+
+struct s2n_quic::provider::event::events::FrameSent exports field:
+  path_id: u64
+
+struct s2n_quic::provider::event::events::FrameSent exports constant:
+  pub const NAME: &'static str
+
+enum s2n_quic::provider::event::events::HandshakeStatus is non-exhaustive
+
+enum s2n_quic::provider::event::events::HandshakeStatus exports variant:
+  Complete
+
+enum s2n_quic::provider::event::events::HandshakeStatus exports variant:
+  Confirmed
+
+enum s2n_quic::provider::event::events::HandshakeStatus exports variant:
+  HandshakeDoneAcked
+
+enum s2n_quic::provider::event::events::HandshakeStatus exports variant:
+  HandshakeDoneLost
+
+enum s2n_quic::provider::event::events::HandshakeStatus implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::HandshakeStatus
+
+enum s2n_quic::provider::event::events::HandshakeStatus implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::HandshakeStatus
+
+enum s2n_quic::provider::event::events::HandshakeStatus implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::HandshakeStatus
+
+enum s2n_quic::provider::event::events::HandshakeStatus implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::HandshakeStatus
+
+enum s2n_quic::provider::event::events::HandshakeStatus implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::HandshakeStatus
+
+enum s2n_quic::provider::event::events::HandshakeStatus implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::HandshakeStatus
+
+enum s2n_quic::provider::event::events::HandshakeStatus implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::HandshakeStatus
+
+variant s2n_quic::provider::event::events::HandshakeStatus::Complete is non-exhaustive
+
+variant s2n_quic::provider::event::events::HandshakeStatus::Confirmed is non-exhaustive
+
+variant s2n_quic::provider::event::events::HandshakeStatus::HandshakeDoneAcked is non-exhaustive
+
+variant s2n_quic::provider::event::events::HandshakeStatus::HandshakeDoneLost is non-exhaustive
+
+struct s2n_quic::provider::event::events::HandshakeStatusUpdated is non-exhaustive
+
+struct s2n_quic::provider::event::events::HandshakeStatusUpdated implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::HandshakeStatusUpdated
+
+struct s2n_quic::provider::event::events::HandshakeStatusUpdated implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::HandshakeStatusUpdated
+
+struct s2n_quic::provider::event::events::HandshakeStatusUpdated implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::HandshakeStatusUpdated
+
+struct s2n_quic::provider::event::events::HandshakeStatusUpdated implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::HandshakeStatusUpdated
+
+struct s2n_quic::provider::event::events::HandshakeStatusUpdated implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::HandshakeStatusUpdated
+
+struct s2n_quic::provider::event::events::HandshakeStatusUpdated implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::HandshakeStatusUpdated
+
+struct s2n_quic::provider::event::events::HandshakeStatusUpdated implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::HandshakeStatusUpdated
+
+struct s2n_quic::provider::event::events::HandshakeStatusUpdated implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::HandshakeStatusUpdated
+
+struct s2n_quic::provider::event::events::HandshakeStatusUpdated exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::HandshakeStatusUpdated exports field:
+  status: s2n_quic::provider::event::events::HandshakeStatus
+
+struct s2n_quic::provider::event::events::KeepAliveTimerExpired is non-exhaustive
+
+struct s2n_quic::provider::event::events::KeepAliveTimerExpired implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::KeepAliveTimerExpired
+
+struct s2n_quic::provider::event::events::KeepAliveTimerExpired implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::KeepAliveTimerExpired
+
+struct s2n_quic::provider::event::events::KeepAliveTimerExpired implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::KeepAliveTimerExpired
+
+struct s2n_quic::provider::event::events::KeepAliveTimerExpired implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::KeepAliveTimerExpired
+
+struct s2n_quic::provider::event::events::KeepAliveTimerExpired implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::KeepAliveTimerExpired
+
+struct s2n_quic::provider::event::events::KeepAliveTimerExpired implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::KeepAliveTimerExpired
+
+struct s2n_quic::provider::event::events::KeepAliveTimerExpired implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::KeepAliveTimerExpired
+
+struct s2n_quic::provider::event::events::KeepAliveTimerExpired implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::KeepAliveTimerExpired
+
+struct s2n_quic::provider::event::events::KeepAliveTimerExpired exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::KeepAliveTimerExpired exports field:
+  timeout: core::time::Duration
+
+enum s2n_quic::provider::event::events::KeySpace is non-exhaustive
+
+enum s2n_quic::provider::event::events::KeySpace exports variant:
+  Handshake
+
+enum s2n_quic::provider::event::events::KeySpace exports variant:
+  Initial
+
+enum s2n_quic::provider::event::events::KeySpace exports variant:
+  OneRtt
+
+enum s2n_quic::provider::event::events::KeySpace exports variant:
+  ZeroRtt
+
+enum s2n_quic::provider::event::events::KeySpace implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::KeySpace
+
+enum s2n_quic::provider::event::events::KeySpace implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::KeySpace
+
+enum s2n_quic::provider::event::events::KeySpace implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::KeySpace
+
+enum s2n_quic::provider::event::events::KeySpace implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::KeySpace
+
+enum s2n_quic::provider::event::events::KeySpace implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::KeySpace
+
+enum s2n_quic::provider::event::events::KeySpace implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::KeySpace
+
+enum s2n_quic::provider::event::events::KeySpace implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::KeySpace
+
+variant s2n_quic::provider::event::events::KeySpace::Handshake is non-exhaustive
+
+variant s2n_quic::provider::event::events::KeySpace::Initial is non-exhaustive
+
+variant s2n_quic::provider::event::events::KeySpace::OneRtt is non-exhaustive
+
+variant s2n_quic::provider::event::events::KeySpace::ZeroRtt is non-exhaustive
+
+struct s2n_quic::provider::event::events::KeySpaceDiscarded is non-exhaustive
+
+struct s2n_quic::provider::event::events::KeySpaceDiscarded implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::KeySpaceDiscarded
+
+struct s2n_quic::provider::event::events::KeySpaceDiscarded implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::KeySpaceDiscarded
+
+struct s2n_quic::provider::event::events::KeySpaceDiscarded implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::KeySpaceDiscarded
+
+struct s2n_quic::provider::event::events::KeySpaceDiscarded implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::KeySpaceDiscarded
+
+struct s2n_quic::provider::event::events::KeySpaceDiscarded implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::KeySpaceDiscarded
+
+struct s2n_quic::provider::event::events::KeySpaceDiscarded implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::KeySpaceDiscarded
+
+struct s2n_quic::provider::event::events::KeySpaceDiscarded implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::KeySpaceDiscarded
+
+struct s2n_quic::provider::event::events::KeySpaceDiscarded implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::KeySpaceDiscarded
+
+struct s2n_quic::provider::event::events::KeySpaceDiscarded exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::KeySpaceDiscarded exports field:
+  space: s2n_quic::provider::event::events::KeySpace
+
+enum s2n_quic::provider::event::events::KeyType is non-exhaustive
+
+enum s2n_quic::provider::event::events::KeyType exports variant:
+  Handshake
+
+enum s2n_quic::provider::event::events::KeyType exports variant:
+  Initial
+
+enum s2n_quic::provider::event::events::KeyType exports variant:
+  OneRtt
+
+enum s2n_quic::provider::event::events::KeyType exports variant:
+  ZeroRtt
+
+enum s2n_quic::provider::event::events::KeyType implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::KeyType
+
+enum s2n_quic::provider::event::events::KeyType implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::KeyType
+
+enum s2n_quic::provider::event::events::KeyType implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::KeyType
+
+enum s2n_quic::provider::event::events::KeyType implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::KeyType
+
+enum s2n_quic::provider::event::events::KeyType implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::KeyType
+
+enum s2n_quic::provider::event::events::KeyType implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::KeyType
+
+enum s2n_quic::provider::event::events::KeyType implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::KeyType
+
+variant s2n_quic::provider::event::events::KeyType::Handshake is non-exhaustive
+
+variant s2n_quic::provider::event::events::KeyType::Initial is non-exhaustive
+
+variant s2n_quic::provider::event::events::KeyType::OneRtt is non-exhaustive
+
+variant s2n_quic::provider::event::events::KeyType::OneRtt exports field:
+  generation:
+  u16
+
+variant s2n_quic::provider::event::events::KeyType::ZeroRtt is non-exhaustive
+
+struct s2n_quic::provider::event::events::KeyUpdate is non-exhaustive
+
+struct s2n_quic::provider::event::events::KeyUpdate exports field:
+  cipher_suite: s2n_quic::provider::event::events::CipherSuite
+
+struct s2n_quic::provider::event::events::KeyUpdate implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::KeyUpdate
+
+struct s2n_quic::provider::event::events::KeyUpdate implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::KeyUpdate
+
+struct s2n_quic::provider::event::events::KeyUpdate implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::KeyUpdate
+
+struct s2n_quic::provider::event::events::KeyUpdate implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::KeyUpdate
+
+struct s2n_quic::provider::event::events::KeyUpdate implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::KeyUpdate
+
+struct s2n_quic::provider::event::events::KeyUpdate implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::KeyUpdate
+
+struct s2n_quic::provider::event::events::KeyUpdate implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::KeyUpdate
+
+struct s2n_quic::provider::event::events::KeyUpdate implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::KeyUpdate
+
+struct s2n_quic::provider::event::events::KeyUpdate exports field:
+  key_type: s2n_quic::provider::event::events::KeyType
+
+struct s2n_quic::provider::event::events::KeyUpdate exports constant:
+  pub const NAME: &'static str
+
+enum s2n_quic::provider::event::events::MigrationDenyReason is non-exhaustive
+
+enum s2n_quic::provider::event::events::MigrationDenyReason exports variant:
+  ConnectionMigrationDisabled
+
+enum s2n_quic::provider::event::events::MigrationDenyReason exports variant:
+  IpScopeChange
+
+enum s2n_quic::provider::event::events::MigrationDenyReason exports variant:
+  PortScopeChanged
+
+enum s2n_quic::provider::event::events::MigrationDenyReason implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::MigrationDenyReason
+
+enum s2n_quic::provider::event::events::MigrationDenyReason implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::MigrationDenyReason
+
+enum s2n_quic::provider::event::events::MigrationDenyReason implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::MigrationDenyReason
+
+enum s2n_quic::provider::event::events::MigrationDenyReason implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::MigrationDenyReason
+
+enum s2n_quic::provider::event::events::MigrationDenyReason implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::MigrationDenyReason
+
+enum s2n_quic::provider::event::events::MigrationDenyReason implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::MigrationDenyReason
+
+enum s2n_quic::provider::event::events::MigrationDenyReason implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::MigrationDenyReason
+
+variant s2n_quic::provider::event::events::MigrationDenyReason::ConnectionMigrationDisabled is non-exhaustive
+
+variant s2n_quic::provider::event::events::MigrationDenyReason::IpScopeChange is non-exhaustive
+
+variant s2n_quic::provider::event::events::MigrationDenyReason::PortScopeChanged is non-exhaustive
+
+enum s2n_quic::provider::event::events::PacketDropReason is non-exhaustive
+
+enum s2n_quic::provider::event::events::PacketDropReason exports variant:
+  ConnectionError
+
+enum s2n_quic::provider::event::events::PacketDropReason exports variant:
+  ConnectionIdMismatch
+
+enum s2n_quic::provider::event::events::PacketDropReason exports variant:
+  DecodingFailed
+
+enum s2n_quic::provider::event::events::PacketDropReason exports variant:
+  DecryptionFailed
+
+enum s2n_quic::provider::event::events::PacketDropReason exports variant:
+  HandshakeNotComplete
+
+enum s2n_quic::provider::event::events::PacketDropReason exports variant:
+  NonEmptyRetryToken
+
+enum s2n_quic::provider::event::events::PacketDropReason exports variant:
+  RetryDiscarded
+
+enum s2n_quic::provider::event::events::PacketDropReason exports variant:
+  UnprotectFailed
+
+enum s2n_quic::provider::event::events::PacketDropReason exports variant:
+  VersionMismatch
+
+enum s2n_quic::provider::event::events::PacketDropReason implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::PacketDropReason<'a>
+
+enum s2n_quic::provider::event::events::PacketDropReason implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::PacketDropReason<'a>
+
+enum s2n_quic::provider::event::events::PacketDropReason implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::PacketDropReason<'a>
+
+enum s2n_quic::provider::event::events::PacketDropReason implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::PacketDropReason<'a>
+
+enum s2n_quic::provider::event::events::PacketDropReason implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::PacketDropReason<'a>
+
+enum s2n_quic::provider::event::events::PacketDropReason implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PacketDropReason<'a>
+
+enum s2n_quic::provider::event::events::PacketDropReason implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::PacketDropReason<'a>
+
+variant s2n_quic::provider::event::events::PacketDropReason::ConnectionError is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketDropReason::ConnectionError exports field:
+  path:
+  s2n_quic::provider::event::events::Path<'a>
+
+variant s2n_quic::provider::event::events::PacketDropReason::ConnectionIdMismatch is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketDropReason::ConnectionIdMismatch exports field:
+  packet_cid:
+  &'a [u8]
+
+variant s2n_quic::provider::event::events::PacketDropReason::ConnectionIdMismatch exports field:
+  path:
+  s2n_quic::provider::event::events::Path<'a>
+
+variant s2n_quic::provider::event::events::PacketDropReason::DecodingFailed is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketDropReason::DecodingFailed exports field:
+  path:
+  s2n_quic::provider::event::events::Path<'a>
+
+variant s2n_quic::provider::event::events::PacketDropReason::DecryptionFailed is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketDropReason::DecryptionFailed exports field:
+  packet_header:
+  s2n_quic::provider::event::events::PacketHeader
+
+variant s2n_quic::provider::event::events::PacketDropReason::DecryptionFailed exports field:
+  path:
+  s2n_quic::provider::event::events::Path<'a>
+
+variant s2n_quic::provider::event::events::PacketDropReason::HandshakeNotComplete is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketDropReason::HandshakeNotComplete exports field:
+  path:
+  s2n_quic::provider::event::events::Path<'a>
+
+variant s2n_quic::provider::event::events::PacketDropReason::NonEmptyRetryToken is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketDropReason::NonEmptyRetryToken exports field:
+  path:
+  s2n_quic::provider::event::events::Path<'a>
+
+variant s2n_quic::provider::event::events::PacketDropReason::RetryDiscarded is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketDropReason::RetryDiscarded exports field:
+  path:
+  s2n_quic::provider::event::events::Path<'a>
+
+variant s2n_quic::provider::event::events::PacketDropReason::RetryDiscarded exports field:
+  reason:
+  s2n_quic::provider::event::events::RetryDiscardReason<'a>
+
+variant s2n_quic::provider::event::events::PacketDropReason::UnprotectFailed is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketDropReason::UnprotectFailed exports field:
+  path:
+  s2n_quic::provider::event::events::Path<'a>
+
+variant s2n_quic::provider::event::events::PacketDropReason::UnprotectFailed exports field:
+  space:
+  s2n_quic::provider::event::events::KeySpace
+
+variant s2n_quic::provider::event::events::PacketDropReason::VersionMismatch is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketDropReason::VersionMismatch exports field:
+  path:
+  s2n_quic::provider::event::events::Path<'a>
+
+variant s2n_quic::provider::event::events::PacketDropReason::VersionMismatch exports field:
+  version:
+  u32
+
+struct s2n_quic::provider::event::events::PacketDropped is non-exhaustive
+
+struct s2n_quic::provider::event::events::PacketDropped implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::PacketDropped<'a>
+
+struct s2n_quic::provider::event::events::PacketDropped implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::PacketDropped<'a>
+
+struct s2n_quic::provider::event::events::PacketDropped implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::PacketDropped<'a>
+
+struct s2n_quic::provider::event::events::PacketDropped implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::PacketDropped<'a>
+
+struct s2n_quic::provider::event::events::PacketDropped implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::PacketDropped<'a>
+
+struct s2n_quic::provider::event::events::PacketDropped implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::PacketDropped<'a>
+
+struct s2n_quic::provider::event::events::PacketDropped implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PacketDropped<'a>
+
+struct s2n_quic::provider::event::events::PacketDropped implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::PacketDropped<'a>
+
+struct s2n_quic::provider::event::events::PacketDropped exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::PacketDropped exports field:
+  reason: s2n_quic::provider::event::events::PacketDropReason<'a>
+
+enum s2n_quic::provider::event::events::PacketHeader is non-exhaustive
+
+enum s2n_quic::provider::event::events::PacketHeader exports variant:
+  Handshake
+
+enum s2n_quic::provider::event::events::PacketHeader exports variant:
+  Initial
+
+enum s2n_quic::provider::event::events::PacketHeader exports variant:
+  OneRtt
+
+enum s2n_quic::provider::event::events::PacketHeader exports variant:
+  Retry
+
+enum s2n_quic::provider::event::events::PacketHeader exports variant:
+  StatelessReset
+
+enum s2n_quic::provider::event::events::PacketHeader exports variant:
+  VersionNegotiation
+
+enum s2n_quic::provider::event::events::PacketHeader exports variant:
+  ZeroRtt
+
+enum s2n_quic::provider::event::events::PacketHeader implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::PacketHeader
+
+enum s2n_quic::provider::event::events::PacketHeader implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::PacketHeader
+
+enum s2n_quic::provider::event::events::PacketHeader implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::PacketHeader
+
+enum s2n_quic::provider::event::events::PacketHeader implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::PacketHeader
+
+enum s2n_quic::provider::event::events::PacketHeader implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::PacketHeader
+
+enum s2n_quic::provider::event::events::PacketHeader implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PacketHeader
+
+enum s2n_quic::provider::event::events::PacketHeader implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::PacketHeader
+
+variant s2n_quic::provider::event::events::PacketHeader::Handshake is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketHeader::Handshake exports field:
+  number:
+  u64
+
+variant s2n_quic::provider::event::events::PacketHeader::Handshake exports field:
+  version:
+  u32
+
+variant s2n_quic::provider::event::events::PacketHeader::Initial is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketHeader::Initial exports field:
+  number:
+  u64
+
+variant s2n_quic::provider::event::events::PacketHeader::Initial exports field:
+  version:
+  u32
+
+variant s2n_quic::provider::event::events::PacketHeader::OneRtt is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketHeader::OneRtt exports field:
+  number:
+  u64
+
+variant s2n_quic::provider::event::events::PacketHeader::Retry is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketHeader::Retry exports field:
+  version:
+  u32
+
+variant s2n_quic::provider::event::events::PacketHeader::StatelessReset is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketHeader::VersionNegotiation is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketHeader::ZeroRtt is non-exhaustive
+
+variant s2n_quic::provider::event::events::PacketHeader::ZeroRtt exports field:
+  number:
+  u64
+
+variant s2n_quic::provider::event::events::PacketHeader::ZeroRtt exports field:
+  version:
+  u32
+
+struct s2n_quic::provider::event::events::PacketLost is non-exhaustive
+
+struct s2n_quic::provider::event::events::PacketLost exports field:
+  bytes_lost: u16
+
+struct s2n_quic::provider::event::events::PacketLost implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::PacketLost<'a>
+
+struct s2n_quic::provider::event::events::PacketLost implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::PacketLost<'a>
+
+struct s2n_quic::provider::event::events::PacketLost implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::PacketLost<'a>
+
+struct s2n_quic::provider::event::events::PacketLost implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::PacketLost<'a>
+
+struct s2n_quic::provider::event::events::PacketLost implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::PacketLost<'a>
+
+struct s2n_quic::provider::event::events::PacketLost implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::PacketLost<'a>
+
+struct s2n_quic::provider::event::events::PacketLost implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PacketLost<'a>
+
+struct s2n_quic::provider::event::events::PacketLost implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::PacketLost<'a>
+
+struct s2n_quic::provider::event::events::PacketLost exports field:
+  is_mtu_probe: bool
+
+struct s2n_quic::provider::event::events::PacketLost exports field:
+  packet_header: s2n_quic::provider::event::events::PacketHeader
+
+struct s2n_quic::provider::event::events::PacketLost exports field:
+  path: s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::PacketLost exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::PacketReceived is non-exhaustive
+
+struct s2n_quic::provider::event::events::PacketReceived implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::PacketReceived
+
+struct s2n_quic::provider::event::events::PacketReceived implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::PacketReceived
+
+struct s2n_quic::provider::event::events::PacketReceived implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::PacketReceived
+
+struct s2n_quic::provider::event::events::PacketReceived implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::PacketReceived
+
+struct s2n_quic::provider::event::events::PacketReceived implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::PacketReceived
+
+struct s2n_quic::provider::event::events::PacketReceived implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::PacketReceived
+
+struct s2n_quic::provider::event::events::PacketReceived implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PacketReceived
+
+struct s2n_quic::provider::event::events::PacketReceived implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::PacketReceived
+
+struct s2n_quic::provider::event::events::PacketReceived exports field:
+  packet_header: s2n_quic::provider::event::events::PacketHeader
+
+struct s2n_quic::provider::event::events::PacketReceived exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::PacketSent is non-exhaustive
+
+struct s2n_quic::provider::event::events::PacketSent implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::PacketSent
+
+struct s2n_quic::provider::event::events::PacketSent implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::PacketSent
+
+struct s2n_quic::provider::event::events::PacketSent implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::PacketSent
+
+struct s2n_quic::provider::event::events::PacketSent implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::PacketSent
+
+struct s2n_quic::provider::event::events::PacketSent implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::PacketSent
+
+struct s2n_quic::provider::event::events::PacketSent implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::PacketSent
+
+struct s2n_quic::provider::event::events::PacketSent implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PacketSent
+
+struct s2n_quic::provider::event::events::PacketSent implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::PacketSent
+
+struct s2n_quic::provider::event::events::PacketSent exports field:
+  packet_header: s2n_quic::provider::event::events::PacketHeader
+
+struct s2n_quic::provider::event::events::PacketSent exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::Path is non-exhaustive
+
+struct s2n_quic::provider::event::events::Path exports field:
+  id: u64
+
+struct s2n_quic::provider::event::events::Path implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::Path implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::Path implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::Path implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::Path implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::Path implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::Path implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::Path exports field:
+  is_active: bool
+
+struct s2n_quic::provider::event::events::Path exports field:
+  local_addr: s2n_quic::provider::event::events::SocketAddress<'a>
+
+struct s2n_quic::provider::event::events::Path exports field:
+  local_cid: s2n_quic::provider::event::events::ConnectionId<'a>
+
+struct s2n_quic::provider::event::events::Path exports field:
+  remote_addr: s2n_quic::provider::event::events::SocketAddress<'a>
+
+struct s2n_quic::provider::event::events::Path exports field:
+  remote_cid: s2n_quic::provider::event::events::ConnectionId<'a>
+
+enum s2n_quic::provider::event::events::PathChallengeStatus is non-exhaustive
+
+enum s2n_quic::provider::event::events::PathChallengeStatus exports variant:
+  Abandoned
+
+enum s2n_quic::provider::event::events::PathChallengeStatus exports variant:
+  Validated
+
+enum s2n_quic::provider::event::events::PathChallengeStatus implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::PathChallengeStatus
+
+enum s2n_quic::provider::event::events::PathChallengeStatus implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::PathChallengeStatus
+
+enum s2n_quic::provider::event::events::PathChallengeStatus implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::PathChallengeStatus
+
+enum s2n_quic::provider::event::events::PathChallengeStatus implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::PathChallengeStatus
+
+enum s2n_quic::provider::event::events::PathChallengeStatus implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::PathChallengeStatus
+
+enum s2n_quic::provider::event::events::PathChallengeStatus implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PathChallengeStatus
+
+enum s2n_quic::provider::event::events::PathChallengeStatus implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::PathChallengeStatus
+
+variant s2n_quic::provider::event::events::PathChallengeStatus::Abandoned is non-exhaustive
+
+variant s2n_quic::provider::event::events::PathChallengeStatus::Validated is non-exhaustive
+
+struct s2n_quic::provider::event::events::PathChallengeUpdated is non-exhaustive
+
+struct s2n_quic::provider::event::events::PathChallengeUpdated exports field:
+  challenge_data: &'a [u8]
+
+struct s2n_quic::provider::event::events::PathChallengeUpdated implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::PathChallengeUpdated<'a>
+
+struct s2n_quic::provider::event::events::PathChallengeUpdated implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::PathChallengeUpdated<'a>
+
+struct s2n_quic::provider::event::events::PathChallengeUpdated implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::PathChallengeUpdated<'a>
+
+struct s2n_quic::provider::event::events::PathChallengeUpdated implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::PathChallengeUpdated<'a>
+
+struct s2n_quic::provider::event::events::PathChallengeUpdated implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::PathChallengeUpdated<'a>
+
+struct s2n_quic::provider::event::events::PathChallengeUpdated implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::PathChallengeUpdated<'a>
+
+struct s2n_quic::provider::event::events::PathChallengeUpdated implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PathChallengeUpdated<'a>
+
+struct s2n_quic::provider::event::events::PathChallengeUpdated implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::PathChallengeUpdated<'a>
+
+struct s2n_quic::provider::event::events::PathChallengeUpdated exports field:
+  path: s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::PathChallengeUpdated exports field:
+  path_challenge_status: s2n_quic::provider::event::events::PathChallengeStatus
+
+struct s2n_quic::provider::event::events::PathChallengeUpdated exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::PathCreated is non-exhaustive
+
+struct s2n_quic::provider::event::events::PathCreated exports field:
+  active: s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::PathCreated implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::PathCreated<'a>
+
+struct s2n_quic::provider::event::events::PathCreated implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::PathCreated<'a>
+
+struct s2n_quic::provider::event::events::PathCreated implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::PathCreated<'a>
+
+struct s2n_quic::provider::event::events::PathCreated implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::PathCreated<'a>
+
+struct s2n_quic::provider::event::events::PathCreated implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::PathCreated<'a>
+
+struct s2n_quic::provider::event::events::PathCreated implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::PathCreated<'a>
+
+struct s2n_quic::provider::event::events::PathCreated implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PathCreated<'a>
+
+struct s2n_quic::provider::event::events::PathCreated implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::PathCreated<'a>
+
+struct s2n_quic::provider::event::events::PathCreated exports field:
+  new: s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::PathCreated exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::PlatformEventLoopWakeup is non-exhaustive
+
+struct s2n_quic::provider::event::events::PlatformEventLoopWakeup implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::PlatformEventLoopWakeup
+
+struct s2n_quic::provider::event::events::PlatformEventLoopWakeup implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::PlatformEventLoopWakeup
+
+struct s2n_quic::provider::event::events::PlatformEventLoopWakeup implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::PlatformEventLoopWakeup
+
+struct s2n_quic::provider::event::events::PlatformEventLoopWakeup implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::PlatformEventLoopWakeup
+
+struct s2n_quic::provider::event::events::PlatformEventLoopWakeup implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::PlatformEventLoopWakeup
+
+struct s2n_quic::provider::event::events::PlatformEventLoopWakeup implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::PlatformEventLoopWakeup
+
+struct s2n_quic::provider::event::events::PlatformEventLoopWakeup implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PlatformEventLoopWakeup
+
+struct s2n_quic::provider::event::events::PlatformEventLoopWakeup implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::PlatformEventLoopWakeup
+
+struct s2n_quic::provider::event::events::PlatformEventLoopWakeup exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::PlatformEventLoopWakeup exports field:
+  rx_ready: bool
+
+struct s2n_quic::provider::event::events::PlatformEventLoopWakeup exports field:
+  timeout_expired: bool
+
+struct s2n_quic::provider::event::events::PlatformEventLoopWakeup exports field:
+  tx_ready: bool
+
+enum s2n_quic::provider::event::events::PlatformFeatureConfiguration is non-exhaustive
+
+enum s2n_quic::provider::event::events::PlatformFeatureConfiguration exports variant:
+  Ecn
+
+enum s2n_quic::provider::event::events::PlatformFeatureConfiguration exports variant:
+  Gso
+
+enum s2n_quic::provider::event::events::PlatformFeatureConfiguration exports variant:
+  MaxMtu
+
+enum s2n_quic::provider::event::events::PlatformFeatureConfiguration implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::PlatformFeatureConfiguration
+
+enum s2n_quic::provider::event::events::PlatformFeatureConfiguration implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::PlatformFeatureConfiguration
+
+enum s2n_quic::provider::event::events::PlatformFeatureConfiguration implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::PlatformFeatureConfiguration
+
+enum s2n_quic::provider::event::events::PlatformFeatureConfiguration implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::PlatformFeatureConfiguration
+
+enum s2n_quic::provider::event::events::PlatformFeatureConfiguration implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::PlatformFeatureConfiguration
+
+enum s2n_quic::provider::event::events::PlatformFeatureConfiguration implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PlatformFeatureConfiguration
+
+enum s2n_quic::provider::event::events::PlatformFeatureConfiguration implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::PlatformFeatureConfiguration
+
+variant s2n_quic::provider::event::events::PlatformFeatureConfiguration::Ecn is non-exhaustive
+
+variant s2n_quic::provider::event::events::PlatformFeatureConfiguration::Ecn exports field:
+  enabled:
+  bool
+
+variant s2n_quic::provider::event::events::PlatformFeatureConfiguration::Gso is non-exhaustive
+
+variant s2n_quic::provider::event::events::PlatformFeatureConfiguration::Gso exports field:
+  max_segments:
+  usize
+
+variant s2n_quic::provider::event::events::PlatformFeatureConfiguration::MaxMtu is non-exhaustive
+
+variant s2n_quic::provider::event::events::PlatformFeatureConfiguration::MaxMtu exports field:
+  mtu:
+  u16
+
+struct s2n_quic::provider::event::events::PlatformFeatureConfigured is non-exhaustive
+
+struct s2n_quic::provider::event::events::PlatformFeatureConfigured exports field:
+  configuration: s2n_quic::provider::event::events::PlatformFeatureConfiguration
+
+struct s2n_quic::provider::event::events::PlatformFeatureConfigured implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::PlatformFeatureConfigured
+
+struct s2n_quic::provider::event::events::PlatformFeatureConfigured implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::PlatformFeatureConfigured
+
+struct s2n_quic::provider::event::events::PlatformFeatureConfigured implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::PlatformFeatureConfigured
+
+struct s2n_quic::provider::event::events::PlatformFeatureConfigured implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::PlatformFeatureConfigured
+
+struct s2n_quic::provider::event::events::PlatformFeatureConfigured implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::PlatformFeatureConfigured
+
+struct s2n_quic::provider::event::events::PlatformFeatureConfigured implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::PlatformFeatureConfigured
+
+struct s2n_quic::provider::event::events::PlatformFeatureConfigured implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PlatformFeatureConfigured
+
+struct s2n_quic::provider::event::events::PlatformFeatureConfigured implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::PlatformFeatureConfigured
+
+struct s2n_quic::provider::event::events::PlatformFeatureConfigured exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::PlatformRx is non-exhaustive
+
+struct s2n_quic::provider::event::events::PlatformRx exports field:
+  count: usize
+
+struct s2n_quic::provider::event::events::PlatformRx implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::PlatformRx
+
+struct s2n_quic::provider::event::events::PlatformRx implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::PlatformRx
+
+struct s2n_quic::provider::event::events::PlatformRx implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::PlatformRx
+
+struct s2n_quic::provider::event::events::PlatformRx implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::PlatformRx
+
+struct s2n_quic::provider::event::events::PlatformRx implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::PlatformRx
+
+struct s2n_quic::provider::event::events::PlatformRx implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::PlatformRx
+
+struct s2n_quic::provider::event::events::PlatformRx implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PlatformRx
+
+struct s2n_quic::provider::event::events::PlatformRx implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::PlatformRx
+
+struct s2n_quic::provider::event::events::PlatformRx exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::PlatformRxError is non-exhaustive
+
+struct s2n_quic::provider::event::events::PlatformRxError exports field:
+  errno: i32
+
+struct s2n_quic::provider::event::events::PlatformRxError implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::PlatformRxError
+
+struct s2n_quic::provider::event::events::PlatformRxError implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::PlatformRxError
+
+struct s2n_quic::provider::event::events::PlatformRxError implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::PlatformRxError
+
+struct s2n_quic::provider::event::events::PlatformRxError implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::PlatformRxError
+
+struct s2n_quic::provider::event::events::PlatformRxError implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::PlatformRxError
+
+struct s2n_quic::provider::event::events::PlatformRxError implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::PlatformRxError
+
+struct s2n_quic::provider::event::events::PlatformRxError implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PlatformRxError
+
+struct s2n_quic::provider::event::events::PlatformRxError implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::PlatformRxError
+
+struct s2n_quic::provider::event::events::PlatformRxError exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::PlatformTx is non-exhaustive
+
+struct s2n_quic::provider::event::events::PlatformTx exports field:
+  count: usize
+
+struct s2n_quic::provider::event::events::PlatformTx implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::PlatformTx
+
+struct s2n_quic::provider::event::events::PlatformTx implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::PlatformTx
+
+struct s2n_quic::provider::event::events::PlatformTx implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::PlatformTx
+
+struct s2n_quic::provider::event::events::PlatformTx implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::PlatformTx
+
+struct s2n_quic::provider::event::events::PlatformTx implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::PlatformTx
+
+struct s2n_quic::provider::event::events::PlatformTx implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::PlatformTx
+
+struct s2n_quic::provider::event::events::PlatformTx implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PlatformTx
+
+struct s2n_quic::provider::event::events::PlatformTx implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::PlatformTx
+
+struct s2n_quic::provider::event::events::PlatformTx exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::PlatformTxError is non-exhaustive
+
+struct s2n_quic::provider::event::events::PlatformTxError exports field:
+  errno: i32
+
+struct s2n_quic::provider::event::events::PlatformTxError implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::PlatformTxError
+
+struct s2n_quic::provider::event::events::PlatformTxError implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::PlatformTxError
+
+struct s2n_quic::provider::event::events::PlatformTxError implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::PlatformTxError
+
+struct s2n_quic::provider::event::events::PlatformTxError implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::PlatformTxError
+
+struct s2n_quic::provider::event::events::PlatformTxError implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::PlatformTxError
+
+struct s2n_quic::provider::event::events::PlatformTxError implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::PlatformTxError
+
+struct s2n_quic::provider::event::events::PlatformTxError implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PlatformTxError
+
+struct s2n_quic::provider::event::events::PlatformTxError implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::PlatformTxError
+
+struct s2n_quic::provider::event::events::PlatformTxError exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::PreferredAddress is non-exhaustive
+
+struct s2n_quic::provider::event::events::PreferredAddress exports field:
+  connection_id: s2n_quic::provider::event::events::ConnectionId<'a>
+
+struct s2n_quic::provider::event::events::PreferredAddress implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::PreferredAddress<'a>
+
+struct s2n_quic::provider::event::events::PreferredAddress implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::PreferredAddress<'a>
+
+struct s2n_quic::provider::event::events::PreferredAddress implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::PreferredAddress<'a>
+
+struct s2n_quic::provider::event::events::PreferredAddress implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::PreferredAddress<'a>
+
+struct s2n_quic::provider::event::events::PreferredAddress implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::PreferredAddress<'a>
+
+struct s2n_quic::provider::event::events::PreferredAddress implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::PreferredAddress<'a>
+
+struct s2n_quic::provider::event::events::PreferredAddress implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::PreferredAddress<'a>
+
+struct s2n_quic::provider::event::events::PreferredAddress exports field:
+  ipv4_address: core::option::Option<s2n_quic::provider::event::events::SocketAddress<'a>>
+
+struct s2n_quic::provider::event::events::PreferredAddress exports field:
+  ipv6_address: core::option::Option<s2n_quic::provider::event::events::SocketAddress<'a>>
+
+struct s2n_quic::provider::event::events::PreferredAddress exports field:
+  stateless_reset_token: &'a [u8]
+
+struct s2n_quic::provider::event::events::RecoveryMetrics is non-exhaustive
+
+struct s2n_quic::provider::event::events::RecoveryMetrics exports field:
+  bytes_in_flight: u32
+
+struct s2n_quic::provider::event::events::RecoveryMetrics exports field:
+  congestion_window: u32
+
+struct s2n_quic::provider::event::events::RecoveryMetrics implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::RecoveryMetrics<'a>
+
+struct s2n_quic::provider::event::events::RecoveryMetrics implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::RecoveryMetrics<'a>
+
+struct s2n_quic::provider::event::events::RecoveryMetrics implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::RecoveryMetrics<'a>
+
+struct s2n_quic::provider::event::events::RecoveryMetrics implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::RecoveryMetrics<'a>
+
+struct s2n_quic::provider::event::events::RecoveryMetrics implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::RecoveryMetrics<'a>
+
+struct s2n_quic::provider::event::events::RecoveryMetrics implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::RecoveryMetrics<'a>
+
+struct s2n_quic::provider::event::events::RecoveryMetrics implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::RecoveryMetrics<'a>
+
+struct s2n_quic::provider::event::events::RecoveryMetrics implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::RecoveryMetrics<'a>
+
+struct s2n_quic::provider::event::events::RecoveryMetrics exports field:
+  latest_rtt: core::time::Duration
+
+struct s2n_quic::provider::event::events::RecoveryMetrics exports field:
+  max_ack_delay: core::time::Duration
+
+struct s2n_quic::provider::event::events::RecoveryMetrics exports field:
+  min_rtt: core::time::Duration
+
+struct s2n_quic::provider::event::events::RecoveryMetrics exports field:
+  path: s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::RecoveryMetrics exports field:
+  pto_count: u32
+
+struct s2n_quic::provider::event::events::RecoveryMetrics exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::RecoveryMetrics exports field:
+  rtt_variance: core::time::Duration
+
+struct s2n_quic::provider::event::events::RecoveryMetrics exports field:
+  smoothed_rtt: core::time::Duration
+
+enum s2n_quic::provider::event::events::RetryDiscardReason is non-exhaustive
+
+enum s2n_quic::provider::event::events::RetryDiscardReason exports variant:
+  InitialAlreadyProcessed
+
+enum s2n_quic::provider::event::events::RetryDiscardReason exports variant:
+  InvalidIntegrityTag
+
+enum s2n_quic::provider::event::events::RetryDiscardReason exports variant:
+  RetryAlreadyProcessed
+
+enum s2n_quic::provider::event::events::RetryDiscardReason exports variant:
+  ScidEqualsDcid
+
+enum s2n_quic::provider::event::events::RetryDiscardReason implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::RetryDiscardReason<'a>
+
+enum s2n_quic::provider::event::events::RetryDiscardReason implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::RetryDiscardReason<'a>
+
+enum s2n_quic::provider::event::events::RetryDiscardReason implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::RetryDiscardReason<'a>
+
+enum s2n_quic::provider::event::events::RetryDiscardReason implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::RetryDiscardReason<'a>
+
+enum s2n_quic::provider::event::events::RetryDiscardReason implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::RetryDiscardReason<'a>
+
+enum s2n_quic::provider::event::events::RetryDiscardReason implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::RetryDiscardReason<'a>
+
+enum s2n_quic::provider::event::events::RetryDiscardReason implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::RetryDiscardReason<'a>
+
+variant s2n_quic::provider::event::events::RetryDiscardReason::InitialAlreadyProcessed is non-exhaustive
+
+variant s2n_quic::provider::event::events::RetryDiscardReason::InvalidIntegrityTag is non-exhaustive
+
+variant s2n_quic::provider::event::events::RetryDiscardReason::RetryAlreadyProcessed is non-exhaustive
+
+variant s2n_quic::provider::event::events::RetryDiscardReason::ScidEqualsDcid is non-exhaustive
+
+variant s2n_quic::provider::event::events::RetryDiscardReason::ScidEqualsDcid exports field:
+  cid:
+  &'a [u8]
+
+struct s2n_quic::provider::event::events::RxStreamProgress is non-exhaustive
+
+struct s2n_quic::provider::event::events::RxStreamProgress exports field:
+  bytes: usize
+
+struct s2n_quic::provider::event::events::RxStreamProgress implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::RxStreamProgress
+
+struct s2n_quic::provider::event::events::RxStreamProgress implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::RxStreamProgress
+
+struct s2n_quic::provider::event::events::RxStreamProgress implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::RxStreamProgress
+
+struct s2n_quic::provider::event::events::RxStreamProgress implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::RxStreamProgress
+
+struct s2n_quic::provider::event::events::RxStreamProgress implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::RxStreamProgress
+
+struct s2n_quic::provider::event::events::RxStreamProgress implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::RxStreamProgress
+
+struct s2n_quic::provider::event::events::RxStreamProgress implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::RxStreamProgress
+
+struct s2n_quic::provider::event::events::RxStreamProgress implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::RxStreamProgress
+
+struct s2n_quic::provider::event::events::RxStreamProgress exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::ServerNameInformation is non-exhaustive
+
+struct s2n_quic::provider::event::events::ServerNameInformation exports field:
+  chosen_server_name: &'a str
+
+struct s2n_quic::provider::event::events::ServerNameInformation implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::ServerNameInformation<'a>
+
+struct s2n_quic::provider::event::events::ServerNameInformation implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::ServerNameInformation<'a>
+
+struct s2n_quic::provider::event::events::ServerNameInformation implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::ServerNameInformation<'a>
+
+struct s2n_quic::provider::event::events::ServerNameInformation implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::ServerNameInformation<'a>
+
+struct s2n_quic::provider::event::events::ServerNameInformation implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::ServerNameInformation<'a>
+
+struct s2n_quic::provider::event::events::ServerNameInformation implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::ServerNameInformation<'a>
+
+struct s2n_quic::provider::event::events::ServerNameInformation implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::ServerNameInformation<'a>
+
+struct s2n_quic::provider::event::events::ServerNameInformation implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::ServerNameInformation<'a>
+
+struct s2n_quic::provider::event::events::ServerNameInformation exports constant:
+  pub const NAME: &'static str
+
+enum s2n_quic::provider::event::events::SocketAddress is non-exhaustive
+
+enum s2n_quic::provider::event::events::SocketAddress exports variant:
+  IpV4
+
+enum s2n_quic::provider::event::events::SocketAddress exports variant:
+  IpV6
+
+enum s2n_quic::provider::event::events::SocketAddress implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::SocketAddress<'a>
+
+enum s2n_quic::provider::event::events::SocketAddress implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::SocketAddress<'a>
+
+enum s2n_quic::provider::event::events::SocketAddress implements trait:
+  impl<'a> core::fmt::Display for s2n_quic::provider::event::events::SocketAddress<'a>
+
+enum s2n_quic::provider::event::events::SocketAddress implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::SocketAddress<'a>
+
+enum s2n_quic::provider::event::events::SocketAddress implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::SocketAddress<'a>
+
+enum s2n_quic::provider::event::events::SocketAddress implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::SocketAddress<'a>
+
+enum s2n_quic::provider::event::events::SocketAddress implements trait:
+  impl<'a> s2n_quic_core::event::IntoEvent<s2n_quic::provider::event::events::SocketAddress<'a>> for &'a s2n_quic_core::inet::ip::SocketAddress
+
+enum s2n_quic::provider::event::events::SocketAddress implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::SocketAddress<'a>
+
+enum s2n_quic::provider::event::events::SocketAddress implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::SocketAddress<'a>
+
+enum s2n_quic::provider::event::events::SocketAddress exports function:
+  pub fn ip(&self) -> &'a [u8]
+
+enum s2n_quic::provider::event::events::SocketAddress exports function:
+  pub fn port(&self) -> u16
+
+variant s2n_quic::provider::event::events::SocketAddress::IpV4 is non-exhaustive
+
+variant s2n_quic::provider::event::events::SocketAddress::IpV4 exports field:
+  ip:
+  &'a [u8; 4]
+
+variant s2n_quic::provider::event::events::SocketAddress::IpV4 exports field:
+  port:
+  u16
+
+variant s2n_quic::provider::event::events::SocketAddress::IpV6 is non-exhaustive
+
+variant s2n_quic::provider::event::events::SocketAddress::IpV6 exports field:
+  ip:
+  &'a [u8; 16]
+
+variant s2n_quic::provider::event::events::SocketAddress::IpV6 exports field:
+  port:
+  u16
+
+enum s2n_quic::provider::event::events::StreamType is non-exhaustive
+
+enum s2n_quic::provider::event::events::StreamType exports variant:
+  Bidirectional
+
+enum s2n_quic::provider::event::events::StreamType exports variant:
+  Unidirectional
+
+enum s2n_quic::provider::event::events::StreamType implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::StreamType
+
+enum s2n_quic::provider::event::events::StreamType implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::StreamType
+
+enum s2n_quic::provider::event::events::StreamType implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::StreamType
+
+enum s2n_quic::provider::event::events::StreamType implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::StreamType
+
+enum s2n_quic::provider::event::events::StreamType implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::StreamType
+
+enum s2n_quic::provider::event::events::StreamType implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::StreamType
+
+enum s2n_quic::provider::event::events::StreamType implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::StreamType
+
+variant s2n_quic::provider::event::events::StreamType::Bidirectional is non-exhaustive
+
+variant s2n_quic::provider::event::events::StreamType::Unidirectional is non-exhaustive
+
+enum s2n_quic::provider::event::events::Subject is non-exhaustive
+
+enum s2n_quic::provider::event::events::Subject exports variant:
+  Connection
+
+enum s2n_quic::provider::event::events::Subject exports variant:
+  Endpoint
+
+enum s2n_quic::provider::event::events::Subject implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::Subject
+
+enum s2n_quic::provider::event::events::Subject implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::Subject
+
+enum s2n_quic::provider::event::events::Subject implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::Subject
+
+enum s2n_quic::provider::event::events::Subject implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::Subject
+
+enum s2n_quic::provider::event::events::Subject implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::Subject
+
+enum s2n_quic::provider::event::events::Subject implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::Subject
+
+enum s2n_quic::provider::event::events::Subject implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::Subject
+
+variant s2n_quic::provider::event::events::Subject::Connection is non-exhaustive
+
+variant s2n_quic::provider::event::events::Subject::Connection exports field:
+  id:
+  u64
+
+variant s2n_quic::provider::event::events::Subject::Endpoint is non-exhaustive
+
+trait s2n_quic::provider::event::events::Subscriber exports function:
+  pub fn create_connection_context(
+  &mut self,
+  meta: &s2n_quic::provider::event::ConnectionMeta,
+  info: &s2n_quic::provider::event::ConnectionInfo) -> Self::s2n_quic::provider::event::Subscriber::ConnectionContext
+
+struct s2n_quic::provider::event::events::TlsClientHello is non-exhaustive
+
+struct s2n_quic::provider::event::events::TlsClientHello implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::TlsClientHello<'a>
+
+struct s2n_quic::provider::event::events::TlsClientHello implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::TlsClientHello<'a>
+
+struct s2n_quic::provider::event::events::TlsClientHello implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::TlsClientHello<'a>
+
+struct s2n_quic::provider::event::events::TlsClientHello implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::TlsClientHello<'a>
+
+struct s2n_quic::provider::event::events::TlsClientHello implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::TlsClientHello<'a>
+
+struct s2n_quic::provider::event::events::TlsClientHello implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::TlsClientHello<'a>
+
+struct s2n_quic::provider::event::events::TlsClientHello implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::TlsClientHello<'a>
+
+struct s2n_quic::provider::event::events::TlsClientHello implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::TlsClientHello<'a>
+
+struct s2n_quic::provider::event::events::TlsClientHello exports field:
+  payload: &'a [&'a [u8]]
+
+struct s2n_quic::provider::event::events::TlsClientHello exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::TlsServerHello is non-exhaustive
+
+struct s2n_quic::provider::event::events::TlsServerHello implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::TlsServerHello<'a>
+
+struct s2n_quic::provider::event::events::TlsServerHello implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::TlsServerHello<'a>
+
+struct s2n_quic::provider::event::events::TlsServerHello implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::TlsServerHello<'a>
+
+struct s2n_quic::provider::event::events::TlsServerHello implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::TlsServerHello<'a>
+
+struct s2n_quic::provider::event::events::TlsServerHello implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::TlsServerHello<'a>
+
+struct s2n_quic::provider::event::events::TlsServerHello implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::TlsServerHello<'a>
+
+struct s2n_quic::provider::event::events::TlsServerHello implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::TlsServerHello<'a>
+
+struct s2n_quic::provider::event::events::TlsServerHello implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::TlsServerHello<'a>
+
+struct s2n_quic::provider::event::events::TlsServerHello exports field:
+  payload: &'a [&'a [u8]]
+
+struct s2n_quic::provider::event::events::TlsServerHello exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::TransportParameters is non-exhaustive
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  ack_delay_exponent: u8
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  active_connection_id_limit: u64
+
+struct s2n_quic::provider::event::events::TransportParameters implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::TransportParameters<'a>
+
+struct s2n_quic::provider::event::events::TransportParameters implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::TransportParameters<'a>
+
+struct s2n_quic::provider::event::events::TransportParameters implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::TransportParameters<'a>
+
+struct s2n_quic::provider::event::events::TransportParameters implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::TransportParameters<'a>
+
+struct s2n_quic::provider::event::events::TransportParameters implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::TransportParameters<'a>
+
+struct s2n_quic::provider::event::events::TransportParameters implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::TransportParameters<'a>
+
+struct s2n_quic::provider::event::events::TransportParameters implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::TransportParameters<'a>
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  initial_max_stream_data_bidi_local: u64
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  initial_max_stream_data_bidi_remote: u64
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  initial_max_stream_data_uni: u64
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  initial_max_streams_bidi: u64
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  initial_max_streams_uni: u64
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  initial_source_connection_id: core::option::Option<s2n_quic::provider::event::events::ConnectionId<'a>>
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  max_ack_delay: core::time::Duration
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  max_idle_timeout: core::time::Duration
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  max_udp_payload_size: u64
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  migration_support: bool
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  original_destination_connection_id: core::option::Option<s2n_quic::provider::event::events::ConnectionId<'a>>
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  preferred_address: core::option::Option<s2n_quic::provider::event::events::PreferredAddress<'a>>
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  retry_source_connection_id: core::option::Option<s2n_quic::provider::event::events::ConnectionId<'a>>
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  stateless_reset_token: core::option::Option<&'a [u8]>
+
+struct s2n_quic::provider::event::events::TransportParametersReceived is non-exhaustive
+
+struct s2n_quic::provider::event::events::TransportParametersReceived implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::TransportParametersReceived<'a>
+
+struct s2n_quic::provider::event::events::TransportParametersReceived implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::TransportParametersReceived<'a>
+
+struct s2n_quic::provider::event::events::TransportParametersReceived implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::TransportParametersReceived<'a>
+
+struct s2n_quic::provider::event::events::TransportParametersReceived implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::TransportParametersReceived<'a>
+
+struct s2n_quic::provider::event::events::TransportParametersReceived implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::TransportParametersReceived<'a>
+
+struct s2n_quic::provider::event::events::TransportParametersReceived implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::TransportParametersReceived<'a>
+
+struct s2n_quic::provider::event::events::TransportParametersReceived implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::TransportParametersReceived<'a>
+
+struct s2n_quic::provider::event::events::TransportParametersReceived implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::TransportParametersReceived<'a>
+
+struct s2n_quic::provider::event::events::TransportParametersReceived exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::TransportParametersReceived exports field:
+  transport_parameters: s2n_quic::provider::event::events::TransportParameters<'a>
+
+struct s2n_quic::provider::event::events::TxStreamProgress is non-exhaustive
+
+struct s2n_quic::provider::event::events::TxStreamProgress exports field:
+  bytes: usize
+
+struct s2n_quic::provider::event::events::TxStreamProgress implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::TxStreamProgress
+
+struct s2n_quic::provider::event::events::TxStreamProgress implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::TxStreamProgress
+
+struct s2n_quic::provider::event::events::TxStreamProgress implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::TxStreamProgress
+
+struct s2n_quic::provider::event::events::TxStreamProgress implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::TxStreamProgress
+
+struct s2n_quic::provider::event::events::TxStreamProgress implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::TxStreamProgress
+
+struct s2n_quic::provider::event::events::TxStreamProgress implements trait:
+  impl s2n_quic::provider::event::Event for s2n_quic::provider::event::events::TxStreamProgress
+
+struct s2n_quic::provider::event::events::TxStreamProgress implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::TxStreamProgress
+
+struct s2n_quic::provider::event::events::TxStreamProgress implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::TxStreamProgress
+
+struct s2n_quic::provider::event::events::TxStreamProgress exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::VersionInformation is non-exhaustive
+
+struct s2n_quic::provider::event::events::VersionInformation exports field:
+  chosen_version: core::option::Option<u32>
+
+struct s2n_quic::provider::event::events::VersionInformation exports field:
+  client_versions: &'a [u32]
+
+struct s2n_quic::provider::event::events::VersionInformation implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::VersionInformation<'a>
+
+struct s2n_quic::provider::event::events::VersionInformation implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::VersionInformation<'a>
+
+struct s2n_quic::provider::event::events::VersionInformation implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::VersionInformation<'a>
+
+struct s2n_quic::provider::event::events::VersionInformation implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::VersionInformation<'a>
+
+struct s2n_quic::provider::event::events::VersionInformation implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::VersionInformation<'a>
+
+struct s2n_quic::provider::event::events::VersionInformation implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::VersionInformation<'a>
+
+struct s2n_quic::provider::event::events::VersionInformation implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::VersionInformation<'a>
+
+struct s2n_quic::provider::event::events::VersionInformation implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::VersionInformation<'a>
+
+struct s2n_quic::provider::event::events::VersionInformation exports constant:
+  pub const NAME: &'static str
+
+struct s2n_quic::provider::event::events::VersionInformation exports field:
+  server_versions: &'a [u32]
+
+module s2n_quic::provider::event::query exports enum:
+  s2n_quic::provider::event::query::ControlFlow
+
+module s2n_quic::provider::event::query exports enum:
+  s2n_quic::provider::event::query::Error
+
+module s2n_quic::provider::event::query exports struct:
+  s2n_quic::provider::event::query::Once
+
+module s2n_quic::provider::event::query exports trait:
+  s2n_quic::provider::event::query::Query
+
+module s2n_quic::provider::event::query exports trait:
+  s2n_quic::provider::event::query::QueryMut
+
+enum s2n_quic::provider::event::query::ControlFlow exports function:
+  #[must_use]
+  pub fn and_then(self, f: impl core::ops::function::FnOnce() -> s2n_quic::provider::event::query::ControlFlow) -> s2n_quic::provider::event::query::ControlFlow
+
+enum s2n_quic::provider::event::query::ControlFlow exports variant:
+  Break
+
+enum s2n_quic::provider::event::query::ControlFlow exports variant:
+  Continue
+
+enum s2n_quic::provider::event::query::ControlFlow implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::query::ControlFlow
+
+enum s2n_quic::provider::event::query::ControlFlow implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::event::query::ControlFlow> for s2n_quic::provider::event::query::ControlFlow
+
+enum s2n_quic::provider::event::query::ControlFlow implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::query::ControlFlow
+
+enum s2n_quic::provider::event::query::ControlFlow implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::query::ControlFlow
+
+enum s2n_quic::provider::event::query::ControlFlow implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::query::ControlFlow
+
+enum s2n_quic::provider::event::query::ControlFlow implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::query::ControlFlow
+
+enum s2n_quic::provider::event::query::ControlFlow implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::query::ControlFlow
+
+enum s2n_quic::provider::event::query::ControlFlow implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::query::ControlFlow
+
+enum s2n_quic::provider::event::query::Error is non-exhaustive
+
+enum s2n_quic::provider::event::query::Error exports variant:
+  ConnectionLockPoisoned
+
+enum s2n_quic::provider::event::query::Error exports variant:
+  ContextTypeMismatch
+
+enum s2n_quic::provider::event::query::Error implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::query::Error
+
+enum s2n_quic::provider::event::query::Error implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::query::Error
+
+enum s2n_quic::provider::event::query::Error implements trait:
+  impl core::fmt::Display for s2n_quic::provider::event::query::Error
+
+enum s2n_quic::provider::event::query::Error implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::query::Error
+
+enum s2n_quic::provider::event::query::Error implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::query::Error
+
+enum s2n_quic::provider::event::query::Error implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::query::Error
+
+enum s2n_quic::provider::event::query::Error implements trait:
+  impl std::error::Error for s2n_quic::provider::event::query::Error
+
+enum s2n_quic::provider::event::query::Error implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::query::Error
+
+enum s2n_quic::provider::event::query::Error implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::query::Error
+
+struct s2n_quic::provider::event::query::Once implements trait:
+  impl<F, EventContext, Outcome> core::marker::Send for s2n_quic::provider::event::query::Once<F, EventContext, Outcome> where
+  EventContext: core::marker::Send,
+  F: core::marker::Send,
+  Outcome: core::marker::Send,
+
+struct s2n_quic::provider::event::query::Once implements trait:
+  impl<F, EventContext, Outcome> core::marker::Sync for s2n_quic::provider::event::query::Once<F, EventContext, Outcome> where
+  EventContext: core::marker::Sync,
+  F: core::marker::Sync,
+  Outcome: core::marker::Sync,
+
+struct s2n_quic::provider::event::query::Once implements trait:
+  impl<F, EventContext, Outcome> core::marker::Unpin for s2n_quic::provider::event::query::Once<F, EventContext, Outcome> where
+  EventContext: core::marker::Unpin,
+  F: core::marker::Unpin,
+  Outcome: core::marker::Unpin,
+
+struct s2n_quic::provider::event::query::Once implements trait:
+  impl<F, EventContext, Outcome> s2n_quic::provider::event::query::Query for s2n_quic::provider::event::query::Once<F, EventContext, Outcome> where
+  EventContext: 'static,
+  F: core::ops::function::FnOnce(&EventContext) -> Outcome,
+
+struct s2n_quic::provider::event::query::Once implements trait:
+  impl<F, EventContext, Outcome> s2n_quic::provider::event::query::QueryMut for s2n_quic::provider::event::query::Once<F, EventContext, Outcome> where
+  EventContext: 'static,
+  F: core::ops::function::FnOnce(&mut EventContext) -> Outcome,
+
+struct s2n_quic::provider::event::query::Once implements trait:
+  impl<F, EventContext, Outcome> std::panic::RefUnwindSafe for s2n_quic::provider::event::query::Once<F, EventContext, Outcome> where
+  EventContext: std::panic::RefUnwindSafe,
+  F: std::panic::RefUnwindSafe,
+  Outcome: std::panic::RefUnwindSafe,
+
+struct s2n_quic::provider::event::query::Once implements trait:
+  impl<F, EventContext, Outcome> std::panic::UnwindSafe for s2n_quic::provider::event::query::Once<F, EventContext, Outcome> where
+  EventContext: std::panic::UnwindSafe,
+  F: std::panic::UnwindSafe,
+  Outcome: std::panic::UnwindSafe,
+
+struct s2n_quic::provider::event::query::Once exports function:
+  pub fn new(query: F) -> s2n_quic::provider::event::query::Once<F, ConnectionContext, Outcome>
+
+struct s2n_quic::provider::event::query::Once exports function:
+  pub fn new_mut(query: F) -> s2n_quic::provider::event::query::Once<F, ConnectionContext, Outcome>
+
+trait s2n_quic::provider::event::query::Query exports function:
+  pub fn execute(&mut self, context: &(dyn core::any::Any + 'static)) -> s2n_quic::provider::event::query::ControlFlow
+
+trait s2n_quic::provider::event::query::QueryMut exports function:
+  pub fn execute_mut(&mut self, context: &mut (dyn core::any::Any + 'static)) -> s2n_quic::provider::event::query::ControlFlow
+
+module s2n_quic::provider::event::supervisor exports struct:
+  s2n_quic::provider::event::supervisor::Context
+
+module s2n_quic::provider::event::supervisor exports enum:
+  s2n_quic::provider::event::supervisor::Outcome
+
+struct s2n_quic::provider::event::supervisor::Context is non-exhaustive
+
+struct s2n_quic::provider::event::supervisor::Context exports field:
+  connection_count: usize
+
+struct s2n_quic::provider::event::supervisor::Context implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::supervisor::Context<'a>
+
+struct s2n_quic::provider::event::supervisor::Context implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::supervisor::Context<'a>
+
+struct s2n_quic::provider::event::supervisor::Context implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::supervisor::Context<'a>
+
+struct s2n_quic::provider::event::supervisor::Context implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::supervisor::Context<'a>
+
+struct s2n_quic::provider::event::supervisor::Context implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::supervisor::Context<'a>
+
+struct s2n_quic::provider::event::supervisor::Context implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::supervisor::Context<'a>
+
+struct s2n_quic::provider::event::supervisor::Context exports field:
+  inflight_handshakes: usize
+
+struct s2n_quic::provider::event::supervisor::Context exports field:
+  is_handshaking: bool
+
+struct s2n_quic::provider::event::supervisor::Context exports function:
+  pub fn new(
+  inflight_handshakes: usize,
+  connection_count: usize,
+  remote_address: &'a s2n_quic_core::inet::ip::SocketAddress,
+  is_handshaking: bool) -> s2n_quic::provider::event::supervisor::Context<'a>
+
+struct s2n_quic::provider::event::supervisor::Context exports field:
+  remote_address: s2n_quic_core::event::generated::builder::SocketAddress<'a>
+
+enum s2n_quic::provider::event::supervisor::Outcome is non-exhaustive
+
+enum s2n_quic::provider::event::supervisor::Outcome exports variant:
+  Close
+
+enum s2n_quic::provider::event::supervisor::Outcome exports variant:
+  Continue
+
+enum s2n_quic::provider::event::supervisor::Outcome exports variant:
+  ImmediateClose
+
+enum s2n_quic::provider::event::supervisor::Outcome implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::supervisor::Outcome
+
+enum s2n_quic::provider::event::supervisor::Outcome implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::event::supervisor::Outcome> for s2n_quic::provider::event::supervisor::Outcome
+
+enum s2n_quic::provider::event::supervisor::Outcome implements trait:
+  impl core::default::Default for s2n_quic::provider::event::supervisor::Outcome
+
+enum s2n_quic::provider::event::supervisor::Outcome implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::supervisor::Outcome
+
+enum s2n_quic::provider::event::supervisor::Outcome implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::supervisor::Outcome
+
+enum s2n_quic::provider::event::supervisor::Outcome implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::supervisor::Outcome
+
+enum s2n_quic::provider::event::supervisor::Outcome implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::supervisor::Outcome
+
+enum s2n_quic::provider::event::supervisor::Outcome implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::supervisor::Outcome
+
+enum s2n_quic::provider::event::supervisor::Outcome implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::supervisor::Outcome
+
+variant s2n_quic::provider::event::supervisor::Outcome::Close exports field:
+  error_code:
+  s2n_quic::application::Error
+
+variant s2n_quic::provider::event::supervisor::Outcome::ImmediateClose exports field:
+  reason:
+  &'static str
+
+module s2n_quic::provider::event::tracing exports struct:
+  s2n_quic::provider::event::tracing::Provider
+
+module s2n_quic::provider::event::tracing exports struct:
+  s2n_quic::provider::event::tracing::Subscriber
+
+struct s2n_quic::provider::event::tracing::Provider implements trait:
+  impl core::default::Default for s2n_quic::provider::event::tracing::Provider
+
+struct s2n_quic::provider::event::tracing::Provider implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::tracing::Provider
+
+struct s2n_quic::provider::event::tracing::Provider implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::tracing::Provider
+
+struct s2n_quic::provider::event::tracing::Provider implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::tracing::Provider
+
+struct s2n_quic::provider::event::tracing::Provider implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::tracing::Provider
+
+struct s2n_quic::provider::event::tracing::Provider implements trait:
+  impl s2n_quic::provider::event::Provider for s2n_quic::provider::event::tracing::Provider
+
+struct s2n_quic::provider::event::tracing::Provider implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::tracing::Provider
+
+struct s2n_quic::provider::event::tracing::Provider implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::tracing::Provider
+
+struct s2n_quic::provider::event::tracing::Subscriber implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::event::tracing::Subscriber
+
+struct s2n_quic::provider::event::tracing::Subscriber implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::event::tracing::Subscriber
+
+struct s2n_quic::provider::event::tracing::Subscriber implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::tracing::Subscriber
+
+struct s2n_quic::provider::event::tracing::Subscriber implements trait:
+  impl core::default::Default for s2n_quic::provider::event::tracing::Subscriber
+
+struct s2n_quic::provider::event::tracing::Subscriber implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::tracing::Subscriber
+
+struct s2n_quic::provider::event::tracing::Subscriber implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::tracing::Subscriber
+
+struct s2n_quic::provider::event::tracing::Subscriber implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::tracing::Subscriber
+
+struct s2n_quic::provider::event::tracing::Subscriber implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::tracing::Subscriber
+
+struct s2n_quic::provider::event::tracing::Subscriber implements trait:
+  impl s2n_quic::provider::event::Subscriber for s2n_quic::provider::event::tracing::Subscriber
+
+module s2n_quic::provider::io exports struct:
+  s2n_quic::provider::io::Default
+
+module s2n_quic::provider::io exports trait:
+  s2n_quic::provider::io::Provider
+
+module s2n_quic::provider::io exports trait:
+  s2n_quic::provider::io::TryInto
+
+module s2n_quic::provider::io exports module:
+  s2n_quic::provider::io::tokio
+
+struct s2n_quic::provider::io::Default implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::Default implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::Default implements trait:
+  impl core::default::Default for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::Default implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::Default implements trait:
+  impl core::marker::Send for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::Default implements trait:
+  impl core::marker::Sync for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::Default implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::Default implements trait:
+  impl s2n_quic::provider::io::Provider for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::Default exports function:
+  pub fn builder() -> s2n_quic::provider::io::tokio::Builder
+
+struct s2n_quic::provider::io::Default exports function:
+  pub fn new<A>(addr: A) -> core::result::Result<s2n_quic::provider::io::Default, std::io::error::Error> where
+  A: std::net::addr::ToSocketAddrs,
+
+struct s2n_quic::provider::io::Default exports function:
+  pub fn start<E>(
+  self,
+  endpoint: E) -> core::result::Result<(tokio::runtime::task::join::JoinHandle<()>, s2n_quic_core::inet::ip::SocketAddress), std::io::error::Error> where
+  E: s2n_quic_core::endpoint::Endpoint<PathHandle = s2n_quic_platform::message::msg::Handle>,
+
+trait s2n_quic::provider::io::Provider exports function:
+  fn start<E:
+  s2n_quic_core::endpoint::Endpoint<PathHandle = Self::s2n_quic::provider::io::Provider::PathHandle>>(
+  self,
+  endpoint: E) -> core::result::Result<s2n_quic_core::inet::ip::SocketAddress, Self::s2n_quic::provider::io::Provider::Error>
+
+trait s2n_quic::provider::io::TryInto exports function:
+  fn try_into(self) -> core::result::Result<Self::s2n_quic::provider::io::TryInto::Provider, Self::s2n_quic::provider::io::TryInto::Error>
+
+module s2n_quic::provider::io::tokio exports struct:
+  s2n_quic::provider::io::tokio::Builder
+
+module s2n_quic::provider::io::tokio exports struct:
+  s2n_quic::provider::io::tokio::Provider
+
+struct s2n_quic::provider::io::tokio::Builder exports function:
+  #[must_use]
+  pub fn with_handle(self, handle: tokio::runtime::handle::Handle) -> s2n_quic::provider::io::tokio::Builder
+
+struct s2n_quic::provider::io::tokio::Builder implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::io::tokio::Builder
+
+struct s2n_quic::provider::io::tokio::Builder implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::io::tokio::Builder
+
+struct s2n_quic::provider::io::tokio::Builder implements trait:
+  impl core::default::Default for s2n_quic::provider::io::tokio::Builder
+
+struct s2n_quic::provider::io::tokio::Builder implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::io::tokio::Builder
+
+struct s2n_quic::provider::io::tokio::Builder implements trait:
+  impl core::marker::Send for s2n_quic::provider::io::tokio::Builder
+
+struct s2n_quic::provider::io::tokio::Builder implements trait:
+  impl core::marker::Sync for s2n_quic::provider::io::tokio::Builder
+
+struct s2n_quic::provider::io::tokio::Builder implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::io::tokio::Builder
+
+struct s2n_quic::provider::io::tokio::Builder exports function:
+  pub fn build(self) -> core::result::Result<s2n_quic::provider::io::Default, std::io::error::Error>
+
+struct s2n_quic::provider::io::tokio::Builder exports function:
+  pub fn with_gso_disabled(self) -> core::result::Result<s2n_quic::provider::io::tokio::Builder, std::io::error::Error>
+
+struct s2n_quic::provider::io::tokio::Builder exports function:
+  pub fn with_max_mtu(self, max_mtu: u16) -> core::result::Result<s2n_quic::provider::io::tokio::Builder, std::io::error::Error>
+
+struct s2n_quic::provider::io::tokio::Builder exports function:
+  pub fn with_receive_address(self, addr: std::net::addr::SocketAddr) -> core::result::Result<s2n_quic::provider::io::tokio::Builder, std::io::error::Error>
+
+struct s2n_quic::provider::io::tokio::Builder exports function:
+  pub fn with_recv_buffer_size(
+  self,
+  recv_buffer_size: usize) -> core::result::Result<s2n_quic::provider::io::tokio::Builder, std::io::error::Error>
+
+struct s2n_quic::provider::io::tokio::Builder exports function:
+  pub fn with_reuse_port(self) -> core::result::Result<s2n_quic::provider::io::tokio::Builder, std::io::error::Error>
+
+struct s2n_quic::provider::io::tokio::Builder exports function:
+  pub fn with_rx_socket(self, socket: std::net::udp::UdpSocket) -> core::result::Result<s2n_quic::provider::io::tokio::Builder, std::io::error::Error>
+
+struct s2n_quic::provider::io::tokio::Builder exports function:
+  pub fn with_send_address(self, addr: std::net::addr::SocketAddr) -> core::result::Result<s2n_quic::provider::io::tokio::Builder, std::io::error::Error>
+
+struct s2n_quic::provider::io::tokio::Builder exports function:
+  pub fn with_send_buffer_size(
+  self,
+  send_buffer_size: usize) -> core::result::Result<s2n_quic::provider::io::tokio::Builder, std::io::error::Error>
+
+struct s2n_quic::provider::io::tokio::Builder exports function:
+  pub fn with_tx_socket(self, socket: std::net::udp::UdpSocket) -> core::result::Result<s2n_quic::provider::io::tokio::Builder, std::io::error::Error>
+
+struct s2n_quic::provider::io::tokio::Provider implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::tokio::Provider implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::tokio::Provider implements trait:
+  impl core::default::Default for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::tokio::Provider implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::tokio::Provider implements trait:
+  impl core::marker::Send for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::tokio::Provider implements trait:
+  impl core::marker::Sync for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::tokio::Provider implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::tokio::Provider implements trait:
+  impl s2n_quic::provider::io::Provider for s2n_quic::provider::io::Default
+
+struct s2n_quic::provider::io::tokio::Provider exports function:
+  pub fn builder() -> s2n_quic::provider::io::tokio::Builder
+
+struct s2n_quic::provider::io::tokio::Provider exports function:
+  pub fn new<A>(addr: A) -> core::result::Result<s2n_quic::provider::io::Default, std::io::error::Error> where
+  A: std::net::addr::ToSocketAddrs,
+
+struct s2n_quic::provider::io::tokio::Provider exports function:
+  pub fn start<E>(
+  self,
+  endpoint: E) -> core::result::Result<(tokio::runtime::task::join::JoinHandle<()>, s2n_quic_core::inet::ip::SocketAddress), std::io::error::Error> where
+  E: s2n_quic_core::endpoint::Endpoint<PathHandle = s2n_quic_platform::message::msg::Handle>,
+
+module s2n_quic::provider::limits exports struct:
+  s2n_quic::provider::limits::ConnectionInfo
+
+module s2n_quic::provider::limits exports trait:
+  s2n_quic::provider::limits::Limiter
+
+module s2n_quic::provider::limits exports struct:
+  s2n_quic::provider::limits::Limits
+
+module s2n_quic::provider::limits exports trait:
+  s2n_quic::provider::limits::Provider
+
+module s2n_quic::provider::limits exports trait:
+  s2n_quic::provider::limits::TryInto
+
+module s2n_quic::provider::limits exports module:
+  s2n_quic::provider::limits::default
+
+module s2n_quic::provider::limits exports struct:
+  s2n_quic::provider::limits::default::Provider
+
+struct s2n_quic::provider::limits::ConnectionInfo is non-exhaustive
+
+struct s2n_quic::provider::limits::ConnectionInfo implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::limits::ConnectionInfo<'a>
+
+struct s2n_quic::provider::limits::ConnectionInfo implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::limits::ConnectionInfo<'a>
+
+struct s2n_quic::provider::limits::ConnectionInfo implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::limits::ConnectionInfo<'a>
+
+struct s2n_quic::provider::limits::ConnectionInfo implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::limits::ConnectionInfo<'a>
+
+struct s2n_quic::provider::limits::ConnectionInfo implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::limits::ConnectionInfo<'a>
+
+struct s2n_quic::provider::limits::ConnectionInfo implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::limits::ConnectionInfo<'a>
+
+struct s2n_quic::provider::limits::ConnectionInfo exports field:
+  remote_address: s2n_quic::provider::event::events::SocketAddress<'a>
+
+trait s2n_quic::provider::limits::Limiter exports function:
+  pub fn on_connection(&mut self, info: &s2n_quic::provider::limits::ConnectionInfo<'_>) -> s2n_quic::provider::limits::Limits
+
+struct s2n_quic::provider::limits::Limits implements trait:
+  impl core::clone::Clone for s2n_quic::provider::limits::Limits
+
+struct s2n_quic::provider::limits::Limits implements trait:
+  impl core::default::Default for s2n_quic::provider::limits::Limits
+
+struct s2n_quic::provider::limits::Limits implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::limits::Limits
+
+struct s2n_quic::provider::limits::Limits implements trait:
+  impl core::marker::Send for s2n_quic::provider::limits::Limits
+
+struct s2n_quic::provider::limits::Limits implements trait:
+  impl core::marker::Sync for s2n_quic::provider::limits::Limits
+
+struct s2n_quic::provider::limits::Limits implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::limits::Limits
+
+struct s2n_quic::provider::limits::Limits implements trait:
+  impl s2n_quic::provider::limits::Limiter for s2n_quic::provider::limits::Limits
+
+struct s2n_quic::provider::limits::Limits implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::limits::Limits
+
+struct s2n_quic::provider::limits::Limits implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::limits::Limits
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub const fn new() -> s2n_quic::provider::limits::Limits
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub fn with_ack_elicitation_interval(
+  self,
+  value: u8) -> core::result::Result<s2n_quic::provider::limits::Limits, s2n_quic_core::transport::parameters::ValidationError>
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub fn with_bidirectional_local_data_window(
+  self,
+  value: u64) -> core::result::Result<s2n_quic::provider::limits::Limits, s2n_quic_core::transport::parameters::ValidationError>
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub fn with_bidirectional_remote_data_window(
+  self,
+  value: u64) -> core::result::Result<s2n_quic::provider::limits::Limits, s2n_quic_core::transport::parameters::ValidationError>
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub fn with_data_window(self, value: u64) -> core::result::Result<s2n_quic::provider::limits::Limits, s2n_quic_core::transport::parameters::ValidationError>
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub fn with_max_ack_delay(
+  self,
+  value: core::time::Duration) -> core::result::Result<s2n_quic::provider::limits::Limits, s2n_quic_core::transport::parameters::ValidationError>
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub fn with_max_ack_ranges(self, value: u8) -> core::result::Result<s2n_quic::provider::limits::Limits, s2n_quic_core::transport::parameters::ValidationError>
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub fn with_max_active_connection_ids(
+  self,
+  value: u64) -> core::result::Result<s2n_quic::provider::limits::Limits, s2n_quic_core::transport::parameters::ValidationError>
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub fn with_max_handshake_duration(
+  self,
+  value: core::time::Duration) -> core::result::Result<s2n_quic::provider::limits::Limits, s2n_quic_core::transport::parameters::ValidationError>
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub fn with_max_idle_timeout(
+  self,
+  value: core::time::Duration) -> core::result::Result<s2n_quic::provider::limits::Limits, s2n_quic_core::transport::parameters::ValidationError>
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub fn with_max_keep_alive_period(
+  self,
+  value: core::time::Duration) -> core::result::Result<s2n_quic::provider::limits::Limits, s2n_quic_core::transport::parameters::ValidationError>
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub fn with_max_open_bidirectional_streams(
+  self,
+  value: u64) -> core::result::Result<s2n_quic::provider::limits::Limits, s2n_quic_core::transport::parameters::ValidationError>
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub fn with_max_open_local_unidirectional_streams(
+  self,
+  value: u64) -> core::result::Result<s2n_quic::provider::limits::Limits, s2n_quic_core::transport::parameters::ValidationError>
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub fn with_max_open_remote_unidirectional_streams(
+  self,
+  value: u64) -> core::result::Result<s2n_quic::provider::limits::Limits, s2n_quic_core::transport::parameters::ValidationError>
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub fn with_max_send_buffer_size(
+  self,
+  value: u32) -> core::result::Result<s2n_quic::provider::limits::Limits, s2n_quic_core::transport::parameters::ValidationError>
+
+struct s2n_quic::provider::limits::Limits exports function:
+  pub fn with_unidirectional_data_window(
+  self,
+  value: u64) -> core::result::Result<s2n_quic::provider::limits::Limits, s2n_quic_core::transport::parameters::ValidationError>
+
+trait s2n_quic::provider::limits::Provider exports function:
+  fn start(self) -> core::result::Result<Self::s2n_quic::provider::limits::Provider::Limits, Self::s2n_quic::provider::limits::Provider::Error>
+
+trait s2n_quic::provider::limits::TryInto exports function:
+  fn try_into(self) -> core::result::Result<Self::s2n_quic::provider::limits::TryInto::Provider, Self::s2n_quic::provider::limits::TryInto::Error>
+
+module s2n_quic::provider::limits::default exports struct:
+  s2n_quic::provider::limits::default::Provider
+
+struct s2n_quic::provider::limits::default::Provider implements trait:
+  impl core::default::Default for s2n_quic::provider::limits::default::Provider
+
+struct s2n_quic::provider::limits::default::Provider implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::limits::default::Provider
+
+struct s2n_quic::provider::limits::default::Provider implements trait:
+  impl core::marker::Send for s2n_quic::provider::limits::default::Provider
+
+struct s2n_quic::provider::limits::default::Provider implements trait:
+  impl core::marker::Sync for s2n_quic::provider::limits::default::Provider
+
+struct s2n_quic::provider::limits::default::Provider implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::limits::default::Provider
+
+struct s2n_quic::provider::limits::default::Provider implements trait:
+  impl s2n_quic::provider::limits::Provider for s2n_quic::provider::limits::default::Provider
+
+struct s2n_quic::provider::limits::default::Provider implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::limits::default::Provider
+
+struct s2n_quic::provider::limits::default::Provider implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::limits::default::Provider
+
+module s2n_quic::provider::stateless_reset_token exports struct:
+  s2n_quic::provider::stateless_reset_token::Default
+
+module s2n_quic::provider::stateless_reset_token exports trait:
+  s2n_quic::provider::stateless_reset_token::Generator
+
+module s2n_quic::provider::stateless_reset_token exports trait:
+  s2n_quic::provider::stateless_reset_token::Provider
+
+module s2n_quic::provider::stateless_reset_token exports trait:
+  s2n_quic::provider::stateless_reset_token::TryInto
+
+struct s2n_quic::provider::stateless_reset_token::Default implements trait:
+  impl core::default::Default for s2n_quic::provider::stateless_reset_token::Default
+
+struct s2n_quic::provider::stateless_reset_token::Default implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::stateless_reset_token::Default
+
+struct s2n_quic::provider::stateless_reset_token::Default implements trait:
+  impl core::marker::Send for s2n_quic::provider::stateless_reset_token::Default
+
+struct s2n_quic::provider::stateless_reset_token::Default implements trait:
+  impl core::marker::Sync for s2n_quic::provider::stateless_reset_token::Default
+
+struct s2n_quic::provider::stateless_reset_token::Default implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::stateless_reset_token::Default
+
+struct s2n_quic::provider::stateless_reset_token::Default implements trait:
+  impl s2n_quic::provider::stateless_reset_token::Provider for s2n_quic::provider::stateless_reset_token::Default
+
+struct s2n_quic::provider::stateless_reset_token::Default implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::stateless_reset_token::Default
+
+struct s2n_quic::provider::stateless_reset_token::Default implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::stateless_reset_token::Default
+
+trait s2n_quic::provider::stateless_reset_token::Generator exports function:
+  pub fn generate(&mut self, local_connection_id: &[u8]) -> s2n_quic_core::stateless_reset::token::Token
+
+trait s2n_quic::provider::stateless_reset_token::Provider exports function:
+  fn start(self) -> core::result::Result<Self::s2n_quic::provider::stateless_reset_token::Provider::Generator, Self::s2n_quic::provider::stateless_reset_token::Provider::Error>
+
+trait s2n_quic::provider::stateless_reset_token::TryInto exports function:
+  fn try_into(self) -> core::result::Result<Self::s2n_quic::provider::stateless_reset_token::TryInto::Provider, Self::s2n_quic::provider::stateless_reset_token::TryInto::Error>
+
+module s2n_quic::provider::tls exports struct:
+  s2n_quic::provider::tls::Default
+
+module s2n_quic::provider::tls exports trait:
+  s2n_quic::provider::tls::Provider
+
+module s2n_quic::provider::tls exports trait:
+  s2n_quic::provider::tls::TryInto
+
+module s2n_quic::provider::tls exports module:
+  s2n_quic::provider::tls::default
+
+module s2n_quic::provider::tls exports module:
+  s2n_quic::provider::tls::rustls
+
+module s2n_quic::provider::tls exports module:
+  s2n_quic::provider::tls::s2n_tls
+
+struct s2n_quic::provider::tls::Default implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::Default
+
+struct s2n_quic::provider::tls::Default implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::Default
+
+struct s2n_quic::provider::tls::Default implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::Default
+
+struct s2n_quic::provider::tls::Default implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::Default
+
+struct s2n_quic::provider::tls::Default implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::Default
+
+struct s2n_quic::provider::tls::Default implements trait:
+  impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::Default
+
+struct s2n_quic::provider::tls::Default implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::Default
+
+struct s2n_quic::provider::tls::Default implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::Default
+
+trait s2n_quic::provider::tls::Provider exports function:
+  fn start_client(self) -> core::result::Result<Self::s2n_quic::provider::tls::Provider::Client, Self::s2n_quic::provider::tls::Provider::Error>
+
+trait s2n_quic::provider::tls::Provider exports function:
+  fn start_server(self) -> core::result::Result<Self::s2n_quic::provider::tls::Provider::Server, Self::s2n_quic::provider::tls::Provider::Error>
+
+trait s2n_quic::provider::tls::TryInto exports function:
+  fn try_into(self) -> core::result::Result<Self::s2n_quic::provider::tls::TryInto::Provider, Self::s2n_quic::provider::tls::TryInto::Error>
+
+module s2n_quic::provider::tls::default exports struct:
+  s2n_quic::provider::tls::default::Client
+
+module s2n_quic::provider::tls::default exports struct:
+  s2n_quic::provider::tls::default::Server
+
+module s2n_quic::provider::tls::default exports module:
+  s2n_quic::provider::tls::default::certificate
+
+module s2n_quic::provider::tls::default exports module:
+  s2n_quic::provider::tls::default::client
+
+module s2n_quic::provider::tls::default exports module:
+  s2n_quic::provider::tls::default::server
+
+struct s2n_quic::provider::tls::default::Client implements trait:
+  impl !core::marker::Sync for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::Client implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::Client implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::Client implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::Client implements trait:
+  impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::Client implements trait:
+  impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::Client implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::Client implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::Client exports function:
+  pub fn builder() -> s2n_quic::provider::tls::s2n_tls::client::Builder
+
+struct s2n_quic::provider::tls::default::Server implements trait:
+  impl !core::marker::Sync for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::Server implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::Server implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::Server implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::Server implements trait:
+  impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::Server implements trait:
+  impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::Server implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::Server implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::Server exports function:
+  pub fn builder() -> s2n_quic::provider::tls::s2n_tls::server::Builder
+
+module s2n_quic::provider::tls::default::certificate exports struct:
+  s2n_quic::provider::tls::default::certificate::Certificate
+
+module s2n_quic::provider::tls::default::certificate exports trait:
+  s2n_quic::provider::tls::default::certificate::IntoCertificate
+
+module s2n_quic::provider::tls::default::certificate exports trait:
+  s2n_quic::provider::tls::default::certificate::IntoPrivateKey
+
+module s2n_quic::provider::tls::default::certificate exports struct:
+  s2n_quic::provider::tls::default::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::default::certificate::Certificate implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::certificate::Certificate
+
+struct s2n_quic::provider::tls::default::certificate::Certificate implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::s2n_tls::certificate::Certificate
+
+struct s2n_quic::provider::tls::default::certificate::Certificate implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::certificate::Certificate
+
+struct s2n_quic::provider::tls::default::certificate::Certificate implements trait:
+  impl s2n_quic::provider::tls::s2n_tls::certificate::IntoCertificate for s2n_quic::provider::tls::s2n_tls::certificate::Certificate
+
+struct s2n_quic::provider::tls::default::certificate::Certificate implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::certificate::Certificate
+
+struct s2n_quic::provider::tls::default::certificate::Certificate implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::certificate::Certificate
+
+trait s2n_quic::provider::tls::default::certificate::IntoCertificate exports function:
+  pub fn into_certificate(self) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::certificate::Certificate, s2n_tls::raw::error::Error>
+
+trait s2n_quic::provider::tls::default::certificate::IntoPrivateKey exports function:
+  pub fn into_private_key(self) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey, s2n_tls::raw::error::Error>
+
+struct s2n_quic::provider::tls::default::certificate::PrivateKey implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::default::certificate::PrivateKey implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::default::certificate::PrivateKey implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::default::certificate::PrivateKey implements trait:
+  impl s2n_quic::provider::tls::s2n_tls::certificate::IntoPrivateKey for s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::default::certificate::PrivateKey implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::default::certificate::PrivateKey implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey
+
+module s2n_quic::provider::tls::default::client exports struct:
+  s2n_quic::provider::tls::default::client::Builder
+
+module s2n_quic::provider::tls::default::client exports struct:
+  s2n_quic::provider::tls::default::client::Client
+
+struct s2n_quic::provider::tls::default::client::Builder implements trait:
+  impl !core::marker::Sync for s2n_quic::provider::tls::s2n_tls::client::Builder
+
+struct s2n_quic::provider::tls::default::client::Builder implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::s2n_tls::client::Builder
+
+struct s2n_quic::provider::tls::default::client::Builder implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::client::Builder
+
+struct s2n_quic::provider::tls::default::client::Builder implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::client::Builder
+
+struct s2n_quic::provider::tls::default::client::Builder implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::client::Builder
+
+struct s2n_quic::provider::tls::default::client::Builder implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::client::Builder
+
+struct s2n_quic::provider::tls::default::client::Builder exports function:
+  pub fn build(self) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::Client, s2n_tls::raw::error::Error>
+
+struct s2n_quic::provider::tls::default::client::Builder exports function:
+  pub fn with_application_protocols<P, I>(
+  self,
+  protocols: P) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::client::Builder, s2n_tls::raw::error::Error> where
+  P: core::iter::traits::collect::IntoIterator<Item = I>,
+  I: core::convert::AsRef<[u8]>,
+
+struct s2n_quic::provider::tls::default::client::Builder exports function:
+  pub fn with_certificate<C>(self, certificate: C) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::client::Builder, s2n_tls::raw::error::Error> where
+  C: s2n_quic::provider::tls::s2n_tls::certificate::IntoCertificate,
+
+struct s2n_quic::provider::tls::default::client::Builder exports function:
+  pub fn with_key_logging(self) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::client::Builder, s2n_tls::raw::error::Error>
+
+struct s2n_quic::provider::tls::default::client::Builder exports function:
+  pub fn with_max_cert_chain_depth(self, len: u16) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::client::Builder, s2n_tls::raw::error::Error>
+
+struct s2n_quic::provider::tls::default::client::Client implements trait:
+  impl !core::marker::Sync for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::client::Client implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::client::Client implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::client::Client implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::client::Client implements trait:
+  impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::client::Client implements trait:
+  impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::client::Client implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::client::Client implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::default::client::Client exports function:
+  pub fn builder() -> s2n_quic::provider::tls::s2n_tls::client::Builder
+
+module s2n_quic::provider::tls::default::server exports struct:
+  s2n_quic::provider::tls::default::server::Builder
+
+module s2n_quic::provider::tls::default::server exports struct:
+  s2n_quic::provider::tls::default::server::Server
+
+struct s2n_quic::provider::tls::default::server::Builder implements trait:
+  impl !core::marker::Sync for s2n_quic::provider::tls::s2n_tls::server::Builder
+
+struct s2n_quic::provider::tls::default::server::Builder implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::s2n_tls::server::Builder
+
+struct s2n_quic::provider::tls::default::server::Builder implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::server::Builder
+
+struct s2n_quic::provider::tls::default::server::Builder implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::server::Builder
+
+struct s2n_quic::provider::tls::default::server::Builder implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::server::Builder
+
+struct s2n_quic::provider::tls::default::server::Builder implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::server::Builder
+
+struct s2n_quic::provider::tls::default::server::Builder exports function:
+  pub fn build(self) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::Server, s2n_tls::raw::error::Error>
+
+struct s2n_quic::provider::tls::default::server::Builder exports function:
+  pub fn with_application_protocols<P, I>(
+  self,
+  protocols: P) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::server::Builder, s2n_tls::raw::error::Error> where
+  P: core::iter::traits::collect::IntoIterator<Item = I>,
+  I: core::convert::AsRef<[u8]>,
+
+struct s2n_quic::provider::tls::default::server::Builder exports function:
+  pub fn with_certificate<C, PK>(
+  self,
+  certificate: C,
+  private_key: PK) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::server::Builder, s2n_tls::raw::error::Error> where
+  C: s2n_quic::provider::tls::s2n_tls::certificate::IntoCertificate,
+  PK: s2n_quic::provider::tls::s2n_tls::certificate::IntoPrivateKey,
+
+struct s2n_quic::provider::tls::default::server::Builder exports function:
+  pub fn with_key_logging(self) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::server::Builder, s2n_tls::raw::error::Error>
+
+struct s2n_quic::provider::tls::default::server::Server implements trait:
+  impl !core::marker::Sync for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::server::Server implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::server::Server implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::server::Server implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::server::Server implements trait:
+  impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::server::Server implements trait:
+  impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::server::Server implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::server::Server implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::default::server::Server exports function:
+  pub fn builder() -> s2n_quic::provider::tls::s2n_tls::server::Builder
+
+module s2n_quic::provider::tls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::Certificate
+
+module s2n_quic::provider::tls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::Client
+
+module s2n_quic::provider::tls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::PrivateKey
+
+module s2n_quic::provider::tls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::Server
+
+module s2n_quic::provider::tls::rustls exports module:
+  s2n_quic::provider::tls::rustls::certificate
+
+module s2n_quic::provider::tls::rustls exports module:
+  s2n_quic::provider::tls::rustls::client
+
+module s2n_quic::provider::tls::rustls exports module:
+  s2n_quic::provider::tls::rustls::rustls
+
+module s2n_quic::provider::tls::rustls exports module:
+  s2n_quic::provider::tls::rustls::server
+
+struct s2n_quic::provider::tls::rustls::Certificate implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::Certificate implements trait:
+  impl core::cmp::Ord for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::Certificate implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::Certificate> for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::Certificate implements trait:
+  impl core::cmp::PartialOrd<s2n_quic::provider::tls::rustls::Certificate> for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::Certificate implements trait:
+  impl core::convert::AsRef<[u8]> for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::Certificate implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::Certificate implements trait:
+  impl core::hash::Hash for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::Certificate implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::Certificate implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::Certificate implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::Certificate implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::Certificate implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::Certificate implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::Client implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::Client implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::Client implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::ClientConfig> for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::Client implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::Client implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::Client implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::Client implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::Client implements trait:
+  impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::Client implements trait:
+  impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::Client exports function:
+  pub fn builder() -> s2n_quic::provider::tls::rustls::client::Builder
+
+struct s2n_quic::provider::tls::rustls::Client exports function:
+  pub fn new(config: s2n_quic::provider::tls::rustls::rustls::ClientConfig) -> s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::PrivateKey implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::PrivateKey implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::PrivateKey> for s2n_quic::provider::tls::rustls::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::PrivateKey implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::PrivateKey implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::PrivateKey implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::PrivateKey implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::PrivateKey implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::PrivateKey implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::Server implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::Server implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::Server implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::ServerConfig> for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::Server implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::Server implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::Server implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::Server implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::Server implements trait:
+  impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::Server implements trait:
+  impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::Server exports function:
+  pub fn builder() -> s2n_quic::provider::tls::rustls::server::Builder
+
+struct s2n_quic::provider::tls::rustls::Server exports function:
+  pub fn new(config: s2n_quic::provider::tls::rustls::rustls::ServerConfig) -> s2n_quic::provider::tls::rustls::Server
+
+module s2n_quic::provider::tls::rustls::certificate exports struct:
+  s2n_quic::provider::tls::rustls::certificate::Certificate
+
+module s2n_quic::provider::tls::rustls::certificate exports trait:
+  s2n_quic::provider::tls::rustls::certificate::IntoCertificate
+
+module s2n_quic::provider::tls::rustls::certificate exports trait:
+  s2n_quic::provider::tls::rustls::certificate::IntoPrivateKey
+
+module s2n_quic::provider::tls::rustls::certificate exports struct:
+  s2n_quic::provider::tls::rustls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::certificate::Certificate implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::certificate::Certificate
+
+struct s2n_quic::provider::tls::rustls::certificate::Certificate implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::certificate::Certificate
+
+struct s2n_quic::provider::tls::rustls::certificate::Certificate implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::certificate::Certificate
+
+struct s2n_quic::provider::tls::rustls::certificate::Certificate implements trait:
+  impl s2n_quic::provider::tls::rustls::certificate::IntoCertificate for s2n_quic::provider::tls::rustls::certificate::Certificate
+
+struct s2n_quic::provider::tls::rustls::certificate::Certificate implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::certificate::Certificate
+
+struct s2n_quic::provider::tls::rustls::certificate::Certificate implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::certificate::Certificate
+
+trait s2n_quic::provider::tls::rustls::certificate::IntoCertificate exports function:
+  pub fn into_certificate(self) -> core::result::Result<s2n_quic::provider::tls::rustls::certificate::Certificate, s2n_quic::provider::tls::rustls::rustls::Error>
+
+trait s2n_quic::provider::tls::rustls::certificate::IntoPrivateKey exports function:
+  pub fn into_private_key(self) -> core::result::Result<s2n_quic::provider::tls::rustls::certificate::PrivateKey, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::certificate::PrivateKey implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::certificate::PrivateKey implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::certificate::PrivateKey implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::certificate::PrivateKey implements trait:
+  impl s2n_quic::provider::tls::rustls::certificate::IntoPrivateKey for s2n_quic::provider::tls::rustls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::certificate::PrivateKey implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::certificate::PrivateKey implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::certificate::PrivateKey
+
+module s2n_quic::provider::tls::rustls::client exports struct:
+  s2n_quic::provider::tls::rustls::client::Builder
+
+module s2n_quic::provider::tls::rustls::client exports struct:
+  s2n_quic::provider::tls::rustls::client::Client
+
+struct s2n_quic::provider::tls::rustls::client::Builder implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::client::Builder
+
+struct s2n_quic::provider::tls::rustls::client::Builder implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::client::Builder
+
+struct s2n_quic::provider::tls::rustls::client::Builder implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::rustls::client::Builder
+
+struct s2n_quic::provider::tls::rustls::client::Builder implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::client::Builder
+
+struct s2n_quic::provider::tls::rustls::client::Builder implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::client::Builder
+
+struct s2n_quic::provider::tls::rustls::client::Builder implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::client::Builder
+
+struct s2n_quic::provider::tls::rustls::client::Builder exports function:
+  pub fn build(self) -> core::result::Result<s2n_quic::provider::tls::rustls::Client, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::client::Builder exports function:
+  pub fn new() -> s2n_quic::provider::tls::rustls::client::Builder
+
+struct s2n_quic::provider::tls::rustls::client::Builder exports function:
+  pub fn with_application_protocols<P, I>(
+  self,
+  protocols: P) -> core::result::Result<s2n_quic::provider::tls::rustls::client::Builder, s2n_quic::provider::tls::rustls::rustls::Error> where
+  P: core::iter::traits::iterator::Iterator<Item = I>,
+  I: core::convert::AsRef<[u8]>,
+
+struct s2n_quic::provider::tls::rustls::client::Builder exports function:
+  pub fn with_certificate<C>(self, certificate: C) -> core::result::Result<s2n_quic::provider::tls::rustls::client::Builder, s2n_quic::provider::tls::rustls::rustls::Error> where
+  C: s2n_quic::provider::tls::rustls::certificate::IntoCertificate,
+
+struct s2n_quic::provider::tls::rustls::client::Builder exports function:
+  pub fn with_key_logging(self) -> core::result::Result<s2n_quic::provider::tls::rustls::client::Builder, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::client::Builder exports function:
+  pub fn with_max_cert_chain_depth(self, len: u16) -> core::result::Result<s2n_quic::provider::tls::rustls::client::Builder, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::client::Client implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::client::Client implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::client::Client implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::ClientConfig> for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::client::Client implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::client::Client implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::client::Client implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::client::Client implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::client::Client implements trait:
+  impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::client::Client implements trait:
+  impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::client::Client exports function:
+  pub fn builder() -> s2n_quic::provider::tls::rustls::client::Builder
+
+struct s2n_quic::provider::tls::rustls::client::Client exports function:
+  pub fn new(config: s2n_quic::provider::tls::rustls::rustls::ClientConfig) -> s2n_quic::provider::tls::rustls::Client
+
+crate s2n_quic::provider::tls::rustls::rustls exports static:
+  s2n_quic::provider::tls::rustls::rustls::ALL_CIPHER_SUITES
+
+crate s2n_quic::provider::tls::rustls::rustls exports static:
+  s2n_quic::provider::tls::rustls::rustls::ALL_KX_GROUPS
+
+crate s2n_quic::provider::tls::rustls::rustls exports static:
+  s2n_quic::provider::tls::rustls::rustls::ALL_VERSIONS
+
+crate s2n_quic::provider::tls::rustls::rustls exports enum:
+  s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::Certificate
+
+crate s2n_quic::provider::tls::rustls::rustls exports enum:
+  s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::ClientConfig
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::CommonState
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::ConfigBuilder
+
+crate s2n_quic::provider::tls::rustls::rustls exports trait:
+  s2n_quic::provider::tls::rustls::rustls::ConfigSide
+
+crate s2n_quic::provider::tls::rustls::rustls exports enum:
+  s2n_quic::provider::tls::rustls::rustls::Connection
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::ConnectionCommon
+
+crate s2n_quic::provider::tls::rustls::rustls exports static:
+  s2n_quic::provider::tls::rustls::rustls::DEFAULT_CIPHER_SUITES
+
+crate s2n_quic::provider::tls::rustls::rustls exports static:
+  s2n_quic::provider::tls::rustls::rustls::DEFAULT_VERSIONS
+
+crate s2n_quic::provider::tls::rustls::rustls exports type:
+  s2n_quic::provider::tls::rustls::rustls::DistinguishedNames
+
+crate s2n_quic::provider::tls::rustls::rustls exports enum:
+  s2n_quic::provider::tls::rustls::rustls::Error
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::IoState
+
+crate s2n_quic::provider::tls::rustls::rustls exports trait:
+  s2n_quic::provider::tls::rustls::rustls::KeyLog
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::KeyLogFile
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::NoKeyLog
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::PrivateKey
+
+crate s2n_quic::provider::tls::rustls::rustls exports enum:
+  s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::Reader
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::RootCertStore
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::ServerConfig
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+crate s2n_quic::provider::tls::rustls::rustls exports enum:
+  s2n_quic::provider::tls::rustls::rustls::ServerName
+
+crate s2n_quic::provider::tls::rustls::rustls exports trait:
+  s2n_quic::provider::tls::rustls::rustls::SideData
+
+crate s2n_quic::provider::tls::rustls::rustls exports enum:
+  s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::Stream
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::StreamOwned
+
+crate s2n_quic::provider::tls::rustls::rustls exports enum:
+  s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::SupportedKxGroup
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::Ticketer
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::WantsKxGroups
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::WantsVerifier
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::WantsVersions
+
+crate s2n_quic::provider::tls::rustls::rustls exports struct:
+  s2n_quic::provider::tls::rustls::rustls::Writer
+
+crate s2n_quic::provider::tls::rustls::rustls exports module:
+  s2n_quic::provider::tls::rustls::rustls::cipher_suite
+
+crate s2n_quic::provider::tls::rustls::rustls exports module:
+  s2n_quic::provider::tls::rustls::rustls::client
+
+crate s2n_quic::provider::tls::rustls::rustls exports module:
+  s2n_quic::provider::tls::rustls::rustls::internal
+
+crate s2n_quic::provider::tls::rustls::rustls exports module:
+  s2n_quic::provider::tls::rustls::rustls::kx_group
+
+crate s2n_quic::provider::tls::rustls::rustls exports module:
+  s2n_quic::provider::tls::rustls::rustls::manual
+
+crate s2n_quic::provider::tls::rustls::rustls exports module:
+  s2n_quic::provider::tls::rustls::rustls::quic
+
+crate s2n_quic::provider::tls::rustls::rustls exports module:
+  s2n_quic::provider::tls::rustls::rustls::server
+
+crate s2n_quic::provider::tls::rustls::rustls exports module:
+  s2n_quic::provider::tls::rustls::rustls::sign
+
+crate s2n_quic::provider::tls::rustls::rustls exports module:
+  s2n_quic::provider::tls::rustls::rustls::version
+
+enum s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm exports variant:
+  Aes128Gcm
+
+enum s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm exports variant:
+  Aes256Gcm
+
+enum s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm exports variant:
+  Chacha20Poly1305
+
+enum s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm> for s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm
+
+struct s2n_quic::provider::tls::rustls::rustls::Certificate implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::rustls::Certificate implements trait:
+  impl core::cmp::Ord for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::rustls::Certificate implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::Certificate> for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::rustls::Certificate implements trait:
+  impl core::cmp::PartialOrd<s2n_quic::provider::tls::rustls::Certificate> for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::rustls::Certificate implements trait:
+  impl core::convert::AsRef<[u8]> for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::rustls::Certificate implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::rustls::Certificate implements trait:
+  impl core::hash::Hash for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::rustls::Certificate implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::rustls::Certificate implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::rustls::Certificate implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::rustls::Certificate implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::rustls::Certificate implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::rustls::Certificate implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::Certificate
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  SSL_FORTEZZA_KEA_WITH_FORTEZZA_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  SSL_FORTEZZA_KEA_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  SSL_RSA_FIPS_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS13_AES_128_CCM_8_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS13_AES_128_CCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS13_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS13_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS13_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_EXPORT1024_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_EXPORT1024_WITH_RC4_56_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_3DES_EDE_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_128_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_256_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_SEED_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_128_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_256_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_NULL_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_NULL_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_3DES_EDE_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_128_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_128_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_128_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_256_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_256_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_256_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_SEED_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_EXPORT_WITH_DES40_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_AES_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_SEED_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_EXPORT_WITH_DES40_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_AES_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_SEED_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_EXPORT_WITH_DES40_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_EXPORT_WITH_RC4_40_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_AES_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_RC4_128_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_DH_anon_WITH_SEED_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_128_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_256_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_NULL_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_NULL_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_DES_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_NULL_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_RC4_128_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECNRA_WITH_3DES_EDE_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_ECNRA_WITH_DES_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_anon_EXPORT_WITH_DES40_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_anon_EXPORT_WITH_RC4_40_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_anon_NULL_WITH_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_DES_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_RC4_128_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECMQV_ECDSA_NULL_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECMQV_ECDSA_WITH_3DES_EDE_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECMQV_ECDSA_WITH_DES_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECMQV_ECDSA_WITH_RC4_128_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECMQV_ECNRA_NULL_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECMQV_ECNRA_WITH_3DES_EDE_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECMQV_ECNRA_WITH_DES_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_ECMQV_ECNRA_WITH_RC4_128_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_EMPTY_RENEGOTIATION_INFO_SCSV
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_GOSTR341001_WITH_28147_CNT_IMIT
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_GOSTR341001_WITH_NULL_GOSTR3411
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_GOSTR341094_WITH_28147_CNT_IMIT
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_GOSTR341094_WITH_NULL_GOSTR3411
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_KRB5_EXPORT_WITH_DES_CBC_40_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_KRB5_EXPORT_WITH_DES_CBC_40_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_KRB5_EXPORT_WITH_RC2_CBC_40_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_KRB5_EXPORT_WITH_RC2_CBC_40_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_KRB5_EXPORT_WITH_RC4_40_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_KRB5_EXPORT_WITH_RC4_40_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_KRB5_WITH_3DES_EDE_CBC_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_KRB5_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_KRB5_WITH_DES_CBC_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_KRB5_WITH_DES_CBC_SHA_or_SSL_FORTEZZA_KEA_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_KRB5_WITH_IDEA_CBC_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_KRB5_WITH_IDEA_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_KRB5_WITH_RC4_128_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_KRB5_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_NULL_WITH_NULL_NULL
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_DHE_WITH_AES_128_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_DHE_WITH_AES_256_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_128_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_128_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_256_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_256_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_NULL_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_NULL_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_PSK_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_EXPORT1024_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_EXPORT1024_WITH_RC2_CBC_56_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_EXPORT1024_WITH_RC4_56_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_EXPORT1024_WITH_RC4_56_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_EXPORT_WITH_DES40_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_EXPORT_WITH_RC4_40_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_NULL_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_NULL_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_3DES_EDE_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_128_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_128_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_128_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_256_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_256_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_256_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_CAMELLIA_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_CAMELLIA_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_IDEA_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_NULL_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_NULL_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_RC4_128_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_RSA_WITH_SEED_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_SRP_SHA_DSS_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_SRP_SHA_DSS_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_SRP_SHA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  TLS_SRP_SHA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports variant:
+  Unknown(u16)
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::CipherSuite> for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite implements trait:
+  impl core::convert::From<u16> for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports function:
+  pub fn as_str(&self) -> core::option::Option<&'static str>
+
+enum s2n_quic::provider::tls::rustls::rustls::CipherSuite exports function:
+  pub fn get_u16(&self) -> u16
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig exports field:
+  alpn_protocols: alloc::vec::Vec<alloc::vec::Vec<u8, alloc::alloc::Global>, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig exports field:
+  client_auth_cert_resolver: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::client::ResolvesClientCert + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig exports field:
+  enable_early_data: bool
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig exports field:
+  enable_sni: bool
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig exports field:
+  enable_tickets: bool
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::ClientConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::ClientConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::ClientConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::ClientConfig> for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::ClientConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::ClientConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::ClientConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig exports field:
+  key_log: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::KeyLog + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig exports field:
+  max_fragment_size: core::option::Option<usize>
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig exports function:
+  pub fn builder() -> s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<s2n_quic::provider::tls::rustls::rustls::ClientConfig, s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites>
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConfig exports field:
+  session_storage: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::client::StoresClientSessions + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::ClientConnection> for s2n_quic::provider::tls::rustls::rustls::Connection
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection implements trait:
+  impl core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection implements trait:
+  impl core::ops::deref::DerefMut for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::quic::ClientQuicExt for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::quic::QuicExt for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection exports function:
+  pub fn complete_io<T>(&mut self, io: &mut T) -> core::result::Result<(usize, usize), std::io::error::Error> where
+  T: std::io::Read + std::io::Write,
+  s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<Data>: core::marker::Sized,
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection exports function:
+  pub fn early_data(&mut self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData<'_>>
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection exports function:
+  pub fn export_keying_material(
+  &self,
+  output: &mut [u8],
+  label: &[u8],
+  context: core::option::Option<&[u8]>) -> core::result::Result<(), s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection exports function:
+  pub fn is_early_data_accepted(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection exports function:
+  pub fn new(
+  config: alloc::sync::Arc<s2n_quic::provider::tls::rustls::rustls::ClientConfig>,
+  name: s2n_quic::provider::tls::rustls::rustls::ServerName) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::ClientConnection, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection exports function:
+  pub fn process_new_packets(&mut self) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::IoState, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection exports function:
+  pub fn read_tls(&mut self, rd: &mut dyn std::io::Read) -> core::result::Result<usize, std::io::error::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection exports function:
+  pub fn reader(&mut self) -> s2n_quic::provider::tls::rustls::rustls::Reader<'_>ⓘ
+
+struct s2n_quic::provider::tls::rustls::rustls::ClientConnection exports function:
+  pub fn writer(&mut self) -> s2n_quic::provider::tls::rustls::rustls::Writer<'_>ⓘ
+
+struct s2n_quic::provider::tls::rustls::rustls::CommonState implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::CommonState
+
+struct s2n_quic::provider::tls::rustls::rustls::CommonState implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::CommonState
+
+struct s2n_quic::provider::tls::rustls::rustls::CommonState implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::CommonState
+
+struct s2n_quic::provider::tls::rustls::rustls::CommonState implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::CommonState
+
+struct s2n_quic::provider::tls::rustls::rustls::CommonState implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::CommonState
+
+struct s2n_quic::provider::tls::rustls::rustls::CommonState exports function:
+  pub fn alpn_protocol(&self) -> core::option::Option<&[u8]>
+
+struct s2n_quic::provider::tls::rustls::rustls::CommonState exports function:
+  pub fn is_handshaking(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::CommonState exports function:
+  pub fn negotiated_cipher_suite(&self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite>
+
+struct s2n_quic::provider::tls::rustls::rustls::CommonState exports function:
+  pub fn peer_certificates(&self) -> core::option::Option<&[s2n_quic::provider::tls::rustls::Certificate]>
+
+struct s2n_quic::provider::tls::rustls::rustls::CommonState exports function:
+  pub fn protocol_version(&self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::ProtocolVersion>
+
+struct s2n_quic::provider::tls::rustls::rustls::CommonState exports function:
+  pub fn send_close_notify(&mut self)
+
+struct s2n_quic::provider::tls::rustls::rustls::CommonState exports function:
+  pub fn set_buffer_limit(&mut self, limit: core::option::Option<usize>)
+
+struct s2n_quic::provider::tls::rustls::rustls::CommonState exports function:
+  pub fn wants_read(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::CommonState exports function:
+  pub fn wants_write(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::CommonState exports function:
+  pub fn write_tls(&mut self, wr: &mut dyn std::io::Write) -> core::result::Result<usize, std::io::error::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder implements trait:
+  impl<Side, State> core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<Side, State> where
+  State: core::clone::Clone,
+  Side: core::clone::Clone + s2n_quic::provider::tls::rustls::rustls::ConfigSide,
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder implements trait:
+  impl<Side, State> core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<Side, State> where
+  Side: s2n_quic::provider::tls::rustls::rustls::ConfigSide,
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder implements trait:
+  impl<Side, State> core::marker::Send for s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<Side, State> where
+  Side: core::marker::Send,
+  State: core::marker::Send,
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder implements trait:
+  impl<Side, State> core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<Side, State> where
+  Side: core::marker::Sync,
+  State: core::marker::Sync,
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder implements trait:
+  impl<Side, State> core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<Side, State> where
+  Side: core::marker::Unpin,
+  State: core::marker::Unpin,
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder implements trait:
+  impl<Side, State> std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<Side, State> where
+  Side: std::panic::RefUnwindSafe,
+  State: std::panic::RefUnwindSafe,
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder implements trait:
+  impl<Side, State> std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<Side, State> where
+  Side: std::panic::UnwindSafe,
+  State: std::panic::UnwindSafe,
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_cert_resolver(
+  self,
+  cert_resolver: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCert + 'static>) -> s2n_quic::provider::tls::rustls::rustls::ServerConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_certificate_transparency_logs(
+  self,
+  logs: &'static [&'static sct::Log<'_>],
+  validation_deadline: std::time::SystemTime) -> s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<s2n_quic::provider::tls::rustls::rustls::ClientConfig, s2n_quic::provider::tls::rustls::rustls::client::WantsClientCert>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_cipher_suites(
+  self,
+  cipher_suites: &[s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite]) -> s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<S, s2n_quic::provider::tls::rustls::rustls::WantsKxGroups>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_client_cert_resolver(
+  self,
+  client_auth_cert_resolver: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::client::ResolvesClientCert + 'static>) -> s2n_quic::provider::tls::rustls::rustls::ClientConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_client_cert_verifier(
+  self,
+  client_cert_verifier: alloc::sync::Arc<dyn ClientCertVerifier + 'static>) -> s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<s2n_quic::provider::tls::rustls::rustls::ServerConfig, s2n_quic::provider::tls::rustls::rustls::server::WantsServerCert>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_kx_groups(
+  self,
+  kx_groups: &[&'static s2n_quic::provider::tls::rustls::rustls::SupportedKxGroup]) -> s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<S, s2n_quic::provider::tls::rustls::rustls::WantsVersions>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_no_client_auth(self) -> s2n_quic::provider::tls::rustls::rustls::ClientConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_no_client_auth(self) -> s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<s2n_quic::provider::tls::rustls::rustls::ServerConfig, s2n_quic::provider::tls::rustls::rustls::server::WantsServerCert>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_protocol_versions(
+  self,
+  versions: &[&'static s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion]) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<S, s2n_quic::provider::tls::rustls::rustls::WantsVerifier>, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_root_certificates(
+  self,
+  root_store: s2n_quic::provider::tls::rustls::rustls::RootCertStore) -> s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<s2n_quic::provider::tls::rustls::rustls::ClientConfig, s2n_quic::provider::tls::rustls::rustls::client::WantsTransparencyPolicyOrClientCert>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_safe_default_cipher_suites(self) -> s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<S, s2n_quic::provider::tls::rustls::rustls::WantsKxGroups>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_safe_default_kx_groups(self) -> s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<S, s2n_quic::provider::tls::rustls::rustls::WantsVersions>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_safe_default_protocol_versions(
+  self) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<S, s2n_quic::provider::tls::rustls::rustls::WantsVerifier>, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_safe_defaults(self) -> s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<S, s2n_quic::provider::tls::rustls::rustls::WantsVerifier>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_single_cert(
+  self,
+  cert_chain: alloc::vec::Vec<s2n_quic::provider::tls::rustls::Certificate, alloc::alloc::Global>,
+  key_der: s2n_quic::provider::tls::rustls::PrivateKey) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::ClientConfig, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_single_cert(
+  self,
+  cert_chain: alloc::vec::Vec<s2n_quic::provider::tls::rustls::Certificate, alloc::alloc::Global>,
+  key_der: s2n_quic::provider::tls::rustls::PrivateKey) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::ServerConfig, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConfigBuilder exports function:
+  pub fn with_single_cert_with_ocsp_and_sct(
+  self,
+  cert_chain: alloc::vec::Vec<s2n_quic::provider::tls::rustls::Certificate, alloc::alloc::Global>,
+  key_der: s2n_quic::provider::tls::rustls::PrivateKey,
+  ocsp: alloc::vec::Vec<u8, alloc::alloc::Global>,
+  scts: alloc::vec::Vec<u8, alloc::alloc::Global>) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::ServerConfig, s2n_quic::provider::tls::rustls::rustls::Error>
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports variant:
+  Client(s2n_quic::provider::tls::rustls::rustls::ClientConnection)
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports variant:
+  Server(s2n_quic::provider::tls::rustls::rustls::ServerConnection)
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::Connection
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::Connection
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::ClientConnection> for s2n_quic::provider::tls::rustls::rustls::Connection
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::ServerConnection> for s2n_quic::provider::tls::rustls::rustls::Connection
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::Connection
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::Connection
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::Connection
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection implements trait:
+  impl core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::Connection
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection implements trait:
+  impl core::ops::deref::DerefMut for s2n_quic::provider::tls::rustls::rustls::Connection
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::quic::QuicExt for s2n_quic::provider::tls::rustls::rustls::Connection
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn alpn_protocol(&self) -> core::option::Option<&[u8]>
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn complete_io<T>(&mut self, io: &mut T) -> core::result::Result<(usize, usize), std::io::error::Error> where
+  T: std::io::Read + std::io::Write,
+  s2n_quic::provider::tls::rustls::rustls::Connection: core::marker::Sized,
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn export_keying_material(
+  &self,
+  output: &mut [u8],
+  label: &[u8],
+  context: core::option::Option<&[u8]>) -> core::result::Result<(), s2n_quic::provider::tls::rustls::rustls::Error>
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn is_handshaking(&self) -> bool
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn negotiated_cipher_suite(&self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite>
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn peer_certificates(&self) -> core::option::Option<&[s2n_quic::provider::tls::rustls::Certificate]>
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn process_new_packets(&mut self) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::IoState, s2n_quic::provider::tls::rustls::rustls::Error>
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn protocol_version(&self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::ProtocolVersion>
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn read_tls(&mut self, rd: &mut dyn std::io::Read) -> core::result::Result<usize, std::io::error::Error>
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn reader(&mut self) -> s2n_quic::provider::tls::rustls::rustls::Reader<'_>ⓘ
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn send_close_notify(&mut self)
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn set_buffer_limit(&mut self, limit: core::option::Option<usize>)
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn wants_read(&self) -> bool
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn wants_write(&self) -> bool
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn write_tls(&mut self, wr: &mut dyn std::io::Write) -> core::result::Result<usize, std::io::error::Error>
+
+enum s2n_quic::provider::tls::rustls::rustls::Connection exports function:
+  pub fn writer(&mut self) -> s2n_quic::provider::tls::rustls::rustls::Writer<'_>ⓘ
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon implements trait:
+  impl<Data> !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<Data>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon implements trait:
+  impl<Data> !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<Data>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon implements trait:
+  impl<Data> core::marker::Send for s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<Data> where
+  Data: core::marker::Send,
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon implements trait:
+  impl<Data> core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<Data> where
+  Data: core::marker::Sync,
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon implements trait:
+  impl<Data> core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<Data> where
+  Data: core::marker::Unpin,
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon implements trait:
+  impl<T> core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<T>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon implements trait:
+  impl<T> core::ops::deref::DerefMut for s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<T>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn alpn_protocol(&self) -> core::option::Option<&[u8]>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn complete_io<T>(&mut self, io: &mut T) -> core::result::Result<(usize, usize), std::io::error::Error> where
+  T: std::io::Read + std::io::Write,
+  s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<Data>: core::marker::Sized,
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn export_keying_material(
+  &self,
+  output: &mut [u8],
+  label: &[u8],
+  context: core::option::Option<&[u8]>) -> core::result::Result<(), s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn is_handshaking(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn negotiated_cipher_suite(&self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn peer_certificates(&self) -> core::option::Option<&[s2n_quic::provider::tls::rustls::Certificate]>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn process_new_packets(&mut self) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::IoState, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn protocol_version(&self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::ProtocolVersion>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn read_tls(&mut self, rd: &mut dyn std::io::Read) -> core::result::Result<usize, std::io::error::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn reader(&mut self) -> s2n_quic::provider::tls::rustls::rustls::Reader<'_>ⓘ
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn send_close_notify(&mut self)
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn set_buffer_limit(&mut self, limit: core::option::Option<usize>)
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn wants_read(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn wants_write(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn write_tls(&mut self, wr: &mut dyn std::io::Write) -> core::result::Result<usize, std::io::error::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ConnectionCommon exports function:
+  pub fn writer(&mut self) -> s2n_quic::provider::tls::rustls::rustls::Writer<'_>ⓘ
+
+typedef s2n_quic::provider::tls::rustls::rustls::DistinguishedNames exports typedef:
+  type DistinguishedNames = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, alloc::alloc::Global>;
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  AlertReceived(s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription)
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  BadMaxFragmentSize
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  CorruptMessage
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  CorruptMessagePayload(s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType)
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  DecryptError
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  EncryptError
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  FailedToGetCurrentTime
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  FailedToGetRandomBytes
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  General(alloc::string::String)
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  HandshakeNotComplete
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  InappropriateHandshakeMessage
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  InappropriateMessage
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  InvalidCertificateData(alloc::string::String)
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  InvalidCertificateEncoding
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  InvalidCertificateSignature
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  InvalidCertificateSignatureType
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  InvalidSct(sct::Error)
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  NoApplicationProtocol
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  NoCertificatesPresented
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  PeerIncompatibleError(alloc::string::String)
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  PeerMisbehavedError(alloc::string::String)
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  PeerSentOversizedRecord
+
+enum s2n_quic::provider::tls::rustls::rustls::Error exports variant:
+  UnsupportedNameType
+
+enum s2n_quic::provider::tls::rustls::rustls::Error implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::Error
+
+enum s2n_quic::provider::tls::rustls::rustls::Error implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::Error> for s2n_quic::provider::tls::rustls::rustls::Error
+
+enum s2n_quic::provider::tls::rustls::rustls::Error implements trait:
+  impl core::convert::From<GetRandomFailed> for s2n_quic::provider::tls::rustls::rustls::Error
+
+enum s2n_quic::provider::tls::rustls::rustls::Error implements trait:
+  impl core::convert::From<std::time::SystemTimeError> for s2n_quic::provider::tls::rustls::rustls::Error
+
+enum s2n_quic::provider::tls::rustls::rustls::Error implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::Error
+
+enum s2n_quic::provider::tls::rustls::rustls::Error implements trait:
+  impl core::fmt::Display for s2n_quic::provider::tls::rustls::rustls::Error
+
+enum s2n_quic::provider::tls::rustls::rustls::Error implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::Error
+
+enum s2n_quic::provider::tls::rustls::rustls::Error implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::Error
+
+enum s2n_quic::provider::tls::rustls::rustls::Error implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::Error
+
+enum s2n_quic::provider::tls::rustls::rustls::Error implements trait:
+  impl std::error::Error for s2n_quic::provider::tls::rustls::rustls::Error
+
+enum s2n_quic::provider::tls::rustls::rustls::Error implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::Error
+
+enum s2n_quic::provider::tls::rustls::rustls::Error implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::Error
+
+variant s2n_quic::provider::tls::rustls::rustls::Error::InappropriateHandshakeMessage exports field:
+  expect_types:
+  alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType, alloc::alloc::Global>
+
+variant s2n_quic::provider::tls::rustls::rustls::Error::InappropriateHandshakeMessage exports field:
+  got_type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType
+
+variant s2n_quic::provider::tls::rustls::rustls::Error::InappropriateMessage exports field:
+  expect_types:
+  alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType, alloc::alloc::Global>
+
+variant s2n_quic::provider::tls::rustls::rustls::Error::InappropriateMessage exports field:
+  got_type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+struct s2n_quic::provider::tls::rustls::rustls::IoState implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::IoState> for s2n_quic::provider::tls::rustls::rustls::IoState
+
+struct s2n_quic::provider::tls::rustls::rustls::IoState implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::IoState
+
+struct s2n_quic::provider::tls::rustls::rustls::IoState implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::IoState
+
+struct s2n_quic::provider::tls::rustls::rustls::IoState implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::IoState
+
+struct s2n_quic::provider::tls::rustls::rustls::IoState implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::IoState
+
+struct s2n_quic::provider::tls::rustls::rustls::IoState implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::IoState
+
+struct s2n_quic::provider::tls::rustls::rustls::IoState implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::IoState
+
+struct s2n_quic::provider::tls::rustls::rustls::IoState exports function:
+  pub fn peer_has_closed(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::IoState exports function:
+  pub fn plaintext_bytes_to_read(&self) -> usize
+
+struct s2n_quic::provider::tls::rustls::rustls::IoState exports function:
+  pub fn tls_bytes_to_write(&self) -> usize
+
+trait s2n_quic::provider::tls::rustls::rustls::KeyLog exports function:
+  pub fn log(&self, label: &str, client_random: &[u8], secret: &[u8])
+
+struct s2n_quic::provider::tls::rustls::rustls::KeyLogFile implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::KeyLogFile
+
+struct s2n_quic::provider::tls::rustls::rustls::KeyLogFile implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::KeyLogFile
+
+struct s2n_quic::provider::tls::rustls::rustls::KeyLogFile implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::KeyLogFile
+
+struct s2n_quic::provider::tls::rustls::rustls::KeyLogFile implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::KeyLog for s2n_quic::provider::tls::rustls::rustls::KeyLogFile
+
+struct s2n_quic::provider::tls::rustls::rustls::KeyLogFile implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::KeyLogFile
+
+struct s2n_quic::provider::tls::rustls::rustls::KeyLogFile implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::KeyLogFile
+
+struct s2n_quic::provider::tls::rustls::rustls::KeyLogFile exports function:
+  pub fn new() -> s2n_quic::provider::tls::rustls::rustls::KeyLogFile
+
+struct s2n_quic::provider::tls::rustls::rustls::NoKeyLog implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::NoKeyLog
+
+struct s2n_quic::provider::tls::rustls::rustls::NoKeyLog implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::NoKeyLog
+
+struct s2n_quic::provider::tls::rustls::rustls::NoKeyLog implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::NoKeyLog
+
+struct s2n_quic::provider::tls::rustls::rustls::NoKeyLog implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::KeyLog for s2n_quic::provider::tls::rustls::rustls::NoKeyLog
+
+struct s2n_quic::provider::tls::rustls::rustls::NoKeyLog implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::NoKeyLog
+
+struct s2n_quic::provider::tls::rustls::rustls::NoKeyLog implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::NoKeyLog
+
+struct s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor
+
+struct s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor
+
+struct s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor
+
+struct s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor
+
+struct s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor
+
+struct s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor
+
+struct s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor
+
+struct s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor exports function:
+  pub fn from_subject_spki_name_constraints(
+  subject: impl core::convert::Into<alloc::vec::Vec<u8, alloc::alloc::Global>>,
+  spki: impl core::convert::Into<alloc::vec::Vec<u8, alloc::alloc::Global>>,
+  name_constraints: core::option::Option<impl core::convert::Into<alloc::vec::Vec<u8, alloc::alloc::Global>>>) -> s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor
+
+struct s2n_quic::provider::tls::rustls::rustls::PrivateKey implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::rustls::PrivateKey implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::PrivateKey> for s2n_quic::provider::tls::rustls::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::rustls::PrivateKey implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::rustls::PrivateKey implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::rustls::PrivateKey implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::rustls::PrivateKey implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::rustls::PrivateKey implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::PrivateKey
+
+struct s2n_quic::provider::tls::rustls::rustls::PrivateKey implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::PrivateKey
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion exports variant:
+  DTLSv1_0
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion exports variant:
+  DTLSv1_2
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion exports variant:
+  SSLv2
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion exports variant:
+  SSLv3
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion exports variant:
+  TLSv1_0
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion exports variant:
+  TLSv1_1
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion exports variant:
+  TLSv1_2
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion exports variant:
+  TLSv1_3
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion exports variant:
+  Unknown(u16)
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::ProtocolVersion> for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion implements trait:
+  impl core::convert::From<u16> for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion exports function:
+  pub fn as_str(&self) -> core::option::Option<&'static str>
+
+enum s2n_quic::provider::tls::rustls::rustls::ProtocolVersion exports function:
+  pub fn get_u16(&self) -> u16
+
+struct s2n_quic::provider::tls::rustls::rustls::Reader implements trait:
+  impl<'a> !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::Reader<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::Reader implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::tls::rustls::rustls::Reader<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::Reader implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::Reader<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::Reader implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::Reader<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::Reader implements trait:
+  impl<'a> std::io::Read for s2n_quic::provider::tls::rustls::rustls::Reader<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::Reader implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::Reader<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::RootCertStore implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::RootCertStore
+
+struct s2n_quic::provider::tls::rustls::rustls::RootCertStore implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::RootCertStore
+
+struct s2n_quic::provider::tls::rustls::rustls::RootCertStore implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::RootCertStore
+
+struct s2n_quic::provider::tls::rustls::rustls::RootCertStore implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::RootCertStore
+
+struct s2n_quic::provider::tls::rustls::rustls::RootCertStore implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::RootCertStore
+
+struct s2n_quic::provider::tls::rustls::rustls::RootCertStore implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::RootCertStore
+
+struct s2n_quic::provider::tls::rustls::rustls::RootCertStore implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::RootCertStore
+
+struct s2n_quic::provider::tls::rustls::rustls::RootCertStore exports function:
+  pub fn add(&mut self, der: &s2n_quic::provider::tls::rustls::Certificate) -> core::result::Result<(), webpki::error::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::RootCertStore exports function:
+  pub fn add_parsable_certificates(
+  &mut self,
+  der_certs: &[alloc::vec::Vec<u8, alloc::alloc::Global>]) -> (usize, usize)
+
+struct s2n_quic::provider::tls::rustls::rustls::RootCertStore exports function:
+  pub fn add_server_trust_anchors(
+  &mut self,
+  trust_anchors: impl core::iter::traits::iterator::Iterator<Item = s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor>)
+
+struct s2n_quic::provider::tls::rustls::rustls::RootCertStore exports function:
+  pub fn empty() -> s2n_quic::provider::tls::rustls::rustls::RootCertStore
+
+struct s2n_quic::provider::tls::rustls::rustls::RootCertStore exports function:
+  pub fn is_empty(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::RootCertStore exports function:
+  pub fn len(&self) -> usize
+
+struct s2n_quic::provider::tls::rustls::rustls::RootCertStore exports function:
+  pub fn subjects(&self) -> alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::RootCertStore exports field:
+  roots: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::OwnedTrustAnchor, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig exports field:
+  alpn_protocols: alloc::vec::Vec<alloc::vec::Vec<u8, alloc::alloc::Global>, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig exports field:
+  cert_resolver: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCert + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig exports field:
+  ignore_client_order: bool
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::ServerConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::ServerConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::ServerConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::ServerConfig> for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::ServerConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::ServerConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::ServerConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig exports field:
+  key_log: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::KeyLog + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig exports field:
+  max_early_data_size: u32
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig exports field:
+  max_fragment_size: core::option::Option<usize>
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig exports function:
+  pub fn builder() -> s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<s2n_quic::provider::tls::rustls::rustls::ServerConfig, s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites>
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig exports field:
+  send_half_rtt_data: bool
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig exports field:
+  session_storage: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::server::StoresServerSessions + 'static + core::marker::Send + core::marker::Sync>
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConfig exports field:
+  ticketer: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::server::ProducesTickets + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::ServerConnection> for s2n_quic::provider::tls::rustls::rustls::Connection
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection implements trait:
+  impl core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection implements trait:
+  impl core::ops::deref::DerefMut for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::quic::QuicExt for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::quic::ServerQuicExt for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection exports function:
+  pub fn complete_io<T>(&mut self, io: &mut T) -> core::result::Result<(usize, usize), std::io::error::Error> where
+  T: std::io::Read + std::io::Write,
+  s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<Data>: core::marker::Sized,
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection exports function:
+  pub fn early_data(&mut self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::server::ReadEarlyData<'_>>
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection exports function:
+  pub fn export_keying_material(
+  &self,
+  output: &mut [u8],
+  label: &[u8],
+  context: core::option::Option<&[u8]>) -> core::result::Result<(), s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection exports function:
+  pub fn new(config: alloc::sync::Arc<s2n_quic::provider::tls::rustls::rustls::ServerConfig>) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::ServerConnection, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection exports function:
+  pub fn process_new_packets(&mut self) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::IoState, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection exports function:
+  pub fn read_tls(&mut self, rd: &mut dyn std::io::Read) -> core::result::Result<usize, std::io::error::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection exports function:
+  pub fn reader(&mut self) -> s2n_quic::provider::tls::rustls::rustls::Reader<'_>ⓘ
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection exports function:
+  pub fn received_resumption_data(&self) -> core::option::Option<&[u8]>
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection exports function:
+  pub fn reject_early_data(&mut self)
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection exports function:
+  pub fn set_resumption_data(&mut self, data: &[u8])
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection exports function:
+  pub fn sni_hostname(&self) -> core::option::Option<&str>
+
+struct s2n_quic::provider::tls::rustls::rustls::ServerConnection exports function:
+  pub fn writer(&mut self) -> s2n_quic::provider::tls::rustls::rustls::Writer<'_>ⓘ
+
+enum s2n_quic::provider::tls::rustls::rustls::ServerName is non-exhaustive
+
+enum s2n_quic::provider::tls::rustls::rustls::ServerName exports variant:
+  DnsName(DnsName)
+
+enum s2n_quic::provider::tls::rustls::rustls::ServerName implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::ServerName implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::ServerName> for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::ServerName implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::ServerName implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::ServerName implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::ServerName implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::ServerName implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::ServerName implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::ServerName implements trait:
+  impl<'_> core::convert::TryFrom<&'_ str> for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports variant:
+  ECDSA_NISTP256_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports variant:
+  ECDSA_NISTP384_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports variant:
+  ECDSA_NISTP521_SHA512
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports variant:
+  ECDSA_SHA1_Legacy
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports variant:
+  ED25519
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports variant:
+  ED448
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports variant:
+  RSA_PKCS1_SHA1
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports variant:
+  RSA_PKCS1_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports variant:
+  RSA_PKCS1_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports variant:
+  RSA_PKCS1_SHA512
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports variant:
+  RSA_PSS_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports variant:
+  RSA_PSS_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports variant:
+  RSA_PSS_SHA512
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports variant:
+  Unknown(u16)
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::SignatureScheme> for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme implements trait:
+  impl core::convert::From<u16> for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DecomposedSignatureScheme for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports function:
+  pub fn as_str(&self) -> core::option::Option<&'static str>
+
+enum s2n_quic::provider::tls::rustls::rustls::SignatureScheme exports function:
+  pub fn get_u16(&self) -> u16
+
+struct s2n_quic::provider::tls::rustls::rustls::Stream exports field:
+  conn: &'a mut C
+
+struct s2n_quic::provider::tls::rustls::rustls::Stream implements trait:
+  impl<'a, C, T, S> std::io::Read for s2n_quic::provider::tls::rustls::rustls::Stream<'a, C, T> where
+  C: 'a + core::ops::deref::DerefMut<Target = s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<S>> + core::ops::deref::Deref,
+  T: 'a + std::io::Read + std::io::Write,
+  S: s2n_quic::provider::tls::rustls::rustls::SideData,
+
+struct s2n_quic::provider::tls::rustls::rustls::Stream implements trait:
+  impl<'a, C, T, S> std::io::Write for s2n_quic::provider::tls::rustls::rustls::Stream<'a, C, T> where
+  C: 'a + core::ops::deref::DerefMut<Target = s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<S>> + core::ops::deref::Deref,
+  T: 'a + std::io::Read + std::io::Write,
+  S: s2n_quic::provider::tls::rustls::rustls::SideData,
+
+struct s2n_quic::provider::tls::rustls::rustls::Stream implements trait:
+  impl<'a, C, T> !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::Stream<'a, C, T>
+
+struct s2n_quic::provider::tls::rustls::rustls::Stream implements trait:
+  impl<'a, C, T> core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::Stream<'a, C, T> where
+  C: 'a + core::fmt::Debug + ?core::marker::Sized,
+  T: 'a + core::fmt::Debug + std::io::Read + std::io::Write + ?core::marker::Sized,
+
+struct s2n_quic::provider::tls::rustls::rustls::Stream implements trait:
+  impl<'a, C:
+  ?core::marker::Sized, T:
+  ?core::marker::Sized> core::marker::Send for s2n_quic::provider::tls::rustls::rustls::Stream<'a, C, T> where
+  C: core::marker::Send,
+  T: core::marker::Send,
+
+struct s2n_quic::provider::tls::rustls::rustls::Stream implements trait:
+  impl<'a, C:
+  ?core::marker::Sized, T:
+  ?core::marker::Sized> core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::Stream<'a, C, T> where
+  C: core::marker::Sync,
+  T: core::marker::Sync,
+
+struct s2n_quic::provider::tls::rustls::rustls::Stream implements trait:
+  impl<'a, C:
+  ?core::marker::Sized, T:
+  ?core::marker::Sized> core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::Stream<'a, C, T>
+
+struct s2n_quic::provider::tls::rustls::rustls::Stream implements trait:
+  impl<'a, C:
+  ?core::marker::Sized, T:
+  ?core::marker::Sized> std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::Stream<'a, C, T> where
+  C: std::panic::RefUnwindSafe,
+  T: std::panic::RefUnwindSafe,
+
+struct s2n_quic::provider::tls::rustls::rustls::Stream exports function:
+  pub fn new(conn: &'a mut C, sock: &'a mut T) -> s2n_quic::provider::tls::rustls::rustls::Stream<'a, C, T>ⓘ
+
+struct s2n_quic::provider::tls::rustls::rustls::Stream exports field:
+  sock: &'a mut T
+
+struct s2n_quic::provider::tls::rustls::rustls::StreamOwned exports field:
+  conn: C
+
+struct s2n_quic::provider::tls::rustls::rustls::StreamOwned implements trait:
+  impl<C, T, S> std::io::Read for s2n_quic::provider::tls::rustls::rustls::StreamOwned<C, T> where
+  C: core::ops::deref::DerefMut<Target = s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<S>> + core::ops::deref::Deref,
+  T: std::io::Read + std::io::Write,
+  S: s2n_quic::provider::tls::rustls::rustls::SideData,
+
+struct s2n_quic::provider::tls::rustls::rustls::StreamOwned implements trait:
+  impl<C, T, S> std::io::Write for s2n_quic::provider::tls::rustls::rustls::StreamOwned<C, T> where
+  C: core::ops::deref::DerefMut<Target = s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<S>> + core::ops::deref::Deref,
+  T: std::io::Read + std::io::Write,
+  S: s2n_quic::provider::tls::rustls::rustls::SideData,
+
+struct s2n_quic::provider::tls::rustls::rustls::StreamOwned implements trait:
+  impl<C, T> core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::StreamOwned<C, T> where
+  C: core::fmt::Debug,
+  T: core::fmt::Debug + std::io::Read + std::io::Write,
+
+struct s2n_quic::provider::tls::rustls::rustls::StreamOwned implements trait:
+  impl<C, T> core::marker::Send for s2n_quic::provider::tls::rustls::rustls::StreamOwned<C, T> where
+  C: core::marker::Send,
+  T: core::marker::Send,
+
+struct s2n_quic::provider::tls::rustls::rustls::StreamOwned implements trait:
+  impl<C, T> core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::StreamOwned<C, T> where
+  C: core::marker::Sync,
+  T: core::marker::Sync,
+
+struct s2n_quic::provider::tls::rustls::rustls::StreamOwned implements trait:
+  impl<C, T> core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::StreamOwned<C, T> where
+  C: core::marker::Unpin,
+  T: core::marker::Unpin,
+
+struct s2n_quic::provider::tls::rustls::rustls::StreamOwned implements trait:
+  impl<C, T> std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::StreamOwned<C, T> where
+  C: std::panic::RefUnwindSafe,
+  T: std::panic::RefUnwindSafe,
+
+struct s2n_quic::provider::tls::rustls::rustls::StreamOwned implements trait:
+  impl<C, T> std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::StreamOwned<C, T> where
+  C: std::panic::UnwindSafe,
+  T: std::panic::UnwindSafe,
+
+struct s2n_quic::provider::tls::rustls::rustls::StreamOwned exports function:
+  pub fn get_mut(&mut self) -> &mut T
+
+struct s2n_quic::provider::tls::rustls::rustls::StreamOwned exports function:
+  pub fn get_ref(&self) -> &T
+
+struct s2n_quic::provider::tls::rustls::rustls::StreamOwned exports function:
+  pub fn new(conn: C, sock: T) -> s2n_quic::provider::tls::rustls::rustls::StreamOwned<C, T>ⓘ
+
+struct s2n_quic::provider::tls::rustls::rustls::StreamOwned exports field:
+  sock: T
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite exports variant:
+  Tls12(&'static s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite)
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite exports variant:
+  Tls13(&'static s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite)
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite> for s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite implements trait:
+  impl core::convert::From<&'static s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite> for s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite implements trait:
+  impl core::convert::From<&'static s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite> for s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite exports function:
+  pub fn hash_algorithm(&self) -> &'static ring::digest::Algorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite exports function:
+  pub fn suite(&self) -> s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite exports function:
+  pub fn usable_for_signature_algorithm(
+  &self,
+  _sig_alg: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm) -> bool
+
+enum s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite exports function:
+  pub fn version(&self) -> &'static s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion
+
+struct s2n_quic::provider::tls::rustls::rustls::SupportedKxGroup implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::SupportedKxGroup
+
+struct s2n_quic::provider::tls::rustls::rustls::SupportedKxGroup implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::SupportedKxGroup
+
+struct s2n_quic::provider::tls::rustls::rustls::SupportedKxGroup implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::SupportedKxGroup
+
+struct s2n_quic::provider::tls::rustls::rustls::SupportedKxGroup implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::SupportedKxGroup
+
+struct s2n_quic::provider::tls::rustls::rustls::SupportedKxGroup implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::SupportedKxGroup
+
+struct s2n_quic::provider::tls::rustls::rustls::SupportedKxGroup implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::SupportedKxGroup
+
+struct s2n_quic::provider::tls::rustls::rustls::SupportedKxGroup exports field:
+  name: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup
+
+struct s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion> for s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion
+
+struct s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion
+
+struct s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion
+
+struct s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion
+
+struct s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion
+
+struct s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion
+
+struct s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion
+
+struct s2n_quic::provider::tls::rustls::rustls::SupportedProtocolVersion exports field:
+  version: s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+struct s2n_quic::provider::tls::rustls::rustls::Ticketer implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::Ticketer
+
+struct s2n_quic::provider::tls::rustls::rustls::Ticketer implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::Ticketer
+
+struct s2n_quic::provider::tls::rustls::rustls::Ticketer implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::Ticketer
+
+struct s2n_quic::provider::tls::rustls::rustls::Ticketer implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::Ticketer
+
+struct s2n_quic::provider::tls::rustls::rustls::Ticketer implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::Ticketer
+
+struct s2n_quic::provider::tls::rustls::rustls::Ticketer exports function:
+  pub fn new() -> core::result::Result<alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::server::ProducesTickets + 'static>, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite exports field:
+  common: s2n_quic::provider::tls::rustls::rustls::cipher_suite::CipherSuiteCommon
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite exports field:
+  explicit_nonce_len: usize
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite exports field:
+  fixed_iv_len: usize
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite> for s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite implements trait:
+  impl core::convert::From<&'static s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite> for s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite exports field:
+  kx: s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite exports function:
+  pub fn hash_algorithm(&self) -> &'static ring::digest::Algorithm
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite exports function:
+  pub fn resolve_sig_schemes(
+  &self,
+  offered: &[s2n_quic::provider::tls::rustls::rustls::SignatureScheme]) -> alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::SignatureScheme, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite exports field:
+  sign: &'static [s2n_quic::provider::tls::rustls::rustls::SignatureScheme]
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite exports field:
+  common: s2n_quic::provider::tls::rustls::rustls::cipher_suite::CipherSuiteCommon
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite> for s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite implements trait:
+  impl core::convert::From<&'static s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite> for s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite exports function:
+  pub fn can_resume_from(
+  &self,
+  prev: &'static s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite) -> core::option::Option<&'static s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite>
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite exports function:
+  pub fn derive_decrypter(
+  &self,
+  secret: &ring::hkdf::Prk) -> alloc::boxed::Box<dyn s2n_quic::provider::tls::rustls::rustls::internal::cipher::MessageDecrypter + 'static, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite exports function:
+  pub fn hash_algorithm(&self) -> &'static ring::digest::Algorithm
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsKxGroups implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::WantsKxGroups
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsKxGroups implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::WantsKxGroups
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsKxGroups implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::WantsKxGroups
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsKxGroups implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::WantsKxGroups
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsKxGroups implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::WantsKxGroups
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsKxGroups implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::WantsKxGroups
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsVerifier implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::WantsVerifier
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsVerifier implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::WantsVerifier
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsVerifier implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::WantsVerifier
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsVerifier implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::WantsVerifier
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsVerifier implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::WantsVerifier
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsVersions implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::WantsVersions
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsVersions implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::WantsVersions
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsVersions implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::WantsVersions
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsVersions implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::WantsVersions
+
+struct s2n_quic::provider::tls::rustls::rustls::WantsVersions implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::WantsVersions
+
+struct s2n_quic::provider::tls::rustls::rustls::Writer implements trait:
+  impl<'a> !core::marker::Send for s2n_quic::provider::tls::rustls::rustls::Writer<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::Writer implements trait:
+  impl<'a> !core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::Writer<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::Writer implements trait:
+  impl<'a> !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::Writer<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::Writer implements trait:
+  impl<'a> !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::Writer<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::Writer implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::Writer<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::Writer implements trait:
+  impl<'a> std::io::Write for s2n_quic::provider::tls::rustls::rustls::Writer<'a>
+
+module s2n_quic::provider::tls::rustls::rustls::cipher_suite exports struct:
+  s2n_quic::provider::tls::rustls::rustls::cipher_suite::CipherSuiteCommon
+
+module s2n_quic::provider::tls::rustls::rustls::cipher_suite exports static:
+  s2n_quic::provider::tls::rustls::rustls::cipher_suite::TLS13_AES_128_GCM_SHA256
+
+module s2n_quic::provider::tls::rustls::rustls::cipher_suite exports static:
+  s2n_quic::provider::tls::rustls::rustls::cipher_suite::TLS13_AES_256_GCM_SHA384
+
+module s2n_quic::provider::tls::rustls::rustls::cipher_suite exports static:
+  s2n_quic::provider::tls::rustls::rustls::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256
+
+module s2n_quic::provider::tls::rustls::rustls::cipher_suite exports static:
+  s2n_quic::provider::tls::rustls::rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+
+module s2n_quic::provider::tls::rustls::rustls::cipher_suite exports static:
+  s2n_quic::provider::tls::rustls::rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+
+module s2n_quic::provider::tls::rustls::rustls::cipher_suite exports static:
+  s2n_quic::provider::tls::rustls::rustls::cipher_suite::TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+
+module s2n_quic::provider::tls::rustls::rustls::cipher_suite exports static:
+  s2n_quic::provider::tls::rustls::rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+
+module s2n_quic::provider::tls::rustls::rustls::cipher_suite exports static:
+  s2n_quic::provider::tls::rustls::rustls::cipher_suite::TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+
+module s2n_quic::provider::tls::rustls::rustls::cipher_suite exports static:
+  s2n_quic::provider::tls::rustls::rustls::cipher_suite::TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+
+struct s2n_quic::provider::tls::rustls::rustls::cipher_suite::CipherSuiteCommon exports field:
+  bulk: s2n_quic::provider::tls::rustls::rustls::BulkAlgorithm
+
+struct s2n_quic::provider::tls::rustls::rustls::cipher_suite::CipherSuiteCommon implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::cipher_suite::CipherSuiteCommon
+
+struct s2n_quic::provider::tls::rustls::rustls::cipher_suite::CipherSuiteCommon implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::cipher_suite::CipherSuiteCommon
+
+struct s2n_quic::provider::tls::rustls::rustls::cipher_suite::CipherSuiteCommon implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::cipher_suite::CipherSuiteCommon
+
+struct s2n_quic::provider::tls::rustls::rustls::cipher_suite::CipherSuiteCommon implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::cipher_suite::CipherSuiteCommon
+
+struct s2n_quic::provider::tls::rustls::rustls::cipher_suite::CipherSuiteCommon implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::cipher_suite::CipherSuiteCommon
+
+struct s2n_quic::provider::tls::rustls::rustls::cipher_suite::CipherSuiteCommon exports field:
+  suite: s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+module s2n_quic::provider::tls::rustls::rustls::client exports struct:
+  s2n_quic::provider::tls::rustls::rustls::client::ClientConfig
+
+module s2n_quic::provider::tls::rustls::rustls::client exports struct:
+  s2n_quic::provider::tls::rustls::rustls::client::ClientConnection
+
+module s2n_quic::provider::tls::rustls::rustls::client exports struct:
+  s2n_quic::provider::tls::rustls::rustls::client::ClientConnectionData
+
+module s2n_quic::provider::tls::rustls::rustls::client exports trait:
+  s2n_quic::provider::tls::rustls::rustls::client::ClientQuicExt
+
+module s2n_quic::provider::tls::rustls::rustls::client exports struct:
+  s2n_quic::provider::tls::rustls::rustls::client::ClientSessionMemoryCache
+
+module s2n_quic::provider::tls::rustls::rustls::client exports struct:
+  s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError
+
+module s2n_quic::provider::tls::rustls::rustls::client exports struct:
+  s2n_quic::provider::tls::rustls::rustls::client::NoClientSessionStorage
+
+module s2n_quic::provider::tls::rustls::rustls::client exports trait:
+  s2n_quic::provider::tls::rustls::rustls::client::ResolvesClientCert
+
+module s2n_quic::provider::tls::rustls::rustls::client exports enum:
+  s2n_quic::provider::tls::rustls::rustls::client::ServerName
+
+module s2n_quic::provider::tls::rustls::rustls::client exports trait:
+  s2n_quic::provider::tls::rustls::rustls::client::StoresClientSessions
+
+module s2n_quic::provider::tls::rustls::rustls::client exports struct:
+  s2n_quic::provider::tls::rustls::rustls::client::WantsClientCert
+
+module s2n_quic::provider::tls::rustls::rustls::client exports struct:
+  s2n_quic::provider::tls::rustls::rustls::client::WantsTransparencyPolicyOrClientCert
+
+module s2n_quic::provider::tls::rustls::rustls::client exports struct:
+  s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig exports field:
+  alpn_protocols: alloc::vec::Vec<alloc::vec::Vec<u8, alloc::alloc::Global>, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig exports field:
+  client_auth_cert_resolver: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::client::ResolvesClientCert + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig exports field:
+  enable_early_data: bool
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig exports field:
+  enable_sni: bool
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig exports field:
+  enable_tickets: bool
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::ClientConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::ClientConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::ClientConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::ClientConfig> for s2n_quic::provider::tls::rustls::Client
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::ClientConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::ClientConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::ClientConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig exports field:
+  key_log: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::KeyLog + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig exports field:
+  max_fragment_size: core::option::Option<usize>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig exports function:
+  pub fn builder() -> s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<s2n_quic::provider::tls::rustls::rustls::ClientConfig, s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConfig exports field:
+  session_storage: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::client::StoresClientSessions + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::ClientConnection> for s2n_quic::provider::tls::rustls::rustls::Connection
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection implements trait:
+  impl core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection implements trait:
+  impl core::ops::deref::DerefMut for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::quic::ClientQuicExt for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::quic::QuicExt for s2n_quic::provider::tls::rustls::rustls::ClientConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection exports function:
+  pub fn complete_io<T>(&mut self, io: &mut T) -> core::result::Result<(usize, usize), std::io::error::Error> where
+  T: std::io::Read + std::io::Write,
+  s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<Data>: core::marker::Sized,
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection exports function:
+  pub fn early_data(&mut self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData<'_>>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection exports function:
+  pub fn export_keying_material(
+  &self,
+  output: &mut [u8],
+  label: &[u8],
+  context: core::option::Option<&[u8]>) -> core::result::Result<(), s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection exports function:
+  pub fn is_early_data_accepted(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection exports function:
+  pub fn new(
+  config: alloc::sync::Arc<s2n_quic::provider::tls::rustls::rustls::ClientConfig>,
+  name: s2n_quic::provider::tls::rustls::rustls::ServerName) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::ClientConnection, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection exports function:
+  pub fn process_new_packets(&mut self) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::IoState, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection exports function:
+  pub fn read_tls(&mut self, rd: &mut dyn std::io::Read) -> core::result::Result<usize, std::io::error::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection exports function:
+  pub fn reader(&mut self) -> s2n_quic::provider::tls::rustls::rustls::Reader<'_>ⓘ
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnection exports function:
+  pub fn writer(&mut self) -> s2n_quic::provider::tls::rustls::rustls::Writer<'_>ⓘ
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnectionData implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::client::ClientConnectionData
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnectionData implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::client::ClientConnectionData
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnectionData implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::client::ClientConnectionData
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnectionData implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::client::ClientConnectionData
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientConnectionData implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::client::ClientConnectionData
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientSessionMemoryCache implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::client::ClientSessionMemoryCache
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientSessionMemoryCache implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::client::ClientSessionMemoryCache
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientSessionMemoryCache implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::client::ClientSessionMemoryCache
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientSessionMemoryCache implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::client::StoresClientSessions for s2n_quic::provider::tls::rustls::rustls::client::ClientSessionMemoryCache
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientSessionMemoryCache implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::client::ClientSessionMemoryCache
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientSessionMemoryCache implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::client::ClientSessionMemoryCache
+
+struct s2n_quic::provider::tls::rustls::rustls::client::ClientSessionMemoryCache exports function:
+  pub fn new(size: usize) -> alloc::sync::Arc<s2n_quic::provider::tls::rustls::rustls::client::ClientSessionMemoryCache>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError
+
+struct s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError implements trait:
+  impl core::fmt::Display for s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError
+
+struct s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError
+
+struct s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError
+
+struct s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError
+
+struct s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError implements trait:
+  impl std::error::Error for s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError
+
+struct s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError
+
+struct s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::client::InvalidDnsNameError
+
+struct s2n_quic::provider::tls::rustls::rustls::client::NoClientSessionStorage implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::client::NoClientSessionStorage
+
+struct s2n_quic::provider::tls::rustls::rustls::client::NoClientSessionStorage implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::client::NoClientSessionStorage
+
+struct s2n_quic::provider::tls::rustls::rustls::client::NoClientSessionStorage implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::client::NoClientSessionStorage
+
+struct s2n_quic::provider::tls::rustls::rustls::client::NoClientSessionStorage implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::client::StoresClientSessions for s2n_quic::provider::tls::rustls::rustls::client::NoClientSessionStorage
+
+struct s2n_quic::provider::tls::rustls::rustls::client::NoClientSessionStorage implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::client::NoClientSessionStorage
+
+struct s2n_quic::provider::tls::rustls::rustls::client::NoClientSessionStorage implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::client::NoClientSessionStorage
+
+trait s2n_quic::provider::tls::rustls::rustls::client::ResolvesClientCert exports function:
+  pub fn has_certs(&self) -> bool
+
+trait s2n_quic::provider::tls::rustls::rustls::client::ResolvesClientCert exports function:
+  pub fn resolve(
+  &self,
+  acceptable_issuers: &[&[u8]],
+  sigschemes: &[s2n_quic::provider::tls::rustls::rustls::SignatureScheme]) -> core::option::Option<alloc::sync::Arc<s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey>>
+
+enum s2n_quic::provider::tls::rustls::rustls::client::ServerName is non-exhaustive
+
+enum s2n_quic::provider::tls::rustls::rustls::client::ServerName exports variant:
+  DnsName(DnsName)
+
+enum s2n_quic::provider::tls::rustls::rustls::client::ServerName implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::client::ServerName implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::ServerName> for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::client::ServerName implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::client::ServerName implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::client::ServerName implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::client::ServerName implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::client::ServerName implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::client::ServerName implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::client::ServerName implements trait:
+  impl<'_> core::convert::TryFrom<&'_ str> for s2n_quic::provider::tls::rustls::rustls::ServerName
+
+trait s2n_quic::provider::tls::rustls::rustls::client::StoresClientSessions exports function:
+  pub fn get(&self, key: &[u8]) -> core::option::Option<alloc::vec::Vec<u8, alloc::alloc::Global>>
+
+trait s2n_quic::provider::tls::rustls::rustls::client::StoresClientSessions exports function:
+  pub fn put(&self, key: alloc::vec::Vec<u8, alloc::alloc::Global>, value: alloc::vec::Vec<u8, alloc::alloc::Global>) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WantsClientCert implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::client::WantsClientCert
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WantsClientCert implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::client::WantsClientCert
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WantsClientCert implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::client::WantsClientCert
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WantsClientCert implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::client::WantsClientCert
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WantsClientCert implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::client::WantsClientCert
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WantsTransparencyPolicyOrClientCert implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::client::WantsTransparencyPolicyOrClientCert
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WantsTransparencyPolicyOrClientCert implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::client::WantsTransparencyPolicyOrClientCert
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WantsTransparencyPolicyOrClientCert implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::client::WantsTransparencyPolicyOrClientCert
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WantsTransparencyPolicyOrClientCert implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::client::WantsTransparencyPolicyOrClientCert
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WantsTransparencyPolicyOrClientCert implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::client::WantsTransparencyPolicyOrClientCert
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData implements trait:
+  impl<'a> !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData implements trait:
+  impl<'a> !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData implements trait:
+  impl<'a> std::io::Write for s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::client::WriteEarlyData exports function:
+  pub fn bytes_left(&self) -> usize
+
+module s2n_quic::provider::tls::rustls::rustls::internal exports module:
+  s2n_quic::provider::tls::rustls::rustls::internal::cipher
+
+module s2n_quic::provider::tls::rustls::rustls::internal exports module:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs
+
+module s2n_quic::provider::tls::rustls::rustls::internal::cipher exports trait:
+  s2n_quic::provider::tls::rustls::rustls::internal::cipher::MessageDecrypter
+
+trait s2n_quic::provider::tls::rustls::rustls::internal::cipher::MessageDecrypter exports function:
+  pub fn decrypt(&self, m: s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage, seq: u64) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage, s2n_quic::provider::tls::rustls::rustls::Error>
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs exports module:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs exports module:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::base
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs exports module:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs exports module:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs exports module:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs exports module:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs exports module:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs exports module:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs exports module:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs exports module:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::message
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs exports module:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload exports field:
+  description: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload exports field:
+  level: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::base exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::base exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::base exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::base exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload exports function:
+  pub fn empty() -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload exports function:
+  pub fn new(bytes: impl core::convert::Into<alloc::vec::Vec<u8, alloc::alloc::Global>>) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload exports function:
+  pub fn read(r: &mut s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader<'_>) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16 implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16 implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16 implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16 implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16 implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16 implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16 implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16 implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16 implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16 exports function:
+  pub fn empty() -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16 exports function:
+  pub fn encode_slice(slice: &[u8], bytes: &mut alloc::vec::Vec<u8, alloc::alloc::Global>)
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16 exports function:
+  pub fn new(bytes: alloc::vec::Vec<u8, alloc::alloc::Global>) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24 implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24 implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24 implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24 implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24 implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24 implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24 implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24 implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24 implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24 exports function:
+  pub fn new(bytes: alloc::vec::Vec<u8, alloc::alloc::Global>) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8 implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8 implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8 implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8 implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8 implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8 implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8 implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8 implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8 implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8 implements trait:
+  impl<'_> core::convert::From<ring::hkdf::Okm<'_, PayloadU8Len>> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8 exports function:
+  pub fn empty() -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8 exports function:
+  pub fn into_inner(self) -> alloc::vec::Vec<u8, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8 exports function:
+  pub fn new(bytes: alloc::vec::Vec<u8, alloc::alloc::Global>) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec exports trait:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec exports function:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::decode_u16
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec exports function:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::decode_u32
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec exports function:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::decode_u64
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec exports function:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::encode_vec_u16
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec exports function:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::encode_vec_u24
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec exports function:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::encode_vec_u8
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec exports function:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::put_u16
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec exports function:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::put_u64
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec exports function:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::read_vec_u16
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec exports function:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::read_vec_u24_limited
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec exports function:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::read_vec_u8
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24
+
+trait s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec exports function:
+  pub fn encode(&self, bytes: &mut alloc::vec::Vec<u8, alloc::alloc::Global>)
+
+trait s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec exports function:
+  pub fn read(&mut s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader<'_>) -> core::option::Option<Self>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader exports function:
+  pub fn any_left(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader exports function:
+  pub fn init(bytes: &[u8]) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader<'_>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader exports function:
+  pub fn left(&self) -> usize
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader exports function:
+  pub fn rest(&mut self) -> &[u8]
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader exports function:
+  pub fn sub(&mut self, len: usize) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader<'_>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader exports function:
+  pub fn take(&mut self, len: usize) -> core::option::Option<&[u8]>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader exports function:
+  pub fn used(&self) -> usize
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24 implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24 implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24 implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24 implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24 implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24 implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24 implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24 implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24 exports function:
+  pub fn decode(bytes: &[u8]) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::u24>
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer exports field:
+  desynced: bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer exports field:
+  frames: alloc::collections::vec_deque::VecDeque<s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer exports function:
+  pub fn has_pending(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer exports function:
+  pub fn new() -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::deframer::MessageDeframer exports function:
+  pub fn read(&mut self, rd: &mut dyn std::io::Read) -> core::result::Result<usize, std::io::error::Error>
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  AccessDenied
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  BadCertificate
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  BadCertificateHashValue
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  BadCertificateStatusResponse
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  BadRecordMac
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  CertificateExpired
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  CertificateRequired
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  CertificateRevoked
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  CertificateUnknown
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  CertificateUnobtainable
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  CloseNotify
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  DecodeError
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  DecompressionFailure
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  DecryptError
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  DecryptionFailed
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  ExportRestriction
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  HandshakeFailure
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  IllegalParameter
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  InappropriateFallback
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  InsufficientSecurity
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  InternalError
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  MissingExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  NoApplicationProtocol
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  NoCertificate
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  NoRenegotiation
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  RecordOverflow
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  UnexpectedMessage
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  UnknownCA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  UnknownPSKIdentity
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  UnrecognisedName
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  UnsupportedCertificate
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  UnsupportedExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports variant:
+  UserCanceled
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel exports variant:
+  Fatal
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel exports variant:
+  Warning
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType exports variant:
+  OCSP
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  SSL_FORTEZZA_KEA_WITH_FORTEZZA_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  SSL_FORTEZZA_KEA_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  SSL_RSA_FIPS_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  SSL_RSA_FIPS_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS13_AES_128_CCM_8_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS13_AES_128_CCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS13_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS13_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS13_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_EXPORT1024_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_EXPORT1024_WITH_RC4_56_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_3DES_EDE_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_128_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_256_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_CAMELLIA_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_DSS_WITH_SEED_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_128_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_256_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_NULL_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_NULL_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_PSK_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_3DES_EDE_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_128_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_128_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_128_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_256_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_256_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_256_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_CAMELLIA_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DHE_RSA_WITH_SEED_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_EXPORT_WITH_DES40_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_AES_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_CAMELLIA_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_DSS_WITH_SEED_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_EXPORT_WITH_DES40_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_AES_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_CAMELLIA_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_RSA_WITH_SEED_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_EXPORT_WITH_DES40_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_EXPORT_WITH_RC4_40_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_AES_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_CAMELLIA_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_RC4_128_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_DH_anon_WITH_SEED_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_128_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_256_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_256_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_ECDSA_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_NULL_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_NULL_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_PSK_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDHE_RSA_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_256_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_DES_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_NULL_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECDSA_WITH_RC4_128_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECNRA_WITH_3DES_EDE_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_ECNRA_WITH_DES_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_RSA_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_anon_EXPORT_WITH_DES40_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_anon_EXPORT_WITH_RC4_40_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_anon_NULL_WITH_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_3DES_EDE_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_DES_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECDH_anon_WITH_RC4_128_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECMQV_ECDSA_NULL_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECMQV_ECDSA_WITH_3DES_EDE_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECMQV_ECDSA_WITH_DES_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECMQV_ECDSA_WITH_RC4_128_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECMQV_ECNRA_NULL_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECMQV_ECNRA_WITH_3DES_EDE_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECMQV_ECNRA_WITH_DES_CBC_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_ECMQV_ECNRA_WITH_RC4_128_SHA_draft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_EMPTY_RENEGOTIATION_INFO_SCSV
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_GOSTR341001_WITH_28147_CNT_IMIT
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_GOSTR341001_WITH_NULL_GOSTR3411
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_GOSTR341094_WITH_28147_CNT_IMIT
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_GOSTR341094_WITH_NULL_GOSTR3411
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_KRB5_EXPORT_WITH_DES_CBC_40_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_KRB5_EXPORT_WITH_DES_CBC_40_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_KRB5_EXPORT_WITH_RC2_CBC_40_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_KRB5_EXPORT_WITH_RC2_CBC_40_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_KRB5_EXPORT_WITH_RC4_40_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_KRB5_EXPORT_WITH_RC4_40_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_KRB5_WITH_3DES_EDE_CBC_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_KRB5_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_KRB5_WITH_DES_CBC_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_KRB5_WITH_DES_CBC_SHA_or_SSL_FORTEZZA_KEA_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_KRB5_WITH_IDEA_CBC_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_KRB5_WITH_IDEA_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_KRB5_WITH_RC4_128_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_KRB5_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_NULL_WITH_NULL_NULL
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_DHE_WITH_AES_128_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_DHE_WITH_AES_256_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_128_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_128_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_256_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_256_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_NULL_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_NULL_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_PSK_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_EXPORT1024_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_EXPORT1024_WITH_RC2_CBC_56_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_EXPORT1024_WITH_RC4_56_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_EXPORT1024_WITH_RC4_56_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_EXPORT_WITH_DES40_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_EXPORT_WITH_RC2_CBC_40_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_EXPORT_WITH_RC4_40_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_AES_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_CAMELLIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_CHACHA20_POLY1305_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_NULL_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_NULL_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_PSK_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_3DES_EDE_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_128_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_128_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_128_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_256_CBC_RMD
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_256_CCM
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_256_CCM_8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_AES_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_ARIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_ARIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_ARIA_256_CBC_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_ARIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_CAMELLIA_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_CAMELLIA_128_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_CAMELLIA_128_GCM_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_CAMELLIA_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_CAMELLIA_256_CBC_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_CAMELLIA_256_GCM_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_DES_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_IDEA_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_NULL_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_NULL_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_NULL_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_RC4_128_MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_RC4_128_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_RSA_WITH_SEED_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_SRP_SHA_DSS_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_SRP_SHA_DSS_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_SRP_SHA_DSS_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_SRP_SHA_WITH_AES_128_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  TLS_SRP_SHA_WITH_AES_256_CBC_SHA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports variant:
+  Unknown(u16)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::CipherSuite> for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite implements trait:
+  impl core::convert::From<u16> for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports function:
+  pub fn as_str(&self) -> core::option::Option<&'static str>
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CipherSuite exports function:
+  pub fn get_u16(&self) -> u16
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType exports variant:
+  DSSEphemeralDH
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType exports variant:
+  DSSFixedDH
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType exports variant:
+  DSSSign
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType exports variant:
+  ECDSAFixedECDH
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType exports variant:
+  ECDSASign
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType exports variant:
+  FortezzaDMS
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType exports variant:
+  RSAEphemeralDH
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType exports variant:
+  RSAFixedDH
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType exports variant:
+  RSAFixedECDH
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType exports variant:
+  RSASign
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression exports variant:
+  Deflate
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression exports variant:
+  LSZ
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression exports variant:
+  Null
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType exports variant:
+  Alert
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType exports variant:
+  ApplicationData
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType exports variant:
+  ChangeCipherSpec
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType exports variant:
+  Handshake
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType exports variant:
+  Heartbeat
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType exports variant:
+  ExplicitChar2
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType exports variant:
+  ExplicitPrime
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType exports variant:
+  NamedCurve
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat exports variant:
+  ANSIX962CompressedChar2
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat exports variant:
+  ANSIX962CompressedPrime
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat exports variant:
+  Uncompressed
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  ALProtocolNegotiation
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  CertificateAuthorities
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  CertificateType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  ChannelId
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  ClientAuthz
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  ClientCertificateUrl
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  Cookie
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  ECPointFormats
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  EarlyData
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  EllipticCurves
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  ExtendedMasterSecret
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  Heartbeat
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  KeyShare
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  MaxFragmentLength
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  NextProtocolNegotiation
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  OIDFilters
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  PSKKeyExchangeModes
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  Padding
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  PostHandshakeAuth
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  PreSharedKey
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  RenegotiationInfo
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  SCT
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  SRP
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  ServerAuthz
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  ServerName
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  SessionTicket
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  SignatureAlgorithms
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  SignatureAlgorithmsCert
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  StatusRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  SupportedVersions
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  TicketEarlyDataInfo
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  TransportParameters
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  TransportParametersDraft
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  TruncatedHMAC
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  TrustedCAKeys
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  Unknown(u16)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  UseSRTP
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports variant:
+  UserMapping
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType implements trait:
+  impl core::convert::From<u16> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports function:
+  pub fn as_str(&self) -> core::option::Option<&'static str>
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType exports function:
+  pub fn get_u16(&self) -> u16
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  Certificate
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  CertificateRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  CertificateStatus
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  CertificateURL
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  CertificateVerify
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  ClientHello
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  ClientKeyExchange
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  EncryptedExtensions
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  EndOfEarlyData
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  Finished
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  HelloRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  HelloRetryRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  HelloVerifyRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  KeyUpdate
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  MessageHash
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  NewSessionTicket
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  ServerHello
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  ServerHelloDone
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  ServerKeyExchange
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm exports variant:
+  MD5
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm exports variant:
+  NONE
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm exports variant:
+  SHA1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm exports variant:
+  SHA224
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm exports variant:
+  SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm exports variant:
+  SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm exports variant:
+  SHA512
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType exports variant:
+  Request
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType exports variant:
+  Response
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMessageType exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode exports variant:
+  PeerAllowedToSend
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode exports variant:
+  PeerNotAllowedToSend
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HeartbeatMode exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest exports variant:
+  UpdateNotRequested
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest exports variant:
+  UpdateRequested
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  Unknown(u16)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  X25519
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  X448
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  arbitrary_explicit_char2_curves
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  arbitrary_explicit_prime_curves
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  brainpoolp256r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  brainpoolp384r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  brainpoolp512r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve implements trait:
+  impl core::convert::From<u16> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports function:
+  pub fn as_str(&self) -> core::option::Option<&'static str>
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports function:
+  pub fn get_u16(&self) -> u16
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  secp160k1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  secp160r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  secp160r2
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  secp192k1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  secp192r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  secp224k1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  secp224r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  secp256k1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  secp256r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  secp384r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  secp521r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  sect163k1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  sect163r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  sect163r2
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  sect193r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  sect193r2
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  sect233k1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  sect233r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  sect239k1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  sect283k1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  sect283r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  sect409k1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  sect409r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  sect571k1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedCurve exports variant:
+  sect571r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup exports variant:
+  FFDHE2048
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup exports variant:
+  FFDHE3072
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup exports variant:
+  FFDHE4096
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup exports variant:
+  FFDHE6144
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup exports variant:
+  FFDHE8192
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup exports variant:
+  Unknown(u16)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup exports variant:
+  X25519
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup exports variant:
+  X448
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup implements trait:
+  impl core::convert::From<u16> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup exports function:
+  pub fn as_str(&self) -> core::option::Option<&'static str>
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup exports function:
+  pub fn get_u16(&self) -> u16
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup exports variant:
+  secp256r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup exports variant:
+  secp384r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup exports variant:
+  secp521r1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode exports variant:
+  PSK_DHE_KE
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode exports variant:
+  PSK_KE
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion exports variant:
+  DTLSv1_0
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion exports variant:
+  DTLSv1_2
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion exports variant:
+  SSLv2
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion exports variant:
+  SSLv3
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion exports variant:
+  TLSv1_0
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion exports variant:
+  TLSv1_1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion exports variant:
+  TLSv1_2
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion exports variant:
+  TLSv1_3
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion exports variant:
+  Unknown(u16)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::ProtocolVersion> for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion implements trait:
+  impl core::convert::From<u16> for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion exports function:
+  pub fn as_str(&self) -> core::option::Option<&'static str>
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ProtocolVersion exports function:
+  pub fn get_u16(&self) -> u16
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType exports variant:
+  HostName
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm exports variant:
+  Anonymous
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm exports variant:
+  DSA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm exports variant:
+  ECDSA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm exports variant:
+  ED25519
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm exports variant:
+  ED448
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm exports variant:
+  RSA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm exports variant:
+  Unknown(u8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm implements trait:
+  impl core::convert::From<u8> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm exports function:
+  pub fn get_u8(&self) -> u8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports variant:
+  ECDSA_NISTP256_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports variant:
+  ECDSA_NISTP384_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports variant:
+  ECDSA_NISTP521_SHA512
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports variant:
+  ECDSA_SHA1_Legacy
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports variant:
+  ED25519
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports variant:
+  ED448
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports variant:
+  RSA_PKCS1_SHA1
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports variant:
+  RSA_PKCS1_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports variant:
+  RSA_PKCS1_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports variant:
+  RSA_PKCS1_SHA512
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports variant:
+  RSA_PSS_SHA256
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports variant:
+  RSA_PSS_SHA384
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports variant:
+  RSA_PSS_SHA512
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports variant:
+  Unknown(u16)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::SignatureScheme> for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme implements trait:
+  impl core::convert::From<u16> for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DecomposedSignatureScheme for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports function:
+  pub fn as_str(&self) -> core::option::Option<&'static str>
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureScheme exports function:
+  pub fn get_u16(&self) -> u16
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter exports constant:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MAX_FRAGMENT_LEN
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter exports constant:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MAX_FRAGMENT_SIZE
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter exports constant:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::PACKET_OVERHEAD
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter exports function:
+  pub fn fragment(&self, msg: s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage, out: &mut alloc::collections::vec_deque::VecDeque<s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage>)
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter exports function:
+  pub fn fragment_borrow(
+  &self,
+  typ: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType,
+  version: s2n_quic::provider::tls::rustls::rustls::ProtocolVersion,
+  payload: &'a [u8],
+  out: &mut alloc::collections::vec_deque::VecDeque<s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage<'a>>)
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter exports function:
+  pub fn new(max_fragment_size: core::option::Option<usize>) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::fragmenter::MessageFragmenter exports function:
+  pub fn set_max_fragment_size(&mut self, new: core::option::Option<usize>) -> core::result::Result<(), s2n_quic::provider::tls::rustls::rustls::Error>
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtensions
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtensions
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayload
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientCertificateTypes
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports trait:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ConvertProtocolNameList
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports trait:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ConvertServerNameList
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports trait:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DecomposedSignatureScheme
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DistinguishedName
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DistinguishedNames
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECPointFormatList
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::EncryptedExtensions
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports trait:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HasServerExtensions
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntries
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NamedGroups
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtensions
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PSKKeyExchangeModes
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyBinder
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyBinders
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentities
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ProtocolNameList
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ProtocolVersions
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SCTList
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNameRequest
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports trait:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SupportedPointFormats
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SupportedSignatureSchemes
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::VecU16OfPayloadU16
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::VecU16OfPayloadU8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension exports variant:
+  AuthorityNames(alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension exports variant:
+  SignatureAlgorithms(alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::SignatureScheme, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension exports variant:
+  Unknown(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension exports function:
+  pub fn get_type(&self) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtensions exports typedef:
+  type CertReqExtensions = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension, alloc::alloc::Global>;
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry exports field:
+  cert: s2n_quic::provider::tls::rustls::Certificate
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry exports field:
+  exts: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry exports function:
+  pub fn get_ocsp_response(&self) -> core::option::Option<&alloc::vec::Vec<u8, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry exports function:
+  pub fn get_scts(&self) -> core::option::Option<&alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry exports function:
+  pub fn has_duplicate_extension(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry exports function:
+  pub fn has_unknown_extension(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry exports function:
+  pub fn new(cert: s2n_quic::provider::tls::rustls::Certificate) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension exports variant:
+  CertificateStatus(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension exports variant:
+  SignedCertificateTimestamp(alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension exports variant:
+  Unknown(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension exports function:
+  pub fn get_cert_status(&self) -> core::option::Option<&alloc::vec::Vec<u8, alloc::alloc::Global>>
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension exports function:
+  pub fn get_sct_list(&self) -> core::option::Option<&alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, alloc::alloc::Global>>
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension exports function:
+  pub fn get_type(&self) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension exports function:
+  pub fn make_sct(sct_list: alloc::vec::Vec<u8, alloc::alloc::Global>) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtensions exports typedef:
+  type CertificateExtensions = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateExtension, alloc::alloc::Global>;
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayload exports typedef:
+  type CertificatePayload = alloc::vec::Vec<s2n_quic::provider::tls::rustls::Certificate, alloc::alloc::Global>;
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 exports field:
+  context: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 exports field:
+  entries: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 exports function:
+  pub fn any_entry_has_duplicate_extension(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 exports function:
+  pub fn any_entry_has_extension(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 exports function:
+  pub fn any_entry_has_unknown_extension(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 exports function:
+  pub fn convert(&self) -> alloc::vec::Vec<s2n_quic::provider::tls::rustls::Certificate, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 exports function:
+  pub fn get_end_entity_ocsp(&self) -> alloc::vec::Vec<u8, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 exports function:
+  pub fn get_end_entity_scts(&self) -> core::option::Option<alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13 exports function:
+  pub fn new(entries: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateEntry, alloc::alloc::Global>) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload exports field:
+  canames: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload exports field:
+  certtypes: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload exports field:
+  sigschemes: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::SignatureScheme, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13 exports field:
+  context: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13 exports field:
+  extensions: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13 implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13 implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13 implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13 implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13 implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13 implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13 implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13 exports function:
+  pub fn find_extension(&self, ext: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType) -> core::option::Option<&s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertReqExtension>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13 exports function:
+  pub fn get_authorities_extension(&self) -> core::option::Option<&alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13 exports function:
+  pub fn get_sigalgs_extension(&self) -> core::option::Option<&alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::SignatureScheme, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus exports field:
+  ocsp_response: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU24
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus exports function:
+  pub fn into_inner(self) -> alloc::vec::Vec<u8, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus exports function:
+  pub fn new(ocsp: alloc::vec::Vec<u8, alloc::alloc::Global>) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest exports variant:
+  OCSP(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest exports variant:
+  Unknown((s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::CertificateStatusType, s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload))
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest exports function:
+  pub fn build_ocsp() -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientCertificateTypes exports typedef:
+  type ClientCertificateTypes = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ClientCertificateType, alloc::alloc::Global>;
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientECDHParams exports field:
+  public: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  CertificateStatusRequest(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatusRequest)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  Cookie(s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  ECPointFormats(alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  EarlyData
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  ExtendedMasterSecretRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  KeyShare(alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  NamedGroups(alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  PresharedKey(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  PresharedKeyModes(alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  Protocols(alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  ServerName(alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  SessionTicket(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  SignatureAlgorithms(alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::SignatureScheme, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  SignedCertificateTimestampRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  SupportedVersions(alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::ProtocolVersion, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  TransportParameters(alloc::vec::Vec<u8, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  TransportParametersDraft(alloc::vec::Vec<u8, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports variant:
+  Unknown(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports function:
+  pub fn get_type(&self) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension exports function:
+  pub fn make_sni(dns_name: webpki::name::dns_name::DnsNameRef<'_>) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports field:
+  cipher_suites: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::CipherSuite, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports field:
+  client_version: s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports field:
+  compression_methods: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports field:
+  extensions: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn check_psk_ext_is_last(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn early_data_extension_offered(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn ems_support_offered(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn find_extension(&self, ext: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType) -> core::option::Option<&s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn get_alpn_extension(&self) -> core::option::Option<&alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn get_ecpoints_extension(&self) -> core::option::Option<&alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn get_keyshare_extension(&self) -> core::option::Option<&alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn get_namedgroups_extension(&self) -> core::option::Option<&alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn get_psk(&self) -> core::option::Option<&s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn get_psk_modes(&self) -> core::option::Option<&alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn get_quic_params_extension(&self) -> core::option::Option<alloc::vec::Vec<u8, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn get_sigalgs_extension(&self) -> core::option::Option<&alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::SignatureScheme, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn get_sni_extension(&self) -> core::option::Option<&alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn get_ticket_extension(&self) -> core::option::Option<&s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientExtension>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn get_versions_extension(&self) -> core::option::Option<&alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::ProtocolVersion, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn has_duplicate_extension(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn has_keyshare_extension_with_duplicates(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn psk_mode_offered(&self, mode: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports function:
+  pub fn set_psk_binder(&mut self, binder: impl core::convert::Into<alloc::vec::Vec<u8, alloc::alloc::Global>>)
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports field:
+  random: s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload exports field:
+  session_id: s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket exports variant:
+  Offer(s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket exports variant:
+  Request
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientSessionTicket
+
+trait s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ConvertProtocolNameList exports function:
+  pub fn as_single_slice(&self) -> core::option::Option<&[u8]>
+
+trait s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ConvertProtocolNameList exports function:
+  pub fn from_slices(names: &[&[u8]]) -> Self
+
+trait s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ConvertProtocolNameList exports function:
+  pub fn to_slices(&self) -> alloc::vec::Vec<&[u8], alloc::alloc::Global>
+
+trait s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ConvertServerNameList exports function:
+  pub fn get_single_hostname(&self) -> core::option::Option<webpki::name::dns_name::DnsNameRef<'_>>
+
+trait s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ConvertServerNameList exports function:
+  pub fn has_duplicate_names_for_type(&self) -> bool
+
+trait s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DecomposedSignatureScheme exports function:
+  pub fn make(alg: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm, hash: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HashAlgorithm) -> s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+trait s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DecomposedSignatureScheme exports function:
+  pub fn sign(&self) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct exports function:
+  pub fn new(
+  scheme: s2n_quic::provider::tls::rustls::rustls::SignatureScheme,
+  sig: alloc::vec::Vec<u8, alloc::alloc::Global>) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct exports field:
+  scheme: s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct exports field:
+  sig: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DistinguishedName exports typedef:
+  type DistinguishedName = s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16;
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DistinguishedNames exports typedef:
+  type DistinguishedNames = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, alloc::alloc::Global>;
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange exports field:
+  dss: s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange exports field:
+  params: s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters exports field:
+  curve_type: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECCurveType
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters exports field:
+  named_group: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECPointFormatList exports typedef:
+  type ECPointFormatList = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat, alloc::alloc::Global>;
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::EncryptedExtensions exports typedef:
+  type EncryptedExtensions = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension, alloc::alloc::Global>;
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload exports field:
+  payload: s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload exports function:
+  pub fn build_handshake_hash(hash: &[u8]) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload exports function:
+  pub fn build_key_update_notify() -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload exports function:
+  pub fn get_encoding_for_binder_signing(&self) -> alloc::vec::Vec<u8, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload exports function:
+  pub fn read_version(
+  r: &mut s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader<'_>,
+  vers: s2n_quic::provider::tls::rustls::rustls::ProtocolVersion) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload exports field:
+  typ: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  Certificate(alloc::vec::Vec<s2n_quic::provider::tls::rustls::Certificate, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  CertificateRequest(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  CertificateRequestTLS13(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateRequestPayloadTLS13)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  CertificateStatus(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificateStatus)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  CertificateTLS13(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::CertificatePayloadTLS13)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  CertificateVerify(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::DigitallySignedStruct)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  ClientHello(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ClientHelloPayload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  ClientKeyExchange(s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  EncryptedExtensions(alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  EndOfEarlyData
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  Finished(s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  HelloRequest
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  HelloRetryRequest(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  KeyUpdate(s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::KeyUpdateRequest)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  MessageHash(s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  NewSessionTicket(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  NewSessionTicketTLS13(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  ServerHello(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  ServerHelloDone
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  ServerKeyExchange(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload exports variant:
+  Unknown(s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakePayload
+
+trait s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HasServerExtensions exports function:
+  pub fn get_extensions(&self) -> &[s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension]
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension exports variant:
+  Cookie(s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension exports variant:
+  KeyShare(s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension exports variant:
+  SupportedVersions(s2n_quic::provider::tls::rustls::rustls::ProtocolVersion)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension exports variant:
+  Unknown(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension exports function:
+  pub fn get_type(&self) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest exports field:
+  cipher_suite: s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest exports field:
+  extensions: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryExtension, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest exports field:
+  legacy_version: s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest exports function:
+  pub fn get_cookie(&self) -> core::option::Option<&s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest exports function:
+  pub fn get_requested_key_share_group(&self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest exports function:
+  pub fn get_supported_versions(&self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::ProtocolVersion>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest exports function:
+  pub fn has_duplicate_extension(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest exports function:
+  pub fn has_unknown_extension(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HelloRetryRequest exports field:
+  session_id: s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm exports variant:
+  BulkOnly
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm exports variant:
+  DH
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm exports variant:
+  DHE
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm exports variant:
+  ECDH
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm exports variant:
+  ECDHE
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm exports variant:
+  RSA
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntries exports typedef:
+  type KeyShareEntries = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry, alloc::alloc::Global>;
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry exports field:
+  group: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry exports field:
+  payload: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry exports function:
+  pub fn new(group: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup, payload: &[u8]) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NamedGroups exports typedef:
+  type NamedGroups = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup, alloc::alloc::Global>;
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension exports variant:
+  EarlyData(u32)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension exports variant:
+  Unknown(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension exports function:
+  pub fn get_type(&self) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtensions exports typedef:
+  type NewSessionTicketExtensions = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension, alloc::alloc::Global>;
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload exports field:
+  lifetime_hint: u32
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload exports function:
+  pub fn new(
+  lifetime_hint: u32,
+  ticket: alloc::vec::Vec<u8, alloc::alloc::Global>) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayload exports field:
+  ticket: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 exports field:
+  age_add: u32
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 exports field:
+  exts: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 exports field:
+  lifetime: u32
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 exports field:
+  nonce: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 exports function:
+  pub fn find_extension(
+  &self,
+  ext: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType) -> core::option::Option<&s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketExtension>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 exports function:
+  pub fn get_max_early_data_size(&self) -> core::option::Option<u32>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 exports function:
+  pub fn has_duplicate_extension(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 exports function:
+  pub fn new(
+  lifetime: u32,
+  age_add: u32,
+  nonce: alloc::vec::Vec<u8, alloc::alloc::Global>,
+  ticket: alloc::vec::Vec<u8, alloc::alloc::Global>) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::NewSessionTicketPayloadTLS13 exports field:
+  ticket: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest exports field:
+  extensions: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::OCSPCertificateStatusRequest exports field:
+  responder_ids: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, alloc::alloc::Global>
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PSKKeyExchangeModes exports typedef:
+  type PSKKeyExchangeModes = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::PSKKeyExchangeMode, alloc::alloc::Global>;
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyBinder exports typedef:
+  type PresharedKeyBinder = s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8;
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyBinders exports typedef:
+  type PresharedKeyBinders = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8, alloc::alloc::Global>;
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentities exports typedef:
+  type PresharedKeyIdentities = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity, alloc::alloc::Global>;
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity exports field:
+  identity: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity exports field:
+  obfuscated_ticket_age: u32
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity exports function:
+  pub fn new(id: alloc::vec::Vec<u8, alloc::alloc::Global>, age: u32) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer exports field:
+  binders: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer exports field:
+  identities: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer exports function:
+  pub fn new(
+  id: s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyIdentity,
+  binder: alloc::vec::Vec<u8, alloc::alloc::Global>) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::PresharedKeyOffer
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ProtocolNameList exports typedef:
+  type ProtocolNameList = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8, alloc::alloc::Global>;
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ProtocolVersions exports typedef:
+  type ProtocolVersions = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::ProtocolVersion, alloc::alloc::Global>;
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random implements trait:
+  impl core::convert::From<[u8; 32]> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random exports function:
+  pub fn new() -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random, GetRandomFailed>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random exports function:
+  pub fn write_slice(&self, bytes: &mut [u8])
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SCTList exports typedef:
+  type SCTList = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, alloc::alloc::Global>;
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams exports field:
+  curve_params: s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECParameters
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams exports function:
+  pub fn new(named_group: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::NamedGroup, pubkey: &[u8]) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerECDHParams exports field:
+  public: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports variant:
+  CertificateStatusAck
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports variant:
+  ECPointFormats(alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports variant:
+  EarlyData
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports variant:
+  ExtendedMasterSecretAck
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports variant:
+  KeyShare(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports variant:
+  PresharedKey(u16)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports variant:
+  Protocols(alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports variant:
+  RenegotiationInfo(s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports variant:
+  ServerNameAck
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports variant:
+  SessionTicketAck
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports variant:
+  SignedCertificateTimestamp(alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports variant:
+  SupportedVersions(s2n_quic::provider::tls::rustls::rustls::ProtocolVersion)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports variant:
+  TransportParameters(alloc::vec::Vec<u8, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports variant:
+  TransportParametersDraft(alloc::vec::Vec<u8, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports variant:
+  Unknown(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports function:
+  pub fn get_type(&self) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports function:
+  pub fn make_alpn(proto: &[&[u8]]) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports function:
+  pub fn make_empty_renegotiation_info() -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension exports function:
+  pub fn make_sct(sctl: alloc::vec::Vec<u8, alloc::alloc::Global>) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload exports field:
+  cipher_suite: s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload exports field:
+  compression_method: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::Compression
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload exports field:
+  extensions: alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerExtension, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HasServerExtensions for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload exports field:
+  legacy_version: s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload exports function:
+  pub fn ems_support_acked(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload exports function:
+  pub fn get_ecpoints_extension(&self) -> core::option::Option<&alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload exports function:
+  pub fn get_key_share(&self) -> core::option::Option<&s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyShareEntry>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload exports function:
+  pub fn get_psk_index(&self) -> core::option::Option<u16>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload exports function:
+  pub fn get_sct_list(&self) -> core::option::Option<&alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload exports function:
+  pub fn get_supported_versions(&self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::ProtocolVersion>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload exports field:
+  random: s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::Random
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerHelloPayload exports field:
+  session_id: s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload exports variant:
+  ECDHE(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload exports variant:
+  Unknown(s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerKeyExchangePayload exports function:
+  pub fn unwrap_given_kxa(
+  &self,
+  kxa: &s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::KeyExchangeAlgorithm) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ECDHEServerKeyExchange>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName exports field:
+  payload: s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName exports field:
+  typ: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ServerNameType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload exports variant:
+  HostName((s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, webpki::name::dns_name::DnsName))
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload exports variant:
+  Unknown(s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload exports function:
+  pub fn new_hostname(hostname: webpki::name::dns_name::DnsName) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNamePayload
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerNameRequest exports typedef:
+  type ServerNameRequest = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::ServerName, alloc::alloc::Global>;
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID implements trait:
+  impl core::cmp::PartialEq<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID exports function:
+  pub fn empty() -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID exports function:
+  pub fn is_empty(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID exports function:
+  pub fn len(&self) -> usize
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID exports function:
+  pub fn random() -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID, GetRandomFailed>
+
+trait s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SupportedPointFormats exports function:
+  pub fn supported() -> alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ECPointFormat, alloc::alloc::Global>
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SupportedSignatureSchemes exports typedef:
+  type SupportedSignatureSchemes = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::SignatureScheme, alloc::alloc::Global>;
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension exports field:
+  payload: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::UnknownExtension exports field:
+  typ: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ExtensionType
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::VecU16OfPayloadU16 exports typedef:
+  type VecU16OfPayloadU16 = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16, alloc::alloc::Global>;
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::VecU16OfPayloadU8 exports typedef:
+  type VecU16OfPayloadU8 = alloc::vec::Vec<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8, alloc::alloc::Global>;
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner exports field:
+  frames: alloc::collections::vec_deque::VecDeque<s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner exports function:
+  pub fn is_empty(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner exports function:
+  pub fn new() -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner exports function:
+  pub fn take_message(&mut self, msg: s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage) -> core::option::Option<usize>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::hsjoiner::HandshakeJoiner exports function:
+  pub fn want_message(&self, msg: &s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage) -> bool
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::message exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::message exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::message exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::message exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::message exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::message exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage exports field:
+  payload: &'a [u8]
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage exports field:
+  typ: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage exports field:
+  version: s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message implements trait:
+  impl core::convert::TryFrom<s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message exports field:
+  payload: s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message exports function:
+  pub fn build_alert(level: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertLevel, desc: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message exports function:
+  pub fn build_key_update_notify() -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message exports function:
+  pub fn is_handshake_type(&self, hstyp: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::HandshakeType) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message exports field:
+  version: s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError exports variant:
+  IllegalContentType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError exports variant:
+  IllegalLength
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError exports variant:
+  IllegalProtocolVersion
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError exports variant:
+  TooShortForHeader
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError exports variant:
+  TooShortForLength
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload exports variant:
+  Alert(s2n_quic::provider::tls::rustls::rustls::internal::msgs::alert::AlertMessagePayload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload exports variant:
+  ApplicationData(s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload exports variant:
+  ChangeCipherSpec(s2n_quic::provider::tls::rustls::rustls::internal::msgs::ccs::ChangeCipherSpecPayload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload exports variant:
+  Handshake(s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::HandshakeMessagePayload)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload exports function:
+  pub fn content_type(&self) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload exports function:
+  pub fn encode(&self, bytes: &mut alloc::vec::Vec<u8, alloc::alloc::Global>)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload exports function:
+  pub fn new(
+  typ: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType,
+  vers: s2n_quic::provider::tls::rustls::rustls::ProtocolVersion,
+  payload: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessagePayload, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage exports field:
+  payload: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage exports constant:
+  pub const MAX_WIRE_SIZE: usize
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage exports function:
+  pub fn encode(self) -> alloc::vec::Vec<u8, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage exports function:
+  pub fn into_plain_message(self) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage exports function:
+  pub fn read(r: &mut s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader<'_>) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage, s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::MessageError>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage exports field:
+  typ: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage exports field:
+  version: s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage implements trait:
+  impl core::convert::TryFrom<s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage exports field:
+  payload: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::Payload
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage exports function:
+  pub fn borrow(&self) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::BorrowedPlainMessage<'_>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage exports function:
+  pub fn into_unencrypted_opaque(self) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::OpaqueMessage
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage exports field:
+  typ: s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::ContentType
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage exports field:
+  version: s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist exports enum:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist exports type:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionKey
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue
+
+module s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist exports struct:
+  s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon exports function:
+  pub fn rewind_epoch(&mut self, delta: u32)
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon exports function:
+  pub fn secret(&self) -> &[u8]
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon exports function:
+  pub fn server_cert_chain(&self) -> &[s2n_quic::provider::tls::rustls::Certificate]
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon exports function:
+  pub fn ticket(&self) -> &[u8]
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey exports function:
+  pub fn hint_for_server_name(server_name: &s2n_quic::provider::tls::rustls::rustls::ServerName) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey exports function:
+  pub fn session_for_server_name(server_name: &s2n_quic::provider::tls::rustls::rustls::ServerName) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionKey
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue exports variant:
+  Tls12(s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue exports variant:
+  Tls13(s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue)
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue
+
+enum s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue exports function:
+  pub fn read(
+  reader: &mut s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader<'_>,
+  suite: s2n_quic::provider::tls::rustls::rustls::CipherSuite,
+  supported: &[s2n_quic::provider::tls::rustls::rustls::SupportedCipherSuite]) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved implements trait:
+  impl<T> core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved<T> where
+  T: core::marker::Send,
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved implements trait:
+  impl<T> core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved<T> where
+  T: core::marker::Sync,
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved implements trait:
+  impl<T> core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved<T> where
+  T: core::marker::Unpin,
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved implements trait:
+  impl<T> core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved<T>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved implements trait:
+  impl<T> std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved<T> where
+  T: std::panic::RefUnwindSafe,
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved implements trait:
+  impl<T> std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved<T> where
+  T: std::panic::UnwindSafe,
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved exports function:
+  pub fn has_expired(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved exports function:
+  pub fn new(value: T, retrieved_at: TimeBase) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved<T>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved exports function:
+  pub fn obfuscated_ticket_age(&self) -> u32
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved exports function:
+  pub fn tls13(&self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved<&s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Retrieved exports field:
+  value: T
+
+typedef s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionKey exports typedef:
+  type ServerSessionKey = s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID;
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue exports field:
+  age_obfuscation_offset: u32
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue exports field:
+  alpn: core::option::Option<s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue exports field:
+  application_data: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU16
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue exports field:
+  cipher_suite: s2n_quic::provider::tls::rustls::rustls::CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue exports field:
+  client_cert_chain: core::option::Option<alloc::vec::Vec<s2n_quic::provider::tls::rustls::Certificate, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue exports field:
+  creation_time_sec: u64
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue exports field:
+  extended_ms: bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Codec for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue exports field:
+  master_secret: s2n_quic::provider::tls::rustls::rustls::internal::msgs::base::PayloadU8
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue exports function:
+  pub fn is_fresh(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue exports function:
+  pub fn new(
+  sni: core::option::Option<&webpki::name::dns_name::DnsName>,
+  v: s2n_quic::provider::tls::rustls::rustls::ProtocolVersion,
+  cs: s2n_quic::provider::tls::rustls::rustls::CipherSuite,
+  ms: alloc::vec::Vec<u8, alloc::alloc::Global>,
+  client_cert_chain: core::option::Option<alloc::vec::Vec<s2n_quic::provider::tls::rustls::Certificate, alloc::alloc::Global>>,
+  alpn: core::option::Option<alloc::vec::Vec<u8, alloc::alloc::Global>>,
+  application_data: alloc::vec::Vec<u8, alloc::alloc::Global>,
+  creation_time: TimeBase,
+  age_obfuscation_offset: u32) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue exports function:
+  pub fn set_extended_ms_used(&mut self)
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue exports function:
+  pub fn set_freshness(
+  self,
+  obfuscated_client_age_ms: u32,
+  time_now: TimeBase) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue exports field:
+  sni: core::option::Option<webpki::name::dns_name::DnsName>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ServerSessionValue exports field:
+  version: s2n_quic::provider::tls::rustls::rustls::ProtocolVersion
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue exports field:
+  common: s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue implements trait:
+  impl core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue exports function:
+  pub fn extended_ms(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue exports function:
+  pub fn get_encoding(&self) -> alloc::vec::Vec<u8, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue exports function:
+  pub fn new(
+  suite: &'static s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite,
+  session_id: s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID,
+  ticket: alloc::vec::Vec<u8, alloc::alloc::Global>,
+  master_secret: alloc::vec::Vec<u8, alloc::alloc::Global>,
+  server_cert_chain: alloc::vec::Vec<s2n_quic::provider::tls::rustls::Certificate, alloc::alloc::Global>,
+  time_now: TimeBase,
+  lifetime_secs: u32,
+  extended_ms: bool) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue exports function:
+  pub fn secret(&self) -> &[u8]
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue exports function:
+  pub fn server_cert_chain(&self) -> &[s2n_quic::provider::tls::rustls::Certificate]
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue exports function:
+  pub fn suite(&self) -> &'static s2n_quic::provider::tls::rustls::rustls::Tls12CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue exports function:
+  pub fn take_ticket(&mut self) -> alloc::vec::Vec<u8, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue exports function:
+  pub fn ticket(&self) -> &[u8]
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls12ClientSessionValue exports field:
+  session_id: s2n_quic::provider::tls::rustls::rustls::internal::msgs::handshake::SessionID
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue exports field:
+  common: s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionCommon
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue implements trait:
+  impl core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue exports function:
+  pub fn get_encoding(&self) -> alloc::vec::Vec<u8, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue exports function:
+  pub fn max_early_data_size(&self) -> u32
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue exports function:
+  pub fn new(
+  suite: &'static s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite,
+  ticket: alloc::vec::Vec<u8, alloc::alloc::Global>,
+  secret: alloc::vec::Vec<u8, alloc::alloc::Global>,
+  server_cert_chain: alloc::vec::Vec<s2n_quic::provider::tls::rustls::Certificate, alloc::alloc::Global>,
+  time_now: TimeBase,
+  lifetime_secs: u32,
+  age_add: u32,
+  max_early_data_size: u32) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue exports function:
+  pub fn read(
+  suite: &'static s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite,
+  r: &mut s2n_quic::provider::tls::rustls::rustls::internal::msgs::codec::Reader<'_>) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue>
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue exports function:
+  pub fn secret(&self) -> &[u8]
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue exports function:
+  pub fn server_cert_chain(&self) -> &[s2n_quic::provider::tls::rustls::Certificate]
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue exports function:
+  pub fn suite(&self) -> &'static s2n_quic::provider::tls::rustls::rustls::Tls13CipherSuite
+
+struct s2n_quic::provider::tls::rustls::rustls::internal::msgs::persist::Tls13ClientSessionValue exports function:
+  pub fn ticket(&self) -> &[u8]
+
+module s2n_quic::provider::tls::rustls::rustls::kx_group exports static:
+  s2n_quic::provider::tls::rustls::rustls::kx_group::SECP256R1
+
+module s2n_quic::provider::tls::rustls::rustls::kx_group exports static:
+  s2n_quic::provider::tls::rustls::rustls::kx_group::SECP384R1
+
+module s2n_quic::provider::tls::rustls::rustls::kx_group exports static:
+  s2n_quic::provider::tls::rustls::rustls::kx_group::X25519
+
+module s2n_quic::provider::tls::rustls::rustls::manual exports module:
+  s2n_quic::provider::tls::rustls::rustls::manual::_01_impl_vulnerabilities
+
+module s2n_quic::provider::tls::rustls::rustls::manual exports module:
+  s2n_quic::provider::tls::rustls::rustls::manual::_02_tls_vulnerabilities
+
+module s2n_quic::provider::tls::rustls::rustls::manual exports module:
+  s2n_quic::provider::tls::rustls::rustls::manual::_03_howto
+
+module s2n_quic::provider::tls::rustls::rustls::manual exports module:
+  s2n_quic::provider::tls::rustls::rustls::manual::_04_features
+
+module s2n_quic::provider::tls::rustls::rustls::manual exports module:
+  s2n_quic::provider::tls::rustls::rustls::manual::_05_defaults
+
+module s2n_quic::provider::tls::rustls::rustls::quic exports trait:
+  s2n_quic::provider::tls::rustls::rustls::quic::ClientQuicExt
+
+module s2n_quic::provider::tls::rustls::rustls::quic exports struct:
+  s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys
+
+module s2n_quic::provider::tls::rustls::rustls::quic exports struct:
+  s2n_quic::provider::tls::rustls::rustls::quic::HeaderProtectionKey
+
+module s2n_quic::provider::tls::rustls::rustls::quic exports enum:
+  s2n_quic::provider::tls::rustls::rustls::quic::KeyChange
+
+module s2n_quic::provider::tls::rustls::rustls::quic exports struct:
+  s2n_quic::provider::tls::rustls::rustls::quic::Keys
+
+module s2n_quic::provider::tls::rustls::rustls::quic exports struct:
+  s2n_quic::provider::tls::rustls::rustls::quic::PacketKey
+
+module s2n_quic::provider::tls::rustls::rustls::quic exports struct:
+  s2n_quic::provider::tls::rustls::rustls::quic::PacketKeySet
+
+module s2n_quic::provider::tls::rustls::rustls::quic exports trait:
+  s2n_quic::provider::tls::rustls::rustls::quic::QuicExt
+
+module s2n_quic::provider::tls::rustls::rustls::quic exports struct:
+  s2n_quic::provider::tls::rustls::rustls::quic::Secrets
+
+module s2n_quic::provider::tls::rustls::rustls::quic exports trait:
+  s2n_quic::provider::tls::rustls::rustls::quic::ServerQuicExt
+
+module s2n_quic::provider::tls::rustls::rustls::quic exports struct:
+  s2n_quic::provider::tls::rustls::rustls::quic::Tag
+
+module s2n_quic::provider::tls::rustls::rustls::quic exports enum:
+  s2n_quic::provider::tls::rustls::rustls::quic::Version
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys exports field:
+  header: s2n_quic::provider::tls::rustls::rustls::quic::HeaderProtectionKey
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys exports field:
+  packet: s2n_quic::provider::tls::rustls::rustls::quic::PacketKey
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::HeaderProtectionKey implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::quic::HeaderProtectionKey
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::HeaderProtectionKey implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::quic::HeaderProtectionKey
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::HeaderProtectionKey implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::quic::HeaderProtectionKey
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::HeaderProtectionKey implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::HeaderProtectionKey
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::HeaderProtectionKey implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::HeaderProtectionKey
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::HeaderProtectionKey exports function:
+  pub fn decrypt_in_place(
+  &self,
+  sample: &[u8],
+  first: &mut u8,
+  packet_number: &mut [u8]) -> core::result::Result<(), s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::HeaderProtectionKey exports function:
+  pub fn encrypt_in_place(
+  &self,
+  sample: &[u8],
+  first: &mut u8,
+  packet_number: &mut [u8]) -> core::result::Result<(), s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::HeaderProtectionKey exports function:
+  pub fn sample_len(&self) -> usize
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::KeyChange exports variant:
+  Handshake
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::KeyChange exports variant:
+  OneRtt
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::KeyChange implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::quic::KeyChange
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::KeyChange implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::quic::KeyChange
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::KeyChange implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::quic::KeyChange
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::KeyChange implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::KeyChange
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::KeyChange implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::KeyChange
+
+variant s2n_quic::provider::tls::rustls::rustls::quic::KeyChange::Handshake exports field:
+  keys:
+  s2n_quic::provider::tls::rustls::rustls::quic::Keys
+
+variant s2n_quic::provider::tls::rustls::rustls::quic::KeyChange::OneRtt exports field:
+  keys:
+  s2n_quic::provider::tls::rustls::rustls::quic::Keys
+
+variant s2n_quic::provider::tls::rustls::rustls::quic::KeyChange::OneRtt exports field:
+  next:
+  s2n_quic::provider::tls::rustls::rustls::quic::Secrets
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Keys implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::quic::Keys
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Keys implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::quic::Keys
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Keys implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::quic::Keys
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Keys implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::Keys
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Keys implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::Keys
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Keys exports field:
+  local: s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Keys exports function:
+  pub fn initial(
+  version: s2n_quic::provider::tls::rustls::rustls::quic::Version,
+  client_dst_connection_id: &[u8],
+  is_client: bool) -> s2n_quic::provider::tls::rustls::rustls::quic::Keys
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Keys exports field:
+  remote: s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKey implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::quic::PacketKey
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKey implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::quic::PacketKey
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKey implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::quic::PacketKey
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKey implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::PacketKey
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKey implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::PacketKey
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKey exports function:
+  pub fn confidentiality_limit(&self) -> u64
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKey exports function:
+  pub fn decrypt_in_place(
+  &self,
+  packet_number: u64,
+  header: &[u8],
+  payload: &'a mut [u8]) -> core::result::Result<&'a [u8], s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKey exports function:
+  pub fn encrypt_in_place(
+  &self,
+  packet_number: u64,
+  header: &[u8],
+  payload: &mut [u8]) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::quic::Tag, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKey exports function:
+  pub fn integrity_limit(&self) -> u64
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKey exports function:
+  pub fn tag_len(&self) -> usize
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKeySet implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::quic::PacketKeySet
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKeySet implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::quic::PacketKeySet
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKeySet implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::quic::PacketKeySet
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKeySet implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::PacketKeySet
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKeySet implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::PacketKeySet
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKeySet exports field:
+  local: s2n_quic::provider::tls::rustls::rustls::quic::PacketKey
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::PacketKeySet exports field:
+  remote: s2n_quic::provider::tls::rustls::rustls::quic::PacketKey
+
+trait s2n_quic::provider::tls::rustls::rustls::quic::QuicExt exports function:
+  pub fn alert(&self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::AlertDescription>
+
+trait s2n_quic::provider::tls::rustls::rustls::quic::QuicExt exports function:
+  pub fn quic_transport_parameters(&self) -> core::option::Option<&[u8]>
+
+trait s2n_quic::provider::tls::rustls::rustls::quic::QuicExt exports function:
+  pub fn read_hs(&mut self, plaintext: &[u8]) -> core::result::Result<(), s2n_quic::provider::tls::rustls::rustls::Error>
+
+trait s2n_quic::provider::tls::rustls::rustls::quic::QuicExt exports function:
+  pub fn write_hs(&mut self, buf: &mut alloc::vec::Vec<u8, alloc::alloc::Global>) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::quic::KeyChange>
+
+trait s2n_quic::provider::tls::rustls::rustls::quic::QuicExt exports function:
+  pub fn zero_rtt_keys(&self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::quic::DirectionalKeys>
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Secrets implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::quic::Secrets
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Secrets implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::quic::Secrets
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Secrets implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::quic::Secrets
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Secrets implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::quic::Secrets
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Secrets implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::quic::Secrets
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Secrets implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::Secrets
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Secrets implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::Secrets
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Secrets exports function:
+  pub fn next_packet_keys(&mut self) -> s2n_quic::provider::tls::rustls::rustls::quic::PacketKeySet
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Tag implements trait:
+  impl core::convert::AsRef<[u8]> for s2n_quic::provider::tls::rustls::rustls::quic::Tag
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Tag implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::quic::Tag
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Tag implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::quic::Tag
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Tag implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::quic::Tag
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Tag implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::Tag
+
+struct s2n_quic::provider::tls::rustls::rustls::quic::Tag implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::Tag
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::Version is non-exhaustive
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::Version exports variant:
+  V1
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::Version exports variant:
+  V1Draft
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::Version implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::quic::Version
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::Version implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::quic::Version
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::Version implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::quic::Version
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::Version implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::quic::Version
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::Version implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::Version
+
+enum s2n_quic::provider::tls::rustls::rustls::quic::Version implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::quic::Version
+
+module s2n_quic::provider::tls::rustls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::rustls::server::Accepted
+
+module s2n_quic::provider::tls::rustls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::rustls::server::Acceptor
+
+module s2n_quic::provider::tls::rustls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAnonymousOrAuthenticatedClient
+
+module s2n_quic::provider::tls::rustls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAuthenticatedClient
+
+module s2n_quic::provider::tls::rustls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::rustls::server::ClientHello
+
+module s2n_quic::provider::tls::rustls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::rustls::server::NoClientAuth
+
+module s2n_quic::provider::tls::rustls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::rustls::server::NoServerSessionStorage
+
+module s2n_quic::provider::tls::rustls::rustls::server exports trait:
+  s2n_quic::provider::tls::rustls::rustls::server::ProducesTickets
+
+module s2n_quic::provider::tls::rustls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::rustls::server::ReadEarlyData
+
+module s2n_quic::provider::tls::rustls::rustls::server exports trait:
+  s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCert
+
+module s2n_quic::provider::tls::rustls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni
+
+module s2n_quic::provider::tls::rustls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::rustls::server::ServerConfig
+
+module s2n_quic::provider::tls::rustls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::rustls::server::ServerConnection
+
+module s2n_quic::provider::tls::rustls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::rustls::server::ServerConnectionData
+
+module s2n_quic::provider::tls::rustls::rustls::server exports trait:
+  s2n_quic::provider::tls::rustls::rustls::server::ServerQuicExt
+
+module s2n_quic::provider::tls::rustls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::rustls::server::ServerSessionMemoryCache
+
+module s2n_quic::provider::tls::rustls::rustls::server exports trait:
+  s2n_quic::provider::tls::rustls::rustls::server::StoresServerSessions
+
+module s2n_quic::provider::tls::rustls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::rustls::server::WantsServerCert
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Accepted implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::Accepted
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Accepted implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::Accepted
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Accepted implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::server::Accepted
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Accepted implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::server::Accepted
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Accepted implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::server::Accepted
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Accepted exports function:
+  pub fn client_hello(&self) -> s2n_quic::provider::tls::rustls::rustls::server::ClientHello<'_>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Accepted exports function:
+  pub fn into_connection(
+  self,
+  config: alloc::sync::Arc<s2n_quic::provider::tls::rustls::rustls::ServerConfig>) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::ServerConnection, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Acceptor implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::Acceptor
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Acceptor implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::Acceptor
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Acceptor implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::server::Acceptor
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Acceptor implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::server::Acceptor
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Acceptor implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::server::Acceptor
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Acceptor exports function:
+  pub fn accept(&mut self) -> core::result::Result<core::option::Option<s2n_quic::provider::tls::rustls::rustls::server::Accepted>, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Acceptor exports function:
+  pub fn new() -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::server::Acceptor, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Acceptor exports function:
+  pub fn read_tls(&mut self, rd: &mut dyn std::io::Read) -> core::result::Result<usize, std::io::error::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::Acceptor exports function:
+  pub fn wants_read(&self) -> bool
+
+struct s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAnonymousOrAuthenticatedClient implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAnonymousOrAuthenticatedClient
+
+struct s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAnonymousOrAuthenticatedClient implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAnonymousOrAuthenticatedClient
+
+struct s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAnonymousOrAuthenticatedClient implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAnonymousOrAuthenticatedClient
+
+struct s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAnonymousOrAuthenticatedClient implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAnonymousOrAuthenticatedClient
+
+struct s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAnonymousOrAuthenticatedClient implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAnonymousOrAuthenticatedClient
+
+struct s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAnonymousOrAuthenticatedClient exports function:
+  pub fn new(roots: s2n_quic::provider::tls::rustls::rustls::RootCertStore) -> alloc::sync::Arc<dyn ClientCertVerifier + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAuthenticatedClient implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAuthenticatedClient
+
+struct s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAuthenticatedClient implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAuthenticatedClient
+
+struct s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAuthenticatedClient implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAuthenticatedClient
+
+struct s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAuthenticatedClient implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAuthenticatedClient
+
+struct s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAuthenticatedClient implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAuthenticatedClient
+
+struct s2n_quic::provider::tls::rustls::rustls::server::AllowAnyAuthenticatedClient exports function:
+  pub fn new(roots: s2n_quic::provider::tls::rustls::rustls::RootCertStore) -> alloc::sync::Arc<dyn ClientCertVerifier + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ClientHello implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::tls::rustls::rustls::server::ClientHello<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ClientHello implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::server::ClientHello<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ClientHello implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::server::ClientHello<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ClientHello implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::ClientHello<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ClientHello implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::ClientHello<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ClientHello exports function:
+  pub fn alpn(&self) -> core::option::Option<impl core::iter::traits::iterator::Iterator<Item = &'a [u8]>>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ClientHello exports function:
+  pub fn server_name(&self) -> core::option::Option<&str>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ClientHello exports function:
+  pub fn signature_schemes(&self) -> &[s2n_quic::provider::tls::rustls::rustls::SignatureScheme]
+
+struct s2n_quic::provider::tls::rustls::rustls::server::NoClientAuth implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::server::NoClientAuth
+
+struct s2n_quic::provider::tls::rustls::rustls::server::NoClientAuth implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::server::NoClientAuth
+
+struct s2n_quic::provider::tls::rustls::rustls::server::NoClientAuth implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::server::NoClientAuth
+
+struct s2n_quic::provider::tls::rustls::rustls::server::NoClientAuth implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::NoClientAuth
+
+struct s2n_quic::provider::tls::rustls::rustls::server::NoClientAuth implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::NoClientAuth
+
+struct s2n_quic::provider::tls::rustls::rustls::server::NoClientAuth exports function:
+  pub fn new() -> alloc::sync::Arc<dyn ClientCertVerifier + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::NoServerSessionStorage implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::server::NoServerSessionStorage
+
+struct s2n_quic::provider::tls::rustls::rustls::server::NoServerSessionStorage implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::server::NoServerSessionStorage
+
+struct s2n_quic::provider::tls::rustls::rustls::server::NoServerSessionStorage implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::server::NoServerSessionStorage
+
+struct s2n_quic::provider::tls::rustls::rustls::server::NoServerSessionStorage implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::server::StoresServerSessions for s2n_quic::provider::tls::rustls::rustls::server::NoServerSessionStorage
+
+struct s2n_quic::provider::tls::rustls::rustls::server::NoServerSessionStorage implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::NoServerSessionStorage
+
+struct s2n_quic::provider::tls::rustls::rustls::server::NoServerSessionStorage implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::NoServerSessionStorage
+
+trait s2n_quic::provider::tls::rustls::rustls::server::ProducesTickets exports function:
+  pub fn decrypt(&self, cipher: &[u8]) -> core::option::Option<alloc::vec::Vec<u8, alloc::alloc::Global>>
+
+trait s2n_quic::provider::tls::rustls::rustls::server::ProducesTickets exports function:
+  pub fn enabled(&self) -> bool
+
+trait s2n_quic::provider::tls::rustls::rustls::server::ProducesTickets exports function:
+  pub fn encrypt(&self, plain: &[u8]) -> core::option::Option<alloc::vec::Vec<u8, alloc::alloc::Global>>
+
+trait s2n_quic::provider::tls::rustls::rustls::server::ProducesTickets exports function:
+  pub fn lifetime(&self) -> u32
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ReadEarlyData implements trait:
+  impl<'a> !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::ReadEarlyData<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ReadEarlyData implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::tls::rustls::rustls::server::ReadEarlyData<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ReadEarlyData implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::server::ReadEarlyData<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ReadEarlyData implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::server::ReadEarlyData<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ReadEarlyData implements trait:
+  impl<'a> std::io::Read for s2n_quic::provider::tls::rustls::rustls::server::ReadEarlyData<'a>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ReadEarlyData implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::ReadEarlyData<'a>
+
+trait s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCert exports function:
+  pub fn resolve(
+  &self,
+  client_hello: s2n_quic::provider::tls::rustls::rustls::server::ClientHello<'_>) -> core::option::Option<alloc::sync::Arc<s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey>>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCert for s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni exports function:
+  pub fn add(&mut self, name: &str, ck: s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey) -> core::result::Result<(), s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni exports function:
+  pub fn new() -> s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCertUsingSni
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig exports field:
+  alpn_protocols: alloc::vec::Vec<alloc::vec::Vec<u8, alloc::alloc::Global>, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig exports field:
+  cert_resolver: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCert + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig exports field:
+  ignore_client_order: bool
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::ServerConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::ServerConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::ServerConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::ServerConfig> for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::ServerConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::ServerConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::ServerConfig
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig exports field:
+  key_log: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::KeyLog + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig exports field:
+  max_early_data_size: u32
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig exports field:
+  max_fragment_size: core::option::Option<usize>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig exports function:
+  pub fn builder() -> s2n_quic::provider::tls::rustls::rustls::ConfigBuilder<s2n_quic::provider::tls::rustls::rustls::ServerConfig, s2n_quic::provider::tls::rustls::rustls::WantsCipherSuites>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig exports field:
+  send_half_rtt_data: bool
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig exports field:
+  session_storage: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::server::StoresServerSessions + 'static + core::marker::Send + core::marker::Sync>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConfig exports field:
+  ticketer: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::server::ProducesTickets + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::ServerConnection> for s2n_quic::provider::tls::rustls::rustls::Connection
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection implements trait:
+  impl core::ops::deref::Deref for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection implements trait:
+  impl core::ops::deref::DerefMut for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::quic::QuicExt for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::quic::ServerQuicExt for s2n_quic::provider::tls::rustls::rustls::ServerConnection
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection exports function:
+  pub fn complete_io<T>(&mut self, io: &mut T) -> core::result::Result<(usize, usize), std::io::error::Error> where
+  T: std::io::Read + std::io::Write,
+  s2n_quic::provider::tls::rustls::rustls::ConnectionCommon<Data>: core::marker::Sized,
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection exports function:
+  pub fn early_data(&mut self) -> core::option::Option<s2n_quic::provider::tls::rustls::rustls::server::ReadEarlyData<'_>>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection exports function:
+  pub fn export_keying_material(
+  &self,
+  output: &mut [u8],
+  label: &[u8],
+  context: core::option::Option<&[u8]>) -> core::result::Result<(), s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection exports function:
+  pub fn new(config: alloc::sync::Arc<s2n_quic::provider::tls::rustls::rustls::ServerConfig>) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::ServerConnection, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection exports function:
+  pub fn process_new_packets(&mut self) -> core::result::Result<s2n_quic::provider::tls::rustls::rustls::IoState, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection exports function:
+  pub fn read_tls(&mut self, rd: &mut dyn std::io::Read) -> core::result::Result<usize, std::io::error::Error>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection exports function:
+  pub fn reader(&mut self) -> s2n_quic::provider::tls::rustls::rustls::Reader<'_>ⓘ
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection exports function:
+  pub fn received_resumption_data(&self) -> core::option::Option<&[u8]>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection exports function:
+  pub fn reject_early_data(&mut self)
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection exports function:
+  pub fn set_resumption_data(&mut self, data: &[u8])
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection exports function:
+  pub fn sni_hostname(&self) -> core::option::Option<&str>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnection exports function:
+  pub fn writer(&mut self) -> s2n_quic::provider::tls::rustls::rustls::Writer<'_>ⓘ
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnectionData implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::rustls::rustls::server::ServerConnectionData
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnectionData implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::server::ServerConnectionData
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnectionData implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::server::ServerConnectionData
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnectionData implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::server::ServerConnectionData
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnectionData implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::ServerConnectionData
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerConnectionData implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::ServerConnectionData
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerSessionMemoryCache implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::server::ServerSessionMemoryCache
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerSessionMemoryCache implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::server::ServerSessionMemoryCache
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerSessionMemoryCache implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::server::ServerSessionMemoryCache
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerSessionMemoryCache implements trait:
+  impl s2n_quic::provider::tls::rustls::rustls::server::StoresServerSessions for s2n_quic::provider::tls::rustls::rustls::server::ServerSessionMemoryCache
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerSessionMemoryCache implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::ServerSessionMemoryCache
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerSessionMemoryCache implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::ServerSessionMemoryCache
+
+struct s2n_quic::provider::tls::rustls::rustls::server::ServerSessionMemoryCache exports function:
+  pub fn new(size: usize) -> alloc::sync::Arc<s2n_quic::provider::tls::rustls::rustls::server::ServerSessionMemoryCache>
+
+trait s2n_quic::provider::tls::rustls::rustls::server::StoresServerSessions exports function:
+  pub fn can_cache(&self) -> bool
+
+trait s2n_quic::provider::tls::rustls::rustls::server::StoresServerSessions exports function:
+  pub fn get(&self, key: &[u8]) -> core::option::Option<alloc::vec::Vec<u8, alloc::alloc::Global>>
+
+trait s2n_quic::provider::tls::rustls::rustls::server::StoresServerSessions exports function:
+  pub fn put(&self, key: alloc::vec::Vec<u8, alloc::alloc::Global>, value: alloc::vec::Vec<u8, alloc::alloc::Global>) -> bool
+
+trait s2n_quic::provider::tls::rustls::rustls::server::StoresServerSessions exports function:
+  pub fn take(&self, key: &[u8]) -> core::option::Option<alloc::vec::Vec<u8, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::server::WantsServerCert implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::WantsServerCert
+
+struct s2n_quic::provider::tls::rustls::rustls::server::WantsServerCert implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::server::WantsServerCert
+
+struct s2n_quic::provider::tls::rustls::rustls::server::WantsServerCert implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::server::WantsServerCert
+
+struct s2n_quic::provider::tls::rustls::rustls::server::WantsServerCert implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::server::WantsServerCert
+
+struct s2n_quic::provider::tls::rustls::rustls::server::WantsServerCert implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::server::WantsServerCert
+
+module s2n_quic::provider::tls::rustls::rustls::sign exports struct:
+  s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey
+
+module s2n_quic::provider::tls::rustls::rustls::sign exports struct:
+  s2n_quic::provider::tls::rustls::rustls::sign::SignError
+
+module s2n_quic::provider::tls::rustls::rustls::sign exports trait:
+  s2n_quic::provider::tls::rustls::rustls::sign::Signer
+
+module s2n_quic::provider::tls::rustls::rustls::sign exports trait:
+  s2n_quic::provider::tls::rustls::rustls::sign::SigningKey
+
+module s2n_quic::provider::tls::rustls::rustls::sign exports function:
+  s2n_quic::provider::tls::rustls::rustls::sign::any_ecdsa_type
+
+module s2n_quic::provider::tls::rustls::rustls::sign exports function:
+  s2n_quic::provider::tls::rustls::rustls::sign::any_eddsa_type
+
+module s2n_quic::provider::tls::rustls::rustls::sign exports function:
+  s2n_quic::provider::tls::rustls::rustls::sign::any_supported_type
+
+module s2n_quic::provider::tls::rustls::rustls::sign exports function:
+  s2n_quic::provider::tls::rustls::rustls::sign::supported_sign_tls13
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey exports field:
+  cert: alloc::vec::Vec<s2n_quic::provider::tls::rustls::Certificate, alloc::alloc::Global>
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey implements trait:
+  impl core::clone::Clone for s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey exports field:
+  key: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::sign::SigningKey + 'static>
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey exports field:
+  ocsp: core::option::Option<alloc::vec::Vec<u8, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey exports function:
+  pub fn end_entity_cert(&self) -> core::result::Result<&s2n_quic::provider::tls::rustls::Certificate, s2n_quic::provider::tls::rustls::rustls::sign::SignError>
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey exports function:
+  pub fn new(
+  cert: alloc::vec::Vec<s2n_quic::provider::tls::rustls::Certificate, alloc::alloc::Global>,
+  key: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::sign::SigningKey + 'static>) -> s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::CertifiedKey exports field:
+  sct_list: core::option::Option<alloc::vec::Vec<u8, alloc::alloc::Global>>
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::SignError implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::tls::rustls::rustls::sign::SignError
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::SignError implements trait:
+  impl core::fmt::Display for s2n_quic::provider::tls::rustls::rustls::sign::SignError
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::SignError implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::rustls::sign::SignError
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::SignError implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::rustls::sign::SignError
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::SignError implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::rustls::sign::SignError
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::SignError implements trait:
+  impl std::error::Error for s2n_quic::provider::tls::rustls::rustls::sign::SignError
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::SignError implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::rustls::sign::SignError
+
+struct s2n_quic::provider::tls::rustls::rustls::sign::SignError implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::rustls::sign::SignError
+
+trait s2n_quic::provider::tls::rustls::rustls::sign::Signer exports function:
+  pub fn scheme(&self) -> s2n_quic::provider::tls::rustls::rustls::SignatureScheme
+
+trait s2n_quic::provider::tls::rustls::rustls::sign::Signer exports function:
+  pub fn sign(&self, message: &[u8]) -> core::result::Result<alloc::vec::Vec<u8, alloc::alloc::Global>, s2n_quic::provider::tls::rustls::rustls::Error>
+
+trait s2n_quic::provider::tls::rustls::rustls::sign::SigningKey exports function:
+  pub fn algorithm(&self) -> s2n_quic::provider::tls::rustls::rustls::internal::msgs::enums::SignatureAlgorithm
+
+trait s2n_quic::provider::tls::rustls::rustls::sign::SigningKey exports function:
+  pub fn choose_scheme(
+  &self,
+  offered: &[s2n_quic::provider::tls::rustls::rustls::SignatureScheme]) -> core::option::Option<alloc::boxed::Box<dyn s2n_quic::provider::tls::rustls::rustls::sign::Signer + 'static, alloc::alloc::Global>>
+
+module s2n_quic::provider::tls::rustls::rustls::version exports static:
+  s2n_quic::provider::tls::rustls::rustls::version::TLS12
+
+module s2n_quic::provider::tls::rustls::rustls::version exports static:
+  s2n_quic::provider::tls::rustls::rustls::version::TLS13
+
+module s2n_quic::provider::tls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::server::Builder
+
+module s2n_quic::provider::tls::rustls::server exports struct:
+  s2n_quic::provider::tls::rustls::server::Server
+
+struct s2n_quic::provider::tls::rustls::server::Builder implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::server::Builder
+
+struct s2n_quic::provider::tls::rustls::server::Builder implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::server::Builder
+
+struct s2n_quic::provider::tls::rustls::server::Builder implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::rustls::server::Builder
+
+struct s2n_quic::provider::tls::rustls::server::Builder implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::server::Builder
+
+struct s2n_quic::provider::tls::rustls::server::Builder implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::server::Builder
+
+struct s2n_quic::provider::tls::rustls::server::Builder implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::server::Builder
+
+struct s2n_quic::provider::tls::rustls::server::Builder exports function:
+  pub fn build(self) -> core::result::Result<s2n_quic::provider::tls::rustls::Server, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::server::Builder exports function:
+  pub fn new() -> s2n_quic::provider::tls::rustls::server::Builder
+
+struct s2n_quic::provider::tls::rustls::server::Builder exports function:
+  pub fn with_application_protocols<P, I>(
+  self,
+  protocols: P) -> core::result::Result<s2n_quic::provider::tls::rustls::server::Builder, s2n_quic::provider::tls::rustls::rustls::Error> where
+  P: core::iter::traits::iterator::Iterator<Item = I>,
+  I: core::convert::AsRef<[u8]>,
+
+struct s2n_quic::provider::tls::rustls::server::Builder exports function:
+  pub fn with_cert_resolver(
+  self,
+  cert_resolver: alloc::sync::Arc<dyn s2n_quic::provider::tls::rustls::rustls::server::ResolvesServerCert + 'static>) -> core::result::Result<s2n_quic::provider::tls::rustls::server::Builder, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::server::Builder exports function:
+  pub fn with_certificate<C, PK>(
+  self,
+  certificate: C,
+  private_key: PK) -> core::result::Result<s2n_quic::provider::tls::rustls::server::Builder, s2n_quic::provider::tls::rustls::rustls::Error> where
+  C: s2n_quic::provider::tls::rustls::certificate::IntoCertificate,
+  PK: s2n_quic::provider::tls::rustls::certificate::IntoPrivateKey,
+
+struct s2n_quic::provider::tls::rustls::server::Builder exports function:
+  pub fn with_key_logging(self) -> core::result::Result<s2n_quic::provider::tls::rustls::server::Builder, s2n_quic::provider::tls::rustls::rustls::Error>
+
+struct s2n_quic::provider::tls::rustls::server::Server implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::server::Server implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::server::Server implements trait:
+  impl core::convert::From<s2n_quic::provider::tls::rustls::rustls::ServerConfig> for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::server::Server implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::server::Server implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::server::Server implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::server::Server implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::server::Server implements trait:
+  impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::server::Server implements trait:
+  impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::rustls::Server
+
+struct s2n_quic::provider::tls::rustls::server::Server exports function:
+  pub fn builder() -> s2n_quic::provider::tls::rustls::server::Builder
+
+struct s2n_quic::provider::tls::rustls::server::Server exports function:
+  pub fn new(config: s2n_quic::provider::tls::rustls::rustls::ServerConfig) -> s2n_quic::provider::tls::rustls::Server
+
+module s2n_quic::provider::tls::s2n_tls exports struct:
+  s2n_quic::provider::tls::s2n_tls::Client
+
+module s2n_quic::provider::tls::s2n_tls exports struct:
+  s2n_quic::provider::tls::s2n_tls::Server
+
+module s2n_quic::provider::tls::s2n_tls exports module:
+  s2n_quic::provider::tls::s2n_tls::certificate
+
+module s2n_quic::provider::tls::s2n_tls exports module:
+  s2n_quic::provider::tls::s2n_tls::client
+
+module s2n_quic::provider::tls::s2n_tls exports module:
+  s2n_quic::provider::tls::s2n_tls::server
+
+struct s2n_quic::provider::tls::s2n_tls::Client implements trait:
+  impl !core::marker::Sync for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::Client implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::Client implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::Client implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::Client implements trait:
+  impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::Client implements trait:
+  impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::Client implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::Client implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::Client exports function:
+  pub fn builder() -> s2n_quic::provider::tls::s2n_tls::client::Builder
+
+struct s2n_quic::provider::tls::s2n_tls::Server implements trait:
+  impl !core::marker::Sync for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::Server implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::Server implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::Server implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::Server implements trait:
+  impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::Server implements trait:
+  impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::Server implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::Server implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::Server exports function:
+  pub fn builder() -> s2n_quic::provider::tls::s2n_tls::server::Builder
+
+module s2n_quic::provider::tls::s2n_tls::certificate exports struct:
+  s2n_quic::provider::tls::s2n_tls::certificate::Certificate
+
+module s2n_quic::provider::tls::s2n_tls::certificate exports trait:
+  s2n_quic::provider::tls::s2n_tls::certificate::IntoCertificate
+
+module s2n_quic::provider::tls::s2n_tls::certificate exports trait:
+  s2n_quic::provider::tls::s2n_tls::certificate::IntoPrivateKey
+
+module s2n_quic::provider::tls::s2n_tls::certificate exports struct:
+  s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::s2n_tls::certificate::Certificate implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::certificate::Certificate
+
+struct s2n_quic::provider::tls::s2n_tls::certificate::Certificate implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::s2n_tls::certificate::Certificate
+
+struct s2n_quic::provider::tls::s2n_tls::certificate::Certificate implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::certificate::Certificate
+
+struct s2n_quic::provider::tls::s2n_tls::certificate::Certificate implements trait:
+  impl s2n_quic::provider::tls::s2n_tls::certificate::IntoCertificate for s2n_quic::provider::tls::s2n_tls::certificate::Certificate
+
+struct s2n_quic::provider::tls::s2n_tls::certificate::Certificate implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::certificate::Certificate
+
+struct s2n_quic::provider::tls::s2n_tls::certificate::Certificate implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::certificate::Certificate
+
+trait s2n_quic::provider::tls::s2n_tls::certificate::IntoCertificate exports function:
+  pub fn into_certificate(self) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::certificate::Certificate, s2n_tls::raw::error::Error>
+
+trait s2n_quic::provider::tls::s2n_tls::certificate::IntoPrivateKey exports function:
+  pub fn into_private_key(self) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey, s2n_tls::raw::error::Error>
+
+struct s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey implements trait:
+  impl core::marker::Sync for s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey implements trait:
+  impl s2n_quic::provider::tls::s2n_tls::certificate::IntoPrivateKey for s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey
+
+struct s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::certificate::PrivateKey
+
+module s2n_quic::provider::tls::s2n_tls::client exports struct:
+  s2n_quic::provider::tls::s2n_tls::client::Builder
+
+module s2n_quic::provider::tls::s2n_tls::client exports struct:
+  s2n_quic::provider::tls::s2n_tls::client::Client
+
+struct s2n_quic::provider::tls::s2n_tls::client::Builder implements trait:
+  impl !core::marker::Sync for s2n_quic::provider::tls::s2n_tls::client::Builder
+
+struct s2n_quic::provider::tls::s2n_tls::client::Builder implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::s2n_tls::client::Builder
+
+struct s2n_quic::provider::tls::s2n_tls::client::Builder implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::client::Builder
+
+struct s2n_quic::provider::tls::s2n_tls::client::Builder implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::client::Builder
+
+struct s2n_quic::provider::tls::s2n_tls::client::Builder implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::client::Builder
+
+struct s2n_quic::provider::tls::s2n_tls::client::Builder implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::client::Builder
+
+struct s2n_quic::provider::tls::s2n_tls::client::Builder exports function:
+  pub fn build(self) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::Client, s2n_tls::raw::error::Error>
+
+struct s2n_quic::provider::tls::s2n_tls::client::Builder exports function:
+  pub fn with_application_protocols<P, I>(
+  self,
+  protocols: P) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::client::Builder, s2n_tls::raw::error::Error> where
+  P: core::iter::traits::collect::IntoIterator<Item = I>,
+  I: core::convert::AsRef<[u8]>,
+
+struct s2n_quic::provider::tls::s2n_tls::client::Builder exports function:
+  pub fn with_certificate<C>(self, certificate: C) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::client::Builder, s2n_tls::raw::error::Error> where
+  C: s2n_quic::provider::tls::s2n_tls::certificate::IntoCertificate,
+
+struct s2n_quic::provider::tls::s2n_tls::client::Builder exports function:
+  pub fn with_key_logging(self) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::client::Builder, s2n_tls::raw::error::Error>
+
+struct s2n_quic::provider::tls::s2n_tls::client::Builder exports function:
+  pub fn with_max_cert_chain_depth(self, len: u16) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::client::Builder, s2n_tls::raw::error::Error>
+
+struct s2n_quic::provider::tls::s2n_tls::client::Client implements trait:
+  impl !core::marker::Sync for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::client::Client implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::client::Client implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::client::Client implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::client::Client implements trait:
+  impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::client::Client implements trait:
+  impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::client::Client implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::client::Client implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::Client
+
+struct s2n_quic::provider::tls::s2n_tls::client::Client exports function:
+  pub fn builder() -> s2n_quic::provider::tls::s2n_tls::client::Builder
+
+module s2n_quic::provider::tls::s2n_tls::server exports struct:
+  s2n_quic::provider::tls::s2n_tls::server::Builder
+
+module s2n_quic::provider::tls::s2n_tls::server exports struct:
+  s2n_quic::provider::tls::s2n_tls::server::Server
+
+struct s2n_quic::provider::tls::s2n_tls::server::Builder implements trait:
+  impl !core::marker::Sync for s2n_quic::provider::tls::s2n_tls::server::Builder
+
+struct s2n_quic::provider::tls::s2n_tls::server::Builder implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::s2n_tls::server::Builder
+
+struct s2n_quic::provider::tls::s2n_tls::server::Builder implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::server::Builder
+
+struct s2n_quic::provider::tls::s2n_tls::server::Builder implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::server::Builder
+
+struct s2n_quic::provider::tls::s2n_tls::server::Builder implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::server::Builder
+
+struct s2n_quic::provider::tls::s2n_tls::server::Builder implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::server::Builder
+
+struct s2n_quic::provider::tls::s2n_tls::server::Builder exports function:
+  pub fn build(self) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::Server, s2n_tls::raw::error::Error>
+
+struct s2n_quic::provider::tls::s2n_tls::server::Builder exports function:
+  pub fn with_application_protocols<P, I>(
+  self,
+  protocols: P) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::server::Builder, s2n_tls::raw::error::Error> where
+  P: core::iter::traits::collect::IntoIterator<Item = I>,
+  I: core::convert::AsRef<[u8]>,
+
+struct s2n_quic::provider::tls::s2n_tls::server::Builder exports function:
+  pub fn with_certificate<C, PK>(
+  self,
+  certificate: C,
+  private_key: PK) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::server::Builder, s2n_tls::raw::error::Error> where
+  C: s2n_quic::provider::tls::s2n_tls::certificate::IntoCertificate,
+  PK: s2n_quic::provider::tls::s2n_tls::certificate::IntoPrivateKey,
+
+struct s2n_quic::provider::tls::s2n_tls::server::Builder exports function:
+  pub fn with_key_logging(self) -> core::result::Result<s2n_quic::provider::tls::s2n_tls::server::Builder, s2n_tls::raw::error::Error>
+
+struct s2n_quic::provider::tls::s2n_tls::server::Server implements trait:
+  impl !core::marker::Sync for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::server::Server implements trait:
+  impl core::default::Default for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::server::Server implements trait:
+  impl core::marker::Send for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::server::Server implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::server::Server implements trait:
+  impl s2n_quic::provider::tls::Provider for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::server::Server implements trait:
+  impl s2n_quic_core::crypto::tls::Endpoint for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::server::Server implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::server::Server implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::tls::s2n_tls::Server
+
+struct s2n_quic::provider::tls::s2n_tls::server::Server exports function:
+  pub fn builder() -> s2n_quic::provider::tls::s2n_tls::server::Builder
+
+module s2n_quic::server exports struct:
+  s2n_quic::server::Builder
+
+module s2n_quic::server exports struct:
+  s2n_quic::server::DefaultProviders
+
+module s2n_quic::server exports struct:
+  s2n_quic::server::Name
+
+module s2n_quic::server exports struct:
+  s2n_quic::server::Server
+
+module s2n_quic::server exports trait:
+  s2n_quic::server::ServerProviders
+
+struct s2n_quic::server::Builder implements trait:
+  impl core::default::Default for s2n_quic::server::Builder<s2n_quic::server::DefaultProviders>
+
+struct s2n_quic::server::Builder implements trait:
+  impl<Providers:
+  core::fmt::Debug> core::fmt::Debug for s2n_quic::server::Builder<Providers>
+
+struct s2n_quic::server::Builder implements trait:
+  impl<Providers> core::marker::Send for s2n_quic::server::Builder<Providers> where
+  Providers: core::marker::Send,
+
+struct s2n_quic::server::Builder implements trait:
+  impl<Providers> core::marker::Sync for s2n_quic::server::Builder<Providers> where
+  Providers: core::marker::Sync,
+
+struct s2n_quic::server::Builder implements trait:
+  impl<Providers> core::marker::Unpin for s2n_quic::server::Builder<Providers> where
+  Providers: core::marker::Unpin,
+
+struct s2n_quic::server::Builder implements trait:
+  impl<Providers> std::panic::RefUnwindSafe for s2n_quic::server::Builder<Providers> where
+  Providers: std::panic::RefUnwindSafe,
+
+struct s2n_quic::server::Builder implements trait:
+  impl<Providers> std::panic::UnwindSafe for s2n_quic::server::Builder<Providers> where
+  Providers: std::panic::UnwindSafe,
+
+struct s2n_quic::server::Builder exports function:
+  pub fn start(self) -> core::result::Result<s2n_quic::server::Server, s2n_quic::provider::StartError>
+
+struct s2n_quic::server::Builder exports function:
+  pub fn with_address_token<T, U>(
+  self,
+  address_token: T) -> core::result::Result<s2n_quic::server::Builder<impl s2n_quic::server::ServerProviders>, T::s2n_quic::provider::address_token::TryInto::Error> where
+  T: s2n_quic::provider::address_token::TryInto,
+  U: s2n_quic::server::ServerProviders,
+  Self: With<T::s2n_quic::provider::address_token::TryInto::Provider, Output = s2n_quic::server::Builder<U>>,
+
+struct s2n_quic::server::Builder exports function:
+  pub fn with_connection_id<T, U>(
+  self,
+  connection_id: T) -> core::result::Result<s2n_quic::server::Builder<impl s2n_quic::server::ServerProviders>, T::s2n_quic::provider::connection_id::TryInto::Error> where
+  T: s2n_quic::provider::connection_id::TryInto,
+  U: s2n_quic::server::ServerProviders,
+  Self: With<T::s2n_quic::provider::connection_id::TryInto::Provider, Output = s2n_quic::server::Builder<U>>,
+
+struct s2n_quic::server::Builder exports function:
+  pub fn with_endpoint_limits<T, U>(
+  self,
+  endpoint_limits: T) -> core::result::Result<s2n_quic::server::Builder<impl s2n_quic::server::ServerProviders>, T::s2n_quic::provider::endpoint_limits::TryInto::Error> where
+  T: s2n_quic::provider::endpoint_limits::TryInto,
+  U: s2n_quic::server::ServerProviders,
+  Self: With<T::s2n_quic::provider::endpoint_limits::TryInto::Provider, Output = s2n_quic::server::Builder<U>>,
+
+struct s2n_quic::server::Builder exports function:
+  pub fn with_event<T, U>(
+  self,
+  event: T) -> core::result::Result<s2n_quic::server::Builder<impl s2n_quic::server::ServerProviders>, T::s2n_quic::provider::event::TryInto::Error> where
+  T: s2n_quic::provider::event::TryInto,
+  U: s2n_quic::server::ServerProviders,
+  Self: With<T::s2n_quic::provider::event::TryInto::Provider, Output = s2n_quic::server::Builder<U>>,
+
+struct s2n_quic::server::Builder exports function:
+  pub fn with_io<T, U>(
+  self,
+  io: T) -> core::result::Result<s2n_quic::server::Builder<impl s2n_quic::server::ServerProviders>, T::s2n_quic::provider::io::TryInto::Error> where
+  T: s2n_quic::provider::io::TryInto,
+  U: s2n_quic::server::ServerProviders,
+  Self: With<T::s2n_quic::provider::io::TryInto::Provider, Output = s2n_quic::server::Builder<U>>,
+
+struct s2n_quic::server::Builder exports function:
+  pub fn with_limits<T, U>(
+  self,
+  limits: T) -> core::result::Result<s2n_quic::server::Builder<impl s2n_quic::server::ServerProviders>, T::s2n_quic::provider::limits::TryInto::Error> where
+  T: s2n_quic::provider::limits::TryInto,
+  U: s2n_quic::server::ServerProviders,
+  Self: With<T::s2n_quic::provider::limits::TryInto::Provider, Output = s2n_quic::server::Builder<U>>,
+
+struct s2n_quic::server::Builder exports function:
+  pub fn with_stateless_reset_token<T, U>(
+  self,
+  stateless_reset_token: T) -> core::result::Result<s2n_quic::server::Builder<impl s2n_quic::server::ServerProviders>, T::s2n_quic::provider::stateless_reset_token::TryInto::Error> where
+  T: s2n_quic::provider::stateless_reset_token::TryInto,
+  U: s2n_quic::server::ServerProviders,
+  Self: With<T::s2n_quic::provider::stateless_reset_token::TryInto::Provider, Output = s2n_quic::server::Builder<U>>,
+
+struct s2n_quic::server::Builder exports function:
+  pub fn with_tls<T, U>(
+  self,
+  tls: T) -> core::result::Result<s2n_quic::server::Builder<impl s2n_quic::server::ServerProviders>, T::s2n_quic::provider::tls::TryInto::Error> where
+  T: s2n_quic::provider::tls::TryInto,
+  U: s2n_quic::server::ServerProviders,
+  Self: With<T::s2n_quic::provider::tls::TryInto::Provider, Output = s2n_quic::server::Builder<U>>,
+
+struct s2n_quic::server::DefaultProviders implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::server::DefaultProviders
+
+struct s2n_quic::server::DefaultProviders implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::server::DefaultProviders
+
+struct s2n_quic::server::DefaultProviders implements trait:
+  impl core::default::Default for s2n_quic::server::DefaultProviders
+
+struct s2n_quic::server::DefaultProviders implements trait:
+  impl core::fmt::Debug for s2n_quic::server::DefaultProviders
+
+struct s2n_quic::server::DefaultProviders implements trait:
+  impl core::marker::Send for s2n_quic::server::DefaultProviders
+
+struct s2n_quic::server::DefaultProviders implements trait:
+  impl core::marker::Sync for s2n_quic::server::DefaultProviders
+
+struct s2n_quic::server::DefaultProviders implements trait:
+  impl core::marker::Unpin for s2n_quic::server::DefaultProviders
+
+struct s2n_quic::server::Name exports function:
+  #[must_use = "this returns the remaining substring as a new slice, \         without modifying the original"]
+  pub fn strip_prefix<'a, P>(&'a self, prefix: P) -> core::option::Option<&'a str> where
+  P: core::str::pattern::Pattern<'a>,
+
+struct s2n_quic::server::Name exports function:
+  #[must_use = "this returns the remaining substring as a new slice, \         without modifying the original"]
+  pub fn strip_suffix<'a, P>(&'a self, suffix: P) -> core::option::Option<&'a str> where
+  P: core::str::pattern::Pattern<'a>,
+  <P as core::str::pattern::Pattern<'a>>::core::str::pattern::Pattern::Searcher: core::str::pattern::ReverseSearcher<'a>,
+
+struct s2n_quic::server::Name exports function:
+  #[must_use = "this returns the replaced string as a new allocation, \         without modifying the original"]
+  pub fn replace<'a, P>(&'a self, from: P, to: &str) -> alloc::string::String where
+  P: core::str::pattern::Pattern<'a>,
+
+struct s2n_quic::server::Name exports function:
+  #[must_use = "this returns the replaced string as a new allocation, \         without modifying the original"]
+  pub fn replacen<'a, P>(&'a self, pat: P, to: &str, count: usize) -> alloc::string::String where
+  P: core::str::pattern::Pattern<'a>,
+
+struct s2n_quic::server::Name exports function:
+  #[must_use = "this returns the trimmed string as a new slice, \         without modifying the original"]
+  pub fn trim_end(&self) -> &str
+
+struct s2n_quic::server::Name exports function:
+  #[must_use = "this returns the trimmed string as a new slice, \         without modifying the original"]
+  pub fn trim_end_matches<'a, P>(&'a self, pat: P) -> &'a str where
+  P: core::str::pattern::Pattern<'a>,
+  <P as core::str::pattern::Pattern<'a>>::core::str::pattern::Pattern::Searcher: core::str::pattern::ReverseSearcher<'a>,
+
+struct s2n_quic::server::Name exports function:
+  #[must_use = "this returns the trimmed string as a new slice, \         without modifying the original"]
+  pub fn trim_matches<'a, P>(&'a self, pat: P) -> &'a str where
+  P: core::str::pattern::Pattern<'a>,
+  <P as core::str::pattern::Pattern<'a>>::core::str::pattern::Pattern::Searcher: core::str::pattern::DoubleEndedSearcher<'a>,
+
+struct s2n_quic::server::Name exports function:
+  #[must_use = "this returns the trimmed string as a new slice, \         without modifying the original"]
+  pub fn trim_start(&self) -> &str
+
+struct s2n_quic::server::Name exports function:
+  #[must_use = "this returns the trimmed string as a new slice, \         without modifying the original"]
+  pub fn trim_start_matches<'a, P>(&'a self, pat: P) -> &'a str where
+  P: core::str::pattern::Pattern<'a>,
+
+struct s2n_quic::server::Name exports function:
+  #[must_use = "this returns the trimmed string as a slice, \         without modifying the original"]
+  pub fn trim(&self) -> &str
+
+struct s2n_quic::server::Name implements trait:
+  impl core::clone::Clone for s2n_quic::server::Name
+
+struct s2n_quic::server::Name implements trait:
+  impl core::convert::From<alloc::string::String> for s2n_quic::server::Name
+
+struct s2n_quic::server::Name implements trait:
+  impl core::fmt::Debug for s2n_quic::server::Name
+
+struct s2n_quic::server::Name implements trait:
+  impl core::marker::Send for s2n_quic::server::Name
+
+struct s2n_quic::server::Name implements trait:
+  impl core::marker::Sync for s2n_quic::server::Name
+
+struct s2n_quic::server::Name implements trait:
+  impl core::marker::Unpin for s2n_quic::server::Name
+
+struct s2n_quic::server::Name implements trait:
+  impl core::ops::deref::Deref for s2n_quic::server::Name
+
+struct s2n_quic::server::Name implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::server::Name
+
+struct s2n_quic::server::Name implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::server::Name
+
+struct s2n_quic::server::Name implements trait:
+  impl<'_> core::convert::From<&'_ str> for s2n_quic::server::Name
+
+struct s2n_quic::server::Name exports function:
+  pub const fn as_bytes(&self) -> &[u8]
+
+struct s2n_quic::server::Name exports function:
+  pub const fn as_ptr(&self) -> *const u8
+
+struct s2n_quic::server::Name exports function:
+  pub const fn is_empty(&self) -> bool
+
+struct s2n_quic::server::Name exports function:
+  pub const fn len(&self) -> usize
+
+struct s2n_quic::server::Name exports function:
+  pub fn bytes(&self) -> core::str::iter::Bytes<'_>
+
+struct s2n_quic::server::Name exports function:
+  pub fn char_indices(&self) -> core::str::iter::CharIndices<'_>
+
+struct s2n_quic::server::Name exports function:
+  pub fn chars(&self) -> core::str::iter::Chars<'_>
+
+struct s2n_quic::server::Name exports function:
+  pub fn contains<'a, P>(&'a self, pat: P) -> bool where
+  P: core::str::pattern::Pattern<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn encode_utf16(&self) -> core::str::iter::EncodeUtf16<'_>
+
+struct s2n_quic::server::Name exports function:
+  pub fn ends_with<'a, P>(&'a self, pat: P) -> bool where
+  P: core::str::pattern::Pattern<'a>,
+  <P as core::str::pattern::Pattern<'a>>::core::str::pattern::Pattern::Searcher: core::str::pattern::ReverseSearcher<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn eq_ignore_ascii_case(&self, other: &str) -> bool
+
+struct s2n_quic::server::Name exports function:
+  pub fn escape_debug(&self) -> core::str::iter::EscapeDebug<'_>
+
+struct s2n_quic::server::Name exports function:
+  pub fn escape_default(&self) -> core::str::iter::EscapeDefault<'_>
+
+struct s2n_quic::server::Name exports function:
+  pub fn escape_unicode(&self) -> core::str::iter::EscapeUnicode<'_>
+
+struct s2n_quic::server::Name exports function:
+  pub fn find<'a, P>(&'a self, pat: P) -> core::option::Option<usize> where
+  P: core::str::pattern::Pattern<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn get<I>(&self, i: I) -> core::option::Option<&<I as core::slice::index::SliceIndex<str>>::core::slice::index::SliceIndex::Output> where
+  I: core::slice::index::SliceIndex<str>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn into_bytes(self) -> bytes::bytes::Bytes
+
+struct s2n_quic::server::Name exports function:
+  pub fn is_ascii(&self) -> bool
+
+struct s2n_quic::server::Name exports function:
+  pub fn is_char_boundary(&self, index: usize) -> bool
+
+struct s2n_quic::server::Name exports function:
+  pub fn lines(&self) -> core::str::iter::Lines<'_>
+
+struct s2n_quic::server::Name exports function:
+  pub fn lines_any(&self) -> core::str::iter::LinesAny<'_>
+
+struct s2n_quic::server::Name exports function:
+  pub fn match_indices<'a, P>(&'a self, pat: P) -> core::str::iter::MatchIndices<'a, P> where
+  P: core::str::pattern::Pattern<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn matches<'a, P>(&'a self, pat: P) -> core::str::iter::Matches<'a, P> where
+  P: core::str::pattern::Pattern<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn parse<F>(&self) -> core::result::Result<F, <F as core::str::traits::FromStr>::core::str::traits::FromStr::Err> where
+  F: core::str::traits::FromStr,
+
+struct s2n_quic::server::Name exports function:
+  pub fn repeat(&self, n: usize) -> alloc::string::String
+
+struct s2n_quic::server::Name exports function:
+  pub fn rfind<'a, P>(&'a self, pat: P) -> core::option::Option<usize> where
+  P: core::str::pattern::Pattern<'a>,
+  <P as core::str::pattern::Pattern<'a>>::core::str::pattern::Pattern::Searcher: core::str::pattern::ReverseSearcher<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn rmatch_indices<'a, P>(&'a self, pat: P) -> core::str::iter::RMatchIndices<'a, P> where
+  P: core::str::pattern::Pattern<'a>,
+  <P as core::str::pattern::Pattern<'a>>::core::str::pattern::Pattern::Searcher: core::str::pattern::ReverseSearcher<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn rmatches<'a, P>(&'a self, pat: P) -> core::str::iter::RMatches<'a, P> where
+  P: core::str::pattern::Pattern<'a>,
+  <P as core::str::pattern::Pattern<'a>>::core::str::pattern::Pattern::Searcher: core::str::pattern::ReverseSearcher<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn rsplit<'a, P>(&'a self, pat: P) -> core::str::iter::RSplit<'a, P> where
+  P: core::str::pattern::Pattern<'a>,
+  <P as core::str::pattern::Pattern<'a>>::core::str::pattern::Pattern::Searcher: core::str::pattern::ReverseSearcher<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn rsplit_once<'a, P>(&'a self, delimiter: P) -> core::option::Option<(&'a str, &'a str)> where
+  P: core::str::pattern::Pattern<'a>,
+  <P as core::str::pattern::Pattern<'a>>::core::str::pattern::Pattern::Searcher: core::str::pattern::ReverseSearcher<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn rsplit_terminator<'a, P>(&'a self, pat: P) -> core::str::iter::RSplitTerminator<'a, P> where
+  P: core::str::pattern::Pattern<'a>,
+  <P as core::str::pattern::Pattern<'a>>::core::str::pattern::Pattern::Searcher: core::str::pattern::ReverseSearcher<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn rsplitn<'a, P>(&'a self, n: usize, pat: P) -> core::str::iter::RSplitN<'a, P> where
+  P: core::str::pattern::Pattern<'a>,
+  <P as core::str::pattern::Pattern<'a>>::core::str::pattern::Pattern::Searcher: core::str::pattern::ReverseSearcher<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn split<'a, P>(&'a self, pat: P) -> core::str::iter::Split<'a, P> where
+  P: core::str::pattern::Pattern<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn split_ascii_whitespace(&self) -> core::str::iter::SplitAsciiWhitespace<'_>
+
+struct s2n_quic::server::Name exports function:
+  pub fn split_at(&self, mid: usize) -> (&str, &str)
+
+struct s2n_quic::server::Name exports function:
+  pub fn split_inclusive<'a, P>(&'a self, pat: P) -> core::str::iter::SplitInclusive<'a, P> where
+  P: core::str::pattern::Pattern<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn split_once<'a, P>(&'a self, delimiter: P) -> core::option::Option<(&'a str, &'a str)> where
+  P: core::str::pattern::Pattern<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn split_terminator<'a, P>(&'a self, pat: P) -> core::str::iter::SplitTerminator<'a, P> where
+  P: core::str::pattern::Pattern<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn split_whitespace(&self) -> core::str::iter::SplitWhitespace<'_>
+
+struct s2n_quic::server::Name exports function:
+  pub fn splitn<'a, P>(&'a self, n: usize, pat: P) -> core::str::iter::SplitN<'a, P> where
+  P: core::str::pattern::Pattern<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn starts_with<'a, P>(&'a self, pat: P) -> bool where
+  P: core::str::pattern::Pattern<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn to_ascii_lowercase(&self) -> alloc::string::String
+
+struct s2n_quic::server::Name exports function:
+  pub fn to_ascii_uppercase(&self) -> alloc::string::String
+
+struct s2n_quic::server::Name exports function:
+  pub fn to_lowercase(&self) -> alloc::string::String
+
+struct s2n_quic::server::Name exports function:
+  pub fn to_uppercase(&self) -> alloc::string::String
+
+struct s2n_quic::server::Name exports function:
+  pub fn trim_left(&self) -> &str
+
+struct s2n_quic::server::Name exports function:
+  pub fn trim_left_matches<'a, P>(&'a self, pat: P) -> &'a str where
+  P: core::str::pattern::Pattern<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub fn trim_right(&self) -> &str
+
+struct s2n_quic::server::Name exports function:
+  pub fn trim_right_matches<'a, P>(&'a self, pat: P) -> &'a str where
+  P: core::str::pattern::Pattern<'a>,
+  <P as core::str::pattern::Pattern<'a>>::core::str::pattern::Pattern::Searcher: core::str::pattern::ReverseSearcher<'a>,
+
+struct s2n_quic::server::Name exports function:
+  pub unsafe fn get_unchecked<I>(&self, i: I) -> &<I as core::slice::index::SliceIndex<str>>::core::slice::index::SliceIndex::Output where
+  I: core::slice::index::SliceIndex<str>,
+
+struct s2n_quic::server::Name exports function:
+  pub unsafe fn slice_unchecked(&self, begin: usize, end: usize) -> &str
+
+struct s2n_quic::server::Server implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::server::Server
+
+struct s2n_quic::server::Server implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::server::Server
+
+struct s2n_quic::server::Server implements trait:
+  impl core::fmt::Debug for s2n_quic::server::Server
+
+struct s2n_quic::server::Server implements trait:
+  impl core::marker::Send for s2n_quic::server::Server
+
+struct s2n_quic::server::Server implements trait:
+  impl core::marker::Sync for s2n_quic::server::Server
+
+struct s2n_quic::server::Server implements trait:
+  impl core::marker::Unpin for s2n_quic::server::Server
+
+struct s2n_quic::server::Server implements trait:
+  impl futures_core::stream::Stream for s2n_quic::server::Server
+
+struct s2n_quic::server::Server exports function:
+  pub async fn accept(&mut self) -> core::option::Option<s2n_quic::connection::Connection>
+
+struct s2n_quic::server::Server exports function:
+  pub fn builder() -> s2n_quic::server::Builder<impl s2n_quic::server::ServerProviders>
+
+struct s2n_quic::server::Server exports function:
+  pub fn local_addr(&self) -> core::result::Result<std::net::addr::SocketAddr, std::io::error::Error>
+
+struct s2n_quic::server::Server exports function:
+  pub fn poll_accept(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<core::option::Option<s2n_quic::connection::Connection>>
+
+module s2n_quic::stream exports struct:
+  s2n_quic::stream::BidirectionalStream
+
+module s2n_quic::stream exports enum:
+  s2n_quic::stream::Error
+
+module s2n_quic::stream exports enum:
+  s2n_quic::stream::LocalStream
+
+module s2n_quic::stream exports enum:
+  s2n_quic::stream::PeerStream
+
+module s2n_quic::stream exports struct:
+  s2n_quic::stream::ReceiveStream
+
+module s2n_quic::stream exports type:
+  s2n_quic::stream::Result
+
+module s2n_quic::stream exports struct:
+  s2n_quic::stream::SendStream
+
+module s2n_quic::stream exports trait:
+  s2n_quic::stream::SplittableStream
+
+module s2n_quic::stream exports enum:
+  s2n_quic::stream::Stream
+
+module s2n_quic::stream exports enum:
+  s2n_quic::stream::Type
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::stream::BidirectionalStream
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::stream::BidirectionalStream
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl core::convert::From<s2n_quic::stream::BidirectionalStream> for s2n_quic::stream::LocalStream
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl core::convert::From<s2n_quic::stream::BidirectionalStream> for s2n_quic::stream::PeerStream
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl core::convert::From<s2n_quic::stream::BidirectionalStream> for s2n_quic::stream::Stream
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl core::fmt::Debug for s2n_quic::stream::BidirectionalStream
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl core::marker::Send for s2n_quic::stream::BidirectionalStream
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl core::marker::Sync for s2n_quic::stream::BidirectionalStream
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl core::marker::Unpin for s2n_quic::stream::BidirectionalStream
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl futures_core::stream::Stream for s2n_quic::stream::BidirectionalStream
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl futures_io::if_std::AsyncRead for s2n_quic::stream::BidirectionalStream
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl futures_io::if_std::AsyncWrite for s2n_quic::stream::BidirectionalStream
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl futures_sink::Sink<bytes::bytes::Bytes> for s2n_quic::stream::BidirectionalStream
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl s2n_quic::stream::SplittableStream for s2n_quic::stream::BidirectionalStream
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl tokio::io::async_read::AsyncRead for s2n_quic::stream::BidirectionalStream
+
+struct s2n_quic::stream::BidirectionalStream implements trait:
+  impl tokio::io::async_write::AsyncWrite for s2n_quic::stream::BidirectionalStream
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub async fn close(&mut self) -> s2n_quic::stream::Result<()>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub async fn flush(&mut self) -> s2n_quic::stream::Result<()>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub async fn receive(&mut self) -> s2n_quic::stream::Result<core::option::Option<bytes::bytes::Bytes>>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub async fn receive_vectored(
+  &mut self,
+  chunks: &mut [bytes::bytes::Bytes]) -> s2n_quic::stream::Result<(usize, bool)>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub async fn send(&mut self, data: bytes::bytes::Bytes) -> s2n_quic::stream::Result<()>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub async fn send_vectored(&mut self, chunks: &mut [bytes::bytes::Bytes]) -> s2n_quic::stream::Result<()>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub fn connection(&self) -> s2n_quic::connection::Handle
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub fn finish(&mut self) -> s2n_quic::stream::Result<()>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub fn id(&self) -> u64
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub fn poll_close(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<()>>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub fn poll_flush(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<()>>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub fn poll_receive(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<core::option::Option<bytes::bytes::Bytes>>>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub fn poll_receive_vectored(
+  &mut self,
+  chunks: &mut [bytes::bytes::Bytes],
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<(usize, bool)>>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub fn poll_send(
+  &mut self,
+  chunk: &mut bytes::bytes::Bytes,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<()>>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub fn poll_send_ready(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<usize>>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub fn poll_send_vectored(
+  &mut self,
+  chunks: &mut [bytes::bytes::Bytes],
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<usize>>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub fn reset(&mut self, error_code: s2n_quic::application::Error) -> s2n_quic::stream::Result<()>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub fn send_data(&mut self, chunk: bytes::bytes::Bytes) -> s2n_quic::stream::Result<()>
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub fn split(self) -> (s2n_quic::stream::ReceiveStream, s2n_quic::stream::SendStream)
+
+struct s2n_quic::stream::BidirectionalStream exports function:
+  pub fn stop_sending(&mut self, error_code: s2n_quic::application::Error) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::Error is non-exhaustive
+
+enum s2n_quic::stream::Error exports variant:
+  ConnectionError
+
+enum s2n_quic::stream::Error exports variant:
+  InvalidStream
+
+enum s2n_quic::stream::Error exports variant:
+  MaxStreamDataSizeExceeded
+
+enum s2n_quic::stream::Error exports variant:
+  NonEmptyOutput
+
+enum s2n_quic::stream::Error exports variant:
+  NonReadable
+
+enum s2n_quic::stream::Error exports variant:
+  NonWritable
+
+enum s2n_quic::stream::Error exports variant:
+  SendAfterFinish
+
+enum s2n_quic::stream::Error exports variant:
+  SendingBlocked
+
+enum s2n_quic::stream::Error exports variant:
+  StreamReset
+
+enum s2n_quic::stream::Error implements trait:
+  impl core::clone::Clone for s2n_quic::stream::Error
+
+enum s2n_quic::stream::Error implements trait:
+  impl core::cmp::PartialEq<s2n_quic::stream::Error> for s2n_quic::stream::Error
+
+enum s2n_quic::stream::Error implements trait:
+  impl core::convert::From<s2n_quic::connection::Error> for s2n_quic::stream::Error
+
+enum s2n_quic::stream::Error implements trait:
+  impl core::convert::From<s2n_quic_core::transport::error::Error> for s2n_quic::stream::Error
+
+enum s2n_quic::stream::Error implements trait:
+  impl core::fmt::Debug for s2n_quic::stream::Error
+
+enum s2n_quic::stream::Error implements trait:
+  impl core::fmt::Display for s2n_quic::stream::Error
+
+enum s2n_quic::stream::Error implements trait:
+  impl core::marker::Send for s2n_quic::stream::Error
+
+enum s2n_quic::stream::Error implements trait:
+  impl core::marker::Sync for s2n_quic::stream::Error
+
+enum s2n_quic::stream::Error implements trait:
+  impl core::marker::Unpin for s2n_quic::stream::Error
+
+enum s2n_quic::stream::Error implements trait:
+  impl s2n_quic_core::application::error::TryInto for s2n_quic::stream::Error
+
+enum s2n_quic::stream::Error implements trait:
+  impl std::error::Error for s2n_quic::stream::Error
+
+enum s2n_quic::stream::Error implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::stream::Error
+
+enum s2n_quic::stream::Error implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::stream::Error
+
+enum s2n_quic::stream::Error implements trait:
+  impl<'a> core::convert::From<s2n_quic_core::frame::connection_close::ConnectionClose<'a>> for s2n_quic::stream::Error
+
+enum s2n_quic::stream::Error exports function:
+  pub fn source(&self) -> &'static core::panic::Location<'static>
+
+variant s2n_quic::stream::Error::ConnectionError is non-exhaustive
+
+variant s2n_quic::stream::Error::ConnectionError exports field:
+  error:
+  s2n_quic::connection::Error
+
+variant s2n_quic::stream::Error::InvalidStream is non-exhaustive
+
+variant s2n_quic::stream::Error::InvalidStream exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::stream::Error::MaxStreamDataSizeExceeded is non-exhaustive
+
+variant s2n_quic::stream::Error::MaxStreamDataSizeExceeded exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::stream::Error::NonEmptyOutput is non-exhaustive
+
+variant s2n_quic::stream::Error::NonEmptyOutput exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::stream::Error::NonReadable is non-exhaustive
+
+variant s2n_quic::stream::Error::NonReadable exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::stream::Error::NonWritable is non-exhaustive
+
+variant s2n_quic::stream::Error::NonWritable exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::stream::Error::SendAfterFinish is non-exhaustive
+
+variant s2n_quic::stream::Error::SendAfterFinish exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::stream::Error::SendingBlocked is non-exhaustive
+
+variant s2n_quic::stream::Error::SendingBlocked exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+variant s2n_quic::stream::Error::StreamReset is non-exhaustive
+
+variant s2n_quic::stream::Error::StreamReset exports field:
+  error:
+  s2n_quic::application::Error
+
+variant s2n_quic::stream::Error::StreamReset exports field:
+  source:
+  &'static core::panic::Location<'static>
+
+enum s2n_quic::stream::LocalStream exports variant:
+  Bidirectional(s2n_quic::stream::BidirectionalStream)
+
+enum s2n_quic::stream::LocalStream exports variant:
+  Send(s2n_quic::stream::SendStream)
+
+enum s2n_quic::stream::LocalStream implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::stream::LocalStream
+
+enum s2n_quic::stream::LocalStream implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::stream::LocalStream
+
+enum s2n_quic::stream::LocalStream implements trait:
+  impl core::convert::From<s2n_quic::stream::BidirectionalStream> for s2n_quic::stream::LocalStream
+
+enum s2n_quic::stream::LocalStream implements trait:
+  impl core::convert::From<s2n_quic::stream::SendStream> for s2n_quic::stream::LocalStream
+
+enum s2n_quic::stream::LocalStream implements trait:
+  impl core::fmt::Debug for s2n_quic::stream::LocalStream
+
+enum s2n_quic::stream::LocalStream implements trait:
+  impl core::marker::Send for s2n_quic::stream::LocalStream
+
+enum s2n_quic::stream::LocalStream implements trait:
+  impl core::marker::Sync for s2n_quic::stream::LocalStream
+
+enum s2n_quic::stream::LocalStream implements trait:
+  impl core::marker::Unpin for s2n_quic::stream::LocalStream
+
+enum s2n_quic::stream::LocalStream implements trait:
+  impl futures_core::stream::Stream for s2n_quic::stream::LocalStream
+
+enum s2n_quic::stream::LocalStream implements trait:
+  impl futures_io::if_std::AsyncRead for s2n_quic::stream::LocalStream
+
+enum s2n_quic::stream::LocalStream implements trait:
+  impl futures_io::if_std::AsyncWrite for s2n_quic::stream::LocalStream
+
+enum s2n_quic::stream::LocalStream implements trait:
+  impl futures_sink::Sink<bytes::bytes::Bytes> for s2n_quic::stream::LocalStream
+
+enum s2n_quic::stream::LocalStream implements trait:
+  impl s2n_quic::stream::SplittableStream for s2n_quic::stream::LocalStream
+
+enum s2n_quic::stream::LocalStream implements trait:
+  impl tokio::io::async_read::AsyncRead for s2n_quic::stream::LocalStream
+
+enum s2n_quic::stream::LocalStream implements trait:
+  impl tokio::io::async_write::AsyncWrite for s2n_quic::stream::LocalStream
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub async fn close(&mut self) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub async fn flush(&mut self) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub async fn receive(&mut self) -> s2n_quic::stream::Result<core::option::Option<bytes::bytes::Bytes>>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub async fn receive_vectored(
+  &mut self,
+  chunks: &mut [bytes::bytes::Bytes]) -> s2n_quic::stream::Result<(usize, bool)>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub async fn send(&mut self, data: bytes::bytes::Bytes) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub async fn send_vectored(&mut self, chunks: &mut [bytes::bytes::Bytes]) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub fn connection(&self) -> s2n_quic::connection::Handle
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub fn finish(&mut self) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub fn id(&self) -> u64
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub fn poll_close(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<()>>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub fn poll_flush(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<()>>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub fn poll_receive(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<core::option::Option<bytes::bytes::Bytes>>>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub fn poll_receive_vectored(
+  &mut self,
+  chunks: &mut [bytes::bytes::Bytes],
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<(usize, bool)>>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub fn poll_send(
+  &mut self,
+  chunk: &mut bytes::bytes::Bytes,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<()>>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub fn poll_send_ready(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<usize>>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub fn poll_send_vectored(
+  &mut self,
+  chunks: &mut [bytes::bytes::Bytes],
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<usize>>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub fn reset(&mut self, error_code: s2n_quic::application::Error) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub fn send_data(&mut self, chunk: bytes::bytes::Bytes) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub fn split(self) -> (core::option::Option<s2n_quic::stream::ReceiveStream>, core::option::Option<s2n_quic::stream::SendStream>)
+
+enum s2n_quic::stream::LocalStream exports function:
+  pub fn stop_sending(&mut self, error_code: s2n_quic::application::Error) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::PeerStream exports variant:
+  Bidirectional(s2n_quic::stream::BidirectionalStream)
+
+enum s2n_quic::stream::PeerStream exports variant:
+  Receive(s2n_quic::stream::ReceiveStream)
+
+enum s2n_quic::stream::PeerStream implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::stream::PeerStream
+
+enum s2n_quic::stream::PeerStream implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::stream::PeerStream
+
+enum s2n_quic::stream::PeerStream implements trait:
+  impl core::convert::From<s2n_quic::stream::BidirectionalStream> for s2n_quic::stream::PeerStream
+
+enum s2n_quic::stream::PeerStream implements trait:
+  impl core::convert::From<s2n_quic::stream::ReceiveStream> for s2n_quic::stream::PeerStream
+
+enum s2n_quic::stream::PeerStream implements trait:
+  impl core::fmt::Debug for s2n_quic::stream::PeerStream
+
+enum s2n_quic::stream::PeerStream implements trait:
+  impl core::marker::Send for s2n_quic::stream::PeerStream
+
+enum s2n_quic::stream::PeerStream implements trait:
+  impl core::marker::Sync for s2n_quic::stream::PeerStream
+
+enum s2n_quic::stream::PeerStream implements trait:
+  impl core::marker::Unpin for s2n_quic::stream::PeerStream
+
+enum s2n_quic::stream::PeerStream implements trait:
+  impl futures_core::stream::Stream for s2n_quic::stream::PeerStream
+
+enum s2n_quic::stream::PeerStream implements trait:
+  impl futures_io::if_std::AsyncRead for s2n_quic::stream::PeerStream
+
+enum s2n_quic::stream::PeerStream implements trait:
+  impl futures_io::if_std::AsyncWrite for s2n_quic::stream::PeerStream
+
+enum s2n_quic::stream::PeerStream implements trait:
+  impl futures_sink::Sink<bytes::bytes::Bytes> for s2n_quic::stream::PeerStream
+
+enum s2n_quic::stream::PeerStream implements trait:
+  impl s2n_quic::stream::SplittableStream for s2n_quic::stream::PeerStream
+
+enum s2n_quic::stream::PeerStream implements trait:
+  impl tokio::io::async_read::AsyncRead for s2n_quic::stream::PeerStream
+
+enum s2n_quic::stream::PeerStream implements trait:
+  impl tokio::io::async_write::AsyncWrite for s2n_quic::stream::PeerStream
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub async fn close(&mut self) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub async fn flush(&mut self) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub async fn receive(&mut self) -> s2n_quic::stream::Result<core::option::Option<bytes::bytes::Bytes>>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub async fn receive_vectored(
+  &mut self,
+  chunks: &mut [bytes::bytes::Bytes]) -> s2n_quic::stream::Result<(usize, bool)>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub async fn send(&mut self, data: bytes::bytes::Bytes) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub async fn send_vectored(&mut self, chunks: &mut [bytes::bytes::Bytes]) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub fn connection(&self) -> s2n_quic::connection::Handle
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub fn finish(&mut self) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub fn id(&self) -> u64
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub fn poll_close(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<()>>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub fn poll_flush(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<()>>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub fn poll_receive(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<core::option::Option<bytes::bytes::Bytes>>>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub fn poll_receive_vectored(
+  &mut self,
+  chunks: &mut [bytes::bytes::Bytes],
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<(usize, bool)>>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub fn poll_send(
+  &mut self,
+  chunk: &mut bytes::bytes::Bytes,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<()>>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub fn poll_send_ready(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<usize>>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub fn poll_send_vectored(
+  &mut self,
+  chunks: &mut [bytes::bytes::Bytes],
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<usize>>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub fn reset(&mut self, error_code: s2n_quic::application::Error) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub fn send_data(&mut self, chunk: bytes::bytes::Bytes) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub fn split(self) -> (core::option::Option<s2n_quic::stream::ReceiveStream>, core::option::Option<s2n_quic::stream::SendStream>)
+
+enum s2n_quic::stream::PeerStream exports function:
+  pub fn stop_sending(&mut self, error_code: s2n_quic::application::Error) -> s2n_quic::stream::Result<()>
+
+struct s2n_quic::stream::ReceiveStream implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::stream::ReceiveStream
+
+struct s2n_quic::stream::ReceiveStream implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::stream::ReceiveStream
+
+struct s2n_quic::stream::ReceiveStream implements trait:
+  impl core::convert::From<s2n_quic::stream::ReceiveStream> for s2n_quic::stream::PeerStream
+
+struct s2n_quic::stream::ReceiveStream implements trait:
+  impl core::convert::From<s2n_quic::stream::ReceiveStream> for s2n_quic::stream::Stream
+
+struct s2n_quic::stream::ReceiveStream implements trait:
+  impl core::fmt::Debug for s2n_quic::stream::ReceiveStream
+
+struct s2n_quic::stream::ReceiveStream implements trait:
+  impl core::marker::Send for s2n_quic::stream::ReceiveStream
+
+struct s2n_quic::stream::ReceiveStream implements trait:
+  impl core::marker::Sync for s2n_quic::stream::ReceiveStream
+
+struct s2n_quic::stream::ReceiveStream implements trait:
+  impl core::marker::Unpin for s2n_quic::stream::ReceiveStream
+
+struct s2n_quic::stream::ReceiveStream implements trait:
+  impl futures_core::stream::Stream for s2n_quic::stream::ReceiveStream
+
+struct s2n_quic::stream::ReceiveStream implements trait:
+  impl futures_io::if_std::AsyncRead for s2n_quic::stream::ReceiveStream
+
+struct s2n_quic::stream::ReceiveStream implements trait:
+  impl s2n_quic::stream::SplittableStream for s2n_quic::stream::ReceiveStream
+
+struct s2n_quic::stream::ReceiveStream implements trait:
+  impl tokio::io::async_read::AsyncRead for s2n_quic::stream::ReceiveStream
+
+struct s2n_quic::stream::ReceiveStream exports function:
+  pub async fn receive(&mut self) -> s2n_quic::stream::Result<core::option::Option<bytes::bytes::Bytes>>
+
+struct s2n_quic::stream::ReceiveStream exports function:
+  pub async fn receive_vectored(
+  &mut self,
+  chunks: &mut [bytes::bytes::Bytes]) -> s2n_quic::stream::Result<(usize, bool)>
+
+struct s2n_quic::stream::ReceiveStream exports function:
+  pub fn connection(&self) -> s2n_quic::connection::Handle
+
+struct s2n_quic::stream::ReceiveStream exports function:
+  pub fn id(&self) -> u64
+
+struct s2n_quic::stream::ReceiveStream exports function:
+  pub fn poll_receive(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<core::option::Option<bytes::bytes::Bytes>>>
+
+struct s2n_quic::stream::ReceiveStream exports function:
+  pub fn poll_receive_vectored(
+  &mut self,
+  chunks: &mut [bytes::bytes::Bytes],
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<(usize, bool)>>
+
+struct s2n_quic::stream::ReceiveStream exports function:
+  pub fn stop_sending(&mut self, error_code: s2n_quic::application::Error) -> s2n_quic::stream::Result<()>
+
+typedef s2n_quic::stream::Result exports typedef:
+  type Result<T, E
+  =
+  s2n_quic::stream::Error> = core::result::Result<T, E>;
+
+struct s2n_quic::stream::SendStream implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::stream::SendStream
+
+struct s2n_quic::stream::SendStream implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::stream::SendStream
+
+struct s2n_quic::stream::SendStream implements trait:
+  impl core::convert::From<s2n_quic::stream::SendStream> for s2n_quic::stream::LocalStream
+
+struct s2n_quic::stream::SendStream implements trait:
+  impl core::convert::From<s2n_quic::stream::SendStream> for s2n_quic::stream::Stream
+
+struct s2n_quic::stream::SendStream implements trait:
+  impl core::fmt::Debug for s2n_quic::stream::SendStream
+
+struct s2n_quic::stream::SendStream implements trait:
+  impl core::marker::Send for s2n_quic::stream::SendStream
+
+struct s2n_quic::stream::SendStream implements trait:
+  impl core::marker::Sync for s2n_quic::stream::SendStream
+
+struct s2n_quic::stream::SendStream implements trait:
+  impl core::marker::Unpin for s2n_quic::stream::SendStream
+
+struct s2n_quic::stream::SendStream implements trait:
+  impl futures_io::if_std::AsyncWrite for s2n_quic::stream::SendStream
+
+struct s2n_quic::stream::SendStream implements trait:
+  impl futures_sink::Sink<bytes::bytes::Bytes> for s2n_quic::stream::SendStream
+
+struct s2n_quic::stream::SendStream implements trait:
+  impl s2n_quic::stream::SplittableStream for s2n_quic::stream::SendStream
+
+struct s2n_quic::stream::SendStream implements trait:
+  impl tokio::io::async_write::AsyncWrite for s2n_quic::stream::SendStream
+
+struct s2n_quic::stream::SendStream exports function:
+  pub async fn close(&mut self) -> s2n_quic::stream::Result<()>
+
+struct s2n_quic::stream::SendStream exports function:
+  pub async fn flush(&mut self) -> s2n_quic::stream::Result<()>
+
+struct s2n_quic::stream::SendStream exports function:
+  pub async fn send(&mut self, data: bytes::bytes::Bytes) -> s2n_quic::stream::Result<()>
+
+struct s2n_quic::stream::SendStream exports function:
+  pub async fn send_vectored(&mut self, chunks: &mut [bytes::bytes::Bytes]) -> s2n_quic::stream::Result<()>
+
+struct s2n_quic::stream::SendStream exports function:
+  pub fn connection(&self) -> s2n_quic::connection::Handle
+
+struct s2n_quic::stream::SendStream exports function:
+  pub fn finish(&mut self) -> s2n_quic::stream::Result<()>
+
+struct s2n_quic::stream::SendStream exports function:
+  pub fn id(&self) -> u64
+
+struct s2n_quic::stream::SendStream exports function:
+  pub fn poll_close(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<()>>
+
+struct s2n_quic::stream::SendStream exports function:
+  pub fn poll_flush(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<()>>
+
+struct s2n_quic::stream::SendStream exports function:
+  pub fn poll_send(
+  &mut self,
+  chunk: &mut bytes::bytes::Bytes,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<()>>
+
+struct s2n_quic::stream::SendStream exports function:
+  pub fn poll_send_ready(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<usize>>
+
+struct s2n_quic::stream::SendStream exports function:
+  pub fn poll_send_vectored(
+  &mut self,
+  chunks: &mut [bytes::bytes::Bytes],
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<usize>>
+
+struct s2n_quic::stream::SendStream exports function:
+  pub fn reset(&mut self, error_code: s2n_quic::application::Error) -> s2n_quic::stream::Result<()>
+
+struct s2n_quic::stream::SendStream exports function:
+  pub fn send_data(&mut self, chunk: bytes::bytes::Bytes) -> s2n_quic::stream::Result<()>
+
+trait s2n_quic::stream::SplittableStream exports function:
+  fn split(self) -> (core::option::Option<s2n_quic::stream::ReceiveStream>, core::option::Option<s2n_quic::stream::SendStream>)
+
+enum s2n_quic::stream::Stream exports variant:
+  Bidirectional(s2n_quic::stream::BidirectionalStream)
+
+enum s2n_quic::stream::Stream exports variant:
+  Receive(s2n_quic::stream::ReceiveStream)
+
+enum s2n_quic::stream::Stream exports variant:
+  Send(s2n_quic::stream::SendStream)
+
+enum s2n_quic::stream::Stream implements trait:
+  impl !std::panic::RefUnwindSafe for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream implements trait:
+  impl !std::panic::UnwindSafe for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream implements trait:
+  impl core::convert::From<s2n_quic::stream::BidirectionalStream> for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream implements trait:
+  impl core::convert::From<s2n_quic::stream::ReceiveStream> for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream implements trait:
+  impl core::convert::From<s2n_quic::stream::SendStream> for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream implements trait:
+  impl core::fmt::Debug for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream implements trait:
+  impl core::marker::Send for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream implements trait:
+  impl core::marker::Sync for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream implements trait:
+  impl core::marker::Unpin for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream implements trait:
+  impl futures_core::stream::Stream for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream implements trait:
+  impl futures_io::if_std::AsyncRead for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream implements trait:
+  impl futures_io::if_std::AsyncWrite for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream implements trait:
+  impl futures_sink::Sink<bytes::bytes::Bytes> for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream implements trait:
+  impl s2n_quic::stream::SplittableStream for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream implements trait:
+  impl tokio::io::async_read::AsyncRead for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream implements trait:
+  impl tokio::io::async_write::AsyncWrite for s2n_quic::stream::Stream
+
+enum s2n_quic::stream::Stream exports function:
+  pub async fn close(&mut self) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::Stream exports function:
+  pub async fn flush(&mut self) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::Stream exports function:
+  pub async fn receive(&mut self) -> s2n_quic::stream::Result<core::option::Option<bytes::bytes::Bytes>>
+
+enum s2n_quic::stream::Stream exports function:
+  pub async fn receive_vectored(
+  &mut self,
+  chunks: &mut [bytes::bytes::Bytes]) -> s2n_quic::stream::Result<(usize, bool)>
+
+enum s2n_quic::stream::Stream exports function:
+  pub async fn send(&mut self, data: bytes::bytes::Bytes) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::Stream exports function:
+  pub async fn send_vectored(&mut self, chunks: &mut [bytes::bytes::Bytes]) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::Stream exports function:
+  pub fn connection(&self) -> s2n_quic::connection::Handle
+
+enum s2n_quic::stream::Stream exports function:
+  pub fn finish(&mut self) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::Stream exports function:
+  pub fn id(&self) -> u64
+
+enum s2n_quic::stream::Stream exports function:
+  pub fn poll_close(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<()>>
+
+enum s2n_quic::stream::Stream exports function:
+  pub fn poll_flush(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<()>>
+
+enum s2n_quic::stream::Stream exports function:
+  pub fn poll_receive(
+  &mut self,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<core::option::Option<bytes::bytes::Bytes>>>
+
+enum s2n_quic::stream::Stream exports function:
+  pub fn poll_receive_vectored(
+  &mut self,
+  chunks: &mut [bytes::bytes::Bytes],
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<(usize, bool)>>
+
+enum s2n_quic::stream::Stream exports function:
+  pub fn poll_send(
+  &mut self,
+  chunk: &mut bytes::bytes::Bytes,
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<()>>
+
+enum s2n_quic::stream::Stream exports function:
+  pub fn poll_send_ready(&mut self, cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<usize>>
+
+enum s2n_quic::stream::Stream exports function:
+  pub fn poll_send_vectored(
+  &mut self,
+  chunks: &mut [bytes::bytes::Bytes],
+  cx: &mut core::task::wake::Context<'_>) -> core::task::poll::Poll<s2n_quic::stream::Result<usize>>
+
+enum s2n_quic::stream::Stream exports function:
+  pub fn reset(&mut self, error_code: s2n_quic::application::Error) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::Stream exports function:
+  pub fn send_data(&mut self, chunk: bytes::bytes::Bytes) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::Stream exports function:
+  pub fn split(self) -> (core::option::Option<s2n_quic::stream::ReceiveStream>, core::option::Option<s2n_quic::stream::SendStream>)
+
+enum s2n_quic::stream::Stream exports function:
+  pub fn stop_sending(&mut self, error_code: s2n_quic::application::Error) -> s2n_quic::stream::Result<()>
+
+enum s2n_quic::stream::Type exports variant:
+  Bidirectional
+
+enum s2n_quic::stream::Type exports variant:
+  Unidirectional
+
+enum s2n_quic::stream::Type implements trait:
+  impl core::clone::Clone for s2n_quic::stream::Type
+
+enum s2n_quic::stream::Type implements trait:
+  impl core::cmp::PartialEq<s2n_quic::stream::Type> for s2n_quic::stream::Type
+
+enum s2n_quic::stream::Type implements trait:
+  impl core::fmt::Debug for s2n_quic::stream::Type
+
+enum s2n_quic::stream::Type implements trait:
+  impl core::marker::Send for s2n_quic::stream::Type
+
+enum s2n_quic::stream::Type implements trait:
+  impl core::marker::Sync for s2n_quic::stream::Type
+
+enum s2n_quic::stream::Type implements trait:
+  impl core::marker::Unpin for s2n_quic::stream::Type
+
+enum s2n_quic::stream::Type implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::stream::Type
+
+enum s2n_quic::stream::Type implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::stream::Type
+
+enum s2n_quic::stream::Type implements trait:
+  impl<'a, '_> s2n_quic_core::event::IntoEvent<s2n_quic_core::event::generated::builder::StreamType> for &'_ s2n_quic::stream::Type
+
+enum s2n_quic::stream::Type exports function:
+  pub fn is_bidirectional(self) -> bool
+
+enum s2n_quic::stream::Type exports function:
+  pub fn is_unidirectional(self) -> bool
+
+

--- a/scripts/compliance
+++ b/scripts/compliance
@@ -7,8 +7,13 @@ mkdir -p target/compliance
 BLOB=${1:-main}
 
 # ensure the tool is built
-test -f target/release/duvet || \
-  cargo build --bin duvet --release
+if [ ! -f target/release/duvet ]; then
+  mkdir -p target/release
+  cd common/duvet
+  cargo build --release
+  cp target/release/duvet ../../target/release/duvet
+  cd ../..
+fi
 
 ./target/release/duvet \
   report \

--- a/scripts/docdiff
+++ b/scripts/docdiff
@@ -1,0 +1,14 @@
+#/usr/bin/env bash
+
+set -e
+
+# ensure the tool is built
+if [ ! -f target/release/docdiff ]; then
+  mkdir -p target/release
+  cd common/docdiff
+  cargo build --release
+  cp target/release/docdiff ../../target/release/docdiff
+  cd ../..
+fi
+
+./target/release/docdiff s2n-quic


### PR DESCRIPTION
### Description of changes: 

This change adds a `docdiff` tool to track public API changes with a `.snap` file. The tool generates the crate documentation with `cargo doc` and scrapes the HTML files for all of the exported structs, enums, traits, etc. and compares it against the `api.snap` file in the crate. This will ensure nothing in the public API changes without an explicit `cargo insta review`.

I tried getting semverver to work but it panicked in a few places and doesn't seem actively maintained (See #18)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

