### PR TITLE
release: push s2n-quic-qns to Amazon Elastic Container Registry Public

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -449,17 +449,9 @@ jobs:
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get -o Acquire::Retries=3 install -y gnuplot
 
-      - name: Login to GitHub Packages
-        if: github.event.pull_request
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Pull s2n-quic-qns:main
         if: github.event.pull_request
-        run: docker pull ghcr.io/aws/s2n-quic/s2n-quic-qns:main
+        run: docker pull public.ecr.aws/y1p7y6w8/s2n-quic-qns:main
 
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,8 @@ on:
   push:
     branches:
       - main
+    tags:
+      - "v*.*.*"
 
   pull_request:
     branches:
@@ -28,7 +30,7 @@ jobs:
       - name: Compute tags
         id: tags
         run: |
-          DOCKER_IMAGE=ghcr.io/aws/s2n-quic/s2n-quic-qns
+          DOCKER_IMAGE=public.ecr.aws/y1p7y6w8/s2n-quic-qns
           VERSION=main
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
@@ -40,12 +42,12 @@ jobs:
           fi
           echo "::set-output name=tags::${TAGS}"
 
-      - name: Login to GitHub Packages
+      - name: Login to Amazon Elastic Container Registry Public
         uses: docker/login-action@v1
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
       - name: Build and push image
         uses: docker/build-push-action@v2

--- a/quic/s2n-quic-qns/benchmark/docker-compose.yml
+++ b/quic/s2n-quic-qns/benchmark/docker-compose.yml
@@ -58,7 +58,7 @@ services:
         ipv6_address: fd00:cafe:cafe:100::100
 
   server-main:
-    image: ghcr.io/aws/s2n-quic/s2n-quic-qns:main
+    image: public.ecr.aws/y1p7y6w8/s2n-quic-qns:main
     container_name: server-main
     hostname: server
     stdin_open: true


### PR DESCRIPTION
### Description of changes: 

This change migrates publishing of the s2n-quic-qns image from GitHub container registry to Amazon Elastic Container Registry Public. I've also added a tags event to trigger the release workflow on so it is executed on tag pushes that match semver syntax.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

