### PR TITLE
ci: authenticate ECR pull

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -449,6 +449,15 @@ jobs:
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get -o Acquire::Retries=3 install -y gnuplot
 
+      # authenticate pull to avoid hitting pull quota
+      - name: Login to Amazon Elastic Container Registry Public
+        if: github.event.pull_request
+        uses: docker/login-action@v1
+        with:
+          registry: public.ecr.aws
+          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
       - name: Pull s2n-quic-qns:main
         if: github.event.pull_request
         run: docker pull public.ecr.aws/y1p7y6w8/s2n-quic-qns:main


### PR DESCRIPTION
### Description of changes: 

The service quota for unauthenticated pull requests to Amazon ECR is 1 per second, which we occasionally exceed. This change we login to Amazon ECR prior to pulling so that the service quota of 10 per second is applied.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

