### PR TITLE
netbench: fix test timer expiration

### DIFF
--- a/netbench/netbench/src/driver.rs
+++ b/netbench/netbench/src/driver.rs
@@ -64,10 +64,6 @@ impl<'a, C: Connection> Driver<'a, C> {
         let mut poll_accept = false;
         let mut all_ready = true;
 
-        if let Some(target) = timer::Provider::next_expiration(&self) {
-            all_ready |= timer.poll(target, cx).is_ready();
-        };
-
         trace.enter(now, 0, 0);
         let result = self.local_thread.poll(
             &mut self.connection,
@@ -127,6 +123,10 @@ impl<'a, C: Connection> Driver<'a, C> {
                 Poll::Pending => all_ready = false,
             }
         }
+
+        if let Some(target) = timer::Provider::next_expiration(&self) {
+            all_ready |= timer.poll(target, cx).is_ready();
+        };
 
         if all_ready {
             self.is_finished = true;

--- a/netbench/netbench/src/multiplex/stream.rs
+++ b/netbench/netbench/src/multiplex/stream.rs
@@ -137,6 +137,8 @@ pub struct Controller {
 
 impl Controller {
     pub fn new(local_window: u64, peer_window: u64) -> Self {
+        let local_window = local_window.max(1);
+        let peer_window = peer_window.max(1);
         Self {
             open_offset: 0,
             peer_window_offset: local_window,
@@ -165,7 +167,8 @@ impl Controller {
     }
 
     pub fn transmit(&mut self) -> Option<u64> {
-        if self.local_window_offset != self.transmitted_window_offset {
+        // send a max streams if we are using more than half capacity
+        if self.local_window_offset >= self.transmitted_window_offset * 2 {
             self.transmitted_window_offset = self.local_window_offset;
             Some(self.local_window_offset)
         } else {

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__checkpoint__client.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__checkpoint__client.snap
@@ -1,7 +1,7 @@
 ---
 source: netbench/src/multiplex.rs
-assertion_line: 635
-expression: (client_trace.1).as_str().unwrap()
+assertion_line: 685
+expression: client_trace.as_str().unwrap()
 
 ---
 0:00:00.000001: 0:0.0:exec: Scope { threads: [[OpenSendStream { stream_id: 0 }, SendRate { stream_id: 0, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 0, bytes: Byte(1000) }, Unpark { checkpoint: 0 }, Send { stream_id: 0, bytes: Byte(1000) }, SendFinish { stream_id: 0 }], [OpenSendStream { stream_id: 1 }, Park { checkpoint: 0 }, SendRate { stream_id: 1, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 1, bytes: Byte(1000) }, SendFinish { stream_id: 1 }]] }

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__checkpoint__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__checkpoint__server.snap
@@ -1,7 +1,7 @@
 ---
 source: netbench/src/multiplex.rs
-assertion_line: 637
-expression: (server_trace.1).as_str().unwrap()
+assertion_line: 685
+expression: server_trace.as_str().unwrap()
 
 ---
 0:00:00.000001: 1:accept: stream=0

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_max_streams__client.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_max_streams__client.snap
@@ -1,6 +1,6 @@
 ---
 source: netbench/src/multiplex.rs
-assertion_line: 598
+assertion_line: 641
 expression: client_trace.as_str().unwrap()
 
 ---

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_max_streams__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_max_streams__server.snap
@@ -1,6 +1,6 @@
 ---
 source: netbench/src/multiplex.rs
-assertion_line: 598
+assertion_line: 641
 expression: server_trace.as_str().unwrap()
 
 ---

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_stream_window__client.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_stream_window__client.snap
@@ -1,6 +1,6 @@
 ---
 source: netbench/src/multiplex.rs
-assertion_line: 596
+assertion_line: 622
 expression: client_trace.as_str().unwrap()
 
 ---

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_stream_window__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__low_stream_window__server.snap
@@ -1,6 +1,6 @@
 ---
 source: netbench/src/multiplex.rs
-assertion_line: 596
+assertion_line: 622
 expression: server_trace.as_str().unwrap()
 
 ---

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__multiple_streams__client.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__multiple_streams__client.snap
@@ -1,7 +1,7 @@
 ---
 source: netbench/src/multiplex.rs
-assertion_line: 617
-expression: (client_trace.1).as_str().unwrap()
+assertion_line: 667
+expression: client_trace.as_str().unwrap()
 
 ---
 0:00:00.000001: 0:0.0:exec: Scope { threads: [[OpenSendStream { stream_id: 0 }, SendRate { stream_id: 0, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 0, bytes: Byte(1000) }, SendFinish { stream_id: 0 }], [OpenSendStream { stream_id: 1 }, SendRate { stream_id: 1, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 1, bytes: Byte(1000) }, SendFinish { stream_id: 1 }], [OpenSendStream { stream_id: 2 }, SendRate { stream_id: 2, rate: Rate { bytes: Byte(100), period: 50ms } }, Send { stream_id: 2, bytes: Byte(1000) }, SendFinish { stream_id: 2 }]] }

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__multiple_streams__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__multiple_streams__server.snap
@@ -1,7 +1,7 @@
 ---
 source: netbench/src/multiplex.rs
-assertion_line: 619
-expression: (server_trace.1).as_str().unwrap()
+assertion_line: 667
+expression: server_trace.as_str().unwrap()
 
 ---
 0:00:00.000001: 1:accept: stream=0

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_slow_recv_stream__client.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_slow_recv_stream__client.snap
@@ -1,6 +1,6 @@
 ---
 source: netbench/src/multiplex.rs
-assertion_line: 587
+assertion_line: 610
 expression: client_trace.as_str().unwrap()
 
 ---

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_slow_recv_stream__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_slow_recv_stream__server.snap
@@ -1,10 +1,11 @@
 ---
 source: netbench/src/multiplex.rs
-assertion_line: 560
-expression: (server_trace.1).as_str().unwrap()
+assertion_line: 610
+expression: server_trace.as_str().unwrap()
 
 ---
 0:00:00.000001: 1:accept: stream=0
+0:00:00.000001: 1:1.0:exec: ReceiveRate { stream_id: 0, rate: Rate { bytes: Byte(100), period: 50ms } }
 0:00:00.000001: 1:1.0:exec: Receive { stream_id: 0, bytes: Byte(1000) }
 0:00:00.000001: 1:1.0:recv: stream=0, len=100
 0:00:00.050001: 1:1.0:recv: stream=0, len=100

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_slow_send_stream__client.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_slow_send_stream__client.snap
@@ -1,7 +1,7 @@
 ---
 source: netbench/src/multiplex.rs
-assertion_line: 560
-expression: (client_trace.1).as_str().unwrap()
+assertion_line: 598
+expression: client_trace.as_str().unwrap()
 
 ---
 0:00:00.000001: 0:0.0:exec: OpenSendStream { stream_id: 0 }

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_slow_send_stream__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_slow_send_stream__server.snap
@@ -1,0 +1,21 @@
+---
+source: netbench/src/multiplex.rs
+assertion_line: 598
+expression: server_trace.as_str().unwrap()
+
+---
+0:00:00.000001: 1:accept: stream=0
+0:00:00.000001: 1:1.0:exec: Receive { stream_id: 0, bytes: Byte(1000) }
+0:00:00.000001: 1:1.0:recv: stream=0, len=100
+0:00:00.050001: 1:1.0:recv: stream=0, len=100
+0:00:00.100001: 1:1.0:recv: stream=0, len=100
+0:00:00.150001: 1:1.0:recv: stream=0, len=100
+0:00:00.200001: 1:1.0:recv: stream=0, len=100
+0:00:00.250001: 1:1.0:recv: stream=0, len=100
+0:00:00.300001: 1:1.0:recv: stream=0, len=100
+0:00:00.350001: 1:1.0:recv: stream=0, len=100
+0:00:00.400001: 1:1.0:recv: stream=0, len=100
+0:00:00.450001: 1:1.0:recv: stream=0, len=100
+0:00:00.450001: 1:1.0:exec: ReceiveFinish { stream_id: 0 }
+0:00:00.450001: 1:1.0:recv finish: stream=0
+

--- a/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_stream__server.snap
+++ b/netbench/netbench/src/snapshots/netbench__multiplex__tests__single_stream__server.snap
@@ -1,7 +1,7 @@
 ---
 source: netbench/src/multiplex.rs
-assertion_line: 549
-expression: (server_trace.1).as_str().unwrap()
+assertion_line: 587
+expression: server_trace.as_str().unwrap()
 
 ---
 0:00:00.000001: 1:accept: stream=0

--- a/netbench/netbench/src/timer.rs
+++ b/netbench/netbench/src/timer.rs
@@ -31,13 +31,11 @@ impl Default for Testing {
 
 impl Testing {
     pub fn advance_pair(&mut self, other: &mut Self) -> Option<Timestamp> {
-        let target = self.target.map(|target| {
-            if let Some(other) = other.target {
-                target.min(other)
-            } else {
-                target
-            }
-        });
+        let target = match (self.target, other.target) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (a, None) => a,
+            (None, b) => b,
+        };
 
         if let Some(target) = target {
             self.set(target);


### PR DESCRIPTION
### Description of changes: 

After merging #1133, I found a bug with the testing timer expiration that only advances the timer if the client timer has a pending time. I've added a test to make sure it's working now. I've also cleaned up a few of the multiplexing closing logic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

