### PR TITLE
ci: update public ECR repo with custom alias

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -460,7 +460,7 @@ jobs:
 
       - name: Pull s2n-quic-qns:main
         if: github.event.pull_request
-        run: docker pull public.ecr.aws/y1p7y6w8/s2n-quic-qns:main
+        run: docker pull public.ecr.aws/s2n/s2n-quic-qns:main
 
       - uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Compute tags
         id: tags
         run: |
-          DOCKER_IMAGE=public.ecr.aws/y1p7y6w8/s2n-quic-qns
+          DOCKER_IMAGE=public.ecr.aws/s2n/s2n-quic-qns
           VERSION=main
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}

--- a/quic/s2n-quic-qns/benchmark/docker-compose.yml
+++ b/quic/s2n-quic-qns/benchmark/docker-compose.yml
@@ -58,7 +58,7 @@ services:
         ipv6_address: fd00:cafe:cafe:100::100
 
   server-main:
-    image: public.ecr.aws/y1p7y6w8/s2n-quic-qns:main
+    image: public.ecr.aws/s2n/s2n-quic-qns:main
     container_name: server-main
     hostname: server
     stdin_open: true


### PR DESCRIPTION
### Description of changes: 

This change updates the CI workflows to push/pull from the Amazon Elastic Container Repository using the "s2n" alias.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

