### PR TITLE
core: disable pacing when RTT is less than 2ms

### DIFF
--- a/quic/s2n-quic-core/src/recovery/pacing.rs
+++ b/quic/s2n-quic-core/src/recovery/pacing.rs
@@ -62,7 +62,6 @@ impl Pacer {
         slow_start: bool,
     ) {
         if rtt_estimator.smoothed_rtt() < MINIMUM_PACING_RTT {
-            self.next_packet_departure_time = None;
             return;
         }
 

--- a/quic/s2n-quic-core/src/recovery/pacing.rs
+++ b/quic/s2n-quic-core/src/recovery/pacing.rs
@@ -57,6 +57,12 @@ impl Pacer {
         max_datagram_size: u16,
         slow_start: bool,
     ) {
+        // low RTT networks should not using pacing since it'll take longer to wake up from
+        // a timer than it would deliver a packet
+        if rtt_estimator.smoothed_rtt() < Duration::from_millis(2) {
+            return;
+        }
+
         if self.capacity == 0 {
             if let Some(next_packet_departure_time) = self.next_packet_departure_time {
                 let interval = Self::interval(


### PR DESCRIPTION
### Description of changes: 

We currently pace out packets regardless of RTT. This can cause bandwidth limiting in networks where the RTT is low because it takes longer to put the connection to sleep and wake up than it does to send the packet now.

This change disables packet pacing for RTTs lower than 2ms.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

