### PR TITLE
platform: refactor the clock/timer functionality

### DIFF
--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -837,6 +837,7 @@ pub mod api {
         pub timeout_expired: bool,
         pub rx_ready: bool,
         pub tx_ready: bool,
+        pub application_wakeup: bool,
     }
     impl Event for PlatformEventLoopWakeup {
         const NAME: &'static str = "platform:event_loop_wakeup";
@@ -1808,8 +1809,9 @@ pub mod tracing {
                 timeout_expired,
                 rx_ready,
                 tx_ready,
+                application_wakeup,
             } = event;
-            tracing :: event ! (target : "platform_event_loop_wakeup" , parent : parent , tracing :: Level :: DEBUG , timeout_expired = tracing :: field :: debug (timeout_expired) , rx_ready = tracing :: field :: debug (rx_ready) , tx_ready = tracing :: field :: debug (tx_ready));
+            tracing :: event ! (target : "platform_event_loop_wakeup" , parent : parent , tracing :: Level :: DEBUG , timeout_expired = tracing :: field :: debug (timeout_expired) , rx_ready = tracing :: field :: debug (rx_ready) , tx_ready = tracing :: field :: debug (tx_ready) , application_wakeup = tracing :: field :: debug (application_wakeup));
         }
     }
 }
@@ -3257,6 +3259,7 @@ pub mod builder {
         pub timeout_expired: bool,
         pub rx_ready: bool,
         pub tx_ready: bool,
+        pub application_wakeup: bool,
     }
     impl IntoEvent<api::PlatformEventLoopWakeup> for PlatformEventLoopWakeup {
         #[inline]
@@ -3265,11 +3268,13 @@ pub mod builder {
                 timeout_expired,
                 rx_ready,
                 tx_ready,
+                application_wakeup,
             } = self;
             api::PlatformEventLoopWakeup {
                 timeout_expired: timeout_expired.into_event(),
                 rx_ready: rx_ready.into_event(),
                 tx_ready: tx_ready.into_event(),
+                application_wakeup: application_wakeup.into_event(),
             }
         }
     }

--- a/quic/s2n-quic-events/events/platform.rs
+++ b/quic/s2n-quic-events/events/platform.rs
@@ -74,4 +74,5 @@ struct PlatformEventLoopWakeup {
     timeout_expired: bool,
     rx_ready: bool,
     tx_ready: bool,
+    application_wakeup: bool,
 }

--- a/quic/s2n-quic-platform/src/io/tokio/clock.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/clock.rs
@@ -41,8 +41,11 @@ impl ClockTrait for Clock {
 
 #[derive(Debug)]
 pub struct Timer {
+    /// A reference to the current clock
     clock: Clock,
+    /// The `Instant` at which the timer should expire
     target: Option<Instant>,
+    /// The handle to the timer entry in the tokio runtime
     sleep: Pin<Box<Sleep>>,
 }
 
@@ -74,6 +77,7 @@ impl Timer {
         // add the delay to the clock's epoch
         let next_time = self.clock.0 + delay;
 
+        // If the target hasn't changed then don't do anything
         if Some(next_time) == self.target {
             return;
         }

--- a/quic/s2n-quic-platform/src/io/tokio/clock.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/clock.rs
@@ -1,0 +1,98 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+use s2n_quic_core::time::{self, Clock as ClockTrait, Timestamp};
+use tokio::time::{sleep_until, Instant, Sleep};
+
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Debug)]
+pub struct Clock(Instant);
+
+impl Default for Clock {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clock {
+    pub fn new() -> Self {
+        Self(Instant::now())
+    }
+
+    pub fn timer(&self) -> Timer {
+        Timer::new(self.clone())
+    }
+}
+
+impl ClockTrait for Clock {
+    fn get_time(&self) -> time::Timestamp {
+        let duration = self.0.elapsed();
+        unsafe {
+            // Safety: time duration is only derived from a single `Instant`
+            time::Timestamp::from_duration(duration)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Timer {
+    clock: Clock,
+    target: Option<Instant>,
+    sleep: Pin<Box<Sleep>>,
+}
+
+impl Timer {
+    fn new(clock: Clock) -> Self {
+        let target = clock.0 + DEFAULT_TIMEOUT;
+        let sleep = Box::pin(sleep_until(target));
+        Self {
+            clock,
+            target: Some(target),
+            sleep,
+        }
+    }
+
+    pub fn reset(&mut self, timestamp: Timestamp) {
+        let delay = unsafe {
+            // Safety: the same clock epoch is being used
+            timestamp.as_duration()
+        };
+
+        // floor the delay to milliseconds to reduce timer churn
+        let delay = Duration::from_millis(delay.as_millis() as u64);
+
+        // add the delay to the clock's epoch
+        let next_time = self.clock.0 + delay;
+
+        if Some(next_time) == self.target {
+            return;
+        }
+
+        // if the clock has changed let the sleep future know
+        self.sleep.as_mut().reset(next_time);
+        self.target = Some(next_time);
+    }
+
+    pub fn cancel(&mut self) {
+        self.target = None;
+    }
+}
+
+impl Future for Timer {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.target.is_none() {
+            return Poll::Pending;
+        }
+
+        self.sleep.as_mut().poll(cx)
+    }
+}

--- a/quic/s2n-quic/api.snap
+++ b/quic/s2n-quic/api.snap
@@ -1,8 +1,7 @@
 ---
-source: common/docdiff/src/main.rs
-assertion_line: 58
+source: src/main.rs
+assertion_line: 61
 expression: dump
-input_file: quic/s2n-quic/src/lib.rs
 
 ---
 trait impl core::convert::TryFrom<s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message associates type:
@@ -4205,6 +4204,9 @@ struct s2n_quic::provider::event::events::PathCreated exports constant:
   pub const NAME: &'static str
 
 struct s2n_quic::provider::event::events::PlatformEventLoopWakeup is non-exhaustive
+
+struct s2n_quic::provider::event::events::PlatformEventLoopWakeup exports field:
+  application_wakeup: bool
 
 struct s2n_quic::provider::event::events::PlatformEventLoopWakeup implements trait:
   impl core::clone::Clone for s2n_quic::provider::event::events::PlatformEventLoopWakeup

--- a/scripts/events
+++ b/scripts/events
@@ -1,1 +1,5 @@
+#!/usr/bin/env bash
+
 cargo +nightly run --bin s2n-quic-events
+# since events are exposed in the public api, we need to update the diff
+INSTA_UPDATE=always ./scripts/docdiff

--- a/scripts/perf/build
+++ b/scripts/perf/build
@@ -19,7 +19,7 @@ if [ ! -f target/perf/quinn/bin/perf_client ] || [ ! -f target/perf/quinn/bin/pe
   mkdir -p target/perf/quinn
   cargo +stable install \
     --git https://github.com/quinn-rs/quinn \
-    --rev 730fdaf723eef125c175fbcdba1ac3fe3324f7ce \
+    --rev 7b4b4c31e5878bdbce56ab2737dd8cfbafe1c4db \
     --bin perf_client \
     --bin perf_server \
     --root target/perf/quinn \


### PR DESCRIPTION
### Description of changes: 

* Add a `application_wakeup` field to the event loop event struct
* Move the clock and timer functionality in the tokio integration to a separate module - it was getting a bit big and intertwined with the rest of the code
* Add a call to docdiff to update the `api.snap` file after generating/changing events
* Updates quinn to the latest commit - it's been broken for a bit after tokio updated to mio 0.8

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

