### PR TITLE
transport: add OpenToken to track poll_open_stream requests

### DIFF
--- a/quic/s2n-quic-transport/src/connection/api.rs
+++ b/quic/s2n-quic-transport/src/connection/api.rs
@@ -31,7 +31,7 @@ pub struct Connection {
     /// straightforward manner.
     pub(super) api: ConnectionApi,
 
-    /// The open token associated with this each connection handle.
+    /// The open token associated with each connection handle.
     ///
     /// This is used to correctly track `poll_open_stream` requests.
     open_token: OpenToken,

--- a/quic/s2n-quic-transport/src/connection/api.rs
+++ b/quic/s2n-quic-transport/src/connection/api.rs
@@ -4,13 +4,12 @@
 //! Defines the public QUIC connection API
 
 use crate::{
-    connection::{self, ConnectionApi},
+    connection::{self, ConnectionApi, OpenToken},
     stream::{ops, Stream, StreamError, StreamId},
 };
 use bytes::Bytes;
 use core::{
     fmt,
-    num::NonZeroU64,
     sync::atomic::{self, Ordering},
     task::{Context, Poll},
 };
@@ -211,132 +210,5 @@ impl Connection {
         query: &mut dyn QueryMut,
     ) -> Result<(), connection::Error> {
         self.api.query_event_context_mut(query)
-    }
-}
-
-/// An opaque token issued to each connection handle which allows the stream
-/// controller to track any pending open requests.
-///
-/// Each connection handle must have a unique instance of a token so their wakers are correctly
-/// tracked.
-#[derive(Debug)]
-pub struct OpenToken(Option<NonZeroU64>);
-
-impl OpenToken {
-    /// Creates a new open token
-    ///
-    /// This should be held on the connection handle and should be presented each time
-    /// `poll_open_stream` is called.
-    #[inline]
-    pub const fn new() -> Self {
-        Self(None)
-    }
-
-    /// Creates an open token counter, used for issuing tokens to callers
-    #[inline]
-    pub(crate) fn counter() -> Self {
-        Self(Some(unsafe {
-            // Safety: 1 is always non-zero
-            NonZeroU64::new_unchecked(1)
-        }))
-    }
-
-    /// Returns the next open token for a connection
-    #[inline]
-    pub(crate) fn next(&mut self) -> Self {
-        let v = self.0.expect("token counter should always be initialized");
-        let next = Self(Some(v));
-        self.0 = Some(unsafe {
-            // Safety: N + 1 is always non-zero
-            NonZeroU64::new_unchecked(v.get() + 1)
-        });
-        next
-    }
-
-    /// Returns the index that the caller's waker should be stored, given the expired token
-    #[inline]
-    pub(crate) fn index(&self, expired_token: &Self) -> Option<usize> {
-        let base = expired_token.0.map_or(0, |v| v.get());
-        // since we're dealing with NonZeroU64, add one to get the correct index
-        let base = base + 1;
-        let v = self.0?;
-        let v = v.get().checked_sub(base)?;
-        Some(v as usize)
-    }
-
-    /// Expires a `count` number of tokens
-    ///
-    /// This should be called each time at least one waker is woken and removed from the waker list
-    #[inline]
-    pub(crate) fn expire(&mut self, count: usize) {
-        if let Some(v) = self.0.as_mut() {
-            *v = unsafe {
-                // Safety: non-zero N + count is always non-zero
-                NonZeroU64::new_unchecked(v.get() + count as u64)
-            };
-        } else if let Some(v) = NonZeroU64::new(count as _) {
-            *self = Self(Some(v));
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn open_token_test() {
-        let mut caller_tokens = [OpenToken::new(), OpenToken::new(), OpenToken::new()];
-        let mut expired_token = OpenToken::new();
-        let mut token_counter = OpenToken::counter();
-
-        assert_eq!(
-            caller_tokens[0].index(&expired_token),
-            None,
-            "empty caller token with no expired tokens"
-        );
-
-        // give the caller a token
-        caller_tokens[0] = token_counter.next();
-        assert_eq!(
-            caller_tokens[0].index(&expired_token),
-            Some(0),
-            "issued caller with no expired tokens should be index 0"
-        );
-
-        // expire the issued token
-        expired_token.expire(1);
-        assert_eq!(
-            caller_tokens[0].index(&expired_token),
-            None,
-            "issued caller token should now be expired"
-        );
-
-        for (idx, token) in caller_tokens.iter_mut().enumerate() {
-            *token = token_counter.next();
-            assert_eq!(
-                token.index(&expired_token),
-                Some(idx),
-                "issued caller should be indexed in order",
-            );
-        }
-
-        // expire just the first token
-        expired_token.expire(1);
-
-        assert_eq!(
-            caller_tokens[0].index(&expired_token),
-            None,
-            "first caller token should now be expired"
-        );
-
-        for (idx, token) in caller_tokens[1..].iter().enumerate() {
-            assert_eq!(
-                token.index(&expired_token),
-                Some(idx),
-                "caller {} should not be expired",
-                idx + 1,
-            );
-        }
     }
 }

--- a/quic/s2n-quic-transport/src/connection/api.rs
+++ b/quic/s2n-quic-transport/src/connection/api.rs
@@ -10,6 +10,7 @@ use crate::{
 use bytes::Bytes;
 use core::{
     fmt,
+    num::NonZeroU64,
     sync::atomic::{self, Ordering},
     task::{Context, Poll},
 };
@@ -29,6 +30,11 @@ pub struct Connection {
     /// generic parameters and allows applications to interact with connections in a
     /// straightforward manner.
     pub(super) api: ConnectionApi,
+
+    /// The open token associated with this each connection handle.
+    ///
+    /// This is used to correctly track `poll_open_stream` requests.
+    open_token: OpenToken,
 }
 
 impl fmt::Debug for Connection {
@@ -90,6 +96,8 @@ impl Clone for Connection {
             .fetch_add(1, Ordering::Relaxed);
         Self {
             api: self.api.clone(),
+            // don't clone the open token - each instance should have its own token
+            open_token: OpenToken::new(),
         }
     }
 }
@@ -104,7 +112,10 @@ impl Connection {
         // https://github.com/rust-lang/rust/blob/e012a191d768adeda1ee36a99ef8b92d51920154/library/alloc/src/sync.rs#L1329
         api.application_handle_count()
             .fetch_add(1, Ordering::Relaxed);
-        Self { api }
+        Self {
+            api,
+            open_token: OpenToken::new(),
+        }
     }
 
     /// Accepts an incoming [`Stream`]
@@ -133,7 +144,8 @@ impl Connection {
         stream_type: StreamType,
         context: &Context,
     ) -> Poll<Result<Stream, connection::Error>> {
-        self.api.poll_open_stream(&self.api, stream_type, context)
+        self.api
+            .poll_open_stream(&self.api, stream_type, &mut self.open_token, context)
     }
 
     #[inline]
@@ -199,5 +211,132 @@ impl Connection {
         query: &mut dyn QueryMut,
     ) -> Result<(), connection::Error> {
         self.api.query_event_context_mut(query)
+    }
+}
+
+/// An opaque token issued to each connection handle which allows the stream
+/// controller to track any pending open requests.
+///
+/// Each connection handle must have a unique instance of a token so their wakers are correctly
+/// tracked.
+#[derive(Debug)]
+pub struct OpenToken(Option<NonZeroU64>);
+
+impl OpenToken {
+    /// Creates a new open token
+    ///
+    /// This should be held on the connection handle and should be presented each time
+    /// `poll_open_stream` is called.
+    #[inline]
+    pub const fn new() -> Self {
+        Self(None)
+    }
+
+    /// Creates an open token counter, used for issuing tokens to callers
+    #[inline]
+    pub(crate) fn counter() -> Self {
+        Self(Some(unsafe {
+            // Safety: 1 is always non-zero
+            NonZeroU64::new_unchecked(1)
+        }))
+    }
+
+    /// Returns the next open token for a connection
+    #[inline]
+    pub(crate) fn next(&mut self) -> Self {
+        let v = self.0.expect("token counter should always be initialized");
+        let next = Self(Some(v));
+        self.0 = Some(unsafe {
+            // Safety: N + 1 is always non-zero
+            NonZeroU64::new_unchecked(v.get() + 1)
+        });
+        next
+    }
+
+    /// Returns the index that the caller's waker should be stored, given the expired token
+    #[inline]
+    pub(crate) fn index(&self, expired_token: &Self) -> Option<usize> {
+        let base = expired_token.0.map_or(0, |v| v.get());
+        // since we're dealing with NonZeroU64, add one to get the correct index
+        let base = base + 1;
+        let v = self.0?;
+        let v = v.get().checked_sub(base)?;
+        Some(v as usize)
+    }
+
+    /// Expires a `count` number of tokens
+    ///
+    /// This should be called each time at least one waker is woken and removed from the waker list
+    #[inline]
+    pub(crate) fn expire(&mut self, count: usize) {
+        if let Some(v) = self.0.as_mut() {
+            *v = unsafe {
+                // Safety: non-zero N + count is always non-zero
+                NonZeroU64::new_unchecked(v.get() + count as u64)
+            };
+        } else if let Some(v) = NonZeroU64::new(count as _) {
+            *self = Self(Some(v));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_token_test() {
+        let mut caller_tokens = [OpenToken::new(), OpenToken::new(), OpenToken::new()];
+        let mut expired_token = OpenToken::new();
+        let mut token_counter = OpenToken::counter();
+
+        assert_eq!(
+            caller_tokens[0].index(&expired_token),
+            None,
+            "empty caller token with no expired tokens"
+        );
+
+        // give the caller a token
+        caller_tokens[0] = token_counter.next();
+        assert_eq!(
+            caller_tokens[0].index(&expired_token),
+            Some(0),
+            "issued caller with no expired tokens should be index 0"
+        );
+
+        // expire the issued token
+        expired_token.expire(1);
+        assert_eq!(
+            caller_tokens[0].index(&expired_token),
+            None,
+            "issued caller token should now be expired"
+        );
+
+        for (idx, token) in caller_tokens.iter_mut().enumerate() {
+            *token = token_counter.next();
+            assert_eq!(
+                token.index(&expired_token),
+                Some(idx),
+                "issued caller should be indexed in order",
+            );
+        }
+
+        // expire just the first token
+        expired_token.expire(1);
+
+        assert_eq!(
+            caller_tokens[0].index(&expired_token),
+            None,
+            "first caller token should now be expired"
+        );
+
+        for (idx, token) in caller_tokens[1..].iter().enumerate() {
+            assert_eq!(
+                token.index(&expired_token),
+                Some(idx),
+                "caller {} should not be expired",
+                idx + 1,
+            );
+        }
     }
 }

--- a/quic/s2n-quic-transport/src/connection/api_provider.rs
+++ b/quic/s2n-quic-transport/src/connection/api_provider.rs
@@ -48,6 +48,7 @@ pub(crate) trait ConnectionApiProvider: Sync + Send {
         &self,
         arc_self: &Arc<dyn ConnectionApiProvider>,
         stream_type: StreamType,
+        open_token: &mut connection::OpenToken,
         context: &Context,
     ) -> Poll<Result<Stream, connection::Error>>;
 

--- a/quic/s2n-quic-transport/src/connection/connection_container.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container.rs
@@ -246,9 +246,11 @@ impl<C: connection::Trait, L: connection::Lock<C>> ConnectionApiProvider for Con
         &self,
         arc_self: &ConnectionApi,
         stream_type: stream::StreamType,
+        open_token: &mut connection::OpenToken,
         context: &Context,
     ) -> Poll<Result<stream::Stream, connection::Error>> {
-        let response = self.api_poll_call(|conn| conn.poll_open_stream(stream_type, context));
+        let response =
+            self.api_poll_call(|conn| conn.poll_open_stream(stream_type, open_token, context));
 
         match response {
             Poll::Pending => Poll::Pending,

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -242,6 +242,7 @@ impl connection::Trait for TestConnection {
     fn poll_open_stream(
         &mut self,
         _stream_type: stream::StreamType,
+        _token: &mut connection::OpenToken,
         _context: &Context,
     ) -> Poll<Result<stream::StreamId, connection::Error>> {
         todo!()

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1689,6 +1689,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
     fn poll_open_stream(
         &mut self,
         stream_type: stream::StreamType,
+        open_token: &mut connection::OpenToken,
         context: &Context,
     ) -> Poll<Result<stream::StreamId, connection::Error>> {
         self.error?;
@@ -1698,7 +1699,9 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             .application_mut()
             .ok_or_else(connection::Error::unspecified)?;
 
-        space.stream_manager.poll_open(stream_type, context)
+        space
+            .stream_manager
+            .poll_open(stream_type, open_token, context)
     }
 
     fn application_close(&mut self, error: Option<application::Error>) {

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -374,6 +374,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     fn poll_open_stream(
         &mut self,
         stream_type: stream::StreamType,
+        open_token: &mut connection::OpenToken,
         context: &Context,
     ) -> Poll<Result<stream::StreamId, connection::Error>>;
 

--- a/quic/s2n-quic-transport/src/connection/mod.rs
+++ b/quic/s2n-quic-transport/src/connection/mod.rs
@@ -22,6 +22,7 @@ mod errors;
 pub(crate) mod finalization;
 mod internal_connection_id;
 pub(crate) mod local_id_registry;
+pub(crate) mod open_token;
 pub(crate) mod peer_id_registry;
 pub(crate) mod transmission;
 
@@ -36,9 +37,10 @@ pub(crate) use local_id_registry::LocalIdRegistry;
 pub(crate) use peer_id_registry::PeerIdRegistry;
 pub(crate) use transmission::{ConnectionTransmission, ConnectionTransmissionContext};
 
-pub use api::{Connection, OpenToken};
+pub use api::Connection;
 pub use connection_impl::ConnectionImpl as Implementation;
 pub use connection_trait::Lock;
+pub use open_token::Pair as OpenToken;
 /// re-export core
 pub use s2n_quic_core::connection::*;
 

--- a/quic/s2n-quic-transport/src/connection/mod.rs
+++ b/quic/s2n-quic-transport/src/connection/mod.rs
@@ -36,7 +36,7 @@ pub(crate) use local_id_registry::LocalIdRegistry;
 pub(crate) use peer_id_registry::PeerIdRegistry;
 pub(crate) use transmission::{ConnectionTransmission, ConnectionTransmissionContext};
 
-pub use api::Connection;
+pub use api::{Connection, OpenToken};
 pub use connection_impl::ConnectionImpl as Implementation;
 pub use connection_trait::Lock;
 /// re-export core

--- a/quic/s2n-quic-transport/src/connection/open_token.rs
+++ b/quic/s2n-quic-transport/src/connection/open_token.rs
@@ -1,0 +1,158 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::num::NonZeroU64;
+
+/// An opaque token issued to each connection handle which allows the stream
+/// controller to track any pending open requests.
+///
+/// Each connection handle must have a unique instance of a token so their wakers are correctly
+/// tracked.
+#[derive(Debug)]
+pub struct Pair {
+    /// Stores the token for the unidirectional stream type
+    pub(crate) unidirectional: Token,
+    /// Stores the token for the bididirectional stream type
+    pub(crate) bidirectional: Token,
+}
+
+impl Pair {
+    /// Creates a new open token
+    ///
+    /// This should be held on the connection handle and should be presented each time
+    /// `poll_open_stream` is called.
+    #[inline]
+    pub const fn new() -> Self {
+        Self {
+            unidirectional: Token::new(),
+            bidirectional: Token::new(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Token(Option<NonZeroU64>);
+
+impl Token {
+    #[inline]
+    pub const fn new() -> Self {
+        Self(None)
+    }
+
+    /// Returns the index that the caller's waker should be stored, given the expired token
+    #[inline]
+    pub fn index(&self, expired_token: &Self) -> Option<usize> {
+        let base = expired_token.0.map_or(0, |v| v.get());
+        // since we're dealing with NonZeroU64, add one to get the correct index
+        let base = base + 1;
+        let v = self.0?;
+        let v = v.get().checked_sub(base)?;
+        Some(v as usize)
+    }
+
+    /// Expires a `count` number of tokens
+    ///
+    /// This should be called each time at least one waker is woken and removed from the waker list
+    #[inline]
+    pub fn expire(&mut self, count: usize) {
+        if let Some(v) = self.0.as_mut() {
+            *v = unsafe {
+                // Safety: non-zero N + count is always non-zero
+                NonZeroU64::new_unchecked(v.get() + count as u64)
+            };
+        } else if let Some(v) = NonZeroU64::new(count as _) {
+            *self = Self(Some(v));
+        }
+    }
+
+    /// Resets the token state
+    #[inline]
+    pub fn clear(&mut self) {
+        *self = Self(None);
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Counter(NonZeroU64);
+
+impl Counter {
+    pub const fn new() -> Self {
+        Self(unsafe {
+            // Safety: 1 is always non-zero
+            NonZeroU64::new_unchecked(1)
+        })
+    }
+
+    /// Returns the next open token for a connection
+    #[inline]
+    pub fn next(&mut self) -> Token {
+        let v = self.0;
+        let next = Token(Some(v));
+        self.0 = unsafe {
+            // Safety: N + 1 is always non-zero
+            NonZeroU64::new_unchecked(v.get() + 1)
+        };
+        next
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_token_test() {
+        let mut caller_tokens = [Token::new(), Token::new(), Token::new()];
+        let mut expired_token = Token::new();
+        let mut token_counter = Counter::new();
+
+        assert_eq!(
+            caller_tokens[0].index(&expired_token),
+            None,
+            "empty caller token with no expired tokens"
+        );
+
+        // give the caller a token
+        caller_tokens[0] = token_counter.next();
+        assert_eq!(
+            caller_tokens[0].index(&expired_token),
+            Some(0),
+            "issued caller with no expired tokens should be index 0"
+        );
+
+        // expire the issued token
+        expired_token.expire(1);
+        assert_eq!(
+            caller_tokens[0].index(&expired_token),
+            None,
+            "issued caller token should now be expired"
+        );
+
+        for (idx, token) in caller_tokens.iter_mut().enumerate() {
+            *token = token_counter.next();
+            assert_eq!(
+                token.index(&expired_token),
+                Some(idx),
+                "issued caller should be indexed in order",
+            );
+        }
+
+        // expire just the first token
+        expired_token.expire(1);
+
+        assert_eq!(
+            caller_tokens[0].index(&expired_token),
+            None,
+            "first caller token should now be expired"
+        );
+
+        for (idx, token) in caller_tokens[1..].iter().enumerate() {
+            assert_eq!(
+                token.index(&expired_token),
+                Some(idx),
+                "caller {} should not be expired",
+                idx + 1,
+            );
+        }
+    }
+}

--- a/quic/s2n-quic-transport/src/stream/controller.rs
+++ b/quic/s2n-quic-transport/src/stream/controller.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    connection,
     contexts::OnTransmitError,
     sync::{IncrementalValueSync, PeriodicSync, ValueToFrameWriter},
     transmission,
@@ -103,11 +104,18 @@ impl Controller {
     pub fn poll_local_open_stream(
         &mut self,
         stream_type: StreamType,
+        open_token: &mut connection::OpenToken,
         context: &Context,
     ) -> Poll<()> {
         match stream_type {
-            StreamType::Bidirectional => self.bidi_controller.outgoing.poll_open_stream(context),
-            StreamType::Unidirectional => self.uni_controller.outgoing.poll_open_stream(context),
+            StreamType::Bidirectional => self
+                .bidi_controller
+                .outgoing
+                .poll_open_stream(open_token, context),
+            StreamType::Unidirectional => self
+                .uni_controller
+                .outgoing
+                .poll_open_stream(open_token, context),
         }
     }
 
@@ -317,6 +325,10 @@ struct OutgoingController {
     streams_blocked_sync: PeriodicSync<VarInt, StreamsBlockedToFrameWriter>,
     opened_streams: VarInt,
     closed_streams: VarInt,
+    /// Keeps track of all of the issued open tokens
+    token_counter: connection::OpenToken,
+    /// Keeps track of all of the expired open tokens
+    expired_token: connection::OpenToken,
 }
 
 impl OutgoingController {
@@ -331,6 +343,8 @@ impl OutgoingController {
             streams_blocked_sync: PeriodicSync::new(),
             opened_streams: VarInt::from_u8(0),
             closed_streams: VarInt::from_u8(0),
+            token_counter: connection::OpenToken::counter(),
+            expired_token: connection::OpenToken::new(),
         }
     }
 
@@ -352,10 +366,24 @@ impl OutgoingController {
         self.wake_unblocked();
     }
 
-    fn poll_open_stream(&mut self, context: &Context) -> Poll<()> {
+    fn poll_open_stream(
+        &mut self,
+        open_token: &mut connection::OpenToken,
+        context: &Context,
+    ) -> Poll<()> {
         if self.available_stream_capacity() < VarInt::from_u32(1) {
-            // Store a waker that can be woken when we get more credit
-            self.wakers.push(context.waker().clone());
+            if let Some(index) = open_token.index(&self.expired_token) {
+                let prev = &self.wakers[index];
+                // update the waker if it's changed
+                if !prev.will_wake(context.waker()) {
+                    self.wakers[index] = context.waker().clone();
+                }
+            } else {
+                // Store a waker that can be woken when we get more credit
+                self.wakers.push(context.waker().clone());
+                // give them a waker to remember their position in the list
+                *open_token = self.token_counter.next();
+            }
 
             //= https://www.rfc-editor.org/rfc/rfc9000#section-4.6
             //# An endpoint that is unable to open a new stream due to the peer's
@@ -372,6 +400,10 @@ impl OutgoingController {
 
             return Poll::Pending;
         }
+
+        // reset the open token since they're no longer blocked
+        *open_token = connection::OpenToken::new();
+
         Poll::Ready(())
     }
 
@@ -421,6 +453,9 @@ impl OutgoingController {
         self.wakers
             .drain(..unblocked_wakers_count)
             .for_each(|waker| waker.wake());
+
+        // keep track of the number of tokens that have expired
+        self.expired_token.expire(unblocked_wakers_count);
     }
 
     /// Returns the number of streams currently open

--- a/quic/s2n-quic-transport/src/stream/stream_manager.rs
+++ b/quic/s2n-quic-transport/src/stream/stream_manager.rs
@@ -539,6 +539,7 @@ impl<S: StreamTrait> AbstractStreamManager<S> {
     pub fn poll_open(
         &mut self,
         stream_type: StreamType,
+        open_token: &mut connection::OpenToken,
         context: &Context,
     ) -> Poll<Result<StreamId, connection::Error>> {
         // If StreamManager was closed, return the error
@@ -555,7 +556,7 @@ impl<S: StreamTrait> AbstractStreamManager<S> {
         if self
             .inner
             .stream_controller
-            .poll_local_open_stream(stream_type, context)
+            .poll_local_open_stream(stream_type, open_token, context)
             .is_pending()
         {
             return Poll::Pending;


### PR DESCRIPTION
### Description of changes: 

This change adds a `OpenToken` struct to the connection handle which allows the stream controller to track `poll_open_stream` requests.

### Testing:

I've added unit tests for the `OpenToken` behavior. I've also updated all of the stream manager tests to use the new API.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

