### PR TITLE
netbench: add tokio timer

### DIFF
--- a/netbench/netbench/Cargo.toml
+++ b/netbench/netbench/Cargo.toml
@@ -25,4 +25,4 @@ tokio = { version = "1", features = ["net", "time"] }
 [dev-dependencies]
 futures-test = "0.3"
 insta = "1"
-tokio = { version = "1", features = ["io-util", "net", "time"] }
+tokio = { version = "1", features = ["io-util", "net", "test-util", "time"] }

--- a/netbench/netbench/src/timer.rs
+++ b/netbench/netbench/src/timer.rs
@@ -1,10 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use core::{
-    task::{Context, Poll, Waker},
-    time::Duration,
-};
+use core::task::{Context, Poll};
 pub use s2n_quic_core::time::Timestamp;
 
 pub trait Timer {
@@ -12,61 +9,10 @@ pub trait Timer {
     fn poll(&mut self, target: Timestamp, cx: &mut Context) -> Poll<()>;
 }
 
-#[derive(Debug)]
-pub struct Testing {
-    now: Timestamp,
-    target: Option<Timestamp>,
-    waker: Option<Waker>,
-}
+#[cfg(any(test, feature = "testing"))]
+mod testing;
+mod tokio;
 
-impl Default for Testing {
-    fn default() -> Self {
-        Self {
-            now: unsafe { Timestamp::from_duration(Duration::ZERO) },
-            target: None,
-            waker: None,
-        }
-    }
-}
-
-impl Testing {
-    pub fn advance_pair(&mut self, other: &mut Self) -> Option<Timestamp> {
-        let target = match (self.target, other.target) {
-            (Some(a), Some(b)) => Some(a.min(b)),
-            (a, None) => a,
-            (None, b) => b,
-        };
-
-        if let Some(target) = target {
-            self.set(target);
-            other.set(target);
-            Some(self.now)
-        } else {
-            None
-        }
-    }
-
-    fn set(&mut self, target: Timestamp) {
-        self.now = target;
-        self.target = None;
-        if let Some(waker) = self.waker.take() {
-            waker.wake();
-        }
-    }
-}
-
-impl Timer for Testing {
-    fn now(&self) -> s2n_quic_core::time::Timestamp {
-        self.now
-    }
-
-    fn poll(&mut self, target: Timestamp, cx: &mut Context<'_>) -> Poll<()> {
-        if target == self.now {
-            Poll::Ready(())
-        } else {
-            self.target = Some(target);
-            self.waker = Some(cx.waker().clone());
-            Poll::Pending
-        }
-    }
-}
+pub use self::tokio::Timer as Tokio;
+#[cfg(any(test, feature = "testing"))]
+pub use testing::Timer as Testing;

--- a/netbench/netbench/src/timer/testing.rs
+++ b/netbench/netbench/src/timer/testing.rs
@@ -1,0 +1,67 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Timestamp;
+use core::{
+    task::{Context, Poll, Waker},
+    time::Duration,
+};
+
+#[derive(Debug)]
+pub struct Timer {
+    now: Timestamp,
+    target: Option<Timestamp>,
+    waker: Option<Waker>,
+}
+
+impl Default for Timer {
+    fn default() -> Self {
+        Self {
+            now: unsafe { Timestamp::from_duration(Duration::ZERO) },
+            target: None,
+            waker: None,
+        }
+    }
+}
+
+impl Timer {
+    pub fn advance_pair(&mut self, other: &mut Self) -> Option<Timestamp> {
+        let target = match (self.target, other.target) {
+            (Some(a), Some(b)) => Some(a.min(b)),
+            (a, None) => a,
+            (None, b) => b,
+        };
+
+        if let Some(target) = target {
+            self.set(target);
+            other.set(target);
+            Some(self.now)
+        } else {
+            None
+        }
+    }
+
+    fn set(&mut self, target: Timestamp) {
+        self.now = target;
+        self.target = None;
+        if let Some(waker) = self.waker.take() {
+            waker.wake();
+        }
+    }
+}
+
+impl super::Timer for Timer {
+    fn now(&self) -> Timestamp {
+        self.now
+    }
+
+    fn poll(&mut self, target: Timestamp, cx: &mut Context<'_>) -> Poll<()> {
+        if target == self.now {
+            Poll::Ready(())
+        } else {
+            self.target = Some(target);
+            self.waker = Some(cx.waker().clone());
+            Poll::Pending
+        }
+    }
+}

--- a/netbench/netbench/src/timer/tokio.rs
+++ b/netbench/netbench/src/timer/tokio.rs
@@ -1,0 +1,96 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Timestamp;
+use core::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+use futures::ready;
+use tokio::time::{sleep, Instant, Sleep};
+
+#[derive(Debug)]
+pub struct Timer {
+    start: Instant,
+    target: Option<Timestamp>,
+    sleep: Pin<Box<Sleep>>,
+}
+
+impl Timer {
+    fn set_target(&mut self, target: Timestamp) {
+        self.target = Some(target);
+        let duration = unsafe { target.as_duration() };
+        self.sleep.as_mut().reset(self.start + duration);
+    }
+}
+
+impl Default for Timer {
+    fn default() -> Self {
+        Self {
+            start: Instant::now(),
+            target: None,
+            sleep: Box::pin(sleep(Duration::from_secs(0))),
+        }
+    }
+}
+
+impl super::Timer for Timer {
+    fn now(&self) -> Timestamp {
+        let duration = self.start.elapsed();
+        unsafe { Timestamp::from_duration(duration) }
+    }
+
+    fn poll(&mut self, target: Timestamp, cx: &mut Context) -> Poll<()> {
+        if let Some(prev_target) = self.target.as_mut() {
+            if *prev_target != target {
+                self.set_target(target);
+            }
+        } else {
+            self.set_target(target);
+        }
+
+        ready!(self.sleep.as_mut().poll(cx));
+
+        self.target = None;
+
+        Poll::Ready(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::timer::Timer as _;
+    use futures_test::task::new_count_waker;
+
+    #[tokio::test(start_paused = true)]
+    async fn timer_test() {
+        let mut timer = Timer::default();
+        let (waker, _count) = new_count_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        tokio::time::advance(Duration::from_secs(1)).await;
+
+        let mut now = timer.now();
+
+        let mut times = [now; 5];
+        for (idx, time) in times.iter_mut().enumerate() {
+            *time += Duration::from_secs(idx as _);
+        }
+
+        assert!(timer.poll(now, &mut cx).is_ready());
+
+        for _ in 0..times.len() {
+            // poll a bunch of different times in loop to make sure all of the branches are covered
+            for time in times.iter().chain(times.iter().rev()).copied() {
+                assert_eq!(timer.poll(time, &mut cx).is_ready(), time <= now);
+                assert_eq!(timer.poll(time, &mut cx).is_ready(), time <= now);
+            }
+
+            tokio::time::advance(Duration::from_secs(1)).await;
+            now += Duration::from_secs(1);
+        }
+    }
+}

--- a/netbench/netbench/src/trace.rs
+++ b/netbench/netbench/src/trace.rs
@@ -342,7 +342,7 @@ impl core::ops::Div<Duration> for Throughput<Byte> {
 
 impl fmt::Display for Throughput<Rate> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "throughtput: rx={}, tx={}", self.rx, self.tx)
+        write!(f, "throughput: rx={}, tx={}", self.rx, self.tx)
     }
 }
 

--- a/netbench/netbench/src/trace.rs
+++ b/netbench/netbench/src/trace.rs
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{operation as op, timer::Timestamp};
-use core::{fmt, time::Duration};
+use crate::{operation as op, timer::Timestamp, units::*};
+use core::fmt;
 use std::sync::{
     atomic::{AtomicBool, AtomicU64, Ordering},
     Arc,
@@ -300,16 +300,16 @@ impl<O: Output> Trace for Logger<'_, O> {
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct Throughput<Counter> {
+pub struct Throughput<Counter = Arc<AtomicU64>> {
     rx: Counter,
     tx: Counter,
 }
 
-impl Throughput<Arc<AtomicU64>> {
-    pub fn take(&self) -> Throughput<u64> {
+impl Throughput {
+    pub fn take(&self) -> Throughput<Byte> {
         Throughput {
-            rx: self.rx.swap(0, Ordering::Relaxed),
-            tx: self.tx.swap(0, Ordering::Relaxed),
+            rx: self.rx.swap(0, Ordering::Relaxed).bytes(),
+            tx: self.tx.swap(0, Ordering::Relaxed).bytes(),
         }
     }
 
@@ -321,7 +321,7 @@ impl Throughput<Arc<AtomicU64>> {
             while !r_handle.0.fetch_or(false, Ordering::Relaxed) {
                 tokio::time::sleep(freq).await;
                 let v = values.take();
-                eprintln!("{:?}", v);
+                eprintln!("{}", v / freq);
             }
         });
 
@@ -329,7 +329,24 @@ impl Throughput<Arc<AtomicU64>> {
     }
 }
 
-impl Trace for Throughput<Arc<AtomicU64>> {
+impl core::ops::Div<Duration> for Throughput<Byte> {
+    type Output = Throughput<Rate>;
+
+    fn div(self, duration: Duration) -> Throughput<Rate> {
+        Throughput {
+            rx: self.rx / duration,
+            tx: self.tx / duration,
+        }
+    }
+}
+
+impl fmt::Display for Throughput<Rate> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "throughtput: rx={}, tx={}", self.rx, self.tx)
+    }
+}
+
+impl Trace for Throughput {
     fn send(&mut self, _now: Timestamp, _stream_id: u64, len: u64) {
         self.tx.fetch_add(len, Ordering::Relaxed);
     }


### PR DESCRIPTION
### Description of changes: 

This change adds tokio support for the netbench driver `Timer` trait.

### Testing:

I added a unit test using tokio's time testing utils to validate that it works as intended.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

