### PR TITLE
release: use exact versions for all internal dependencies

### DIFF
--- a/quic/s2n-quic-bench/Cargo.toml
+++ b/quic/s2n-quic-bench/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 [dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", features = ["testing"] }
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core", features = ["testing"] }
-s2n-quic-crypto = { version = "0.1.0", path = "../s2n-quic-crypto", features = ["testing"] }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-crypto = { version = "=0.1.0", path = "../s2n-quic-crypto", features = ["testing"] }
 
 [[bench]]
 name = "bench"

--- a/quic/s2n-quic-h3/Cargo.toml
+++ b/quic/s2n-quic-h3/Cargo.toml
@@ -11,5 +11,5 @@ publish = false
 bytes = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false }
 h3 = { git = "https://github.com/hyperium/h3" } # TODO: Update once hyperium h3 is in crates.io
-s2n-quic = { version = "1.0.0", path = "../s2n-quic", default-features = false }
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core", default-features = false }
+s2n-quic = { version = "=1.0.0", path = "../s2n-quic", default-features = false }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", default-features = false }

--- a/quic/s2n-quic-integration/Cargo.toml
+++ b/quic/s2n-quic-integration/Cargo.toml
@@ -16,9 +16,9 @@ bolero-generator = "0.6"
 bytes = { version = "1", default-features = false }
 futures = "0.3"
 lazy_static = "1"
-s2n-quic = { version = "1.0.0", path = "../s2n-quic" }
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core", features = ["std", "testing"] }
-s2n-quic-platform = { version = "0.1.0", path = "../s2n-quic-platform" }
+s2n-quic = { version = "=1.0.0", path = "../s2n-quic" }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["std", "testing"] }
+s2n-quic-platform = { version = "=0.1.0", path = "../s2n-quic-platform" }
 tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -22,7 +22,7 @@ errno = "0.2"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 lazy_static = { version = "1", optional = true }
 pin-project = { version = "1", optional = true }
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core", default-features = false }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", default-features = false }
 socket2 = { version = "0.4", features = ["all"], optional = true }
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt", "time"], optional = true }
 zeroize = { version = "1", default-features = false, optional = true }
@@ -33,5 +33,5 @@ libc = "0.2"
 [dev-dependencies]
 bolero = "0.6"
 bolero-generator = { version = "0.6", default-features = false }
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -14,8 +14,8 @@ bytes = { version = "1", default-features = false }
 dhat = { version = "0.2", optional = true }
 futures = "0.3"
 http = "0.2"
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core", features = ["testing"] }
-s2n-quic-h3 = { version = "0.1.0", path = "../s2n-quic-h3" }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-h3 = { version = "=0.1.0", path = "../s2n-quic-h3" }
 structopt = "0.3"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
@@ -23,7 +23,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2"
 
 [target.'cfg(unix)'.dependencies]
-s2n-quic = { version = "1.0.0", path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-rustls", "provider-tls-s2n"] }
+s2n-quic = { version = "=1.0.0", path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-rustls", "provider-tls-s2n"] }
 
 [target.'cfg(not(unix))'.dependencies]
-s2n-quic = { version = "1.0.0", path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-rustls"] }
+s2n-quic = { version = "=1.0.0", path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-rustls"] }

--- a/quic/s2n-quic-ring/Cargo.toml
+++ b/quic/s2n-quic-ring/Cargo.toml
@@ -11,14 +11,14 @@ license = "Apache-2.0"
 hex-literal = "0.3"
 lazy_static = { version = "1", default-features = false }
 s2n-codec = { version = "0.1.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core", default-features = false }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", default-features = false }
 ring = { version = "0.16", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
 bolero = "0.6"
 insta = "1"
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
 
 [[test]]
 name = "fuzz_target"

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -11,9 +11,9 @@ license = "Apache-2.0"
 rustls = { version = "0.20", features = ["quic"] }
 rustls-pemfile = "0.3"
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core", default-features = false }
-s2n-quic-ring = { version = "0.1.0", path = "../s2n-quic-ring", default-features = false }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", default-features = false }
+s2n-quic-ring = { version = "=0.1.0", path = "../s2n-quic-ring", default-features = false }
 
 [dev-dependencies]
 insta = "1"
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [target.'cfg(unix)'.dependencies]
-s2n-quic-tls = { version = "0.1.0", path = "../s2n-quic-tls" }
+s2n-quic-tls = { version = "=0.1.0", path = "../s2n-quic-tls" }
 
 [target.'cfg(not(unix))'.dependencies]
-s2n-quic-rustls = { version = "0.1.0", path = "../s2n-quic-rustls" }
+s2n-quic-rustls = { version = "=0.1.0", path = "../s2n-quic-rustls" }

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -12,8 +12,8 @@ bytes = { version = "1", default-features = false }
 errno = "0.2"
 libc = "0.2"
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core", default-features = false }
-s2n-quic-ring = { version = "0.1.0", path = "../s2n-quic-ring", default-features = false }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", default-features = false }
+s2n-quic-ring = { version = "=0.1.0", path = "../s2n-quic-ring", default-features = false }
 s2n-tls = { version = "0.0.3", features = ["quic"] }
 
 [dev-dependencies]
@@ -24,8 +24,8 @@ checkers = "0.6"
 # NOTE: The version of the `openssl-sys` crate is not the same as OpenSSL itself.
 #       Versions 1.0.1 - 3.0.0 are automatically discovered.
 openssl-sys = { version = "<= 0.9.68", features = ["vendored"] }
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core", features = ["testing"] }
-s2n-quic-rustls = { version = "0.1.0", path = "../s2n-quic-rustls" }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-rustls = { version = "=0.1.0", path = "../s2n-quic-rustls" }
 
 # we don't use openssl-sys directly; it's just here to pin and vendor in dev
 [package.metadata.cargo-udeps.ignore]

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -18,7 +18,7 @@ futures-core = { version = "0.3", default-features = false, features = ["alloc"]
 hashbrown = "0.11"
 intrusive-collections = "0.9"
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
 siphasher = "0.3"
 smallvec = { version = "1", default-features = false }
 
@@ -27,5 +27,5 @@ bolero = "0.6"
 futures-test = "0.3" # For testing Waker interactions
 insta = "1"
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core", features = ["testing"] }
-s2n-quic-platform = { version = "0.1.0", path = "../s2n-quic-platform", features = ["testing"] }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-platform = { version = "=0.1.0", path = "../s2n-quic-platform", features = ["testing"] }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -36,12 +36,12 @@ rand = "0.8"
 rand_chacha = "0.3"
 ring = { version = "0.16", optional = true, default-features = false }
 s2n-codec = { version = "0.1.0", path = "../../common/s2n-codec" }
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core" }
-s2n-quic-platform = { version = "0.1.0", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
-s2n-quic-rustls = { version = "0.1.0", path = "../s2n-quic-rustls", optional = true }
-s2n-quic-tls = { version = "0.1.0", path = "../s2n-quic-tls", optional = true }
-s2n-quic-tls-default = { version = "0.1.0", path = "../s2n-quic-tls-default", optional = true }
-s2n-quic-transport = { version = "0.1.1", path = "../s2n-quic-transport" }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core" }
+s2n-quic-platform = { version = "=0.1.0", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
+s2n-quic-rustls = { version = "=0.1.0", path = "../s2n-quic-rustls", optional = true }
+s2n-quic-tls = { version = "=0.1.0", path = "../s2n-quic-tls", optional = true }
+s2n-quic-tls-default = { version = "=0.1.0", path = "../s2n-quic-tls-default", optional = true }
+s2n-quic-transport = { version = "=0.1.1", path = "../s2n-quic-transport" }
 tokio = { version = "1", default-features = false }
 zerocopy = { version = "=0.6.0", optional = true }
 zerocopy-derive = { version = "=0.3.0", optional = true }
@@ -49,6 +49,6 @@ zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 bolero = { version = "0.6" }
-s2n-quic-core = { version = "0.1.1", path = "../s2n-quic-core", features = ["testing"] }
-s2n-quic-platform = { version = "0.1.0", path = "../s2n-quic-platform", features = ["testing"] }
+s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-platform = { version = "=0.1.0", path = "../s2n-quic-platform", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
### Resolved issues:

### Description of changes: 
Based on https://doc.rust-lang.org/cargo/reference/resolver.html#semver-compatibility the current dependency matching results in:

`1.2.3` or `^1.2.3`  => `>=1.2.3`, `<2.0.0`

What we want instead is:

`=1.2.3` => `=1.2.3`

### Call-outs:


### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

