### PR TITLE
feat(netbench): add built-in drivers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -633,3 +633,4 @@ jobs:
           ./scripts/typos --format json | tee /tmp/typos.json | jq -rs '.[] | "::error file=\(.path),line=\(.line_num),col=\(.byte_offset)::\(.typo) should be \"" + (.corrections // [] | join("\" or \"") + "\"")'
           cat /tmp/typos.json
           ! grep -q '[^[:space:]]' /tmp/typos.json
+

--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -121,7 +121,7 @@ jobs:
         id: scenarios
         run: |
           ./netbench/target/release/netbench-scenarios
-          SCENARIOS=$(ls target/netbench | xargs basename -s .json | jq -Rs 'rtrimstr("\n") | split("\n")')
+          SCENARIOS=$(find target/netbench -type f -exec basename -s .json {} \; | jq -Rcs 'rtrimstr("\n") | split("\n")')
           echo "::set-output name=scenarios::$SCENARIOS"
 
       - name: Prepare artifact

--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -156,13 +156,15 @@ jobs:
       - name: Prepare artifact
         run: |
           chmod +x ./netbench-driver*
-          export SCENARIO=scenarios/${{ matrix.scenario }}
 
       # TODO use netbench-cli instead when it's available
       - name: Run server
         run: |
+          export SCENARIO=scenarios/${{ matrix.scenario }}
           ./netbench-driver-${{ matrix.driver }}-server &
 
       - name: Run client
         run: |
+          export SCENARIO=scenarios/${{ matrix.scenario }}
+          export SERVER_0=localhost:4433
           ./netbench-driver-${{ matrix.driver }}-client

--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -121,7 +121,7 @@ jobs:
         id: scenarios
         run: |
           ./netbench/target/release/netbench-scenarios \
-            --request-response.response_size=8GiB
+            --request_response.response_size=8GiB
 
           SCENARIOS=$(find target/netbench -type f -exec basename -s .json {} \; | jq -Rcs 'rtrimstr("\n") | split("\n")')
           echo "::set-output name=scenarios::$SCENARIOS"

--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -120,7 +120,9 @@ jobs:
       - name: Generate scenarios
         id: scenarios
         run: |
-          ./netbench/target/release/netbench-scenarios
+          ./netbench/target/release/netbench-scenarios \
+            --request-response.response_size=8GiB
+
           SCENARIOS=$(find target/netbench -type f -exec basename -s .json {} \; | jq -Rcs 'rtrimstr("\n") | split("\n")')
           echo "::set-output name=scenarios::$SCENARIOS"
 

--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -1,0 +1,168 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+name: netbench
+
+env:
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  RUST_BACKTRACE: 1
+  # Pin the nightly toolchain to prevent breakage.
+  # This should be occasionally updated.
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2021-11-17
+  CDN: https://dnglbrstg7yg.cloudfront.net
+
+jobs:
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
+          profile: minimal
+          override: true
+          components: rustfmt
+
+      - name: Run cargo fmt
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: fmt
+          args: --manifest-path netbench/Cargo.toml --all -- --check
+
+  clippy:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable, beta]
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: ${{ matrix.toolchain }}
+          profile: minimal
+          override: true
+          components: clippy
+
+      - uses: camshaft/rust-cache@v1
+
+      # TODO translate json reports to in-action warnings
+      - name: Run cargo clippy
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: clippy
+          args: --manifest-path netbench/Cargo.toml --all-features --all-targets -- -D warnings
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          lfs: true
+
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: stable
+          override: true
+
+      - uses: camshaft/rust-cache@v1
+
+      - name: Restore fuzz corpus
+        shell: bash
+        run: |
+          find . -name 'corpus.tar.gz' -exec dirname {} ';' | xargs -L 1 bash -c 'cd "$0" && rm -rf corpus && tar xf corpus.tar.gz'
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+          args: --manifest-path netbench/Cargo.toml --tests
+
+      - name: Run cargo test
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: test
+          args: --manifest-path netbench/Cargo.toml
+
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      scenarios: ${{ steps.scenarios.outputs.scenarios }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: stable
+          override: true
+
+      - uses: camshaft/rust-cache@v1
+
+      - name: Run cargo build
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+          args: --manifest-path netbench/Cargo.toml --release
+
+      - name: Generate scenarios
+        id: scenarios
+        run: |
+          ./netbench/target/release/netbench-scenarios
+          SCENARIOS=$(ls target/netbench | xargs basename -s .json | jq -Rs 'rtrimstr("\n") | split("\n")')
+          echo "::set-output name=scenarios::$SCENARIOS"
+
+      - name: Prepare artifact
+        run: |
+          mkdir -p artifact
+          cp -r target/netbench artifact/scenarios
+          cp netbench/target/release/netbench-driver* artifact
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: netbench
+          path: artifact
+
+  run:
+    runs-on: ubuntu-latest
+    needs: [build]
+    strategy:
+      fail-fast: false
+      matrix:
+        driver:
+          - s2n-quic
+          - native-tls
+          - tcp
+        scenario: ${{ fromJson(needs.build.outputs.scenarios) }}
+
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: netbench
+          path: .
+
+      - name: Prepare artifact
+        run: |
+          chmod +x ./netbench-driver*
+          export SCENARIO=scenarios/${{ matrix.scenario }}
+
+      # TODO use netbench-cli instead when it's available
+      - name: Run server
+        run: |
+          ./netbench-driver-${{ matrix.driver }}-server &
+
+      - name: Run client
+        run: |
+          ./netbench-driver-${{ matrix.driver }}-client

--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -146,6 +146,8 @@ jobs:
           - native-tls
           - tcp
         scenario: ${{ fromJson(needs.build.outputs.scenarios) }}
+    env:
+      SCENARIO: scenarios/${{ matrix.scenario }}.json
 
     steps:
       - uses: actions/download-artifact@v2
@@ -160,11 +162,9 @@ jobs:
       # TODO use netbench-cli instead when it's available
       - name: Run server
         run: |
-          export SCENARIO=scenarios/${{ matrix.scenario }}
           ./netbench-driver-${{ matrix.driver }}-server &
 
       - name: Run client
         run: |
-          export SCENARIO=scenarios/${{ matrix.scenario }}
           export SERVER_0=localhost:4433
           ./netbench-driver-${{ matrix.driver }}-client

--- a/netbench/netbench-driver/Cargo.toml
+++ b/netbench/netbench-driver/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "netbench-driver"
+version = "0.1.0"
+authors = ["AWS s2n"]
+edition = "2018"
+license = "Apache-2.0"
+
+[dependencies]
+bytes = "1"
+futures = "0.3"
+netbench = { version = "0.1", path = "../netbench" }
+s2n-quic = { version = "1", path = "../../quic/s2n-quic", features = ["provider-tls-s2n"] }
+s2n-quic-core = { version = "0.1", path = "../../quic/s2n-quic-core", features = ["testing"] }
+structopt = "0.3"
+tokio = { version = "1", features = ["io-util", "net", "time"] }
+tokio-native-tls = "0.3"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Pin to this version until s2n-tls supports OpenSSL 3.0
+# Build the vendored version to make it easy to test in dev
+#
+# NOTE: The version of the `openssl-sys` crate is not the same as OpenSSL itself.
+#       Versions 1.0.1 - 3.0.0 are automatically discovered.
+openssl-sys = { version = "<= 0.9.68", features = ["vendored"] }

--- a/netbench/netbench-driver/README.md
+++ b/netbench/netbench-driver/README.md
@@ -1,0 +1,22 @@
+# netbench-driver
+
+This crate contains drivers for each transport protocol.
+
+## Running driver tests
+
+Netbench will have a dedicated CLI to automate running tests. Until then, the drivers can be used directly.
+
+```
+export DRIVER=s2n-quic
+cargo build --release --bin netbench-driver-$DRIVER-server --bin netbench-driver-$DRIVER-client --bin netbench-scenarios
+./target/release/netbench-scenarios
+./target/release/netbench-driver-$DRIVER-server ./target/netbench/request_response.json
+```
+
+In another terminal
+
+```
+export DRIVER=s2n-quic
+export SERVER_0=localhost:4433
+./target/release/netbench-driver-$DRIVER-client ./target/netbench/request_response.json
+```

--- a/netbench/netbench-driver/README.md
+++ b/netbench/netbench-driver/README.md
@@ -6,7 +6,7 @@ This crate contains drivers for each transport protocol.
 
 Netbench will have a dedicated CLI to automate running tests. Until then, the drivers can be used directly.
 
-```
+```sh
 export DRIVER=s2n-quic
 cargo build --release --bin netbench-driver-$DRIVER-server --bin netbench-driver-$DRIVER-client --bin netbench-scenarios
 ./target/release/netbench-scenarios
@@ -15,8 +15,14 @@ cargo build --release --bin netbench-driver-$DRIVER-server --bin netbench-driver
 
 In another terminal
 
-```
+```sh
 export DRIVER=s2n-quic
 export SERVER_0=localhost:4433
 ./target/release/netbench-driver-$DRIVER-client ./target/netbench/request_response.json
+```
+
+## Building docker images
+
+```sh
+sudo docker-compose --file netbench/netbench-driver/etc/docker-compose.yml --project-directory . build
 ```

--- a/netbench/netbench-driver/etc/Dockerfile
+++ b/netbench/netbench-driver/etc/Dockerfile
@@ -1,0 +1,87 @@
+FROM rust:latest as planner
+WORKDIR app
+RUN cargo install cargo-chef --version 0.1.23
+COPY Cargo.toml /app
+COPY common /app/common
+COPY quic /app/quic
+COPY netbench /app/netbench
+RUN set -eux; \
+  cargo chef prepare --recipe-path recipe.json; \
+  cd netbench; \
+  cargo chef prepare --recipe-path recipe.json;
+
+FROM rust:latest as cacher
+WORKDIR app
+RUN cargo install cargo-chef --version 0.1.23
+COPY --from=planner /app/recipe.json recipe.json
+COPY --from=planner /app/netbench/recipe.json netbench/recipe.json
+
+ARG release="true"
+RUN set -eux; \
+  export ARGS=""; \
+  if [ "$release" = "true" ]; then \
+    export ARGS="--release"; \
+  fi; \
+  cargo chef cook $ARGS --recipe-path recipe.json; \
+  cd netbench; \
+  cargo chef cook $ARGS --recipe-path recipe.json; \
+  echo cooked;
+
+FROM rust:latest AS builder
+WORKDIR app
+
+RUN set -eux; \
+  apt-get update; \
+  apt-get install -y cmake clang;
+
+# copy sources
+COPY Cargo.toml /app
+COPY common /app/common
+COPY quic /app/quic
+COPY netbench /app/netbench
+
+# Copy over the cached dependencies
+COPY --from=cacher /app/target target
+COPY --from=cacher /app/netbench/target netbench/target
+COPY --from=cacher /usr/local/cargo /usr/local/cargo
+
+ARG release="true"
+
+# build libs to improve caching between drivers
+RUN set -eux; \
+  export ARGS=""; \
+  if [ "$release" = "true" ]; then \
+    export ARGS="--release"; \
+  fi; \
+  cd netbench; \
+  cargo build --lib $ARGS;
+
+ARG DRIVER="s2n-quic"
+ARG ENDPOINT="client"
+
+RUN set -eux; \
+  mkdir -p /app/bin; \
+  export TARGET="netbench-driver-$DRIVER-$ENDPOINT"; \
+  echo "#!/usr/bin/env bash\neval /usr/bin/$TARGET \$@" > /app/bin/start; \
+  cd netbench; \
+  if [ "$release" = "true" ]; then \
+    cargo build --bin $TARGET --release; \
+    cp target/release/$TARGET /app/bin; \
+  else \
+    cargo build --bin $TARGET; \
+    cp target/debug/$TARGET /app/bin; \
+  fi; \
+  rm -rf target
+
+FROM debian:latest
+
+ENV RUST_BACKTRACE="1"
+
+# copy driver
+COPY --from=builder /app/bin /tmp/netbench
+RUN set -eux; \
+  chmod +x /tmp/netbench/*; \
+  mv /tmp/netbench/* /usr/bin; \
+  echo done
+
+ENTRYPOINT ["/usr/bin/start"]

--- a/netbench/netbench-driver/etc/docker-compose.yml
+++ b/netbench/netbench-driver/etc/docker-compose.yml
@@ -1,0 +1,57 @@
+version: "3.7"
+
+services:
+  netbench-driver-s2n-quic-client:
+    build:
+      args:
+        DRIVER: s2n-quic
+        ENDPOINT: client
+      context: ./
+      dockerfile: ./netbench/netbench-driver/etc/Dockerfile
+    image: netbench/driver-s2n-quic-client
+
+  netbench-driver-s2n-quic-server:
+    build:
+      args:
+        DRIVER: s2n-quic
+        ENDPOINT: server
+      context: ./
+      dockerfile: ./netbench/netbench-driver/etc/Dockerfile
+    image: netbench/driver-s2n-quic-server
+
+  netbench-driver-native-tls-client:
+    build:
+      args:
+        DRIVER: native-tls
+        ENDPOINT: client
+      context: ./
+      dockerfile: ./netbench/netbench-driver/etc/Dockerfile
+    image: netbench/driver-native-tls-client
+
+  netbench-driver-native-tls-server:
+    build:
+      args:
+        DRIVER: native-tls
+        ENDPOINT: server
+      context: ./
+      dockerfile: ./netbench/netbench-driver/etc/Dockerfile
+    image: netbench/driver-native-tls-server
+
+  netbench-driver-tcp-client:
+    build:
+      args:
+        DRIVER: tcp
+        ENDPOINT: client
+      context: ./
+      dockerfile: ./netbench/netbench-driver/etc/Dockerfile
+    image: netbench/driver-tcp-client
+
+  netbench-driver-tcp-server:
+    build:
+      args:
+        DRIVER: tcp
+        ENDPOINT: server
+      context: ./
+      dockerfile: ./netbench/netbench-driver/etc/Dockerfile
+    image: netbench/driver-tcp-server
+

--- a/netbench/netbench-driver/src/bin/netbench-driver-native-tls-client.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-native-tls-client.rs
@@ -1,0 +1,95 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use netbench::{multiplex, scenario, Result};
+use std::{collections::HashSet, future::Future, net::SocketAddr, pin::Pin, sync::Arc};
+use structopt::StructOpt;
+use tokio::{io::AsyncWriteExt, net::TcpStream};
+use tokio_native_tls::{
+    native_tls::{Certificate, TlsConnector},
+    TlsStream,
+};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    Client::from_args().run().await
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Client {
+    #[structopt(flatten)]
+    opts: netbench_driver::Client,
+}
+
+impl Client {
+    pub async fn run(&self) -> Result<()> {
+        let addresses = self.opts.address_map().await?;
+        let scenario = self.opts.scenario();
+
+        let client = self.client()?;
+        let client = netbench::Client::new(client, &scenario, &addresses);
+        let mut trace = self.opts.trace();
+        let mut checkpoints = HashSet::new();
+        let mut timer = netbench::timer::Tokio::default();
+        client.run(&mut trace, &mut checkpoints, &mut timer).await?;
+
+        Ok(())
+    }
+
+    fn client(&self) -> Result<ClientImpl> {
+        let mut builder = TlsConnector::builder();
+        for ca in self.opts.certificate_authorities() {
+            let ca = Certificate::from_pem(ca.pem.as_bytes())?;
+            builder.add_root_certificate(ca);
+        }
+        let connector = builder.build()?;
+        let connector: tokio_native_tls::TlsConnector = connector.into();
+        let connector = Arc::new(connector);
+
+        let config = multiplex::Config::default();
+
+        Ok(ClientImpl { config, connector })
+    }
+}
+
+type Connection<'a> = netbench::Driver<'a, multiplex::Connection<TlsStream<TcpStream>>>;
+
+#[derive(Clone, Debug)]
+struct ClientImpl {
+    config: multiplex::Config,
+    connector: Arc<tokio_native_tls::TlsConnector>,
+}
+
+impl<'a> netbench::client::Client<'a> for ClientImpl {
+    type Connect = Pin<Box<dyn Future<Output = Result<Self::Connection>> + 'a>>;
+    type Connection = Connection<'a>;
+
+    fn connect(
+        &mut self,
+        addr: SocketAddr,
+        server_name: &str,
+        server_conn_id: u64,
+        scenario: &'a Arc<scenario::Connection>,
+    ) -> Self::Connect {
+        let config = self.config.clone();
+        let connector = self.connector.clone();
+        let server_name = server_name.to_string();
+
+        let fut = async move {
+            let conn = TcpStream::connect(addr).await?;
+            let mut conn = connector.connect(&server_name, conn).await?;
+
+            // The native-tls crate does not expose the server name on the server so we need to
+            // write the connection id for now.
+            conn.write_u64(server_conn_id).await?;
+
+            let conn = Box::pin(conn);
+            let conn = multiplex::Connection::new(conn, config);
+            let conn: Connection = netbench::Driver::new(scenario, conn);
+
+            Result::Ok(conn)
+        };
+
+        Box::pin(fut)
+    }
+}

--- a/netbench/netbench-driver/src/bin/netbench-driver-native-tls-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-native-tls-server.rs
@@ -1,0 +1,101 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use netbench::{multiplex, scenario, Result, Timer};
+use std::{collections::HashSet, sync::Arc};
+use structopt::StructOpt;
+use tokio::{
+    io::AsyncReadExt,
+    net::{TcpListener, TcpStream},
+    spawn,
+};
+use tokio_native_tls::native_tls::{Identity, TlsAcceptor};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    Server::from_args().run().await
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Server {
+    #[structopt(flatten)]
+    opts: netbench_driver::Server,
+}
+
+impl Server {
+    pub async fn run(&self) -> Result<()> {
+        let scenario = self.opts.scenario();
+
+        let server = self.server().await?;
+
+        let trace = self.opts.trace();
+        let ident = self.identity()?;
+        let acceptor = TlsAcceptor::builder(ident).build()?;
+        let acceptor: tokio_native_tls::TlsAcceptor = acceptor.into();
+        let acceptor = Arc::new(acceptor);
+
+        // TODO load configuration from scenario
+        let config = netbench::multiplex::Config::default();
+
+        let mut conn_id = 0;
+        loop {
+            let (connection, _addr) = server.accept().await?;
+            let scenario = scenario.clone();
+            let id = conn_id;
+            conn_id += 1;
+            let acceptor = acceptor.clone();
+            let trace = trace.clone();
+            let config = config.clone();
+            spawn(async move {
+                if let Err(err) =
+                    handle_connection(acceptor, connection, id, scenario, trace, config).await
+                {
+                    eprintln!("error: {}", err);
+                }
+            });
+        }
+
+        async fn handle_connection(
+            acceptor: Arc<tokio_native_tls::TlsAcceptor>,
+            connection: TcpStream,
+            conn_id: u64,
+            scenario: Arc<scenario::Server>,
+            mut trace: impl netbench::Trace,
+            config: multiplex::Config,
+        ) -> Result<()> {
+            let mut connection = acceptor.accept(connection).await?;
+            let server_idx = connection.read_u64().await?;
+            let scenario = scenario
+                .connections
+                .get(server_idx as usize)
+                .ok_or("invalid connection id")?;
+            let connection = Box::pin(connection);
+
+            let conn = netbench::Driver::new(
+                scenario,
+                netbench::multiplex::Connection::new(connection, config),
+            );
+
+            let mut checkpoints = HashSet::new();
+            let mut timer = netbench::timer::Tokio::default();
+
+            trace.enter(timer.now(), conn_id, 0);
+            conn.run(&mut trace, &mut checkpoints, &mut timer).await?;
+            trace.exit(timer.now());
+
+            Ok(())
+        }
+    }
+
+    async fn server(&self) -> Result<TcpListener> {
+        let server = TcpListener::bind((self.opts.ip, self.opts.port)).await?;
+        Ok(server)
+    }
+
+    fn identity(&self) -> Result<Identity> {
+        let (_, private_key) = self.opts.certificate();
+        let cert = &private_key.pkcs12;
+        let ident = Identity::from_pkcs12(cert, "")?;
+        Ok(ident)
+    }
+}

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-quic-client.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-quic-client.rs
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use netbench::Result;
+use s2n_quic::provider::{io, tls::default::certificate::IntoCertificate};
+use std::collections::HashSet;
+use structopt::StructOpt;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), String> {
+    Client::from_args().run().await.map_err(|e| e.to_string())
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Client {
+    #[structopt(flatten)]
+    opts: netbench_driver::Client,
+
+    #[structopt(long)]
+    disable_gso: bool,
+}
+
+impl Client {
+    pub async fn run(&self) -> Result<()> {
+        let addresses = self.opts.address_map().await?;
+        let scenario = self.opts.scenario();
+
+        let client = self.client()?;
+        let client = netbench::Client::new(client, &scenario, &addresses);
+        let mut trace = self.opts.trace();
+        let mut checkpoints = HashSet::new();
+        let mut timer = netbench::timer::Tokio::default();
+        let mut client = client.run(&mut trace, &mut checkpoints, &mut timer).await?;
+
+        client.wait_idle().await?;
+
+        Ok(())
+    }
+
+    fn client(&self) -> Result<s2n_quic::Client> {
+        let mut tls = s2n_quic::provider::tls::default::Client::builder()
+            // handle larger cert chains
+            .with_max_cert_chain_depth(10)?
+            .with_application_protocols(
+                self.opts.application_protocols.iter().map(String::as_bytes),
+            )?
+            .with_key_logging()?;
+
+        for ca in self.opts.certificate_authorities() {
+            tls = tls.with_certificate(ca.pem.as_str())?;
+        }
+
+        let tls = tls.build()?;
+
+        let mut io_builder =
+            io::Default::builder().with_receive_address((self.opts.local_ip, 0u16).into())?;
+
+        if self.disable_gso {
+            io_builder = io_builder.with_gso_disabled()?;
+        }
+
+        let io = io_builder.build()?;
+
+        let client = s2n_quic::Client::builder()
+            .with_io(io)?
+            .with_tls(tls)?
+            .start()
+            .unwrap();
+
+        Ok(client)
+    }
+}

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-quic-client.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-quic-client.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use netbench::Result;
-use s2n_quic::provider::{io, tls::default::certificate::IntoCertificate};
+use s2n_quic::provider::io;
 use std::collections::HashSet;
 use structopt::StructOpt;
 

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-quic-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-quic-server.rs
@@ -2,13 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use netbench::{scenario, Result, Timer};
-use s2n_quic::{
-    provider::{
-        io,
-        tls::default::certificate::{IntoCertificate, IntoPrivateKey},
-    },
-    Connection,
-};
+use s2n_quic::{provider::io, Connection};
 use std::{collections::HashSet, sync::Arc};
 use structopt::StructOpt;
 use tokio::spawn;
@@ -70,8 +64,8 @@ impl Server {
 
     fn server(&self) -> Result<s2n_quic::Server> {
         let (certificate, private_key) = self.opts.certificate();
-        let certificate = certificate.pem.as_str().into_certificate()?;
-        let private_key = private_key.pem.as_str().into_private_key()?;
+        let certificate = certificate.pem.as_str();
+        let private_key = private_key.pem.as_str();
 
         let tls = s2n_quic::provider::tls::default::Server::builder()
             .with_certificate(certificate, private_key)?

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-quic-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-quic-server.rs
@@ -1,0 +1,101 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use netbench::{scenario, Result, Timer};
+use s2n_quic::{
+    provider::{
+        io,
+        tls::default::certificate::{IntoCertificate, IntoPrivateKey},
+    },
+    Connection,
+};
+use std::{collections::HashSet, sync::Arc};
+use structopt::StructOpt;
+use tokio::spawn;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    Server::from_args().run().await
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Server {
+    #[structopt(flatten)]
+    opts: netbench_driver::Server,
+
+    #[structopt(long)]
+    disable_gso: bool,
+}
+
+impl Server {
+    pub async fn run(&self) -> Result<()> {
+        let scenario = self.opts.scenario();
+        let trace = self.opts.trace();
+
+        let mut server = self.server()?;
+
+        while let Some(connection) = server.accept().await {
+            let scenario = scenario.clone();
+            let trace = trace.clone();
+            spawn(async move {
+                if let Err(error) = handle_connection(connection, scenario, trace).await {
+                    eprintln!("error: {:#}", error);
+                }
+            });
+        }
+
+        return Err("server shut down unexpectedly".into());
+
+        async fn handle_connection(
+            connection: Connection,
+            scenario: Arc<scenario::Server>,
+            mut trace: impl netbench::Trace,
+        ) -> Result<()> {
+            let conn_id = connection.id();
+            let server_name = connection.server_name()?.ok_or("missing server name")?;
+            let scenario = scenario.on_server_name(&server_name)?;
+            let conn =
+                netbench::Driver::new(scenario, netbench::s2n_quic::Connection::new(connection));
+
+            let mut checkpoints = HashSet::new();
+            let mut timer = netbench::timer::Tokio::default();
+
+            trace.enter(timer.now(), conn_id, 0);
+            conn.run(&mut trace, &mut checkpoints, &mut timer).await?;
+            trace.exit(timer.now());
+
+            Ok(())
+        }
+    }
+
+    fn server(&self) -> Result<s2n_quic::Server> {
+        let (certificate, private_key) = self.opts.certificate();
+        let certificate = certificate.pem.as_str().into_certificate()?;
+        let private_key = private_key.pem.as_str().into_private_key()?;
+
+        let tls = s2n_quic::provider::tls::default::Server::builder()
+            .with_certificate(certificate, private_key)?
+            .with_application_protocols(
+                self.opts.application_protocols.iter().map(String::as_bytes),
+            )?
+            .with_key_logging()?
+            .build()?;
+
+        let mut io_builder =
+            io::Default::builder().with_receive_address((self.opts.ip, self.opts.port).into())?;
+
+        if self.disable_gso {
+            io_builder = io_builder.with_gso_disabled()?;
+        }
+
+        let io = io_builder.build()?;
+
+        let server = s2n_quic::Server::builder()
+            .with_io(io)?
+            .with_tls(tls)?
+            .start()
+            .unwrap();
+
+        Ok(server)
+    }
+}

--- a/netbench/netbench-driver/src/bin/netbench-driver-tcp-client.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-tcp-client.rs
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use netbench::{multiplex, scenario, Result};
+use std::{collections::HashSet, future::Future, net::SocketAddr, pin::Pin, sync::Arc};
+use structopt::StructOpt;
+use tokio::{io::AsyncWriteExt, net::TcpStream};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    Client::from_args().run().await
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Client {
+    #[structopt(flatten)]
+    opts: netbench_driver::Client,
+}
+
+impl Client {
+    pub async fn run(&self) -> Result<()> {
+        let addresses = self.opts.address_map().await?;
+        let scenario = self.opts.scenario();
+
+        // TODO pull from scenario configuration
+        let config = multiplex::Config::default();
+
+        let client = ClientImpl { config };
+
+        let client = netbench::Client::new(client, &scenario, &addresses);
+        let mut trace = self.opts.trace();
+        let mut checkpoints = HashSet::new();
+        let mut timer = netbench::timer::Tokio::default();
+        client.run(&mut trace, &mut checkpoints, &mut timer).await?;
+
+        Ok(())
+    }
+}
+
+type Connection<'a> = netbench::Driver<'a, multiplex::Connection<TcpStream>>;
+
+#[derive(Clone, Debug)]
+struct ClientImpl {
+    config: multiplex::Config,
+}
+
+impl<'a> netbench::client::Client<'a> for ClientImpl {
+    type Connect = Pin<Box<dyn Future<Output = Result<Self::Connection>> + 'a>>;
+    type Connection = Connection<'a>;
+
+    fn connect(
+        &mut self,
+        addr: SocketAddr,
+        _server_name: &str,
+        server_conn_id: u64,
+        scenario: &'a Arc<scenario::Connection>,
+    ) -> Self::Connect {
+        let config = self.config.clone();
+
+        let fut = async move {
+            let mut conn = TcpStream::connect(addr).await?;
+
+            // tell the server which connection ID to use
+            conn.write_u64(server_conn_id).await?;
+
+            let conn = Box::pin(conn);
+            let conn = multiplex::Connection::new(conn, config);
+            let conn: Connection = netbench::Driver::new(scenario, conn);
+
+            Result::Ok(conn)
+        };
+
+        Box::pin(fut)
+    }
+}

--- a/netbench/netbench-driver/src/bin/netbench-driver-tcp-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-tcp-server.rs
@@ -1,0 +1,82 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use netbench::{multiplex, scenario, Result, Timer};
+use std::{collections::HashSet, sync::Arc};
+use structopt::StructOpt;
+use tokio::{
+    io::AsyncReadExt,
+    net::{TcpListener, TcpStream},
+    spawn,
+};
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    Server::from_args().run().await
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Server {
+    #[structopt(flatten)]
+    opts: netbench_driver::Server,
+}
+
+impl Server {
+    pub async fn run(&self) -> Result<()> {
+        let scenario = self.opts.scenario();
+
+        let server = self.server().await?;
+        let trace = self.opts.trace();
+
+        // TODO load configuration from scenario
+        let config = multiplex::Config::default();
+
+        let mut conn_id = 0;
+        loop {
+            let (connection, _addr) = server.accept().await?;
+            let scenario = scenario.clone();
+            let id = conn_id;
+            conn_id += 1;
+            let trace = trace.clone();
+            let config = config.clone();
+            spawn(async move {
+                if let Err(err) = handle_connection(connection, id, scenario, trace, config).await {
+                    eprintln!("error: {}", err);
+                }
+            });
+        }
+
+        async fn handle_connection(
+            mut connection: TcpStream,
+            conn_id: u64,
+            scenario: Arc<scenario::Server>,
+            mut trace: impl netbench::Trace,
+            config: multiplex::Config,
+        ) -> Result<()> {
+            let server_idx = connection.read_u64().await?;
+            let scenario = scenario
+                .connections
+                .get(server_idx as usize)
+                .ok_or("invalid connection id")?;
+            let connection = Box::pin(connection);
+            let conn = netbench::Driver::new(
+                scenario,
+                netbench::multiplex::Connection::new(connection, config),
+            );
+
+            let mut checkpoints = HashSet::new();
+            let mut timer = netbench::timer::Tokio::default();
+
+            trace.enter(timer.now(), conn_id, 0);
+            conn.run(&mut trace, &mut checkpoints, &mut timer).await?;
+            trace.exit(timer.now());
+
+            Ok(())
+        }
+    }
+
+    async fn server(&self) -> Result<TcpListener> {
+        let server = TcpListener::bind((self.opts.ip, self.opts.port)).await?;
+        Ok(server)
+    }
+}

--- a/netbench/netbench-driver/src/lib.rs
+++ b/netbench/netbench-driver/src/lib.rs
@@ -1,0 +1,173 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use netbench::{
+    client::{self, AddressMap},
+    scenario, trace, Error, Result,
+};
+use std::{net::IpAddr, ops::Deref, path::Path, str::FromStr, sync::Arc, time::Duration};
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct Server {
+    #[structopt(short, long, default_value = "::")]
+    pub ip: IpAddr,
+
+    #[structopt(short, long, default_value = "4433", env = "PORT")]
+    pub port: u16,
+
+    #[structopt(long, default_value = "netbench")]
+    pub application_protocols: Vec<String>,
+
+    #[structopt(long, default_value = "0", env = "SERVER_ID")]
+    pub server_id: usize,
+
+    #[structopt(long, default_value = "throughput", possible_values = &["throughput","stdio"])]
+    pub trace: Vec<String>,
+
+    #[structopt(long, short = "V")]
+    pub verbose: bool,
+
+    #[structopt(env = "SCENARIO")]
+    pub scenario: Scenario,
+}
+
+impl Server {
+    pub fn scenario(&self) -> Arc<scenario::Server> {
+        let id = self.server_id;
+        self.scenario.servers[id].clone()
+    }
+
+    pub fn certificate(&self) -> (&Arc<scenario::Certificate>, &Arc<scenario::Certificate>) {
+        let id = self.server_id;
+        let server = &self.scenario.servers[id];
+        let cert = &self.scenario.certificates[server.certificate as usize];
+        let private_key = &self.scenario.certificates[server.private_key as usize];
+        (cert, private_key)
+    }
+
+    pub fn trace(&self) -> (Option<trace::Throughput>, Option<trace::StdioLogger>) {
+        let throughput = if self.trace.iter().any(|v| v == "throughput") {
+            let trace = trace::Throughput::default();
+            trace.reporter(Duration::from_secs(1));
+            Some(trace)
+        } else {
+            None
+        };
+
+        let stdio = if self.trace.iter().any(|v| v == "stdio") {
+            let id = self.server_id as u64;
+            let mut trace = trace::StdioLogger::new(id, self.scenario.traces.clone());
+            trace.verbose(self.verbose);
+            Some(trace)
+        } else {
+            None
+        };
+
+        (throughput, stdio)
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Client {
+    #[structopt(long, default_value = "netbench")]
+    pub application_protocols: Vec<String>,
+
+    #[structopt(short, long, default_value = "::")]
+    pub local_ip: IpAddr,
+
+    #[structopt(long, default_value = "0", env = "CLIENT_ID")]
+    pub client_id: usize,
+
+    #[structopt(long, default_value = "throughput", possible_values = &["throughput","stdio"])]
+    pub trace: Vec<String>,
+
+    #[structopt(long, short = "V")]
+    pub verbose: bool,
+
+    #[structopt(env = "SCENARIO")]
+    pub scenario: Scenario,
+}
+
+impl Client {
+    pub fn scenario(&self) -> Arc<scenario::Client> {
+        let id = self.client_id;
+        self.scenario.clients[id].clone()
+    }
+
+    pub fn certificate_authorities(&self) -> impl Iterator<Item = Arc<scenario::Certificate>> + '_ {
+        let id = self.client_id;
+        let certs = &self.scenario.certificates;
+        self.scenario.clients[id]
+            .certificate_authorities
+            .iter()
+            .copied()
+            .map(move |ca| certs[ca as usize].clone())
+    }
+
+    pub async fn address_map(&self) -> Result<AddressMap> {
+        let id = self.client_id as u64;
+        AddressMap::new(&self.scenario, id, &mut Resolver).await
+    }
+
+    pub fn trace(&self) -> (Option<trace::Throughput>, Option<trace::StdioLogger>) {
+        let throughput = if self.trace.iter().any(|v| v == "throughput") {
+            let trace = trace::Throughput::default();
+            trace.reporter(Duration::from_secs(1));
+            Some(trace)
+        } else {
+            None
+        };
+
+        let stdio = if self.trace.iter().any(|v| v == "stdio") {
+            let id = self.client_id as u64;
+            let mut trace = trace::StdioLogger::new(id, self.scenario.traces.clone());
+            trace.verbose(self.verbose);
+            Some(trace)
+        } else {
+            None
+        };
+
+        (throughput, stdio)
+    }
+}
+
+struct Resolver;
+
+impl Resolver {
+    fn get(&self, key: String) -> Result<String> {
+        let host =
+            std::env::var(&key).map_err(|_| format!("missing {} environment variable", key))?;
+        Ok(host)
+    }
+}
+
+impl client::Resolver for Resolver {
+    fn server(&mut self, id: u64) -> Result<String> {
+        self.get(format!("SERVER_{}", id))
+    }
+
+    fn router(&mut self, router_id: u64, server_id: u64) -> Result<String> {
+        self.get(format!("ROUTER_{}_SERVER_{}", router_id, server_id))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Scenario(Arc<scenario::Scenario>);
+
+impl FromStr for Scenario {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let scenario = scenario::Scenario::open(Path::new(s))?;
+        Ok(Self(Arc::new(scenario)))
+    }
+}
+
+impl Deref for Scenario {
+    type Target = scenario::Scenario;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.deref()
+    }
+}

--- a/netbench/netbench-scenarios/src/lib.rs
+++ b/netbench/netbench-scenarios/src/lib.rs
@@ -51,7 +51,7 @@ pub fn main<C: Configs>() -> Result<()> {
     Ok(())
 }
 
-const LONG_ABOUT: &'static str = r#"
+const LONG_ABOUT: &str = r#"
 FORMATS:
     BYTES
         42b         ->    42 bits

--- a/netbench/netbench/src/client.rs
+++ b/netbench/netbench/src/client.rs
@@ -1,0 +1,214 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    driver::timer,
+    operation as ops,
+    scenario::{self, Scenario},
+    timer::Timer,
+    Checkpoints, Result, Trace,
+};
+use std::{
+    collections::BTreeMap,
+    future::Future,
+    net::SocketAddr,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+mod thread;
+
+pub trait Client<'a> {
+    type Connect: Future<Output = Result<Self::Connection>> + Unpin;
+    type Connection: Connection;
+
+    fn connect(
+        &mut self,
+        addr: SocketAddr,
+        hostname: &str,
+        server_conn_id: u64,
+        ops: &'a Arc<scenario::Connection>,
+    ) -> Self::Connect;
+}
+
+pub trait Connection: crate::driver::timer::Provider {
+    fn poll<T: Trace, Ch: Checkpoints>(
+        &mut self,
+        trace: &mut T,
+        checkpoints: &mut Ch,
+        now: crate::driver::timer::Timestamp,
+        cx: &mut Context,
+    ) -> Poll<Result<()>>;
+}
+
+pub struct Driver<'a, C: Client<'a>> {
+    client: C,
+    thread: thread::Thread<'a, C>,
+    addresses: &'a AddressMap,
+}
+
+impl<'a, C: Client<'a>> Driver<'a, C> {
+    pub fn new(client: C, scenario: &'a scenario::Client, addresses: &'a AddressMap) -> Self {
+        Self {
+            client,
+            thread: thread::Thread::new(scenario, &scenario.scenario),
+            addresses,
+        }
+    }
+
+    pub async fn run<T: Trace, Ch: Checkpoints, Ti: Timer>(
+        mut self,
+        trace: &mut T,
+        checkpoints: &mut Ch,
+        timer: &mut Ti,
+    ) -> Result<C> {
+        futures::future::poll_fn(|cx| self.poll_with_timer(trace, checkpoints, timer, cx)).await?;
+        Ok(self.client)
+    }
+
+    pub fn poll_with_timer<T: Trace, Ch: Checkpoints, Ti: Timer>(
+        &mut self,
+        trace: &mut T,
+        checkpoints: &mut Ch,
+        timer: &mut Ti,
+        cx: &mut Context,
+    ) -> Poll<Result<()>> {
+        let now = timer.now();
+        let res = self.poll(trace, checkpoints, now, cx);
+
+        if let Some(target) = timer::Provider::next_expiration(&self) {
+            // update the timer with the next expiration
+            let _ = timer.poll(target, cx);
+        };
+
+        res
+    }
+
+    pub fn poll<T: Trace, Ch: Checkpoints>(
+        &mut self,
+        trace: &mut T,
+        checkpoints: &mut Ch,
+        now: timer::Timestamp,
+        cx: &mut Context,
+    ) -> Poll<Result<()>> {
+        self.thread.poll(
+            &mut self.client,
+            self.addresses,
+            trace,
+            checkpoints,
+            now,
+            cx,
+        )
+    }
+}
+
+impl<'a, C: Client<'a>> timer::Provider for Driver<'a, C> {
+    fn timers<Q>(&self, query: &mut Q) -> timer::Result
+    where
+        Q: timer::Query,
+    {
+        self.thread.timers(query)
+    }
+}
+
+pub struct AddressMap {
+    routers: Vec<BTreeMap<u64, SocketAddr>>,
+    servers: Vec<SocketAddr>,
+    hostnames: Vec<String>,
+}
+
+pub trait Resolver {
+    fn server(&mut self, server_id: u64) -> Result<String>;
+    fn router(&mut self, router_id: u64, server_id: u64) -> Result<String>;
+}
+
+async fn resolve_routes<R: Resolver>(
+    id: u64,
+    ops: &[ops::Client],
+    routes: &mut BTreeMap<u64, SocketAddr>,
+    resolver: &mut R,
+) -> Result<()> {
+    let mut pending: Vec<_> = ops.iter().collect();
+
+    while let Some(op) = pending.pop() {
+        match op {
+            ops::Client::Connect {
+                server_id,
+                router_id,
+                ..
+            } if Some(id) == *router_id => {
+                let host = resolver.router(id, *server_id)?;
+                let mut addr = tokio::net::lookup_host(host).await?;
+                let addr = addr.next().ok_or("invalid address")?;
+                routes.insert(*server_id, addr);
+            }
+            ops::Client::Scope { threads } => {
+                for thread in threads {
+                    pending.extend(thread);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+impl AddressMap {
+    pub async fn new<R: Resolver>(
+        scenario: &Scenario,
+        client_id: u64,
+        resolver: &mut R,
+    ) -> Result<Self> {
+        let client = &scenario.clients[client_id as usize];
+
+        let mut servers = vec![];
+        for id in 0..scenario.servers.len() {
+            let host = resolver.server(id as u64)?;
+            let mut addr = tokio::net::lookup_host(host).await?;
+            let addr = addr.next().ok_or("invalid address")?;
+            servers.push(addr);
+        }
+
+        let mut routers = vec![];
+        for router_id in 0..scenario.routers.len() {
+            let mut routes = BTreeMap::new();
+
+            resolve_routes(router_id as u64, &client.scenario, &mut routes, resolver).await?;
+
+            routers.push(routes);
+        }
+
+        let hostname_len = scenario
+            .servers
+            .iter()
+            .map(|server| server.connections.len())
+            .max()
+            .unwrap_or(0);
+
+        let mut hostnames = vec![];
+        for idx in 0..hostname_len {
+            hostnames.push(format!("{}.{}.net", idx, scenario.id));
+        }
+
+        Ok(Self {
+            servers,
+            routers,
+            hostnames,
+        })
+    }
+
+    pub fn server(&self, server_id: u64) -> SocketAddr {
+        self.servers[server_id as usize]
+    }
+
+    pub fn router(&self, router_id: u64, server_id: u64) -> SocketAddr {
+        *self.routers[router_id as usize]
+            .get(&server_id)
+            .expect("missing server route")
+    }
+
+    pub fn hostname(&self, connection_id: u64) -> &str {
+        &self.hostnames[connection_id as usize]
+    }
+}

--- a/netbench/netbench/src/client/thread.rs
+++ b/netbench/netbench/src/client/thread.rs
@@ -1,0 +1,208 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{AddressMap, Client, Connection};
+use crate::{
+    driver::timer::{self, Timer, Timestamp},
+    operation as op, scenario, Checkpoints, Result, Trace,
+};
+use core::{
+    future::Future,
+    task::{Context, Poll},
+};
+use futures::ready;
+
+pub struct Thread<'a, C: Client<'a>> {
+    scenario: &'a scenario::Client,
+    ops: &'a [op::Client],
+    index: usize,
+    op: Option<Op<'a, C>>,
+    timer: Timer,
+}
+
+impl<'a, C: Client<'a>> Thread<'a, C> {
+    pub fn new(scenario: &'a scenario::Client, ops: &'a [op::Client]) -> Self {
+        Self {
+            scenario,
+            ops,
+            index: 0,
+            op: None,
+            timer: Timer::default(),
+        }
+    }
+
+    pub(super) fn poll<T: Trace, Ch: Checkpoints>(
+        &mut self,
+        client: &mut C,
+        address_map: &AddressMap,
+        trace: &mut T,
+        checkpoints: &mut Ch,
+        now: Timestamp,
+        cx: &mut Context,
+    ) -> Poll<Result<()>> {
+        loop {
+            while self.op.is_none() {
+                if let Some(op) = self.ops.get(self.index) {
+                    self.index += 1;
+                    self.on_op(client, address_map, op, trace, checkpoints, now, cx);
+                } else {
+                    // we are all done processing the operations
+                    return Poll::Ready(Ok(()));
+                }
+            }
+
+            ready!(self.poll_op(client, address_map, trace, checkpoints, now, cx))?;
+            self.op = None;
+        }
+    }
+
+    fn on_op<T: Trace, Ch: Checkpoints>(
+        &mut self,
+        client: &mut C,
+        addresses: &AddressMap,
+        op: &'a op::Client,
+        trace: &mut T,
+        checkpoints: &mut Ch,
+        now: Timestamp,
+        cx: &mut Context,
+    ) {
+        trace.exec_client(now, op);
+        use op::Client::*;
+        match op {
+            Sleep { timeout } => {
+                self.timer.sleep(now, *timeout);
+                self.op = Some(Op::Sleep);
+            }
+            Connect {
+                server_id,
+                router_id,
+                server_connection_id,
+                client_connection_id,
+            } => {
+                let addr = if let Some(router_id) = router_id {
+                    addresses.router(*router_id, *server_id)
+                } else {
+                    addresses.server(*server_id)
+                };
+                let hostname = addresses.hostname(*server_connection_id);
+                let ops = &self.scenario.connections[*client_connection_id as usize];
+                let connect = client.connect(addr, hostname, *server_connection_id, ops);
+                self.op = Some(Op::Connect {
+                    connect,
+                    id: *client_connection_id,
+                    start: now,
+                });
+            }
+            Park { checkpoint } => {
+                trace.park(now, *checkpoint);
+                self.op = Some(Op::Wait {
+                    checkpoint: *checkpoint,
+                });
+            }
+            Unpark { checkpoint } => {
+                checkpoints.unpark(*checkpoint, cx);
+            }
+            Trace { trace_id } => {
+                trace.trace(now, *trace_id);
+            }
+            Scope { threads } => {
+                if !threads.is_empty() {
+                    let threads = threads
+                        .iter()
+                        .map(|thread| Thread::new(self.scenario, thread))
+                        .collect();
+                    self.op = Some(Op::Scope { threads });
+                }
+            }
+        }
+    }
+
+    fn poll_op<T: Trace, Ch: Checkpoints>(
+        &mut self,
+        client: &mut C,
+        addresses: &AddressMap,
+        trace: &mut T,
+        checkpoints: &mut Ch,
+        now: Timestamp,
+        cx: &mut Context,
+    ) -> Poll<Result<()>> {
+        match self.op.as_mut().unwrap() {
+            Op::Sleep => {
+                ready!(self.timer.poll(now));
+            }
+            Op::Connect { connect, id, start } => {
+                let connect = core::pin::Pin::new(connect);
+                let connection = ready!(connect.poll(cx))?;
+                let time = now - *start;
+                trace.connect(now, *id, time);
+                self.op = Some(Op::Connection { connection });
+                return self.poll_op(client, addresses, trace, checkpoints, now, cx);
+            }
+            Op::Connection { connection } => {
+                ready!(connection.poll(trace, checkpoints, now, cx))?;
+            }
+            Op::Wait { checkpoint } => {
+                ready!(checkpoints.park(*checkpoint));
+                trace.unpark(now, *checkpoint);
+            }
+            Op::Scope { threads } => {
+                let mut all_ready = true;
+                let op_idx = self.index;
+                for (idx, thread) in threads.iter_mut().enumerate() {
+                    trace.enter(now, op_idx as _, idx);
+                    let result = thread.poll(client, addresses, trace, checkpoints, now, cx);
+                    trace.exit(now);
+                    match result {
+                        Poll::Ready(Ok(_)) => {}
+                        Poll::Ready(Err(err)) => return Err(err).into(),
+                        Poll::Pending => all_ready = false,
+                    }
+                }
+                if !all_ready {
+                    return Poll::Pending;
+                }
+            }
+        }
+
+        // clear the timer for the next operation
+        self.timer.cancel();
+        Ok(()).into()
+    }
+}
+
+impl<'a, C: Client<'a>> timer::Provider for Thread<'a, C> {
+    #[inline]
+    fn timers<Q: timer::Query>(&self, query: &mut Q) -> timer::Result {
+        self.timer.timers(query)?;
+        match &self.op {
+            Some(Op::Connection { connection }) => {
+                connection.timers(query)?;
+            }
+            Some(Op::Scope { threads }) => {
+                for thread in threads {
+                    thread.timers(query)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
+enum Op<'a, C: Client<'a>> {
+    Sleep,
+    Connect {
+        connect: C::Connect,
+        id: u64,
+        start: Timestamp,
+    },
+    Connection {
+        connection: C::Connection,
+    },
+    Wait {
+        checkpoint: u64,
+    },
+    Scope {
+        threads: Vec<Thread<'a, C>>,
+    },
+}

--- a/netbench/netbench/src/client/thread.rs
+++ b/netbench/netbench/src/client/thread.rs
@@ -56,6 +56,7 @@ impl<'a, C: Client<'a>> Thread<'a, C> {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn on_op<T: Trace, Ch: Checkpoints>(
         &mut self,
         client: &mut C,

--- a/netbench/netbench/src/lib.rs
+++ b/netbench/netbench/src/lib.rs
@@ -5,6 +5,7 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 pub type Error = Box<dyn std::error::Error>;
 
 mod checkpoints;
+pub mod client;
 mod connection;
 mod driver;
 #[cfg(any(test, feature = "testing"))]
@@ -21,6 +22,7 @@ pub mod trace;
 pub mod units;
 
 pub use checkpoints::Checkpoints;
+pub use client::Driver as Client;
 pub use connection::Connection;
 pub use driver::Driver;
 pub use timer::Timer;

--- a/netbench/netbench/src/multiplex.rs
+++ b/netbench/netbench/src/multiplex.rs
@@ -518,13 +518,13 @@ mod tests {
         let mut cx = core::task::Context::from_waker(&waker);
 
         loop {
-            let c = client.poll(
+            let c = client.poll_with_timer(
                 &mut client_trace,
                 &mut client_checkpoints,
                 &mut client_timer,
                 &mut cx,
             );
-            let s = server.poll(
+            let s = server.poll_with_timer(
                 &mut server_trace,
                 &mut server_checkpoints,
                 &mut server_timer,

--- a/netbench/netbench/src/operation.rs
+++ b/netbench/netbench/src/operation.rs
@@ -64,8 +64,10 @@ pub enum Client {
         server_connection_id: u64,
         client_connection_id: u64,
     },
-    /// Synchronizes two checkpoints across different threads
-    Sync { checkpoint: u64 },
+    /// Parks the current thread and waits for the checkpoint to be unparked
+    Park { checkpoint: u64 },
+    /// Notifies the parked checkpoint that it can continue
+    Unpark { checkpoint: u64 },
     /// Emit a trace event
     Trace { trace_id: u64 },
     /// Perform operations concurrently

--- a/netbench/netbench/src/scenario.rs
+++ b/netbench/netbench/src/scenario.rs
@@ -106,7 +106,7 @@ pub struct Certificate {
 pub(crate) mod pkcs12_format {
     use serde::{self, Deserialize, Deserializer, Serializer};
 
-    pub fn serialize<S>(bytes: &Vec<u8>, serializer: S) -> Result<S::Ok, S::Error>
+    pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {

--- a/netbench/netbench/src/scenario/builder/certificate.rs
+++ b/netbench/netbench/src/scenario/builder/certificate.rs
@@ -18,7 +18,7 @@ pub(crate) enum Certificate {
         intermediates: Vec<&'static SignatureAlgorithm>,
     },
     // Placeholder for a public cert
-    Certificate,
+    Public,
 }
 
 fn create_ca(domain: &str, name: String, alg: &'static SignatureAlgorithm) -> rcgen::Certificate {
@@ -139,7 +139,7 @@ impl Certificate {
                         pkcs12: vec![],
                     }));
                 }
-                Self::Certificate => {
+                Self::Public => {
                     // noop - handled by private key
                 }
             }
@@ -190,7 +190,7 @@ impl Authority {
             authority,
             intermediates,
         }) as u64;
-        let certificate = self.state.certificates.push(Certificate::Certificate) as u64;
+        let certificate = self.state.certificates.push(Certificate::Public) as u64;
 
         KeyPair {
             private_key,

--- a/netbench/netbench/src/timer.rs
+++ b/netbench/netbench/src/timer.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::task::{Context, Poll};
-pub use s2n_quic_core::time::Timestamp;
+pub use s2n_quic_core::time::{
+    timer::{Provider, Query, Result},
+    Timestamp,
+};
 
 pub trait Timer {
     fn now(&self) -> Timestamp;

--- a/netbench/netbench/src/units/rate.rs
+++ b/netbench/netbench/src/units/rate.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::units::{duration_format, Byte, Duration, DurationExt};
+use crate::units::{duration_format, Byte, ByteExt, Duration, DurationExt};
 use core::fmt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -18,6 +18,15 @@ impl fmt::Display for Rate {
         if self.period == 1.seconds() {
             return write!(f, "{}ps", self.bytes);
         }
+
+        // force the period to be in seconds
+        if f.alternate() {
+            let factor = 1.0 / self.period.as_secs_f64();
+            let bytes = (*self.bytes as f64 * factor) as u64;
+            let bytes = bytes.bytes();
+            return write!(f, "{}ps", bytes);
+        }
+
         write!(f, "{}/{:?}", self.bytes, self.period)
     }
 }

--- a/quic/s2n-quic-core/src/time/timer.rs
+++ b/quic/s2n-quic-core/src/time/timer.rs
@@ -81,6 +81,14 @@ pub trait Provider {
         timeout
     }
 
+    /// Returns `true` if there are any timers armed
+    #[inline]
+    fn is_armed(&self) -> bool {
+        let mut is_armed = false;
+        let _ = self.timers(&mut is_armed);
+        is_armed
+    }
+
     /// Counts the number of armed timers in the provider
     #[inline]
     fn armed_timer_count(&self) -> usize {
@@ -169,6 +177,17 @@ impl Query for ArmedCount {
     fn on_timer(&mut self, timer: &Timer) -> Result {
         if timer.is_armed() {
             self.0 += 1;
+        }
+        Ok(())
+    }
+}
+
+impl Query for bool {
+    #[inline]
+    fn on_timer(&mut self, timer: &Timer) -> Result {
+        if timer.is_armed() {
+            *self = true;
+            return Err(QueryBreak);
         }
         Ok(())
     }

--- a/quic/s2n-quic-core/src/time/timer.rs
+++ b/quic/s2n-quic-core/src/time/timer.rs
@@ -84,9 +84,9 @@ pub trait Provider {
     /// Returns `true` if there are any timers armed
     #[inline]
     fn is_armed(&self) -> bool {
-        let mut is_armed = false;
+        let mut is_armed = IsArmed::default();
         let _ = self.timers(&mut is_armed);
-        is_armed
+        is_armed.0
     }
 
     /// Counts the number of armed timers in the provider
@@ -182,11 +182,15 @@ impl Query for ArmedCount {
     }
 }
 
-impl Query for bool {
+/// Returns `true` if any of the timers are armed
+#[derive(Debug, Default)]
+pub struct IsArmed(pub bool);
+
+impl Query for IsArmed {
     #[inline]
     fn on_timer(&mut self, timer: &Timer) -> Result {
         if timer.is_armed() {
-            *self = true;
+            self.0 = true;
             return Err(QueryBreak);
         }
         Ok(())


### PR DESCRIPTION
### Description of changes: 

This change adds netbench drivers for s2n-quic, [native-tls](https://docs.rs/tokio-native-tls/0.3.0/tokio_native_tls/index.html), and tcp. s2n-tls will be added after the async bindings are available.

I added a README on how to run one of the drivers locally. This will change after I get the CLI working, but should be enough to get an idea of how to run it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

