### PR TITLE
ci(interop): update interop ref and patch

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -13,6 +13,7 @@ multiple-versions = "deny"
 skip-tree = [
     { name = "bolero" }, # bolero is always going to be just a test dependency
     { name = "criterion" }, # criterion is always going to be just a test dependency
+    { name = "cuckoofilter" }, # This dependency needs to be updated or removed (see https://github.com/axiomhq/rust-cuckoofilter/pull/53)
 ]
 
 [sources]

--- a/.github/interop/runner.patch
+++ b/.github/interop/runner.patch
@@ -38,33 +38,10 @@ index 7541cae..ba1b4da 100644
        - VERSION=$VERSION
      depends_on:
 diff --git a/implementations.json b/implementations.json
-index 3df16da..70ff578 100644
+index 5a88ee2..df511e3 100644
 --- a/implementations.json
 +++ b/implementations.json
-@@ -1,24 +1,24 @@
- {
-+  "s2n-quic": {
-+    "image": "aws/s2n-quic-qns:latest",
-+    "url": "https://github.com/aws/s2n-quic",
-+    "role": "both"
-+  },
-+  "s2n-quic-rustls": {
-+    "image": "aws/s2n-quic-qns-rustls:latest",
-+    "url": "https://github.com/aws/s2n-quic",
-+    "role": "both"
-+  },
-   "quic-go": {
-     "image": "martenseemann/quic-go-interop:latest",
-     "url": "https://github.com/lucas-clemente/quic-go",
-     "role": "both"
-   },
--  "quicly": {
--    "image": "h2oserver/quicly-interop-runner:latest",
--    "url": "https://github.com/h2o/quicly",
--    "role": "both"
--  },
-   "ngtcp2": {
-     "image": "ghcr.io/ngtcp2/ngtcp2-interop:latest",
+@@ -9,11 +9,6 @@
      "url": "https://github.com/ngtcp2/ngtcp2",
      "role": "both"
    },
@@ -76,6 +53,21 @@ index 3df16da..70ff578 100644
    "mvfst": {
      "image": "lnicco/mvfst-qns:latest",
      "url": "https://github.com/facebookincubator/mvfst",
+@@ -79,8 +74,13 @@
+     "url": "https://github.com/quinn-rs/quinn",
+     "role": "both"
+   },
++  "s2n-quic-rustls": {
++    "image": "aws/s2n-quic-qns-rustls:latest",
++    "url": "https://github.com/aws/s2n-quic",
++    "role": "both"
++  },
+   "s2n-quic": {
+-    "image": "public.ecr.aws/s2n/s2n-quic-qns:latest",
++    "image": "aws/s2n-quic-qns:latest",
+     "url": "https://github.com/aws/s2n-quic",
+     "role": "both"
+   }
 diff --git a/interop.py b/interop.py
 index 4dea51d..d84bdac 100644
 --- a/interop.py
@@ -152,7 +144,7 @@ index c2d6d1f..844bbd5 100644
  print("\nPulling the iperf endpoint...")
  os.system("docker pull martenseemann/quic-interop-iperf-endpoint")
 diff --git a/testcases.py b/testcases.py
-index 1d81d25..99394cc 100644
+index 2741a0d..a8d1e14 100644
 --- a/testcases.py
 +++ b/testcases.py
 @@ -90,6 +90,10 @@ class TestCase(abc.ABC):
@@ -240,6 +232,15 @@ index 1d81d25..99394cc 100644
      @staticmethod
      def abbreviation():
          return "G"
+@@ -1455,7 +1435,7 @@ class MeasurementGoodput(Measurement):
+ 
+     @staticmethod
+     def repetitions() -> int:
+-        return 5
++        return 1
+ 
+     def get_paths(self):
+         self._files = [self._generate_random_file(self.FILESIZE)]
 @@ -1528,8 +1508,8 @@ TESTCASES = [
      TestCaseChaCha20,
      TestCaseMultiplexing,

--- a/.github/interop/runner.patch
+++ b/.github/interop/runner.patch
@@ -161,6 +161,16 @@ index c2d6d1f..844bbd5 100644
  
  print("\nPulling the iperf endpoint...")
  os.system("docker pull martenseemann/quic-interop-iperf-endpoint")
+diff --git a/run.py b/run.py
+index fbd9515..aa8d6ed 100755
+--- a/run.py
++++ b/run.py
+@@ -136,4 +136,4 @@ def main():
+ 
+ 
+ if __name__ == "__main__":
+-    sys.exit(main())
++    main()
 diff --git a/testcases.py b/testcases.py
 index 2741a0d..a8d1e14 100644
 --- a/testcases.py

--- a/.github/interop/runner.patch
+++ b/.github/interop/runner.patch
@@ -69,7 +69,7 @@ index 5a88ee2..df511e3 100644
      "role": "both"
    }
 diff --git a/interop.py b/interop.py
-index 4dea51d..d84bdac 100644
+index 4dea51d..3239567 100644
 --- a/interop.py
 +++ b/interop.py
 @@ -124,6 +124,7 @@ class InteropRunner:
@@ -96,7 +96,25 @@ index 4dea51d..d84bdac 100644
              "WWW=" + testcase.www_dir() + " "
              "DOWNLOADS=" + testcase.download_dir() + " "
              "SERVER_LOGS=" + server_log_dir.name + " "
-@@ -474,23 +477,26 @@ class InteropRunner:
+@@ -456,9 +459,14 @@ class InteropRunner:
+         logging.debug(values)
+         res = MeasurementResult()
+         res.result = TestResult.SUCCEEDED
+-        res.details = "{:.0f} (± {:.0f}) {}".format(
+-            statistics.mean(values), statistics.stdev(values), test.unit()
+-        )
++        if len(values) == 1:
++            res.details = "{:.0f} {}".format(
++                values[0], test.unit()
++            )
++        else:
++            res.details = "{:.0f} (± {:.0f}) {}".format(
++                statistics.mean(values), statistics.stdev(values), test.unit()
++            )
+         return res
+ 
+     def run(self):
+@@ -474,23 +482,26 @@ class InteropRunner:
                      client,
                      self._implementations[client]["image"],
                  )

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -260,7 +260,7 @@ jobs:
         run: |
           # enable IPv6 support
           sudo modprobe ip6table_filter
-          python3 run.py --client ${{ matrix.client }} --server ${{ matrix.server }} --json results/result.json --debug --log-dir results/logs || true
+          python3 run.py --client ${{ matrix.client }} --server ${{ matrix.server }} --json results/result.json --debug --log-dir results/logs
           mkdir -p results/logs
 
       - name: Prepare artifacts

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -15,11 +15,11 @@ env:
   RUST_BACKTRACE: 1
   # This kept breaking builds so we're pinning for now. We should do our best to keep
   # up with the changes, though.
-  INTEROP_RUNNER_REF: a4ba14bd5ca769007fc11b37b6aaea89fdbf1d9e
+  INTEROP_RUNNER_REF: add48d0229f2c7a0093abd76c3b2b6c36ff47def
   # This should be updated when updating wesleyrosenblum/quic-network-simulator
   NETWORK_SIMULATOR_REF: sha256:20abe0bed8c0e39e1d8750507b24295f7c978bdd7e05fa6f3a5afed4b76dc191
   IPERF_ENDPOINT_REF: sha256:cb50cc8019d45d9cad5faecbe46a3c21dd5e871949819a5175423755a9045106
-  WIRESHARK_VERSION: 3.6.1
+  WIRESHARK_VERSION: 3.6.2
   CDN: https://dnglbrstg7yg.cloudfront.net
   LOG_URL: logs/latest/SERVER_CLIENT/TEST/index.html
   H3_SPEC_VERSION: v0.1.8

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -14,6 +14,7 @@ bytes = { version = "1", default-features = false }
 dhat = { version = "0.2", optional = true }
 futures = "0.3"
 http = "0.2"
+openssl-sys = { version = "<= 0.9.68", features = ["vendored"] }
 s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-h3 = { version = "=0.1.0", path = "../s2n-quic-h3" }
 structopt = "0.3"
@@ -27,3 +28,7 @@ s2n-quic = { version = "=1.0.0", path = "../s2n-quic", features = ["provider-eve
 
 [target.'cfg(not(unix))'.dependencies]
 s2n-quic = { version = "=1.0.0", path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-rustls"] }
+
+# we don't use openssl-sys directly; it's just here to pin and vendor in dev
+[package.metadata.cargo-udeps.ignore]
+development = [ "openssl-sys" ]

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -31,4 +31,4 @@ s2n-quic = { version = "=1.0.0", path = "../s2n-quic", features = ["provider-eve
 
 # we don't use openssl-sys directly; it's just here to pin and vendor in dev
 [package.metadata.cargo-udeps.ignore]
-development = [ "openssl-sys" ]
+normal = [ "openssl-sys" ]

--- a/quic/s2n-quic-qns/etc/Dockerfile
+++ b/quic/s2n-quic-qns/etc/Dockerfile
@@ -1,14 +1,5 @@
 FROM martenseemann/quic-network-simulator-endpoint:latest
 
-# install libcrypto
-RUN set -eux; \
-  apt-get update; \
-  apt-get -y install libssl-dev; \
-  rm -rf /var/lib/apt/lists/*; \
-  apt-get clean; \
-  rm -rf /tmp/*; \
-  echo done;
-
 # copy entrypoint
 COPY run_endpoint.sh /
 RUN chmod +x run_endpoint.sh

--- a/quic/s2n-quic-qns/etc/Dockerfile.build
+++ b/quic/s2n-quic-qns/etc/Dockerfile.build
@@ -45,15 +45,6 @@ FROM martenseemann/quic-network-simulator-endpoint:latest
 
 ENV RUST_BACKTRACE="1"
 
-# install libcrypto
-RUN set -eux; \
-  apt-get update; \
-  apt-get -y install libssl-dev; \
-  rm -rf /var/lib/apt/lists/*; \
-  apt-get clean; \
-  rm -rf /tmp/*; \
-  echo done;
-
 # copy entrypoint
 COPY quic/s2n-quic-qns/etc/run_endpoint.sh .
 RUN chmod +x run_endpoint.sh

--- a/scripts/interop/run
+++ b/scripts/interop/run
@@ -17,7 +17,7 @@ if [ ! -d $INTEROP_DIR ]; then
   git clone https://github.com/marten-seemann/quic-interop-runner $INTEROP_DIR
   # make sure to keep this up to date with the interop workflow
   cd $INTEROP_DIR
-  git checkout a4ba14bd5ca769007fc11b37b6aaea89fdbf1d9e
+  git checkout add48d0229f2c7a0093abd76c3b2b6c36ff47def
   git apply --3way ../../.github/interop/runner.patch
   cd ../../
 fi


### PR DESCRIPTION
### Description of changes: 

This updates the quic-interop-runner to the latest ref. I've also updated the patch to only do a single round of throughput tests to cut down on the time spent in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

