### PR TITLE
chore: update version for s2n-quic v1.0.1 release

### DIFF
--- a/quic/s2n-quic-bench/Cargo.toml
+++ b/quic/s2n-quic-bench/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "s2n-quic-bench"
+# this in an unpublished internal crate so the version should not be changed
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2018"
@@ -10,7 +11,7 @@ publish = false
 [dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", features = ["testing"] }
-s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-crypto = { version = "=0.1.0", path = "../s2n-quic-crypto", features = ["testing"] }
 
 [[bench]]

--- a/quic/s2n-quic-bench/Cargo.toml
+++ b/quic/s2n-quic-bench/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 
 [dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
-s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", features = ["testing"] }
-s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
-s2n-quic-crypto = { version = "=0.1.0", path = "../s2n-quic-crypto", features = ["testing"] }
+s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
+s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-crypto = { path = "../s2n-quic-crypto", features = ["testing"] }
 
 [[bench]]
 name = "bench"

--- a/quic/s2n-quic-bench/Cargo.toml
+++ b/quic/s2n-quic-bench/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 
 [dependencies]
 criterion = { version = "0.3", features = ["html_reports"] }
-s2n-codec = { version = "0.1", path = "../../common/s2n-codec", features = ["testing"] }
+s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", features = ["testing"] }
 s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-crypto = { version = "=0.1.0", path = "../s2n-quic-crypto", features = ["testing"] }
 

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -24,7 +24,7 @@ hex-literal = "0.3"
 # used for event snapshot testing - needs an internal API so we require a minimum version
 insta = { version = ">=1.12", optional = true }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
-s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features = false }
+s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }
 subtle = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }
 zerocopy = "=0.6.0"
@@ -38,7 +38,7 @@ insta = "1"
 futures-test = "0.3"
 ip_network = "0.4"
 plotters = { version = "0.3", default-features = false, features = ["svg_backend", "line_series"] }
-s2n-codec = { version = "0.1", path = "../../common/s2n-codec", features = ["testing"] }
+s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
 
 [[test]]
 name = "crypto"

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-core"
-version = "0.1.1"
+version = "0.1.2"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]

--- a/quic/s2n-quic-events/Cargo.toml
+++ b/quic/s2n-quic-events/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "s2n-quic-events"
+# this in an unpublished internal crate so the version should not be changed
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2018"

--- a/quic/s2n-quic-h3/Cargo.toml
+++ b/quic/s2n-quic-h3/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "s2n-quic-h3"
+# this in an unpublished internal crate so the version should not be changed
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2018"
@@ -11,5 +12,5 @@ publish = false
 bytes = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false }
 h3 = { git = "https://github.com/hyperium/h3" } # TODO: Update once hyperium h3 is in crates.io
-s2n-quic = { version = "=1.0.0", path = "../s2n-quic", default-features = false }
-s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", default-features = false }
+s2n-quic = { version = "=1.0.1", path = "../s2n-quic", default-features = false }
+s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", default-features = false }

--- a/quic/s2n-quic-h3/Cargo.toml
+++ b/quic/s2n-quic-h3/Cargo.toml
@@ -12,5 +12,5 @@ publish = false
 bytes = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false }
 h3 = { git = "https://github.com/hyperium/h3" } # TODO: Update once hyperium h3 is in crates.io
-s2n-quic = { version = "=1.0.1", path = "../s2n-quic", default-features = false }
-s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", default-features = false }
+s2n-quic = { path = "../s2n-quic", default-features = false }
+s2n-quic-core = { path = "../s2n-quic-core", default-features = false }

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-platform"
-version = "0.1.0"
+version = "0.1.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -22,7 +22,7 @@ errno = "0.2"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 lazy_static = { version = "1", optional = true }
 pin-project = { version = "1", optional = true }
-s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", default-features = false }
+s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", default-features = false }
 socket2 = { version = "0.4", features = ["all"], optional = true }
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt", "time"], optional = true }
 zeroize = { version = "1", default-features = false, optional = true }
@@ -33,5 +33,5 @@ libc = "0.2"
 [dev-dependencies]
 bolero = "0.6"
 bolero-generator = { version = "0.6", default-features = false }
-s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -33,5 +33,5 @@ libc = "0.2"
 [dev-dependencies]
 bolero = "0.6"
 bolero-generator = { version = "0.6", default-features = false }
-s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "s2n-quic-qns"
+# this in an unpublished internal crate so the version should not be changed
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2018"
@@ -15,7 +16,7 @@ dhat = { version = "0.2", optional = true }
 futures = "0.3"
 http = "0.2"
 openssl-sys = { version = "<= 0.9.68", features = ["vendored"] }
-s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-h3 = { version = "=0.1.0", path = "../s2n-quic-h3" }
 structopt = "0.3"
 tokio = { version = "1", features = ["full"] }
@@ -24,10 +25,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2"
 
 [target.'cfg(unix)'.dependencies]
-s2n-quic = { version = "=1.0.0", path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-rustls", "provider-tls-s2n"] }
+s2n-quic = { version = "=1.0.1", path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-rustls", "provider-tls-s2n"] }
 
 [target.'cfg(not(unix))'.dependencies]
-s2n-quic = { version = "=1.0.0", path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-rustls"] }
+s2n-quic = { version = "=1.0.1", path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-rustls"] }
 
 # we don't use openssl-sys directly; it's just here to pin and vendor in dev
 [package.metadata.cargo-udeps.ignore]

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -16,8 +16,8 @@ dhat = { version = "0.2", optional = true }
 futures = "0.3"
 http = "0.2"
 openssl-sys = { version = "<= 0.9.68", features = ["vendored"] }
-s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
-s2n-quic-h3 = { version = "=0.1.0", path = "../s2n-quic-h3" }
+s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-h3 = { path = "../s2n-quic-h3" }
 structopt = "0.3"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
@@ -25,10 +25,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2"
 
 [target.'cfg(unix)'.dependencies]
-s2n-quic = { version = "=1.0.1", path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-rustls", "provider-tls-s2n"] }
+s2n-quic = { path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-rustls", "provider-tls-s2n"] }
 
 [target.'cfg(not(unix))'.dependencies]
-s2n-quic = { version = "=1.0.1", path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-rustls"] }
+s2n-quic = { path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-rustls"] }
 
 # we don't use openssl-sys directly; it's just here to pin and vendor in dev
 [package.metadata.cargo-udeps.ignore]

--- a/quic/s2n-quic-ring/Cargo.toml
+++ b/quic/s2n-quic-ring/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-ring"
-version = "0.1.0"
+version = "0.1.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -11,14 +11,14 @@ license = "Apache-2.0"
 hex-literal = "0.3"
 lazy_static = { version = "1", default-features = false }
 s2n-codec = { version = "0.1.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", default-features = false }
+s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", default-features = false }
 ring = { version = "0.16", default-features = false }
 zeroize = { version = "1", default-features = false }
 
 [dev-dependencies]
 bolero = "0.6"
 insta = "1"
-s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
 
 [[test]]
 name = "fuzz_target"

--- a/quic/s2n-quic-ring/Cargo.toml
+++ b/quic/s2n-quic-ring/Cargo.toml
@@ -18,7 +18,7 @@ zeroize = { version = "1", default-features = false }
 [dev-dependencies]
 bolero = "0.6"
 insta = "1"
-s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 
 [[test]]
 name = "fuzz_target"

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-rustls"
-version = "0.1.0"
+version = "0.1.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -11,9 +11,9 @@ license = "Apache-2.0"
 rustls = { version = "0.20", features = ["quic"] }
 rustls-pemfile = "0.3"
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", default-features = false }
-s2n-quic-ring = { version = "=0.1.0", path = "../s2n-quic-ring", default-features = false }
+s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", default-features = false }
+s2n-quic-ring = { version = "=0.1.1", path = "../s2n-quic-ring", default-features = false }
 
 [dev-dependencies]
 insta = "1"
-s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -10,10 +10,10 @@ license = "Apache-2.0"
 [dependencies]
 rustls = { version = "0.20", features = ["quic"] }
 rustls-pemfile = "0.3"
-s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features = false }
+s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", default-features = false }
 s2n-quic-ring = { version = "=0.1.1", path = "../s2n-quic-ring", default-features = false }
 
 [dev-dependencies]
 insta = "1"
-s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-tls-default"
-version = "0.1.0"
+version = "0.1.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -8,7 +8,7 @@ edition = "2018"
 license = "Apache-2.0"
 
 [target.'cfg(unix)'.dependencies]
-s2n-quic-tls = { version = "=0.1.0", path = "../s2n-quic-tls" }
+s2n-quic-tls = { version = "=0.1.1", path = "../s2n-quic-tls" }
 
 [target.'cfg(not(unix))'.dependencies]
-s2n-quic-rustls = { version = "=0.1.0", path = "../s2n-quic-rustls" }
+s2n-quic-rustls = { version = "=0.1.1", path = "../s2n-quic-rustls" }

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 bytes = { version = "1", default-features = false }
 errno = "0.2"
 libc = "0.2"
-s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features = false }
+s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", default-features = false }
 s2n-quic-ring = { version = "=0.1.1", path = "../s2n-quic-ring", default-features = false }
 s2n-tls = { version = "0.0.3", features = ["quic"] }
@@ -24,8 +24,8 @@ checkers = "0.6"
 # NOTE: The version of the `openssl-sys` crate is not the same as OpenSSL itself.
 #       Versions 1.0.1 - 3.0.0 are automatically discovered.
 openssl-sys = { version = "<= 0.9.68", features = ["vendored"] }
-s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
-s2n-quic-rustls = { version = "=0.1.1", path = "../s2n-quic-rustls" }
+s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-rustls = { path = "../s2n-quic-rustls" }
 
 # we don't use openssl-sys directly; it's just here to pin and vendor in dev
 [package.metadata.cargo-udeps.ignore]

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-tls"
-version = "0.1.0"
+version = "0.1.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -12,8 +12,8 @@ bytes = { version = "1", default-features = false }
 errno = "0.2"
 libc = "0.2"
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", default-features = false }
-s2n-quic-ring = { version = "=0.1.0", path = "../s2n-quic-ring", default-features = false }
+s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", default-features = false }
+s2n-quic-ring = { version = "=0.1.1", path = "../s2n-quic-ring", default-features = false }
 s2n-tls = { version = "0.0.3", features = ["quic"] }
 
 [dev-dependencies]
@@ -24,8 +24,8 @@ checkers = "0.6"
 # NOTE: The version of the `openssl-sys` crate is not the same as OpenSSL itself.
 #       Versions 1.0.1 - 3.0.0 are automatically discovered.
 openssl-sys = { version = "<= 0.9.68", features = ["vendored"] }
-s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
-s2n-quic-rustls = { version = "=0.1.0", path = "../s2n-quic-rustls" }
+s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-rustls = { version = "=0.1.1", path = "../s2n-quic-rustls" }
 
 # we don't use openssl-sys directly; it's just here to pin and vendor in dev
 [package.metadata.cargo-udeps.ignore]

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-transport"
-version = "0.1.1"
+version = "0.1.2"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -18,7 +18,7 @@ futures-core = { version = "0.3", default-features = false, features = ["alloc"]
 hashbrown = "0.11"
 intrusive-collections = "0.9"
 s2n-codec = { version = "0.1", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
-s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
+s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
 siphasher = "0.3"
 smallvec = { version = "1", default-features = false }
 
@@ -27,5 +27,5 @@ bolero = "0.6"
 futures-test = "0.3" # For testing Waker interactions
 insta = "1"
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
-s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
-s2n-quic-platform = { version = "=0.1.0", path = "../s2n-quic-platform", features = ["testing"] }
+s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-platform = { version = "=0.1.1", path = "../s2n-quic-platform", features = ["testing"] }

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -17,7 +17,7 @@ futures-channel = { version = "0.3", default-features = false, features = ["allo
 futures-core = { version = "0.3", default-features = false, features = ["alloc"] }
 hashbrown = "0.11"
 intrusive-collections = "0.9"
-s2n-codec = { version = "0.1", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
+s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
 s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
 siphasher = "0.3"
 smallvec = { version = "1", default-features = false }
@@ -27,5 +27,5 @@ bolero = "0.6"
 futures-test = "0.3" # For testing Waker interactions
 insta = "1"
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
-s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
-s2n-quic-platform = { version = "=0.1.1", path = "../s2n-quic-platform", features = ["testing"] }
+s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic"
-version = "1.0.0"
+version = "1.0.1"
 description = "A Rust implementation of the IETF QUIC protocol"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -36,12 +36,12 @@ rand = "0.8"
 rand_chacha = "0.3"
 ring = { version = "0.16", optional = true, default-features = false }
 s2n-codec = { version = "0.1.0", path = "../../common/s2n-codec" }
-s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core" }
-s2n-quic-platform = { version = "=0.1.0", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
-s2n-quic-rustls = { version = "=0.1.0", path = "../s2n-quic-rustls", optional = true }
-s2n-quic-tls = { version = "=0.1.0", path = "../s2n-quic-tls", optional = true }
-s2n-quic-tls-default = { version = "=0.1.0", path = "../s2n-quic-tls-default", optional = true }
-s2n-quic-transport = { version = "=0.1.1", path = "../s2n-quic-transport" }
+s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core" }
+s2n-quic-platform = { version = "=0.1.1", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
+s2n-quic-rustls = { version = "=0.1.1", path = "../s2n-quic-rustls", optional = true }
+s2n-quic-tls = { version = "=0.1.1", path = "../s2n-quic-tls", optional = true }
+s2n-quic-tls-default = { version = "=0.1.1", path = "../s2n-quic-tls-default", optional = true }
+s2n-quic-transport = { version = "=0.1.2", path = "../s2n-quic-transport" }
 tokio = { version = "1", default-features = false }
 zerocopy = { version = "=0.6.0", optional = true }
 zerocopy-derive = { version = "=0.3.0", optional = true }
@@ -49,6 +49,6 @@ zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 bolero = { version = "0.6" }
-s2n-quic-core = { version = "=0.1.1", path = "../s2n-quic-core", features = ["testing"] }
-s2n-quic-platform = { version = "=0.1.0", path = "../s2n-quic-platform", features = ["testing"] }
+s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-platform = { version = "=0.1.1", path = "../s2n-quic-platform", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -49,6 +49,6 @@ zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 bolero = { version = "0.6" }
-s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", features = ["testing"] }
-s2n-quic-platform = { version = "=0.1.1", path = "../s2n-quic-platform", features = ["testing"] }
+s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
### Description of changes: 

This change updates the versions for all published crates that had changes or changed dependencies in preparation for the v1.0.1 release

I've also specified an exact version for the s2n-codec crate, and have removed the version from internal dev-dependencies.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

