### PR TITLE
chore: exclude corpus files when publishing to crates.io

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -6,6 +6,8 @@ repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"
+# Exclude corpus files when publishing to crates.io
+exclude = ["corpus.tar.gz"]
 
 [features]
 default = ["std", "bytes"]

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -6,6 +6,8 @@ repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"
+# Exclude corpus files when publishing to crates.io
+exclude = ["corpus.tar.gz"]
 
 [features]
 default = ["alloc", "std"]

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"
+# Exclude corpus files when publishing to crates.io
+exclude = ["corpus.tar.gz"]
 
 [features]
 default = []

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -6,6 +6,8 @@ repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"
+# Exclude corpus files when publishing to crates.io
+exclude = ["corpus.tar.gz"]
 
 [features]
 default = ["std", "tokio-runtime", "wipe"]

--- a/quic/s2n-quic-ring/Cargo.toml
+++ b/quic/s2n-quic-ring/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["corpus.tar.gz"]
 [dependencies]
 hex-literal = "0.3"
 lazy_static = { version = "1", default-features = false }
-s2n-codec = { version = "0.1.0", path = "../../common/s2n-codec", default-features = false }
+s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", default-features = false }
 ring = { version = "0.16", default-features = false }
 zeroize = { version = "1", default-features = false }

--- a/quic/s2n-quic-ring/Cargo.toml
+++ b/quic/s2n-quic-ring/Cargo.toml
@@ -6,6 +6,8 @@ repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"
+# Exclude corpus files when publishing to crates.io
+exclude = ["corpus.tar.gz"]
 
 [dependencies]
 hex-literal = "0.3"

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -6,6 +6,8 @@ repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"
+# Exclude corpus files when publishing to crates.io
+exclude = ["corpus.tar.gz"]
 
 [dependencies]
 rustls = { version = "0.20", features = ["quic"] }

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -6,6 +6,8 @@ repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"
+# Exclude corpus files when publishing to crates.io
+exclude = ["corpus.tar.gz"]
 
 [target.'cfg(unix)'.dependencies]
 s2n-quic-tls = { version = "=0.1.1", path = "../s2n-quic-tls" }

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -6,6 +6,8 @@ repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"
+# Exclude corpus files when publishing to crates.io
+exclude = ["corpus.tar.gz"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -6,6 +6,8 @@ repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"
+# Exclude corpus files when publishing to crates.io
+exclude = ["corpus.tar.gz"]
 
 [features]
 default = ["std"]

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -6,8 +6,8 @@ repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"
-# Exclude corpus files when publishing to crates.io
-exclude = ["corpus.tar.gz"]
+# Exclude api.snap and corpus files when publishing to crates.io
+exclude = ["api.snap", "corpus.tar.gz"]
 
 [features]
 default = [

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -6,6 +6,8 @@ repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2018"
 license = "Apache-2.0"
+# Exclude corpus files when publishing to crates.io
+exclude = ["corpus.tar.gz"]
 
 [features]
 default = [

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -37,7 +37,7 @@ hash_hasher = { version = "2", optional = true }
 rand = "0.8"
 rand_chacha = "0.3"
 ring = { version = "0.16", optional = true, default-features = false }
-s2n-codec = { version = "0.1.0", path = "../../common/s2n-codec" }
+s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec" }
 s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core" }
 s2n-quic-platform = { version = "=0.1.1", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
 s2n-quic-rustls = { version = "=0.1.1", path = "../s2n-quic-rustls", optional = true }


### PR DESCRIPTION
### Description of changes: 

This change excludes fuzz test corpus files from the crates published to crates.io. I've also corrected the s2n-codec version to be an exact version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

