### PR TITLE
ci: use comma for separating docker image tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           TAGS="${DOCKER_IMAGE}:${VERSION}"
           # mark the latest on release
           if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            TAGS="$TAGS\n${DOCKER_IMAGE}:latest"
+            TAGS="$TAGS,${DOCKER_IMAGE}:latest"
           fi
           echo "::set-output name=tags::${TAGS}"
 


### PR DESCRIPTION
### Description of changes: 

The release workflow was failing due to the newline separating docker image tags being sanitized:

`Error: buildx failed with: error: invalid tag "public.ecr.aws/s2n/s2n-quic-qns:1.0.1\\npublic.ecr.aws/s2n/s2n-quic-qns:latest": invalid reference format`

This change uses a comma instead of the newline, which is also accepted according to https://github.com/docker/build-push-action#inputs

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

