### PR TITLE
feat(s2n-quic-tls): import key schedule fixes from s2n-tls

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -536,33 +536,7 @@ jobs:
           chmod +x h3spec
           chmod +x s2n-quic-qns-debug
 
-      - name: Run test (s2n-tls)
-        # the skipped tests here require modifications to the TLS library
-        # TODO remove the skips once these are fixed
-        #      https://github.com/aws/s2n-quic/issues/858
-        #      https://github.com/aws/s2n-quic/issues/859
-        if: ${{ matrix.tls == 's2n-tls' }}
-        run: |
-          ./s2n-quic-qns-debug interop server --port 4433 --tls ${{ matrix.tls }} &
-          # wait for the server to boot
-          sleep 3
-          ./h3spec localhost 4433 \
-            ` h3spec appends the KeyUpdate message to the end of the valid Handshake data. `\
-            ` s2n-quic considers the handshake "done" before it receives the bad message,  `\
-            ` and instead fails because the bad message is considered leftover data. See:  `\
-            ` https://github.com/aws/s2n-quic/blob/bb74c8e98adf12d805d26987fad02ffe45df97a7/quic/s2n-quic-transport/src/space/crypto_stream.rs#L64-L73 `\
-            --skip "MUST send unexpected_message TLS alert if KeyUpdate in Handshake is received [TLS 6]" \
-            \
-            ` s2n-quic chooses to ignore CRYPTO frames in application data. See:           `\
-            ` https://github.com/aws/s2n-quic/blob/bb74c8e98adf12d805d26987fad02ffe45df97a7/quic/s2n-quic-transport/src/space/application.rs#L625-L630 `\
-            --skip "MUST send unexpected_message TLS alert if KeyUpdate in 1-RTT is received [TLS 6]" \
-            \
-            ` The quic_transport_parameters are part of the ClientHello.                   `\
-            ` s2n-quic currently does not respond to malformed ClientHellos. See:          `\
-            ` https://github.com/aws/s2n-quic/blob/bb74c8e98adf12d805d26987fad02ffe45df97a7/quic/s2n-quic-transport/src/endpoint/mod.rs#L725 `\
-            --skip "MUST send missing_extension TLS alert if the quic_transport_parameters extension does not included [TLS 8.2]"
-
-      - name: Run test (rustls)
+      - name: Run test (${{ matrix.tls }})
         # the skipped tests here require modifications to the TLS library
         # TODO remove the skips once these are fixed
         #      https://github.com/aws/s2n-quic/issues/858

--- a/quic/s2n-quic-core/src/crypto/tls/testing.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/testing.rs
@@ -151,7 +151,6 @@ impl<S: tls::Session, C: tls::Session> Pair<S, C> {
         eprintln!("1/2 RTT");
 
         self.check_progress();
-
         Ok(())
     }
 
@@ -170,13 +169,10 @@ impl<S: tls::Session, C: tls::Session> Pair<S, C> {
                     "server should have handshake keys after reading the ClientHello"
                 );
 
-                // TODO remove this when s2n-tls fixes its key schedule
-                if !core::any::type_name::<S>().contains("s2n_quic_tls") {
-                    assert!(
-                        self.server.1.application.crypto.is_some(),
-                        "server should have application keys after reading the ClientHello"
-                    );
-                }
+                assert!(
+                    self.server.1.application.crypto.is_some(),
+                    "server should have application keys after reading the ClientHello"
+                );
 
                 assert!(!self.server.1.handshake_complete);
                 assert!(!self.client.1.handshake_complete);
@@ -196,12 +192,6 @@ impl<S: tls::Session, C: tls::Session> Pair<S, C> {
                 );
             }
             4 => {
-                // TODO remove this when s2n-tls fixes its key schedule
-                assert!(
-                    self.server.1.application.crypto.is_some(),
-                    "server should have application keys after reading the ClientHello"
-                );
-
                 assert!(
                     self.server.1.handshake_complete,
                     "server should finish after reading the ClientFinished"

--- a/quic/s2n-quic-core/src/crypto/tls/testing.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/testing.rs
@@ -166,12 +166,12 @@ impl<S: tls::Session, C: tls::Session> Pair<S, C> {
             2 => {
                 assert!(
                     self.server.1.handshake.crypto.is_some(),
-                    "server should have handshake keys after reading the ClientHello"
+                    "server should have handshake keys after sending the ServerHello"
                 );
 
                 assert!(
                     self.server.1.application.crypto.is_some(),
-                    "server should have application keys after reading the ClientHello"
+                    "server should have application keys after sending a ServerFinished"
                 );
 
                 assert!(!self.server.1.handshake_complete);
@@ -184,7 +184,7 @@ impl<S: tls::Session, C: tls::Session> Pair<S, C> {
                 );
                 assert!(
                     self.client.1.application.crypto.is_some(),
-                    "client should have application keys after reading the ServerHello"
+                    "client should have application keys after reading the ServerFinished"
                 );
                 assert!(
                     self.client.1.handshake_complete,

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -13,10 +13,11 @@ exclude = ["corpus.tar.gz"]
 bytes = { version = "1", default-features = false }
 errno = "0.2"
 libc = "0.2"
+
 s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", default-features = false }
 s2n-quic-ring = { version = "=0.1.1", path = "../s2n-quic-ring", default-features = false }
-s2n-tls = { version = "0.0.3", features = ["quic"] }
+s2n-tls = { version = "=0.0.4", features = ["quic"] }
 
 [dev-dependencies]
 checkers = "0.6"

--- a/quic/s2n-quic-tls/src/callback.rs
+++ b/quic/s2n-quic-tls/src/callback.rs
@@ -216,9 +216,8 @@ where
                             // Safety: conn needs to outlive params
                             get_application_params(conn)?
                         };
-                        self.context.on_one_rtt_keys(key, header_key, params)?;
 
-                        self.state.tx_phase.transition();
+                        self.context.on_one_rtt_keys(key, header_key, params)?;
                     }
                 }
 
@@ -324,6 +323,18 @@ pub struct State {
     rx_phase: HandshakePhase,
     tx_phase: HandshakePhase,
     secrets: Secrets,
+}
+
+impl State {
+    /// Complete the handshake
+    pub fn on_handshake_complete(&mut self) {
+        debug_assert_eq!(self.tx_phase, HandshakePhase::Handshake);
+        debug_assert_eq!(self.rx_phase, HandshakePhase::Handshake);
+        self.tx_phase.transition();
+        self.rx_phase.transition();
+        debug_assert_eq!(self.tx_phase, HandshakePhase::Application);
+        debug_assert_eq!(self.rx_phase, HandshakePhase::Application);
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]

--- a/quic/s2n-quic-tls/src/client.rs
+++ b/quic/s2n-quic-tls/src/client.rs
@@ -126,7 +126,7 @@ impl tls::Endpoint for Client {
             let mut session = Session::new(endpoint::Type::Client, config, params).unwrap();
             session
                 .connection
-                .set_server_name(server_name.as_bytes())
+                .set_server_name(&server_name)
                 .expect("invalid sni value");
             session
         })

--- a/quic/s2n-quic-tls/src/session.rs
+++ b/quic/s2n-quic-tls/src/session.rs
@@ -86,8 +86,9 @@ impl tls::Session for Session {
 
         match result {
             Poll::Ready(Ok(())) => {
-                // only emit handshake done once
+                // s2n-tls has indicated that the handshake is complete
                 if !self.handshake_complete {
+                    self.state.on_handshake_complete();
                     context.on_handshake_complete()?;
                     self.handshake_complete = true;
                 }

--- a/quic/s2n-quic-tls/src/tests.rs
+++ b/quic/s2n-quic-tls/src/tests.rs
@@ -24,6 +24,22 @@ fn s2n_server() -> server::Server {
         .unwrap()
 }
 
+fn rustls_server() -> s2n_quic_rustls::server::Server {
+    s2n_quic_rustls::server::Builder::default()
+        .with_certificate(CERT_PEM, KEY_PEM)
+        .unwrap()
+        .build()
+        .unwrap()
+}
+
+fn rustls_client() -> s2n_quic_rustls::client::Client {
+    s2n_quic_rustls::client::Builder::default()
+        .with_certificate(CERT_PEM)
+        .unwrap()
+        .build()
+        .unwrap()
+}
+
 #[test]
 #[cfg_attr(miri, ignore)]
 fn s2n_client_s2n_server_test() {
@@ -36,11 +52,7 @@ fn s2n_client_s2n_server_test() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn rustls_client_s2n_server_test() {
-    let mut client_endpoint = s2n_quic_rustls::client::Builder::default()
-        .with_certificate(CERT_PEM)
-        .unwrap()
-        .build()
-        .unwrap();
+    let mut client_endpoint = rustls_client();
     let mut server_endpoint = s2n_server();
 
     run(&mut server_endpoint, &mut client_endpoint);
@@ -50,11 +62,7 @@ fn rustls_client_s2n_server_test() {
 #[cfg_attr(miri, ignore)]
 fn s2n_client_rustls_server_test() {
     let mut client_endpoint = s2n_client();
-    let mut server_endpoint = s2n_quic_rustls::server::Builder::default()
-        .with_certificate(CERT_PEM, KEY_PEM)
-        .unwrap()
-        .build()
-        .unwrap();
+    let mut server_endpoint = rustls_server();
 
     run(&mut server_endpoint, &mut client_endpoint);
 }


### PR DESCRIPTION
### Resolved issues:

### Description of changes: 
s2n-tls has updated its key schedule to supply tls keys as soon as they are available. This now matches rustls behavior so we can undo workarounds for testing rustls vs s2n-tls.

### Call-outs:

Todo:
- [x] remove path dependency on s2n-tls (Blocked on s2n-tls release https://github.com/aws/s2n-tls/pull/3233)
- [x] cleanup
- [x] update s2n-tls h3spec which should now be in parity with rustls

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

