### PR TITLE
fix(s2n-quic-qns): ignore any additional words on request line

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -1,106 +1,234 @@
 {
   "ipv6": {
-    "aioquic": ["client"],
+    "aioquic": [
+      "client"
+    ],
     "kwik": [],
-    "lsquic": ["client"],
+    "lsquic": [
+      "client"
+    ],
     "msquic": [],
-    "mvfst": ["client"],
-    "neqo": ["client"],
-    "ngtcp2": ["client"],
-    "picoquic": ["client"],
-    "quic-go": ["client"],
-    "quiche": ["client"],
+    "mvfst": [],
+    "neqo": [
+      "client"
+    ],
+    "ngtcp2": [
+      "client"
+    ],
+    "picoquic": [
+      "client"
+    ],
+    "quic-go": [
+      "client"
+    ],
+    "quiche": [
+      "client"
+    ],
+    "s2n-quic": [
+      "client",
+      "server"
+    ],
     "xquic": []
   },
   "handshake": {
-    "aioquic": ["client"],
+    "aioquic": [
+      "client"
+    ],
     "kwik": [],
-    "lsquic": ["client"],
+    "lsquic": [
+      "client"
+    ],
     "msquic": [],
     "mvfst": [],
-    "neqo": ["client"],
-    "ngtcp2": ["client"],
+    "neqo": [
+      "client"
+    ],
+    "ngtcp2": [
+      "client"
+    ],
     "picoquic": [],
-    "quic-go": ["client"],
-    "quiche": ["client"],
+    "quic-go": [
+      "client"
+    ],
+    "quiche": [
+      "client"
+    ],
+    "s2n-quic": [
+      "client",
+      "server"
+    ],
     "xquic": []
   },
   "transfer": {
-    "aioquic": ["client"],
+    "aioquic": [
+      "client"
+    ],
     "kwik": [],
-    "lsquic": ["client"],
+    "lsquic": [
+      "client"
+    ],
     "msquic": [],
-    "mvfst": ["client"],
-    "neqo": ["client"],
-    "ngtcp2": ["client"],
-    "picoquic": ["client"],
-    "quic-go": ["client"],
-    "quiche": ["client"],
+    "mvfst": [],
+    "neqo": [
+      "client"
+    ],
+    "ngtcp2": [
+      "client"
+    ],
+    "picoquic": [
+      "client"
+    ],
+    "quic-go": [
+      "client"
+    ],
+    "quiche": [
+      "client"
+    ],
+    "s2n-quic": [
+      "client",
+      "server"
+    ],
     "xquic": []
   },
   "longrtt": {
-    "aioquic": ["client"],
+    "aioquic": [
+      "client"
+    ],
     "kwik": [],
     "lsquic": [],
     "msquic": [],
     "mvfst": [],
-    "neqo": ["client"],
-    "ngtcp2": ["client"],
-    "picoquic": ["client"],
-    "quic-go": ["client"],
-    "quiche": ["client"],
+    "neqo": [
+      "client"
+    ],
+    "ngtcp2": [
+      "client"
+    ],
+    "picoquic": [
+      "client"
+    ],
+    "quic-go": [
+      "client"
+    ],
+    "quiche": [
+      "client"
+    ],
+    "s2n-quic": [
+      "client",
+      "server"
+    ],
     "xquic": []
   },
   "chacha20": {
-    "aioquic": ["client"],
+    "aioquic": [
+      "client"
+    ],
     "kwik": [],
     "lsquic": [],
     "msquic": [],
     "mvfst": [],
-    "neqo": ["client"],
-    "ngtcp2": ["client"],
-    "picoquic": ["client"],
-    "quic-go": ["client"],
+    "neqo": [
+      "client"
+    ],
+    "ngtcp2": [
+      "client"
+    ],
+    "picoquic": [
+      "client"
+    ],
+    "quic-go": [
+      "client"
+    ],
     "quiche": [],
     "xquic": []
   },
   "multiplexing": {
-    "aioquic": ["client"],
+    "aioquic": [
+      "client"
+    ],
     "kwik": [],
     "lsquic": [],
     "msquic": [],
     "mvfst": [],
     "neqo": [],
-    "ngtcp2": ["client"],
-    "picoquic": ["client"],
-    "quic-go": ["client"],
-    "quiche": ["client"],
+    "ngtcp2": [
+      "client"
+    ],
+    "picoquic": [
+      "client"
+    ],
+    "quic-go": [
+      "client"
+    ],
+    "quiche": [
+      "client"
+    ],
+    "s2n-quic": [
+      "client",
+      "server"
+    ],
     "xquic": []
   },
   "retry": {
-    "aioquic": ["client"],
+    "aioquic": [
+      "client"
+    ],
     "kwik": [],
-    "lsquic": ["client"],
+    "lsquic": [
+      "client"
+    ],
     "msquic": [],
     "mvfst": [],
-    "neqo": ["client"],
-    "ngtcp2": ["client"],
-    "picoquic": ["client"],
-    "quic-go": ["client"],
-    "quiche": ["client"],
+    "neqo": [
+      "client"
+    ],
+    "ngtcp2": [
+      "client"
+    ],
+    "picoquic": [
+      "client"
+    ],
+    "quic-go": [
+      "client"
+    ],
+    "quiche": [
+      "client"
+    ],
+    "s2n-quic": [
+      "client",
+      "server"
+    ],
     "xquic": []
   },
   "blackhole": {
-    "aioquic": ["client"],
+    "aioquic": [
+      "client"
+    ],
     "kwik": [],
-    "lsquic": ["client"],
+    "lsquic": [
+      "client"
+    ],
     "msquic": [],
-    "mvfst": ["client"],
-    "neqo": ["client"],
-    "ngtcp2": ["client"],
-    "picoquic": ["client"],
-    "quic-go": ["client"],
-    "quiche": ["client"],
+    "mvfst": [],
+    "neqo": [
+      "client"
+    ],
+    "ngtcp2": [
+      "client"
+    ],
+    "picoquic": [
+      "client"
+    ],
+    "quic-go": [
+      "client"
+    ],
+    "quiche": [
+      "client"
+    ],
+    "s2n-quic": [
+      "client",
+      "server"
+    ],
     "xquic": []
   },
   "keyupdate": {
@@ -109,24 +237,42 @@
     "lsquic": [],
     "msquic": [],
     "mvfst": [],
-    "neqo": ["client"],
-    "ngtcp2": ["client"],
-    "picoquic": ["client"],
-    "quic-go": ["client"],
+    "neqo": [
+      "client"
+    ],
+    "ngtcp2": [
+      "client"
+    ],
+    "picoquic": [
+      "client"
+    ],
+    "quic-go": [
+      "client"
+    ],
     "quiche": [],
     "xquic": []
   },
   "ecn": {
     "aioquic": [],
     "kwik": [],
-    "lsquic": ["client"],
+    "lsquic": [
+      "client"
+    ],
     "msquic": [],
     "mvfst": [],
     "neqo": [],
-    "ngtcp2": ["client"],
-    "picoquic": ["client"],
+    "ngtcp2": [
+      "client"
+    ],
+    "picoquic": [
+      "client"
+    ],
     "quic-go": [],
     "quiche": [],
+    "s2n-quic": [
+      "client",
+      "server"
+    ],
     "xquic": []
   },
   "amplificationlimit": {
@@ -135,11 +281,21 @@
     "lsquic": [],
     "msquic": [],
     "mvfst": [],
-    "neqo": ["client"],
+    "neqo": [
+      "client"
+    ],
     "ngtcp2": [],
-    "picoquic": ["client"],
-    "quic-go": ["client"],
+    "picoquic": [
+      "client"
+    ],
+    "quic-go": [
+      "client"
+    ],
     "quiche": [],
+    "s2n-quic": [
+      "client",
+      "server"
+    ],
     "xquic": []
   },
   "handshakeloss": {
@@ -156,16 +312,32 @@
     "xquic": []
   },
   "transferloss": {
-    "aioquic": ["client"],
+    "aioquic": [
+      "client"
+    ],
     "kwik": [],
-    "lsquic": ["client"],
+    "lsquic": [
+      "client"
+    ],
     "msquic": [],
-    "mvfst": ["client"],
-    "neqo": ["client"],
-    "ngtcp2": ["client"],
+    "mvfst": [],
+    "neqo": [
+      "client"
+    ],
+    "ngtcp2": [
+      "client"
+    ],
     "picoquic": [],
-    "quic-go": ["client"],
-    "quiche": ["client"],
+    "quic-go": [
+      "client"
+    ],
+    "quiche": [
+      "client"
+    ],
+    "s2n-quic": [
+      "client",
+      "server"
+    ],
     "xquic": []
   },
   "handshakecorruption": {
@@ -182,16 +354,34 @@
     "xquic": []
   },
   "transfercorruption": {
-    "aioquic": ["client"],
+    "aioquic": [
+      "client"
+    ],
     "kwik": [],
-    "lsquic": ["client"],
+    "lsquic": [
+      "client"
+    ],
     "msquic": [],
-    "mvfst": ["client"],
-    "neqo": ["client"],
-    "ngtcp2": ["client"],
-    "picoquic": ["client"],
-    "quic-go": ["client"],
-    "quiche": ["client"],
+    "mvfst": [],
+    "neqo": [
+      "client"
+    ],
+    "ngtcp2": [
+      "client"
+    ],
+    "picoquic": [
+      "client"
+    ],
+    "quic-go": [
+      "client"
+    ],
+    "quiche": [
+      "client"
+    ],
+    "s2n-quic": [
+      "client",
+      "server"
+    ],
     "xquic": []
   },
   "rebind-addr": {
@@ -205,6 +395,10 @@
     "picoquic": [],
     "quic-go": [],
     "quiche": [],
+    "s2n-quic": [
+      "client",
+      "server"
+    ],
     "xquic": []
   },
   "rebind-port": {
@@ -218,6 +412,10 @@
     "picoquic": [],
     "quic-go": [],
     "quiche": [],
+    "s2n-quic": [
+      "client",
+      "server"
+    ],
     "xquic": []
   },
   "connectionmigration": {

--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -24,10 +24,6 @@
     "quiche": [
       "client"
     ],
-    "s2n-quic": [
-      "client",
-      "server"
-    ],
     "xquic": []
   },
   "handshake": {
@@ -52,10 +48,6 @@
     ],
     "quiche": [
       "client"
-    ],
-    "s2n-quic": [
-      "client",
-      "server"
     ],
     "xquic": []
   },
@@ -84,10 +76,6 @@
     "quiche": [
       "client"
     ],
-    "s2n-quic": [
-      "client",
-      "server"
-    ],
     "xquic": []
   },
   "longrtt": {
@@ -112,10 +100,6 @@
     ],
     "quiche": [
       "client"
-    ],
-    "s2n-quic": [
-      "client",
-      "server"
     ],
     "xquic": []
   },
@@ -163,10 +147,6 @@
     "quiche": [
       "client"
     ],
-    "s2n-quic": [
-      "client",
-      "server"
-    ],
     "xquic": []
   },
   "retry": {
@@ -194,10 +174,6 @@
     "quiche": [
       "client"
     ],
-    "s2n-quic": [
-      "client",
-      "server"
-    ],
     "xquic": []
   },
   "blackhole": {
@@ -224,10 +200,6 @@
     ],
     "quiche": [
       "client"
-    ],
-    "s2n-quic": [
-      "client",
-      "server"
     ],
     "xquic": []
   },
@@ -269,10 +241,6 @@
     ],
     "quic-go": [],
     "quiche": [],
-    "s2n-quic": [
-      "client",
-      "server"
-    ],
     "xquic": []
   },
   "amplificationlimit": {
@@ -292,10 +260,6 @@
       "client"
     ],
     "quiche": [],
-    "s2n-quic": [
-      "client",
-      "server"
-    ],
     "xquic": []
   },
   "handshakeloss": {
@@ -333,10 +297,6 @@
     ],
     "quiche": [
       "client"
-    ],
-    "s2n-quic": [
-      "client",
-      "server"
     ],
     "xquic": []
   },
@@ -378,10 +338,6 @@
     "quiche": [
       "client"
     ],
-    "s2n-quic": [
-      "client",
-      "server"
-    ],
     "xquic": []
   },
   "rebind-addr": {
@@ -395,10 +351,6 @@
     "picoquic": [],
     "quic-go": [],
     "quiche": [],
-    "s2n-quic": [
-      "client",
-      "server"
-    ],
     "xquic": []
   },
   "rebind-port": {
@@ -412,10 +364,6 @@
     "picoquic": [],
     "quic-go": [],
     "quiche": [],
-    "s2n-quic": [
-      "client",
-      "server"
-    ],
     "xquic": []
   },
   "connectionmigration": {

--- a/quic/s2n-quic-qns/src/server/h09.rs
+++ b/quic/s2n-quic-qns/src/server/h09.rs
@@ -133,6 +133,11 @@ fn parse_h09_request(chunks: &[Bytes], path: &mut String, is_open: bool) -> Resu
             Some(b'/') => path.push('/'),
             Some(b'-') => path.push('-'),
             Some(b'\n' | b'\r') => return Ok(true),
+            // https://www.w3.org/Protocols/HTTP/AsImplemented.html
+            // > The document address will consist of a single word (ie no spaces).
+            // > If any further words are found on the request line, they MUST either be ignored,
+            // > or else treated according to the full HTTP spec.
+            Some(b' ') => return Ok(true),
             Some(c) => return Err(format!("invalid request {}", c as char).into()),
             None => return Ok(!is_open),
         }


### PR DESCRIPTION
### Description of changes: 

According to the [HTTP 0.9 spec](https://www.w3.org/Protocols/HTTP/AsImplemented.html), we're supposed to ignore any trailing words on the request line.

> The document address will consist of a single word (ie no spaces). If any further words are found on the request line, they MUST either be ignored, or else treated according to the full HTTP spec.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

