### PR TITLE
fix(s2n-quic-transport): add multi-thread support

### DIFF
--- a/quic/s2n-quic-qns/src/main.rs
+++ b/quic/s2n-quic-qns/src/main.rs
@@ -22,7 +22,7 @@ const CRASH_ERROR_MESSAGE: &str = "The s2n-quic-qns application shut down unexpe
 #[global_allocator]
 static ALLOCATOR: dhat::DhatAlloc = dhat::DhatAlloc;
 
-#[tokio::main(flavor = "current_thread")]
+#[tokio::main()]
 async fn main() {
     // setup heap profiling if enabled
     #[cfg(feature = "dhat")]

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -217,11 +217,6 @@ impl<Config: endpoint::Config> EventContext<Config> {
     }
 }
 
-/// Safety: we use some `Rc<RefCell<T>>` inside of the connection but these values
-/// never leave the API boundary and will be all sent across threads together
-#[allow(unknown_lints, clippy::non_send_fields_in_send_ty)]
-unsafe impl<Config: endpoint::Config> Send for ConnectionImpl<Config> {}
-
 #[cfg(debug_assertions)]
 impl<Config: endpoint::Config> Drop for ConnectionImpl<Config> {
     fn drop(&mut self) {

--- a/quic/s2n-quic-transport/src/connection/peer_id_registry/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/peer_id_registry/tests.rs
@@ -412,7 +412,8 @@ pub fn consume_new_id_should_return_id() {
 
     assert!(reg
         .state
-        .borrow_mut()
+        .lock()
+        .unwrap()
         .stateless_reset_map
         .remove(&TEST_TOKEN_2)
         .is_none());
@@ -421,7 +422,8 @@ pub fn consume_new_id_should_return_id() {
     // this is an indirect way to test that we inserted a reset token when we consumed id_2
     assert!(reg
         .state
-        .borrow_mut()
+        .lock()
+        .unwrap()
         .stateless_reset_map
         .remove(&TEST_TOKEN_2)
         .is_some());

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -88,12 +88,6 @@ pub struct Endpoint<Cfg: Config> {
     max_mtu: MaxMtu,
 }
 
-/// Safety: The endpoint is marked as `!Send`, because the struct contains `Rc`s.
-/// However those `Rcs` are only referenced by other objects within the `Endpoint`
-/// and which also get moved.
-#[allow(unknown_lints, clippy::non_send_fields_in_send_ty)]
-unsafe impl<Cfg: Config> Send for Endpoint<Cfg> {}
-
 impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
     type PathHandle = Cfg::PathHandle;
     type Subscriber = Cfg::EventSubscriber;


### PR DESCRIPTION
### Resolved issues:

### Description of changes: 
This PR fixes s2n-quic for multi-thread usecases. 

This was previously missed since the tests(qns) only ran on single thread; so this also changes s2n_quic_qns to run in multi-threaded mode so that CI is now verifying the multi-threaded behavior (single thread is a sub-set of multi-thread).

### Call-outs:

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

