### PR TITLE
feat(s2n-quic-tls): enable support for async client hello callback

### DIFF
--- a/quic/s2n-quic-qns/src/server/unstable.rs
+++ b/quic/s2n-quic-qns/src/server/unstable.rs
@@ -3,7 +3,6 @@
 
 use core::task::Poll;
 use s2n_quic::provider::tls::s2n_tls::{ClientHelloHandler, Connection};
-use tokio::time::Sleep;
 
 pub struct MyClientHelloHandler {}
 

--- a/quic/s2n-quic-rustls/src/lib.rs
+++ b/quic/s2n-quic-rustls/src/lib.rs
@@ -52,7 +52,7 @@ fn client_server_test() {
     let mut pair = tls::testing::Pair::new(&mut server, &mut client, "localhost".into());
 
     while pair.is_handshaking() {
-        pair.poll().unwrap();
+        pair.poll(None).unwrap();
     }
 
     pair.finish();

--- a/quic/s2n-quic-tls/src/server.rs
+++ b/quic/s2n-quic-tls/src/server.rs
@@ -66,13 +66,11 @@ impl Default for Builder {
 impl Builder {
     #[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_client_hello")))]
     pub fn with_client_hello_handler<T: 'static + ClientHelloHandler>(
-        self,
-        _handler: T,
+        mut self,
+        handler: T,
     ) -> Result<Self, Error> {
-        unimplemented!();
-        // TODO undo once this is implemented.
-        // self.config.set_client_hello_handler(handler)?;
-        // Ok(self)
+        self.config.set_client_hello_handler(handler)?;
+        Ok(self)
     }
 
     pub fn with_application_protocols<P: IntoIterator<Item = I>, I: AsRef<[u8]>>(

--- a/quic/s2n-quic-tls/src/tests.rs
+++ b/quic/s2n-quic-tls/src/tests.rs
@@ -2,11 +2,44 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{client, server};
+use core::{
+    sync::atomic::{AtomicBool, AtomicU8, Ordering},
+    task::Poll,
+};
 use s2n_quic_core::crypto::tls::{
     self,
     testing::certificates::{CERT_PEM, KEY_PEM},
     Endpoint,
 };
+#[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_client_hello")))]
+use s2n_tls::raw::{config::ClientHelloHandler, connection::Connection};
+use std::sync::Arc;
+
+pub struct MyClientHelloHandler {
+    done: Arc<AtomicBool>,
+    wait_counter: Arc<AtomicU8>,
+}
+
+impl MyClientHelloHandler {
+    fn new(wait_counter: u8) -> Self {
+        MyClientHelloHandler {
+            done: Arc::new(AtomicBool::new(false)),
+            wait_counter: Arc::new(AtomicU8::new(wait_counter)),
+        }
+    }
+}
+
+#[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_client_hello")))]
+impl ClientHelloHandler for MyClientHelloHandler {
+    fn poll_client_hello(&self, _connection: &mut Connection) -> core::task::Poll<Result<(), ()>> {
+        if self.wait_counter.fetch_sub(1, Ordering::SeqCst) == 0 {
+            self.done.store(true, Ordering::SeqCst);
+            return Poll::Ready(Ok(()));
+        }
+
+        Poll::Pending
+    }
+}
 
 fn s2n_client() -> client::Client {
     client::Builder::default()
@@ -22,6 +55,20 @@ fn s2n_server() -> server::Server {
         .unwrap()
         .build()
         .unwrap()
+}
+
+#[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_client_hello")))]
+fn s2n_server_with_client_hello_callback(wait_counter: u8) -> (server::Server, Arc<AtomicBool>) {
+    let handle = MyClientHelloHandler::new(wait_counter);
+    let done = handle.done.clone();
+    let tls = server::Builder::default()
+        .with_certificate(CERT_PEM, KEY_PEM)
+        .unwrap()
+        .with_client_hello_handler(handle)
+        .unwrap()
+        .build()
+        .unwrap();
+    (tls, done)
 }
 
 fn rustls_server() -> s2n_quic_rustls::server::Server {
@@ -42,11 +89,22 @@ fn rustls_client() -> s2n_quic_rustls::client::Client {
 
 #[test]
 #[cfg_attr(miri, ignore)]
+fn s2n_client_s2n_server_ch_callback_test() {
+    for wait_counter in 0..=10 {
+        let mut client_endpoint = s2n_client();
+        let (mut server_endpoint, done) = s2n_server_with_client_hello_callback(wait_counter);
+
+        run(&mut server_endpoint, &mut client_endpoint, Some(done));
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
 fn s2n_client_s2n_server_test() {
     let mut client_endpoint = s2n_client();
     let mut server_endpoint = s2n_server();
 
-    run(&mut server_endpoint, &mut client_endpoint);
+    run(&mut server_endpoint, &mut client_endpoint, None);
 }
 
 #[test]
@@ -55,7 +113,7 @@ fn rustls_client_s2n_server_test() {
     let mut client_endpoint = rustls_client();
     let mut server_endpoint = s2n_server();
 
-    run(&mut server_endpoint, &mut client_endpoint);
+    run(&mut server_endpoint, &mut client_endpoint, None);
 }
 
 #[test]
@@ -64,15 +122,19 @@ fn s2n_client_rustls_server_test() {
     let mut client_endpoint = s2n_client();
     let mut server_endpoint = rustls_server();
 
-    run(&mut server_endpoint, &mut client_endpoint);
+    run(&mut server_endpoint, &mut client_endpoint, None);
 }
 
 /// Executes the handshake to completion
-fn run<S: Endpoint, C: Endpoint>(server: &mut S, client: &mut C) {
+fn run<S: Endpoint, C: Endpoint>(
+    server: &mut S,
+    client: &mut C,
+    client_hello_cb_done: Option<Arc<AtomicBool>>,
+) {
     let mut pair = tls::testing::Pair::new(server, client, "localhost".into());
 
     while pair.is_handshaking() {
-        pair.poll().unwrap();
+        pair.poll(client_hello_cb_done.clone()).unwrap();
     }
 
     pair.finish();


### PR DESCRIPTION
### Resolved issues:

### Description of changes: 
This PR adds support for client_hello callback when using the s2n-tls provider. This mechanism allows for executing some async code when the server processes the client hello (load cert based on server name).

Note the feature is added behind the `unstable` flag since the s2n-tls apis have not yet been stabilized.

### Testing:
- I have added **unit tests** to test the callback behavior.
- qns currently uses the client_hello callback (behind the unstable flag) but it doesnt do anything very interesting at the moment (returns Ready on first call) and also we dont have it enabled by default in our CI. *I dont want to turn it on(atleast with a [sleep future](https://docs.rs/tokio/latest/tokio/time/fn.sleep.html)) since it will affect perf and other benchmarks). This is also something we can address in the future.*

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

