### PR TITLE
feat(s2n-quic-tls, s2n-quic-rustls): emit server_name and application_protocol events sooner in the handshake

### DIFF
--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -19,8 +19,6 @@ pub mod testing;
 pub struct ApplicationParameters<'a> {
     /// The negotiated Application Layer Protocol
     pub application_protocol: &'a [u8],
-    /// Server Name Indication
-    pub server_name: Option<crate::application::ServerName>,
     /// Encoded transport parameters
     pub transport_parameters: &'a [u8],
 }
@@ -53,7 +51,6 @@ pub trait Context<Crypto: CryptoSuite> {
         application_parameters: ApplicationParameters,
     ) -> Result<(), transport::Error>;
 
-    /// Server Name Indication was parsed
     fn on_server_name(
         &mut self,
         server_name: Option<crate::application::ServerName>,

--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -17,8 +17,6 @@ pub mod testing;
 /// Holds all application parameters which are exchanged within the TLS handshake.
 #[derive(Debug)]
 pub struct ApplicationParameters<'a> {
-    /// The negotiated Application Layer Protocol
-    pub application_protocol: &'a [u8],
     /// Encoded transport parameters
     pub transport_parameters: &'a [u8],
 }
@@ -54,6 +52,11 @@ pub trait Context<Crypto: CryptoSuite> {
     fn on_server_name(
         &mut self,
         server_name: crate::application::ServerName,
+    ) -> Result<(), transport::Error>;
+
+    fn on_application_protocol(
+        &mut self,
+        application_protocol: &[u8],
     ) -> Result<(), transport::Error>;
 
     //= https://www.rfc-editor.org/rfc/rfc9001#section-4.1.1

--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -53,6 +53,12 @@ pub trait Context<Crypto: CryptoSuite> {
         application_parameters: ApplicationParameters,
     ) -> Result<(), transport::Error>;
 
+    /// Server Name Indication was parsed
+    fn on_server_name(
+        &mut self,
+        server_name: Option<crate::application::ServerName>,
+    ) -> Result<(), transport::Error>;
+
     //= https://www.rfc-editor.org/rfc/rfc9001#section-4.1.1
     //# The TLS handshake is considered complete when the
     //# TLS stack has reported that the handshake is complete.  This happens

--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -53,7 +53,7 @@ pub trait Context<Crypto: CryptoSuite> {
 
     fn on_server_name(
         &mut self,
-        server_name: Option<crate::application::ServerName>,
+        server_name: crate::application::ServerName,
     ) -> Result<(), transport::Error>;
 
     //= https://www.rfc-editor.org/rfc/rfc9001#section-4.1.1

--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -56,7 +56,7 @@ pub trait Context<Crypto: CryptoSuite> {
 
     fn on_application_protocol(
         &mut self,
-        application_protocol: &[u8],
+        application_protocol: Bytes,
     ) -> Result<(), transport::Error>;
 
     //= https://www.rfc-editor.org/rfc/rfc9001#section-4.1.1

--- a/quic/s2n-quic-core/src/crypto/tls/testing.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/testing.rs
@@ -508,15 +508,14 @@ impl<C: CryptoSuite> tls::Context<C> for Context<C> {
 
     fn on_server_name(
         &mut self,
-        server_name: Option<crate::application::ServerName>,
+        server_name: crate::application::ServerName,
     ) -> Result<(), transport::Error> {
         assert!(
-            self.application.crypto.is_none(),
-            "1-rtt keys emitted before server name parsing"
+            self.handshake.crypto.is_none(),
+            "handshake keys emitted before server name was parsed"
         );
         self.log("server name");
-        self.server_name = server_name.map(|sni| sni.into_bytes());
-
+        self.server_name = Some(server_name.into_bytes());
         Ok(())
     }
 

--- a/quic/s2n-quic-core/src/crypto/tls/testing.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/testing.rs
@@ -516,6 +516,7 @@ impl<C: CryptoSuite> tls::Context<C> for Context<C> {
         );
         self.log("server name");
         self.server_name = server_name.map(|sni| sni.into_bytes());
+
         Ok(())
     }
 

--- a/quic/s2n-quic-core/src/crypto/tls/testing.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/testing.rs
@@ -294,11 +294,10 @@ impl<C: CryptoSuite> Context<C> {
         self.assert_done();
         other.assert_done();
 
-        // TODO fix sni bug in s2n-quic-rustls
-        // assert_eq!(
-        //     self.server_name, other.server_name,
-        //     "sni is not consistent between endpoints"
-        // );
+        assert_eq!(
+            self.server_name, other.server_name,
+            "sni is not consistent between endpoints"
+        );
         assert_eq!(
             self.application_protocol, other.application_protocol,
             "application_protocol is not consistent between endpoints"
@@ -530,7 +529,6 @@ impl<C: CryptoSuite> tls::Context<C> for Context<C> {
         application_protocol: Bytes,
     ) -> Result<(), transport::Error> {
         self.log("application protocol");
-        let application_protocol = application_protocol;
         self.application_protocol = Some(application_protocol);
         Ok(())
     }

--- a/quic/s2n-quic-core/src/crypto/tls/testing.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/testing.rs
@@ -289,10 +289,10 @@ impl<C: CryptoSuite> Context<C> {
         other.assert_done();
 
         // TODO fix sni bug in s2n-quic-rustls
-        //assert_eq!(
-        //    self.sni, other.sni,
-        //    "sni is not consistent between endpoints"
-        //);
+        // assert_eq!(
+        //     self.server_name, other.server_name,
+        //     "sni is not consistent between endpoints"
+        // );
         assert_eq!(
             self.application_protocol, other.application_protocol,
             "application_protocol is not consistent between endpoints"
@@ -322,7 +322,6 @@ impl<C: CryptoSuite> Context<C> {
     }
 
     fn on_application_params(&mut self, params: tls::ApplicationParameters) {
-        self.application_protocol = Some(Bytes::copy_from_slice(params.application_protocol));
         self.transport_parameters = Some(Bytes::copy_from_slice(params.transport_parameters));
     }
 
@@ -516,6 +515,16 @@ impl<C: CryptoSuite> tls::Context<C> for Context<C> {
         );
         self.log("server name");
         self.server_name = Some(server_name.into_bytes());
+        Ok(())
+    }
+
+    fn on_application_protocol(
+        &mut self,
+        application_protocol: &[u8],
+    ) -> Result<(), transport::Error> {
+        self.log("application protocol");
+        let application_protocol = Bytes::copy_from_slice(application_protocol);
+        self.application_protocol = Some(application_protocol);
         Ok(())
     }
 

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 exclude = ["corpus.tar.gz"]
 
 [dependencies]
-bytes = "1"
+bytes = { version = "1", default-features = false }
 rustls = { version = "0.20", features = ["quic"] }
 rustls-pemfile = "0.3"
 s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -10,6 +10,7 @@ license = "Apache-2.0"
 exclude = ["corpus.tar.gz"]
 
 [dependencies]
+bytes = "1"
 rustls = { version = "0.20", features = ["quic"] }
 rustls-pemfile = "0.3"
 s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }

--- a/quic/s2n-quic-rustls/src/client.rs
+++ b/quic/s2n-quic-rustls/src/client.rs
@@ -60,18 +60,18 @@ impl tls::Endpoint for Client {
         //# Endpoints MUST send the quic_transport_parameters extension;
         let transport_parameters = encode_transport_parameters(transport_parameters);
 
-        let server_name =
+        let rustls_server_name =
             rustls::ServerName::try_from(server_name.as_ref()).expect("invalid server name");
 
         let session = rustls::ClientConnection::new_quic(
             self.config.clone(),
             crate::QUIC_VERSION,
-            server_name,
+            rustls_server_name,
             transport_parameters,
         )
         .expect("could not create rustls client session");
 
-        Session::new(session.into())
+        Session::new(session.into(), Some(server_name))
     }
 
     fn max_tag_length(&self) -> usize {

--- a/quic/s2n-quic-rustls/src/server.rs
+++ b/quic/s2n-quic-rustls/src/server.rs
@@ -57,7 +57,7 @@ impl tls::Endpoint for Server {
         )
         .expect("could not create rustls server session");
 
-        Session::new(session.into())
+        Session::new(session.into(), None)
     }
 
     fn new_client_session<Params: EncoderValue>(

--- a/quic/s2n-quic-rustls/src/session.rs
+++ b/quic/s2n-quic-rustls/src/session.rs
@@ -88,11 +88,23 @@ impl Session {
         })
     }
 
+    //= https://www.rfc-editor.org/rfc/rfc9001#section-8.1
+    //# Unless
+    //# another mechanism is used for agreeing on an application protocol,
+    //# endpoints MUST use ALPN for this purpose.
+    //
+    //= https://www.rfc-editor.org/rfc/rfc7301#section-3.1
+    //# Client                                              Server
+    //#
+    //#    ClientHello                     -------->       ServerHello
+    //#      (ALPN extension &                               (ALPN extension &
+    //#       list of protocols)                              selected protocol)
+    //#                                                    [ChangeCipherSpec]
+    //#                                    <--------       Finished
+    //#    [ChangeCipherSpec]
+    //#    Finished                        -------->
+    //#    Application Data                <------->       Application Data
     fn application_protocol(&self) -> Result<&[u8], transport::Error> {
-        //= https://www.rfc-editor.org/rfc/rfc9001#section-8.1
-        //# Unless
-        //# another mechanism is used for agreeing on an application protocol,
-        //# endpoints MUST use ALPN for this purpose.
         let application_protocol = self.connection.alpn_protocol().ok_or_else(||
             //= https://www.rfc-editor.org/rfc/rfc9001#section-8.1
             //# When using ALPN, endpoints MUST immediately close a connection (see

--- a/quic/s2n-quic-rustls/src/session.rs
+++ b/quic/s2n-quic-rustls/src/session.rs
@@ -244,6 +244,9 @@ impl tls::Session for Session {
                         quic::KeyChange::Handshake { keys } => {
                             let (key, header_key) = PacketKeys::new(keys, cipher_suite);
 
+                            if let Some(server_name) = self.server_name() {
+                                context.on_server_name(server_name)?;
+                            }
                             context.on_handshake_keys(key, header_key)?;
 
                             // Transition both phases to Handshake
@@ -254,7 +257,6 @@ impl tls::Session for Session {
                             let (key, header_key) = OneRttKey::new(keys, next, cipher_suite);
                             let application_parameters = self.application_parameters()?;
 
-                            context.on_server_name(self.server_name())?;
                             context.on_one_rtt_keys(key, header_key, application_parameters)?;
 
                             // Transition the tx_phase to Application

--- a/quic/s2n-quic-rustls/src/session.rs
+++ b/quic/s2n-quic-rustls/src/session.rs
@@ -168,6 +168,7 @@ impl Session {
     ) -> Poll<Result<(), transport::Error>> {
         // Tracks if we have attempted to receive data at least once
         let mut has_tried_receive = false;
+
         loop {
             let crypto_data = match self.rx_phase {
                 HandshakePhase::Initial => context.receive_initial(None),
@@ -177,7 +178,7 @@ impl Session {
 
             // receive anything in the incoming buffer
             if let Some(crypto_data) = crypto_data {
-                self.receive(&crypto_data)?
+                self.receive(&crypto_data)?;
             } else if has_tried_receive {
                 return self.poll_complete_handshake(context);
                 // If there's nothing to receive then we're done for now

--- a/quic/s2n-quic-rustls/src/session.rs
+++ b/quic/s2n-quic-rustls/src/session.rs
@@ -100,11 +100,8 @@ impl Session {
                 CryptoError::MISSING_EXTENSION.with_reason("Missing QUIC transport parameters")
             })?;
 
-        let server_name = self.server_name();
-
         Ok(tls::ApplicationParameters {
             application_protocol,
-            server_name,
             transport_parameters,
         })
     }

--- a/quic/s2n-quic-rustls/src/session.rs
+++ b/quic/s2n-quic-rustls/src/session.rs
@@ -257,6 +257,7 @@ impl tls::Session for Session {
                             let (key, header_key) = OneRttKey::new(keys, next, cipher_suite);
                             let application_parameters = self.application_parameters()?;
 
+                            context.on_server_name(self.server_name())?;
                             context.on_one_rtt_keys(key, header_key, application_parameters)?;
 
                             // Transition the tx_phase to Application

--- a/quic/s2n-quic-rustls/src/session.rs
+++ b/quic/s2n-quic-rustls/src/session.rs
@@ -271,23 +271,24 @@ impl tls::Session for Session {
                             };
 
                             context.on_handshake_keys(key, header_key)?;
+                            // TODO: https://github.com/aws/s2n-quic/pull/1238/files#r833764775
+                            // Due the way `self::poll()` works, combined with how our unit tests are
+                            // structured (core::tls::testing::Pair::poll() polls client and then
+                            // server once), the client only sees the alpn value in the second
+                            // iteration. The fix would involve calling only 'receive' on the client
+                            // and processing the server_hello.
+                            //
+                            // if let Connection::Client(_) = &self.connection {
+                            //     // TODO use interning for these values
+                            //     // issue: https://github.com/aws/s2n-quic/issues/248
+                            //     let application_protocol =
+                            //         Bytes::copy_from_slice(self.application_protocol()?);
+                            //     context.on_application_protocol(application_protocol)?;
+                            // };
 
                             // Transition both phases to Handshake
                             self.tx_phase.transition();
                             self.rx_phase.transition();
-
-                            // Read the SERVER_HELLO from the handshake rx buffer
-                            let crypto_data = context.receive_handshake(None);
-                            if let Some(crypto_data) = crypto_data {
-                                self.receive(&crypto_data)?;
-                            }
-                            if let Connection::Client(_) = &self.connection {
-                                // TODO use interning for these values
-                                // issue: https://github.com/aws/s2n-quic/issues/248
-                                let application_protocol =
-                                    Bytes::copy_from_slice(self.application_protocol()?);
-                                context.on_application_protocol(application_protocol)?;
-                            };
                         }
                         quic::KeyChange::OneRtt { keys, next } => {
                             if let Connection::Client(_) = &self.connection {

--- a/quic/s2n-quic-rustls/src/session.rs
+++ b/quic/s2n-quic-rustls/src/session.rs
@@ -271,12 +271,11 @@ impl tls::Session for Session {
                             };
 
                             context.on_handshake_keys(key, header_key)?;
-                            // TODO: https://github.com/aws/s2n-quic/pull/1238/files#r833764775
-                            // Due the way `self::poll()` works, combined with how our unit tests are
-                            // structured (core::tls::testing::Pair::poll() polls client and then
-                            // server once), the client only sees the alpn value in the second
-                            // iteration. The fix would involve calling only 'receive' on the client
-                            // and processing the server_hello.
+                            // TODO: https://github.com/aws/s2n-quic/issues/1240
+                            // https://github.com/aws/s2n-quic/pull/1238/files#r833764775
+                            // The ServerHello is received in the handshake space, so even though
+                            // we have handshake keys, we still need to read from the handshake
+                            // buffer before accessing server_name and application_protocol.
                             //
                             // if let Connection::Client(_) = &self.connection {
                             //     // TODO use interning for these values

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["corpus.tar.gz"]
 unstable_client_hello = []
 
 [dependencies]
-bytes = { version = "1", default-features = false }
+bytes = "1"
 errno = "0.2"
 libc = "0.2"
 

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -13,7 +13,7 @@ exclude = ["corpus.tar.gz"]
 unstable_client_hello = []
 
 [dependencies]
-bytes = "1"
+bytes = { version = "1", default-features = false }
 errno = "0.2"
 libc = "0.2"
 

--- a/quic/s2n-quic-tls/src/callback.rs
+++ b/quic/s2n-quic-tls/src/callback.rs
@@ -220,12 +220,11 @@ where
                             .expect("invalid cipher");
 
                         self.context.on_handshake_keys(key, header_key)?;
-                        // TODO: https://github.com/aws/s2n-quic/pull/1238/files#r833764775
-                        // Due the way `self::poll()` works, combined with how our unit tests are
-                        // structured (core::tls::testing::Pair::poll() polls client and then
-                        // server once), the client only sees the alpn value in the second
-                        // iteration. The fix would involve calling only 'receive' on the client
-                        // and processing the server_hello.
+                        // TODO: https://github.com/aws/s2n-quic/issues/1240
+                        // https://github.com/aws/s2n-quic/pull/1238/files#r833764775
+                        // The ServerHello is received in the handshake space, so even though
+                        // we have handshake keys, we still need to read from the handshake
+                        // buffer before accessing server_name and application_protocol.
                         //
                         // if self.endpoint == endpoint::Type::Client {
                         //     // TODO use interning for these values

--- a/quic/s2n-quic-tls/src/callback.rs
+++ b/quic/s2n-quic-tls/src/callback.rs
@@ -447,11 +447,8 @@ unsafe fn get_application_params<'a>(
     let transport_parameters =
         get_transport_parameters(connection).ok_or(CryptoError::MISSING_EXTENSION)?;
 
-    let server_name = get_server_name(connection);
-
     Ok(tls::ApplicationParameters {
         application_protocol,
-        server_name,
         transport_parameters,
     })
 }

--- a/quic/s2n-quic-tls/src/callback.rs
+++ b/quic/s2n-quic-tls/src/callback.rs
@@ -473,6 +473,18 @@ unsafe fn get_server_name(connection: *mut s2n_connection) -> Option<ServerName>
 //# Unless
 //# another mechanism is used for agreeing on an application protocol,
 //# endpoints MUST use ALPN for this purpose.
+//
+//= https://www.rfc-editor.org/rfc/rfc7301#section-3.1
+//# Client                                              Server
+//#
+//#    ClientHello                     -------->       ServerHello
+//#      (ALPN extension &                               (ALPN extension &
+//#       list of protocols)                              selected protocol)
+//#                                                    [ChangeCipherSpec]
+//#                                    <--------       Finished
+//#    [ChangeCipherSpec]
+//#    Finished                        -------->
+//#    Application Data                <------->       Application Data
 unsafe fn get_application_protocol<'a>(
     connection: *mut s2n_connection,
 ) -> Result<&'a [u8], CryptoError> {

--- a/quic/s2n-quic-tls/src/callback.rs
+++ b/quic/s2n-quic-tls/src/callback.rs
@@ -203,8 +203,14 @@ where
 
                 match self.state.tx_phase {
                     HandshakePhase::Initial => {
+                        unsafe {
+                            if let Some(server_name) = get_server_name(conn) {
+                                self.context.on_server_name(server_name)?;
+                            }
+                        }
                         let (key, header_key) = HandshakeKey::new(self.endpoint, aead_algo, pair)
                             .expect("invalid cipher");
+
                         self.context.on_handshake_keys(key, header_key)?;
 
                         self.state.tx_phase.transition();
@@ -215,8 +221,6 @@ where
                             OneRttKey::new(self.endpoint, aead_algo, pair).expect("invalid cipher");
 
                         let params = unsafe {
-                            self.context.on_server_name(get_server_name(conn))?;
-
                             // Safety: conn needs to outlive params
                             get_application_params(conn)?
                         };

--- a/quic/s2n-quic-tls/src/callback.rs
+++ b/quic/s2n-quic-tls/src/callback.rs
@@ -215,6 +215,8 @@ where
                             OneRttKey::new(self.endpoint, aead_algo, pair).expect("invalid cipher");
 
                         let params = unsafe {
+                            self.context.on_server_name(get_server_name(conn))?;
+
                             // Safety: conn needs to outlive params
                             get_application_params(conn)?
                         };

--- a/quic/s2n-quic-tls/src/client.rs
+++ b/quic/s2n-quic-tls/src/client.rs
@@ -123,12 +123,7 @@ impl tls::Endpoint for Client {
     ) -> Self::Session {
         let config = self.config.clone();
         self.params.with(params, |params| {
-            let mut session = Session::new(endpoint::Type::Client, config, params).unwrap();
-            session
-                .connection
-                .set_server_name(&server_name)
-                .expect("invalid server name value");
-            session
+            Session::new(endpoint::Type::Client, config, params, Some(server_name)).unwrap()
         })
     }
 

--- a/quic/s2n-quic-tls/src/server.rs
+++ b/quic/s2n-quic-tls/src/server.rs
@@ -138,7 +138,7 @@ impl tls::Endpoint for Server {
     fn new_server_session<Params: EncoderValue>(&mut self, params: &Params) -> Self::Session {
         let config = self.config.clone();
         self.params.with(params, |params| {
-            Session::new(endpoint::Type::Server, config, params).unwrap()
+            Session::new(endpoint::Type::Server, config, params, None).unwrap()
         })
     }
 

--- a/quic/s2n-quic-tls/src/session.rs
+++ b/quic/s2n-quic-tls/src/session.rs
@@ -23,6 +23,7 @@ pub struct Session {
     state: callback::State,
     handshake_complete: bool,
     send_buffer: BytesMut,
+    emitted_server_name: bool,
 }
 
 impl Session {
@@ -44,6 +45,7 @@ impl Session {
             state: Default::default(),
             handshake_complete: false,
             send_buffer: BytesMut::new(),
+            emitted_server_name: false,
         })
     }
 }
@@ -72,6 +74,7 @@ impl tls::Session for Session {
             suite: PhantomData,
             err: None,
             send_buffer: &mut self.send_buffer,
+            emitted_server_name: &mut self.emitted_server_name,
         };
 
         unsafe {

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1721,7 +1721,6 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
     }
 
     fn application_protocol(&self) -> Bytes {
-        // TODO move ALPN to connection
         self.space_manager.application_protocol.clone()
     }
 

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1717,8 +1717,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
     }
 
     fn server_name(&self) -> Option<ServerName> {
-        // TODO move SNI to connection
-        self.space_manager.application()?.server_name.clone()
+        self.space_manager.server_name.clone()
     }
 
     fn application_protocol(&self) -> Bytes {

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1722,11 +1722,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
 
     fn application_protocol(&self) -> Bytes {
         // TODO move ALPN to connection
-        if let Some(space) = self.space_manager.application() {
-            space.application_protocol.clone()
-        } else {
-            Bytes::from_static(&[])
-        }
+        self.space_manager.application_protocol.clone()
     }
 
     fn ping(&mut self) -> Result<(), connection::Error> {

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -15,7 +15,6 @@ use crate::{
     sync::flag,
     transmission,
 };
-use bytes::Bytes;
 use core::{convert::TryInto, fmt, marker::PhantomData};
 use once_cell::sync::OnceCell;
 use s2n_codec::EncoderBuffer;
@@ -61,14 +60,6 @@ pub struct ApplicationSpace<Config: endpoint::Config> {
     key_set: KeySet<<<Config::TLSEndpoint as tls::Endpoint>::Session as CryptoSuite>::OneRttKey>,
     header_key: <<Config::TLSEndpoint as tls::Endpoint>::Session as CryptoSuite>::OneRttHeaderKey,
 
-    //= https://www.rfc-editor.org/rfc/rfc9000#section-7
-    //# Endpoints MUST explicitly negotiate an application protocol.
-
-    //= https://www.rfc-editor.org/rfc/rfc9001#section-8.1
-    //# Unless
-    //# another mechanism is used for agreeing on an application protocol,
-    //# endpoints MUST use ALPN for this purpose.
-    pub application_protocol: Bytes,
     ping: flag::Ping,
     keep_alive: KeepAlive,
     processed_packet_numbers: SlidingWindow,
@@ -79,7 +70,6 @@ impl<Config: endpoint::Config> fmt::Debug for ApplicationSpace<Config> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("ApplicationSpace")
             .field("ack_manager", &self.ack_manager)
-            .field("application_protocol", &self.application_protocol)
             .field("ping", &self.ping)
             .field("processed_packet_numbers", &self.processed_packet_numbers)
             .field("recovery_manager", &self.recovery_manager)
@@ -98,7 +88,6 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         stream_manager: AbstractStreamManager<Config::Stream>,
         ack_manager: AckManager,
         keep_alive: KeepAlive,
-        application_protocol: Bytes,
         max_mtu: MaxMtu,
     ) -> Self {
         let key_set = KeySet::new(key, Self::key_limits(max_mtu));
@@ -110,7 +99,6 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
             stream_manager,
             key_set,
             header_key,
-            application_protocol,
             ping: flag::Ping::default(),
             keep_alive,
             processed_packet_numbers: SlidingWindow::default(),

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -20,7 +20,6 @@ use core::{convert::TryInto, fmt, marker::PhantomData};
 use once_cell::sync::OnceCell;
 use s2n_codec::EncoderBuffer;
 use s2n_quic_core::{
-    application::ServerName,
     crypto::{application::KeySet, limited, tls, CryptoSuite},
     event::{self, ConnectionPublisher as _, IntoEvent},
     frame::{
@@ -70,7 +69,6 @@ pub struct ApplicationSpace<Config: endpoint::Config> {
     //# another mechanism is used for agreeing on an application protocol,
     //# endpoints MUST use ALPN for this purpose.
     pub application_protocol: Bytes,
-    pub server_name: Option<ServerName>,
     ping: flag::Ping,
     keep_alive: KeepAlive,
     processed_packet_numbers: SlidingWindow,
@@ -85,7 +83,6 @@ impl<Config: endpoint::Config> fmt::Debug for ApplicationSpace<Config> {
             .field("ping", &self.ping)
             .field("processed_packet_numbers", &self.processed_packet_numbers)
             .field("recovery_manager", &self.recovery_manager)
-            .field("server_name", &self.server_name)
             .field("stream_manager", &self.stream_manager)
             .field("tx_packet_numbers", &self.tx_packet_numbers)
             .finish()
@@ -101,7 +98,6 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         stream_manager: AbstractStreamManager<Config::Stream>,
         ack_manager: AckManager,
         keep_alive: KeepAlive,
-        server_name: Option<ServerName>,
         application_protocol: Bytes,
         max_mtu: MaxMtu,
     ) -> Self {
@@ -114,7 +110,6 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
             stream_manager,
             key_set,
             header_key,
-            server_name,
             application_protocol,
             ping: flag::Ping::default(),
             keep_alive,

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -16,6 +16,7 @@ use core::{
 use s2n_codec::DecoderBufferMut;
 use s2n_quic_core::{
     ack,
+    application::ServerName,
     connection::{limits::Limits, InitialId, PeerId},
     crypto::{tls, tls::Session, CryptoSuite, Key},
     event::{self, IntoEvent},
@@ -63,6 +64,8 @@ pub struct PacketSpaceManager<Config: endpoint::Config> {
     zero_rtt_crypto:
         Option<Box<<<Config::TLSEndpoint as tls::Endpoint>::Session as CryptoSuite>::ZeroRttKey>>,
     handshake_status: HandshakeStatus,
+    /// Server Name Indication
+    pub server_name: Option<ServerName>,
 }
 
 impl<Config: endpoint::Config> fmt::Debug for PacketSpaceManager<Config> {
@@ -155,6 +158,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
             application: None,
             zero_rtt_crypto: None,
             handshake_status: HandshakeStatus::default(),
+            server_name: None,
         }
     }
 
@@ -203,6 +207,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
                 handshake_status: &mut self.handshake_status,
                 local_id_registry,
                 limits,
+                server_name: &mut self.server_name,
                 waker,
                 publisher,
             };

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -66,6 +66,14 @@ pub struct PacketSpaceManager<Config: endpoint::Config> {
     handshake_status: HandshakeStatus,
     /// Server Name Indication
     pub server_name: Option<ServerName>,
+    //= https://www.rfc-editor.org/rfc/rfc9000#section-7
+    //# Endpoints MUST explicitly negotiate an application protocol.
+
+    //= https://www.rfc-editor.org/rfc/rfc9001#section-8.1
+    //# Unless
+    //# another mechanism is used for agreeing on an application protocol,
+    //# endpoints MUST use ALPN for this purpose.
+    pub application_protocol: Bytes,
 }
 
 impl<Config: endpoint::Config> fmt::Debug for PacketSpaceManager<Config> {
@@ -159,6 +167,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
             zero_rtt_crypto: None,
             handshake_status: HandshakeStatus::default(),
             server_name: None,
+            application_protocol: Bytes::from_static(&[]),
         }
     }
 
@@ -208,6 +217,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
                 local_id_registry,
                 limits,
                 server_name: &mut self.server_name,
+                application_protocol: &mut self.application_protocol,
                 waker,
                 publisher,
             };

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -167,7 +167,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
             zero_rtt_crypto: None,
             handshake_status: HandshakeStatus::default(),
             server_name: None,
-            application_protocol: Bytes::from_static(&[]),
+            application_protocol: Bytes::new(),
         }
     }
 

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -395,16 +395,12 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
         Ok(())
     }
 
-    fn on_server_name(&mut self, server_name: Option<ServerName>) -> Result<(), transport::Error> {
-        // TODO use interning for these values
-        // issue: https://github.com/aws/s2n-quic/issues/248
-        if let Some(server_name) = &server_name {
-            self.publisher
-                .on_server_name_information(event::builder::ServerNameInformation {
-                    chosen_server_name: server_name,
-                });
-        }
-        *self.server_name = server_name;
+    fn on_server_name(&mut self, server_name: ServerName) -> Result<(), transport::Error> {
+        self.publisher
+            .on_server_name_information(event::builder::ServerNameInformation {
+                chosen_server_name: &server_name,
+            });
+        *self.server_name = Some(server_name);
 
         Ok(())
     }

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -396,12 +396,8 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
 
     fn on_application_protocol(
         &mut self,
-        application_protocol: &[u8],
+        application_protocol: Bytes,
     ) -> Result<(), transport::Error> {
-        // TODO use interning for these values
-        // issue: https://github.com/aws/s2n-quic/issues/248
-        let application_protocol = Bytes::copy_from_slice(application_protocol);
-
         self.publisher.on_application_protocol_information(
             event::builder::ApplicationProtocolInformation {
                 chosen_application_protocol: &application_protocol,

--- a/specs/www.rfc-editor.org/rfc/rfc7301.txt
+++ b/specs/www.rfc-editor.org/rfc/rfc7301.txt
@@ -1,0 +1,507 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                         S. Friedl
+Request for Comments: 7301                           Cisco Systems, Inc.
+Category: Standards Track                                       A. Popov
+ISSN: 2070-1721                                          Microsoft Corp.
+                                                              A. Langley
+                                                             Google Inc.
+                                                              E. Stephan
+                                                                  Orange
+                                                               July 2014
+
+
+                     Transport Layer Security (TLS)
+            Application-Layer Protocol Negotiation Extension
+
+Abstract
+
+   This document describes a Transport Layer Security (TLS) extension
+   for application-layer protocol negotiation within the TLS handshake.
+   For instances in which multiple application protocols are supported
+   on the same TCP or UDP port, this extension allows the application
+   layer to negotiate which protocol will be used within the TLS
+   connection.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7301.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Friedl, et al.               Standards Track                    [Page 1]
+
+RFC 7301         TLS App-Layer Protocol Negotiation Ext        July 2014
+
+
+Copyright Notice
+
+   Copyright (c) 2014 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Requirements Language . . . . . . . . . . . . . . . . . . . .   3
+   3.  Application-Layer Protocol Negotiation  . . . . . . . . . . .   3
+     3.1.  The Application-Layer Protocol Negotiation Extension  . .   3
+     3.2.  Protocol Selection  . . . . . . . . . . . . . . . . . . .   5
+   4.  Design Considerations . . . . . . . . . . . . . . . . . . . .   6
+   5.  Security Considerations . . . . . . . . . . . . . . . . . . .   6
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .   7
+   7.  Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .   8
+   8.  References  . . . . . . . . . . . . . . . . . . . . . . . . .   8
+     8.1.  Normative References  . . . . . . . . . . . . . . . . . .   8
+     8.2.  Informative References  . . . . . . . . . . . . . . . . .   8
+
+1.  Introduction
+
+   Increasingly, application-layer protocols are encapsulated in the TLS
+   protocol [RFC5246].  This encapsulation enables applications to use
+   the existing, secure communications links already present on port 443
+   across virtually the entire global IP infrastructure.
+
+   When multiple application protocols are supported on a single server-
+   side port number, such as port 443, the client and the server need to
+   negotiate an application protocol for use with each connection.  It
+   is desirable to accomplish this negotiation without adding network
+   round-trips between the client and the server, as each round-trip
+   will degrade an end-user's experience.  Further, it would be
+   advantageous to allow certificate selection based on the negotiated
+   application protocol.
+
+
+
+
+
+
+Friedl, et al.               Standards Track                    [Page 2]
+
+RFC 7301         TLS App-Layer Protocol Negotiation Ext        July 2014
+
+
+   This document specifies a TLS extension that permits the application
+   layer to negotiate protocol selection within the TLS handshake.  This
+   work was requested by the HTTPbis WG to address the negotiation of
+   HTTP/2 ([HTTP2]) over TLS; however, ALPN facilitates negotiation of
+   arbitrary application-layer protocols.
+
+   With ALPN, the client sends the list of supported application
+   protocols as part of the TLS ClientHello message.  The server chooses
+   a protocol and sends the selected protocol as part of the TLS
+   ServerHello message.  The application protocol negotiation can thus
+   be accomplished within the TLS handshake, without adding network
+   round-trips, and allows the server to associate a different
+   certificate with each application protocol, if desired.
+
+2.  Requirements Language
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+3.  Application-Layer Protocol Negotiation
+
+3.1.  The Application-Layer Protocol Negotiation Extension
+
+   A new extension type ("application_layer_protocol_negotiation(16)")
+   is defined and MAY be included by the client in its "ClientHello"
+   message.
+
+   enum {
+       application_layer_protocol_negotiation(16), (65535)
+   } ExtensionType;
+
+   The "extension_data" field of the
+   ("application_layer_protocol_negotiation(16)") extension SHALL
+   contain a "ProtocolNameList" value.
+
+   opaque ProtocolName<1..2^8-1>;
+
+   struct {
+       ProtocolName protocol_name_list<2..2^16-1>
+   } ProtocolNameList;
+
+   "ProtocolNameList" contains the list of protocols advertised by the
+   client, in descending order of preference.  Protocols are named by
+   IANA-registered, opaque, non-empty byte strings, as described further
+   in Section 6 ("IANA Considerations") of this document.  Empty strings
+   MUST NOT be included and byte strings MUST NOT be truncated.
+
+
+
+
+Friedl, et al.               Standards Track                    [Page 3]
+
+RFC 7301         TLS App-Layer Protocol Negotiation Ext        July 2014
+
+
+   Servers that receive a ClientHello containing the
+   "application_layer_protocol_negotiation" extension MAY return a
+   suitable protocol selection response to the client.  The server will
+   ignore any protocol name that it does not recognize.  A new
+   ServerHello extension type
+   ("application_layer_protocol_negotiation(16)") MAY be returned to the
+   client within the extended ServerHello message.  The "extension_data"
+   field of the ("application_layer_protocol_negotiation(16)") extension
+   is structured the same as described above for the client
+   "extension_data", except that the "ProtocolNameList" MUST contain
+   exactly one "ProtocolName".
+
+   Therefore, a full handshake with the
+   "application_layer_protocol_negotiation" extension in the ClientHello
+   and ServerHello messages has the following flow (contrast with
+   Section 7.3 of [RFC5246]):
+
+   Client                                              Server
+
+   ClientHello                     -------->       ServerHello
+     (ALPN extension &                               (ALPN extension &
+      list of protocols)                              selected protocol)
+                                                   Certificate*
+                                                   ServerKeyExchange*
+                                                   CertificateRequest*
+                                   <--------       ServerHelloDone
+   Certificate*
+   ClientKeyExchange
+   CertificateVerify*
+   [ChangeCipherSpec]
+   Finished                        -------->
+                                                   [ChangeCipherSpec]
+                                   <--------       Finished
+   Application Data                <------->       Application Data
+
+                                 Figure 1
+
+   * Indicates optional or situation-dependent messages that are not
+   always sent.
+
+
+
+
+
+
+
+
+
+
+
+
+Friedl, et al.               Standards Track                    [Page 4]
+
+RFC 7301         TLS App-Layer Protocol Negotiation Ext        July 2014
+
+
+   An abbreviated handshake with the
+   "application_layer_protocol_negotiation" extension has the following
+   flow:
+
+   Client                                              Server
+
+   ClientHello                     -------->       ServerHello
+     (ALPN extension &                               (ALPN extension &
+      list of protocols)                              selected protocol)
+                                                   [ChangeCipherSpec]
+                                   <--------       Finished
+   [ChangeCipherSpec]
+   Finished                        -------->
+   Application Data                <------->       Application Data
+
+                                 Figure 2
+
+   Unlike many other TLS extensions, this extension does not establish
+   properties of the session, only of the connection.  When session
+   resumption or session tickets [RFC5077] are used, the previous
+   contents of this extension are irrelevant, and only the values in the
+   new handshake messages are considered.
+
+3.2.  Protocol Selection
+
+   It is expected that a server will have a list of protocols that it
+   supports, in preference order, and will only select a protocol if the
+   client supports it.  In that case, the server SHOULD select the most
+   highly preferred protocol that it supports and that is also
+   advertised by the client.  In the event that the server supports no
+   protocols that the client advertises, then the server SHALL respond
+   with a fatal "no_application_protocol" alert.
+
+   enum {
+       no_application_protocol(120),
+       (255)
+   } AlertDescription;
+
+   The protocol identified in the
+   "application_layer_protocol_negotiation" extension type in the
+   ServerHello SHALL be definitive for the connection, until
+   renegotiated.  The server SHALL NOT respond with a selected protocol
+   and subsequently use a different protocol for application data
+   exchange.
+
+
+
+
+
+
+
+Friedl, et al.               Standards Track                    [Page 5]
+
+RFC 7301         TLS App-Layer Protocol Negotiation Ext        July 2014
+
+
+4.  Design Considerations
+
+   The ALPN extension is intended to follow the typical design of TLS
+   protocol extensions.  Specifically, the negotiation is performed
+   entirely within the client/server hello exchange in accordance with
+   the established TLS architecture.  The
+   "application_layer_protocol_negotiation" ServerHello extension is
+   intended to be definitive for the connection (until the connection is
+   renegotiated) and is sent in plaintext to permit network elements to
+   provide differentiated service for the connection when the TCP or UDP
+   port number is not definitive for the application-layer protocol to
+   be used in the connection.  By placing ownership of protocol
+   selection on the server, ALPN facilitates scenarios in which
+   certificate selection or connection rerouting may be based on the
+   negotiated protocol.
+
+   Finally, by managing protocol selection in the clear as part of the
+   handshake, ALPN avoids introducing false confidence with respect to
+   the ability to hide the negotiated protocol in advance of
+   establishing the connection.  If hiding the protocol is required,
+   then renegotiation after connection establishment, which would
+   provide true TLS security guarantees, would be a preferred
+   methodology.
+
+5.  Security Considerations
+
+   The ALPN extension does not impact the security of TLS session
+   establishment or application data exchange.  ALPN serves to provide
+   an externally visible marker for the application-layer protocol
+   associated with the TLS connection.  Historically, the application-
+   layer protocol associated with a connection could be ascertained from
+   the TCP or UDP port number in use.
+
+   Implementers and document editors who intend to extend the protocol
+   identifier registry by adding new protocol identifiers should
+   consider that in TLS versions 1.2 and below the client sends these
+   identifiers in the clear.  They should also consider that, for at
+   least the next decade, it is expected that browsers would normally
+   use these earlier versions of TLS in the initial ClientHello.
+
+   Care must be taken when such identifiers may leak personally
+   identifiable information, or when such leakage may lead to profiling
+   or to leaking of sensitive information.  If any of these apply to
+   this new protocol identifier, the identifier SHOULD NOT be used in
+   TLS configurations where it would be visible in the clear, and
+   documents specifying such protocol identifiers SHOULD recommend
+   against such unsafe use.
+
+
+
+
+Friedl, et al.               Standards Track                    [Page 6]
+
+RFC 7301         TLS App-Layer Protocol Negotiation Ext        July 2014
+
+
+6.  IANA Considerations
+
+   The IANA has updated its "ExtensionType Values" registry to include
+   the following entry:
+
+      16 application_layer_protocol_negotiation
+
+   This document establishes a registry for protocol identifiers
+   entitled "Application-Layer Protocol Negotiation (ALPN) Protocol IDs"
+   under the existing "Transport Layer Security (TLS) Extensions"
+   heading.
+
+   Entries in this registry require the following fields:
+
+   o  Protocol: The name of the protocol.
+   o  Identification Sequence: The precise set of octet values that
+      identifies the protocol.  This could be the UTF-8 encoding
+      [RFC3629] of the protocol name.
+   o  Reference: A reference to a specification that defines the
+      protocol.
+
+   This registry operates under the "Expert Review" policy as defined in
+   [RFC5226].  The designated expert is advised to encourage the
+   inclusion of a reference to a permanent and readily available
+   specification that enables the creation of interoperable
+   implementations of the identified protocol.
+
+   The initial set of registrations for this registry is as follows:
+
+   Protocol:  HTTP/1.1
+   Identification Sequence:
+      0x68 0x74 0x74 0x70 0x2f 0x31 0x2e 0x31 ("http/1.1")
+   Reference:  [RFC7230]
+
+   Protocol:  SPDY/1
+   Identification Sequence:
+      0x73 0x70 0x64 0x79 0x2f 0x31 ("spdy/1")
+   Reference:
+      http://dev.chromium.org/spdy/spdy-protocol/spdy-protocol-draft1
+
+   Protocol:  SPDY/2
+   Identification Sequence:
+      0x73 0x70 0x64 0x79 0x2f 0x32 ("spdy/2")
+   Reference:
+      http://dev.chromium.org/spdy/spdy-protocol/spdy-protocol-draft2
+
+
+
+
+
+
+Friedl, et al.               Standards Track                    [Page 7]
+
+RFC 7301         TLS App-Layer Protocol Negotiation Ext        July 2014
+
+
+   Protocol:  SPDY/3
+   Identification Sequence:
+      0x73 0x70 0x64 0x79 0x2f 0x33 ("spdy/3")
+   Reference:
+      http://dev.chromium.org/spdy/spdy-protocol/spdy-protocol-draft3
+
+7.  Acknowledgements
+
+   This document benefitted specifically from the Next Protocol
+   Negotiation (NPN) extension document authored by Adam Langley and
+   from discussions with Tom Wesselman and Cullen Jennings, both of
+   Cisco.
+
+8.  References
+
+8.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC3629]  Yergeau, F., "UTF-8, a transformation format of ISO
+              10646", STD 63, RFC 3629, November 2003.
+
+   [RFC5226]  Narten, T. and H. Alvestrand, "Guidelines for Writing an
+              IANA Considerations Section in RFCs", BCP 26, RFC 5226,
+              May 2008.
+
+   [RFC5246]  Dierks, T. and E. Rescorla, "The Transport Layer Security
+              (TLS) Protocol Version 1.2", RFC 5246, August 2008.
+
+   [RFC7230]  Fielding, R. and J. Reschke, "Hypertext Transfer Protocol
+              (HTTP/1.1): Message Syntax and Routing", RFC 7230, June
+              2014.
+
+8.2.  Informative References
+
+   [HTTP2]    Belshe, M., Peon, R., and M. Thomson, "Hypertext Transfer
+              Protocol version 2", Work in Progress, June 2014.
+
+   [RFC5077]  Salowey, J., Zhou, H., Eronen, P., and H. Tschofenig,
+              "Transport Layer Security (TLS) Session Resumption without
+              Server-Side State", RFC 5077, January 2008.
+
+
+
+
+
+
+
+
+
+Friedl, et al.               Standards Track                    [Page 8]
+
+RFC 7301         TLS App-Layer Protocol Negotiation Ext        July 2014
+
+
+Authors' Addresses
+
+   Stephan Friedl
+   Cisco Systems, Inc.
+   170 West Tasman Drive
+   San Jose, CA  95134
+   USA
+
+   Phone: (720)562-6785
+   EMail: sfriedl@cisco.com
+
+
+   Andrei Popov
+   Microsoft Corp.
+   One Microsoft Way
+   Redmond, WA  98052
+   USA
+
+   EMail: andreipo@microsoft.com
+
+
+   Adam Langley
+   Google Inc.
+   USA
+
+   EMail: agl@google.com
+
+
+   Emile Stephan
+   Orange
+   2 avenue Pierre Marzin
+   Lannion  F-22307
+   France
+
+   EMail: emile.stephan@orange.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Friedl, et al.               Standards Track                    [Page 9]
+


### PR DESCRIPTION
### Description of changes: 
Currently s2n-quic emits the `on_server_name_information` event after it receives and installs the 1-rtt keys (and does a bunch of validation). This means that its possible to abort the handshake if any of the validation fails and not emit the server_name event.

This makes it difficult for servers to debug which clients(server_name) is experiencing failures.

This PR moves the `on_server_name_information` event to right after the server_name is parsed which solves the issue above.

Similarly this PR also emits the `application_protocol` and the associated event earlier.

### Callout:
- [x] We could also do something similar for ALPN (TODO: validate if we should do this)

### Testing:
Existing test which complete the handshake should still pass. There is an inline assert which confirms that `on_server_name` happens prior to 1-rtt keys.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

