### PR TITLE
refactor(s2n-quic-core): move SentPackets, SentPacketInfo, and path::Id to core

### DIFF
--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -1,7 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::inet::{SocketAddress, SocketAddressV4, SocketAddressV6};
+use crate::{
+    event,
+    inet::{SocketAddress, SocketAddressV4, SocketAddressV6},
+};
 use core::{
     convert::{TryFrom, TryInto},
     fmt,
@@ -44,6 +47,34 @@ const MIN_ALLOWED_MAX_MTU: u16 = MINIMUM_MTU + UDP_HEADER_LEN + IP_MIN_HEADER_LE
 
 // Initial PTO backoff multiplier is 1 indicating no additional increase to the backoff.
 pub const INITIAL_PTO_BACKOFF: u32 = 1;
+
+/// Internal Id of a path in the manager
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
+pub struct Id(pub u8);
+
+impl Id {
+    pub fn new(id: u8) -> Self {
+        Self(id)
+    }
+
+    pub fn as_u8(&self) -> u8 {
+        self.0
+    }
+}
+
+impl event::IntoEvent<u64> for Id {
+    #[inline]
+    fn into_event(self) -> u64 {
+        self.0 as u64
+    }
+}
+
+#[cfg(any(test, feature = "testing"))]
+impl Id {
+    pub fn test_id() -> Self {
+        Id::new(0)
+    }
+}
 
 /// An interface for an object that represents a unique path between two endpoints
 pub trait Handle: 'static + Copy + Send + fmt::Debug {

--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -50,10 +50,14 @@ pub const INITIAL_PTO_BACKOFF: u32 = 1;
 
 /// Internal Id of a path in the manager
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
-pub struct Id(pub u8);
+pub struct Id(u8);
 
 impl Id {
-    pub fn new(id: u8) -> Self {
+    /// Create a new path::Id
+    ///
+    /// # Safety
+    /// This should only be used by the path::Manager
+    pub unsafe fn new(id: u8) -> Self {
         Self(id)
     }
 
@@ -72,7 +76,7 @@ impl event::IntoEvent<u64> for Id {
 #[cfg(any(test, feature = "testing"))]
 impl Id {
     pub fn test_id() -> Self {
-        Id::new(0)
+        unsafe { Id::new(0) }
     }
 }
 

--- a/quic/s2n-quic-core/src/recovery/mod.rs
+++ b/quic/s2n-quic-core/src/recovery/mod.rs
@@ -4,12 +4,14 @@
 pub use congestion_controller::CongestionController;
 pub use cubic::CubicCongestionController;
 pub use rtt_estimator::*;
+pub use sent_packets::*;
 
 pub mod congestion_controller;
 pub mod cubic;
 mod hybrid_slow_start;
 mod pacing;
 mod rtt_estimator;
+mod sent_packets;
 
 //= https://www.rfc-editor.org/rfc/rfc9002#section-7.7
 //# Senders SHOULD limit bursts to the initial congestion window; see

--- a/quic/s2n-quic-core/src/recovery/sent_packets.rs
+++ b/quic/s2n-quic-core/src/recovery/sent_packets.rs
@@ -78,7 +78,7 @@ mod test {
             u16::MAX as usize + 1,
             NoopClock.get_time(),
             AckElicitation::Eliciting,
-            path::Id::new(0),
+            unsafe { path::Id::new(0) },
             ExplicitCongestionNotification::default(),
         );
     }

--- a/quic/s2n-quic-core/src/recovery/sent_packets.rs
+++ b/quic/s2n-quic-core/src/recovery/sent_packets.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    frame::ack_elicitation::AckElicitation, inet::ExplicitCongestionNotification,
-    packet::number::Map as PacketNumberMap, path, time::Timestamp,
+    frame::ack_elicitation::AckElicitation, inet::ExplicitCongestionNotification, path,
+    time::Timestamp,
 };
 use core::convert::TryInto;
 
@@ -11,7 +11,8 @@ use core::convert::TryInto;
 
 //= https://www.rfc-editor.org/rfc/rfc9002#section-A.1.1
 
-pub type SentPackets = PacketNumberMap<SentPacketInfo>;
+#[cfg(feature = "alloc")]
+pub type SentPackets = crate::packet::number::Map<SentPacketInfo>;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 #[non_exhaustive]

--- a/quic/s2n-quic-core/src/recovery/sent_packets.rs
+++ b/quic/s2n-quic-core/src/recovery/sent_packets.rs
@@ -14,6 +14,7 @@ use core::convert::TryInto;
 pub type SentPackets = PacketNumberMap<SentPacketInfo>;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub struct SentPacketInfo {
     /// Indicates whether the packet counts towards bytes in flight
     pub congestion_controlled: bool,

--- a/quic/s2n-quic-core/src/recovery/sent_packets.rs
+++ b/quic/s2n-quic-core/src/recovery/sent_packets.rs
@@ -84,6 +84,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)] // snapshot tests don't work on miri
     fn sent_packet_info_size_test() {
         insta::assert_debug_snapshot!(
             stringify!(sent_packet_info_size_test),

--- a/quic/s2n-quic-core/src/recovery/sent_packets.rs
+++ b/quic/s2n-quic-core/src/recovery/sent_packets.rs
@@ -1,12 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::path;
-use core::convert::TryInto;
-use s2n_quic_core::{
+use crate::{
     frame::ack_elicitation::AckElicitation, inet::ExplicitCongestionNotification,
-    packet::number::Map as PacketNumberMap, time::Timestamp,
+    packet::number::Map as PacketNumberMap, path, time::Timestamp,
 };
+use core::convert::TryInto;
 
 //= https://www.rfc-editor.org/rfc/rfc9002#section-A.1
 
@@ -61,9 +60,12 @@ impl SentPacketInfo {
 
 #[cfg(test)]
 mod test {
-    use crate::{path, recovery::SentPacketInfo};
-    use s2n_quic_core::{
-        frame::ack_elicitation::AckElicitation, inet::ExplicitCongestionNotification,
+    use crate::{
+        frame::ack_elicitation::AckElicitation,
+        inet::ExplicitCongestionNotification,
+        path,
+        recovery::SentPacketInfo,
+        time::{Clock, NoopClock},
     };
 
     #[test]
@@ -71,8 +73,8 @@ mod test {
     fn too_large_packet() {
         SentPacketInfo::new(
             true,
-            u16::max_value() as usize + 1,
-            s2n_quic_platform::time::now(),
+            u16::MAX as usize + 1,
+            NoopClock.get_time(),
             AckElicitation::Eliciting,
             path::Id::new(0),
             ExplicitCongestionNotification::default(),

--- a/quic/s2n-quic-core/src/recovery/snapshots/s2n_quic_core__recovery__sent_packets__test__sent_packet_info_size_test.snap
+++ b/quic/s2n-quic-core/src/recovery/snapshots/s2n_quic_core__recovery__sent_packets__test__sent_packet_info_size_test.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/sent_packets.rs
+expression: "core::mem::size_of::<SentPacketInfo>()"
+---
+16

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -5,7 +5,7 @@
 
 use crate::{
     connection::PeerIdRegistry,
-    endpoint,
+    endpoint, path,
     path::{challenge, Path},
     transmission,
 };
@@ -91,7 +91,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         random_generator: &mut Config::RandomGenerator,
         publisher: &mut Pub,
     ) -> Result<(), transport::Error> {
-        debug_assert!(new_path_id != Id(self.active));
+        debug_assert!(new_path_id != path_id(self.active));
 
         let prev_path_id = self.active_path_id();
 
@@ -154,7 +154,7 @@ impl<Config: endpoint::Config> Manager<Config> {
     /// Return the Id of the active path
     #[inline]
     pub fn active_path_id(&self) -> Id {
-        Id(self.active)
+        path_id(self.active)
     }
 
     pub fn check_active_path_is_synced(&self) {
@@ -198,7 +198,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             .iter()
             .enumerate()
             .find(|(_id, path)| Path::eq_by_handle(path, handle))
-            .map(|(id, path)| (Id(id as u8), path))
+            .map(|(id, path)| (path_id(id as u8), path))
     }
 
     /// Returns the Path for the provided address if the PathManager knows about it
@@ -208,7 +208,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             .iter_mut()
             .enumerate()
             .find(|(_id, path)| Path::eq_by_handle(path, handle))
-            .map(|(id, path)| (Id(id as u8), path))
+            .map(|(id, path)| (path_id(id as u8), path))
     }
 
     /// Returns an iterator over all paths pending path_challenge or path_response
@@ -367,7 +367,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         if new_path_idx >= MAX_ALLOWED_PATHS {
             return Err(DatagramDropReason::PathLimitExceeded);
         }
-        let new_path_id = Id(new_path_idx as u8);
+        let new_path_id = path_id(new_path_idx as u8);
 
         //= https://www.rfc-editor.org/rfc/rfc9000#section-9.4
         //= type=TODO
@@ -612,7 +612,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         }
 
         // Remove the temporary status after successfully processing a packet
-        if self.pending_packet_authentication == Some(path_id.0) {
+        if self.pending_packet_authentication == Some(path_id.as_u8()) {
             self.pending_packet_authentication = None;
 
             // We can finally arm the challenge after authenticating the packet
@@ -713,7 +713,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         publisher: &mut Pub,
     ) -> Result<(), connection::Error> {
         for (id, path) in self.paths.iter_mut().enumerate() {
-            path.on_timeout(timestamp, Id(id as u8), random_generator, publisher);
+            path.on_timeout(timestamp, path_id(id as u8), random_generator, publisher);
         }
 
         if self.active_path().failed_validation() {
@@ -723,8 +723,8 @@ impl<Config: endpoint::Config> Manager<Config> {
                     //# To protect the connection from failing due to such a spurious
                     //# migration, an endpoint MUST revert to using the last validated peer
                     //# address when validation of a new peer address fails.
-                    let prev_path_id = Id(self.active);
-                    let new_path_id = Id(last_known_active_validated_path);
+                    let prev_path_id = path_id(self.active);
+                    let new_path_id = path_id(last_known_active_validated_path);
                     self.activate_path(publisher, prev_path_id, new_path_id);
                     self.last_known_active_validated_path = None;
                 }
@@ -805,6 +805,13 @@ impl<Config: endpoint::Config> Manager<Config> {
     }
 }
 
+#[inline]
+fn path_id(id: u8) -> path::Id {
+    // Safety: The path::Manager is responsible for managing path ID and is thus
+    //         responsible for using them safely
+    unsafe { path::Id::new(id) }
+}
+
 impl<Config: endpoint::Config> timer::Provider for Manager<Config> {
     #[inline]
     fn timers<Q: timer::Query>(&self, query: &mut Q) -> timer::Result {
@@ -844,7 +851,7 @@ impl<'a, Config: endpoint::Config> PathsPendingValidation<'a, Config> {
             self.index += 1;
 
             if path.is_challenge_pending() || path.is_response_pending() {
-                return Some((Id(self.index - 1), self.path_manager));
+                return Some((path_id(self.index - 1), self.path_manager));
             }
         }
     }
@@ -872,14 +879,14 @@ impl<Config: endpoint::Config> core::ops::Index<Id> for Manager<Config> {
 
     #[inline]
     fn index(&self, id: Id) -> &Self::Output {
-        &self.paths[id.0 as usize]
+        &self.paths[id.as_u8() as usize]
     }
 }
 
 impl<Config: endpoint::Config> core::ops::IndexMut<Id> for Manager<Config> {
     #[inline]
     fn index_mut(&mut self, id: Id) -> &mut Self::Output {
-        &mut self.paths[id.0 as usize]
+        &mut self.paths[id.as_u8() as usize]
     }
 }
 

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -19,7 +19,7 @@ use s2n_quic_core::{
     packet::number::PacketNumberSpace,
     path::{
         migration::{self, Validator as _},
-        Handle as _, MaxMtu,
+        Handle as _, Id, MaxMtu,
     },
     random::Generator as _,
     recovery::{
@@ -867,20 +867,6 @@ impl<Config: endpoint::Config> transmission::interest::Provider for Manager<Conf
     }
 }
 
-/// Internal Id of a path in the manager
-#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
-pub struct Id(u8);
-
-impl Id {
-    pub fn new(id: u8) -> Self {
-        Self(id)
-    }
-
-    pub fn as_u8(&self) -> u8 {
-        self.0
-    }
-}
-
 impl<Config: endpoint::Config> core::ops::Index<Id> for Manager<Config> {
     type Output = Path<Config>;
 
@@ -894,13 +880,6 @@ impl<Config: endpoint::Config> core::ops::IndexMut<Id> for Manager<Config> {
     #[inline]
     fn index_mut(&mut self, id: Id) -> &mut Self::Output {
         &mut self.paths[id.0 as usize]
-    }
-}
-
-impl event::IntoEvent<u64> for Id {
-    #[inline]
-    fn into_event(self) -> u64 {
-        self.0 as u64
     }
 }
 

--- a/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
@@ -322,9 +322,9 @@ impl Model {
     }
 
     fn on_bytes_transmitted(&mut self, path_id_generator: u8, bytes: u16) {
-        let path_id = path_id_generator as usize % self.subject.paths.len();
+        let id = path_id_generator as usize % self.subject.paths.len();
 
-        let path = &mut self.subject[Id(path_id as u8)];
+        let path = &mut self.subject[path_id(id as u8)];
         if !path.at_amplification_limit() {
             path.on_bytes_transmitted(bytes as usize);
         }

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -1804,9 +1804,3 @@ pub struct Helper {
     pub second_path_id: Id,
     pub manager: ServerManager,
 }
-
-impl Id {
-    pub fn test_id() -> Self {
-        Id::new(0)
-    }
-}

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -442,7 +442,7 @@ fn on_ack_frame() {
     assert_eq!(2, context.on_rtt_update_count);
 
     // Ack packet 10, but with a path that is not peer validated
-    context.path_manager[path::Id::new(0)] = Path::new(
+    context.path_manager[unsafe { path::Id::new(0) }] = Path::new(
         Default::default(),
         connection::PeerId::TEST_ID,
         connection::LocalId::TEST_ID,
@@ -2287,7 +2287,7 @@ fn update_pto_timer() {
     assert!(!manager.pto.timer.is_armed());
 
     // Reset the path back to not peer validated
-    context.path_manager[path::Id::new(0)] = Path::new(
+    context.path_manager[unsafe { path::Id::new(0) }] = Path::new(
         Default::default(),
         connection::PeerId::TEST_ID,
         connection::LocalId::TEST_ID,
@@ -2509,7 +2509,7 @@ fn on_timeout() {
             1,
             now,
             AckElicitation::Eliciting,
-            path::Id::new(0),
+            unsafe { path::Id::new(0) },
             ecn,
         ),
     );
@@ -2893,8 +2893,8 @@ fn helper_generate_multi_path_manager(
     let second_addr = SocketAddress::from(second_addr);
     let second_addr = RemoteAddress::from(second_addr);
 
-    let first_path_id = path::Id::new(0);
-    let second_path_id = path::Id::new(1);
+    let first_path_id = unsafe { path::Id::new(0) };
+    let second_path_id = unsafe { path::Id::new(1) };
 
     // confirm we have one path
     let mut path_manager =

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -1657,25 +1657,11 @@ fn remove_lost_packets_persistent_congestion_path_aware() {
     let sent_packets_to_remove = vec![
         (
             space.new_packet_number(VarInt::from_u8(9)),
-            SentPacketInfo {
-                congestion_controlled: true,
-                sent_bytes: 1,
-                time_sent: now,
-                ack_elicitation: AckElicitation::Eliciting,
-                ecn,
-                path_id: first_path_id,
-            },
+            SentPacketInfo::new(true, 1, now, AckElicitation::Eliciting, first_path_id, ecn),
         ),
         (
             space.new_packet_number(VarInt::from_u8(9)),
-            SentPacketInfo {
-                congestion_controlled: true,
-                sent_bytes: 1,
-                time_sent: now,
-                ack_elicitation: AckElicitation::Eliciting,
-                ecn,
-                path_id: second_path_id,
-            },
+            SentPacketInfo::new(true, 1, now, AckElicitation::Eliciting, second_path_id, ecn),
         ),
     ];
 
@@ -2518,14 +2504,14 @@ fn on_timeout() {
     expected_pto_backoff *= 2;
     manager.sent_packets.insert(
         space.new_packet_number(VarInt::from_u8(1)),
-        SentPacketInfo {
-            congestion_controlled: true,
-            sent_bytes: 1,
-            time_sent: now,
-            ack_elicitation: AckElicitation::Eliciting,
+        SentPacketInfo::new(
+            true,
+            1,
+            now,
+            AckElicitation::Eliciting,
+            path::Id::new(0),
             ecn,
-            path_id: path::Id::new(0),
-        },
+        ),
     );
     manager.pto.timer.set(now - Duration::from_secs(5));
     manager.on_timeout(now, &mut context, &mut publisher);

--- a/quic/s2n-quic-transport/src/recovery/mod.rs
+++ b/quic/s2n-quic-transport/src/recovery/mod.rs
@@ -4,7 +4,5 @@
 pub use manager::*;
 /// re-export core
 pub use s2n_quic_core::recovery::*;
-pub use sent_packets::*;
 
 mod manager;
-mod sent_packets;

--- a/quic/s2n-quic-transport/src/recovery/snapshots/s2n_quic_transport__recovery__sent_packets__test__sent_packet_info_size_test.snap
+++ b/quic/s2n-quic-transport/src/recovery/snapshots/s2n_quic_transport__recovery__sent_packets__test__sent_packet_info_size_test.snap
@@ -1,6 +1,0 @@
----
-source: quic/s2n-quic-transport/src/recovery/sent_packets.rs
-expression: "core::mem::size_of::<SentPacketInfo>()"
-
----
-16


### PR DESCRIPTION
### Description of changes: 

In anticipation of potentially adding `SentPacketInfo` to the public API (either through the CongestionController trait or the Bandwidth Estimator or both), this change moves `SentPacketInfo` and `SentPackets` to `s2n-quic-core` and makes `SentPacketInfo` non-exhaustive.  This also required moving `path::Id`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

