### PR TITLE
fix(s2n-quic-transport): add consistency checks to connection nodes

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -12,7 +12,10 @@ use crate::{
 };
 use bolero::{check, generator::*};
 use bytes::Bytes;
-use core::task::{Context, Poll};
+use core::{
+    task::{Context, Poll},
+    time::Duration,
+};
 use s2n_quic_core::{
     application, event,
     event::builder::DatagramDropReason,
@@ -27,7 +30,7 @@ use s2n_quic_core::{
         zero_rtt::ProtectedZeroRtt,
     },
     path::MaxMtu,
-    time::Timestamp,
+    time::{Timer, Timestamp},
 };
 use std::sync::Mutex;
 
@@ -36,6 +39,7 @@ struct TestConnection {
     has_been_accepted: bool,
     is_closed: bool,
     interests: ConnectionInterests,
+    close_timer: Timer,
 }
 
 impl Default for TestConnection {
@@ -44,7 +48,11 @@ impl Default for TestConnection {
             is_handshaking: true,
             has_been_accepted: false,
             is_closed: false,
-            interests: ConnectionInterests::default(),
+            interests: ConnectionInterests {
+                transmission: true,
+                ..Default::default()
+            },
+            close_timer: Default::default(),
         }
     }
 }
@@ -69,11 +77,12 @@ impl connection::Trait for TestConnection {
         _error: connection::Error,
         _close_formatter: &<Self::Config as endpoint::Config>::ConnectionCloseFormatter,
         _packet_buffer: &mut endpoint::PacketBuffer,
-        _timestamp: Timestamp,
+        timestamp: Timestamp,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) {
         assert!(!self.is_closed);
-        self.is_closed = true;
+        assert!(!self.close_timer.is_armed());
+        self.close_timer.set(timestamp + Duration::from_secs(1));
     }
 
     fn mark_as_accepted(&mut self) {
@@ -103,11 +112,14 @@ impl connection::Trait for TestConnection {
     fn on_timeout(
         &mut self,
         _connection_id_mapper: &mut connection::ConnectionIdMapper,
-        _timestamp: Timestamp,
+        timestamp: Timestamp,
         _supervisor_context: &supervisor::Context,
         _random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) -> Result<(), connection::Error> {
+        if self.close_timer.poll_expiration(timestamp).is_ready() {
+            self.is_closed = true;
+        }
         Ok(())
     }
 
@@ -418,7 +430,16 @@ fn container_test() {
                         was_called = true;
 
                         let i = &mut conn.interests;
-                        i.finalization = *finalization;
+
+                        if *finalization {
+                            // in the finalization state, that should be the only interest
+                            *i = ConnectionInterests {
+                                finalization: true,
+                                ..Default::default()
+                            };
+                            return;
+                        }
+
                         i.closing = *closing;
                         if !conn.has_been_accepted {
                             i.accept = *accept;
@@ -429,6 +450,11 @@ fn container_test() {
                         i.transmission = *transmission;
                         i.new_connection_id = *new_connection_id;
                         i.timeout = timeout.map(|ms| now + Duration::from_millis(ms as _));
+
+                        // we need to express at least one interest to ensure progress
+                        if !(i.transmission || i.new_connection_id || i.timeout.is_some()) {
+                            i.transmission = true;
+                        }
                     });
 
                     if *finalization {
@@ -454,10 +480,17 @@ fn container_test() {
                 Operation::Timeout(ms) => {
                     now += Duration::from_millis(*ms as _);
                     container.iterate_timeout_list(now, |conn, _context| {
+                        let i = &mut conn.interests;
+
                         assert!(
-                            conn.interests.timeout.take().unwrap() <= now,
+                            i.timeout.take().unwrap() <= now,
                             "connections should only be present when timeout interest is expressed"
                         );
+
+                        // we need to express at least one interest to ensure progress
+                        if !(i.transmission || i.new_connection_id || i.timeout.is_some()) {
+                            i.transmission = true;
+                        }
                     });
                 }
                 Operation::Transmit(count) => {

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -142,7 +142,7 @@ impl From<connection::Error> for ConnectionState {
             }
             _ => {
                 // catch all
-                ConnectionState::Closing
+                ConnectionState::Finished
             }
         }
     }
@@ -724,10 +724,26 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 self.close_sender.close(packet, timeout, timestamp);
             } else if cfg!(debug_assertions) {
                 panic!("missing packet spaces before sending connection close frame");
-            } else {
-                // if we couldn't send anything, just discard the connection
-                self.state = ConnectionState::Finished;
             }
+        }
+
+        if self.close_sender.has_transmission_interest() {
+            debug_assert_eq!(
+                self.state,
+                ConnectionState::Closing,
+                "Closing state expected with transmission interest"
+            );
+            self.state = ConnectionState::Closing;
+        } else if !matches!(
+            self.state,
+            ConnectionState::Draining | ConnectionState::Finished
+        ) {
+            debug_assert!(
+                false,
+                "Draining or Finished state expected without transmission interest; got {:?}",
+                self.state,
+            );
+            self.state = ConnectionState::Finished;
         }
 
         //= https://www.rfc-editor.org/rfc/rfc9000#section-10.2.1
@@ -740,29 +756,12 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         //# sufficient information to identify packets for a closing connection;
         //# the endpoint MAY discard all other connection state.
         let mut publisher = self.event_context.publisher(timestamp, subscriber);
-        self.space_manager.discard_initial(
+        self.space_manager.close(
+            error,
             self.path_manager.active_path_mut(),
             active_path_id,
             &mut publisher,
         );
-        self.space_manager.discard_handshake(
-            self.path_manager.active_path_mut(),
-            active_path_id,
-            &mut publisher,
-        );
-        self.space_manager.discard_zero_rtt_crypto();
-
-        // We don't discard the application space so the application can
-        // be notified and read what happened.
-        if let Some((application, _handshake_status)) = self.space_manager.application_mut() {
-            //= https://www.rfc-editor.org/rfc/rfc9000#section-10.2
-            //# A CONNECTION_CLOSE frame
-            //# causes all streams to immediately become closed; open streams can be
-            //# assumed to be implicitly reset.
-
-            // Close all streams with the derived error
-            application.stream_manager.close(error);
-        }
     }
 
     /// Generates and registers new connection IDs using the given `ConnectionIdFormat`
@@ -1597,10 +1596,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         use timer::Provider as _;
         use transmission::interest::Provider as _;
 
-        let mut interests = ConnectionInterests {
-            timeout: self.next_expiration(),
-            ..Default::default()
-        };
+        let mut interests = ConnectionInterests::default();
 
         if self.accept_state == AcceptState::HandshakeCompleted {
             interests.accept = true;
@@ -1637,6 +1633,16 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 // Remove the connection from the endpoint
                 interests.finalization = true;
             }
+        }
+
+        if interests.finalization {
+            // clear all of the other interests if we're finalizing
+            interests = ConnectionInterests {
+                finalization: true,
+                ..Default::default()
+            };
+        } else {
+            interests.timeout = self.next_expiration();
         }
 
         interests


### PR DESCRIPTION
### Description of changes: 

This change adds some consistency checks to connection nodes in the connection container. These checks will ensure connections are continually making progress through interests.

### Testing:

Since these are internal consistency checks, the existing tests should cover most cases. I'm working on adding fuzzing through netbench in another branch and this will help cover the remaining failure scenarios.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

