### PR TITLE
feat(s2n-quic): implement unstable packet interceptor provider

### DIFF
--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -4740,6 +4740,7 @@ mod traits {
         fn on_keep_alive_timer_expired(&mut self, event: builder::KeepAliveTimerExpired);
         #[doc = r" Returns the QUIC version negotiated for the current connection, if any"]
         fn quic_version(&self) -> u32;
+        fn subject(&self) -> Subject;
     }
     pub struct ConnectionPublisherSubscriber<'a, Sub: Subscriber> {
         meta: ConnectionMeta,
@@ -5060,6 +5061,10 @@ mod traits {
         #[inline]
         fn quic_version(&self) -> u32 {
             self.quic_version
+        }
+        #[inline]
+        fn subject(&self) -> api::Subject {
+            self.meta.subject()
         }
     }
 }
@@ -6031,6 +6036,9 @@ pub mod testing {
         }
         fn quic_version(&self) -> u32 {
             1
+        }
+        fn subject(&self) -> api::Subject {
+            api::Subject::Connection { id: 0 }
         }
     }
     impl Drop for Publisher {

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -4740,6 +4740,7 @@ mod traits {
         fn on_keep_alive_timer_expired(&mut self, event: builder::KeepAliveTimerExpired);
         #[doc = r" Returns the QUIC version negotiated for the current connection, if any"]
         fn quic_version(&self) -> u32;
+        #[doc = r" Returns the [`Subject`] for the current publisher"]
         fn subject(&self) -> Subject;
     }
     pub struct ConnectionPublisherSubscriber<'a, Sub: Subscriber> {

--- a/quic/s2n-quic-core/src/packet/interceptor.rs
+++ b/quic/s2n-quic-core/src/packet/interceptor.rs
@@ -13,7 +13,7 @@ pub struct Packet {
 /// Trait which enables an application to intercept packets that are transmitted and received
 pub trait Interceptor: 'static + Send {
     #[inline(always)]
-    fn intercept_rx_packet<'a>(
+    fn intercept_rx_payload<'a>(
         &mut self,
         subject: Subject,
         packet: Packet,
@@ -25,7 +25,7 @@ pub trait Interceptor: 'static + Send {
     }
 
     #[inline(always)]
-    fn intercept_tx_packet<'a>(
+    fn intercept_tx_payload<'a>(
         &mut self,
         subject: Subject,
         packet: Packet,

--- a/quic/s2n-quic-core/src/packet/interceptor.rs
+++ b/quic/s2n-quic-core/src/packet/interceptor.rs
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{packet::number::PacketNumber, time::Timestamp};
+use s2n_codec::{DecoderBufferMut, EncoderBuffer};
+
+#[derive(Debug)]
+pub struct Packet {
+    pub number: PacketNumber,
+    pub timestamp: Timestamp,
+}
+
+/// Trait which enables an application to intercept packets that are transmitted and received
+pub trait Interceptor: 'static + Send {
+    #[inline(always)]
+    fn intercept_rx_packet<'a>(
+        &mut self,
+        packet: Packet,
+        payload: DecoderBufferMut<'a>,
+    ) -> DecoderBufferMut<'a> {
+        let _ = packet;
+        payload
+    }
+
+    #[inline(always)]
+    fn intercept_tx_packet<'a>(&mut self, packet: Packet, payload: &mut EncoderBuffer<'a>) {
+        let _ = packet;
+        let _ = payload;
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Disabled(());
+
+impl Interceptor for Disabled {}

--- a/quic/s2n-quic-core/src/packet/interceptor.rs
+++ b/quic/s2n-quic-core/src/packet/interceptor.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{packet::number::PacketNumber, time::Timestamp};
+use crate::{event::api::Subject, packet::number::PacketNumber, time::Timestamp};
 use s2n_codec::{DecoderBufferMut, EncoderBuffer};
 
 #[derive(Debug)]
@@ -15,15 +15,23 @@ pub trait Interceptor: 'static + Send {
     #[inline(always)]
     fn intercept_rx_packet<'a>(
         &mut self,
+        subject: Subject,
         packet: Packet,
         payload: DecoderBufferMut<'a>,
     ) -> DecoderBufferMut<'a> {
+        let _ = subject;
         let _ = packet;
         payload
     }
 
     #[inline(always)]
-    fn intercept_tx_packet<'a>(&mut self, packet: Packet, payload: &mut EncoderBuffer<'a>) {
+    fn intercept_tx_packet<'a>(
+        &mut self,
+        subject: Subject,
+        packet: Packet,
+        payload: &mut EncoderBuffer<'a>,
+    ) {
+        let _ = subject;
         let _ = packet;
         let _ = payload;
     }

--- a/quic/s2n-quic-core/src/packet/interceptor.rs
+++ b/quic/s2n-quic-core/src/packet/interceptor.rs
@@ -4,6 +4,7 @@
 use crate::{event::api::Subject, packet::number::PacketNumber, time::Timestamp};
 use s2n_codec::{DecoderBufferMut, EncoderBuffer};
 
+/// TODO add `non_exhaustive` once/if this feature is stable
 #[derive(Debug)]
 pub struct Packet {
     pub number: PacketNumber,

--- a/quic/s2n-quic-core/src/packet/mod.rs
+++ b/quic/s2n-quic-core/src/packet/mod.rs
@@ -21,6 +21,7 @@ pub mod retry;
 
 pub mod decoding;
 pub mod encoding;
+pub mod interceptor;
 pub mod key_phase;
 pub mod long;
 

--- a/quic/s2n-quic-events/src/main.rs
+++ b/quic/s2n-quic-events/src/main.rs
@@ -445,6 +445,8 @@ impl ToTokens for Output {
 
                     /// Returns the QUIC version negotiated for the current connection, if any
                     fn quic_version(&self) -> u32;
+
+                    fn subject(&self) -> Subject;
                 }
 
                 pub struct ConnectionPublisherSubscriber<'a, Sub: Subscriber> {
@@ -486,6 +488,11 @@ impl ToTokens for Output {
                     #[inline]
                     fn quic_version(&self) -> u32 {
                         self.quic_version
+                    }
+
+                    #[inline]
+                    fn subject(&self) -> api::Subject {
+                        self.meta.subject()
                     }
                 }
             }
@@ -580,6 +587,10 @@ impl ToTokens for Output {
 
                     fn quic_version(&self) -> u32 {
                         1
+                    }
+
+                    fn subject(&self) -> api::Subject {
+                        api::Subject::Connection { id: 0 }
                     }
                 }
 

--- a/quic/s2n-quic-events/src/main.rs
+++ b/quic/s2n-quic-events/src/main.rs
@@ -446,6 +446,7 @@ impl ToTokens for Output {
                     /// Returns the QUIC version negotiated for the current connection, if any
                     fn quic_version(&self) -> u32;
 
+                    /// Returns the [`Subject`] for the current publisher
                     fn subject(&self) -> Subject;
                 }
 

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -79,6 +79,7 @@ impl connection::Trait for TestConnection {
         _packet_buffer: &mut endpoint::PacketBuffer,
         timestamp: Timestamp,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
+        _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
     ) {
         assert!(!self.is_closed);
         assert!(!self.close_timer.is_armed());
@@ -105,6 +106,7 @@ impl connection::Trait for TestConnection {
         _queue: &mut Tx,
         _timestamp: Timestamp,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
+        _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
     ) -> Result<(), crate::contexts::ConnectionOnTransmitError> {
         Ok(())
     }
@@ -138,6 +140,7 @@ impl connection::Trait for TestConnection {
         _packet: ProtectedInitial,
         _random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
+        _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -150,6 +153,7 @@ impl connection::Trait for TestConnection {
         _packet: CleartextInitial,
         _random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
+        _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -162,6 +166,7 @@ impl connection::Trait for TestConnection {
         _packet: ProtectedHandshake,
         _random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
+        _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -174,6 +179,7 @@ impl connection::Trait for TestConnection {
         _packet: ProtectedShort,
         _random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
+        _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -185,6 +191,7 @@ impl connection::Trait for TestConnection {
         _path_id: path::Id,
         _packet: ProtectedVersionNegotiation,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
+        _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -196,6 +203,7 @@ impl connection::Trait for TestConnection {
         _path_id: path::Id,
         _packet: ProtectedZeroRtt,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
+        _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -207,6 +215,7 @@ impl connection::Trait for TestConnection {
         _path_id: path::Id,
         _packet: ProtectedRetry,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
+        _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }

--- a/quic/s2n-quic-transport/src/connection/transmission.rs
+++ b/quic/s2n-quic-transport/src/connection/transmission.rs
@@ -28,6 +28,7 @@ pub struct ConnectionTransmissionContext<'a, 'sub, Config: endpoint::Config> {
     pub min_packet_len: Option<usize>,
     pub transmission_mode: transmission::Mode,
     pub publisher: &'a mut event::ConnectionPublisherSubscriber<'sub, Config::EventSubscriber>,
+    pub packet_interceptor: &'a mut Config::PacketInterceptor,
 }
 
 impl<'a, 'sub, Config: endpoint::Config> ConnectionTransmissionContext<'a, 'sub, Config> {

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -5,7 +5,8 @@
 
 use crate::{connection, stream};
 use s2n_quic_core::{
-    crypto::tls, endpoint, event, path, random, recovery::congestion_controller, stateless_reset,
+    crypto::tls, endpoint, event, packet, path, random, recovery::congestion_controller,
+    stateless_reset,
 };
 
 /// Configuration parameters for a QUIC endpoint
@@ -39,6 +40,8 @@ pub trait Config: 'static + Send + Sized + core::fmt::Debug {
     type PathHandle: path::Handle;
     /// The path migration validator for the endpoint
     type PathMigrationValidator: path::migration::Validator;
+    /// The packet_interceptor implementation for the endpoint
+    type PacketInterceptor: packet::interceptor::Interceptor;
 
     /// The type of the local endpoint
     const ENDPOINT_TYPE: endpoint::Type;
@@ -78,4 +81,6 @@ pub struct Context<'a, Cfg: Config> {
     pub event_subscriber: &'a mut Cfg::EventSubscriber,
 
     pub path_migration: &'a mut Cfg::PathMigrationValidator,
+
+    pub packet_interceptor: &'a mut Cfg::PacketInterceptor,
 }

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -310,6 +310,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                         packet,
                         endpoint_context.random_generator,
                         endpoint_context.event_subscriber,
+                        endpoint_context.packet_interceptor,
                     )
                     .map_err(|err| {
                         use connection::ProcessingError;
@@ -346,6 +347,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                     remaining,
                     endpoint_context.random_generator,
                     endpoint_context.event_subscriber,
+                    endpoint_context.packet_interceptor,
                 )?;
 
                 Ok(())

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -137,8 +137,12 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
         let timestamp = clock.get_time();
 
         self.connections.iterate_transmission_list(|connection| {
-            transmit_result =
-                connection.on_transmit(queue, timestamp, endpoint_context.event_subscriber);
+            transmit_result = connection.on_transmit(
+                queue,
+                timestamp,
+                endpoint_context.event_subscriber,
+                endpoint_context.packet_interceptor,
+            );
             if transmit_result.is_err() {
                 // If one connection fails, return
                 ConnectionContainerIterationResult::BreakAndInsertAtBack
@@ -210,6 +214,7 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
                         close_packet_buffer,
                         timestamp,
                         endpoint_context.event_subscriber,
+                        endpoint_context.packet_interceptor,
                     );
                 }
             });
@@ -557,6 +562,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                     packet,
                     endpoint_context.random_generator,
                     endpoint_context.event_subscriber,
+                    endpoint_context.packet_interceptor,
                 ) {
                     match err {
                         ProcessingError::DuplicatePacket => {
@@ -587,6 +593,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                                 close_packet_buffer,
                                 datagram.timestamp,
                                 endpoint_context.event_subscriber,
+                                endpoint_context.packet_interceptor,
                             );
                             return Err(());
                         }
@@ -621,6 +628,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                     remaining,
                     endpoint_context.random_generator,
                     endpoint_context.event_subscriber,
+                    endpoint_context.packet_interceptor,
                 ) {
                     conn.close(
                         err,
@@ -628,6 +636,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                         close_packet_buffer,
                         datagram.timestamp,
                         endpoint_context.event_subscriber,
+                        endpoint_context.packet_interceptor,
                     );
                     return Err(());
                 }
@@ -874,6 +883,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                 close_packet_buffer,
                 timestamp,
                 endpoint_context.event_subscriber,
+                endpoint_context.packet_interceptor,
             );
         });
 
@@ -900,6 +910,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                         close_packet_buffer,
                         timestamp,
                         endpoint_context.event_subscriber,
+                        endpoint_context.packet_interceptor,
                     );
                 }
             });
@@ -1130,6 +1141,7 @@ pub mod testing {
         type ConnectionCloseFormatter = s2n_quic_core::connection::close::Development;
         type EventSubscriber = Subscriber;
         type PathMigrationValidator = path::migration::default::Validator;
+        type PacketInterceptor = s2n_quic_core::packet::interceptor::Disabled;
 
         fn context(&mut self) -> super::Context<Self> {
             todo!()
@@ -1158,6 +1170,7 @@ pub mod testing {
         type ConnectionCloseFormatter = s2n_quic_core::connection::close::Development;
         type EventSubscriber = Subscriber;
         type PathMigrationValidator = path::migration::default::Validator;
+        type PacketInterceptor = s2n_quic_core::packet::interceptor::Disabled;
 
         fn context(&mut self) -> super::Context<Self> {
             todo!()

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -181,6 +181,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
             tx_packet_numbers: &mut self.tx_packet_numbers,
             path_id: context.path_id,
             publisher: context.publisher,
+            packet_interceptor: context.packet_interceptor,
         };
 
         let spin_bit = self.spin_bit;
@@ -266,6 +267,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
             tx_packet_numbers: &mut self.tx_packet_numbers,
             path_id: context.path_id,
             publisher: context.publisher,
+            packet_interceptor: context.packet_interceptor,
         };
 
         let spin_bit = self.spin_bit;

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -139,6 +139,7 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
             tx_packet_numbers: &mut self.tx_packet_numbers,
             path_id: context.path_id,
             publisher: context.publisher,
+            packet_interceptor: context.packet_interceptor,
         };
 
         let packet = Handshake {
@@ -208,6 +209,7 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
             tx_packet_numbers: &mut self.tx_packet_numbers,
             path_id: context.path_id,
             publisher: context.publisher,
+            packet_interceptor: context.packet_interceptor,
         };
 
         let packet = Handshake {

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -184,6 +184,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
             tx_packet_numbers: &mut self.tx_packet_numbers,
             path_id: context.path_id,
             publisher: context.publisher,
+            packet_interceptor: context.packet_interceptor,
         };
 
         let packet = Initial {
@@ -254,6 +255,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
             tx_packet_numbers: &mut self.tx_packet_numbers,
             path_id: context.path_id,
             publisher: context.publisher,
+            packet_interceptor: context.packet_interceptor,
         };
 
         let packet = Initial {

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -664,7 +664,8 @@ pub trait PacketSpace<Config: endpoint::Config> {
         let mut payload = {
             use s2n_quic_core::packet::interceptor::{Interceptor, Packet};
 
-            packet_interceptor.intercept_rx_packet(
+            // intercept the payload after it is decrypted, but before we process the frames
+            packet_interceptor.intercept_rx_payload(
                 publisher.subject(),
                 Packet {
                     number: packet_number,

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -665,6 +665,7 @@ pub trait PacketSpace<Config: endpoint::Config> {
             use s2n_quic_core::packet::interceptor::{Interceptor, Packet};
 
             packet_interceptor.intercept_rx_packet(
+                publisher.subject(),
                 Packet {
                     number: packet_number,
                     timestamp: datagram.timestamp,

--- a/quic/s2n-quic-transport/src/transmission/mod.rs
+++ b/quic/s2n-quic-transport/src/transmission/mod.rs
@@ -114,9 +114,14 @@ impl<'a, 'sub, Config: endpoint::Config, P: Payload> PacketPayloadEncoder
             }
 
             {
-                // allow the packet_interceptor provider to do its thing
-                use s2n_quic_core::packet::interceptor::{Interceptor, Packet};
+                use s2n_quic_core::{
+                    event::ConnectionPublisher,
+                    packet::interceptor::{Interceptor, Packet},
+                };
+
+                // allow the packet interceptor provider to do its thing
                 self.packet_interceptor.intercept_tx_packet(
+                    self.publisher.subject(),
                     Packet {
                         number: self.packet_number,
                         timestamp: self.timestamp,

--- a/quic/s2n-quic-transport/src/transmission/mod.rs
+++ b/quic/s2n-quic-transport/src/transmission/mod.rs
@@ -119,8 +119,8 @@ impl<'a, 'sub, Config: endpoint::Config, P: Payload> PacketPayloadEncoder
                     packet::interceptor::{Interceptor, Packet},
                 };
 
-                // allow the packet interceptor provider to do its thing
-                self.packet_interceptor.intercept_tx_packet(
+                // intercept the payload before it is encrypted
+                self.packet_interceptor.intercept_tx_payload(
                     self.publisher.subject(),
                     Packet {
                         number: self.packet_number,

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -32,6 +32,10 @@ provider-tls-s2n = ["s2n-quic-tls"]
 #
 # This depends on experimental behavior in s2n-tls.
 unstable_client_hello = ["s2n-quic-tls/unstable_client_hello"]
+# This feature enables the packet interceptor provider, which is invoked on each cleartext packet
+unstable-provider-packet-interceptor = []
+# This feature enables the random provider
+unstable-provider-random = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }

--- a/quic/s2n-quic/src/client/builder.rs
+++ b/quic/s2n-quic/src/client/builder.rs
@@ -245,6 +245,22 @@ impl<Providers: ClientProviders> Builder<Providers> {
         ClientProviders
     );
 
+    #[cfg(all(s2n_quic_unstable, feature = "unstable-provider-packet-interceptor"))]
+    impl_provider_method!(
+        /// Sets the packet interceptor provider for the [`Client`]
+        with_packet_interceptor,
+        packet_interceptor,
+        ServerProviders
+    );
+
+    #[cfg(all(s2n_quic_unstable, feature = "unstable-provider-random"))]
+    impl_provider_method!(
+        /// Sets the random provider for the [`Client`]
+        with_random,
+        random,
+        ServerProviders
+    );
+
     /// Starts the [`Client`] with the configured providers
     ///
     /// # Examples

--- a/quic/s2n-quic/src/client/providers.rs
+++ b/quic/s2n-quic/src/client/providers.rs
@@ -4,11 +4,7 @@
 use super::*;
 use core::marker::PhantomData;
 use s2n_quic_core::{connection::id::Generator, crypto, path};
-use s2n_quic_transport::{
-    connection,
-    endpoint::{self},
-    stream,
-};
+use s2n_quic_transport::{connection, endpoint, stream};
 
 impl_providers_state! {
     #[derive(Debug, Default)]
@@ -16,6 +12,7 @@ impl_providers_state! {
         congestion_controller: CongestionController,
         connection_close_formatter: ConnectionCloseFormatter,
         connection_id: ConnectionID,
+        packet_interceptor: PacketInterceptor,
         stateless_reset_token: StatelessResetToken,
         random: Random,
         event: Event,
@@ -33,6 +30,7 @@ impl<
         CongestionController: congestion_controller::Provider,
         ConnectionCloseFormatter: connection_close_formatter::Provider,
         ConnectionID: connection_id::Provider,
+        PacketInterceptor: packet_interceptor::Provider,
         StatelessResetToken: stateless_reset_token::Provider,
         Random: random::Provider,
         Event: event::Provider,
@@ -45,6 +43,7 @@ impl<
         CongestionController,
         ConnectionCloseFormatter,
         ConnectionID,
+        PacketInterceptor,
         StatelessResetToken,
         Random,
         Event,
@@ -59,6 +58,7 @@ impl<
             congestion_controller,
             connection_close_formatter,
             connection_id,
+            packet_interceptor,
             stateless_reset_token,
             random,
             event,
@@ -73,6 +73,7 @@ impl<
             .start()
             .map_err(StartError::new)?;
         let connection_id = connection_id.start().map_err(StartError::new)?;
+        let packet_interceptor = packet_interceptor.start().map_err(StartError::new)?;
         let stateless_reset_token = stateless_reset_token.start().map_err(StartError::new)?;
         let random = random.start().map_err(StartError::new)?;
         let endpoint_limits = EndpointLimits;
@@ -99,6 +100,7 @@ impl<
             congestion_controller,
             connection_close_formatter,
             connection_id,
+            packet_interceptor,
             stateless_reset_token,
             random,
             endpoint_limits,
@@ -185,6 +187,7 @@ struct EndpointConfig<
     CongestionController,
     ConnectionCloseFormatter,
     ConnectionID,
+    PacketInterceptor,
     PathHandle,
     StatelessResetToken,
     Random,
@@ -196,6 +199,7 @@ struct EndpointConfig<
     congestion_controller: CongestionController,
     connection_close_formatter: ConnectionCloseFormatter,
     connection_id: ConnectionID,
+    packet_interceptor: PacketInterceptor,
     stateless_reset_token: StatelessResetToken,
     random: Random,
     endpoint_limits: EndpointLimits,
@@ -212,6 +216,7 @@ impl<
         CongestionController: congestion_controller::Endpoint,
         ConnectionCloseFormatter: connection_close_formatter::Formatter,
         ConnectionID: connection::id::Format,
+        PacketInterceptor: packet_interceptor::PacketInterceptor,
         PathHandle: path::Handle,
         StatelessResetToken: stateless_reset_token::Generator,
         Random: s2n_quic_core::random::Generator,
@@ -224,6 +229,7 @@ impl<
         CongestionController,
         ConnectionCloseFormatter,
         ConnectionID,
+        PacketInterceptor,
         PathHandle,
         StatelessResetToken,
         Random,
@@ -242,6 +248,7 @@ impl<
         CongestionController: congestion_controller::Endpoint,
         ConnectionCloseFormatter: connection_close_formatter::Formatter,
         ConnectionID: connection::id::Format,
+        PacketInterceptor: packet_interceptor::PacketInterceptor,
         PathHandle: path::Handle,
         StatelessResetToken: stateless_reset_token::Generator,
         Random: s2n_quic_core::random::Generator,
@@ -254,6 +261,7 @@ impl<
         CongestionController,
         ConnectionCloseFormatter,
         ConnectionID,
+        PacketInterceptor,
         PathHandle,
         StatelessResetToken,
         Random,
@@ -279,6 +287,7 @@ impl<
     type ConnectionLimits = Limits;
     type Stream = stream::StreamImpl;
     type PathMigrationValidator = PathMigration;
+    type PacketInterceptor = PacketInterceptor;
 
     const ENDPOINT_TYPE: endpoint::Type = endpoint::Type::Client;
 
@@ -287,6 +296,7 @@ impl<
             congestion_controller: &mut self.congestion_controller,
             connection_close_formatter: &mut self.connection_close_formatter,
             connection_id_format: &mut self.connection_id,
+            packet_interceptor: &mut self.packet_interceptor,
             stateless_reset_token_generator: &mut self.stateless_reset_token,
             random_generator: &mut self.random,
             tls: &mut self.tls,

--- a/quic/s2n-quic/src/provider.rs
+++ b/quic/s2n-quic/src/provider.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use cfg_if::cfg_if;
 use core::fmt;
 
 #[macro_use]
@@ -19,8 +20,23 @@ pub mod tls;
 pub(crate) mod congestion_controller;
 pub(crate) mod connection_close_formatter;
 pub(crate) mod path_migration;
-pub(crate) mod random;
 pub(crate) mod sync;
+
+cfg_if!(
+    if #[cfg(all(s2n_quic_unstable, feature = "unstable-provider-packet-interceptor"))] {
+        pub mod packet_interceptor;
+    } else {
+        pub(crate) mod packet_interceptor;
+    }
+);
+
+cfg_if!(
+    if #[cfg(all(s2n_quic_unstable, feature = "unstable-provider-random"))] {
+        pub mod random;
+    } else {
+        pub(crate) mod random;
+    }
+);
 
 /// An error indicating a failure to start an endpoint
 pub struct StartError(Box<dyn 'static + fmt::Display>);

--- a/quic/s2n-quic/src/provider/packet_interceptor.rs
+++ b/quic/s2n-quic/src/provider/packet_interceptor.rs
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub use s2n_quic_core::packet::interceptor::{Disabled, Interceptor as PacketInterceptor};
+
+/// Provides packet_interceptor support for an endpoint
+pub trait Provider: 'static {
+    type PacketInterceptor: 'static + PacketInterceptor;
+    type Error: core::fmt::Display;
+
+    fn start(self) -> Result<Self::PacketInterceptor, Self::Error>;
+}
+
+pub type Default = Disabled;
+
+impl_provider_utils!();
+
+impl<T: 'static + Send + PacketInterceptor> Provider for T {
+    type PacketInterceptor = T;
+    type Error = core::convert::Infallible;
+
+    fn start(self) -> Result<Self::PacketInterceptor, Self::Error> {
+        Ok(self)
+    }
+}

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -295,6 +295,22 @@ impl<Providers: ServerProviders> Builder<Providers> {
         ServerProviders
     );
 
+    #[cfg(all(s2n_quic_unstable, feature = "unstable-provider-packet-interceptor"))]
+    impl_provider_method!(
+        /// Sets the packet interceptor provider for the [`Server`]
+        with_packet_interceptor,
+        packet_interceptor,
+        ServerProviders
+    );
+
+    #[cfg(all(s2n_quic_unstable, feature = "unstable-provider-random"))]
+    impl_provider_method!(
+        /// Sets the random provider for the [`Server`]
+        with_random,
+        random,
+        ServerProviders
+    );
+
     /// Starts the [`Server`] with the configured providers
     ///
     /// # Examples

--- a/quic/s2n-quic/src/server/providers.rs
+++ b/quic/s2n-quic/src/server/providers.rs
@@ -4,11 +4,7 @@
 use super::*;
 use core::marker::PhantomData;
 use s2n_quic_core::{connection::id::Generator, crypto, path};
-use s2n_quic_transport::{
-    connection,
-    endpoint::{self},
-    stream,
-};
+use s2n_quic_transport::{connection, endpoint, stream};
 
 impl_providers_state! {
     #[derive(Debug, Default)]
@@ -16,6 +12,7 @@ impl_providers_state! {
         congestion_controller: CongestionController,
         connection_close_formatter: ConnectionCloseFormatter,
         connection_id: ConnectionID,
+        packet_interceptor: PacketInterceptor,
         stateless_reset_token: StatelessResetToken,
         random: Random,
         endpoint_limits: EndpointLimits,
@@ -36,6 +33,7 @@ impl<
         CongestionController: congestion_controller::Provider,
         ConnectionCloseFormatter: connection_close_formatter::Provider,
         ConnectionID: connection_id::Provider,
+        PacketInterceptor: packet_interceptor::Provider,
         StatelessResetToken: stateless_reset_token::Provider,
         Random: random::Provider,
         EndpointLimits: endpoint_limits::Provider,
@@ -51,6 +49,7 @@ impl<
         CongestionController,
         ConnectionCloseFormatter,
         ConnectionID,
+        PacketInterceptor,
         StatelessResetToken,
         Random,
         EndpointLimits,
@@ -68,6 +67,7 @@ impl<
             congestion_controller,
             connection_close_formatter,
             connection_id,
+            packet_interceptor,
             stateless_reset_token,
             random,
             endpoint_limits,
@@ -85,6 +85,7 @@ impl<
             .start()
             .map_err(StartError::new)?;
         let connection_id = connection_id.start().map_err(StartError::new)?;
+        let packet_interceptor = packet_interceptor.start().map_err(StartError::new)?;
         let stateless_reset_token = stateless_reset_token.start().map_err(StartError::new)?;
         let random = random.start().map_err(StartError::new)?;
         let endpoint_limits = endpoint_limits.start().map_err(StartError::new)?;
@@ -111,6 +112,7 @@ impl<
             congestion_controller,
             connection_close_formatter,
             connection_id,
+            packet_interceptor,
             stateless_reset_token,
             random,
             endpoint_limits,
@@ -140,6 +142,7 @@ struct EndpointConfig<
     CongestionController,
     ConnectionCloseFormatter,
     ConnectionID,
+    PacketInterceptor,
     PathHandle,
     PathMigration,
     StatelessResetToken,
@@ -154,6 +157,7 @@ struct EndpointConfig<
     congestion_controller: CongestionController,
     connection_close_formatter: ConnectionCloseFormatter,
     connection_id: ConnectionID,
+    packet_interceptor: PacketInterceptor,
     stateless_reset_token: StatelessResetToken,
     random: Random,
     endpoint_limits: EndpointLimits,
@@ -170,6 +174,7 @@ impl<
         CongestionController: congestion_controller::Endpoint,
         ConnectionCloseFormatter: connection_close_formatter::Formatter,
         ConnectionID: connection::id::Format,
+        PacketInterceptor: packet_interceptor::PacketInterceptor,
         PathMigration: path_migration::Validator,
         PathHandle: path::Handle,
         StatelessResetToken: stateless_reset_token::Generator,
@@ -185,6 +190,7 @@ impl<
         CongestionController,
         ConnectionCloseFormatter,
         ConnectionID,
+        PacketInterceptor,
         PathHandle,
         PathMigration,
         StatelessResetToken,
@@ -206,6 +212,7 @@ impl<
         CongestionController: congestion_controller::Endpoint,
         ConnectionCloseFormatter: connection_close_formatter::Formatter,
         ConnectionID: connection::id::Format,
+        PacketInterceptor: packet_interceptor::PacketInterceptor,
         PathHandle: path::Handle,
         PathMigration: path_migration::Validator,
         StatelessResetToken: stateless_reset_token::Generator,
@@ -221,6 +228,7 @@ impl<
         CongestionController,
         ConnectionCloseFormatter,
         ConnectionID,
+        PacketInterceptor,
         PathHandle,
         PathMigration,
         StatelessResetToken,
@@ -249,6 +257,7 @@ impl<
     type ConnectionLimits = Limits;
     type Stream = stream::StreamImpl;
     type PathMigrationValidator = PathMigration;
+    type PacketInterceptor = PacketInterceptor;
 
     const ENDPOINT_TYPE: endpoint::Type = endpoint::Type::Server;
 
@@ -257,6 +266,7 @@ impl<
             congestion_controller: &mut self.congestion_controller,
             connection_close_formatter: &mut self.connection_close_formatter,
             connection_id_format: &mut self.connection_id,
+            packet_interceptor: &mut self.packet_interceptor,
             stateless_reset_token_generator: &mut self.stateless_reset_token,
             random_generator: &mut self.random,
             tls: &mut self.tls,


### PR DESCRIPTION
### Description of changes: 

This change adds a packet interceptor provider which allows an application to intercept each transmitted and received packet before it's encrypted and processed, respectively. This allows for a few interesting applications:

* turn s2n-quic into a general-purpose, online, QUIC fuzzer.
* rewriting a packet in a semantic-preserving way and ensuring s2n-quic correctly processes it (i.e. metamorphic testing).
* testing s2n-quic itself in an offline, non-real time setting

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

