### PR TITLE
build(deps): update s2n-tls requirement from 0.0.4 to 0.0.5

### DIFF
--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -20,7 +20,7 @@ libc = "0.2"
 s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.1.2", path = "../s2n-quic-core", default-features = false }
 s2n-quic-crypto = { version = "=0.1.0", path = "../s2n-quic-crypto", default-features = false }
-s2n-tls = { version = "=0.0.4", features = ["quic"] }
+s2n-tls = { version = "=0.0.5", features = ["quic"] }
 
 [dev-dependencies]
 checkers = "0.6"


### PR DESCRIPTION
### Description of changes: 

s2n-tls 0.0.5 has been published and needs to be updated to the latest version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

