### PR TITLE
ci: fix perf script

### DIFF
--- a/scripts/perf/test
+++ b/scripts/perf/test
@@ -34,7 +34,7 @@ SERVER=$SERVER \
   TMP_DIR=$TMP_DIR \
   OUT_DIR=$OUT_DIR \
   TEST=$TEST \
-  ultraman start --no-timestamp
+  ultraman start --no-timestamp true
 
 function report() {
   echo "$1 - generating report"


### PR DESCRIPTION
### Resolved issues:

The `ultraman` `--no-timestamp` argument changed to take a bool, which causes our perf script to fail. This change updates the usage to the latest interface.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

