### PR TITLE
Defines unreliable datagram transport parameter

### DIFF
--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -45,6 +45,7 @@ pub mod api {
         pub initial_max_stream_data_uni: u64,
         pub initial_max_streams_bidi: u64,
         pub initial_max_streams_uni: u64,
+        pub max_datagram_frame_size: u64,
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
@@ -1883,6 +1884,7 @@ pub mod builder {
         pub initial_max_stream_data_uni: u64,
         pub initial_max_streams_bidi: u64,
         pub initial_max_streams_uni: u64,
+        pub max_datagram_frame_size: u64,
     }
     impl<'a> IntoEvent<api::TransportParameters<'a>> for TransportParameters<'a> {
         #[inline]
@@ -1904,6 +1906,7 @@ pub mod builder {
                 initial_max_stream_data_uni,
                 initial_max_streams_bidi,
                 initial_max_streams_uni,
+                max_datagram_frame_size,
             } = self;
             api::TransportParameters {
                 original_destination_connection_id: original_destination_connection_id.into_event(),
@@ -1923,6 +1926,7 @@ pub mod builder {
                 initial_max_stream_data_uni: initial_max_stream_data_uni.into_event(),
                 initial_max_streams_bidi: initial_max_streams_bidi.into_event(),
                 initial_max_streams_uni: initial_max_streams_uni.into_event(),
+                max_datagram_frame_size: max_datagram_frame_size.into_event(),
             }
         }
     }

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -69,6 +69,7 @@ pub trait TransportParameterValidator: Sized {
 //# original_destination_connection_id, preferred_address,
 //# retry_source_connection_id, and stateless_reset_token.
 
+//= https://www.rfc-editor.org/rfc/rfc9221#section-3
 //# When clients use 0-RTT, they MAY store the value of the server's
 //# max_datagram_frame_size transport parameter. Doing so allows the
 //# client to send DATAGRAM frames in 0-RTT packets.
@@ -380,7 +381,8 @@ macro_rules! duration_transport_parameter {
     };
 }
 
-/// Implements an optional transport parameter
+/// Implements an optional transport parameter. This is used to define transport
+/// parameters that are only sent by one peer in a connection.
 macro_rules! optional_transport_parameter {
     ($ty:ty) => {
         impl TransportParameter for Option<$ty> {
@@ -1468,7 +1470,8 @@ mod snapshot_tests {
                 concat!(stringify!($endpoint_params), "__default"),
                 default_value
             );
-
+            // Tests that a transport parameter will not be sent if it is set
+            // to its default value defined in the rfc.
             let encoded_output: Vec<u8> =
                 assert_codec_round_trip_value!($endpoint_params, default_value);
             let expected_output: Vec<u8> = vec![];

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -69,6 +69,10 @@ pub trait TransportParameterValidator: Sized {
 //# original_destination_connection_id, preferred_address,
 //# retry_source_connection_id, and stateless_reset_token.
 
+//# When clients use 0-RTT, they MAY store the value of the server's
+//# max_datagram_frame_size transport parameter. Doing so allows the
+//# client to send DATAGRAM frames in 0-RTT packets.
+
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct ZeroRttParameters {
     pub active_connection_id_limit: VarInt,
@@ -78,6 +82,7 @@ pub struct ZeroRttParameters {
     pub initial_max_stream_data_uni: VarInt,
     pub initial_max_streams_bidi: VarInt,
     pub initial_max_streams_uni: VarInt,
+    pub max_datagram_frame_size: VarInt,
 }
 
 impl<
@@ -103,6 +108,7 @@ impl<
             initial_max_stream_data_uni,
             initial_max_streams_bidi,
             initial_max_streams_uni,
+            max_datagram_frame_size,
             ..
         } = self;
         ZeroRttParameters {
@@ -113,6 +119,7 @@ impl<
             initial_max_stream_data_uni: **initial_max_stream_data_uni,
             initial_max_streams_bidi: **initial_max_streams_bidi,
             initial_max_streams_uni: **initial_max_streams_uni,
+            max_datagram_frame_size: **max_datagram_frame_size,
         }
     }
 }
@@ -767,6 +774,33 @@ impl TransportParameterValidator for InitialMaxStreamsUni {
     }
 }
 
+//= https://www.rfc-editor.org/rfc/rfc9221#section-3
+//# Support for receiving the DATAGRAM frame types is advertised by means
+//# of a QUIC transport parameter (name=max_datagram_frame_size, value=0x20).
+//# The max_datagram_frame_size transport parameter is an integer value
+//# (represented as a variable-length integer) that represents the maximum
+//# size of a DATAGRAM frame (including the frame type, length, and
+//# payload) the endpoint is willing to receive, in bytes.
+//# The default for this parameter is 0, which indicates that the
+//# endpoint does not support DATAGRAM frames.  A value greater than 0
+//# indicates that the endpoint supports the DATAGRAM frame types and is
+//# willing to receive such frames on this connection.
+transport_parameter!(MaxDatagramFrameSize(VarInt), 0x20, VarInt::from_u16(0));
+
+//= https://www.rfc-editor.org/rfc/rfc9221#section-3
+//# For most uses of DATAGRAM frames, it is RECOMMENDED to send a value of
+//# 65535 in the max_datagram_frame_size transport parameter to indicate that
+//# this endpoint will accept any DATAGRAM frame that fits inside a QUIC packet.
+impl MaxDatagramFrameSize {
+    pub const RECOMMENDED: Self = Self(VarInt::from_u16(65535));
+}
+
+impl TransportParameterValidator for MaxDatagramFrameSize {
+    fn validate(self) -> Result<Self, DecoderError> {
+        Ok(self)
+    }
+}
+
 //= https://www.rfc-editor.org/rfc/rfc9000#section-18.2
 //# ack_delay_exponent (0x0a):  The acknowledgement delay exponent is an
 //#    integer value indicating an exponent used to decode the ACK Delay
@@ -1200,6 +1234,7 @@ impl<'a> IntoEvent<event::builder::TransportParameters<'a>> for &'a ServerTransp
             initial_max_stream_data_uni: self.initial_max_stream_data_uni.into_event(),
             initial_max_streams_bidi: self.initial_max_streams_bidi.into_event(),
             initial_max_streams_uni: self.initial_max_streams_uni.into_event(),
+            max_datagram_frame_size: self.max_datagram_frame_size.into_event(),
         }
     }
 }
@@ -1230,6 +1265,7 @@ impl<'a> IntoEvent<event::builder::TransportParameters<'a>> for &'a ClientTransp
             initial_max_stream_data_uni: self.initial_max_stream_data_uni.into_event(),
             initial_max_streams_bidi: self.initial_max_streams_bidi.into_event(),
             initial_max_streams_uni: self.initial_max_streams_uni.into_event(),
+            max_datagram_frame_size: self.max_datagram_frame_size.into_event(),
         }
     }
 }
@@ -1364,6 +1400,7 @@ impl_transport_parameters!(
         initial_max_stream_data_uni: InitialMaxStreamDataUni,
         initial_max_streams_bidi: InitialMaxStreamsBidi,
         initial_max_streams_uni: InitialMaxStreamsUni,
+        max_datagram_frame_size: MaxDatagramFrameSize,
         ack_delay_exponent: AckDelayExponent,
         max_ack_delay: MaxAckDelay,
         migration_support: MigrationSupport,
@@ -1465,6 +1502,7 @@ mod snapshot_tests {
             initial_max_stream_data_uni: integer_value.try_into().unwrap(),
             initial_max_streams_bidi: integer_value.try_into().unwrap(),
             initial_max_streams_uni: integer_value.try_into().unwrap(),
+            max_datagram_frame_size: MaxDatagramFrameSize::new(0u16).unwrap(),
             ack_delay_exponent: 2u8.try_into().unwrap(),
             max_ack_delay: integer_value.try_into().unwrap(),
             migration_support: MigrationSupport::Disabled,
@@ -1508,6 +1546,7 @@ mod snapshot_tests {
             initial_max_stream_data_uni: integer_value.try_into().unwrap(),
             initial_max_streams_bidi: integer_value.try_into().unwrap(),
             initial_max_streams_uni: integer_value.try_into().unwrap(),
+            max_datagram_frame_size: MaxDatagramFrameSize::new(0u16).unwrap(),
             ack_delay_exponent: 2u8.try_into().unwrap(),
             max_ack_delay: integer_value.try_into().unwrap(),
             migration_support: MigrationSupport::Disabled,

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -69,11 +69,6 @@ pub trait TransportParameterValidator: Sized {
 //# original_destination_connection_id, preferred_address,
 //# retry_source_connection_id, and stateless_reset_token.
 
-//= https://www.rfc-editor.org/rfc/rfc9221#section-3
-//# When clients use 0-RTT, they MAY store the value of the server's
-//# max_datagram_frame_size transport parameter. Doing so allows the
-//# client to send DATAGRAM frames in 0-RTT packets.
-
 #[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
 pub struct ZeroRttParameters {
     pub active_connection_id_limit: VarInt,
@@ -83,6 +78,10 @@ pub struct ZeroRttParameters {
     pub initial_max_stream_data_uni: VarInt,
     pub initial_max_streams_bidi: VarInt,
     pub initial_max_streams_uni: VarInt,
+    //= https://www.rfc-editor.org/rfc/rfc9221#section-3
+    //# When clients use 0-RTT, they MAY store the value of the server's
+    //# max_datagram_frame_size transport parameter. Doing so allows the
+    //# client to send DATAGRAM frames in 0-RTT packets.
     pub max_datagram_frame_size: VarInt,
 }
 
@@ -381,8 +380,8 @@ macro_rules! duration_transport_parameter {
     };
 }
 
-/// Implements an optional transport parameter. This is used to define transport
-/// parameters that are only sent by one peer in a connection.
+/// Implements an optional transport parameter. Used for transport parameters
+/// that don't have a good default, like an IP address.
 macro_rules! optional_transport_parameter {
     ($ty:ty) => {
         impl TransportParameter for Option<$ty> {

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__ClientTransportParameters__default.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__ClientTransportParameters__default.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/mod.rs
-assertion_line: 1452
+assertion_line: 1542
 expression: default_value
 
 ---
@@ -41,6 +41,11 @@ TransportParameters {
         ),
     ),
     initial_max_streams_uni: InitialMaxStreamsUni(
+        VarInt(
+            0,
+        ),
+    ),
+    max_datagram_frame_size: MaxDatagramFrameSize(
         VarInt(
             0,
         ),

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__ServerTransportParameters__default.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__ServerTransportParameters__default.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/mod.rs
-assertion_line: 1447
+assertion_line: 1537
 expression: default_value
 
 ---
@@ -41,6 +41,11 @@ TransportParameters {
         ),
     ),
     initial_max_streams_uni: InitialMaxStreamsUni(
+        VarInt(
+            0,
+        ),
+    ),
+    max_datagram_frame_size: MaxDatagramFrameSize(
         VarInt(
             0,
         ),

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__client_snapshot_test.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__client_snapshot_test.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/mod.rs
-assertion_line: 1529
+assertion_line: 1633
 expression: encoded_output
 
 ---

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__server_snapshot_test.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__snapshot_tests__server_snapshot_test.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/mod.rs
-assertion_line: 1493
+assertion_line: 1596
 expression: encoded_output
 
 ---

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -39,6 +39,7 @@ struct TransportParameters<'a> {
     initial_max_stream_data_uni: u64,
     initial_max_streams_bidi: u64,
     initial_max_streams_uni: u64,
+    max_datagram_frame_size: u64,
 }
 
 struct PreferredAddress<'a> {

--- a/quic/s2n-quic/api.snap
+++ b/quic/s2n-quic/api.snap
@@ -1,5 +1,6 @@
 ---
 source: src/main.rs
+assertion_line: 61
 expression: dump
 ---
 trait impl core::convert::TryFrom<s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message associates type:
@@ -4904,6 +4905,9 @@ struct s2n_quic::provider::event::events::TransportParameters exports field:
 
 struct s2n_quic::provider::event::events::TransportParameters exports field:
   max_ack_delay: core::time::Duration
+
+struct s2n_quic::provider::event::events::TransportParameters exports field:
+  max_datagram_frame_size: u64
 
 struct s2n_quic::provider::event::events::TransportParameters exports field:
   max_idle_timeout: core::time::Duration


### PR DESCRIPTION
### Resolved issues:

part of  #1253
### Description of changes: 

Defines the max_datagram_frame_size transport parameter. Note that currently we do not send this transport parameter because it is set to the default value of 0. When we do want to allow people to recv datagrams we will switch to sending the recommended datagram size.

### Call-outs:

Also added this parameter to our ZeroRttParameters struct as it can be used to send 0-RTT datagrams. Not sure if we are going to need that functionality though. 

### Testing:
Basically nothing changes here since we don't send the default transport parameters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

