### PR TITLE
ci: fix gating of authenticated steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,14 +136,14 @@ jobs:
           args: --all-features --no-deps --workspace --exclude s2n-quic-qns
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET="${{ github.sha }}/doc"
@@ -152,7 +152,7 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "doc / report"
           status: "success"
@@ -345,14 +345,14 @@ jobs:
         run: ./scripts/compliance ${{ github.sha }}
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET="${{ github.sha }}/compliance.html"
@@ -361,7 +361,7 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "compliance / report"
           status: "success"
@@ -398,14 +398,14 @@ jobs:
           args: --html --no-fail-fast --workspace --exclude s2n-quic-qns --exclude s2n-quic-events --all-features
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload results
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET="${{ github.sha }}/coverage"
@@ -414,7 +414,7 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "coverage / report"
           status: "success"
@@ -471,14 +471,14 @@ jobs:
           ./scripts/recovery-sim
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET="${{ github.sha }}/recovery-simulations"
@@ -487,7 +487,7 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "recovery-simulations / report"
           status: "success"
@@ -590,14 +590,14 @@ jobs:
           cargo build -Z timings --release
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET="${{ github.sha }}/timing/index.html"
@@ -606,7 +606,7 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "timing / report"
           status: "success"

--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -211,14 +211,14 @@ jobs:
           path: reports
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload results
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET="${{ github.sha }}/netbench"
@@ -227,7 +227,7 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "netbench / report"
           status: "success"

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -454,7 +454,7 @@ jobs:
 
       # authenticate pull to avoid hitting pull quota
       - name: Login to Amazon Elastic Container Registry Public
-        if: github.event.pull_request
+        if: github.repository == github.event.pull_request.head.repo.full_name
         uses: docker/login-action@v1
         with:
           registry: public.ecr.aws

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -296,14 +296,14 @@ jobs:
           done
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         working-directory: quic-interop-runner
         run: |
@@ -342,7 +342,7 @@ jobs:
 
       - name: Get latest successfull interop commit SHA on main branch
         id: mainsha
-        if: github.event.pull_request && github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event.pull_request && github.repository == github.event.pull_request.head.repo.full_name
         run: |
           curl \
           --url "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/actions/workflows/qns.yml/runs?branch=main&status=success&per_page=1" \
@@ -353,14 +353,14 @@ jobs:
           echo "::set-output name=MAIN_SHA::$MAIN_SHA"
 
       - name: Download latest main interop result
-        if: github.event.pull_request && github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event.pull_request && github.repository == github.event.pull_request.head.repo.full_name
         run: |
           rm -f prev_result.json
           wget $CDN/${{ steps.mainsha.outputs.MAIN_SHA }}/interop/logs/latest/result.json || echo '{}' > result.json
           mv result.json prev_result.json
 
       - name: Generate report for pull request
-        if: github.event.pull_request && github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event.pull_request && github.repository == github.event.pull_request.head.repo.full_name
         run: |
           mkdir -p web/logs/latest
           MAIN_SHA=${{ steps.mainsha.outputs.MAIN_SHA }}
@@ -389,14 +389,14 @@ jobs:
               web/logs/latest/result.json
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           cp .github/interop/*.html web/
@@ -407,7 +407,7 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "interop / report"
           status: "success"
@@ -495,14 +495,14 @@ jobs:
         run: sudo env "PATH=$PATH" "BUILD_S2N_QUIC=false" ./scripts/benchmark/run-all
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload results
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET="${{ github.sha }}/bench"
@@ -511,7 +511,7 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "bench / report"
           status: "success"
@@ -678,14 +678,14 @@ jobs:
           tree -H "." -T "Performance Results" --noreport --charset utf-8 > index.html
 
       - uses: aws-actions/configure-aws-credentials@v1.6.1
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: us-west-1
 
       - name: Upload results
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET="${{ github.sha }}/perf"
@@ -694,7 +694,7 @@ jobs:
           echo "::set-output name=URL::$URL"
 
       - uses: ouzi-dev/commit-status-updater@v1.1.2
-        if: github.event_name == 'push' || github.repository.name == github.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "perf / report"
           status: "success"


### PR DESCRIPTION
### Description of changes: 

In #1181 we added gating of authenticated steps to the GitHub actions CI workflows, since pull requests from forked repositories do not have access to the credentials needed for these steps. Because the repository was private at the time, this could not be tested. This change fixes the gating to properly prevent authenticated steps from running on pull requests from forked repositories.

### Testing:

This PR is the test (it is from a forked repository)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

