### PR TITLE
feat(s2n-quic-core): add DATAGRAM frame

### DIFF
--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -141,6 +141,8 @@ pub mod api {
         ConnectionClose {},
         #[non_exhaustive]
         HandshakeDone {},
+        #[non_exhaustive]
+        Datagram { len: u16 },
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
@@ -1159,6 +1161,16 @@ pub mod api {
             }
         }
     }
+    impl<Data> IntoEvent<builder::Frame> for &crate::frame::Datagram<Data>
+    where
+        Data: s2n_codec::EncoderValue,
+    {
+        fn into_event(self) -> builder::Frame {
+            builder::Frame::Datagram {
+                len: self.data.encoding_size() as _,
+            }
+        }
+    }
     impl<'a> IntoEvent<builder::StreamType> for &crate::stream::StreamType {
         fn into_event(self) -> builder::StreamType {
             match self {
@@ -2076,6 +2088,9 @@ pub mod builder {
         PathResponse,
         ConnectionClose,
         HandshakeDone,
+        Datagram {
+            len: u16,
+        },
     }
     impl IntoEvent<api::Frame> for Frame {
         #[inline]
@@ -2119,6 +2134,9 @@ pub mod builder {
                 Self::PathResponse => PathResponse {},
                 Self::ConnectionClose => ConnectionClose {},
                 Self::HandshakeDone => HandshakeDone {},
+                Self::Datagram { len } => Datagram {
+                    len: len.into_event(),
+                },
             }
         }
     }

--- a/quic/s2n-quic-core/src/frame/ack_elicitation.rs
+++ b/quic/s2n-quic-core/src/frame/ack_elicitation.rs
@@ -71,7 +71,7 @@ impl AckElicitable for crate::frame::ConnectionClose<'_> {
     }
 }
 impl<Data> AckElicitable for crate::frame::Crypto<Data> {}
-//= https://datatracker.ietf.org/doc/html/rfc9221#section-5.2
+//= https://www.rfc-editor.org/rfc/rfc9221#section-5.2
 //# Although DATAGRAM frames are not retransmitted upon loss detection,
 //# they are ack-eliciting ([RFC9002]).
 impl<Data> AckElicitable for crate::frame::Datagram<Data> {}

--- a/quic/s2n-quic-core/src/frame/ack_elicitation.rs
+++ b/quic/s2n-quic-core/src/frame/ack_elicitation.rs
@@ -71,6 +71,10 @@ impl AckElicitable for crate::frame::ConnectionClose<'_> {
     }
 }
 impl<Data> AckElicitable for crate::frame::Crypto<Data> {}
+//= https://datatracker.ietf.org/doc/html/rfc9221#section-5.2
+//# Although DATAGRAM frames are not retransmitted upon loss detection,
+//# they are ack-eliciting ([RFC9002]).
+impl<Data> AckElicitable for crate::frame::Datagram<Data> {}
 impl AckElicitable for crate::frame::DataBlocked {}
 impl AckElicitable for crate::frame::HandshakeDone {}
 impl AckElicitable for crate::frame::MaxData {}

--- a/quic/s2n-quic-core/src/frame/congestion_controlled.rs
+++ b/quic/s2n-quic-core/src/frame/congestion_controlled.rs
@@ -21,6 +21,9 @@ impl<AckRanges> CongestionControlled for crate::frame::Ack<AckRanges> {
 }
 impl CongestionControlled for crate::frame::ConnectionClose<'_> {}
 impl<Data> CongestionControlled for crate::frame::Crypto<Data> {}
+//= https://datatracker.ietf.org/doc/html/rfc9221#section-5.4
+//# DATAGRAM frames employ the QUIC connection's congestion controller.
+impl<Data> CongestionControlled for crate::frame::Datagram<Data> {}
 impl CongestionControlled for crate::frame::DataBlocked {}
 impl CongestionControlled for crate::frame::HandshakeDone {}
 impl CongestionControlled for crate::frame::MaxData {}

--- a/quic/s2n-quic-core/src/frame/congestion_controlled.rs
+++ b/quic/s2n-quic-core/src/frame/congestion_controlled.rs
@@ -21,7 +21,7 @@ impl<AckRanges> CongestionControlled for crate::frame::Ack<AckRanges> {
 }
 impl CongestionControlled for crate::frame::ConnectionClose<'_> {}
 impl<Data> CongestionControlled for crate::frame::Crypto<Data> {}
-//= https://datatracker.ietf.org/doc/html/rfc9221#section-5.4
+//= https://www.rfc-editor.org/rfc/rfc9221#section-5.4
 //# DATAGRAM frames employ the QUIC connection's congestion controller.
 impl<Data> CongestionControlled for crate::frame::Datagram<Data> {}
 impl CongestionControlled for crate::frame::DataBlocked {}

--- a/quic/s2n-quic-core/src/frame/crypto.rs
+++ b/quic/s2n-quic-core/src/frame/crypto.rs
@@ -54,7 +54,7 @@ impl<Data> Crypto<Data> {
         crypto_tag!()
     }
 
-    /// Converts the stream data from one type to another
+    /// Converts the crypto data from one type to another
     pub fn map_data<F: FnOnce(Data) -> Out, Out>(self, map: F) -> Crypto<Out> {
         Crypto {
             offset: self.offset,

--- a/quic/s2n-quic-core/src/frame/datagram.rs
+++ b/quic/s2n-quic-core/src/frame/datagram.rs
@@ -189,7 +189,7 @@ mod tests {
         let length = if let Ok(length) = VarInt::try_into(length) {
             length
         } else {
-            // if the length cannot be represented by `usize` then bail
+            // If the length cannot be represented by `usize` then bail
             return;
         };
 
@@ -202,7 +202,7 @@ mod tests {
             // We should never return a length larger than the data to send
             assert!(length >= max_data_len);
 
-            // we should never exceed the capacity
+            // We should never exceed the capacity
             frame.data = Padding {
                 length: max_data_len,
             };
@@ -213,7 +213,7 @@ mod tests {
             );
 
             if frame.is_last_frame {
-                // the `is_last_frame` should _only_ be set when the encoding size == capacity
+                // The `is_last_frame` should _only_ be set when the encoding size == capacity
                 assert_eq!(
                     frame.encoding_size(),
                     capacity,

--- a/quic/s2n-quic-core/src/frame/datagram.rs
+++ b/quic/s2n-quic-core/src/frame/datagram.rs
@@ -10,7 +10,7 @@ use s2n_codec::{
     decoder_parameterized_value, DecoderBuffer, DecoderBufferMut, Encoder, EncoderValue,
 };
 
-//= https://datatracker.ietf.org/doc/html/rfc9221#section-4
+//= https://www.rfc-editor.org/rfc/rfc9221#section-4
 //# DATAGRAM frames are used to transmit application data in an
 //# unreliable manner.  The Type field in the DATAGRAM frame takes the
 //# form 0b0011000X (or the values 0x30 and 0x31).
@@ -22,8 +22,7 @@ macro_rules! datagram_tag {
 }
 
 const DATAGRAM_TAG: u8 = 0x30;
-
-//= https://datatracker.ietf.org/doc/html/rfc9221#section-4
+//= https://www.rfc-editor.org/rfc/rfc9221#section-4
 //# The least significant bit of the Type field in the DATAGRAM frame is
 //# the LEN bit (0x01), which indicates whether there is a Length field
 //# present: if this bit is set to 0, the Length field is absent and the
@@ -32,14 +31,14 @@ const DATAGRAM_TAG: u8 = 0x30;
 
 const LEN_BIT: u8 = 0x01;
 
-//= https://datatracker.ietf.org/doc/html/rfc9221#section-4
+//= https://www.rfc-editor.org/rfc/rfc9221#section-4
 //# DATAGRAM Frame {
 //#   Type (i) = 0x30..0x31,
 //#   [Length (i)],
 //#   Datagram Data (..),
 //# }
 
-//= https://datatracker.ietf.org/doc/html/rfc9221#section-4
+//= https://www.rfc-editor.org/rfc/rfc9221#section-4
 //# DATAGRAM frames contain the following fields:
 //#
 //# Length:  A variable-length integer specifying the length of the

--- a/quic/s2n-quic-core/src/frame/datagram.rs
+++ b/quic/s2n-quic-core/src/frame/datagram.rs
@@ -1,0 +1,242 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    frame::{FitError, Tag},
+    varint::VarInt,
+};
+use core::{convert::TryFrom, mem::size_of};
+use s2n_codec::{
+    decoder_parameterized_value, DecoderBuffer, DecoderBufferMut, Encoder, EncoderValue,
+};
+
+//= https://datatracker.ietf.org/doc/html/rfc9221#section-4
+//# DATAGRAM frames are used to transmit application data in an
+//# unreliable manner.  The Type field in the DATAGRAM frame takes the
+//# form 0b0011000X (or the values 0x30 and 0x31).
+
+macro_rules! datagram_tag {
+    () => {
+        0x30u8..=0x31u8
+    };
+}
+
+const DATAGRAM_TAG: u8 = 0x30;
+
+//= https://datatracker.ietf.org/doc/html/rfc9221#section-4
+//# The least significant bit of the Type field in the DATAGRAM frame is
+//# the LEN bit (0x01), which indicates whether there is a Length field
+//# present: if this bit is set to 0, the Length field is absent and the
+//# Datagram Data field extends to the end of the packet; if this bit is
+//# set to 1, the Length field is present.
+
+const LEN_BIT: u8 = 0x01;
+
+//= https://datatracker.ietf.org/doc/html/rfc9221#section-4
+//# DATAGRAM Frame {
+//#   Type (i) = 0x30..0x31,
+//#   [Length (i)],
+//#   Datagram Data (..),
+//# }
+
+//= https://datatracker.ietf.org/doc/html/rfc9221#section-4
+//# DATAGRAM frames contain the following fields:
+//#
+//# Length:  A variable-length integer specifying the length of the
+//#    Datagram Data field in bytes.  This field is present only when the
+//#    LEN bit is set to 1.  When the LEN bit is set to 0, the Datagram
+//#    Data field extends to the end of the QUIC packet.  Note that empty
+//#    (i.e., zero-length) datagrams are allowed.
+//#
+//# Datagram Data:  The bytes of the datagram to be delivered.
+
+pub type DatagramRef<'a> = Datagram<&'a [u8]>;
+pub type DatagramMut<'a> = Datagram<&'a mut [u8]>;
+
+#[derive(Debug, PartialEq, Eq)]
+pub struct Datagram<Data> {
+    /// If true, the frame is the last frame in the payload
+    pub is_last_frame: bool,
+
+    /// The bytes to be delivered.
+    pub data: Data,
+}
+
+impl<Data> Datagram<Data> {
+    #[inline]
+    pub fn tag(&self) -> u8 {
+        let mut tag: u8 = DATAGRAM_TAG;
+
+        if !self.is_last_frame {
+            tag |= LEN_BIT;
+        }
+
+        tag
+    }
+
+    /// Converts the datagram data from one type to another
+    pub fn map_data<F: FnOnce(Data) -> Out, Out>(self, map: F) -> Datagram<Out> {
+        Datagram {
+            is_last_frame: self.is_last_frame,
+            data: map(self.data),
+        }
+    }
+}
+
+impl<Data: EncoderValue> Datagram<Data> {
+    /// Tries to fit the frame into the provided capacity
+    ///
+    /// If ok, the new payload length is returned, otherwise the frame cannot
+    /// fit.
+    #[inline]
+    pub fn try_fit(&mut self, capacity: usize) -> Result<usize, FitError> {
+        let mut fixed_len = 0;
+        fixed_len += size_of::<Tag>();
+
+        let remaining_capacity = capacity.checked_sub(fixed_len).ok_or(FitError)?;
+
+        let data_len = self.data.encoding_size();
+        let max_data_len = remaining_capacity.min(data_len);
+
+        // If data fits exactly into the capacity, mark it as the last frame
+        if max_data_len == remaining_capacity {
+            self.is_last_frame = true;
+            return Ok(max_data_len);
+        }
+
+        self.is_last_frame = false;
+
+        let len_prefix_size = VarInt::try_from(max_data_len)
+            .map_err(|_| FitError)?
+            .encoding_size();
+
+        let prefixed_data_len = remaining_capacity
+            .checked_sub(len_prefix_size)
+            .ok_or(FitError)?;
+        let data_len = prefixed_data_len.min(data_len);
+
+        Ok(data_len)
+    }
+}
+
+decoder_parameterized_value!(
+    impl<'a, Data> Datagram<Data> {
+        fn decode(tag: Tag, buffer: Buffer) -> Result<Self> {
+            let is_last_frame = tag & LEN_BIT != LEN_BIT;
+
+            let (data, buffer) = if !is_last_frame {
+                let (data, buffer) = buffer.decode_with_len_prefix::<VarInt, Data>()?;
+                (data, buffer)
+            } else {
+                let len = buffer.len();
+                let (data, buffer) = buffer.decode_slice(len)?;
+                let (data, remaining) = data.decode()?;
+                remaining.ensure_empty()?;
+                (data, buffer)
+            };
+
+            let frame = Datagram {
+                is_last_frame,
+                data,
+            };
+
+            Ok((frame, buffer))
+        }
+    }
+);
+
+impl<Data: EncoderValue> EncoderValue for Datagram<Data> {
+    fn encode<E: Encoder>(&self, buffer: &mut E) {
+        buffer.encode(&self.tag());
+
+        if self.is_last_frame {
+            buffer.encode(&self.data);
+        } else {
+            buffer.encode_with_len_prefix::<VarInt, _>(&self.data);
+        }
+    }
+}
+
+impl<'a> From<Datagram<DecoderBuffer<'a>>> for DatagramRef<'a> {
+    #[inline]
+    fn from(d: Datagram<DecoderBuffer<'a>>) -> Self {
+        d.map_data(|data| data.into_less_safe_slice())
+    }
+}
+
+impl<'a> From<Datagram<DecoderBufferMut<'a>>> for DatagramRef<'a> {
+    #[inline]
+    fn from(d: Datagram<DecoderBufferMut<'a>>) -> Self {
+        d.map_data(|data| &data.into_less_safe_slice()[..])
+    }
+}
+
+impl<'a> From<Datagram<DecoderBufferMut<'a>>> for DatagramMut<'a> {
+    #[inline]
+    fn from(d: Datagram<DecoderBufferMut<'a>>) -> Self {
+        d.map_data(|data| data.into_less_safe_slice())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frame::Padding;
+    use bolero::check;
+    use core::convert::TryInto;
+
+    fn model(length: VarInt, capacity: usize) {
+        let length = if let Ok(length) = VarInt::try_into(length) {
+            length
+        } else {
+            // if the length cannot be represented by `usize` then bail
+            return;
+        };
+
+        let mut frame = Datagram {
+            is_last_frame: false,
+            data: Padding { length },
+        };
+
+        if let Ok(max_data_len) = frame.try_fit(capacity) {
+            // We should never return a length larger than the data to send
+            assert!(length >= max_data_len);
+
+            // we should never exceed the capacity
+            frame.data = Padding {
+                length: max_data_len,
+            };
+            assert!(
+                frame.encoding_size() <= capacity,
+                "the encoding_size should not exceed capacity {:#?}",
+                frame
+            );
+
+            if frame.is_last_frame {
+                // the `is_last_frame` should _only_ be set when the encoding size == capacity
+                assert_eq!(
+                    frame.encoding_size(),
+                    capacity,
+                    "should only be the last frame if == capacity {:#?}",
+                    frame
+                );
+            }
+        } else {
+            assert!(
+                frame.encoding_size() > capacity,
+                "rejection should only occur when encoding size > capacity {:#?}",
+                frame
+            );
+        }
+    }
+
+    #[test]
+    fn try_fit_test() {
+        check!()
+            .with_type()
+            .cloned()
+            .for_each(|(length, capacity)| {
+                model(length, capacity);
+            });
+    }
+}

--- a/quic/s2n-quic-core/src/frame/datagram.rs
+++ b/quic/s2n-quic-core/src/frame/datagram.rs
@@ -166,7 +166,7 @@ impl<'a> From<Datagram<DecoderBuffer<'a>>> for DatagramRef<'a> {
 impl<'a> From<Datagram<DecoderBufferMut<'a>>> for DatagramRef<'a> {
     #[inline]
     fn from(d: Datagram<DecoderBufferMut<'a>>) -> Self {
-        d.map_data(|data| &data.into_less_safe_slice()[..])
+        d.map_data(|data| &*data.into_less_safe_slice())
     }
 }
 

--- a/quic/s2n-quic-core/src/frame/mod.rs
+++ b/quic/s2n-quic-core/src/frame/mod.rs
@@ -250,6 +250,7 @@ frames! {
     path_response_tag => path_response, handle_path_response_frame, PathResponse['a];
     connection_close_tag => connection_close, handle_connection_close_frame, ConnectionClose['a];
     handshake_done_tag => handshake_done, handle_handshake_done_frame, HandshakeDone;
+    datagram_tag => datagram, handle_datagram_frame, Datagram[Data];
 }
 
 #[derive(Clone, Copy, Debug, Default)]

--- a/quic/s2n-quic-core/src/frame/path_validation.rs
+++ b/quic/s2n-quic-core/src/frame/path_validation.rs
@@ -67,6 +67,7 @@ pub trait Probing {
 impl<AckRanges> Probing for crate::frame::Ack<AckRanges> {}
 impl Probing for crate::frame::ConnectionClose<'_> {}
 impl<Data> Probing for crate::frame::Crypto<Data> {}
+impl<Data> Probing for crate::frame::Datagram<Data> {}
 impl Probing for crate::frame::DataBlocked {}
 impl Probing for crate::frame::HandshakeDone {}
 impl Probing for crate::frame::MaxData {}

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__datagram.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__datagram.snap
@@ -1,0 +1,31 @@
+---
+source: quic/s2n-quic-core/src/frame/mod.rs
+assertion_line: 231
+expression: values
+---
+[
+    Datagram(
+        Datagram {
+            is_last_frame: false,
+            data: DecoderBufferMut {
+                bytes: [
+                    73,
+                    39,
+                    109,
+                    32,
+                    97,
+                    32,
+                    100,
+                    97,
+                    116,
+                    97,
+                    103,
+                    114,
+                    97,
+                    109,
+                    33,
+                ],
+            },
+        },
+    ),
+]

--- a/quic/s2n-quic-core/src/frame/test_samples/datagram.bin
+++ b/quic/s2n-quic-core/src/frame/test_samples/datagram.bin
@@ -1,0 +1,1 @@
+1I'm a datagram!

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -310,6 +310,9 @@ enum Frame {
     PathResponse,
     ConnectionClose,
     HandshakeDone,
+    Datagram {
+        len: u16,
+    },
 }
 
 impl IntoEvent<builder::Frame> for &crate::frame::Padding {
@@ -445,6 +448,17 @@ where
     fn into_event(self) -> builder::Frame {
         builder::Frame::Crypto {
             offset: self.offset.as_u64(),
+            len: self.data.encoding_size() as _,
+        }
+    }
+}
+
+impl<Data> IntoEvent<builder::Frame> for &crate::frame::Datagram<Data>
+where
+    Data: s2n_codec::EncoderValue,
+{
+    fn into_event(self) -> builder::Frame {
+        builder::Frame::Datagram {
             len: self.data.encoding_size() as _,
         }
     }

--- a/quic/s2n-quic/api.snap
+++ b/quic/s2n-quic/api.snap
@@ -3186,6 +3186,9 @@ enum s2n_quic::provider::event::events::Frame exports variant:
   DataBlocked
 
 enum s2n_quic::provider::event::events::Frame exports variant:
+  Datagram
+
+enum s2n_quic::provider::event::events::Frame exports variant:
   HandshakeDone
 
 enum s2n_quic::provider::event::events::Frame exports variant:
@@ -3269,6 +3272,12 @@ variant s2n_quic::provider::event::events::Frame::Crypto exports field:
   u64
 
 variant s2n_quic::provider::event::events::Frame::DataBlocked is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::Datagram is non-exhaustive
+
+variant s2n_quic::provider::event::events::Frame::Datagram exports field:
+  len:
+  u16
 
 variant s2n_quic::provider::event::events::Frame::HandshakeDone is non-exhaustive
 


### PR DESCRIPTION
### Resolved issues:

Related to #1253 

### Description of changes: 

Defines the datagram frame to be ack-eliciting and congestion controlled. Since we are not sending the datagram transport parameter we don't have to worry about receiving datagram frames before we're ready to process them.
### Call-outs:

### Testing:

Wasn't exactly sure how this should be tested. There is a try_fit test that I added from the Stream and Crypto frames tests.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

