### PR TITLE
feat(s2n-quic-platform): add testing io implementation

### DIFF
--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -12,12 +12,13 @@ exclude = ["corpus.tar.gz"]
 [features]
 default = ["std", "tokio-runtime", "wipe"]
 std = ["s2n-quic-core/std", "socket2", "lazy_static"]
-testing = ["std", "generator"] # Testing allows to overwrite the system time
+testing = ["std", "generator", "futures/std", "bach"] # Testing allows to overwrite the system time
 generator = ["bolero-generator", "s2n-quic-core/generator"]
 tokio-runtime = ["futures", "pin-project", "tokio"]
 wipe = ["zeroize"]
 
 [dependencies]
+bach = { version = "0.0.4", optional = true }
 bolero-generator = { version = "0.6", default-features = false, optional = true }
 cfg-if = "1"
 errno = "0.2"
@@ -33,7 +34,10 @@ zeroize = { version = "1", default-features = false, optional = true }
 libc = "0.2"
 
 [dev-dependencies]
+bach = { version = "0.0.4" }
 bolero = "0.6"
 bolero-generator = { version = "0.6", default-features = false }
+futures = { version = "0.3", features = ["std"] }
+insta = "1"
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -12,7 +12,8 @@ exclude = ["corpus.tar.gz"]
 [features]
 default = ["std", "tokio-runtime", "wipe"]
 std = ["s2n-quic-core/std", "socket2", "lazy_static"]
-testing = ["std", "generator", "futures/std", "bach"] # Testing allows to overwrite the system time
+testing = ["std", "generator", "futures/std", "io-testing"] # Testing allows to overwrite the system time
+io-testing = ["bach"]
 generator = ["bolero-generator", "s2n-quic-core/generator"]
 tokio-runtime = ["futures", "pin-project", "tokio"]
 wipe = ["zeroize"]

--- a/quic/s2n-quic-platform/src/io.rs
+++ b/quic/s2n-quic-platform/src/io.rs
@@ -1,5 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod select;
+
 #[cfg(feature = "tokio")]
 pub mod tokio;
+
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;

--- a/quic/s2n-quic-platform/src/io.rs
+++ b/quic/s2n-quic-platform/src/io.rs
@@ -1,10 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod select;
+mod select;
 
 #[cfg(feature = "tokio")]
 pub mod tokio;
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(any(test, feature = "io-testing"))]
 pub mod testing;

--- a/quic/s2n-quic-platform/src/io/select.rs
+++ b/quic/s2n-quic-platform/src/io/select.rs
@@ -1,0 +1,120 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use futures::future::{Fuse, FutureExt};
+use pin_project::pin_project;
+use s2n_quic_core::endpoint::CloseError;
+
+/// The main event loop future for selecting readiness of sub-tasks
+///
+/// This future ensures all sub-tasks are polled fairly by yielding once
+/// after completing any of the sub-tasks. This is especially important when the TX queue is
+/// flushed quickly and we never get notified of the RX socket having packets to read.
+#[pin_project]
+pub struct Select<Rx, Tx, Wakeup, Sleep>
+where
+    Rx: Future,
+    Tx: Future,
+    Wakeup: Future,
+    Sleep: Future,
+{
+    #[pin]
+    rx: Fuse<Rx>,
+    rx_out: Option<Rx::Output>,
+    #[pin]
+    tx: Fuse<Tx>,
+    tx_out: Option<Tx::Output>,
+    #[pin]
+    wakeup: Fuse<Wakeup>,
+    #[pin]
+    sleep: Sleep,
+}
+
+impl<Rx, Tx, Wakeup, Sleep> Select<Rx, Tx, Wakeup, Sleep>
+where
+    Rx: Future,
+    Tx: Future,
+    Wakeup: Future,
+    Sleep: Future,
+{
+    #[inline(always)]
+    pub fn new(rx: Rx, tx: Tx, wakeup: Wakeup, sleep: Sleep) -> Self {
+        Self {
+            rx: rx.fuse(),
+            rx_out: None,
+            tx: tx.fuse(),
+            tx_out: None,
+            wakeup: wakeup.fuse(),
+            sleep,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Outcome<Rx, Tx> {
+    pub rx_result: Option<Rx>,
+    pub tx_result: Option<Tx>,
+    pub timeout_expired: bool,
+    pub application_wakeup: bool,
+}
+
+pub type Result<Rx, Tx> = core::result::Result<Outcome<Rx, Tx>, CloseError>;
+
+impl<Rx, Tx, Wakeup, Sleep> Future for Select<Rx, Tx, Wakeup, Sleep>
+where
+    Rx: Future,
+    Tx: Future,
+    Wakeup: Future<Output = core::result::Result<usize, CloseError>>,
+    Sleep: Future,
+{
+    type Output = Result<Rx::Output, Tx::Output>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.project();
+
+        let mut should_wake = false;
+        let mut application_wakeup = false;
+
+        if let Poll::Ready(wakeup) = this.wakeup.poll(cx) {
+            should_wake = true;
+            application_wakeup = true;
+            if let Err(err) = wakeup {
+                return Poll::Ready(Err(err));
+            }
+        }
+
+        if let Poll::Ready(v) = this.rx.poll(cx) {
+            should_wake = true;
+            *this.rx_out = Some(v);
+        }
+
+        if let Poll::Ready(v) = this.tx.poll(cx) {
+            should_wake = true;
+            *this.tx_out = Some(v);
+        }
+
+        let mut timeout_expired = false;
+
+        if this.sleep.poll(cx).is_ready() {
+            timeout_expired = true;
+            should_wake = true;
+        }
+
+        // if none of the subtasks are ready, return
+        if !should_wake {
+            return Poll::Pending;
+        }
+
+        Poll::Ready(Ok(Outcome {
+            rx_result: this.rx_out.take(),
+            tx_result: this.tx_out.take(),
+            timeout_expired,
+            application_wakeup,
+        }))
+    }
+}

--- a/quic/s2n-quic-platform/src/io/testing.rs
+++ b/quic/s2n-quic-platform/src/io/testing.rs
@@ -121,8 +121,14 @@ impl<N: Network> bach::executor::Environment for Env<N> {
 
         self.stalled_iterations += 1;
 
+        // A stalled iteration is a macrostep that didn't actually execute any tasks.
+        //
+        // The idea with limiting it prevents the runtime from looping endlessly and not
+        // actually doing any work. The value of 100 was chosen somewhat arbitrarily as a high
+        // enough number that we won't get false positives but low enough that the number of
+        // loops stays within reasonable ranges.
         if self.stalled_iterations > 100 {
-            panic!("stalled test");
+            panic!("the runtime stalled after 100 iterations");
         }
 
         while let Some(time) = self.time.advance() {

--- a/quic/s2n-quic-platform/src/io/testing.rs
+++ b/quic/s2n-quic-platform/src/io/testing.rs
@@ -1,0 +1,251 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::select::{self, Select};
+use bach::{
+    executor::{self, JoinHandle},
+    time::scheduler,
+};
+use core::{pin::Pin, task::Poll};
+use s2n_quic_core::{endpoint::Endpoint, inet::SocketAddress};
+
+type Error = std::io::Error;
+type Result<T = (), E = Error> = core::result::Result<T, E>;
+
+mod model;
+pub mod network;
+pub mod time;
+
+pub use model::Model;
+pub use network::{Network, PathHandle};
+pub use time::now;
+
+pub use bach::{
+    rand,
+    task::{spawn, spawn_primary},
+};
+
+pub struct Executor<N: Network> {
+    executor: bach::executor::Executor<Env<N>>,
+    handle: Handle,
+}
+
+impl<N: Network> Executor<N> {
+    pub fn new(network: N, seed: u64) -> Self {
+        let mut executor = bach::executor::Executor::new(|handle| Env {
+            handle: handle.clone(),
+            time: scheduler::Scheduler::new(),
+            rand: bach::rand::Scope::new(seed),
+            buffers: network::Buffers::default(),
+            network,
+            stalled_iterations: 0,
+        });
+
+        let handle = Handle {
+            executor: executor.handle().clone(),
+            buffers: executor.environment().buffers.clone(),
+        };
+
+        Self { executor, handle }
+    }
+
+    pub fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    pub fn enter<F: FnOnce() -> O, O>(&mut self, f: F) -> O {
+        self.executor.environment().enter(f)
+    }
+
+    pub fn run(&mut self) {
+        self.executor.block_on_primary();
+    }
+}
+
+struct Env<N> {
+    handle: bach::executor::Handle,
+    time: scheduler::Scheduler,
+    rand: bach::rand::Scope,
+    buffers: network::Buffers,
+    network: N,
+    stalled_iterations: usize,
+}
+
+impl<N> Env<N> {
+    fn enter<F: FnOnce() -> O, O>(&self, f: F) -> O {
+        self.handle.enter(|| self.time.enter(|| self.rand.enter(f)))
+    }
+}
+
+impl<N: Network> bach::executor::Environment for Env<N> {
+    fn run<Tasks, F>(&mut self, tasks: Tasks) -> Poll<()>
+    where
+        Tasks: Iterator<Item = F> + Send,
+        F: 'static + FnOnce() -> Poll<()> + Send,
+    {
+        let mut is_ready = true;
+
+        let Self {
+            handle,
+            time,
+            rand,
+            buffers,
+            network,
+            ..
+        } = self;
+
+        handle.enter(|| {
+            time.enter(|| {
+                rand.enter(|| {
+                    for task in tasks {
+                        is_ready &= task().is_ready();
+                    }
+                    network.execute(buffers);
+                })
+            })
+        });
+
+        if is_ready {
+            Poll::Ready(())
+        } else {
+            Poll::Pending
+        }
+    }
+
+    fn on_macrostep(&mut self, count: usize) {
+        // only advance time after a stall
+        if count > 0 {
+            self.stalled_iterations = 0;
+            return;
+        }
+
+        self.stalled_iterations += 1;
+
+        if self.stalled_iterations > 100 {
+            panic!("stalled test");
+        }
+
+        while let Some(time) = self.time.advance() {
+            let _ = time;
+            if self.time.wake() > 0 {
+                break;
+            }
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct Handle {
+    executor: executor::Handle,
+    buffers: network::Buffers,
+}
+
+impl Handle {
+    pub fn builder(&self) -> Builder {
+        Builder {
+            handle: self.clone(),
+            address: None,
+        }
+    }
+}
+
+pub struct Builder {
+    handle: Handle,
+    address: Option<SocketAddress>,
+}
+
+impl Builder {
+    pub fn build(self) -> Result<Io> {
+        Ok(Io { builder: self })
+    }
+}
+
+pub struct Io {
+    builder: Builder,
+}
+
+impl Io {
+    pub fn start<E: Endpoint<PathHandle = network::PathHandle>>(
+        self,
+        endpoint: E,
+    ) -> Result<(JoinHandle<()>, SocketAddress)> {
+        let Builder {
+            handle: Handle { executor, buffers },
+            address,
+        } = self.builder;
+
+        let handle = address.unwrap_or_else(|| buffers.generate_addr());
+
+        buffers.register(handle);
+
+        let instance = Instance {
+            buffers,
+            handle,
+            endpoint,
+        };
+        let join = executor.spawn(instance.event_loop());
+        Ok((join, handle))
+    }
+}
+
+struct Instance<E> {
+    buffers: network::Buffers,
+    handle: SocketAddress,
+    endpoint: E,
+}
+
+impl<E: Endpoint<PathHandle = network::PathHandle>> Instance<E> {
+    async fn event_loop(self) {
+        let Self {
+            buffers,
+            handle,
+            mut endpoint,
+        } = self;
+
+        let clock = time::Clock::default();
+        let mut timer = time::Timer::default();
+
+        loop {
+            let io_task = buffers.readiness(handle);
+
+            // make a future that never returns since we have a single future that checks both
+            let empty_task = futures::future::pending::<()>();
+
+            let mut wakeups = endpoint.wakeups(&clock);
+            let mut wakeups = Pin::new(&mut wakeups);
+
+            let select::Outcome {
+                rx_result,
+                tx_result: _,
+                timeout_expired: _,
+                application_wakeup: _,
+            } = if let Ok(res) = Select::new(io_task, empty_task, &mut wakeups, &mut timer).await {
+                res
+            } else {
+                // The endpoint has shut down
+                return;
+            };
+
+            if let Some(result) = rx_result {
+                if result.is_err() {
+                    // the endpoint shut down
+                    return;
+                }
+
+                buffers.rx(handle, |queue| {
+                    endpoint.receive(queue, &clock);
+                });
+            }
+
+            buffers.tx(handle, |queue| {
+                endpoint.transmit(queue, &clock);
+            });
+
+            if let Some(timestamp) = endpoint.timeout() {
+                timer.update(timestamp);
+            } else {
+                timer.cancel();
+            }
+        }
+    }
+}

--- a/quic/s2n-quic-platform/src/io/testing/model.rs
+++ b/quic/s2n-quic-platform/src/io/testing/model.rs
@@ -1,0 +1,303 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::network::{Buffers, Network, Packet};
+use core::time::Duration;
+use s2n_quic_core::path::MaxMtu;
+use std::{
+    borrow::Cow,
+    sync::{
+        atomic::{AtomicU16, AtomicU64, Ordering},
+        Arc,
+    },
+};
+
+#[derive(Clone, Default)]
+pub struct Model(Arc<State>);
+
+impl Model {
+    fn jitter(&self) -> Duration {
+        Duration::from_micros(self.0.jitter.load(Ordering::SeqCst))
+    }
+
+    /// The amount of time between sending packets
+    ///
+    /// Setting this value to 0 will transmit all allowed packets at the exact same time.
+    pub fn set_jitter(&self, value: Duration) -> &Self {
+        self.0
+            .jitter
+            .store(value.as_micros() as _, Ordering::SeqCst);
+        self
+    }
+
+    fn network_jitter(&self) -> Duration {
+        Duration::from_micros(self.0.network_jitter.load(Ordering::SeqCst))
+    }
+
+    /// The amount of jitter in the network itself
+    ///
+    /// Setting this value to `>0` will cause packets to be reordered.
+    pub fn set_network_jitter(&self, value: Duration) -> &Self {
+        self.0
+            .network_jitter
+            .store(value.as_micros() as _, Ordering::SeqCst);
+        self
+    }
+
+    fn delay(&self) -> Duration {
+        Duration::from_micros(self.0.delay.load(Ordering::SeqCst))
+    }
+
+    /// The amount of time a packet is delayed before the receiver is able to read it
+    pub fn set_delay(&self, value: Duration) -> &Self {
+        self.0.delay.store(value.as_micros() as _, Ordering::SeqCst);
+        self
+    }
+
+    fn transmit_rate(&self) -> u64 {
+        self.0.transmit_rate.load(Ordering::SeqCst)
+    }
+
+    /// The number of packets that can be transmitted in a single round.
+    ///
+    /// By default, all packet buffers will be cleared on every round.
+    pub fn set_transmit_rate(&self, value: u64) -> &Self {
+        self.0.transmit_rate.store(value, Ordering::SeqCst);
+        self
+    }
+
+    fn retransmit_rate(&self) -> u64 {
+        self.0.retransmit_rate.load(Ordering::SeqCst)
+    }
+
+    /// The odds a packet will be retransmitted.
+    ///
+    /// Each packet will make an independent decision with odds of 1 in N.
+    pub fn set_retransmit_rate(&self, value: u64) -> &Self {
+        self.0.retransmit_rate.store(value, Ordering::SeqCst);
+        self
+    }
+
+    fn corrupt_rate(&self) -> u64 {
+        self.0.corrupt_rate.load(Ordering::SeqCst)
+    }
+
+    /// The odds a packet will be corrupted.
+    ///
+    /// Each packet will make an independent decision with odds of 1 in N.
+    pub fn set_corrupt_rate(&self, value: f64) -> &Self {
+        let value = rate_to_u64(value);
+        self.0.corrupt_rate.store(value, Ordering::SeqCst);
+        self
+    }
+
+    fn drop_rate(&self) -> u64 {
+        self.0.drop_rate.load(Ordering::SeqCst)
+    }
+
+    /// The odds a packet will be dropped.
+    ///
+    /// Each packet will make an independent decision with odds of 1 in N.
+    pub fn set_drop_rate(&self, value: f64) -> &Self {
+        let value = rate_to_u64(value);
+        self.0.drop_rate.store(value, Ordering::SeqCst);
+        self
+    }
+
+    fn mtu(&self) -> u16 {
+        self.0.mtu.load(Ordering::SeqCst)
+    }
+
+    /// The maximum payload size for the network
+    ///
+    /// NOTE: this is the UDP payload and doesn't include Ethernet/IP/UDP headers
+    pub fn set_mtu(&self, value: u16) -> &Self {
+        self.0.mtu.store(value, Ordering::SeqCst);
+        self
+    }
+
+    /// The number of inflight packets
+    fn inflight(&self) -> u64 {
+        self.0.current_inflight.load(Ordering::SeqCst)
+    }
+
+    fn max_inflight(&self) -> u64 {
+        self.0.max_inflight.load(Ordering::SeqCst)
+    }
+
+    /// Sets the maximum number of packets that can be inflight for the network
+    ///
+    /// Any packets that exceed this amount will be dropped
+    pub fn set_max_inflight(&self, value: u64) -> &Self {
+        self.0.max_inflight.store(value, Ordering::SeqCst);
+        self
+    }
+}
+
+fn rate_to_u64(rate: f64) -> u64 {
+    let value = rate.max(0.0).min(1.0);
+    let value = value * u64::MAX as f64;
+    value.round() as u64
+}
+
+struct State {
+    delay: AtomicU64,
+    jitter: AtomicU64,
+    network_jitter: AtomicU64,
+    transmit_rate: AtomicU64,
+    retransmit_rate: AtomicU64,
+    corrupt_rate: AtomicU64,
+    drop_rate: AtomicU64,
+    mtu: AtomicU16,
+    max_inflight: AtomicU64,
+    current_inflight: AtomicU64,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            delay: AtomicU64::new(Duration::from_millis(50).as_micros() as _),
+            jitter: AtomicU64::new(0),
+            network_jitter: AtomicU64::new(0),
+            transmit_rate: AtomicU64::new(u64::MAX),
+            retransmit_rate: AtomicU64::new(0),
+            corrupt_rate: AtomicU64::new(0),
+            drop_rate: AtomicU64::new(0),
+            mtu: AtomicU16::new(MaxMtu::default().into()),
+            max_inflight: AtomicU64::new(u64::MAX),
+            current_inflight: AtomicU64::new(0),
+        }
+    }
+}
+
+impl Network for Model {
+    fn execute(&mut self, buffers: &Buffers) -> usize {
+        let jitter = self.jitter();
+        let network_jitter = self.network_jitter();
+        let transmit_rate = self.transmit_rate();
+        let retransmit_rate = self.retransmit_rate();
+        let corrupt_rate = self.corrupt_rate();
+        let drop_rate = self.drop_rate();
+        let mtu = self.mtu() as usize;
+
+        let now = super::time::now();
+        let mut transmit_time = now + self.delay();
+        let transmit_time = &mut transmit_time;
+
+        let mut transmit = |packet: Cow<Packet>| {
+            // drop the packet if it's over the current MTU
+            if packet.payload.len() > mtu {
+                return 0;
+            }
+
+            // drop the packet if enabled
+            if drop_rate > 0 && super::rand::gen::<u64>() < drop_rate {
+                return 0;
+            }
+
+            let mut packet = packet.into_owned();
+
+            if corrupt_rate > 0 && super::rand::gen::<u64>() < corrupt_rate {
+                // randomly truncate the payload
+                let num_bytes = super::rand::gen_range(0..packet.payload.len());
+                if num_bytes > 0 {
+                    packet.payload.truncate(num_bytes);
+                }
+
+                // randomly swap bytes in the payload
+                let num_bytes = super::rand::gen_range(0..packet.payload.len());
+                if num_bytes > 0 {
+                    super::rand::swap_count(&mut packet.payload, num_bytes);
+                }
+
+                // randomly rewrite bytes in the payload
+                let num_bytes = super::rand::gen_range(0..packet.payload.len());
+                if num_bytes > 0 {
+                    for _ in 0..num_bytes {
+                        let index = super::rand::gen_range(0..packet.payload.len());
+                        packet.payload[index] = super::rand::gen();
+                    }
+                }
+            }
+
+            if !jitter.is_zero() {
+                // add a delay for the next packet to be transmitted
+                *transmit_time += gen_jitter(jitter);
+            }
+
+            // copy the transmit time for this packet
+            let mut transmit_time = *transmit_time;
+
+            if !network_jitter.is_zero() {
+                let jitter = gen_jitter(network_jitter);
+
+                // randomly add or subtract the network jitter
+                if super::rand::gen() {
+                    transmit_time += jitter;
+                } else {
+                    transmit_time = transmit_time.checked_sub(jitter).unwrap_or(now);
+                }
+            }
+
+            // reverse the addresses so the dst/src are correct for the receiver
+            packet.switch();
+
+            let model = self.clone();
+            model.0.current_inflight.fetch_add(1, Ordering::SeqCst);
+            let buffers = buffers.clone();
+
+            // spawn a task that will push the packet onto the receiver queue at the transit time
+            super::spawn(async move {
+                if now != transmit_time {
+                    super::time::delay_until(transmit_time).await;
+                }
+
+                buffers.rx(*packet.path.local_address, |queue| {
+                    model.0.current_inflight.fetch_sub(1, Ordering::SeqCst);
+                    queue.receive(packet);
+                });
+            });
+
+            1
+        };
+
+        let mut transmission_count = 0;
+        buffers.pending_transmissions(|packet| {
+            // drop packets that exceed the maximum number of inflight packets for the network
+            if self.inflight() >= self.max_inflight() {
+                return Ok(());
+            }
+
+            // retransmit the packet until the rate fails or we retransmit 5
+            let mut count = 0;
+            while retransmit_rate > 0
+                && count < 5
+                && super::rand::gen_range(0..retransmit_rate) == 0
+            {
+                transmission_count += transmit(Cow::Borrowed(&packet));
+                count += 1;
+            }
+
+            transmission_count += transmit(Cow::Owned(packet));
+
+            // continue transmitting as long as we are under the rate
+            if transmission_count < transmit_rate {
+                Ok(())
+            } else {
+                Err(())
+            }
+        });
+
+        transmission_count as usize
+    }
+}
+
+fn gen_jitter(max_jitter: Duration) -> Duration {
+    let micros = super::rand::gen_range(0..max_jitter.as_micros() as u64);
+    let micros = micros as f64;
+    // even though we're generated micros, we round to the nearest millisecond
+    // so packets can be grouped together
+    let millis = micros / 1000.0;
+    let millis = f64::round(millis) as u64;
+    Duration::from_millis(millis)
+}

--- a/quic/s2n-quic-platform/src/io/testing/network.rs
+++ b/quic/s2n-quic-platform/src/io/testing/network.rs
@@ -1,0 +1,401 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll, Waker},
+};
+use s2n_quic_core::{
+    inet::{datagram, ExplicitCongestionNotification, SocketAddress},
+    io::{
+        self,
+        tx::{Entry as _, Queue as _},
+    },
+    path::{LocalAddress, MaxMtu, Tuple},
+};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{
+        atomic::{AtomicU16, AtomicU32, Ordering},
+        Arc, Mutex,
+    },
+};
+
+pub type PathHandle = Tuple;
+
+pub trait Network {
+    fn execute(&mut self, buffers: &Buffers) -> usize;
+}
+
+#[derive(Clone, Debug)]
+pub struct Buffers {
+    inner: Arc<Mutex<State>>,
+    next_ip: Arc<AtomicU32>,
+    next_port: Arc<AtomicU16>,
+}
+
+impl Default for Buffers {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+            next_ip: Arc::new(AtomicU32::new(u32::from_be_bytes([1, 0, 0, 0]))),
+            //= https://www.rfc-editor.org/rfc/rfc6335#section-6
+            //# o  the Dynamic Ports, also known as the Private or Ephemeral Ports,
+            //#    from 49152-65535 (never assigned)
+            next_port: Arc::new(AtomicU16::new(49152)),
+        }
+    }
+}
+
+impl Buffers {
+    pub fn tx<F: FnOnce(&mut Queue)>(&self, handle: SocketAddress, f: F) {
+        let mut lock = self.inner.lock().unwrap();
+        if let Some(queue) = lock.tx.get_mut(&handle) {
+            f(queue)
+        }
+    }
+
+    pub fn rx<F: FnOnce(&mut Queue)>(&self, handle: SocketAddress, f: F) {
+        let mut lock = self.inner.lock().unwrap();
+        if let Some(queue) = lock.rx.get_mut(&handle) {
+            f(queue)
+        }
+    }
+
+    pub fn pending_transmissions<F: FnMut(Packet) -> Result<(), ()>>(&self, mut f: F) {
+        let mut lock = self.inner.lock().unwrap();
+
+        let mut queues = vec![];
+
+        // find all of the queues with at least one packet to transmit
+        for queue in lock.tx.values_mut() {
+            if queue.packets.is_empty() {
+                continue;
+            }
+
+            queues.push(queue);
+        }
+
+        loop {
+            let mut has_result = false;
+            for queue in &mut queues {
+                // transmit a single packet at a time per queue so they are fairly
+                // transmitted
+                if let Some(packet) = queue.packets.pop_front() {
+                    let result = f(packet);
+                    has_result = true;
+
+                    // notify the endpoint that it can send now
+                    if let Some(waker) = queue.waker.take() {
+                        waker.wake();
+                    }
+
+                    if result.is_err() {
+                        return;
+                    }
+                }
+            }
+
+            // if all of the queues are empty then just return
+            if !has_result {
+                return;
+            }
+        }
+    }
+
+    pub fn execute<N: Network>(&self, n: &mut N) {
+        n.execute(self);
+    }
+
+    pub(crate) fn readiness(&self, handle: SocketAddress) -> Readiness {
+        Readiness {
+            network: self,
+            handle,
+        }
+    }
+
+    /// Generate a unique address
+    pub fn generate_addr(&self) -> SocketAddress {
+        let ip = self
+            .next_ip
+            .fetch_add(1, Ordering::SeqCst)
+            .to_be_bytes()
+            .into();
+        let port = self.next_port.fetch_add(1, Ordering::SeqCst);
+        let addr = (ip, port);
+        SocketAddress::IpV4(addr.into())
+    }
+
+    /// Register an address on the network
+    pub fn register(&self, handle: SocketAddress) {
+        let mut lock = self.inner.lock().unwrap();
+
+        let queue = Queue::new(handle);
+
+        lock.tx.insert(handle, queue.clone());
+        lock.rx.insert(handle, queue);
+    }
+}
+
+pub(crate) struct Readiness<'a> {
+    network: &'a Buffers,
+    handle: SocketAddress,
+}
+
+impl<'a> Future for Readiness<'a> {
+    type Output = Result<(), ()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut lock = self.network.inner.lock().unwrap();
+
+        if !lock.is_open {
+            return Err(()).into();
+        }
+
+        let mut is_ready = false;
+
+        let tx = lock.tx.get_mut(&self.handle).unwrap();
+        if tx.is_blocked {
+            // if we were blocked and now have capacity wake up the endpoint
+            if tx.has_capacity() {
+                tx.is_blocked = false;
+                is_ready = true;
+            } else {
+                tx.waker = Some(cx.waker().clone());
+            }
+        }
+
+        let rx = lock.rx.get_mut(&self.handle).unwrap();
+        // wake up the endpoint if we have an rx message
+        if io::rx::Queue::is_empty(rx) {
+            rx.waker = Some(cx.waker().clone());
+        } else {
+            is_ready = true;
+        }
+
+        if is_ready {
+            Poll::Ready(Ok(()))
+        } else {
+            Poll::Pending
+        }
+    }
+}
+
+#[derive(Debug)]
+struct State {
+    is_open: bool,
+    tx: HashMap<SocketAddress, Queue>,
+    rx: HashMap<SocketAddress, Queue>,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            is_open: true,
+            tx: Default::default(),
+            rx: Default::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Queue {
+    capacity: usize,
+    mtu: u16,
+    packets: VecDeque<Packet>,
+    pending: Packet,
+    local_address: LocalAddress,
+    is_blocked: bool,
+    waker: Option<Waker>,
+}
+
+impl Queue {
+    fn new(addr: SocketAddress) -> Self {
+        let mtu = MaxMtu::default().into();
+        let local_address = addr.into();
+        Self {
+            capacity: 1024,
+            mtu,
+            packets: VecDeque::new(),
+            pending: Packet::new(mtu, local_address),
+            local_address,
+            is_blocked: false,
+            waker: None,
+        }
+    }
+
+    pub fn receive(&mut self, packet: Packet) {
+        if self.packets.len() == self.capacity {
+            // drop old packets if we're at capacity
+            let _ = self.packets.pop_front();
+        }
+
+        self.packets.push_back(packet);
+
+        if let Some(w) = self.waker.take() {
+            w.wake();
+        }
+    }
+
+    pub fn take(&mut self, count: usize) -> impl Iterator<Item = Packet> + '_ {
+        let count = self.packets.len().min(count);
+        self.packets.drain(..count)
+    }
+
+    pub fn drain(&mut self) -> impl Iterator<Item = Packet> + '_ {
+        self.packets.drain(..)
+    }
+}
+
+impl io::tx::Queue for Queue {
+    type Entry = Packet;
+    type Handle = Tuple;
+
+    const SUPPORTS_ECN: bool = true;
+
+    fn push<M: io::tx::Message<Handle = Self::Handle>>(
+        &mut self,
+        message: M,
+    ) -> Result<io::tx::Outcome, io::tx::Error> {
+        if !self.has_capacity() {
+            self.is_blocked = true;
+            return Err(io::tx::Error::AtCapacity);
+        }
+
+        let len = self.pending.set(message)?;
+        self.pending.payload.truncate(len);
+
+        // create a packet for the next transmission
+        let next = Packet::new(self.mtu, self.local_address);
+        let packet = core::mem::replace(&mut self.pending, next);
+
+        self.packets.push_back(packet);
+
+        Ok(io::tx::Outcome { len, index: 0 })
+    }
+
+    fn as_slice_mut(&mut self) -> &mut [Self::Entry] {
+        self.packets.make_contiguous()
+    }
+
+    fn capacity(&self) -> usize {
+        self.capacity - self.packets.len()
+    }
+
+    fn len(&self) -> usize {
+        self.packets.len()
+    }
+}
+
+impl io::rx::Queue for Queue {
+    type Entry = Packet;
+    type Handle = Tuple;
+
+    fn finish(&mut self, count: usize) {
+        self.packets.drain(..count);
+    }
+
+    fn len(&self) -> usize {
+        self.packets.len()
+    }
+
+    fn as_slice_mut(&mut self) -> &mut [Self::Entry] {
+        self.packets.make_contiguous()
+    }
+
+    fn local_address(&self) -> LocalAddress {
+        self.local_address
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Packet {
+    pub path: Tuple,
+    pub ecn: ExplicitCongestionNotification,
+    pub payload: Vec<u8>,
+}
+
+impl Packet {
+    fn new(mtu: u16, local_address: LocalAddress) -> Self {
+        Self {
+            path: Tuple {
+                local_address,
+                remote_address: Default::default(),
+            },
+            ecn: Default::default(),
+            payload: vec![0u8; mtu as usize],
+        }
+    }
+
+    pub fn switch(&mut self) {
+        let path = self.path;
+        let remote_address = path.local_address.0.into();
+        let local_address = path.remote_address.0.into();
+        self.path = Tuple {
+            remote_address,
+            local_address,
+        };
+    }
+}
+
+impl io::tx::Entry for Packet {
+    type Handle = Tuple;
+
+    fn set<M>(&mut self, mut message: M) -> Result<usize, io::tx::Error>
+    where
+        M: io::tx::Message<Handle = Tuple>,
+    {
+        self.path.remote_address = message.path_handle().remote_address;
+        self.ecn = message.ecn();
+        let len = message.write_payload(&mut self.payload, 0);
+
+        if len == 0 {
+            return Err(io::tx::Error::EmptyPayload);
+        }
+
+        Ok(len)
+    }
+
+    fn payload(&self) -> &[u8] {
+        &self.payload
+    }
+
+    fn payload_mut(&mut self) -> &mut [u8] {
+        &mut self.payload
+    }
+}
+
+impl io::rx::Entry for Packet {
+    type Handle = Tuple;
+
+    fn read(
+        &mut self,
+        _local_address: &LocalAddress,
+    ) -> Option<(datagram::Header<Self::Handle>, &mut [u8])> {
+        let header = datagram::Header {
+            path: self.path,
+            ecn: self.ecn,
+        };
+        let payload = &mut self.payload;
+        Some((header, payload))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_debug_snapshot;
+
+    #[test]
+    fn address_generator() {
+        let buffers = Buffers::default();
+
+        let mut addrs = vec![];
+        for _ in 0..10 {
+            addrs.push(buffers.generate_addr());
+        }
+
+        assert_debug_snapshot!(addrs);
+    }
+}

--- a/quic/s2n-quic-platform/src/io/testing/snapshots/s2n_quic_platform__io__testing__network__tests__address_generator.snap
+++ b/quic/s2n-quic-platform/src/io/testing/snapshots/s2n_quic_platform__io__testing__network__tests__address_generator.snap
@@ -1,0 +1,36 @@
+---
+source: quic/s2n-quic-platform/src/io/testing/network.rs
+expression: addrs
+---
+[
+    IpV4(
+        SocketAddressV4(1.0.0.0:49152),
+    ),
+    IpV4(
+        SocketAddressV4(1.0.0.1:49153),
+    ),
+    IpV4(
+        SocketAddressV4(1.0.0.2:49154),
+    ),
+    IpV4(
+        SocketAddressV4(1.0.0.3:49155),
+    ),
+    IpV4(
+        SocketAddressV4(1.0.0.4:49156),
+    ),
+    IpV4(
+        SocketAddressV4(1.0.0.5:49157),
+    ),
+    IpV4(
+        SocketAddressV4(1.0.0.6:49158),
+    ),
+    IpV4(
+        SocketAddressV4(1.0.0.7:49159),
+    ),
+    IpV4(
+        SocketAddressV4(1.0.0.8:49160),
+    ),
+    IpV4(
+        SocketAddressV4(1.0.0.9:49161),
+    ),
+]

--- a/quic/s2n-quic-platform/src/io/testing/time.rs
+++ b/quic/s2n-quic-platform/src/io/testing/time.rs
@@ -1,0 +1,86 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use bach::time::{self, scheduler};
+use core::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+use futures::ready;
+use s2n_quic_core::time::Timestamp;
+
+pub fn now() -> Timestamp {
+    unsafe { Timestamp::from_duration(time::now()) }
+}
+
+pub fn delay(duration: Duration) -> Timer {
+    Timer::new(now() + duration, duration)
+}
+
+pub fn delay_until(deadline: Timestamp) -> Timer {
+    let delay = deadline.saturating_duration_since(now());
+    Timer::new(deadline, delay)
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct Clock(());
+
+impl s2n_quic_core::time::Clock for Clock {
+    fn get_time(&self) -> Timestamp {
+        now()
+    }
+}
+
+pub struct Timer {
+    timer: scheduler::Timer,
+    deadline: Option<Timestamp>,
+}
+
+impl Default for Timer {
+    fn default() -> Self {
+        let timer = time::delay(Duration::ZERO);
+
+        Self {
+            timer,
+            deadline: None,
+        }
+    }
+}
+
+impl Timer {
+    fn new(deadline: Timestamp, delay: Duration) -> Self {
+        Self {
+            timer: time::delay(delay),
+            deadline: Some(deadline),
+        }
+    }
+
+    pub fn update(&mut self, deadline: Timestamp) {
+        if self.deadline != Some(deadline) {
+            self.cancel();
+            *self = delay_until(deadline);
+        }
+    }
+
+    pub fn cancel(&mut self) {
+        self.deadline = None;
+        self.timer.cancel()
+    }
+}
+
+impl Future for Timer {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if self.deadline.is_none() {
+            return Poll::Pending;
+        }
+
+        ready!(Pin::new(&mut self.timer).poll(cx));
+
+        self.deadline = None;
+        Poll::Ready(())
+    }
+}

--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -1,17 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::select::{self, Select};
 use crate::{buffer::default as buffer, features::gso, socket::default as socket};
 use cfg_if::cfg_if;
-use core::{
-    future::Future,
-    pin::Pin,
-    task::{Context, Poll},
-};
-use futures::future::{Fuse, FutureExt};
-use pin_project::pin_project;
 use s2n_quic_core::{
-    endpoint::{CloseError, Endpoint},
+    endpoint::Endpoint,
     event::{self, EndpointPublisher as _},
     inet::{self, SocketAddress},
     path::MaxMtu,
@@ -517,7 +511,7 @@ impl<E: Endpoint<PathHandle = PathHandle>> Instance<E> {
             // pin the wakeups future so we don't have to move it into the Select future.
             tokio::pin!(wakeups);
 
-            let SelectOutcome {
+            let select::Outcome {
                 rx_result,
                 tx_result,
                 timeout_expired,
@@ -565,114 +559,6 @@ impl<E: Endpoint<PathHandle = PathHandle>> Instance<E> {
                 timer.update(delay);
             }
         }
-    }
-}
-
-/// The main event loop future for selecting readiness of sub-tasks
-///
-/// This future ensures all sub-tasks are polled fairly by yielding once
-/// after completing any of the sub-tasks. This is especially important when the TX queue is
-/// flushed quickly and we never get notified of the RX socket having packets to read.
-#[pin_project]
-struct Select<Rx, Tx, Wakeup, Sleep>
-where
-    Rx: Future,
-    Tx: Future,
-    Wakeup: Future,
-    Sleep: Future,
-{
-    #[pin]
-    rx: Fuse<Rx>,
-    rx_out: Option<Rx::Output>,
-    #[pin]
-    tx: Fuse<Tx>,
-    tx_out: Option<Tx::Output>,
-    #[pin]
-    wakeup: Fuse<Wakeup>,
-    #[pin]
-    sleep: Sleep,
-}
-
-impl<Rx, Tx, Wakeup, Sleep> Select<Rx, Tx, Wakeup, Sleep>
-where
-    Rx: Future,
-    Tx: Future,
-    Wakeup: Future,
-    Sleep: Future,
-{
-    #[inline(always)]
-    fn new(rx: Rx, tx: Tx, wakeup: Wakeup, sleep: Sleep) -> Self {
-        Self {
-            rx: rx.fuse(),
-            rx_out: None,
-            tx: tx.fuse(),
-            tx_out: None,
-            wakeup: wakeup.fuse(),
-            sleep,
-        }
-    }
-}
-
-struct SelectOutcome<Rx, Tx> {
-    rx_result: Option<Rx>,
-    tx_result: Option<Tx>,
-    timeout_expired: bool,
-    application_wakeup: bool,
-}
-
-type SelectResult<Rx, Tx> = Result<SelectOutcome<Rx, Tx>, CloseError>;
-
-impl<Rx, Tx, Wakeup, Sleep> Future for Select<Rx, Tx, Wakeup, Sleep>
-where
-    Rx: Future,
-    Tx: Future,
-    Wakeup: Future<Output = Result<usize, CloseError>>,
-    Sleep: Future,
-{
-    type Output = SelectResult<Rx::Output, Tx::Output>;
-
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        let this = self.project();
-
-        let mut should_wake = false;
-        let mut application_wakeup = false;
-
-        if let Poll::Ready(wakeup) = this.wakeup.poll(cx) {
-            should_wake = true;
-            application_wakeup = true;
-            if let Err(err) = wakeup {
-                return Poll::Ready(Err(err));
-            }
-        }
-
-        if let Poll::Ready(v) = this.rx.poll(cx) {
-            should_wake = true;
-            *this.rx_out = Some(v);
-        }
-
-        if let Poll::Ready(v) = this.tx.poll(cx) {
-            should_wake = true;
-            *this.tx_out = Some(v);
-        }
-
-        let mut timeout_expired = false;
-
-        if this.sleep.poll(cx).is_ready() {
-            timeout_expired = true;
-            should_wake = true;
-        }
-
-        // if none of the subtasks are ready, return
-        if !should_wake {
-            return Poll::Pending;
-        }
-
-        Poll::Ready(Ok(SelectOutcome {
-            rx_result: this.rx_out.take(),
-            tx_result: this.tx_out.take(),
-            timeout_expired,
-            application_wakeup,
-        }))
     }
 }
 
@@ -724,7 +610,10 @@ mod async_fd_shim {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use core::convert::TryInto;
+    use core::{
+        convert::TryInto,
+        task::{Context, Poll},
+    };
     use s2n_quic_core::{
         endpoint::{self, CloseError},
         event,

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -35,7 +35,7 @@ unstable_client_hello = ["s2n-quic-tls/unstable_client_hello"]
 # This feature enables the datagram provider
 unstable-provider-datagram = []
 # This feature enables the testing IO provider
-unstable-provider-io-testing = ["s2n-quic-platform/testing"]
+unstable-provider-io-testing = ["s2n-quic-platform/io-testing"]
 # This feature enables the packet interceptor provider, which is invoked on each cleartext packet
 unstable-provider-packet-interceptor = []
 # This feature enables the random provider

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -34,6 +34,8 @@ provider-tls-s2n = ["s2n-quic-tls"]
 unstable_client_hello = ["s2n-quic-tls/unstable_client_hello"]
 # This feature enables the datagram provider
 unstable-provider-datagram = []
+# This feature enables the testing IO provider
+unstable-provider-io-testing = ["s2n-quic-platform/testing"]
 # This feature enables the packet interceptor provider, which is invoked on each cleartext packet
 unstable-provider-packet-interceptor = []
 # This feature enables the random provider
@@ -62,7 +64,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 bolero = { version = "0.6" }
-s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
+s2n-quic-core = { path = "../s2n-quic-core", features = ["testing", "event-tracing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }
-
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -69,6 +69,9 @@ pub use client::Client;
 pub use connection::Connection;
 pub use server::Server;
 
+#[cfg(test)]
+mod tests;
+
 // Require `--cfg s2n_quic_unstable` is set when using unstable features
 #[cfg(
     all(

--- a/quic/s2n-quic/src/provider/event/mod.rs
+++ b/quic/s2n-quic/src/provider/event/mod.rs
@@ -25,11 +25,11 @@ pub trait Provider {
 pub mod disabled;
 
 /// This module contains event integration with [`tracing`](https://docs.rs/tracing)
-#[cfg(feature = "provider-event-tracing")]
+#[cfg(any(feature = "provider-event-tracing", test))]
 pub mod tracing;
 
 cfg_if! {
-    if #[cfg(feature = "provider-event-tracing")] {
+    if #[cfg(any(feature = "provider-event-tracing", test))] {
         pub use self::tracing as default;
     } else {
         // Events are disabled by default.

--- a/quic/s2n-quic/src/provider/io.rs
+++ b/quic/s2n-quic/src/provider/io.rs
@@ -16,6 +16,9 @@ pub trait Provider: 'static {
     ) -> Result<SocketAddress, Self::Error>;
 }
 
+#[cfg(any(test, all(s2n_quic_unstable, feature = "unstable-provider-io-testing")))]
+pub mod testing;
+
 pub mod tokio;
 
 pub use self::tokio as default;

--- a/quic/s2n-quic/src/provider/io/testing.rs
+++ b/quic/s2n-quic/src/provider/io/testing.rs
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_quic_core::{endpoint::Endpoint, inet::SocketAddress};
+pub use s2n_quic_platform::io::testing;
+use std::io;
+
+pub use self::testing::*;
+
+impl super::Provider for Io {
+    type PathHandle = PathHandle;
+    type Error = io::Error;
+
+    fn start<E: Endpoint<PathHandle = Self::PathHandle>>(
+        self,
+        endpoint: E,
+    ) -> Result<SocketAddress, Self::Error> {
+        let (_join_handle, local_addr) = Io::start(self, endpoint)?;
+        Ok(local_addr)
+    }
+}

--- a/quic/s2n-quic/src/provider/io/testing.rs
+++ b/quic/s2n-quic/src/provider/io/testing.rs
@@ -39,28 +39,6 @@ pub fn test_seed<N: Network, F: FnOnce(&Handle) -> Result<O>, O>(
     seed: u64,
     f: F,
 ) -> Result<Duration> {
-    #[cfg(any(feature = "provider-event-tracing", test))]
-    {
-        use std::sync::Once;
-
-        static TRACING: Once = Once::new();
-
-        // make sure this only gets initialized once
-        TRACING.call_once(|| {
-            let format = tracing_subscriber::fmt::format()
-                .with_level(false) // don't include levels in formatted output
-                .with_timer(tracing_subscriber::fmt::time::uptime())
-                .with_ansi(false)
-                .compact(); // Use a less verbose output format.
-
-            tracing_subscriber::fmt()
-                .with_env_filter(tracing_subscriber::EnvFilter::new("debug"))
-                .event_format(format)
-                .with_test_writer()
-                .init();
-        });
-    }
-
     let mut executor = Executor::new(network, seed);
     let handle = executor.handle().clone();
 

--- a/quic/s2n-quic/src/provider/io/testing.rs
+++ b/quic/s2n-quic/src/provider/io/testing.rs
@@ -1,11 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use core::time::Duration;
 use s2n_quic_core::{endpoint::Endpoint, inet::SocketAddress};
 pub use s2n_quic_platform::io::testing;
 use std::io;
 
 pub use self::testing::*;
+
+pub type Error = Box<dyn 'static + std::error::Error>;
+pub type Result<T = (), E = Error> = core::result::Result<T, E>;
 
 impl super::Provider for Io {
     type PathHandle = PathHandle;
@@ -18,4 +22,54 @@ impl super::Provider for Io {
         let (_join_handle, local_addr) = Io::start(self, endpoint)?;
         Ok(local_addr)
     }
+}
+
+/// Runs a single test with the given network
+///
+/// Returns the total runtime of the test
+pub fn test<N: Network, F: FnOnce(&Handle) -> Result<O>, O>(network: N, f: F) -> Result<Duration> {
+    test_seed(network, 123456789, f)
+}
+
+/// Runs a single test with the given network and seed value
+///
+/// Returns the total runtime of the test
+pub fn test_seed<N: Network, F: FnOnce(&Handle) -> Result<O>, O>(
+    network: N,
+    seed: u64,
+    f: F,
+) -> Result<Duration> {
+    #[cfg(any(feature = "provider-event-tracing", test))]
+    {
+        use std::sync::Once;
+
+        static TRACING: Once = Once::new();
+
+        // make sure this only gets initialized once
+        TRACING.call_once(|| {
+            let format = tracing_subscriber::fmt::format()
+                .with_level(false) // don't include levels in formatted output
+                .with_timer(tracing_subscriber::fmt::time::uptime())
+                .with_ansi(false)
+                .compact(); // Use a less verbose output format.
+
+            tracing_subscriber::fmt()
+                .with_env_filter(tracing_subscriber::EnvFilter::new("debug"))
+                .event_format(format)
+                .with_test_writer()
+                .init();
+        });
+    }
+
+    let mut executor = Executor::new(network, seed);
+    let handle = executor.handle().clone();
+
+    executor.enter(|| f(&handle))?;
+
+    executor.run();
+
+    // return the total runtime of the test
+    let now = executor.enter(time::now);
+    let now = unsafe { now.as_duration() };
+    Ok(now)
 }

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -1,0 +1,159 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    client::Connect,
+    provider::io::testing::{spawn, spawn_primary, time::delay, Executor, Handle, Model},
+    Client, Server,
+};
+use s2n_quic_core::{crypto::tls::testing::certificates, stream::testing::Data};
+use std::{net::SocketAddr, sync::Once, time::Duration};
+
+type Error = Box<dyn 'static + std::error::Error>;
+type Result<T = (), E = Error> = core::result::Result<T, E>;
+
+fn setup<F: FnOnce(&Handle) -> Result<O>, O>(network: Model, f: F) {
+    setup_seed(network, 123456789, f)
+}
+
+fn setup_seed<F: FnOnce(&Handle) -> Result<O>, O>(network: Model, seed: u64, f: F) {
+    static TRACING: Once = Once::new();
+
+    // make sure this only gets initialized once
+    TRACING.call_once(|| {
+        let format = tracing_subscriber::fmt::format()
+            .with_level(false) // don't include levels in formatted output
+            .with_timer(tracing_subscriber::fmt::time::uptime())
+            .with_ansi(false)
+            .compact(); // Use a less verbose output format.
+
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::new("debug"))
+            .event_format(format)
+            .with_test_writer()
+            .init();
+    });
+
+    let mut executor = Executor::new(network, seed);
+    let handle = executor.handle().clone();
+
+    let result = executor.enter(|| f(&handle));
+
+    if let Err(err) = result {
+        panic!("{:?}", err);
+    }
+
+    executor.run();
+}
+
+fn server(handle: &Handle) -> Result<SocketAddr> {
+    let mut server = Server::builder()
+        .with_io(handle.builder().build().unwrap())?
+        .with_tls((certificates::CERT_PEM, certificates::KEY_PEM))?
+        .with_event(crate::provider::event::tracing::Provider::default())?
+        .start()?;
+    let server_addr = server.local_addr()?;
+
+    // accept connections and echo back
+    spawn(async move {
+        while let Some(mut connection) = server.accept().await {
+            spawn(async move {
+                while let Ok(Some(mut stream)) = connection.accept_bidirectional_stream().await {
+                    spawn(async move {
+                        while let Ok(Some(chunk)) = stream.receive().await {
+                            let _ = stream.send(chunk).await;
+                        }
+                    });
+                }
+            });
+        }
+    });
+
+    Ok(server_addr)
+}
+
+fn client(handle: &Handle, server_addr: SocketAddr) -> Result {
+    let client = Client::builder()
+        .with_io(handle.builder().build().unwrap())?
+        .with_tls(certificates::CERT_PEM)?
+        .with_event(crate::provider::event::tracing::Provider::default())?
+        .start()?;
+
+    spawn_primary(async move {
+        let connect = Connect::new(server_addr).with_server_name("localhost");
+        let mut connection = client.connect(connect).await.unwrap();
+
+        let stream = connection.open_bidirectional_stream().await.unwrap();
+        let (mut recv, mut send) = stream.split();
+
+        let mut send_data = Data::new(10_000);
+
+        let mut recv_data = send_data;
+        spawn_primary(async move {
+            while let Some(chunk) = recv.receive().await.unwrap() {
+                recv_data.receive(&[chunk]);
+            }
+            assert!(recv_data.is_finished());
+        });
+
+        while let Some(chunk) = send_data.send_one(usize::MAX) {
+            send.send(chunk).await.unwrap();
+        }
+    });
+
+    Ok(())
+}
+
+fn client_server(handle: &Handle) -> Result<SocketAddr> {
+    let addr = server(handle)?;
+    client(handle, addr)?;
+    Ok(addr)
+}
+
+#[test]
+fn client_server_test() {
+    setup(Model::default(), client_server);
+}
+
+fn blackhole(model: Model, blackhole_duration: Duration) {
+    setup(model.clone(), |handle| {
+        spawn(async move {
+            // switch back and forth between blackhole and not
+            loop {
+                delay(blackhole_duration).await;
+                // drop all packets
+                model.set_drop_rate(1.0);
+
+                delay(blackhole_duration).await;
+                model.set_drop_rate(0.0);
+            }
+        });
+        client_server(handle)
+    })
+}
+
+#[test]
+fn blackhole_success_test() {
+    let model = Model::default();
+
+    let network_delay = Duration::from_millis(1000);
+    model.set_delay(network_delay);
+
+    // setting the blackhole time to `network_delay / 2` causes the connection to
+    // succeed
+    let blackhole_duration = network_delay / 2;
+    blackhole(model, blackhole_duration);
+}
+
+#[test]
+#[should_panic]
+fn blackhole_failure_test() {
+    let model = Model::default();
+
+    let network_delay = Duration::from_millis(1000);
+    model.set_delay(network_delay);
+
+    // setting the blackhole time to `network_delay / 2 + 1` causes the connection to fail
+    let blackhole_duration = network_delay / 2 + Duration::from_millis(1);
+    blackhole(model, blackhole_duration);
+}


### PR DESCRIPTION
### Description of changes: 

This change wires up s2n-quic to my [discrete event simulator](https://en.wikipedia.org/wiki/Discrete-event_simulation) framework, [bach](https://docs.rs/bach), which is an async rust runtime that it executes in hyper-real time by looking at the scheduler and fast-forwarding on to the next event. its execution is completely determined by the initial seed of the executor so it's really easy to reproduce results.

One thing I'm excited about is running [monte carlo](https://en.wikipedia.org/wiki/Monte_Carlo_method) simulations, for example, with network loss rates and get an idea of connection failure rates. It should be really interesting to explore this more and get an idea of the boundaries of failure modes:

```rust
#[test]
fn loss_test() {
    let model = Model::default();
    model.set_delay(Duration::from_millis(100));

    for drop_rate in [30, 35, 40, 50, 60, 75].iter().copied() {
        model.set_drop_rate(drop_rate as f64 / 100.0);
        let mut success = 0;
        for seed in 0..100 {
            let res = setup_seed(model.clone(), seed, client_server);
            if res.is_ok() {
                success += 1;
            }
        }
        eprintln!("Drop rate {}%: {}/100", drop_rate, success);
    }
}
```

```
---- tests::loss_test stdout ----
Drop rate 30%: 100/100
Drop rate 35%: 99/100
Drop rate 40%: 95/100
Drop rate 50%: 87/100
Drop rate 60%: 41/100
Drop rate 65%: 18/100
Drop rate 70%: 3/100
Drop rate 75%: 0/100
```

The IO testing provider is also now exposed as an unstable provider which will allow it to be executed in other test binaries.

### Testing:

I've added some high level tests in the `s2n-quic` crate. This should make it really easy to start testing our public API in a really controlled way.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

