### PR TITLE
feat(s2n-quic): Define the datagram provider

### DIFF
--- a/quic/s2n-quic-core/src/datagram.rs
+++ b/quic/s2n-quic-core/src/datagram.rs
@@ -1,8 +1,15 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-pub trait DatagramApi: Sender + Receiver {}
+pub trait Endpoint: 'static + Send {
+    type Sender: Sender;
+    type Receiver: Receiver;
 
-impl<T: 'static + Sender + Receiver + Send> DatagramApi for T {}
+    fn create_connection(&mut self, info: &ConnectionInfo) -> (Self::Sender, Self::Receiver);
+}
+
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct ConnectionInfo {}
 
 pub trait Sender: 'static + Send {}
 pub trait Receiver: 'static + Send {}
@@ -10,5 +17,16 @@ pub trait Receiver: 'static + Send {}
 #[derive(Debug, Default)]
 pub struct Disabled;
 
-impl Receiver for Disabled {}
-impl Sender for Disabled {}
+impl Endpoint for Disabled {
+    type Sender = DisabledSender;
+    type Receiver = DisabledReceiver;
+
+    fn create_connection(&mut self, _info: &ConnectionInfo) -> (Self::Sender, Self::Receiver) {
+        (DisabledSender, DisabledReceiver)
+    }
+}
+pub struct DisabledSender;
+pub struct DisabledReceiver;
+
+impl Receiver for DisabledReceiver {}
+impl Sender for DisabledSender {}

--- a/quic/s2n-quic-core/src/datagram.rs
+++ b/quic/s2n-quic-core/src/datagram.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+pub trait DatagramApi: Sender + Receiver {}
+
+impl<T: 'static + Sender + Receiver + Send> DatagramApi for T {}
+
+pub trait Sender: 'static + Send {}
+pub trait Receiver: 'static + Send {}
+
+#[derive(Debug, Default)]
+pub struct Disabled;
+
+impl Receiver for Disabled {}
+impl Sender for Disabled {}

--- a/quic/s2n-quic-core/src/lib.rs
+++ b/quic/s2n-quic-core/src/lib.rs
@@ -12,6 +12,7 @@ pub mod connection;
 pub mod counter;
 pub mod crypto;
 pub mod ct;
+pub mod datagram;
 pub mod endpoint;
 pub mod event;
 pub mod frame;

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -43,7 +43,7 @@ pub trait Config: 'static + Send + Sized + core::fmt::Debug {
     /// The packet_interceptor implementation for the endpoint
     type PacketInterceptor: packet::interceptor::Interceptor;
     /// The datagram implementation for the endpoint
-    type Datagram: datagram::DatagramApi;
+    type DatagramEndpoint: datagram::Endpoint;
 
     /// The type of the local endpoint
     const ENDPOINT_TYPE: endpoint::Type;
@@ -86,5 +86,5 @@ pub struct Context<'a, Cfg: Config> {
 
     pub packet_interceptor: &'a mut Cfg::PacketInterceptor,
 
-    pub datagram: &'a mut Cfg::Datagram,
+    pub datagram: &'a mut Cfg::DatagramEndpoint,
 }

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -5,7 +5,7 @@
 
 use crate::{connection, stream};
 use s2n_quic_core::{
-    crypto::tls, endpoint, event, packet, path, random, recovery::congestion_controller,
+    crypto::tls, datagram, endpoint, event, packet, path, random, recovery::congestion_controller,
     stateless_reset,
 };
 
@@ -42,6 +42,8 @@ pub trait Config: 'static + Send + Sized + core::fmt::Debug {
     type PathMigrationValidator: path::migration::Validator;
     /// The packet_interceptor implementation for the endpoint
     type PacketInterceptor: packet::interceptor::Interceptor;
+    /// The datagram implementation for the endpoint
+    type Datagram: datagram::DatagramApi;
 
     /// The type of the local endpoint
     const ENDPOINT_TYPE: endpoint::Type;
@@ -83,4 +85,6 @@ pub struct Context<'a, Cfg: Config> {
     pub path_migration: &'a mut Cfg::PathMigrationValidator,
 
     pub packet_interceptor: &'a mut Cfg::PacketInterceptor,
+
+    pub datagram: &'a mut Cfg::Datagram,
 }

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -1142,6 +1142,7 @@ pub mod testing {
         type EventSubscriber = Subscriber;
         type PathMigrationValidator = path::migration::default::Validator;
         type PacketInterceptor = s2n_quic_core::packet::interceptor::Disabled;
+        type Datagram = s2n_quic_core::datagram::Disabled;
 
         fn context(&mut self) -> super::Context<Self> {
             todo!()
@@ -1171,6 +1172,7 @@ pub mod testing {
         type EventSubscriber = Subscriber;
         type PathMigrationValidator = path::migration::default::Validator;
         type PacketInterceptor = s2n_quic_core::packet::interceptor::Disabled;
+        type Datagram = s2n_quic_core::datagram::Disabled;
 
         fn context(&mut self) -> super::Context<Self> {
             todo!()

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -1142,7 +1142,7 @@ pub mod testing {
         type EventSubscriber = Subscriber;
         type PathMigrationValidator = path::migration::default::Validator;
         type PacketInterceptor = s2n_quic_core::packet::interceptor::Disabled;
-        type Datagram = s2n_quic_core::datagram::Disabled;
+        type DatagramEndpoint = s2n_quic_core::datagram::Disabled;
 
         fn context(&mut self) -> super::Context<Self> {
             todo!()
@@ -1172,7 +1172,7 @@ pub mod testing {
         type EventSubscriber = Subscriber;
         type PathMigrationValidator = path::migration::default::Validator;
         type PacketInterceptor = s2n_quic_core::packet::interceptor::Disabled;
-        type Datagram = s2n_quic_core::datagram::Disabled;
+        type DatagramEndpoint = s2n_quic_core::datagram::Disabled;
 
         fn context(&mut self) -> super::Context<Self> {
             todo!()

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -36,6 +36,8 @@ unstable_client_hello = ["s2n-quic-tls/unstable_client_hello"]
 unstable-provider-packet-interceptor = []
 # This feature enables the random provider
 unstable-provider-random = []
+# This feature enables the datagram provider
+unstable-provider-datagram = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -32,12 +32,12 @@ provider-tls-s2n = ["s2n-quic-tls"]
 #
 # This depends on experimental behavior in s2n-tls.
 unstable_client_hello = ["s2n-quic-tls/unstable_client_hello"]
+# This feature enables the datagram provider
+unstable-provider-datagram = []
 # This feature enables the packet interceptor provider, which is invoked on each cleartext packet
 unstable-provider-packet-interceptor = []
 # This feature enables the random provider
 unstable-provider-random = []
-# This feature enables the datagram provider
-unstable-provider-datagram = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }

--- a/quic/s2n-quic/src/client/providers.rs
+++ b/quic/s2n-quic/src/client/providers.rs
@@ -20,6 +20,7 @@ impl_providers_state! {
         io: IO,
         sync: Sync,
         tls: Tls,
+        datagram: Datagram,
     }
 
     /// Opaque trait containing all of the configured providers
@@ -38,6 +39,7 @@ impl<
         IO: io::Provider,
         Sync: sync::Provider,
         Tls: tls::Provider,
+        Datagram: datagram::Provider,
     >
     Providers<
         CongestionController,
@@ -51,6 +53,7 @@ impl<
         IO,
         Sync,
         Tls,
+        Datagram,
     >
 {
     pub fn start(self) -> Result<Client, StartError> {
@@ -66,6 +69,7 @@ impl<
             io,
             sync,
             tls,
+            datagram,
         } = self;
 
         let congestion_controller = congestion_controller.start().map_err(StartError::new)?;
@@ -83,6 +87,7 @@ impl<
         let sync = sync.start().map_err(StartError::new)?;
         let path_migration = PathMigration;
         let tls = tls.start_client().map_err(StartError::new)?;
+        let datagram = datagram.start().map_err(StartError::new)?;
 
         // Validate providers
         // TODO: Add more validation https://github.com/aws/s2n-quic/issues/285
@@ -111,6 +116,7 @@ impl<
             token,
             path_handle: PhantomData,
             path_migration,
+            datagram,
         };
 
         let (endpoint, connector) = endpoint::Endpoint::new_client(endpoint_config);
@@ -195,6 +201,7 @@ struct EndpointConfig<
     Limits,
     Sync,
     Tls,
+    Datagram,
 > {
     congestion_controller: CongestionController,
     connection_close_formatter: ConnectionCloseFormatter,
@@ -210,6 +217,7 @@ struct EndpointConfig<
     token: Token,
     path_handle: PhantomData<PathHandle>,
     path_migration: PathMigration,
+    datagram: Datagram,
 }
 
 impl<
@@ -224,6 +232,7 @@ impl<
         Limits: s2n_quic_core::connection::limits::Limiter,
         Sync,
         Tls: crypto::tls::Endpoint,
+        Datagram: s2n_quic_core::datagram::DatagramApi,
     > core::fmt::Debug
     for EndpointConfig<
         CongestionController,
@@ -237,6 +246,7 @@ impl<
         Limits,
         Sync,
         Tls,
+        Datagram,
     >
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -256,6 +266,7 @@ impl<
         Limits: s2n_quic_core::connection::limits::Limiter,
         Sync: 'static + Send,
         Tls: crypto::tls::Endpoint,
+        Datagram: s2n_quic_core::datagram::DatagramApi,
     > endpoint::Config
     for EndpointConfig<
         CongestionController,
@@ -269,6 +280,7 @@ impl<
         Limits,
         Sync,
         Tls,
+        Datagram,
     >
 {
     type ConnectionIdFormat = ConnectionID;
@@ -288,6 +300,7 @@ impl<
     type Stream = stream::StreamImpl;
     type PathMigrationValidator = PathMigration;
     type PacketInterceptor = PacketInterceptor;
+    type Datagram = Datagram;
 
     const ENDPOINT_TYPE: endpoint::Type = endpoint::Type::Client;
 
@@ -305,6 +318,7 @@ impl<
             connection_limits: &mut self.limits,
             event_subscriber: &mut self.event,
             path_migration: &mut self.path_migration,
+            datagram: &mut self.datagram,
         }
     }
 }

--- a/quic/s2n-quic/src/client/providers.rs
+++ b/quic/s2n-quic/src/client/providers.rs
@@ -232,7 +232,7 @@ impl<
         Limits: s2n_quic_core::connection::limits::Limiter,
         Sync,
         Tls: crypto::tls::Endpoint,
-        Datagram: s2n_quic_core::datagram::DatagramApi,
+        Datagram: s2n_quic_core::datagram::Endpoint,
     > core::fmt::Debug
     for EndpointConfig<
         CongestionController,
@@ -266,7 +266,7 @@ impl<
         Limits: s2n_quic_core::connection::limits::Limiter,
         Sync: 'static + Send,
         Tls: crypto::tls::Endpoint,
-        Datagram: s2n_quic_core::datagram::DatagramApi,
+        Datagram: s2n_quic_core::datagram::Endpoint,
     > endpoint::Config
     for EndpointConfig<
         CongestionController,
@@ -300,7 +300,7 @@ impl<
     type Stream = stream::StreamImpl;
     type PathMigrationValidator = PathMigration;
     type PacketInterceptor = PacketInterceptor;
-    type Datagram = Datagram;
+    type DatagramEndpoint = Datagram;
 
     const ENDPOINT_TYPE: endpoint::Type = endpoint::Type::Client;
 

--- a/quic/s2n-quic/src/provider.rs
+++ b/quic/s2n-quic/src/provider.rs
@@ -38,6 +38,14 @@ cfg_if!(
     }
 );
 
+cfg_if!(
+    if #[cfg(all(s2n_quic_unstable, feature = "unstable-provider-datagram"))] {
+        pub mod datagram;
+    } else {
+        pub(crate) mod datagram;
+    }
+);
+
 /// An error indicating a failure to start an endpoint
 pub struct StartError(Box<dyn 'static + fmt::Display>);
 

--- a/quic/s2n-quic/src/provider/datagram.rs
+++ b/quic/s2n-quic/src/provider/datagram.rs
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provides unreliable datagram support
+
+use s2n_quic_core::datagram::{DatagramApi, Disabled};
+pub trait Provider: 'static {
+    type DatagramApi: 'static + DatagramApi;
+    type Error: core::fmt::Display;
+
+    fn start(self) -> Result<Self::DatagramApi, Self::Error>;
+}
+
+impl_provider_utils!();
+
+pub type Default = Disabled;
+
+impl<T: 'static + Send + DatagramApi> Provider for T {
+    type DatagramApi = T;
+    type Error = core::convert::Infallible;
+
+    fn start(self) -> Result<Self::DatagramApi, Self::Error> {
+        Ok(self)
+    }
+}

--- a/quic/s2n-quic/src/provider/datagram.rs
+++ b/quic/s2n-quic/src/provider/datagram.rs
@@ -3,23 +3,23 @@
 
 //! Provides unreliable datagram support
 
-use s2n_quic_core::datagram::{DatagramApi, Disabled};
-pub trait Provider: 'static {
-    type DatagramApi: 'static + DatagramApi;
-    type Error: core::fmt::Display;
+use s2n_quic_core::datagram::{Disabled, Endpoint};
+pub trait Provider {
+    type Endpoint: Endpoint;
+    type Error: 'static + core::fmt::Display;
 
-    fn start(self) -> Result<Self::DatagramApi, Self::Error>;
+    fn start(self) -> Result<Self::Endpoint, Self::Error>;
 }
 
 impl_provider_utils!();
 
 pub type Default = Disabled;
 
-impl<T: 'static + Send + DatagramApi> Provider for T {
-    type DatagramApi = T;
+impl<T: 'static + Send + Endpoint> Provider for T {
+    type Endpoint = T;
     type Error = core::convert::Infallible;
 
-    fn start(self) -> Result<Self::DatagramApi, Self::Error> {
+    fn start(self) -> Result<Self::Endpoint, Self::Error> {
         Ok(self)
     }
 }

--- a/quic/s2n-quic/src/server/providers.rs
+++ b/quic/s2n-quic/src/server/providers.rs
@@ -193,7 +193,7 @@ impl<
         Sync,
         Tls: crypto::tls::Endpoint,
         AddressToken: address_token::Format,
-        Datagram: s2n_quic_core::datagram::DatagramApi,
+        Datagram: s2n_quic_core::datagram::Endpoint,
     > core::fmt::Debug
     for EndpointConfig<
         CongestionController,
@@ -233,7 +233,7 @@ impl<
         Sync: 'static + Send,
         Tls: crypto::tls::Endpoint,
         AddressToken: address_token::Format,
-        Datagram: s2n_quic_core::datagram::DatagramApi,
+        Datagram: s2n_quic_core::datagram::Endpoint,
     > endpoint::Config
     for EndpointConfig<
         CongestionController,
@@ -270,7 +270,7 @@ impl<
     type Stream = stream::StreamImpl;
     type PathMigrationValidator = PathMigration;
     type PacketInterceptor = PacketInterceptor;
-    type Datagram = Datagram;
+    type DatagramEndpoint = Datagram;
 
     const ENDPOINT_TYPE: endpoint::Type = endpoint::Type::Server;
 


### PR DESCRIPTION
### Resolved issues:

related to #1253 

### Description of changes: 

Adding the skeleton of a datagram provider. This is a pretty minimal PR. I am not defining the Sender and Receiver traits, as I just wanted to make sure I'm creating the provider correctly. 

### Call-outs:
I'm not sure if this is the cleanest way of implementing the Disabled DatagramEndpoint. Lmk if there's a better way.

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

