### PR TITLE
refactor(s2n-quic-transport): change fn signature to take timestamp

### DIFF
--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -2718,7 +2718,7 @@ fn ack_packets_on_path(
         ecn_counts,
     };
 
-    let _ = manager.on_ack_frame(&datagram, frame, context, publisher);
+    let _ = manager.on_ack_frame(datagram.timestamp, frame, context, publisher);
 
     for packet in acked_packets {
         assert!(manager.sent_packets.get(packet).is_none());
@@ -3066,7 +3066,7 @@ impl<'a> recovery::Context<Config> for MockContext<'a> {
 
     fn validate_packet_ack(
         &mut self,
-        _datagram: &DatagramInfo,
+        _timestamp: Timestamp,
         _packet_number_range: &PacketNumberRange,
     ) -> Result<(), transport::Error> {
         self.validate_packet_ack_count += 1;
@@ -3081,11 +3081,7 @@ impl<'a> recovery::Context<Config> for MockContext<'a> {
         self.on_new_packet_ack_count += 1;
     }
 
-    fn on_packet_ack(
-        &mut self,
-        _datagram: &DatagramInfo,
-        _packet_number_range: &PacketNumberRange,
-    ) {
+    fn on_packet_ack(&mut self, _timestamp: Timestamp, _packet_number_range: &PacketNumberRange) {
         self.on_packet_ack_count += 1;
     }
 

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -439,11 +439,11 @@ impl<'a, Config: endpoint::Config> recovery::Context<Config> for RecoveryContext
 
     fn validate_packet_ack(
         &mut self,
-        datagram: &DatagramInfo,
+        timestamp: Timestamp,
         packet_number_range: &PacketNumberRange,
     ) -> Result<(), transport::Error> {
         self.tx_packet_numbers
-            .on_packet_ack(datagram, packet_number_range)
+            .on_packet_ack(timestamp, packet_number_range)
     }
 
     fn on_new_packet_ack<Pub: event::ConnectionPublisher>(
@@ -454,9 +454,9 @@ impl<'a, Config: endpoint::Config> recovery::Context<Config> for RecoveryContext
         self.crypto_stream.on_packet_ack(packet_number_range);
     }
 
-    fn on_packet_ack(&mut self, datagram: &DatagramInfo, packet_number_range: &PacketNumberRange) {
+    fn on_packet_ack(&mut self, timestamp: Timestamp, packet_number_range: &PacketNumberRange) {
         self.ack_manager
-            .on_packet_ack(datagram, packet_number_range);
+            .on_packet_ack(timestamp, packet_number_range);
     }
 
     fn on_packet_loss<Pub: event::ConnectionPublisher>(
@@ -494,7 +494,7 @@ impl<Config: endpoint::Config> PacketSpace<Config> for HandshakeSpace<Config> {
     fn handle_ack_frame<A: AckRanges, Pub: event::ConnectionPublisher>(
         &mut self,
         frame: Ack<A>,
-        datagram: &DatagramInfo,
+        timestamp: Timestamp,
         path_id: path::Id,
         path_manager: &mut path::Manager<Config>,
         handshake_status: &mut HandshakeStatus,
@@ -505,13 +505,13 @@ impl<Config: endpoint::Config> PacketSpace<Config> for HandshakeSpace<Config> {
         path.on_peer_validated();
         let (recovery_manager, mut context) =
             self.recovery(handshake_status, path_id, path_manager);
-        recovery_manager.on_ack_frame(datagram, frame, &mut context, publisher)
+        recovery_manager.on_ack_frame(timestamp, frame, &mut context, publisher)
     }
 
     fn handle_connection_close_frame(
         &mut self,
         frame: ConnectionClose,
-        _datagram: &DatagramInfo,
+        _timestamp: Timestamp,
         _path: &mut Path<Config>,
     ) -> Result<(), transport::Error> {
         //= https://www.rfc-editor.org/rfc/rfc9000#section-17.2.4

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -579,11 +579,11 @@ impl<'a, Config: endpoint::Config> recovery::Context<Config> for RecoveryContext
 
     fn validate_packet_ack(
         &mut self,
-        datagram: &DatagramInfo,
+        timestamp: Timestamp,
         packet_number_range: &PacketNumberRange,
     ) -> Result<(), transport::Error> {
         self.tx_packet_numbers
-            .on_packet_ack(datagram, packet_number_range)
+            .on_packet_ack(timestamp, packet_number_range)
     }
 
     fn on_new_packet_ack<Pub: event::ConnectionPublisher>(
@@ -594,9 +594,9 @@ impl<'a, Config: endpoint::Config> recovery::Context<Config> for RecoveryContext
         self.crypto_stream.on_packet_ack(packet_number_range);
     }
 
-    fn on_packet_ack(&mut self, datagram: &DatagramInfo, packet_number_range: &PacketNumberRange) {
+    fn on_packet_ack(&mut self, timestamp: Timestamp, packet_number_range: &PacketNumberRange) {
         self.ack_manager
-            .on_packet_ack(datagram, packet_number_range);
+            .on_packet_ack(timestamp, packet_number_range);
     }
 
     fn on_packet_loss<Pub: event::ConnectionPublisher>(
@@ -644,7 +644,7 @@ impl<Config: endpoint::Config> PacketSpace<Config> for InitialSpace<Config> {
     fn handle_ack_frame<A: AckRanges, Pub: event::ConnectionPublisher>(
         &mut self,
         frame: Ack<A>,
-        datagram: &DatagramInfo,
+        timestamp: Timestamp,
         path_id: path::Id,
         path_manager: &mut path::Manager<Config>,
         handshake_status: &mut HandshakeStatus,
@@ -653,13 +653,13 @@ impl<Config: endpoint::Config> PacketSpace<Config> for InitialSpace<Config> {
     ) -> Result<(), transport::Error> {
         let (recovery_manager, mut context) =
             self.recovery(handshake_status, path_id, path_manager);
-        recovery_manager.on_ack_frame(datagram, frame, &mut context, publisher)
+        recovery_manager.on_ack_frame(timestamp, frame, &mut context, publisher)
     }
 
     fn handle_connection_close_frame(
         &mut self,
         frame: ConnectionClose,
-        _datagram: &DatagramInfo,
+        _timestamp: Timestamp,
         _path: &mut Path<Config>,
     ) -> Result<(), transport::Error> {
         //= https://www.rfc-editor.org/rfc/rfc9000#section-17.2.2

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/ack_manager.rs
@@ -15,7 +15,6 @@ use s2n_quic_core::{
     ack,
     counter::{Counter, Saturating},
     frame::{ack::EcnCounts, Ack, Ping},
-    inet::DatagramInfo,
     packet::number::{PacketNumber, PacketNumberSpace},
     time::{timer, Timer, Timestamp},
     varint::VarInt,
@@ -164,7 +163,7 @@ impl AckManager {
     }
 
     /// Called when a set of packets was acknowledged
-    pub fn on_packet_ack<A: ack::Set>(&mut self, _datagram: &DatagramInfo, ack_set: &A) {
+    pub fn on_packet_ack<A: ack::Set>(&mut self, _timestamp: Timestamp, ack_set: &A) {
         if let Some(ack_range) = self.ack_eliciting_transmissions.on_update(ack_set) {
             self.ack_ranges
                 .remove(ack_range)
@@ -360,7 +359,7 @@ mod tests {
     use s2n_quic_core::{
         ack, connection, endpoint,
         frame::{ack_elicitation::AckElicitation, ping, Frame},
-        inet::ExplicitCongestionNotification,
+        inet::{DatagramInfo, ExplicitCongestionNotification},
         time::{Clock, NoopClock},
     };
 

--- a/quic/s2n-quic-transport/src/space/rx_packet_numbers/tests/endpoint.rs
+++ b/quic/s2n-quic-transport/src/space/rx_packet_numbers/tests/endpoint.rs
@@ -56,7 +56,8 @@ impl Endpoint {
 
         if let Some(ack) = packet.ack {
             for ack_range in ack.ack_ranges {
-                self.ack_manager.on_packet_ack(&datagram, &ack_range);
+                self.ack_manager
+                    .on_packet_ack(datagram.timestamp, &ack_range);
             }
         }
 

--- a/quic/s2n-quic-transport/src/space/tx_packet_numbers.rs
+++ b/quic/s2n-quic-transport/src/space/tx_packet_numbers.rs
@@ -3,7 +3,6 @@
 
 use s2n_quic_core::{
     ack,
-    inet::DatagramInfo,
     packet::number::{PacketNumber, PacketNumberSpace},
     time::Timestamp,
     transport,
@@ -29,7 +28,7 @@ impl TxPacketNumbers {
     /// This method gets called when a packet delivery got acknowledged
     pub fn on_packet_ack<A: ack::Set>(
         &mut self,
-        datagram: &DatagramInfo,
+        timestamp: Timestamp,
         ack_set: &A,
     ) -> Result<(), transport::Error> {
         let largest = ack_set.largest();
@@ -46,7 +45,7 @@ impl TxPacketNumbers {
 
         // record the largest packet acked
         if largest > self.largest_sent_acked.0 {
-            self.largest_sent_acked = (largest, datagram.timestamp);
+            self.largest_sent_acked = (largest, timestamp);
         }
 
         Ok(())


### PR DESCRIPTION
This PR changes function signatures to take `Timestamp` instead of `DatagramInfo`.

Some functions in recovery manager take `DatagramInfo` but only use the `Timestamp` field. Since the delayed ack optimization is planning to store ack information and process it later, it would be nice to only store the timestamp rather than the entire datagram info.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

