### PR TITLE
feat(netbench): add io buffering to native-tls and tcp

### DIFF
--- a/netbench/netbench-driver/src/bin/netbench-driver-tcp-client.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-tcp-client.rs
@@ -5,7 +5,10 @@ use netbench::{multiplex, scenario, Result};
 use netbench_driver::Allocator;
 use std::{collections::HashSet, future::Future, net::SocketAddr, pin::Pin, sync::Arc};
 use structopt::StructOpt;
-use tokio::{io::AsyncWriteExt, net::TcpStream};
+use tokio::{
+    io::{self, AsyncWriteExt},
+    net::TcpStream,
+};
 
 #[global_allocator]
 static ALLOCATOR: Allocator = Allocator::new();
@@ -29,7 +32,12 @@ impl Client {
         // TODO pull from scenario configuration
         let config = multiplex::Config::default();
 
-        let client = ClientImpl { config, id: 0 };
+        let client = ClientImpl {
+            config,
+            id: 0,
+            rx_buffer: *self.opts.rx_buffer as _,
+            tx_buffer: *self.opts.tx_buffer as _,
+        };
 
         let client = netbench::Client::new(client, &scenario, &addresses);
         let mut trace = self.opts.trace();
@@ -41,12 +49,15 @@ impl Client {
     }
 }
 
-type Connection<'a> = netbench::Driver<'a, multiplex::Connection<TcpStream>>;
+type Stream = io::BufStream<TcpStream>;
+type Connection<'a> = netbench::Driver<'a, multiplex::Connection<Stream>>;
 
 #[derive(Debug)]
 struct ClientImpl {
     config: multiplex::Config,
     id: u64,
+    rx_buffer: usize,
+    tx_buffer: usize,
 }
 
 impl ClientImpl {
@@ -70,14 +81,17 @@ impl<'a> netbench::client::Client<'a> for ClientImpl {
     ) -> Self::Connect {
         let id = self.id();
         let config = self.config.clone();
+        let rx_buffer = self.rx_buffer;
+        let tx_buffer = self.tx_buffer;
 
         let fut = async move {
-            let mut conn = TcpStream::connect(addr).await?;
+            let conn = TcpStream::connect(addr).await?;
+            let conn = io::BufStream::with_capacity(rx_buffer, tx_buffer, conn);
+            let mut conn = Box::pin(conn);
 
             // tell the server which connection ID to use
             conn.write_u64(server_conn_id).await?;
 
-            let conn = Box::pin(conn);
             let conn = multiplex::Connection::new(id, conn, config);
             let conn: Connection = netbench::Driver::new(scenario, conn);
 

--- a/netbench/netbench-driver/src/lib.rs
+++ b/netbench/netbench-driver/src/lib.rs
@@ -3,7 +3,9 @@
 
 use netbench::{
     client::{self, AddressMap},
-    scenario, trace, Error, Result,
+    scenario, trace,
+    units::Byte,
+    Error, Result,
 };
 use std::{net::IpAddr, ops::Deref, path::Path, str::FromStr, sync::Arc, time::Duration};
 use structopt::StructOpt;
@@ -32,6 +34,12 @@ pub struct Server {
 
     #[structopt(long, short = "V")]
     pub verbose: bool,
+
+    #[structopt(long, default_value = "8KiB")]
+    pub rx_buffer: Byte,
+
+    #[structopt(long, default_value = "8KiB")]
+    pub tx_buffer: Byte,
 
     #[structopt(env = "SCENARIO")]
     pub scenario: Scenario,
@@ -72,6 +80,12 @@ pub struct Client {
 
     #[structopt(long, short = "V")]
     pub verbose: bool,
+
+    #[structopt(long, default_value = "8KiB")]
+    pub rx_buffer: Byte,
+
+    #[structopt(long, default_value = "8KiB")]
+    pub tx_buffer: Byte,
 
     #[structopt(env = "SCENARIO")]
     pub scenario: Scenario,


### PR DESCRIPTION
### Description of changes: 

This change adds the ability to buffer IO on native-tls and TCP sockets. This allows the buffer sizes to be taken into account when running tests for each of the drivers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

