### PR TITLE
fix(s2n-quic-tls): update to latest s2n-tls 0.0.7

### DIFF
--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -20,7 +20,10 @@ libc = "0.2"
 s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.2.0", path = "../s2n-quic-core", default-features = false }
 s2n-quic-crypto = { version = "=0.2.0", path = "../s2n-quic-crypto", default-features = false }
-s2n-tls = { version = "=0.0.5", features = ["quic"] }
+s2n-tls = { version = "=0.0.7", features = ["quic"] }
+
+[target.'cfg(all(s2n_quic_unstable, s2n_quic_enable_pq_tls))'.dependencies]
+s2n-tls = { version = "=0.0.7", features = ["quic", "pq"] }
 
 [dev-dependencies]
 checkers = "0.6"

--- a/quic/s2n-quic-tls/src/client.rs
+++ b/quic/s2n-quic-tls/src/client.rs
@@ -13,7 +13,6 @@ use s2n_tls::raw::{
     config::{self, Config},
     error::Error,
     ffi::s2n_cert_auth_type,
-    security,
 };
 use std::sync::Arc;
 
@@ -48,9 +47,7 @@ impl Default for Builder {
         let mut config = config::Builder::default();
         config.enable_quic().unwrap();
         // https://github.com/aws/s2n-tls/blob/main/docs/USAGE-GUIDE.md#s2n_config_set_cipher_preferences
-        config
-            .set_security_policy(&security::DEFAULT_TLS13)
-            .unwrap();
+        config.set_security_policy(crate::DEFAULT_POLICY).unwrap();
         config
             .set_application_protocol_preference(&[b"h3"])
             .unwrap();

--- a/quic/s2n-quic-tls/src/lib.rs
+++ b/quic/s2n-quic-tls/src/lib.rs
@@ -6,6 +6,11 @@
 #[global_allocator]
 static ALLOCATOR: checkers::Allocator = checkers::Allocator::system();
 
+#[cfg(all(s2n_quic_unstable, s2n_quic_enable_pq_tls))]
+static DEFAULT_POLICY: &s2n_tls::raw::security::Policy = &s2n_tls::raw::security::TESTING_PQ;
+#[cfg(not(all(s2n_quic_unstable, s2n_quic_enable_pq_tls)))]
+static DEFAULT_POLICY: &s2n_tls::raw::security::Policy = &s2n_tls::raw::security::DEFAULT_TLS13;
+
 mod callback;
 mod keylog;
 mod params;

--- a/quic/s2n-quic-tls/src/server.rs
+++ b/quic/s2n-quic-tls/src/server.rs
@@ -15,7 +15,6 @@ use s2n_tls::raw::{
     config::{self, Config, VerifyClientCertificateHandler},
     error::Error,
     ffi::s2n_cert_auth_type,
-    security,
 };
 use std::sync::Arc;
 
@@ -50,9 +49,7 @@ impl Default for Builder {
         let mut config = config::Builder::default();
         config.enable_quic().unwrap();
         // https://github.com/aws/s2n-tls/blob/main/docs/USAGE-GUIDE.md#s2n_config_set_cipher_preferences
-        config
-            .set_security_policy(&security::DEFAULT_TLS13)
-            .unwrap();
+        config.set_security_policy(crate::DEFAULT_POLICY).unwrap();
         config
             .set_application_protocol_preference(&[b"h3"])
             .unwrap();

--- a/quic/s2n-quic-tls/src/session.rs
+++ b/quic/s2n-quic-tls/src/session.rs
@@ -12,9 +12,9 @@ use s2n_quic_core::{
 use s2n_quic_crypto::Suite;
 use s2n_tls::raw::{
     config::Config,
-    connection::Connection,
+    connection::{self, Connection},
     error::Error,
-    ffi::{s2n_blinding, s2n_mode},
+    ffi::s2n_blinding,
 };
 
 #[derive(Debug)]
@@ -37,8 +37,8 @@ impl Session {
         server_name: Option<ServerName>,
     ) -> Result<Self, Error> {
         let mut connection = Connection::new(match endpoint {
-            endpoint::Type::Server => s2n_mode::SERVER,
-            endpoint::Type::Client => s2n_mode::CLIENT,
+            endpoint::Type::Server => connection::Mode::Server,
+            endpoint::Type::Client => connection::Mode::Client,
         });
 
         connection.set_config(config)?;


### PR DESCRIPTION
### Description of changes: 

s2n-tls has published version 0.0.7, which included some breaking changes. This PR updates to the latest version.

As part of the update, I've made it possible to enable post-quantum key shares through an unstable `cfg` flag.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

