### PR TITLE
feat(s2n-quic-core): add havoc utilities

### DIFF
--- a/quic/s2n-quic-core/src/havoc.rs
+++ b/quic/s2n-quic-core/src/havoc.rs
@@ -1,0 +1,630 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    frame::{self, new_connection_id::STATELESS_RESET_TOKEN_LEN},
+    stream::StreamType,
+    varint,
+};
+use core::{convert::TryInto, ops::Range};
+pub use s2n_codec::{Encoder, EncoderBuffer, EncoderValue};
+
+pub trait Random {
+    fn fill(&mut self, bytes: &mut [u8]);
+
+    #[inline]
+    fn shuffle(&mut self, bytes: &mut [u8]) {
+        if bytes.is_empty() {
+            return;
+        }
+
+        let count = self.gen_range(0..bytes.len());
+        for _ in 0..count {
+            let from = self.gen_range(0..bytes.len());
+            let to = self.gen_range(0..bytes.len());
+            bytes.swap(from, to);
+        }
+    }
+
+    #[inline]
+    fn gen_slice<'a>(&mut self, bytes: &'a mut [u8]) -> &'a mut [u8] {
+        if bytes.is_empty() {
+            return bytes;
+        }
+
+        let len = self.gen_range(0..bytes.len());
+        let bytes = &mut bytes[..len];
+        self.fill(bytes);
+        bytes
+    }
+
+    #[inline]
+    fn gen_bool(&mut self) -> bool {
+        self.gen_u8() & 0b1 == 0b1
+    }
+
+    #[inline]
+    fn gen_u8(&mut self) -> u8 {
+        let mut o = [0];
+        self.fill(&mut o);
+        o[0]
+    }
+
+    #[inline]
+    fn gen_u32(&mut self) -> u32 {
+        let mut o = [0; 4];
+        self.fill(&mut o);
+        u32::from_le_bytes(o)
+    }
+
+    #[inline]
+    fn gen_u64(&mut self) -> u64 {
+        let mut o = [0; 8];
+        self.fill(&mut o);
+        u64::from_le_bytes(o)
+    }
+
+    #[inline]
+    fn gen_varint(&mut self) -> varint::VarInt {
+        use varint::VarInt;
+        let max = VarInt::MAX.as_u64().try_into().unwrap_or(usize::MAX);
+        let v = self.gen_range(0..max);
+        unsafe { VarInt::new_unchecked(v as _) }
+    }
+
+    #[inline]
+    fn gen_range(&mut self, range: Range<usize>) -> usize {
+        let value = self.gen_u64() as usize;
+        value.max(range.start).min(range.end.saturating_sub(1))
+    }
+}
+
+pub trait Strategy: Sized {
+    fn havoc<R: Random>(&mut self, rand: &mut R, buffer: &mut EncoderBuffer);
+
+    #[inline]
+    fn havoc_slice<R: Random>(&mut self, rand: &mut R, buffer: &mut [u8]) -> usize {
+        let mut buffer = EncoderBuffer::new(buffer);
+        self.havoc(rand, &mut buffer);
+        buffer.len()
+    }
+
+    fn alternate<B: Strategy>(self, b: B, range: Range<usize>) -> Alternate<Self, B> {
+        Alternate::new(self, b, range)
+    }
+
+    fn repeat(self, range: Range<usize>) -> Repeat<Self> {
+        Repeat::new(self, range)
+    }
+
+    fn randomly(self) -> Randomly<Self> {
+        Randomly { strategy: self }
+    }
+
+    fn toggle(self, range: Range<usize>) -> Toggle<Self> {
+        Toggle::new(self, range)
+    }
+
+    fn and_then<B: Strategy>(self, b: B) -> AndThen<Self, B> {
+        AndThen { a: self, b }
+    }
+
+    fn while_has_capacity(self) -> WhileHasCapacity<Self> {
+        WhileHasCapacity { strategy: self }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Alternate<A: Strategy, B: Strategy> {
+    a: A,
+    b: B,
+    min: usize,
+    max: usize,
+    is_a: bool,
+    remaining: usize,
+}
+
+impl<A: Strategy, B: Strategy> Alternate<A, B> {
+    pub fn new(a: A, b: B, range: Range<usize>) -> Self {
+        debug_assert_ne!(range.start, 0);
+        debug_assert!(range.start <= range.end);
+        Self {
+            a,
+            b,
+            min: range.start,
+            max: range.end,
+            is_a: false,
+            remaining: 0,
+        }
+    }
+}
+
+impl<A: Strategy, B: Strategy> Strategy for Alternate<A, B> {
+    #[inline]
+    fn havoc<R: Random>(&mut self, rand: &mut R, buffer: &mut EncoderBuffer) {
+        loop {
+            if let Some(remaining) = self.remaining.checked_sub(1) {
+                self.remaining = remaining;
+
+                if self.is_a {
+                    self.a.havoc(rand, buffer);
+                } else {
+                    self.b.havoc(rand, buffer);
+                }
+
+                break;
+            }
+
+            self.remaining = rand.gen_range(self.min..self.max);
+            self.is_a = !self.is_a;
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct AndThen<A: Strategy, B: Strategy> {
+    pub a: A,
+    pub b: B,
+}
+
+impl<A: Strategy, B: Strategy> Strategy for AndThen<A, B> {
+    #[inline]
+    fn havoc<R: Random>(&mut self, rand: &mut R, buffer: &mut EncoderBuffer) {
+        self.a.havoc(rand, buffer);
+        self.b.havoc(rand, buffer);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Repeat<S: Strategy> {
+    strategy: S,
+    min: usize,
+    max: usize,
+}
+
+impl<S: Strategy> Repeat<S> {
+    pub fn new(strategy: S, range: Range<usize>) -> Self {
+        Self {
+            strategy,
+            min: range.start,
+            max: range.end,
+        }
+    }
+}
+
+impl<S: Strategy> Strategy for Repeat<S> {
+    #[inline]
+    fn havoc<R: Random>(&mut self, rand: &mut R, buffer: &mut EncoderBuffer) {
+        let count = rand.gen_range(self.min..self.max);
+        for _ in 0..count {
+            self.strategy.havoc(rand, buffer);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct WhileHasCapacity<S: Strategy> {
+    strategy: S,
+}
+
+impl<S: Strategy> WhileHasCapacity<S> {
+    pub fn new(strategy: S) -> Self {
+        Self { strategy }
+    }
+}
+
+impl<S: Strategy> Strategy for WhileHasCapacity<S> {
+    #[inline]
+    fn havoc<R: Random>(&mut self, rand: &mut R, buffer: &mut EncoderBuffer) {
+        // limit the number of iterations in case the strategy isn't filling the buffer
+        for _ in 0..25 {
+            if !buffer.remaining_capacity() == 0 {
+                break;
+            }
+
+            self.strategy.havoc(rand, buffer);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Toggle<S: Strategy> {
+    alt: Alternate<Disabled, S>,
+}
+
+impl<S: Strategy> Toggle<S> {
+    pub fn new(strategy: S, range: Range<usize>) -> Self {
+        Self {
+            alt: Alternate::new(Disabled, strategy, range),
+        }
+    }
+}
+
+impl<S: Strategy> Strategy for Toggle<S> {
+    #[inline]
+    fn havoc<R: Random>(&mut self, rand: &mut R, buffer: &mut EncoderBuffer) {
+        self.alt.havoc(rand, buffer);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Randomly<S: Strategy> {
+    pub strategy: S,
+}
+
+impl<S: Strategy> Strategy for Randomly<S> {
+    #[inline]
+    fn havoc<R: Random>(&mut self, rand: &mut R, buffer: &mut EncoderBuffer) {
+        if rand.gen_bool() {
+            self.strategy.havoc(rand, buffer);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Reset;
+
+impl Strategy for Reset {
+    #[inline]
+    fn havoc<R: Random>(&mut self, _rand: &mut R, buffer: &mut EncoderBuffer) {
+        buffer.set_position(0);
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Zero;
+
+impl Strategy for Zero {
+    #[inline]
+    fn havoc<R: Random>(&mut self, _rand: &mut R, buffer: &mut EncoderBuffer) {
+        for byte in buffer.as_mut_slice() {
+            *byte = 0;
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Shuffle;
+
+impl Strategy for Shuffle {
+    #[inline]
+    fn havoc<R: Random>(&mut self, rand: &mut R, buffer: &mut EncoderBuffer) {
+        if !buffer.is_empty() {
+            rand.shuffle(buffer.as_mut_slice());
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Swap;
+
+impl Strategy for Swap {
+    #[inline]
+    fn havoc<R: Random>(&mut self, rand: &mut R, buffer: &mut EncoderBuffer) {
+        let len = buffer.len();
+        if len > 0 {
+            let from = rand.gen_range(0..len);
+            let to = rand.gen_range(0..len);
+            buffer.as_mut_slice().swap(from, to);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Truncate;
+
+impl Strategy for Truncate {
+    #[inline]
+    fn havoc<R: Random>(&mut self, rand: &mut R, buffer: &mut EncoderBuffer) {
+        let len = buffer.capacity();
+        if len > 0 {
+            let new_len = rand.gen_range(0..len);
+            buffer.set_position(new_len);
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Mutate;
+
+impl Strategy for Mutate {
+    #[inline]
+    fn havoc<R: Random>(&mut self, rand: &mut R, buffer: &mut EncoderBuffer) {
+        let len = buffer.len();
+        if len > 0 {
+            let index = rand.gen_range(0..len);
+            let value = rand.gen_u8();
+            buffer.as_mut_slice()[index] = value;
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Disabled;
+
+impl Strategy for Disabled {
+    #[inline]
+    fn havoc<R: Random>(&mut self, _rand: &mut R, _buffer: &mut EncoderBuffer) {}
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct VarInt {
+    min: usize,
+    max: usize,
+}
+
+impl VarInt {
+    pub fn new(range: Range<varint::VarInt>) -> Self {
+        let min = range.start.as_u64().try_into().unwrap_or(usize::MAX);
+        let max = range.end.as_u64().try_into().unwrap_or(usize::MAX);
+        Self { min, max }
+    }
+}
+
+impl Strategy for VarInt {
+    #[inline]
+    fn havoc<R: Random>(&mut self, rand: &mut R, buffer: &mut EncoderBuffer) {
+        let value = rand.gen_range(self.min..self.max);
+        let value: varint::VarInt = value.try_into().unwrap();
+        if value.encoding_size() <= buffer.remaining_capacity() {
+            buffer.encode(&value);
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Frame;
+
+impl Strategy for Frame {
+    #[inline]
+    fn havoc<R: Random>(&mut self, rand: &mut R, buffer: &mut EncoderBuffer) {
+        type GenFrame<R> = for<'a> fn(
+            rand: &'a mut R,
+            payload: &'a mut [u8],
+        ) -> frame::Frame<'a, AckRanges<'a, R>, &'a mut [u8]>;
+
+        let frames: &[GenFrame<R>] = &[
+            |rand, data| {
+                frame::Padding {
+                    length: rand.gen_range(1..data.len()),
+                }
+                .into()
+            },
+            |_rand, _data| frame::Ping.into(),
+            // TODO ACK
+            |rand, _data| {
+                frame::ResetStream {
+                    stream_id: rand.gen_varint(),
+                    application_error_code: rand.gen_varint(),
+                    final_size: rand.gen_varint(),
+                }
+                .into()
+            },
+            |rand, _data| {
+                frame::StopSending {
+                    stream_id: rand.gen_varint(),
+                    application_error_code: rand.gen_varint(),
+                }
+                .into()
+            },
+            |rand, data| {
+                let data = rand.gen_slice(data);
+                frame::Crypto {
+                    offset: rand.gen_varint(),
+                    data,
+                }
+                .into()
+            },
+            |rand, data| {
+                let token = rand.gen_slice(data);
+                frame::NewToken { token }.into()
+            },
+            |rand, data| {
+                let data = rand.gen_slice(data);
+                frame::Stream {
+                    stream_id: rand.gen_varint(),
+                    offset: rand.gen_varint(),
+                    data,
+                    is_last_frame: rand.gen_bool(),
+                    is_fin: rand.gen_bool(),
+                }
+                .into()
+            },
+            |rand, _data| {
+                frame::MaxData {
+                    maximum_data: rand.gen_varint(),
+                }
+                .into()
+            },
+            |rand, _data| {
+                frame::MaxStreamData {
+                    stream_id: rand.gen_varint(),
+                    maximum_stream_data: rand.gen_varint(),
+                }
+                .into()
+            },
+            |rand, _data| {
+                frame::MaxStreams {
+                    stream_type: if rand.gen_bool() {
+                        StreamType::Unidirectional
+                    } else {
+                        StreamType::Bidirectional
+                    },
+                    maximum_streams: rand.gen_varint(),
+                }
+                .into()
+            },
+            |rand, _data| {
+                frame::DataBlocked {
+                    data_limit: rand.gen_varint(),
+                }
+                .into()
+            },
+            |rand, _data| {
+                frame::StreamDataBlocked {
+                    stream_id: rand.gen_varint(),
+                    stream_data_limit: rand.gen_varint(),
+                }
+                .into()
+            },
+            |rand, _data| {
+                frame::StreamsBlocked {
+                    stream_type: if rand.gen_bool() {
+                        StreamType::Unidirectional
+                    } else {
+                        StreamType::Bidirectional
+                    },
+                    stream_limit: rand.gen_varint(),
+                }
+                .into()
+            },
+            |rand, data| {
+                let (stateless_reset_token, data) = data.split_at_mut(STATELESS_RESET_TOKEN_LEN);
+
+                rand.fill(stateless_reset_token);
+                let stateless_reset_token = (&*stateless_reset_token).try_into().unwrap();
+
+                let connection_id = rand.gen_slice(data);
+
+                frame::NewConnectionId {
+                    sequence_number: rand.gen_varint(),
+                    retire_prior_to: rand.gen_varint(),
+                    connection_id,
+                    stateless_reset_token,
+                }
+                .into()
+            },
+            |rand, _data| {
+                frame::RetireConnectionId {
+                    sequence_number: rand.gen_varint(),
+                }
+                .into()
+            },
+            |rand, data| {
+                let data = &mut data[..frame::path_challenge::DATA_LEN];
+                rand.fill(data);
+                let data = (&*data).try_into().unwrap();
+                frame::PathChallenge { data }.into()
+            },
+            |rand, data| {
+                let data = &mut data[..frame::path_challenge::DATA_LEN];
+                rand.fill(data);
+                let data = (&*data).try_into().unwrap();
+                frame::PathResponse { data }.into()
+            },
+            |rand, data| {
+                frame::ConnectionClose {
+                    error_code: rand.gen_varint(),
+                    frame_type: if rand.gen_bool() {
+                        Some(rand.gen_varint())
+                    } else {
+                        None
+                    },
+                    reason: if rand.gen_bool() {
+                        let reason = rand.gen_slice(data);
+                        Some(reason)
+                    } else {
+                        None
+                    },
+                }
+                .into()
+            },
+            |_rand, _data| frame::HandshakeDone.into(),
+            |rand, data| {
+                let data = rand.gen_slice(data);
+                frame::Datagram {
+                    is_last_frame: rand.gen_bool(),
+                    data,
+                }
+                .into()
+            },
+        ];
+
+        let index = rand.gen_range(0..frames.len());
+        let mut payload = [0u8; 1500];
+        let payload = &mut payload[..buffer.remaining_capacity()];
+        let frame = frames[index](rand, payload);
+
+        if frame.encoding_size() <= buffer.remaining_capacity() {
+            buffer.encode(&frame);
+        }
+    }
+}
+
+// TODO implement this without allocating a bunch for the entries
+struct AckRanges<'a, R> {
+    #[allow(dead_code)]
+    rand: &'a mut R,
+}
+
+impl<'a, R> frame::ack::AckRanges for AckRanges<'a, R> {
+    type Iter = frame::ack::AckRangesIter<'a>;
+
+    fn ack_ranges(&self) -> Self::Iter {
+        todo!()
+    }
+
+    fn largest_acknowledged(&self) -> crate::varint::VarInt {
+        todo!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bolero::check;
+
+    struct RandomSlice<'a>(core::iter::Cycle<core::slice::Iter<'a, u8>>);
+
+    impl<'a> RandomSlice<'a> {
+        pub fn new(slice: &'a [u8]) -> Self {
+            Self(slice.iter().cycle())
+        }
+    }
+
+    impl<'a> Random for RandomSlice<'a> {
+        #[inline]
+        fn fill(&mut self, bytes: &mut [u8]) {
+            for byte in bytes.iter_mut() {
+                *byte = *self.0.next().unwrap_or(&0);
+            }
+        }
+    }
+
+    macro_rules! test {
+        ($name:ident, $strategy:expr) => {
+            #[test]
+            #[cfg_attr(miri, ignore)] // no need to test with miri as there isn't any unsafe
+            fn $name() {
+                check!().for_each(|bytes| {
+                    let mut rand = RandomSlice::new(bytes);
+                    let mut buffer = [0u8; 256];
+                    let buffer = &mut buffer[..rand.gen_u8() as usize];
+                    let mut buffer = EncoderBuffer::new(buffer);
+
+                    let mut strategy = $strategy;
+
+                    for _ in 0..rand.gen_range(1..10) {
+                        strategy.havoc(&mut rand, &mut buffer);
+                    }
+                });
+            }
+        };
+    }
+
+    test!(disabled_test, Disabled);
+    test!(truncate_test, Truncate);
+    test!(reset_test, Reset);
+    test!(zero_test, Zero);
+    test!(swap_test, Swap);
+    test!(shuffle_test, Shuffle);
+    test!(mutate_test, Mutate);
+    test!(alternate_test, Disabled.alternate(Disabled, 1..5));
+    test!(and_then_test, Disabled.and_then(Disabled));
+    test!(repeat_test, Disabled.repeat(0..5));
+    test!(varint_test, VarInt::new(0u8.into()..42u8.into()));
+    test!(frame_test, Frame);
+    test!(while_has_capacity_test, Frame.while_has_capacity());
+    test!(toggle_test, Disabled.toggle(1..5));
+    test!(randomly_test, Disabled.randomly());
+}

--- a/quic/s2n-quic-core/src/lib.rs
+++ b/quic/s2n-quic-core/src/lib.rs
@@ -16,6 +16,7 @@ pub mod datagram;
 pub mod endpoint;
 pub mod event;
 pub mod frame;
+pub mod havoc;
 pub mod inet;
 pub mod io;
 pub mod number;

--- a/quic/s2n-quic-core/src/packet/interceptor.rs
+++ b/quic/s2n-quic-core/src/packet/interceptor.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{event::api::Subject, packet::number::PacketNumber, time::Timestamp};
+use crate::{event::api::Subject, havoc, packet::number::PacketNumber, time::Timestamp};
 use s2n_codec::{DecoderBufferMut, EncoderBuffer};
 
 /// TODO add `non_exhaustive` once/if this feature is stable
@@ -42,3 +42,55 @@ pub trait Interceptor: 'static + Send {
 pub struct Disabled(());
 
 impl Interceptor for Disabled {}
+
+#[derive(Debug, Default)]
+pub struct Havoc<Rx, Tx, R>
+where
+    Rx: 'static + Send + havoc::Strategy,
+    Tx: 'static + Send + havoc::Strategy,
+    R: 'static + Send + havoc::Random,
+{
+    pub rx: Rx,
+    pub tx: Tx,
+    pub random: R,
+}
+
+impl<Rx, Tx, R> Interceptor for Havoc<Rx, Tx, R>
+where
+    Rx: 'static + Send + havoc::Strategy,
+    Tx: 'static + Send + havoc::Strategy,
+    R: 'static + Send + havoc::Random,
+{
+    #[inline]
+    fn intercept_rx_payload<'a>(
+        &mut self,
+        _subject: Subject,
+        _packet: Packet,
+        payload: DecoderBufferMut<'a>,
+    ) -> DecoderBufferMut<'a> {
+        let payload = payload.into_less_safe_slice();
+        let len = payload.len();
+
+        let len = {
+            use s2n_codec::Encoder;
+            let mut payload = EncoderBuffer::new(payload);
+            payload.set_position(len);
+            self.rx.havoc(&mut self.random, &mut payload);
+            payload.len()
+        };
+
+        let payload = &mut payload[..len];
+
+        DecoderBufferMut::new(payload)
+    }
+
+    #[inline]
+    fn intercept_tx_payload<'a>(
+        &mut self,
+        _subject: Subject,
+        _packet: Packet,
+        payload: &mut EncoderBuffer<'a>,
+    ) {
+        self.tx.havoc(&mut self.random, payload);
+    }
+}

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -19,7 +19,7 @@ tokio-runtime = ["futures", "pin-project", "tokio"]
 wipe = ["zeroize"]
 
 [dependencies]
-bach = { version = "0.0.4", optional = true }
+bach = { version = "0.0.5", optional = true }
 bolero-generator = { version = "0.6", default-features = false, optional = true }
 cfg-if = "1"
 errno = "0.2"
@@ -35,7 +35,7 @@ zeroize = { version = "1", default-features = false, optional = true }
 libc = "0.2"
 
 [dev-dependencies]
-bach = { version = "0.0.4" }
+bach = { version = "0.0.5" }
 bolero = "0.6"
 bolero-generator = { version = "0.6", default-features = false }
 futures = { version = "0.3", features = ["std"] }

--- a/quic/s2n-quic-platform/src/io/testing.rs
+++ b/quic/s2n-quic-platform/src/io/testing.rs
@@ -20,10 +20,36 @@ pub use model::Model;
 pub use network::{Network, PathHandle};
 pub use time::now;
 
-pub use bach::{
-    rand,
-    task::{spawn, spawn_primary},
-};
+pub use bach::task::{spawn, spawn_primary};
+
+pub mod rand {
+    pub use ::bach::rand::*;
+
+    #[derive(Clone, Copy, Default)]
+    pub struct Havoc;
+
+    impl s2n_quic_core::havoc::Random for Havoc {
+        #[inline]
+        fn fill(&mut self, bytes: &mut [u8]) {
+            fill_bytes(bytes);
+        }
+
+        #[inline]
+        fn gen_bool(&mut self) -> bool {
+            gen()
+        }
+
+        #[inline]
+        fn shuffle(&mut self, bytes: &mut [u8]) {
+            shuffle(bytes);
+        }
+
+        #[inline]
+        fn gen_range(&mut self, range: core::ops::Range<usize>) -> usize {
+            gen_range(range)
+        }
+    }
+}
 
 pub struct Executor<N: Network> {
     executor: bach::executor::Executor<Env<N>>,


### PR DESCRIPTION
### Description of changes: 

There's a few places we want to havoc a slice of bytes. This change adds a `havoc` module in s2n-quic-core to make this easy to do. I've adapted the IO testing model to utilize the new functionality:

```rust
let new_len = havoc::Truncate
    .randomly()
    .and_then(havoc::Swap.repeat(0..packet.payload.len()).randomly())
    .and_then(havoc::Mutate.repeat(0..packet.payload.len()).randomly())
    .havoc_slice(&mut super::rand::Havoc, &mut packet.payload);
```

### Testing:

I've added fuzz tests for each one of the strategies to make sure they don't panic or spin forever.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

