### PR TITLE
fix(s2n-quic-transport): mark streams in final state without wakers

### DIFF
--- a/quic/s2n-quic-transport/src/stream/receive_stream.rs
+++ b/quic/s2n-quic-transport/src/stream/receive_stream.rs
@@ -570,6 +570,9 @@ impl ReceiveStream {
         // Return the waker to wake up potential users of the stream
         if let Some((waker, _low_watermark)) = self.read_waiter.take() {
             events.store_read_waker(waker);
+        } else {
+            // There aren't any wakers associated with this stream so finalize it
+            self.final_state_observed = true;
         }
     }
 

--- a/quic/s2n-quic-transport/src/stream/tests/receive_stream_tests.rs
+++ b/quic/s2n-quic-transport/src/stream/tests/receive_stream_tests.rs
@@ -652,14 +652,10 @@ fn exceed_stream_flow_control_window() {
         .on_internal_reset(connection::Error::unspecified().into(), &mut events);
 
     assert_eq!(
-        stream_interests(&[]),
-        test_env.stream.get_stream_interests()
-    );
-    test_env.assert_pop_error();
-    assert_eq!(
         stream_interests(&["fin"]),
         test_env.stream.get_stream_interests()
     );
+    test_env.assert_pop_error();
 }
 
 #[test]
@@ -700,14 +696,10 @@ fn exceed_connection_flow_control_window() {
         .on_internal_reset(connection::Error::unspecified().into(), &mut events);
 
     assert_eq!(
-        stream_interests(&[]),
-        test_env.stream.get_stream_interests()
-    );
-    test_env.assert_pop_error();
-    assert_eq!(
         stream_interests(&["fin"]),
         test_env.stream.get_stream_interests()
     );
+    test_env.assert_pop_error();
 }
 
 #[test]


### PR DESCRIPTION
### Description of changes: 

In #1119, the functionality was added to flush streams when the connection was dropped. The change, however, was missing a check for when there isn't a waker associated with the stream. In this case it should consider the stream finalized. It currently does not and causes the connection to wait until the idle timer expires.

### Testing:

I updated the stream tests to reflect the new behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

