### PR TITLE
feat(s2n-quic-transport): Datagram Sender Trait

### DIFF
--- a/quic/s2n-quic-core/src/datagram.rs
+++ b/quic/s2n-quic-core/src/datagram.rs
@@ -4,15 +4,22 @@ pub trait Endpoint: 'static + Send {
     type Sender: Sender;
     type Receiver: Receiver;
 
-    fn create_connection(&mut self, info: &ConnectionInfo) -> (Self::Sender, Self::Receiver);
+    fn new_datagram(&mut self) -> (Self::Sender, Self::Receiver);
 }
 
-#[derive(Debug)]
-#[non_exhaustive]
-pub struct ConnectionInfo {}
-
-pub trait Sender: 'static + Send {}
 pub trait Receiver: 'static + Send {}
+pub trait Sender: 'static + Send {
+    fn on_transmit<P: Packet>(&mut self, _packet: &mut P) {
+        todo!();
+    }
+}
+
+pub trait Packet {
+    fn remaining_capacity(&self) -> usize;
+    fn maximum_datagram_payload(&self) -> usize;
+    fn write_datagram(&mut self, data: &[u8]);
+    fn pending_streams(&self) -> bool;
+}
 
 #[derive(Debug, Default)]
 pub struct Disabled;
@@ -21,7 +28,7 @@ impl Endpoint for Disabled {
     type Sender = DisabledSender;
     type Receiver = DisabledReceiver;
 
-    fn create_connection(&mut self, _info: &ConnectionInfo) -> (Self::Sender, Self::Receiver) {
+    fn new_datagram(&mut self) -> (Self::Sender, Self::Receiver) {
         (DisabledSender, DisabledReceiver)
     }
 }

--- a/quic/s2n-quic-core/src/datagram.rs
+++ b/quic/s2n-quic-core/src/datagram.rs
@@ -9,9 +9,7 @@ pub trait Endpoint: 'static + Send {
 
 pub trait Receiver: 'static + Send {}
 pub trait Sender: 'static + Send {
-    fn on_transmit<P: Packet>(&mut self, _packet: &mut P) {
-        todo!();
-    }
+    fn on_transmit<P: Packet>(&mut self, _packet: &mut P);
 }
 
 pub trait Packet {
@@ -35,5 +33,7 @@ impl Endpoint for Disabled {
 pub struct DisabledSender;
 pub struct DisabledReceiver;
 
+impl Sender for DisabledSender {
+    fn on_transmit<P: Packet>(&mut self, _packet: &mut P) {}
+}
 impl Receiver for DisabledReceiver {}
-impl Sender for DisabledSender {}

--- a/quic/s2n-quic-core/src/datagram.rs
+++ b/quic/s2n-quic-core/src/datagram.rs
@@ -24,9 +24,6 @@ pub trait Packet {
     /// Returns the remaining space in the packet left to write datagrams
     fn remaining_capacity(&self) -> usize;
 
-    /// Returns the largest datagram that can fit in space remaining in the packet
-    fn maximum_datagram_payload(&self) -> usize;
-
     /// Writes a single datagram to a packet. This function should be called
     /// per datagram.
     fn write_datagram(&mut self, data: &[u8]);

--- a/quic/s2n-quic-core/src/datagram.rs
+++ b/quic/s2n-quic-core/src/datagram.rs
@@ -1,21 +1,36 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
+
+/// The datagram endpoint trait provides a way to implement custom unreliable datagram
+/// sending and receiving logic. The Sender type should be implemented for custom
+/// sending behavior, and the Receiver type should be implemented for custom
+/// receiving behavior.
 pub trait Endpoint: 'static + Send {
     type Sender: Sender;
     type Receiver: Receiver;
 
-    fn new_datagram(&mut self) -> (Self::Sender, Self::Receiver);
+    fn split(&mut self) -> (Self::Sender, Self::Receiver);
 }
 
 pub trait Receiver: 'static + Send {}
 pub trait Sender: 'static + Send {
-    fn on_transmit<P: Packet>(&mut self, _packet: &mut P);
+    /// The on_transmit function is a callback that allows users to write
+    /// datagrams directly to the packet.
+    fn on_transmit<P: Packet>(&mut self, packet: &mut P);
 }
 
+/// A packet will be available during the on_transmit callback. Use the methods
+/// defined here to interrogate the packet struct and write datagrams to the packet.
 pub trait Packet {
+    /// Returns the remaining space in the packet left to write datagrams
     fn remaining_capacity(&self) -> usize;
+    /// Returns the largest datagram that can fit in space remaining in the packet
     fn maximum_datagram_payload(&self) -> usize;
+    /// Writes a single datagram to a packet. This function should be called
+    /// per datagram.
     fn write_datagram(&mut self, data: &[u8]);
+    /// Returns whether or not there is reliable data waiting to be sent. Use this
+    /// method to decide whether or not to cede the packet space to the stream data.
     fn pending_streams(&self) -> bool;
 }
 
@@ -26,7 +41,7 @@ impl Endpoint for Disabled {
     type Sender = DisabledSender;
     type Receiver = DisabledReceiver;
 
-    fn new_datagram(&mut self) -> (Self::Sender, Self::Receiver) {
+    fn split(&mut self) -> (Self::Sender, Self::Receiver) {
         (DisabledSender, DisabledReceiver)
     }
 }

--- a/quic/s2n-quic-core/src/datagram.rs
+++ b/quic/s2n-quic-core/src/datagram.rs
@@ -14,8 +14,7 @@ pub trait Endpoint: 'static + Send {
 
 pub trait Receiver: 'static + Send {}
 pub trait Sender: 'static + Send {
-    /// The on_transmit function is a callback that allows users to write
-    /// datagrams directly to the packet.
+    /// A callback that allows users to write datagrams directly to the packet.
     fn on_transmit<P: Packet>(&mut self, packet: &mut P);
 }
 
@@ -24,13 +23,17 @@ pub trait Sender: 'static + Send {
 pub trait Packet {
     /// Returns the remaining space in the packet left to write datagrams
     fn remaining_capacity(&self) -> usize;
+
     /// Returns the largest datagram that can fit in space remaining in the packet
     fn maximum_datagram_payload(&self) -> usize;
+
     /// Writes a single datagram to a packet. This function should be called
     /// per datagram.
     fn write_datagram(&mut self, data: &[u8]);
-    /// Returns whether or not there is reliable data waiting to be sent. Use this
-    /// method to decide whether or not to cede the packet space to the stream data.
+
+    /// Returns whether or not there is reliable data waiting to be sent.
+    ///
+    /// Use method to decide whether or not to cede the packet space to the stream data.
     fn pending_streams(&self) -> bool;
 }
 

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -131,6 +131,7 @@ impl connection::Trait for TestConnection {
         &mut self,
         _timestamp: Timestamp,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
+        _datagram: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
     ) -> Result<(), connection::Error> {
         Ok(())
     }
@@ -143,6 +144,7 @@ impl connection::Trait for TestConnection {
         _random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
+        _datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -156,6 +158,7 @@ impl connection::Trait for TestConnection {
         _random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
+        _datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -169,6 +172,7 @@ impl connection::Trait for TestConnection {
         _random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
+        _datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1246,6 +1246,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
     }
 
     /// Is called when a handshake packet had been received
+    #[allow(clippy::too_many_arguments)]
     fn handle_handshake_packet(
         &mut self,
         datagram: &DatagramInfo,

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -266,6 +266,7 @@ impl<Config: endpoint::Config> ConnectionImpl<Config> {
         &mut self,
         timestamp: Timestamp,
         subscriber: &mut Config::EventSubscriber,
+        datagram: &mut Config::DatagramEndpoint,
     ) -> Result<(), connection::Error> {
         let mut publisher = self.event_context.publisher(timestamp, subscriber);
         let space_manager = &mut self.space_manager;
@@ -277,6 +278,7 @@ impl<Config: endpoint::Config> ConnectionImpl<Config> {
             timestamp,
             &self.waker,
             &mut publisher,
+            datagram,
         ) {
             Poll::Ready(res) => res?,
             Poll::Pending => return Ok(()),
@@ -609,9 +611,11 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         };
 
         if Config::ENDPOINT_TYPE.is_client() {
-            if let Err(error) =
-                connection.update_crypto_state(parameters.timestamp, parameters.event_subscriber)
-            {
+            if let Err(error) = connection.update_crypto_state(
+                parameters.timestamp,
+                parameters.event_subscriber,
+                parameters.datagram_endpoint,
+            ) {
                 connection.with_event_publisher(
                     parameters.timestamp,
                     None,
@@ -1052,12 +1056,13 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         &mut self,
         timestamp: Timestamp,
         subscriber: &mut Config::EventSubscriber,
+        datagram: &mut Config::DatagramEndpoint,
     ) -> Result<(), connection::Error> {
         // reset the queued state first so that new wakeup request are not missed
         self.wakeup_handle.wakeup_handled();
 
         // check if crypto progress can be made
-        self.update_crypto_state(timestamp, subscriber)?;
+        self.update_crypto_state(timestamp, subscriber, datagram)?;
 
         // return an error if the application set one
         self.error?;
@@ -1139,6 +1144,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         random_generator: &mut Config::RandomGenerator,
         subscriber: &mut Config::EventSubscriber,
         packet_interceptor: &mut Config::PacketInterceptor,
+        datagram_endpoint: &mut Config::DatagramEndpoint,
     ) -> Result<(), ProcessingError> {
         //= https://www.rfc-editor.org/rfc/rfc9000#section-7.2
         //= type=TODO
@@ -1178,6 +1184,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 random_generator,
                 subscriber,
                 packet_interceptor,
+                datagram_endpoint,
             )?;
         }
 
@@ -1193,6 +1200,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         random_generator: &mut Config::RandomGenerator,
         subscriber: &mut Config::EventSubscriber,
         packet_interceptor: &mut Config::PacketInterceptor,
+        datagram_endpoint: &mut Config::DatagramEndpoint,
     ) -> Result<(), ProcessingError> {
         if let Some((space, handshake_status)) = self.space_manager.initial_mut() {
             let mut publisher = self.event_context.publisher(datagram.timestamp, subscriber);
@@ -1228,7 +1236,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             )?;
 
             // try to move the crypto state machine forward
-            self.update_crypto_state(datagram.timestamp, subscriber)?;
+            self.update_crypto_state(datagram.timestamp, subscriber, datagram_endpoint)?;
 
             // notify the connection a packet was processed
             self.on_processed_packet(&processed_packet, subscriber)?;
@@ -1246,6 +1254,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         random_generator: &mut Config::RandomGenerator,
         subscriber: &mut Config::EventSubscriber,
         packet_interceptor: &mut Config::PacketInterceptor,
+        datagram_endpoint: &mut Config::DatagramEndpoint,
     ) -> Result<(), ProcessingError> {
         //= https://www.rfc-editor.org/rfc/rfc9000#section-5.2.1
         //= type=TODO
@@ -1308,7 +1317,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             self.path_manager[path_id].on_handshake_packet();
 
             // try to move the crypto state machine forward
-            self.update_crypto_state(datagram.timestamp, subscriber)?;
+            self.update_crypto_state(datagram.timestamp, subscriber, datagram_endpoint)?;
 
             // notify the connection a packet was processed
             self.on_processed_packet(&processed_packet, subscriber)?;

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -106,6 +106,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         &mut self,
         timestamp: Timestamp,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
+        datagram: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
     ) -> Result<(), connection::Error>;
 
     // Packet handling
@@ -119,6 +120,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
+        datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
     ) -> Result<(), ProcessingError>;
 
     /// Is called when an unprotected initial packet had been received
@@ -130,6 +132,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
+        datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
     ) -> Result<(), ProcessingError>;
 
     /// Is called when a handshake packet had been received
@@ -141,6 +144,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
+        datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
     ) -> Result<(), ProcessingError>;
 
     /// Is called when a short packet had been received
@@ -211,6 +215,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
+        datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
     ) -> Result<(), ProcessingError> {
         //= https://www.rfc-editor.org/rfc/rfc9000#section-5.2.1
         //# If a client receives a packet that uses a different version than it
@@ -264,6 +269,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 random_generator,
                 subscriber,
                 packet_interceptor,
+                datagram_endpoint,
             ),
             ProtectedPacket::ZeroRtt(packet) => self.handle_zero_rtt_packet(
                 datagram,
@@ -279,6 +285,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 random_generator,
                 subscriber,
                 packet_interceptor,
+                datagram_endpoint,
             ),
             ProtectedPacket::Retry(packet) => {
                 self.handle_retry_packet(datagram, path_id, packet, subscriber, packet_interceptor)
@@ -299,6 +306,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
+        datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
     ) -> Result<(), connection::Error> {
         let remote_address = path_handle.remote_address();
         let connection_info = ConnectionInfo::new(&remote_address);
@@ -340,6 +348,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                     random_generator,
                     subscriber,
                     packet_interceptor,
+                    datagram_endpoint,
                 );
 
                 if let Err(ProcessingError::ConnectionError(err)) = result {

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -112,6 +112,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     // Packet handling
 
     /// Is called when an initial packet had been received
+    #[allow(clippy::too_many_arguments)]
     fn handle_initial_packet(
         &mut self,
         datagram: &DatagramInfo,
@@ -124,6 +125,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     ) -> Result<(), ProcessingError>;
 
     /// Is called when an unprotected initial packet had been received
+    #[allow(clippy::too_many_arguments)]
     fn handle_cleartext_initial_packet(
         &mut self,
         datagram: &DatagramInfo,
@@ -136,6 +138,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     ) -> Result<(), ProcessingError>;
 
     /// Is called when a handshake packet had been received
+    #[allow(clippy::too_many_arguments)]
     fn handle_handshake_packet(
         &mut self,
         datagram: &DatagramInfo,
@@ -207,6 +210,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     fn quic_version(&self) -> u32;
 
     /// Handles reception of a single QUIC packet
+    #[allow(clippy::too_many_arguments)]
     fn handle_packet(
         &mut self,
         datagram: &DatagramInfo,

--- a/quic/s2n-quic-transport/src/connection/mod.rs
+++ b/quic/s2n-quic-transport/src/connection/mod.rs
@@ -81,4 +81,6 @@ pub struct Parameters<'a, Cfg: endpoint::Config> {
     pub supervisor_context: &'a supervisor::Context<'a>,
     /// The event subscriber for the endpoint
     pub event_subscriber: &'a mut Cfg::EventSubscriber,
+    // The datagram provider for the endpoint
+    pub datagram_endpoint: &'a mut Cfg::DatagramEndpoint,
 }

--- a/quic/s2n-quic-transport/src/connection/mod.rs
+++ b/quic/s2n-quic-transport/src/connection/mod.rs
@@ -79,8 +79,8 @@ pub struct Parameters<'a, Cfg: endpoint::Config> {
     pub event_context: <Cfg::EventSubscriber as event::Subscriber>::ConnectionContext,
     /// The context passed to the connection supervisor
     pub supervisor_context: &'a supervisor::Context<'a>,
-    /// The event subscriber for the endpoint
-    pub event_subscriber: &'a mut Cfg::EventSubscriber,
     // The datagram provider for the endpoint
     pub datagram_endpoint: &'a mut Cfg::DatagramEndpoint,
+    /// The event subscriber for the endpoint
+    pub event_subscriber: &'a mut Cfg::EventSubscriber,
 }

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -268,6 +268,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             event_context,
             supervisor_context: &supervisor_context,
             event_subscriber: endpoint_context.event_subscriber,
+            datagram_endpoint: endpoint_context.datagram,
         };
 
         let mut connection = <Config as endpoint::Config>::Connection::new(connection_parameters)?;
@@ -311,6 +312,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                         endpoint_context.random_generator,
                         endpoint_context.event_subscriber,
                         endpoint_context.packet_interceptor,
+                        endpoint_context.datagram,
                     )
                     .map_err(|err| {
                         use connection::ProcessingError;
@@ -348,6 +350,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                     endpoint_context.random_generator,
                     endpoint_context.event_subscriber,
                     endpoint_context.packet_interceptor,
+                    endpoint_context.datagram,
                 )?;
 
                 Ok(())

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -213,7 +213,11 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
                     }
                 };
 
-                if let Err(error) = conn.on_wakeup(timestamp, endpoint_context.event_subscriber) {
+                if let Err(error) = conn.on_wakeup(
+                    timestamp,
+                    endpoint_context.event_subscriber,
+                    endpoint_context.datagram,
+                ) {
                     conn.close(
                         error,
                         endpoint_context.connection_close_formatter,
@@ -569,6 +573,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                     endpoint_context.random_generator,
                     endpoint_context.event_subscriber,
                     endpoint_context.packet_interceptor,
+                    endpoint_context.datagram,
                 ) {
                     match err {
                         ProcessingError::DuplicatePacket => {
@@ -635,6 +640,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                     endpoint_context.random_generator,
                     endpoint_context.event_subscriber,
                     endpoint_context.packet_interceptor,
+                    endpoint_context.datagram,
                 ) {
                     conn.close(
                         err,
@@ -1114,6 +1120,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
             event_context,
             supervisor_context: &supervisor_context,
             event_subscriber: endpoint_context.event_subscriber,
+            datagram_endpoint: endpoint_context.datagram,
         };
         let connection = <Cfg as crate::endpoint::Config>::Connection::new(connection_parameters)?;
         self.connections

--- a/quic/s2n-quic-transport/src/space/datagram.rs
+++ b/quic/s2n-quic-transport/src/space/datagram.rs
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    endpoint,
+    stream::{AbstractStreamManager, StreamTrait as Stream},
+    transmission::WriteContext,
+};
+use s2n_quic_core::{
+    datagram::{Endpoint, Sender},
+    frame,
+};
+
+pub struct Manager<Config: endpoint::Config> {
+    sender: <<Config as endpoint::Config>::DatagramEndpoint as Endpoint>::Sender,
+    // TODO: Remove this warning once Receiver is implemented
+    #[allow(dead_code)]
+    receiver: <<Config as endpoint::Config>::DatagramEndpoint as Endpoint>::Receiver,
+}
+
+impl<Config: endpoint::Config> Manager<Config> {
+    pub fn new(
+        sender: <<Config as endpoint::Config>::DatagramEndpoint as Endpoint>::Sender,
+        receiver: <<Config as endpoint::Config>::DatagramEndpoint as Endpoint>::Receiver,
+    ) -> Self {
+        Self { sender, receiver }
+    }
+
+    pub fn on_transmit<S: Stream, W: WriteContext>(
+        &mut self,
+        context: &mut W,
+        stream_manager: &mut AbstractStreamManager<S>,
+    ) {
+        let mut packet = Packet {
+            context,
+            pending_streams: stream_manager.pending_streams(),
+        };
+        self.sender.on_transmit(&mut packet);
+    }
+}
+struct Packet<'a, C: WriteContext> {
+    context: &'a mut C,
+    pending_streams: bool,
+}
+
+const FRAME_TYPE_LEN: usize = 1;
+
+impl<'a, C: WriteContext> s2n_quic_core::datagram::Packet for Packet<'a, C> {
+    /// Returns the remaining space in the packet
+    fn remaining_capacity(&self) -> usize {
+        self.context.remaining_capacity()
+    }
+
+    /// Returns the largest datagram that can fit in space remaining in the packet
+    fn maximum_datagram_payload(&self) -> usize {
+        let space = self.context.remaining_capacity();
+        // In the case where the user writes the largest datagram possible
+        // we don't factor in the size of the Length field as
+        // it will be the last frame in the packet.
+        space - FRAME_TYPE_LEN
+    }
+
+    /// Writes a single datagram to a packet
+    fn write_datagram(&mut self, data: &[u8]) {
+        let remaining_capacity = self.context.remaining_capacity();
+        let data_len = data.len();
+        let is_last_frame = remaining_capacity == FRAME_TYPE_LEN + data_len;
+        let frame = frame::Datagram {
+            is_last_frame,
+            data,
+        };
+        self.context.write_frame(&frame);
+    }
+
+    // Returns whether or not there is reliable data ready to send
+    fn pending_streams(&self) -> bool {
+        self.pending_streams
+    }
+}

--- a/quic/s2n-quic-transport/src/space/datagram.rs
+++ b/quic/s2n-quic-transport/src/space/datagram.rs
@@ -11,6 +11,10 @@ use s2n_quic_core::{
     frame,
 };
 
+// Contains the datagram sender and receiver implementations.
+//
+// Used to call datagram callbacks during packet transmission and
+// packet processing.
 pub struct Manager<Config: endpoint::Config> {
     sender: <<Config as endpoint::Config>::DatagramEndpoint as Endpoint>::Sender,
     // TODO: Remove this warning once Receiver is implemented
@@ -26,9 +30,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         Self { sender, receiver }
     }
 
-    // This function creates a packet that a user can interrogate to learn
-    // more about the packet space available for datagrams, and to write
-    // datagrams to the packet.
+    /// A callback that allows users to write datagrams directly to the packet.
     pub fn on_transmit<S: Stream, W: WriteContext>(
         &mut self,
         context: &mut W,

--- a/quic/s2n-quic-transport/src/space/datagram.rs
+++ b/quic/s2n-quic-transport/src/space/datagram.rs
@@ -53,11 +53,6 @@ const FRAME_TYPE_LEN: usize = 1;
 impl<'a, C: WriteContext> s2n_quic_core::datagram::Packet for Packet<'a, C> {
     /// Returns the remaining space in the packet
     fn remaining_capacity(&self) -> usize {
-        self.context.remaining_capacity()
-    }
-
-    /// Returns the largest datagram that can fit in space remaining in the packet
-    fn maximum_datagram_payload(&self) -> usize {
         let space = self.context.remaining_capacity();
         //= https://www.rfc-editor.org/rfc/rfc9221#section-4
         //# The least significant bit of the Type field in the DATAGRAM frame is

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -34,6 +34,7 @@ use s2n_quic_core::{
 
 mod application;
 mod crypto_stream;
+pub(crate) mod datagram;
 mod handshake;
 mod handshake_status;
 mod initial;
@@ -201,6 +202,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         now: Timestamp,
         waker: &Waker,
         publisher: &mut Pub,
+        datagram: &mut Config::DatagramEndpoint,
     ) -> Poll<Result<(), transport::Error>> {
         if let Some(session_info) = self.session_info.as_mut() {
             let mut context: SessionContext<Config, Pub> = SessionContext {
@@ -219,6 +221,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
                 application_protocol: &mut self.application_protocol,
                 waker,
                 publisher,
+                datagram,
             };
 
             match session_info.session.poll(&mut context)? {

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -194,6 +194,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         self.zero_rtt_crypto = None;
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn poll_crypto<Pub: event::ConnectionPublisher>(
         &mut self,
         path_manager: &mut path::Manager<Config>,

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -368,7 +368,7 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
             self.limits.max_keep_alive_period(),
         );
 
-        let (datagram_sender, datagram_receiver) = self.datagram.new_datagram();
+        let (datagram_sender, datagram_receiver) = self.datagram.split();
         let cipher_suite = key.cipher_suite().into_event();
         let max_mtu = self.path_manager.max_mtu();
         *self.application = Some(Box::new(ApplicationSpace::new(

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -20,6 +20,7 @@ use s2n_quic_core::{
     crypto,
     crypto::{tls, CryptoSuite, Key},
     ct::ConstantTimeEq,
+    datagram::Endpoint,
     event,
     event::IntoEvent,
     packet::number::PacketNumberSpace,
@@ -51,6 +52,7 @@ pub struct SessionContext<'a, Config: endpoint::Config, Pub: event::ConnectionPu
     pub application_protocol: &'a mut Bytes,
     pub waker: &'a Waker,
     pub publisher: &'a mut Pub,
+    pub datagram: &'a mut Config::DatagramEndpoint,
 }
 
 impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
@@ -366,6 +368,7 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
             self.limits.max_keep_alive_period(),
         );
 
+        let (datagram_sender, datagram_receiver) = self.datagram.new_datagram();
         let cipher_suite = key.cipher_suite().into_event();
         let max_mtu = self.path_manager.max_mtu();
         *self.application = Some(Box::new(ApplicationSpace::new(
@@ -376,6 +379,8 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
             ack_manager,
             keep_alive,
             max_mtu,
+            datagram_sender,
+            datagram_receiver,
         )));
         self.publisher.on_key_update(event::builder::KeyUpdate {
             key_type: event::builder::KeyType::OneRtt { generation: 0 },

--- a/quic/s2n-quic-transport/src/stream/stream_container.rs
+++ b/quic/s2n-quic-transport/src/stream/stream_container.rs
@@ -618,6 +618,12 @@ impl<S: StreamTrait> StreamContainer<S> {
             self.finalize_done_streams(controller);
         }
     }
+
+    /// Returns whether or not streams have data to send
+    pub fn pending_streams(&self) -> bool {
+        !self.interest_lists.waiting_for_transmission.is_empty()
+            || !self.interest_lists.waiting_for_retransmission.is_empty()
+    }
 }
 
 impl<S: StreamTrait> timer::Provider for StreamContainer<S> {

--- a/quic/s2n-quic-transport/src/stream/stream_manager.rs
+++ b/quic/s2n-quic-transport/src/stream/stream_manager.rs
@@ -387,7 +387,7 @@ impl<S: StreamTrait> StreamManagerState<S> {
 }
 
 /// Manages all active `Stream`s inside a connection.
-/// `AbstractStreamManager` is paramterized over the `Stream` type.
+/// `AbstractStreamManager` is parameterized over the `Stream` type.
 #[derive(Debug)]
 pub struct AbstractStreamManager<S> {
     pub(super) inner: StreamManagerState<S>,
@@ -978,6 +978,11 @@ impl<S: StreamTrait> AbstractStreamManager<S> {
             api_call_context,
             |stream| stream.poll_request(request, context),
         )
+    }
+
+    /// Returns whether or not streams have data to send
+    pub fn pending_streams(&self) -> bool {
+        self.inner.streams.pending_streams()
     }
 }
 

--- a/quic/s2n-quic-transport/src/transmission/application.rs
+++ b/quic/s2n-quic-transport/src/transmission/application.rs
@@ -133,6 +133,9 @@ impl<'a, S: Stream, Config: endpoint::Config> Normal<'a, S, Config> {
 
             self.path_manager.on_transmit(context);
 
+            // By default, unreliable datagrams are sent before stream data. This can be
+            // configured by implementing a custom datagram sender and choosing to cede
+            // packet space for stream data.
             self.datagram_manager
                 .on_transmit(context, self.stream_manager);
 

--- a/quic/s2n-quic-transport/src/transmission/application.rs
+++ b/quic/s2n-quic-transport/src/transmission/application.rs
@@ -133,9 +133,9 @@ impl<'a, S: Stream, Config: endpoint::Config> Normal<'a, S, Config> {
 
             self.path_manager.on_transmit(context);
 
-            // By default, unreliable datagrams are sent before stream data. This can be
-            // configured by implementing a custom datagram sender and choosing to cede
-            // packet space for stream data.
+            // The default sending behavior is to alternate between sending datagrams
+            // and sending stream data. This can be configured by implementing a
+            // custom datagram sender and choosing when to cede packet space for stream data.
             self.datagram_manager
                 .on_transmit(context, self.stream_manager);
 

--- a/quic/s2n-quic-transport/src/transmission/application.rs
+++ b/quic/s2n-quic-transport/src/transmission/application.rs
@@ -8,7 +8,7 @@ use crate::{
     endpoint, path,
     path::mtu,
     recovery,
-    space::HandshakeStatus,
+    space::{datagram, HandshakeStatus},
     stream::{AbstractStreamManager, StreamTrait as Stream},
     sync::{flag, flag::Ping},
     transmission::{self, Mode},
@@ -37,6 +37,7 @@ impl<'a, Config: endpoint::Config> Payload<'a, Config> {
         ping: &'a mut flag::Ping,
         stream_manager: &'a mut AbstractStreamManager<Config::Stream>,
         recovery_manager: &'a mut recovery::Manager<Config>,
+        datagram_manager: &'a mut datagram::Manager<Config>,
     ) -> Self {
         if transmission_mode != Mode::PathValidationOnly {
             debug_assert_eq!(path_id, path_manager.active_path_id());
@@ -52,6 +53,7 @@ impl<'a, Config: endpoint::Config> Payload<'a, Config> {
                     local_id_registry,
                     path_manager,
                     recovery_manager,
+                    datagram_manager,
                 })
             }
             Mode::MtuProbing => transmission::application::Payload::MtuProbe(MtuProbe {
@@ -106,6 +108,7 @@ pub struct Normal<'a, S: Stream, Config: endpoint::Config> {
     local_id_registry: &'a mut connection::LocalIdRegistry,
     path_manager: &'a mut path::Manager<Config>,
     recovery_manager: &'a mut recovery::Manager<Config>,
+    datagram_manager: &'a mut datagram::Manager<Config>,
 }
 
 impl<'a, S: Stream, Config: endpoint::Config> Normal<'a, S, Config> {
@@ -129,6 +132,9 @@ impl<'a, S: Stream, Config: endpoint::Config> Normal<'a, S, Config> {
             self.local_id_registry.on_transmit(context);
 
             self.path_manager.on_transmit(context);
+
+            self.datagram_manager
+                .on_transmit(context, self.stream_manager);
 
             let _ = self.stream_manager.on_transmit(context);
 


### PR DESCRIPTION
### Resolved issues:

related to #1253 

### Description of changes: 

Creates the backend logic around calling customer callbacks to send unreliable datagrams.

### Call-outs:

This PR ended up being larger than I intended, primarily because of all the places I had to feed the datagram provider into in order to call the callback in the correct location. Because of this, I did _not_ include the logic to switch between sending datagrams versus sending control data or adding the transmission_interest function to the sender callback. I want that to be in a separate PR, unless someone says otherwise.

Also this PR includes code customers would use to write datagrams to the wire, I can break that logic into a separate PR it's currently too much to review.

### Testing:


Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

