### PR TITLE
chore: release s2n-quic 1.1.1

### DIFF
--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-core"
-version = "0.2.0"
+version = "0.2.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-platform"
-version = "0.2.0"
+version = "0.2.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -26,7 +26,7 @@ errno = "0.2"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 lazy_static = { version = "1", optional = true }
 pin-project = { version = "1", optional = true }
-s2n-quic-core = { version = "=0.2.0", path = "../s2n-quic-core", default-features = false }
+s2n-quic-core = { version = "=0.2.1", path = "../s2n-quic-core", default-features = false }
 socket2 = { version = "0.4", features = ["all"], optional = true }
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt", "time"], optional = true }
 zeroize = { version = "1", default-features = false, optional = true }

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-rustls"
-version = "0.2.0"
+version = "0.2.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -14,7 +14,7 @@ bytes = { version = "1", default-features = false }
 rustls = { version = "0.20", features = ["quic"] }
 rustls-pemfile = "0.3"
 s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.2.0", path = "../s2n-quic-core", default-features = false }
+s2n-quic-core = { version = "=0.2.1", path = "../s2n-quic-core", default-features = false }
 s2n-quic-crypto = { version = "=0.2.0", path = "../s2n-quic-crypto", default-features = false }
 
 [dev-dependencies]

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-tls-default"
-version = "0.2.0"
+version = "0.2.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -13,4 +13,4 @@ exclude = ["corpus.tar.gz"]
 s2n-quic-tls = { version = "=0.2.1", path = "../s2n-quic-tls" }
 
 [target.'cfg(not(unix))'.dependencies]
-s2n-quic-rustls = { version = "=0.2.0", path = "../s2n-quic-rustls" }
+s2n-quic-rustls = { version = "=0.2.1", path = "../s2n-quic-rustls" }

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -10,7 +10,7 @@ license = "Apache-2.0"
 exclude = ["corpus.tar.gz"]
 
 [target.'cfg(unix)'.dependencies]
-s2n-quic-tls = { version = "=0.2.0", path = "../s2n-quic-tls" }
+s2n-quic-tls = { version = "=0.2.1", path = "../s2n-quic-tls" }
 
 [target.'cfg(not(unix))'.dependencies]
 s2n-quic-rustls = { version = "=0.2.0", path = "../s2n-quic-rustls" }

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-tls"
-version = "0.2.0"
+version = "0.2.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -18,7 +18,7 @@ errno = "0.2"
 libc = "0.2"
 
 s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.2.0", path = "../s2n-quic-core", default-features = false }
+s2n-quic-core = { version = "=0.2.1", path = "../s2n-quic-core", default-features = false }
 s2n-quic-crypto = { version = "=0.2.0", path = "../s2n-quic-crypto", default-features = false }
 s2n-tls = { version = "=0.0.7", features = ["quic"] }
 

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-transport"
-version = "0.2.0"
+version = "0.2.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -21,7 +21,7 @@ hashbrown = "0.11"
 intrusive-collections = "0.9"
 once_cell = "1"
 s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
-s2n-quic-core = { version = "=0.2.0", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
+s2n-quic-core = { version = "=0.2.1", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
 siphasher = "0.3"
 smallvec = { version = "1", default-features = false }
 

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic"
-version = "1.1.0"
+version = "1.1.1"
 description = "A Rust implementation of the IETF QUIC protocol"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -51,12 +51,12 @@ rand = "0.8"
 rand_chacha = "0.3"
 ring = { version = "0.16", optional = true, default-features = false }
 s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec" }
-s2n-quic-core = { version = "=0.2.0", path = "../s2n-quic-core" }
-s2n-quic-platform = { version = "=0.2.0", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
+s2n-quic-core = { version = "=0.2.1", path = "../s2n-quic-core" }
+s2n-quic-platform = { version = "=0.2.1", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
 s2n-quic-rustls = { version = "=0.2.0", path = "../s2n-quic-rustls", optional = true }
-s2n-quic-tls = { version = "=0.2.0", path = "../s2n-quic-tls", optional = true }
+s2n-quic-tls = { version = "=0.2.1", path = "../s2n-quic-tls", optional = true }
 s2n-quic-tls-default = { version = "=0.2.0", path = "../s2n-quic-tls-default", optional = true }
-s2n-quic-transport = { version = "=0.2.0", path = "../s2n-quic-transport" }
+s2n-quic-transport = { version = "=0.2.1", path = "../s2n-quic-transport" }
 tokio = { version = "1", default-features = false }
 zerocopy = { version = "=0.6.0", optional = true }
 zerocopy-derive = { version = "=0.3.0", optional = true }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -53,9 +53,9 @@ ring = { version = "0.16", optional = true, default-features = false }
 s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec" }
 s2n-quic-core = { version = "=0.2.1", path = "../s2n-quic-core" }
 s2n-quic-platform = { version = "=0.2.1", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
-s2n-quic-rustls = { version = "=0.2.0", path = "../s2n-quic-rustls", optional = true }
+s2n-quic-rustls = { version = "=0.2.1", path = "../s2n-quic-rustls", optional = true }
 s2n-quic-tls = { version = "=0.2.1", path = "../s2n-quic-tls", optional = true }
-s2n-quic-tls-default = { version = "=0.2.0", path = "../s2n-quic-tls-default", optional = true }
+s2n-quic-tls-default = { version = "=0.2.1", path = "../s2n-quic-tls-default", optional = true }
 s2n-quic-transport = { version = "=0.2.1", path = "../s2n-quic-transport" }
 tokio = { version = "1", default-features = false }
 zerocopy = { version = "=0.6.0", optional = true }


### PR DESCRIPTION
### Description of changes: 

This bumps the versions of all changed crates based on semver.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

