### PR TITLE
feat(s2n-quic-transport): allow connections to store aggregate ack info and indicate ack interest

### DIFF
--- a/quic/s2n-quic-transport/src/ack/interest.rs
+++ b/quic/s2n-quic-transport/src/ack/interest.rs
@@ -4,7 +4,6 @@
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Interest {
     None,
-    #[allow(dead_code)]
     Immediate,
 }
 

--- a/quic/s2n-quic-transport/src/ack/mod.rs
+++ b/quic/s2n-quic-transport/src/ack/mod.rs
@@ -9,8 +9,7 @@ mod ack_manager;
 pub(crate) mod ack_ranges;
 mod ack_transmission_state;
 pub mod interest;
-#[allow(dead_code)]
-mod pending_ack_ranges;
+pub(crate) mod pending_ack_ranges;
 
 #[cfg(test)]
 mod tests;

--- a/quic/s2n-quic-transport/src/ack/pending_ack_ranges.rs
+++ b/quic/s2n-quic-transport/src/ack/pending_ack_ranges.rs
@@ -8,19 +8,19 @@ use s2n_quic_core::{
     packet::number::{PacketNumber, PacketNumberRange},
 };
 
-/// Stores ACK ranges pending processing
+/// Stores aggregated ACK info for delayed processing
 #[derive(Clone, Debug, Default)]
 pub struct PendingAckRanges {
-    ranges: AckRanges,
+    ack_ranges: AckRanges,
     ecn_counts: EcnCounts,
     ack_delay: Duration,
 }
 
 impl PendingAckRanges {
     #[inline]
-    pub fn new(ranges: AckRanges, ecn_counts: EcnCounts, ack_delay: Duration) -> Self {
+    pub fn new(ack_ranges: AckRanges, ecn_counts: EcnCounts, ack_delay: Duration) -> Self {
         PendingAckRanges {
-            ranges,
+            ack_ranges,
             ecn_counts,
             ack_delay,
         }
@@ -48,7 +48,7 @@ impl PendingAckRanges {
         let mut did_insert = true;
         // TODO: add metrics if ack ranges are being dropped
         for range in acked_packets {
-            did_insert &= self.ranges.insert_packet_number_range(range).is_ok()
+            did_insert &= self.ack_ranges.insert_packet_number_range(range).is_ok()
         }
 
         match did_insert {
@@ -57,16 +57,39 @@ impl PendingAckRanges {
         }
     }
 
-    /// Returns an iterator over all of the values contained in the ranges `IntervalSet`.
+    /// Returns an iterator over all values in the `AckRanges`
     #[inline]
-    pub fn iter(&self) -> interval_set::IntervalIter<PacketNumber> {
-        self.ranges.intervals()
+    pub fn iter(&self) -> interval_set::RangeInclusiveIter<PacketNumber> {
+        self.ack_ranges.inclusive_ranges()
+    }
+
+    /// Returns `EcnCounts` aggregated over all the pending ACKs
+    #[inline]
+    pub fn ecn_counts(&self) -> Option<EcnCounts> {
+        if self.ack_ranges.is_empty() {
+            None
+        } else {
+            Some(self.ecn_counts)
+        }
+    }
+
+    /// Returns the ACK delay associated with all the pending ACKs
+    #[inline]
+    pub fn ack_delay(&self) -> Duration {
+        self.ack_delay
+    }
+
+    /// Returns the largest `PacketNumber` stored in the AckRanges.
+    ///
+    /// If no items are present in the set, `None` is returned.
+    pub fn max_value(&self) -> Option<PacketNumber> {
+        self.ack_ranges.max_value()
     }
 
     /// Clear the ack ranges and reset values
     #[inline]
     pub fn clear(&mut self) {
-        self.ranges.clear();
+        self.ack_ranges.clear();
         self.ecn_counts = EcnCounts::default();
         self.ack_delay = Duration::default();
     }
@@ -74,7 +97,7 @@ impl PendingAckRanges {
     /// Returns if ack ranges are being tracked
     #[inline]
     pub fn is_empty(&self) -> bool {
-        self.ranges.is_empty()
+        self.ack_ranges.is_empty()
     }
 }
 
@@ -114,7 +137,7 @@ mod tests {
         assert_eq!(pending_ack_ranges.ack_delay, now);
         assert_eq!(pending_ack_ranges.ecn_counts, ecn_counts);
         assert!(!pending_ack_ranges.is_empty());
-        assert_eq!(pending_ack_ranges.ranges.interval_len(), 1);
+        assert_eq!(pending_ack_ranges.ack_ranges.interval_len(), 1);
 
         // insert new range with updated ack_delay and ecn_counts
         now = now.saturating_add(Duration::from_millis(1));
@@ -131,7 +154,7 @@ mod tests {
         assert_eq!(pending_ack_ranges.ack_delay, now);
         assert_eq!(pending_ack_ranges.ecn_counts, ecn_counts);
         assert!(!pending_ack_ranges.is_empty());
-        assert_eq!(pending_ack_ranges.ranges.interval_len(), 2);
+        assert_eq!(pending_ack_ranges.ack_ranges.interval_len(), 2);
 
         // ensure pending_ack_ranges clear functionality works
         {
@@ -139,9 +162,9 @@ mod tests {
             pending_ack_ranges.clear();
 
             assert!(pending_ack_ranges.is_empty());
-            assert_eq!(pending_ack_ranges.ranges.interval_len(), 0);
-            assert!(!pending_ack_ranges.ranges.contains(&pn_a));
-            assert!(!pending_ack_ranges.ranges.contains(&pn_b));
+            assert_eq!(pending_ack_ranges.ack_ranges.interval_len(), 0);
+            assert!(!pending_ack_ranges.ack_ranges.contains(&pn_a));
+            assert!(!pending_ack_ranges.ack_ranges.contains(&pn_b));
         }
     }
 
@@ -166,7 +189,13 @@ mod tests {
             .extend(pn_range_b.into_iter(), Some(ecn_counts), now)
             .is_ok());
 
-        let coll: Vec<PacketNumber> = pending_ack_ranges.iter().flatten().collect();
+        let coll: Vec<PacketNumber> = pending_ack_ranges
+            .iter()
+            .flat_map(|range| {
+                let (start, end) = range.into_inner();
+                PacketNumberRange::new(start, end)
+            })
+            .collect();
         assert_eq!(coll.len(), 2);
         let arr = [pn_a, pn_b];
         for pn in coll.iter() {
@@ -189,7 +218,7 @@ mod tests {
         assert!(pending_ack_ranges
             .extend(range_1.into_iter(), Some(ecn_counts), now)
             .is_ok());
-        assert_eq!(pending_ack_ranges.ranges.interval_len(), 1);
+        assert_eq!(pending_ack_ranges.ack_ranges.interval_len(), 1);
     }
 
     #[test]

--- a/quic/s2n-quic-transport/src/connection/connection_container.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container.rs
@@ -63,7 +63,7 @@ intrusive_adapter!(WaitingForConnectionIdAdapter<C, L> = Arc<ConnectionNode<C, L
 // Intrusive list adapter for managing the list of
 // `waiting_for_ack` connections
 intrusive_adapter!(WaitingForAckAdapter<C, L> = Arc<ConnectionNode<C, L>>: ConnectionNode<C, L> {
-    waiting_for_connection_id_link: LinkedListLink
+    waiting_for_ack_link: LinkedListLink
 } where C: connection::Trait, L: connection::Lock<C>);
 
 // Intrusive red black tree adapter for managing a list of `waiting_for_timeout` connections
@@ -957,6 +957,7 @@ impl<C: connection::Trait, L: connection::Lock<C>> ConnectionContainer<C, L> {
 
     /// Iterates over all `Connection`s which are waiting to process ACKs,
     /// and executes the given function on each `Connection`
+    #[allow(dead_code)]
     pub fn iterate_ack_list<F>(&mut self, mut func: F)
     where
         F: FnMut(&mut C),

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -125,7 +125,7 @@ impl connection::Trait for TestConnection {
         Ok(())
     }
 
-    fn on_process_pending_acks(
+    fn on_pending_ack_ranges(
         &mut self,
         _timestamp: Timestamp,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -129,7 +129,8 @@ impl connection::Trait for TestConnection {
         &mut self,
         _timestamp: Timestamp,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
-    ) {
+    ) -> Result<(), connection::Error> {
+        Ok(())
     }
 
     fn on_wakeup(

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -125,7 +125,12 @@ impl connection::Trait for TestConnection {
         Ok(())
     }
 
-    fn on_process_acks(&mut self) {}
+    fn on_process_pending_acks(
+        &mut self,
+        _timestamp: Timestamp,
+        _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
+    ) {
+    }
 
     fn on_wakeup(
         &mut self,

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1060,15 +1060,15 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         // However, the active path could change so it might be necessary to track the
         // active path across some ACK delay processing.
         let path_id = self.path_manager.active_path_id();
-        self.space_manager
-            .on_pending_ack_ranges(
-                timestamp,
-                path_id,
-                &mut self.path_manager,
-                &mut self.local_id_registry,
-                &mut publisher,
-            )
-            .unwrap();
+        if let Err(_err) = self.space_manager.on_pending_ack_ranges(
+            timestamp,
+            path_id,
+            &mut self.path_manager,
+            &mut self.local_id_registry,
+            &mut publisher,
+        ) {
+            // TODO: publish metrics
+        }
     }
 
     /// Handles all external wakeups on the [`Connection`].

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1049,7 +1049,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
     }
 
     /// Process ACKs for the `Connection`.
-    fn on_process_pending_acks(
+    fn on_pending_ack_ranges(
         &mut self,
         timestamp: Timestamp,
         subscriber: &mut Config::EventSubscriber,
@@ -1061,7 +1061,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         // active path across some ACK delay processing.
         let path_id = self.path_manager.active_path_id();
         self.space_manager
-            .on_process_pending_acks(
+            .on_pending_ack_ranges(
                 timestamp,
                 path_id,
                 &mut self.path_manager,

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -100,7 +100,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     ) -> Result<(), connection::Error>;
 
     /// Process pendings ACKs for the `Connection`.
-    fn on_process_pending_acks(
+    fn on_pending_ack_ranges(
         &mut self,
         timestamp: Timestamp,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -104,7 +104,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         &mut self,
         timestamp: Timestamp,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
-    );
+    ) -> Result<(), connection::Error>;
 
     /// Handles all external wakeups on the [`Connection`].
     fn on_wakeup(

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -99,7 +99,12 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) -> Result<(), connection::Error>;
 
-    fn on_process_acks(&mut self);
+    /// Process pendings ACKs for the `Connection`.
+    fn on_process_pending_acks(
+        &mut self,
+        timestamp: Timestamp,
+        subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
+    );
 
     /// Handles all external wakeups on the [`Connection`].
     fn on_wakeup(

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -119,19 +119,21 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
             }
         }
 
-        let endpoint_context = self.config.context();
-        // process ACKs on Connections with interest
-        self.connections.iterate_ack_list(|connection| {
-            let timestamp = match now {
-                Some(time) => time,
-                None => {
-                    now = Some(clock.get_time());
-                    now.expect("value should be set")
-                }
-            };
-
-            connection.on_pending_ack_ranges(timestamp, endpoint_context.event_subscriber);
-        });
+        // TODO process pending acks
+        // let endpoint_context = self.config.context();
+        // // process ACKs on Connections with interest
+        // self.connections.iterate_ack_list(|connection| {
+        //     let timestamp = match now {
+        //         Some(time) => time,
+        //         None => {
+        //             now = Some(clock.get_time());
+        //             now.expect("value should be set")
+        //         }
+        //     };
+        //
+        //     // handle error and potentially close the connection
+        //     connection.on_pending_ack_ranges(timestamp, endpoint_context.event_subscriber);
+        // });
 
         let len = entries.len();
         queue.finish(len);

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -387,7 +387,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         publisher: &mut Pub,
     ) -> Result<(), transport::Error> {
         // Update the largest acked packet if the largest packet acked in this frame is larger
-        let received_new_largest_packet = match self.largest_acked_packet {
+        let acked_new_largest_packet = match self.largest_acked_packet {
             Some(current_largest) if current_largest > largest_acked_packet_number => false,
             _ => {
                 self.largest_acked_packet = Some(largest_acked_packet_number);
@@ -427,7 +427,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             self.process_new_acked_packets(
                 &newly_acked_packets,
                 largest_newly_acked_info,
-                received_new_largest_packet,
+                acked_new_largest_packet,
                 timestamp,
                 ecn_counts,
                 context,

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -323,7 +323,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         let largest_acked_packet_number = pending_ack_ranges
             .max_value()
             .expect("pending range should not be empty");
-        self.process_acks(
+        let result = self.process_acks(
             timestamp,
             pending_ack_ranges.iter(),
             largest_acked_packet_number,
@@ -331,9 +331,15 @@ impl<Config: endpoint::Config> Manager<Config> {
             pending_ack_ranges.ecn_counts(),
             context,
             publisher,
-        )?;
+        );
 
-        Ok(())
+        // reset pending ack information after processing
+        //
+        // If there was an error during processing its probably safer
+        // to clear the queue rather than try again.
+        pending_ack_ranges.clear();
+
+        result
     }
 
     /// Process ACK frame.

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -308,7 +308,7 @@ impl<Config: endpoint::Config> Manager<Config> {
     /// Process pending ACK information.
     ///
     /// Update congestion controller, timers and meta data around acked packet ranges.
-    pub fn on_process_pending_ack_ranges<Ctx: Context<Config>, Pub: event::ConnectionPublisher>(
+    pub fn on_pending_ack_ranges<Ctx: Context<Config>, Pub: event::ConnectionPublisher>(
         &mut self,
         timestamp: Timestamp,
         pending_ack_ranges: &mut PendingAckRanges,
@@ -325,9 +325,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             .expect("pending range should not be empty");
         self.process_acks(
             timestamp,
-            pending_ack_ranges
-                .iter()
-                .map(|ack_range| PacketNumberRange::new(*ack_range.start(), *ack_range.end())),
+            pending_ack_ranges.iter(),
             largest_acked_packet_number,
             pending_ack_ranges.ack_delay(),
             pending_ack_ranges.ecn_counts(),

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -445,7 +445,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         self.retry_cid.as_deref()
     }
 
-    pub fn on_process_pending_acks<Pub: event::ConnectionPublisher>(
+    pub fn on_pending_ack_ranges<Pub: event::ConnectionPublisher>(
         &mut self,
         timestamp: Timestamp,
         path_id: path::Id,
@@ -464,7 +464,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         );
 
         if let Some((space, handshake_status)) = self.application_mut() {
-            space.on_process_pending_acks(
+            space.on_pending_ack_ranges(
                 timestamp,
                 path_id,
                 path_manager,


### PR DESCRIPTION
### Description of changes: 
This PR paves the path for delayed ACK processing. NOTE: delayed ack processing is still not enabled. 

- store `pending_ack_ranges: PendingAckRanges` on space::Application
- indicate interest if there are pending ACKs for the connection
- introduce fn in space/application for `update_pending_acks` and `on_process_pending_acks` which can be used for delayed ack processing
- refactor recovery/manger interface to take `impl Iterator<Item = RangeInclusive<PacketNumber>>`

### Call-outs:
- The next and last task remaining for feature complete is to selectively store ACKs for delayed processing rather than processing immediately


### Testing:
refactor change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

