### PR TITLE
feat: port throttling

### DIFF
--- a/quic/s2n-quic-core/src/endpoint/limits.rs
+++ b/quic/s2n-quic-core/src/endpoint/limits.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    event::Timestamp,
-    event::{api::SocketAddress, IntoEvent},
+    event::{api::SocketAddress, IntoEvent, Timestamp},
     inet,
 };
 

--- a/quic/s2n-quic-core/src/endpoint/limits.rs
+++ b/quic/s2n-quic-core/src/endpoint/limits.rs
@@ -4,6 +4,7 @@
 use crate::{
     event::{api::SocketAddress, IntoEvent},
     inet,
+    time::Timestamp,
 };
 
 /// Outcome describes how the library should proceed on a connection attempt. The implementor will
@@ -74,6 +75,7 @@ pub struct ConnectionAttempt<'a> {
     /// The unverified address of the connecting peer
     /// This address comes from the datagram
     pub remote_address: SocketAddress<'a>,
+    pub time_stamp: Timestamp,
 }
 
 impl<'a> ConnectionAttempt<'a> {
@@ -82,11 +84,13 @@ impl<'a> ConnectionAttempt<'a> {
         inflight_handshakes: usize,
         connection_count: usize,
         remote_address: &'a inet::SocketAddress,
+        time_stamp: Timestamp,
     ) -> Self {
         Self {
             inflight_handshakes,
             connection_count,
             remote_address: remote_address.into_event(),
+            time_stamp,
         }
     }
 }

--- a/quic/s2n-quic-core/src/endpoint/limits.rs
+++ b/quic/s2n-quic-core/src/endpoint/limits.rs
@@ -75,7 +75,7 @@ pub struct ConnectionAttempt<'a> {
     /// The unverified address of the connecting peer
     /// This address comes from the datagram
     pub remote_address: SocketAddress<'a>,
-    pub time_stamp: Timestamp,
+    pub timestamp: Timestamp,
 }
 
 impl<'a> ConnectionAttempt<'a> {
@@ -84,13 +84,13 @@ impl<'a> ConnectionAttempt<'a> {
         inflight_handshakes: usize,
         connection_count: usize,
         remote_address: &'a inet::SocketAddress,
-        time_stamp: Timestamp,
+        timestamp: Timestamp,
     ) -> Self {
         Self {
             inflight_handshakes,
             connection_count,
             remote_address: remote_address.into_event(),
-            time_stamp,
+            timestamp,
         }
     }
 }

--- a/quic/s2n-quic-core/src/endpoint/limits.rs
+++ b/quic/s2n-quic-core/src/endpoint/limits.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    event::Timestamp,
     event::{api::SocketAddress, IntoEvent},
     inet,
-    time::Timestamp,
 };
 
 /// Outcome describes how the library should proceed on a connection attempt. The implementor will

--- a/quic/s2n-quic-core/src/event.rs
+++ b/quic/s2n-quic-core/src/event.rs
@@ -104,12 +104,25 @@ impl Timestamp {
         // with it's documentation captures this intent.
         unsafe { self.0.as_duration() }
     }
+
+    /// Returns the `Duration` which elapsed since an earlier `Timestamp`.
+    /// If `earlier` is more recent, the method returns a `Duration` of 0.
+    #[inline]
+    pub fn saturating_duration_since(self, earlier: Self) -> Duration {
+        self.0.saturating_duration_since(earlier.0)
+    }
 }
 
 impl IntoEvent<Timestamp> for crate::time::Timestamp {
     #[inline]
     fn into_event(self) -> Timestamp {
         Timestamp(self)
+    }
+}
+
+impl From<crate::time::Timestamp> for Timestamp {
+    fn from(timestamp: crate::time::Timestamp) -> Timestamp {
+        Timestamp(timestamp)
     }
 }
 

--- a/quic/s2n-quic-core/src/event.rs
+++ b/quic/s2n-quic-core/src/event.rs
@@ -120,12 +120,6 @@ impl IntoEvent<Timestamp> for crate::time::Timestamp {
     }
 }
 
-impl From<crate::time::Timestamp> for Timestamp {
-    fn from(timestamp: crate::time::Timestamp) -> Timestamp {
-        Timestamp(timestamp)
-    }
-}
-
 pub mod query {
 
     //! This module provides `Query` and `QueryMut` traits, which are used for querying the

--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -325,6 +325,17 @@ const THROTTLED_PORTS: [u16; 3] = [
     11211, // memcache, vulnerable to reflection attacks.
 ];
 const MAX_THROTTLED_PORT: u16 = THROTTLED_PORTS[THROTTLED_PORTS.len() - 1];
+pub const THROTTLED_PORTS_LEN: usize = THROTTLED_PORTS.len();
+
+#[inline]
+pub fn remote_port_throttled_index(port: u16) -> Option<usize> {
+    for (idx, throttled_port) in THROTTLED_PORTS.iter().enumerate() {
+        if *throttled_port == port {
+            return Some(idx);
+        }
+    }
+    None
+}
 
 #[inline]
 pub fn remote_port_throttled(port: u16) -> bool {

--- a/quic/s2n-quic-core/src/time/mod.rs
+++ b/quic/s2n-quic-core/src/time/mod.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-mod clock;
+pub mod clock;
 pub mod timer;
 mod timestamp;
 

--- a/quic/s2n-quic-core/src/time/mod.rs
+++ b/quic/s2n-quic-core/src/time/mod.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod clock;
+mod clock;
 pub mod timer;
 mod timestamp;
 

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -342,6 +342,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
             self.connections.handshake_connections(),
             self.connections.len(),
             &remote_address,
+            timestamp,
         );
 
         let context = self.config.context();

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -342,7 +342,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
             self.connections.handshake_connections(),
             self.connections.len(),
             &remote_address,
-            timestamp,
+            timestamp.into_event(),
         );
 
         let context = self.config.context();

--- a/quic/s2n-quic/api.snap
+++ b/quic/s2n-quic/api.snap
@@ -1,6 +1,5 @@
 ---
 source: src/main.rs
-assertion_line: 61
 expression: dump
 ---
 trait impl core::convert::TryFrom<s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::PlainMessage> for s2n_quic::provider::tls::rustls::rustls::internal::msgs::message::Message associates type:
@@ -1579,6 +1578,9 @@ struct s2n_quic::provider::endpoint_limits::ConnectionAttempt exports field:
 struct s2n_quic::provider::endpoint_limits::ConnectionAttempt exports field:
   remote_address: s2n_quic::provider::event::events::SocketAddress<'a>
 
+struct s2n_quic::provider::endpoint_limits::ConnectionAttempt exports field:
+  timestamp: s2n_quic::provider::event::Timestamp
+
 trait s2n_quic::provider::endpoint_limits::Limiter exports function:
   pub fn on_connection_attempt(&mut self, info: &s2n_quic::provider::endpoint_limits::ConnectionAttempt<'_>) -> s2n_quic::provider::endpoint_limits::Outcome
 
@@ -1889,6 +1891,9 @@ struct s2n_quic::provider::event::Timestamp implements trait:
   impl core::clone::Clone for s2n_quic::provider::event::Timestamp
 
 struct s2n_quic::provider::event::Timestamp implements trait:
+  impl core::convert::From<s2n_quic_core::time::timestamp::Timestamp> for s2n_quic::provider::event::Timestamp
+
+struct s2n_quic::provider::event::Timestamp implements trait:
   impl core::fmt::Debug for s2n_quic::provider::event::Timestamp
 
 struct s2n_quic::provider::event::Timestamp implements trait:
@@ -1908,6 +1913,9 @@ struct s2n_quic::provider::event::Timestamp implements trait:
 
 struct s2n_quic::provider::event::Timestamp exports function:
   pub fn duration_since_start(&self) -> core::time::Duration
+
+struct s2n_quic::provider::event::Timestamp exports function:
+  pub fn saturating_duration_since(self, earlier: s2n_quic::provider::event::Timestamp) -> core::time::Duration
 
 trait s2n_quic::provider::event::TryInto exports function:
   fn try_into(self) -> core::result::Result<Self::s2n_quic::provider::event::TryInto::Provider, Self::s2n_quic::provider::event::TryInto::Error>

--- a/quic/s2n-quic/api.snap
+++ b/quic/s2n-quic/api.snap
@@ -1891,9 +1891,6 @@ struct s2n_quic::provider::event::Timestamp implements trait:
   impl core::clone::Clone for s2n_quic::provider::event::Timestamp
 
 struct s2n_quic::provider::event::Timestamp implements trait:
-  impl core::convert::From<s2n_quic_core::time::timestamp::Timestamp> for s2n_quic::provider::event::Timestamp
-
-struct s2n_quic::provider::event::Timestamp implements trait:
   impl core::fmt::Debug for s2n_quic::provider::event::Timestamp
 
 struct s2n_quic::provider::event::Timestamp implements trait:

--- a/quic/s2n-quic/src/provider/endpoint_limits.rs
+++ b/quic/s2n-quic/src/provider/endpoint_limits.rs
@@ -102,7 +102,8 @@ mod tests {
     fn first_throttle_reset() {
         let remote_address = SocketAddress::default();
         let mock_clock = MockClock::default();
-        let info = ConnectionAttempt::new(0, 0, &remote_address, mock_clock.get_time().into_event());
+        let info =
+            ConnectionAttempt::new(0, 0, &remote_address, mock_clock.get_time().into_event());
 
         let mut rate_limiter = BasicRateLimiter::default();
         // The first time the throttle limit is hit the timer will be created so we expect to be
@@ -131,7 +132,8 @@ mod tests {
         // This test should never throttle because everytime the limit is about to get hit the
         // thread sleeps long enough for the throttle reset timer to fire.
         for request in 0..(THROTTLED_PORT_LIMIT * 3) {
-            let info = ConnectionAttempt::new(0, 0, &remote_address, mock_clock.get_time().into_event());
+            let info =
+                ConnectionAttempt::new(0, 0, &remote_address, mock_clock.get_time().into_event());
             if request % THROTTLED_PORT_LIMIT == 0 {
                 mock_clock.inc_by(sleep_longer_than_short_freq)
             }
@@ -258,9 +260,9 @@ pub mod default {
     #[test]
     fn blocked_port_connection_attempt() {
         use s2n_quic_core::{
+            event::IntoEvent,
             inet::SocketAddress,
             time::{testing::Clock as MockClock, Clock},
-            event::IntoEvent,
         };
 
         let mut remote_address = SocketAddress::default();
@@ -271,7 +273,8 @@ pub mod default {
             let blocked_expected = s2n_quic_core::path::remote_port_blocked(port);
 
             remote_address.set_port(port);
-            let info = ConnectionAttempt::new(0, 0, &remote_address, mock_clock.get_time().into_event());
+            let info =
+                ConnectionAttempt::new(0, 0, &remote_address, mock_clock.get_time().into_event());
             let outcome = limits.on_connection_attempt(&info);
 
             if blocked_expected {

--- a/quic/s2n-quic/src/provider/endpoint_limits.rs
+++ b/quic/s2n-quic/src/provider/endpoint_limits.rs
@@ -259,8 +259,10 @@ pub mod default {
 
     #[test]
     fn blocked_port_connection_attempt() {
-        use s2n_quic_core::inet::SocketAddress;
-        use s2n_quic_core::time::{testing::Clock as MockClock, Clock};
+        use s2n_quic_core::{
+            inet::SocketAddress,
+            time::{testing::Clock as MockClock, Clock},
+        };
 
         let mut remote_address = SocketAddress::default();
         let mut limits = Limits::builder().build().unwrap();

--- a/quic/s2n-quic/src/provider/endpoint_limits.rs
+++ b/quic/s2n-quic/src/provider/endpoint_limits.rs
@@ -93,6 +93,7 @@ mod tests {
     use core::time::Duration;
     use s2n_quic_core::{
         endpoint::limits::ConnectionAttempt,
+        event::IntoEvent,
         inet::SocketAddress,
         time::{testing::Clock as MockClock, Clock},
     };
@@ -101,7 +102,7 @@ mod tests {
     fn first_throttle_reset() {
         let remote_address = SocketAddress::default();
         let mock_clock = MockClock::default();
-        let info = ConnectionAttempt::new(0, 0, &remote_address, mock_clock.get_time().into());
+        let info = ConnectionAttempt::new(0, 0, &remote_address, mock_clock.get_time().into_event());
 
         let mut rate_limiter = BasicRateLimiter::default();
         // The first time the throttle limit is hit the timer will be created so we expect to be
@@ -130,7 +131,7 @@ mod tests {
         // This test should never throttle because everytime the limit is about to get hit the
         // thread sleeps long enough for the throttle reset timer to fire.
         for request in 0..(THROTTLED_PORT_LIMIT * 3) {
-            let info = ConnectionAttempt::new(0, 0, &remote_address, mock_clock.get_time().into());
+            let info = ConnectionAttempt::new(0, 0, &remote_address, mock_clock.get_time().into_event());
             if request % THROTTLED_PORT_LIMIT == 0 {
                 mock_clock.inc_by(sleep_longer_than_short_freq)
             }
@@ -259,6 +260,7 @@ pub mod default {
         use s2n_quic_core::{
             inet::SocketAddress,
             time::{testing::Clock as MockClock, Clock},
+            event::IntoEvent,
         };
 
         let mut remote_address = SocketAddress::default();
@@ -269,7 +271,7 @@ pub mod default {
             let blocked_expected = s2n_quic_core::path::remote_port_blocked(port);
 
             remote_address.set_port(port);
-            let info = ConnectionAttempt::new(0, 0, &remote_address, mock_clock.get_time().into());
+            let info = ConnectionAttempt::new(0, 0, &remote_address, mock_clock.get_time().into_event());
             let outcome = limits.on_connection_attempt(&info);
 
             if blocked_expected {

--- a/quic/s2n-quic/src/provider/endpoint_limits.rs
+++ b/quic/s2n-quic/src/provider/endpoint_limits.rs
@@ -3,11 +3,11 @@
 
 //! Allows applications to limit peer's ability to open new connections
 
-pub use s2n_quic_core::{
-    endpoint::{
-        limits::{ConnectionAttempt, Outcome},
-        Limiter,
-    },
+pub use s2n_quic_core::endpoint::{
+    limits::{ConnectionAttempt, Outcome},
+    Limiter,
+};
+use s2n_quic_core::{
     path::THROTTLED_PORTS_LEN,
     time::Timestamp,
 };

--- a/quic/s2n-quic/src/provider/endpoint_limits.rs
+++ b/quic/s2n-quic/src/provider/endpoint_limits.rs
@@ -7,10 +7,7 @@ pub use s2n_quic_core::endpoint::{
     limits::{ConnectionAttempt, Outcome},
     Limiter,
 };
-use s2n_quic_core::{
-    path::THROTTLED_PORTS_LEN,
-    time::Timestamp,
-};
+use s2n_quic_core::{path::THROTTLED_PORTS_LEN, time::Timestamp};
 
 pub trait Provider: 'static {
     type Limits: 'static + Limiter;

--- a/quic/s2n-quic/src/provider/endpoint_limits.rs
+++ b/quic/s2n-quic/src/provider/endpoint_limits.rs
@@ -202,7 +202,7 @@ pub mod default {
     pub struct Limits {
         /// Maximum number of handshakes to allow before Retry packets are queued
         max_inflight_handshake_limit: Option<usize>,
-        rate_limiter: Option<[BasicRateLimiter;THROTTLED_PORTS_LEN]>,
+        rate_limiter: Option<[BasicRateLimiter; THROTTLED_PORTS_LEN]>,
     }
 
     impl Limits {

--- a/quic/s2n-quic/src/provider/endpoint_limits.rs
+++ b/quic/s2n-quic/src/provider/endpoint_limits.rs
@@ -90,7 +90,7 @@ impl BasicRateLimiter {
     }
 }
 
-#[cfg(any(test, feature = "testing"))]
+#[cfg(test)]
 mod tests {
     use super::{BasicRateLimiter, THROTTLED_PORT_LIMIT, THROTTLE_FREQUENCY};
     use core::time::Duration;

--- a/quic/s2n-quic/src/provider/endpoint_limits.rs
+++ b/quic/s2n-quic/src/provider/endpoint_limits.rs
@@ -35,7 +35,7 @@ impl<T: 'static + Limiter> Provider for T {
 }
 
 const THROTTLED_PORT_LIMIT: usize = 10;
-const THROTTLE_FREQUENCY_MS: u64 = 1000;
+const THROTTLE_FREQUENCY: Duration = Duration::from_secs(1);
 
 #[derive(Default, Debug, Clone, Copy)]
 struct BasicRateLimiter {


### PR DESCRIPTION

### Resolved issues:

resolves #1259 

### Description of changes: 

* Start to throttle some ports that are vulnerable to a reflection
  attack.
* Added a basic rate limiting implementation to perform throttling.

### Call-outs:

I did not test this end to end, only in unit tests.

### Testing:

Ran unit tests on this code. Will try to set up an end to end test.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

