### PR TITLE
feat(netbench): dedupe connection operations

### DIFF
--- a/netbench/netbench-cli/src/report.rs
+++ b/netbench/netbench-cli/src/report.rs
@@ -105,6 +105,7 @@ impl Report {
                     deallocs,
                     syscalls,
                     connections,
+                    accept,
                     send,
                     receive,
                 } = event?;
@@ -168,6 +169,7 @@ impl Report {
                 emit!(ContextSwitches, context_switches);
                 emit!(Syscalls, syscalls);
                 emit!(Connections, connections);
+                emit!(Accept, accept);
                 emit!(AllocBytes, allocs.total);
                 emit!(AllocCount, allocs.count);
                 emit!(ReallocBytes, reallocs.total);
@@ -334,6 +336,7 @@ stat!(
         ContextSwitches = "context-switches",
         Syscalls = "syscalls",
         Connections = "connections",
+        Accept = "accept (streams)",
         AllocBytes = "alloc (bytes)",
         AllocCount = "alloc (count)",
         ReallocBytes = "realloc (bytes)",

--- a/netbench/netbench-cli/src/report.rs
+++ b/netbench/netbench-cli/src/report.rs
@@ -104,6 +104,7 @@ impl Report {
                     reallocs,
                     deallocs,
                     syscalls,
+                    connections,
                     send,
                     receive,
                 } = event?;
@@ -166,6 +167,7 @@ impl Report {
                 emit!(Branches, branches);
                 emit!(ContextSwitches, context_switches);
                 emit!(Syscalls, syscalls);
+                emit!(Connections, connections);
                 emit!(AllocBytes, allocs.total);
                 emit!(AllocCount, allocs.count);
                 emit!(ReallocBytes, reallocs.total);
@@ -331,6 +333,7 @@ stat!(
         Branches = "branches",
         ContextSwitches = "context-switches",
         Syscalls = "syscalls",
+        Connections = "connections",
         AllocBytes = "alloc (bytes)",
         AllocCount = "alloc (count)",
         ReallocBytes = "realloc (bytes)",

--- a/netbench/netbench-collector/src/bpftrace.rs
+++ b/netbench/netbench-collector/src/bpftrace.rs
@@ -73,6 +73,7 @@ impl Report {
         stat!("d", deallocs);
         stat!("S", syscalls);
         stat!("O", connections);
+        stat!("A", accept);
 
         macro_rules! try_map {
             ($prefix:literal, $on_value:expr) => {
@@ -136,6 +137,7 @@ impl Report {
             .saturating_sub(prev.context_switches);
         let syscalls = current.syscalls.saturating_sub(prev.syscalls);
         let connections = current.connections.saturating_sub(prev.connections);
+        let accept = current.accept.saturating_sub(prev.accept);
 
         let time = self.interval.as_millis() as u64 * self.count;
         let time = Duration::from_millis(time);
@@ -149,6 +151,7 @@ impl Report {
             context_switches,
             syscalls,
             connections,
+            accept,
             memory: current.memory,
             virtual_memory: current.virtual_memory,
             allocs: current.allocs,

--- a/netbench/netbench-collector/src/bpftrace.rs
+++ b/netbench/netbench-collector/src/bpftrace.rs
@@ -72,6 +72,7 @@ impl Report {
         stat!("R", reallocs);
         stat!("d", deallocs);
         stat!("S", syscalls);
+        stat!("O", connections);
 
         macro_rules! try_map {
             ($prefix:literal, $on_value:expr) => {
@@ -134,6 +135,7 @@ impl Report {
             .context_switches
             .saturating_sub(prev.context_switches);
         let syscalls = current.syscalls.saturating_sub(prev.syscalls);
+        let connections = current.connections.saturating_sub(prev.connections);
 
         let time = self.interval.as_millis() as u64 * self.count;
         let time = Duration::from_millis(time);
@@ -146,6 +148,7 @@ impl Report {
             branches,
             context_switches,
             syscalls,
+            connections,
             memory: current.memory,
             virtual_memory: current.virtual_memory,
             allocs: current.allocs,

--- a/netbench/netbench-collector/src/netbench.bt
+++ b/netbench/netbench-collector/src/netbench.bt
@@ -43,6 +43,12 @@ usdt:{{bin}}:netbench__connect
   @O=count();
 }
 
+usdt:{{bin}}:netbench__accept
+/pid==cpid/
+{
+  @A=count();
+}
+
 uprobe:{{libc}}:malloc
 /pid==cpid/
 {
@@ -112,6 +118,12 @@ i:ms:{{interval_ms}} {
 
   print(@r);
   clear(@r);
+
+  print(@O);
+  clear(@O);
+
+  print(@A);
+  clear(@A);
 
   print("===");
 }

--- a/netbench/netbench-collector/src/netbench.bt
+++ b/netbench/netbench-collector/src/netbench.bt
@@ -37,6 +37,12 @@ usdt:{{bin}}:netbench__dealloc
   @d=stats(arg0);
 }
 
+usdt:{{bin}}:netbench__connect
+/pid==cpid/
+{
+  @O=count();
+}
+
 uprobe:{{libc}}:malloc
 /pid==cpid/
 {

--- a/netbench/netbench/src/scenario/builder.rs
+++ b/netbench/netbench/src/scenario/builder.rs
@@ -86,7 +86,9 @@ impl Builder {
         let mut builder = client::Builder::new(id, self.state.clone());
         f(&mut builder);
 
-        self.state.clients.borrow_mut()[id as usize].scenario = builder.finish();
+        let client = &mut self.state.clients.borrow_mut()[id as usize];
+
+        client.scenario = builder.finish();
     }
 
     pub(super) fn finish(self) -> super::Scenario {
@@ -97,6 +99,7 @@ impl Builder {
             .into_iter()
             .map(|mut client| {
                 client.certificate_authorities.sort_unstable();
+
                 Arc::new(client)
             })
             .collect();

--- a/netbench/netbench/src/stats.rs
+++ b/netbench/netbench/src/stats.rs
@@ -59,6 +59,8 @@ pub struct Stats {
     #[serde(default, skip_serializing_if = "is_default")]
     pub syscalls: u64,
     #[serde(default, skip_serializing_if = "is_default")]
+    pub connections: u64,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub allocs: Stat,
     #[serde(default, skip_serializing_if = "is_default")]
     pub reallocs: Stat,

--- a/netbench/netbench/src/stats.rs
+++ b/netbench/netbench/src/stats.rs
@@ -61,6 +61,8 @@ pub struct Stats {
     #[serde(default, skip_serializing_if = "is_default")]
     pub connections: u64,
     #[serde(default, skip_serializing_if = "is_default")]
+    pub accept: u64,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub allocs: Stat,
     #[serde(default, skip_serializing_if = "is_default")]
     pub reallocs: Stat,


### PR DESCRIPTION
### Description of changes: 

When writing a nebench scenario, establishing multiple connections with the exact same operations will result in multiple connection entries. This needlessly bloats the scenario JSON.

This change implements a check to compare the connection instructions to existing instructions and returns that ID instead of creating a new one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

