### PR TITLE
feat(netbench): s2n-tls netbench driver

### DIFF
--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -150,6 +150,7 @@ jobs:
           - s2n-quic
           - native-tls
           - tcp
+          - s2n-tls
         scenario: ${{ fromJson(needs.build.outputs.scenarios) }}
     env:
       SCENARIO: scenarios/${{ matrix.scenario }}.json

--- a/netbench/netbench-driver/Cargo.toml
+++ b/netbench/netbench-driver/Cargo.toml
@@ -20,6 +20,8 @@ tokio = { version = "1", features = ["io-util", "net", "time"] }
 tokio-native-tls = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+s2n-tls = { version = "0.0.8" }
+s2n-tls-tokio = { version = "0.0.8" }
 
 # Pin to this version until s2n-tls supports OpenSSL 3.0
 # Build the vendored version to make it easy to test in dev

--- a/netbench/netbench-driver/Cargo.toml
+++ b/netbench/netbench-driver/Cargo.toml
@@ -15,13 +15,13 @@ netbench = { version = "0.1", path = "../netbench" }
 probe = "0.3"
 s2n-quic = { path = "../../quic/s2n-quic", features = ["provider-tls-s2n"] }
 s2n-quic-core = { path = "../../quic/s2n-quic-core", features = ["testing"] }
+s2n-tls = { version = "0.0.8" }
+s2n-tls-tokio = { version = "0.0.8" }
 structopt = "0.3"
 tokio = { version = "1", features = ["io-util", "net", "time"] }
 tokio-native-tls = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-s2n-tls = { version = "0.0.8" }
-s2n-tls-tokio = { version = "0.0.8" }
 
 # Pin to this version until s2n-tls supports OpenSSL 3.0
 # Build the vendored version to make it easy to test in dev

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-client.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-client.rs
@@ -44,7 +44,7 @@ impl Client {
 
     fn client(&self) -> Result<ClientImpl> {
         let connector = TlsConnector::new(self.config()?.build()?);
-        let connector: s2n_tls_tokio::TlsConnector<Config> = connector.into();
+        let connector: s2n_tls_tokio::TlsConnector<Config> = connector;
         let connector = Arc::new(connector);
 
         let config = multiplex::Config::default();

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-client.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-client.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use netbench::{multiplex, scenario, Result};
 use netbench_driver::Allocator;
 use std::{collections::HashSet, future::Future, net::SocketAddr, pin::Pin, sync::Arc};

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-client.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-client.rs
@@ -3,15 +3,15 @@
 
 use netbench::{multiplex, scenario, Result};
 use netbench_driver::Allocator;
-use std::{collections::HashSet, future::Future, net::SocketAddr, pin::Pin, sync::Arc};
-use structopt::StructOpt;
-use tokio::{io::AsyncWriteExt, net::TcpStream};
-use s2n_tls_tokio::{TlsConnector, TlsStream};
 use s2n_tls::raw::{
     config::{Builder, Config},
     error::Error,
     security::DEFAULT_TLS13,
 };
+use s2n_tls_tokio::{TlsConnector, TlsStream};
+use std::{collections::HashSet, future::Future, net::SocketAddr, pin::Pin, sync::Arc};
+use structopt::StructOpt;
+use tokio::{io::AsyncWriteExt, net::TcpStream};
 
 #[global_allocator]
 static ALLOCATOR: Allocator = Allocator::new();
@@ -52,7 +52,7 @@ impl Client {
         Ok(ClientImpl {
             config,
             connector,
-            id: 0
+            id: 0,
         })
     }
 

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-client.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-client.rs
@@ -1,0 +1,117 @@
+use netbench::{multiplex, scenario, Result};
+use netbench_driver::Allocator;
+use std::{collections::HashSet, future::Future, net::SocketAddr, pin::Pin, sync::Arc};
+use structopt::StructOpt;
+use tokio::{io::AsyncWriteExt, net::TcpStream};
+use s2n_tls_tokio::{TlsConnector, TlsStream};
+use s2n_tls::raw::{
+    config::{Builder, Config},
+    error::Error,
+    security::DEFAULT_TLS13,
+};
+
+#[global_allocator]
+static ALLOCATOR: Allocator = Allocator::new();
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    Client::from_args().run().await
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Client {
+    #[structopt(flatten)]
+    opts: netbench_driver::Client,
+}
+
+impl Client {
+    pub async fn run(&self) -> Result<()> {
+        let addresses = self.opts.address_map().await?;
+        let scenario = self.opts.scenario();
+
+        let client = self.client()?;
+        let client = netbench::Client::new(client, &scenario, &addresses);
+        let mut trace = self.opts.trace();
+        let mut checkpoints = HashSet::new();
+        let mut timer = netbench::timer::Tokio::default();
+        client.run(&mut trace, &mut checkpoints, &mut timer).await?;
+
+        Ok(())
+    }
+
+    fn client(&self) -> Result<ClientImpl> {
+        let connector = TlsConnector::new(self.config()?.build()?);
+        let connector: s2n_tls_tokio::TlsConnector = connector.into();
+        let connector = Arc::new(connector);
+
+        let config = multiplex::Config::default();
+
+        Ok(ClientImpl {
+            config,
+            connector,
+            id: 0
+        })
+    }
+
+    fn config(&self) -> Result<Builder, Error> {
+        let mut builder = Config::builder();
+        builder.set_security_policy(&DEFAULT_TLS13)?;
+        for ca in self.opts.certificate_authorities() {
+            builder.trust_pem(ca.pem.as_bytes())?;
+        }
+        unsafe {
+            builder.disable_x509_verification()?;
+        }
+        Ok(builder)
+    }
+}
+
+type Connection<'a> = netbench::Driver<'a, multiplex::Connection<TlsStream<TcpStream>>>;
+
+#[derive(Clone)]
+struct ClientImpl {
+    config: multiplex::Config,
+    connector: Arc<s2n_tls_tokio::TlsConnector>,
+    id: u64,
+}
+
+impl ClientImpl {
+    fn id(&mut self) -> u64 {
+        let id = self.id;
+        self.id = id + 1;
+        id
+    }
+}
+
+impl<'a> netbench::client::Client<'a> for ClientImpl {
+    type Connect = Pin<Box<dyn Future<Output = Result<Self::Connection>> + 'a>>;
+    type Connection = Connection<'a>;
+
+    fn connect(
+        &mut self,
+        addr: SocketAddr,
+        server_name: &str,
+        server_conn_id: u64,
+        scenario: &'a Arc<scenario::Connection>,
+    ) -> Self::Connect {
+        let id = self.id();
+        let config = self.config.clone();
+        let connector = self.connector.clone();
+        let server_name = server_name.to_string();
+
+        let fut = async move {
+            let conn = TcpStream::connect(addr).await?;
+            let mut conn = connector.connect(&server_name, conn).await?;
+
+            conn.write_u64(server_conn_id).await?;
+
+            let conn = Box::pin(conn);
+            let conn = multiplex::Connection::new(id, conn, config);
+            let conn: Connection = netbench::Driver::new(scenario, conn);
+
+            Result::Ok(conn)
+        };
+
+        Box::pin(fut)
+    }
+}

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-client.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-client.rs
@@ -62,9 +62,6 @@ impl Client {
         for ca in self.opts.certificate_authorities() {
             builder.trust_pem(ca.pem.as_bytes())?;
         }
-        unsafe {
-            builder.disable_x509_verification()?;
-        }
         Ok(builder)
     }
 }

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-client.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-client.rs
@@ -5,7 +5,7 @@ use netbench::{multiplex, scenario, Result};
 use netbench_driver::Allocator;
 use std::{collections::HashSet, future::Future, net::SocketAddr, pin::Pin, sync::Arc};
 use structopt::StructOpt;
-use tokio::{io, io::AsyncWriteExt, net::TcpStream};
+use tokio::{io::AsyncWriteExt, net::TcpStream};
 use s2n_tls_tokio::{TlsConnector, TlsStream};
 use s2n_tls::raw::{
     config::{Builder, Config},
@@ -52,9 +52,7 @@ impl Client {
         Ok(ClientImpl {
             config,
             connector,
-            id: 0,
-            rx_buffer: *self.opts.rx_buffer as _,
-            tx_buffer: *self.opts.tx_buffer as _,
+            id: 0
         })
     }
 
@@ -71,16 +69,13 @@ impl Client {
     }
 }
 
-type Stream = io::BufStream<TcpStream>;
-type Connection<'a> = netbench::Driver<'a, multiplex::Connection<TlsStream<Stream>>>;
+type Connection<'a> = netbench::Driver<'a, multiplex::Connection<TlsStream<TcpStream>>>;
 
 #[derive(Clone)]
 struct ClientImpl {
     config: multiplex::Config,
     connector: Arc<s2n_tls_tokio::TlsConnector>,
     id: u64,
-    rx_buffer: usize,
-    tx_buffer: usize,
 }
 
 impl ClientImpl {
@@ -106,13 +101,9 @@ impl<'a> netbench::client::Client<'a> for ClientImpl {
         let config = self.config.clone();
         let connector = self.connector.clone();
         let server_name = server_name.to_string();
-        let rx_buffer = self.rx_buffer;
-        let tx_buffer = self.tx_buffer;
 
         let fut = async move {
             let conn = TcpStream::connect(addr).await?;
-            let conn = io::BufStream::with_capacity(rx_buffer, tx_buffer, conn);
-
             let mut conn = connector.connect(&server_name, conn).await?;
 
             conn.write_u64(server_conn_id).await?;

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
@@ -1,15 +1,13 @@
 use netbench::{multiplex, scenario, Result};
 use netbench_driver::Allocator;
 use std::{collections::HashSet, sync::Arc};
-use std::fs::File;
-use std::io::BufReader;
 use structopt::StructOpt;
 use tokio::{
     io::AsyncReadExt,
     net::{TcpListener, TcpStream},
     spawn,
 };
-use s2n_tls_tokio::{TlsAcceptor, TlsConnector};
+use s2n_tls_tokio::TlsAcceptor;
 use s2n_tls::raw::{
     config::{Builder, Config},
     error::Error,

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
@@ -1,0 +1,117 @@
+use netbench::{multiplex, scenario, Result};
+use netbench_driver::Allocator;
+use std::{collections::HashSet, sync::Arc};
+use std::fs::File;
+use std::io::BufReader;
+use structopt::StructOpt;
+use tokio::{
+    io::AsyncReadExt,
+    net::{TcpListener, TcpStream},
+    spawn,
+};
+use s2n_tls_tokio::{TlsAcceptor, TlsConnector};
+use s2n_tls::raw::{
+    config::{Builder, Config},
+    error::Error,
+    security::DEFAULT_TLS13,
+};
+
+#[global_allocator]
+static ALLOCATOR: Allocator = Allocator::new();
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    Server::from_args().run().await
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Server {
+    #[structopt(flatten)]
+    opts: netbench_driver::Server,
+}
+
+impl Server {
+    pub async fn run(&self) -> Result<()> {
+        let scenario = self.opts.scenario();
+
+        let server = self.server().await?;
+
+        let trace = self.opts.trace();
+        let acceptor = TlsAcceptor::new(self.config()?.build()?);
+        let acceptor: s2n_tls_tokio::TlsAcceptor = acceptor.into();
+        let acceptor = Arc::new(acceptor);
+
+        let config = netbench::multiplex::Config::default();
+
+        let mut conn_id = 0;
+        loop {
+            let (connection, _addr) = server.accept().await?;
+            let scenario = scenario.clone();
+            let id = conn_id;
+            conn_id += 1;
+            let acceptor = acceptor.clone();
+            let trace = trace.clone();
+            let config = config.clone();
+            spawn(async move {
+                if let Err(err) = handle_connection(
+                    acceptor,
+                    connection,
+                    id,
+                    scenario,
+                    trace,
+                    config
+                ).await {
+                    eprintln!("error: {}", err);
+                }
+            });
+        }
+
+        async fn handle_connection(
+            acceptor: Arc<s2n_tls_tokio::TlsAcceptor>,
+            connection: TcpStream,
+            conn_id: u64,
+            scenario: Arc<scenario::Server>,
+            mut trace: impl netbench::Trace,
+            config: multiplex::Config,
+        ) -> Result<()> {
+            let mut connection = acceptor.accept(connection).await?;
+            let server_idx = connection.read_u64().await?;
+            let scenario = scenario
+                .connections
+                .get(server_idx as usize)
+                .ok_or("invalid connection id")?;
+            let connection = Box::pin(connection);
+
+            let conn = netbench::Driver::new(
+                scenario,
+                netbench::multiplex::Connection::new(
+                    conn_id,
+                    connection,
+                    config
+                )
+            );
+
+            let mut checkpoints = HashSet::new();
+            let mut timer = netbench::timer::Tokio::default();
+
+            conn.run(&mut trace, &mut checkpoints, &mut timer).await?;
+
+            Ok(())
+        }
+    }
+
+    async fn server(&self) -> Result<TcpListener> {
+        let server = TcpListener::bind((self.opts.ip, self.opts.port)).await?;
+        Ok(server)
+    }
+
+    fn config(&self) -> Result<Builder, Error> {
+        let (cert, private_key) = self.opts.certificate();
+
+        let mut builder = Config::builder();
+        builder.set_security_policy(&DEFAULT_TLS13)?;
+        builder.load_pem(cert.pem.as_bytes(), private_key.pem.as_bytes())?;
+
+        Ok(builder)
+    }
+}

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
@@ -3,18 +3,18 @@
 
 use netbench::{multiplex, scenario, Result};
 use netbench_driver::Allocator;
+use s2n_tls::raw::{
+    config::{Builder, Config},
+    error::Error,
+    security::DEFAULT_TLS13,
+};
+use s2n_tls_tokio::TlsAcceptor;
 use std::{collections::HashSet, sync::Arc};
 use structopt::StructOpt;
 use tokio::{
     io::AsyncReadExt,
     net::{TcpListener, TcpStream},
     spawn,
-};
-use s2n_tls_tokio::TlsAcceptor;
-use s2n_tls::raw::{
-    config::{Builder, Config},
-    error::Error,
-    security::DEFAULT_TLS13,
 };
 
 #[global_allocator]
@@ -54,14 +54,9 @@ impl Server {
             let trace = trace.clone();
             let config = config.clone();
             spawn(async move {
-                if let Err(err) = handle_connection(
-                    acceptor,
-                    connection,
-                    id,
-                    scenario,
-                    trace,
-                    config
-                ).await {
+                if let Err(err) =
+                    handle_connection(acceptor, connection, id, scenario, trace, config).await
+                {
                     eprintln!("error: {}", err);
                 }
             });
@@ -85,11 +80,7 @@ impl Server {
 
             let conn = netbench::Driver::new(
                 scenario,
-                netbench::multiplex::Connection::new(
-                    conn_id,
-                    connection,
-                    config
-                )
+                netbench::multiplex::Connection::new(conn_id, connection, config),
             );
 
             let mut checkpoints = HashSet::new();

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use netbench::{multiplex, scenario, Result};
 use netbench_driver::Allocator;
 use std::{collections::HashSet, sync::Arc};

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
@@ -38,7 +38,7 @@ impl Server {
 
         let trace = self.opts.trace();
         let acceptor = TlsAcceptor::new(self.config()?.build()?);
-        let acceptor: s2n_tls_tokio::TlsAcceptor<Config> = acceptor.into();
+        let acceptor: s2n_tls_tokio::TlsAcceptor<Config> = acceptor;
         let acceptor = Arc::new(acceptor);
 
         let config = netbench::multiplex::Config::default();
@@ -70,9 +70,11 @@ impl Server {
             config: multiplex::Config,
         ) -> Result<()> {
             let connection = acceptor.accept(connection).await?;
-            let server_name =
-                connection.get_ref().server_name().ok_or("missing server name")?;
-            let scenario = scenario.on_server_name(&server_name)?;
+            let server_name = connection
+                .get_ref()
+                .server_name()
+                .ok_or("missing server name")?;
+            let scenario = scenario.on_server_name(server_name)?;
 
             let connection = Box::pin(connection);
 


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.-->

Adds a client/server netbench driver implementation for s2n-tls.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

Requires a change made in https://github.com/aws/s2n-tls/pull/3299 to build, so the s2n-tls crate version was preemptively set to 0.0.8: ed25c915d5b14b120f43a5f2e302c8794e8ea0ee

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

