### PR TITLE
feat(s2n-quic-transport): enable delayed ack

### DIFF
--- a/quic/s2n-quic-core/src/frame/ack.rs
+++ b/quic/s2n-quic-core/src/frame/ack.rs
@@ -1,7 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{frame::Tag, inet::ExplicitCongestionNotification, number::CheckedSub, varint::VarInt};
+use crate::{
+    frame::Tag,
+    inet::ExplicitCongestionNotification,
+    number::CheckedSub,
+    packet::number::{PacketNumberRange, PacketNumberSpace},
+    varint::VarInt,
+};
 use core::{
     convert::TryInto,
     ops::{RangeInclusive, SubAssign},
@@ -107,6 +113,16 @@ impl<A: AckRanges> Ack<A> {
 
     pub fn largest_acknowledged(&self) -> VarInt {
         self.ack_ranges.largest_acknowledged()
+    }
+
+    pub fn pn_range_iter(
+        &self,
+        space: PacketNumberSpace,
+    ) -> impl Iterator<Item = PacketNumberRange> {
+        self.ack_ranges().map(move |ack_range| {
+            let (start, end) = ack_range.into_inner();
+            PacketNumberRange::new(space.new_packet_number(start), space.new_packet_number(end))
+        })
     }
 }
 

--- a/quic/s2n-quic-transport/src/ack/pending_ack_ranges.rs
+++ b/quic/s2n-quic-transport/src/ack/pending_ack_ranges.rs
@@ -122,12 +122,13 @@ impl PendingAckRanges {
 
     /// Re-initialize all fields.
     ///
-    /// Should be called at the end of a processing round to clear all data.
+    /// Should be called at the end of a processing round to clear all
+    /// data. Resets aggregated ack information and the current_active_path.
     #[inline]
-    pub fn wipe(&mut self) {
+    pub fn reset(&mut self) {
         debug_assert!(
             self.current_active_path.is_some(),
-            "wipe called more than once"
+            "reset called more than once"
         );
         self.reset_aggregate_info();
         self.current_active_path = None;

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__pending_ack_ranges__tests__PendingAckRanges.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__pending_ack_ranges__tests__PendingAckRanges.snap
@@ -1,7 +1,7 @@
 ---
 source: quic/s2n-quic-transport/src/ack/pending_ack_ranges.rs
-assertion_line: 186
+assertion_line: 239
 expression: "size_of::<PendingAckRanges>()"
 
 ---
-80
+88

--- a/quic/s2n-quic-transport/src/connection/connection_container.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container.rs
@@ -451,7 +451,13 @@ impl<C: connection::Trait, L: connection::Lock<C>> InterestLists<C, L> {
                         remove_interest!($list_name);
                     }
                 }
-                debug_assert_eq!($interest, node.$link_name.is_linked());
+                debug_assert_eq!(
+                    $interest,
+                    node.$link_name.is_linked(),
+                    "interest: {}, linked: {}",
+                    $interest,
+                    node.$link_name.is_linked()
+                );
             };
         }
 

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1439,10 +1439,10 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 packet_interceptor,
             )?;
 
-            // there are no pending ACKs to process so wipe the structure to avoid
-            // an unnecessary connection wakeup
+            // there are no pending ACKs to process so reset the structure so that
+            // it can be reused in the next round
             if space.pending_ack_ranges.is_empty() {
-                space.pending_ack_ranges.wipe();
+                space.pending_ack_ranges.reset();
             }
 
             // notify the connection a packet was processed

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -135,8 +135,6 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
             if let Err(error) =
                 connection.on_pending_ack_ranges(timestamp, endpoint_context.event_subscriber)
             {
-                // post metrics: connection close metrics
-
                 connection.close(
                     error,
                     endpoint_context.connection_close_formatter,

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -131,10 +131,12 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
                 }
             };
 
-            // handle error and potentially close the connection
+            // handle error and close the connection
             if let Err(error) =
                 connection.on_pending_ack_ranges(timestamp, endpoint_context.event_subscriber)
             {
+                // post metrics: connection close metrics
+
                 connection.close(
                     error,
                     endpoint_context.connection_close_formatter,

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -337,7 +337,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         //
         // If there was an error during processing its probably safer
         // to clear the queue rather than try again.
-        pending_ack_ranges.clear();
+        pending_ack_ranges.reset_aggregate_info();
 
         result
     }

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -335,8 +335,8 @@ impl<Config: endpoint::Config> Manager<Config> {
 
         // reset pending ack information after processing
         //
-        // If there was an error during processing its probably safer
-        // to clear the queue rather than try again.
+        // If there was an error during processing, the connection is closed
+        // so it should not matter if the queue is cleared.
         pending_ack_ranges.reset_aggregate_info();
 
         result

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -2718,7 +2718,17 @@ fn helper_ack_packets_on_path(
         ecn_counts,
     };
 
-    let _ = manager.on_ack_frame(datagram.timestamp, frame, context, publisher);
+    let space = manager.space;
+    let largest_acked_packet_number = space.new_packet_number(frame.largest_acknowledged());
+    let _ = manager.process_acks(
+        datagram.timestamp,
+        frame.pn_range_iter(space),
+        largest_acked_packet_number,
+        frame.ack_delay(),
+        frame.ecn_counts,
+        context,
+        publisher,
+    );
 
     for packet in acked_packets {
         assert!(manager.sent_packets.get(packet).is_none());

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -756,7 +756,7 @@ impl<Config: endpoint::Config> PacketSpace<Config> for ApplicationSpace<Config> 
         let current_active_path = self
             .pending_ack_ranges
             .current_active_path
-            .expect("current path should set at the start of the round");
+            .expect("current path should be set at the start of the round");
         if current_active_path == path_id {
             if self.update_pending_acks(&frame).is_ok() {
                 return Ok(());

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -471,8 +471,8 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
                 publisher,
             )?;
 
-            // wipe all information associated with the current round
-            space.pending_ack_ranges.wipe();
+            // reset all information associated with the current round
+            space.pending_ack_ranges.reset();
         }
 
         Ok(())

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -22,14 +22,15 @@ use s2n_quic_core::{
     event::{self, IntoEvent},
     frame::{
         ack::AckRanges, crypto::CryptoRef, datagram::DatagramRef, stream::StreamRef, Ack,
-        ConnectionClose, DataBlocked, HandshakeDone, MaxData, MaxStreamData, MaxStreams,
-        NewConnectionId, NewToken, PathChallenge, PathResponse, ResetStream, RetireConnectionId,
-        StopSending, StreamDataBlocked, StreamsBlocked,
+        ConnectionClose, DataBlocked, Frame, FrameMut, HandshakeDone, MaxData, MaxStreamData,
+        MaxStreams, NewConnectionId, NewToken, PathChallenge, PathResponse, ResetStream,
+        RetireConnectionId, StopSending, StreamDataBlocked, StreamsBlocked,
     },
     inet::DatagramInfo,
     packet::number::{PacketNumber, PacketNumberSpace},
     time::{timer, Timestamp},
     transport,
+    varint::VarInt,
 };
 
 mod application;
@@ -704,11 +705,6 @@ pub trait PacketSpace<Config: endpoint::Config> {
         publisher: &mut Pub,
         packet_interceptor: &mut Config::PacketInterceptor,
     ) -> Result<ProcessedPacket<'a>, connection::Error> {
-        use s2n_quic_core::{
-            frame::{Frame, FrameMut},
-            varint::VarInt,
-        };
-
         let mut payload = {
             use s2n_quic_core::packet::interceptor::{Interceptor, Packet};
 


### PR DESCRIPTION
### Description of changes: 
This PR enables delayed ACK processing by attempting to store aggregate ACK information rather than processing it immediately.

### Testing:

More comparison (400Mb send and receive; rate ~20MBps ):
netbench: https://vega.github.io/editor/#/gist/453bbf20f6405e73b70cb72e00be6b87/ack-vs-main-local-wlan.json
flamegraph:
receive cpu usage goes from 24.33% -> 25.81%

![flamegraph_ack](https://user-images.githubusercontent.com/4350690/168688059-5c8d0a7d-9c29-4da1-85a4-c59db1ac1ba6.svg) vs 
![flamegraph_main](https://user-images.githubusercontent.com/4350690/168688098-f7120049-acba-407c-a51f-b02ab461ccd1.svg)


---

Test runs from traffic between 2 computers on local network: [run](https://dnglbrstg7yg.cloudfront.net/8e1890f04727ef7d3acdcb521c5b3cda257778f0/netbench/index.html#https://gist.githubusercontent.com/camshaft/94ae8802c920aa297b01582535522ead/raw/2fea54797d2e9cd9e4fa43db62eab68abb39b8e0/ack_batch.json)
Test runs from traffic between 2 ec2 instances: [run1](https://dnglbrstg7yg.cloudfront.net/8e1890f04727ef7d3acdcb521c5b3cda257778f0/netbench/index.html#https://raw.githubusercontent.com/goatgoose/s2n-quic/sassy-results/netbench/results/ack_results2.json) and [run2](https://dnglbrstg7yg.cloudfront.net/8e1890f04727ef7d3acdcb521c5b3cda257778f0/netbench/index.html#https://raw.githubusercontent.com/goatgoose/s2n-quic/sassy-results/netbench/results/ack_results3.json)

summary:
- all stats look approximately the same

---

comparing stats from [interop run](https://dnglbrstg7yg.cloudfront.net/aafbdfac88f5736cd6061b1a246d1f6e16f74125/interop/index.html?server=s2n-quic-pr1298,s2n-quic&client=quic-go):
[main interop transfer](https://dnglbrstg7yg.cloudfront.net/c51dd3b1455da5c88a2c325778520f7b35099f2b/interop/logs/latest/s2n-quic_quic-go/transfer/index.html) vs [ack interop transfer](https://dnglbrstg7yg.cloudfront.net/aafbdfac88f5736cd6061b1a246d1f6e16f74125/interop/logs/latest/s2n-quic_quic-go/transfer/index.html)

summary:
- same amount of packets/frame
- less Ack frames and less recovery invocations

word count: `cat log.txt | grep $word | wc -l`

```
recovery_metrics          # word
ack 2564                  # word count in ack log
main 3875                 # word count in main log

Ack
ack 8890
main 10930

packet_sent
ack 7466
main 7463

packet_received
ack 3781
main 3747

frame_sent
ack 12696
main 14725

frame_received
ack 3995
main 3978

OneRtt
ack 27979
main 29917
```
---
**Netbench testing (0.5% loss + 200Mb send rate):**

[netbench test](https://vega.github.io/editor/#/gist/033e94fd07cd4c5eb92a65be08f198f5/ack-vs-main-loss05-rate200mb-s2n-quic-server.json)

summary
- stable cpu usage (main seems to degrade after some time)
- higher send (bytes/cpu %)
- lower realloc/dealloc
- lower instructions

Setup:
`sudo tc qdisc add dev lo root netem loss 0.5%`

```
./target/release/netbench-scenarios --request_response.response_size 10GB --request_response.server_send_rate 200MBps

sudo SCENARIO=./target/netbench/request_response.json ./target/release/netbench-collector ./target/release/netbench-driver-s2n-quic-server > s2n_quic_server.json

SCENARIO=./target/netbench/request_response.json SERVER_0=localhost:4433 ./target/release/netbench-driver-s2n-quic-client ./target/netbench/request_response.json
```

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

