### PR TITLE
fix(s2n-quic-transport): determine GSO capability from the segment_len

### DIFF
--- a/quic/s2n-quic-platform/src/io/testing/network.rs
+++ b/quic/s2n-quic-platform/src/io/testing/network.rs
@@ -348,13 +348,7 @@ impl io::tx::Entry for Packet {
     {
         self.path.remote_address = message.path_handle().remote_address;
         self.ecn = message.ecn();
-        let len = message.write_payload(&mut self.payload, 0);
-
-        if len == 0 {
-            return Err(io::tx::Error::EmptyPayload);
-        }
-
-        Ok(len)
+        message.write_payload(io::tx::PayloadBuffer::new(&mut self.payload), 0)
     }
 
     fn payload(&self) -> &[u8] {

--- a/quic/s2n-quic-platform/src/message/mmsg.rs
+++ b/quic/s2n-quic-platform/src/message/mmsg.rs
@@ -203,12 +203,7 @@ impl tx::Entry for Message {
     ) -> Result<usize, tx::Error> {
         let payload = MessageTrait::payload_mut(self);
 
-        let len = message.write_payload(payload, 0);
-
-        // don't send empty payloads
-        if len == 0 {
-            return Err(tx::Error::EmptyPayload);
-        }
+        let len = message.write_payload(tx::PayloadBuffer::new(payload), 0)?;
 
         unsafe {
             debug_assert!(len <= payload.len());

--- a/quic/s2n-quic-platform/src/message/msg.rs
+++ b/quic/s2n-quic-platform/src/message/msg.rs
@@ -534,12 +534,7 @@ impl tx::Entry for Message {
     ) -> Result<usize, tx::Error> {
         let payload = MessageTrait::payload_mut(self);
 
-        let len = message.write_payload(payload, 0);
-
-        // don't send empty payloads
-        if len == 0 {
-            return Err(tx::Error::EmptyPayload);
-        }
+        let len = message.write_payload(tx::PayloadBuffer::new(payload), 0)?;
 
         unsafe {
             debug_assert!(len <= payload.len());

--- a/quic/s2n-quic-platform/src/message/simple.rs
+++ b/quic/s2n-quic-platform/src/message/simple.rs
@@ -181,12 +181,7 @@ impl tx::Entry for Message {
     ) -> Result<usize, tx::Error> {
         let payload = MessageTrait::payload_mut(self);
 
-        let len = message.write_payload(payload, 0);
-
-        // don't send empty payloads
-        if len == 0 {
-            return Err(tx::Error::EmptyPayload);
-        }
+        let len = message.write_payload(tx::PayloadBuffer::new(payload), 0)?;
 
         unsafe {
             debug_assert!(len <= payload.len());

--- a/quic/s2n-quic-transport/src/endpoint/retry.rs
+++ b/quic/s2n-quic-transport/src/endpoint/retry.rs
@@ -157,14 +157,16 @@ impl<Path: path::Handle> tx::Message for &Transmission<Path> {
     }
 
     #[inline]
-    fn can_gso(&self) -> bool {
-        true
+    fn can_gso(&self, segment_len: usize) -> bool {
+        segment_len >= self.as_ref().len()
     }
 
     #[inline]
-    fn write_payload(&mut self, buffer: &mut [u8], _gso_offset: usize) -> usize {
-        let packet = self.as_ref();
-        buffer[..packet.len()].copy_from_slice(packet);
-        packet.len()
+    fn write_payload(
+        &mut self,
+        mut buffer: tx::PayloadBuffer,
+        _gso_offset: usize,
+    ) -> Result<usize, tx::Error> {
+        buffer.write(self.as_ref())
     }
 }

--- a/quic/s2n-quic-transport/src/endpoint/stateless_reset.rs
+++ b/quic/s2n-quic-transport/src/endpoint/stateless_reset.rs
@@ -144,14 +144,16 @@ impl<Path: path::Handle> tx::Message for &Transmission<Path> {
     }
 
     #[inline]
-    fn can_gso(&self) -> bool {
-        true
+    fn can_gso(&self, segment_len: usize) -> bool {
+        segment_len >= self.as_ref().len()
     }
 
     #[inline]
-    fn write_payload(&mut self, buffer: &mut [u8], _gso_offset: usize) -> usize {
-        let packet = self.as_ref();
-        buffer[..packet.len()].copy_from_slice(packet);
-        packet.len()
+    fn write_payload(
+        &mut self,
+        mut buffer: tx::PayloadBuffer,
+        _gso_offset: usize,
+    ) -> Result<usize, tx::Error> {
+        buffer.write(self.as_ref())
     }
 }

--- a/quic/s2n-quic-transport/src/endpoint/version.rs
+++ b/quic/s2n-quic-transport/src/endpoint/version.rs
@@ -259,15 +259,17 @@ impl<Path: path::Handle> tx::Message for &Transmission<Path> {
     }
 
     #[inline]
-    fn can_gso(&self) -> bool {
-        true
+    fn can_gso(&self, segment_len: usize) -> bool {
+        segment_len >= self.as_ref().len()
     }
 
     #[inline]
-    fn write_payload(&mut self, buffer: &mut [u8], _gso_offset: usize) -> usize {
-        let packet = self.as_ref();
-        buffer[..packet.len()].copy_from_slice(packet);
-        packet.len()
+    fn write_payload(
+        &mut self,
+        mut buffer: tx::PayloadBuffer,
+        _gso_offset: usize,
+    ) -> Result<usize, tx::Error> {
+        buffer.write(self.as_ref())
     }
 }
 


### PR DESCRIPTION
### Description of changes: 

When determining if a packet can be included as a GSO segment, we currently just consider the type of packet in this decision. This information can be limiting and artificially limit packet buffer sizes.

This change passes the current GSO segment size to the `can_gso` function, which allows the sender component to now take the segment len into account.

I've also cleaned up the packet writing interface to reduce duplication of logic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.