### PR TITLE
feat(s2n-quic-transport): Adds transmission interest to Datagram Sender

### DIFF
--- a/quic/s2n-quic-core/src/datagram.rs
+++ b/quic/s2n-quic-core/src/datagram.rs
@@ -9,13 +9,21 @@ pub trait Endpoint: 'static + Send {
     type Sender: Sender;
     type Receiver: Receiver;
 
-    fn split(&mut self) -> (Self::Sender, Self::Receiver);
+    fn create_connection(&mut self, info: &ConnectionInfo) -> (Self::Sender, Self::Receiver);
 }
+// ConnectionInfo will eventually contain information needed to set up a
+// datagram provider
+pub struct ConnectionInfo {}
 
 pub trait Receiver: 'static + Send {}
 pub trait Sender: 'static + Send {
     /// A callback that allows users to write datagrams directly to the packet.
     fn on_transmit<P: Packet>(&mut self, packet: &mut P);
+
+    /// A callback that checks if a user has datagrams ready to send
+    ///
+    /// Use method to trigger the on_transmit callback
+    fn has_transmission_interest(&self) -> bool;
 }
 
 /// A packet will be available during the on_transmit callback. Use the methods
@@ -26,12 +34,18 @@ pub trait Packet {
 
     /// Writes a single datagram to a packet. This function should be called
     /// per datagram.
-    fn write_datagram(&mut self, data: &[u8]);
+    fn write_datagram(&mut self, data: &[u8]) -> Result<(), WriteError>;
 
     /// Returns whether or not there is reliable data waiting to be sent.
     ///
     /// Use method to decide whether or not to cede the packet space to the stream data.
-    fn pending_streams(&self) -> bool;
+    fn has_pending_streams(&self) -> bool;
+}
+
+#[non_exhaustive]
+#[derive(Debug)]
+pub enum WriteError {
+    DatagramIsTooLarge,
 }
 
 #[derive(Debug, Default)]
@@ -41,7 +55,7 @@ impl Endpoint for Disabled {
     type Sender = DisabledSender;
     type Receiver = DisabledReceiver;
 
-    fn split(&mut self) -> (Self::Sender, Self::Receiver) {
+    fn create_connection(&mut self, _info: &ConnectionInfo) -> (Self::Sender, Self::Receiver) {
         (DisabledSender, DisabledReceiver)
     }
 }
@@ -50,5 +64,8 @@ pub struct DisabledReceiver;
 
 impl Sender for DisabledSender {
     fn on_transmit<P: Packet>(&mut self, _packet: &mut P) {}
+    fn has_transmission_interest(&self) -> bool {
+        false
+    }
 }
 impl Receiver for DisabledReceiver {}

--- a/quic/s2n-quic-core/src/datagram.rs
+++ b/quic/s2n-quic-core/src/datagram.rs
@@ -11,9 +11,16 @@ pub trait Endpoint: 'static + Send {
 
     fn create_connection(&mut self, info: &ConnectionInfo) -> (Self::Sender, Self::Receiver);
 }
+
 // ConnectionInfo will eventually contain information needed to set up a
 // datagram provider
+#[non_exhaustive]
 pub struct ConnectionInfo {}
+impl ConnectionInfo {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
 
 pub trait Receiver: 'static + Send {}
 pub trait Sender: 'static + Send {
@@ -59,13 +66,17 @@ impl Endpoint for Disabled {
         (DisabledSender, DisabledReceiver)
     }
 }
+
 pub struct DisabledSender;
 pub struct DisabledReceiver;
 
 impl Sender for DisabledSender {
     fn on_transmit<P: Packet>(&mut self, _packet: &mut P) {}
+
+    #[inline]
     fn has_transmission_interest(&self) -> bool {
         false
     }
 }
+
 impl Receiver for DisabledReceiver {}

--- a/quic/s2n-quic-core/src/datagram.rs
+++ b/quic/s2n-quic-core/src/datagram.rs
@@ -16,9 +16,16 @@ pub trait Endpoint: 'static + Send {
 // datagram provider
 #[non_exhaustive]
 pub struct ConnectionInfo {}
+
 impl ConnectionInfo {
     pub fn new() -> Self {
-        Self {}
+        ConnectionInfo {}
+    }
+}
+
+impl Default for ConnectionInfo {
+    fn default() -> Self {
+        ConnectionInfo::new()
     }
 }
 

--- a/quic/s2n-quic-core/src/frame/datagram.rs
+++ b/quic/s2n-quic-core/src/frame/datagram.rs
@@ -18,7 +18,7 @@ macro_rules! datagram_tag {
     };
 }
 
-const DATAGRAM_TAG: u8 = 0x30;
+pub const DATAGRAM_TAG: u8 = 0x30;
 //= https://www.rfc-editor.org/rfc/rfc9221#section-4
 //# The least significant bit of the Type field in the DATAGRAM frame is
 //# the LEN bit (0x01), which indicates whether there is a Length field

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -570,6 +570,7 @@ impl<Config: endpoint::Config> transmission::interest::Provider for ApplicationS
         self.ping.transmission_interest(query)?;
         self.recovery_manager.transmission_interest(query)?;
         self.stream_manager.transmission_interest(query)?;
+        self.datagram_manager.transmission_interest(query)?;
         Ok(())
     }
 }

--- a/quic/s2n-quic-transport/src/space/datagram.rs
+++ b/quic/s2n-quic-transport/src/space/datagram.rs
@@ -4,11 +4,13 @@
 use crate::{
     endpoint,
     stream::{AbstractStreamManager, StreamTrait as Stream},
-    transmission::WriteContext,
+    transmission::{interest, WriteContext},
 };
+use s2n_codec::EncoderValue;
 use s2n_quic_core::{
-    datagram::{Endpoint, Sender},
+    datagram::{Endpoint, Sender, WriteError},
     frame,
+    varint::VarInt,
 };
 
 // Contains the datagram sender and receiver implementations.
@@ -38,48 +40,101 @@ impl<Config: endpoint::Config> Manager<Config> {
     ) {
         let mut packet = Packet {
             context,
-            pending_streams: stream_manager.pending_streams(),
+            has_pending_streams: stream_manager.has_pending_streams(),
         };
         self.sender.on_transmit(&mut packet);
     }
 }
+
+impl<Config: endpoint::Config> interest::Provider for Manager<Config> {
+    #[inline]
+    fn transmission_interest<Q: interest::Query>(&self, query: &mut Q) -> interest::Result {
+        if self.sender.has_transmission_interest() {
+            query.on_new_data()?;
+        }
+        Ok(())
+    }
+}
+
 struct Packet<'a, C: WriteContext> {
     context: &'a mut C,
-    pending_streams: bool,
+    has_pending_streams: bool,
 }
 
 const FRAME_TYPE_LEN: usize = 1;
+const MAX_LEN_VALUE: usize = 8;
 
 impl<'a, C: WriteContext> s2n_quic_core::datagram::Packet for Packet<'a, C> {
     /// Returns the remaining space in the packet
     fn remaining_capacity(&self) -> usize {
         let space = self.context.remaining_capacity();
-        //= https://www.rfc-editor.org/rfc/rfc9221#section-4
-        //# The least significant bit of the Type field in the DATAGRAM frame is
-        //# the LEN bit (0x01), which indicates whether there is a Length field
-        //# present: if this bit is set to 0, the Length field is absent and the
-        //# Datagram Data field extends to the end of the packet; if this bit is
-        //# set to 1, the Length field is present.
-        // In the case where the user writes the largest datagram possible
-        // we don't factor in the size of the Length field as it will be the last
-        // frame in the packet. Thus we only have to factor out the frame type field.
-        space - FRAME_TYPE_LEN
+        // Remove the frame type length and the maximum length value
+        space
+            .saturating_sub(FRAME_TYPE_LEN)
+            .saturating_sub(MAX_LEN_VALUE)
     }
 
     /// Writes a single datagram to a packet
-    fn write_datagram(&mut self, data: &[u8]) {
+    fn write_datagram(&mut self, data: &[u8]) -> Result<(), WriteError> {
         let remaining_capacity = self.context.remaining_capacity();
         let data_len = data.len();
         let is_last_frame = remaining_capacity == FRAME_TYPE_LEN + data_len;
+
+        if !is_last_frame {
+            let encoded_length = match VarInt::new(data_len as u64) {
+                Ok(encoded_length) => encoded_length,
+                Err(_e) => return Err(WriteError::DatagramIsTooLarge),
+            };
+            // Calculates the complete size of the encoded datagram, including the
+            // VarInt size and frame size
+            let encoded_datagram_size = encoded_length.encoding_size() + FRAME_TYPE_LEN + data_len;
+
+            if encoded_datagram_size > remaining_capacity {
+                return Err(WriteError::DatagramIsTooLarge);
+            }
+        }
+
         let frame = frame::Datagram {
             is_last_frame,
             data,
         };
         self.context.write_frame(&frame);
+
+        Ok(())
     }
 
     // Returns whether or not there is reliable data ready to send
-    fn pending_streams(&self) -> bool {
-        self.pending_streams
+    fn has_pending_streams(&self) -> bool {
+        self.has_pending_streams
     }
+}
+
+#[test]
+fn write_datagrams() {
+    use crate::{
+        contexts::testing::{MockWriteContext, OutgoingFrameBuffer},
+        transmission::{Constraint, Mode},
+    };
+    use s2n_quic_core::datagram::Packet as _;
+
+    let mut frame_buffer = OutgoingFrameBuffer::new();
+    let packet_size = 5;
+    frame_buffer.set_max_packet_size(Some(packet_size));
+    let mut write_context = MockWriteContext::new(
+        s2n_quic_platform::time::now(),
+        &mut frame_buffer,
+        Constraint::None,
+        Mode::Normal,
+        endpoint::Type::Server,
+    );
+
+    let mut packet = Packet {
+        context: &mut write_context,
+        has_pending_streams: false,
+    };
+    let max_datagram = vec![1, 2, 3];
+    let too_large_datagram = vec![1, 2, 3, 4];
+    assert!(packet.write_datagram(&max_datagram).is_ok());
+    packet.context.frame_buffer.clear();
+    assert!(packet.write_datagram(&too_large_datagram).is_err());
 }

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -20,7 +20,7 @@ use s2n_quic_core::{
     crypto,
     crypto::{tls, CryptoSuite, Key},
     ct::ConstantTimeEq,
-    datagram::Endpoint,
+    datagram::{ConnectionInfo, Endpoint},
     event,
     event::IntoEvent,
     packet::number::PacketNumberSpace,
@@ -368,7 +368,8 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
             self.limits.max_keep_alive_period(),
         );
 
-        let (datagram_sender, datagram_receiver) = self.datagram.split();
+        let conn_info = ConnectionInfo {};
+        let (datagram_sender, datagram_receiver) = self.datagram.create_connection(&conn_info);
         let cipher_suite = key.cipher_suite().into_event();
         let max_mtu = self.path_manager.max_mtu();
         *self.application = Some(Box::new(ApplicationSpace::new(

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -368,7 +368,7 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
             self.limits.max_keep_alive_period(),
         );
 
-        let conn_info = ConnectionInfo {};
+        let conn_info = ConnectionInfo::new();
         let (datagram_sender, datagram_receiver) = self.datagram.create_connection(&conn_info);
         let cipher_suite = key.cipher_suite().into_event();
         let max_mtu = self.path_manager.max_mtu();

--- a/quic/s2n-quic-transport/src/stream/stream_container.rs
+++ b/quic/s2n-quic-transport/src/stream/stream_container.rs
@@ -620,7 +620,7 @@ impl<S: StreamTrait> StreamContainer<S> {
     }
 
     /// Returns whether or not streams have data to send
-    pub fn pending_streams(&self) -> bool {
+    pub fn has_pending_streams(&self) -> bool {
         !self.interest_lists.waiting_for_transmission.is_empty()
             || !self.interest_lists.waiting_for_retransmission.is_empty()
     }

--- a/quic/s2n-quic-transport/src/stream/stream_manager.rs
+++ b/quic/s2n-quic-transport/src/stream/stream_manager.rs
@@ -981,8 +981,8 @@ impl<S: StreamTrait> AbstractStreamManager<S> {
     }
 
     /// Returns whether or not streams have data to send
-    pub fn pending_streams(&self) -> bool {
-        self.inner.streams.pending_streams()
+    pub fn has_pending_streams(&self) -> bool {
+        self.inner.streams.has_pending_streams()
     }
 }
 

--- a/quic/s2n-quic-transport/src/transmission/application.rs
+++ b/quic/s2n-quic-transport/src/transmission/application.rs
@@ -164,6 +164,7 @@ impl<'a, S: Stream, Config: endpoint::Config> transmission::interest::Provider
         self.ack_manager.transmission_interest(query)?;
         self.handshake_status.transmission_interest(query)?;
         self.stream_manager.transmission_interest(query)?;
+        self.datagram_manager.transmission_interest(query)?;
         self.local_id_registry.transmission_interest(query)?;
         self.path_manager.transmission_interest(query)?;
         self.recovery_manager.transmission_interest(query)?;


### PR DESCRIPTION
### Resolved issues:

related to #1253 
### Description of changes: 
Adds the extra functionality that didn't make it into #1289. Also applies the extra feedback that didn't make it into that PR.

### Call-outs:

Currently this function doesn't contain the functionality to alternate between writing datagrams and writing control data. 

### Testing:

I added a test to show that the datagram sender will refuse to write datagrams that don't fit in the packet.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

