### PR TITLE
feat(s2n-quic-transport): Adds Receiver trait for Datagram Provider

### DIFF
--- a/quic/s2n-quic-core/src/datagram.rs
+++ b/quic/s2n-quic-core/src/datagram.rs
@@ -29,9 +29,12 @@ impl Default for ConnectionInfo {
     }
 }
 
-pub trait Receiver: 'static + Send {}
+pub trait Receiver: 'static + Send {
+    // A callback that gives users direct access to datagrams as they are read off a packet
+    fn on_datagram(&self, datagram: &[u8]);
+}
 pub trait Sender: 'static + Send {
-    /// A callback that allows users to write datagrams directly to the packet.
+    /// A callback that allows users to write datagrams directly to the packet
     fn on_transmit<P: Packet>(&mut self, packet: &mut P);
 
     /// A callback that checks if a user has datagrams ready to send
@@ -86,4 +89,6 @@ impl Sender for DisabledSender {
     }
 }
 
-impl Receiver for DisabledReceiver {}
+impl Receiver for DisabledReceiver {
+    fn on_datagram(&self, _datagram: &[u8]) {}
+}

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -21,10 +21,10 @@ use s2n_quic_core::{
     datagram::Endpoint,
     event::{self, ConnectionPublisher as _, IntoEvent},
     frame::{
-        self, ack::AckRanges, crypto::CryptoRef, stream::StreamRef, Ack, ConnectionClose,
-        DataBlocked, HandshakeDone, MaxData, MaxStreamData, MaxStreams, NewConnectionId, NewToken,
-        PathChallenge, PathResponse, ResetStream, RetireConnectionId, StopSending,
-        StreamDataBlocked, StreamsBlocked,
+        self, ack::AckRanges, crypto::CryptoRef, datagram::DatagramRef, stream::StreamRef, Ack,
+        ConnectionClose, DataBlocked, HandshakeDone, MaxData, MaxStreamData, MaxStreams,
+        NewConnectionId, NewToken, PathChallenge, PathResponse, ResetStream, RetireConnectionId,
+        StopSending, StreamDataBlocked, StreamsBlocked,
     },
     inet::DatagramInfo,
     packet::{
@@ -778,6 +778,11 @@ impl<Config: endpoint::Config> PacketSpace<Config> for ApplicationSpace<Config> 
         packet.bytes_progressed +=
             (self.stream_manager.incoming_bytes_progressed() - bytes_progressed).as_u64() as usize;
 
+        Ok(())
+    }
+
+    fn handle_datagram_frame(&mut self, frame: DatagramRef) -> Result<(), transport::Error> {
+        self.datagram_manager.on_datagram_frame(frame);
         Ok(())
     }
 

--- a/quic/s2n-quic-transport/src/space/datagram.rs
+++ b/quic/s2n-quic-transport/src/space/datagram.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use s2n_codec::EncoderValue;
 use s2n_quic_core::{
-    datagram::{Endpoint, Sender, WriteError},
-    frame,
+    datagram::{Endpoint, Receiver, Sender, WriteError},
+    frame::{self, datagram::DatagramRef},
     varint::VarInt,
 };
 
@@ -19,8 +19,6 @@ use s2n_quic_core::{
 // packet processing.
 pub struct Manager<Config: endpoint::Config> {
     sender: <<Config as endpoint::Config>::DatagramEndpoint as Endpoint>::Sender,
-    // TODO: Remove this warning once Receiver is implemented
-    #[allow(dead_code)]
     receiver: <<Config as endpoint::Config>::DatagramEndpoint as Endpoint>::Receiver,
 }
 
@@ -43,6 +41,12 @@ impl<Config: endpoint::Config> Manager<Config> {
             has_pending_streams: stream_manager.has_pending_streams(),
         };
         self.sender.on_transmit(&mut packet);
+    }
+
+    // A callback that allows users to access datagrams directly after they are
+    // received.
+    pub fn on_datagram_frame(&self, datagram: DatagramRef) {
+        self.receiver.on_datagram(datagram.data);
     }
 }
 

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -663,11 +663,7 @@ pub trait PacketSpace<Config: endpoint::Config> {
             .with_frame_type(frame.tag().into()))
     }
 
-    fn handle_datagram_frame(
-        &mut self,
-        frame: DatagramRef,
-        _packet: &mut ProcessedPacket,
-    ) -> Result<(), transport::Error> {
+    fn handle_datagram_frame(&mut self, frame: DatagramRef) -> Result<(), transport::Error> {
         Err(transport::Error::PROTOCOL_VIOLATION
             .with_reason(Self::INVALID_FRAME_ERROR)
             .with_frame_type(frame.tag().into()))
@@ -810,8 +806,7 @@ pub trait PacketSpace<Config: endpoint::Config> {
                 }
                 Frame::Datagram(frame) => {
                     let on_error = on_frame_processed!(frame);
-                    self.handle_datagram_frame(frame.into(), &mut processed_packet)
-                        .map_err(on_error)?;
+                    self.handle_datagram_frame(frame.into()).map_err(on_error)?;
                 }
                 Frame::DataBlocked(frame) => {
                     let on_error = on_frame_processed!(frame);


### PR DESCRIPTION
### Resolved issues:

related to #1253 

### Description of changes: 

Small PR to add the receiver side to the datagram trait. I thought about just appending it to the last sender PR I did, but I'm trying to keep these issues separate.

### Call-outs:

I think this is it? We just give the datagram to the user each time we encounter a Datagram frame in the application space.
### Testing:




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

