### PR TITLE
feat(s2n-quic-platform): add close capability for testing io

### DIFF
--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -19,7 +19,7 @@ tokio-runtime = ["futures", "pin-project", "tokio"]
 wipe = ["zeroize"]
 
 [dependencies]
-bach = { version = "0.0.5", optional = true }
+bach = { version = "0.0.6", optional = true }
 bolero-generator = { version = "0.6", default-features = false, optional = true }
 cfg-if = "1"
 errno = "0.2"
@@ -35,7 +35,7 @@ zeroize = { version = "1", default-features = false, optional = true }
 libc = "0.2"
 
 [dev-dependencies]
-bach = { version = "0.0.5" }
+bach = { version = "0.0.6" }
 bolero = "0.6"
 bolero-generator = { version = "0.6", default-features = false }
 futures = { version = "0.3", features = ["std"] }

--- a/quic/s2n-quic-platform/src/io/testing/model.rs
+++ b/quic/s2n-quic-platform/src/io/testing/model.rs
@@ -229,14 +229,7 @@ impl Network for Model {
             let mut transmit_time = *transmit_time;
 
             if !network_jitter.is_zero() {
-                let jitter = gen_jitter(network_jitter);
-
-                // randomly add or subtract the network jitter
-                if super::rand::gen() {
-                    transmit_time += jitter;
-                } else {
-                    transmit_time = transmit_time.checked_sub(jitter).unwrap_or(now);
-                }
+                transmit_time += gen_jitter(network_jitter);
             }
 
             // reverse the addresses so the dst/src are correct for the receiver

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -5,7 +5,7 @@ use crate::{
     client::Connect,
     provider::{
         event,
-        io::testing::{spawn, spawn_primary, test, time::delay, Handle, Model, Result},
+        io::testing::{primary, spawn, test, time::delay, Handle, Model, Result},
     },
     Client, Server,
 };
@@ -68,7 +68,7 @@ fn client(handle: &Handle, server_addr: SocketAddr) -> Result {
         .with_event(events())?
         .start()?;
 
-    spawn_primary(async move {
+    primary::spawn(async move {
         let connect = Connect::new(server_addr).with_server_name("localhost");
         let mut connection = client.connect(connect).await.unwrap();
 
@@ -78,7 +78,7 @@ fn client(handle: &Handle, server_addr: SocketAddr) -> Result {
         let mut send_data = Data::new(10_000);
 
         let mut recv_data = send_data;
-        spawn_primary(async move {
+        primary::spawn(async move {
             while let Some(chunk) = recv.receive().await.unwrap() {
                 recv_data.receive(&[chunk]);
             }


### PR DESCRIPTION
### Description of changes: 

Previously, the testing IO provider relied on drop to close the executor and clean up the pending tasks. This caused a problem in which all of the outstanding connections technically failed and weren't able to send a CONNECTION_CLOSE and successfully complete.

This change adds a `close` function and calls it at the end of a test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

