### PR TITLE
fix(s2n-quic): simplify unstable feature flags

### DIFF
--- a/common/docdiff/src/main.rs
+++ b/common/docdiff/src/main.rs
@@ -80,6 +80,8 @@ impl fmt::Display for Dump {
 impl Dump {
     fn new(crate_name: &str) -> Result<Self> {
         cmd!("cargo", "doc", "--all-features", "--workspace")
+            .env("RUSTFLAGS", "--cfg docdiff")
+            .env("RUSTDOCFLAGS", "--cfg docdiff")
             .stdout_path("/dev/null")
             .run()?;
 

--- a/quic/s2n-quic/src/client/builder.rs
+++ b/quic/s2n-quic/src/client/builder.rs
@@ -245,20 +245,20 @@ impl<Providers: ClientProviders> Builder<Providers> {
         ClientProviders
     );
 
-    #[cfg(all(s2n_quic_unstable, feature = "unstable-provider-packet-interceptor"))]
+    #[cfg(all(not(docdiff), feature = "unstable-provider-packet-interceptor"))]
     impl_provider_method!(
         /// Sets the packet interceptor provider for the [`Client`]
         with_packet_interceptor,
         packet_interceptor,
-        ServerProviders
+        ClientProviders
     );
 
-    #[cfg(all(s2n_quic_unstable, feature = "unstable-provider-random"))]
+    #[cfg(all(not(docdiff), feature = "unstable-provider-random"))]
     impl_provider_method!(
         /// Sets the random provider for the [`Client`]
         with_random,
         random,
-        ServerProviders
+        ClientProviders
     );
 
     /// Starts the [`Client`] with the configured providers

--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -77,7 +77,11 @@ mod tests;
     all(
         // add new unstable features to this list
         any(
-            feature = "unstable_client_hello"
+            feature = "unstable_client_hello",
+            feature = "unstable-provider-datagram",
+            feature = "unstable-provider-io-testing",
+            feature = "unstable-provider-packet-interceptor",
+            feature = "unstable-provider-random",
         ),
         // any unstable features requires at least one of the following conditions
         not(any(
@@ -86,6 +90,8 @@ mod tests;
             doctest,
             // we're compiling docs for docs.rs
             docsrs,
+            // we're running docdiff
+            docdiff,
             // we're developing s2n-quic
             s2n_internal_dev,
             // the application has explicitly opted into unstable features

--- a/quic/s2n-quic/src/provider.rs
+++ b/quic/s2n-quic/src/provider.rs
@@ -23,7 +23,7 @@ pub(crate) mod path_migration;
 pub(crate) mod sync;
 
 cfg_if!(
-    if #[cfg(all(s2n_quic_unstable, feature = "unstable-provider-packet-interceptor"))] {
+    if #[cfg(all(not(docdiff), feature = "unstable-provider-packet-interceptor"))] {
         pub mod packet_interceptor;
     } else {
         pub(crate) mod packet_interceptor;
@@ -31,7 +31,7 @@ cfg_if!(
 );
 
 cfg_if!(
-    if #[cfg(all(s2n_quic_unstable, feature = "unstable-provider-random"))] {
+    if #[cfg(all(not(docdiff), feature = "unstable-provider-random"))] {
         pub mod random;
     } else {
         pub(crate) mod random;
@@ -39,7 +39,7 @@ cfg_if!(
 );
 
 cfg_if!(
-    if #[cfg(all(s2n_quic_unstable, feature = "unstable-provider-datagram"))] {
+    if #[cfg(all(not(docdiff), feature = "unstable-provider-datagram"))] {
         pub mod datagram;
     } else {
         pub(crate) mod datagram;

--- a/quic/s2n-quic/src/provider/io.rs
+++ b/quic/s2n-quic/src/provider/io.rs
@@ -16,7 +16,7 @@ pub trait Provider: 'static {
     ) -> Result<SocketAddress, Self::Error>;
 }
 
-#[cfg(any(test, all(s2n_quic_unstable, feature = "unstable-provider-io-testing")))]
+#[cfg(any(test, all(not(docdiff), feature = "unstable-provider-io-testing")))]
 pub mod testing;
 
 pub mod tokio;

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -295,7 +295,7 @@ impl<Providers: ServerProviders> Builder<Providers> {
         ServerProviders
     );
 
-    #[cfg(all(s2n_quic_unstable, feature = "unstable-provider-packet-interceptor"))]
+    #[cfg(all(not(docdiff), feature = "unstable-provider-packet-interceptor"))]
     impl_provider_method!(
         /// Sets the packet interceptor provider for the [`Server`]
         with_packet_interceptor,
@@ -303,7 +303,7 @@ impl<Providers: ServerProviders> Builder<Providers> {
         ServerProviders
     );
 
-    #[cfg(all(s2n_quic_unstable, feature = "unstable-provider-random"))]
+    #[cfg(all(not(docdiff), feature = "unstable-provider-random"))]
     impl_provider_method!(
         /// Sets the random provider for the [`Server`]
         with_random,


### PR DESCRIPTION
### Description of changes: 

Currently, unstable features check that `s2n_quic_unstable` is set in addition to the feature flag itself. This isn't entirely correct, since there are other flags that can be passed to enable unstable features (such as `s2n_internal_dev`).

This change simplifies the unstable feature flags to just query if the feature is set or not. I've also changed docdiff to pass a `cfg` so we can filter out the unstable features from being snapshotted.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

