### PR TITLE
example(post-quantum): initial commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -425,10 +425,11 @@ jobs:
     strategy:
       matrix:
         example:
-          - examples/echo
-          - examples/rustls-provider
           - examples/dos-mitigation
+          - examples/echo
           - examples/event-framework
+          - examples/post-quantum
+          - examples/rustls-provider
 
     steps:
       - uses: actions/checkout@v3

--- a/examples/post-quantum/.cargo/config.toml
+++ b/examples/post-quantum/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags=['--cfg', 's2n_quic_unstable', '--cfg', 's2n_quic_enable_pq_tls']

--- a/examples/post-quantum/Cargo.toml
+++ b/examples/post-quantum/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "post-quantum"
+version = "0.1.0"
+authors = ["AWS s2n"]
+edition = "2018"
+publish = false
+
+[dependencies]
+s2n-quic = { version = "1", path = "../../quic/s2n-quic" }
+tokio = { version = "1", features = ["full"] }
+
+[workspace]
+members = ["."]

--- a/examples/post-quantum/README.md
+++ b/examples/post-quantum/README.md
@@ -1,0 +1,31 @@
+# post-quantum example
+
+When using `s2n-tls` as the TLS provider, `s2n-quic` supports post-quantum key shares. However, because the key share algorithms are going through the standardization process, this functionality is disabled by default. It can be enabled by passing a few compiler flags:
+
+```sh
+export RUSTFLAGS=`--cfg s2n_quic_unstable --cfg s2n_quic_enable_pq_tls`
+```
+
+You can also add a `.cargo/config.toml` to the project (as done in this example):
+
+```toml
+[build]
+rustflags=['--cfg', 's2n_quic_unstable', '--cfg', 's2n_quic_enable_pq_tls']
+```
+
+## Running the example
+
+Now we can spin up a pq-enabled QUIC server:
+
+```sh
+cargo run --bin pq_server
+```
+
+and in another shell, the client:
+
+```sh
+cargo run --bin pq_client
+```
+
+Inspecting traffic with wireshark will show the `key_share` extension with `Group: Unknown (12089)` in both the Client Hello and Server Hello.
+

--- a/examples/post-quantum/src/bin/pq_client.rs
+++ b/examples/post-quantum/src/bin/pq_client.rs
@@ -1,0 +1,36 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_quic::{client::Connect, Client};
+use std::{error::Error, net::SocketAddr};
+use tokio::io::AsyncWriteExt;
+
+/// NOTE: this certificate is to be used for demonstration purposes only!
+pub static CERT_PEM: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../quic/s2n-quic-core/certs/cert.pem"
+));
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let mut client = Client::builder()
+        .with_tls(CERT_PEM)?
+        .with_io("0.0.0.0:0")?
+        .start()?;
+
+    let addr: SocketAddr = "127.0.0.1:4433".parse()?;
+    let connect = Connect::new(addr).with_server_name("localhost");
+    let mut connection = client.connect(connect).await?;
+
+    let mut stream = connection.open_bidirectional_stream().await?;
+    stream.write_all(b"hello post-quantum server!").await?;
+
+    let mut stdout = tokio::io::stdout();
+    tokio::io::copy(&mut stream, &mut stdout).await?;
+
+    connection.close(0u8.into());
+
+    client.wait_idle().await?;
+
+    Ok(())
+}

--- a/examples/post-quantum/src/bin/pq_server.rs
+++ b/examples/post-quantum/src/bin/pq_server.rs
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_quic::Server;
+use std::error::Error;
+use tokio::io::AsyncWriteExt;
+
+/// NOTE: this certificate is to be used for demonstration purposes only!
+pub static CERT_PEM: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../quic/s2n-quic-core/certs/cert.pem"
+));
+/// NOTE: this certificate is to be used for demonstration purposes only!
+pub static KEY_PEM: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../quic/s2n-quic-core/certs/key.pem"
+));
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let mut server = Server::builder()
+        .with_tls((CERT_PEM, KEY_PEM))?
+        .with_io("127.0.0.1:4433")?
+        .start()?;
+
+    while let Some(mut connection) = server.accept().await {
+        // spawn a new task for the connection
+        tokio::spawn(async move {
+            eprintln!("Connection accepted from {:?}", connection.remote_addr());
+
+            while let Ok(Some(mut stream)) = connection.accept_bidirectional_stream().await {
+                // spawn a new task for the stream
+                tokio::spawn(async move {
+                    eprintln!("Stream opened from {:?}", stream.connection().remote_addr());
+
+                    // respond to the client with our own message
+                    if let Ok(Some(data)) = stream.receive().await {
+                        eprintln!("message from the client: {:?}", data);
+                        let _ = stream.write_all(b"hello post-quantum client!\n").await;
+                    }
+                });
+            }
+        });
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
### Description of changes: 

In #1283, we added support for building s2n-quic with support for post-quantum key shares. This PR adds an example of how to enable this functionality in an application, along with a short README about what the example is doing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

