### PR TITLE
feat: add send quantum to congestion controller trait

### DIFF
--- a/quic/s2n-quic-core/src/io/tx.rs
+++ b/quic/s2n-quic-core/src/io/tx.rs
@@ -99,7 +99,7 @@ pub trait Message {
     fn ipv6_flow_label(&mut self) -> u32;
 
     /// Returns true if the packet can be used in a GSO packet
-    fn can_gso(&self, segment_len: usize) -> bool;
+    fn can_gso(&self, segment_len: usize, segment_count: usize) -> bool;
 
     /// Writes the payload of the message to an output buffer
     fn write_payload(&mut self, buffer: PayloadBuffer, gso_offset: usize) -> Result<usize, Error>;
@@ -161,7 +161,7 @@ impl<Handle: path::Handle, Payload: AsRef<[u8]>> Message for (Handle, Payload) {
         0
     }
 
-    fn can_gso(&self, segment_len: usize) -> bool {
+    fn can_gso(&self, segment_len: usize, _segment_count: usize) -> bool {
         segment_len >= self.1.as_ref().len()
     }
 

--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -119,6 +119,16 @@ pub trait CongestionController: 'static + Clone + Send + Debug {
     ///
     /// If the time is in the past or is `None`, the packet should be transmitted immediately.
     fn earliest_departure_time(&self) -> Option<Timestamp>;
+
+    /// The maximum number of bytes for an aggregation of packets scheduled and transmitted together.
+    ///
+    /// If the value is `None`, the congestion controller does not influence the send aggregation.
+    ///
+    /// The effect of this value is dependent on platform support for GSO (Generic Segmentation
+    /// Offload) as well as the configured `MaxSegments` value.
+    fn send_quantum(&self) -> Option<usize> {
+        None
+    }
 }
 
 #[cfg(any(test, feature = "testing"))]

--- a/quic/s2n-quic-platform/src/message/queue/slice.rs
+++ b/quic/s2n-quic-platform/src/message/queue/slice.rs
@@ -156,7 +156,7 @@ impl<'a, Message: message::Message, B> Slice<'a, Message, B> {
         let prev_message = &mut self.messages[gso.index];
         // check to make sure the message can be GSO'd and can be included in the same
         // GSO payload as the previous message
-        if !(message.can_gso(gso.size) && prev_message.can_gso(&mut message)) {
+        if !(message.can_gso(gso.size, gso.count) && prev_message.can_gso(&mut message)) {
             self.flush_gso();
             return Ok(Err(message));
         }

--- a/quic/s2n-quic-transport/src/connection/close_sender.rs
+++ b/quic/s2n-quic-transport/src/connection/close_sender.rs
@@ -152,7 +152,7 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher> tx::Message
     }
 
     #[inline]
-    fn can_gso(&self, segment_len: usize) -> bool {
+    fn can_gso(&self, segment_len: usize, _segment_count: usize) -> bool {
         segment_len >= self.packet.len()
     }
 

--- a/quic/s2n-quic-transport/src/endpoint/retry.rs
+++ b/quic/s2n-quic-transport/src/endpoint/retry.rs
@@ -157,7 +157,7 @@ impl<Path: path::Handle> tx::Message for &Transmission<Path> {
     }
 
     #[inline]
-    fn can_gso(&self, segment_len: usize) -> bool {
+    fn can_gso(&self, segment_len: usize, _segment_count: usize) -> bool {
         segment_len >= self.as_ref().len()
     }
 

--- a/quic/s2n-quic-transport/src/endpoint/stateless_reset.rs
+++ b/quic/s2n-quic-transport/src/endpoint/stateless_reset.rs
@@ -144,7 +144,7 @@ impl<Path: path::Handle> tx::Message for &Transmission<Path> {
     }
 
     #[inline]
-    fn can_gso(&self, segment_len: usize) -> bool {
+    fn can_gso(&self, segment_len: usize, _segment_count: usize) -> bool {
         segment_len >= self.as_ref().len()
     }
 

--- a/quic/s2n-quic-transport/src/endpoint/version.rs
+++ b/quic/s2n-quic-transport/src/endpoint/version.rs
@@ -259,7 +259,7 @@ impl<Path: path::Handle> tx::Message for &Transmission<Path> {
     }
 
     #[inline]
-    fn can_gso(&self, segment_len: usize) -> bool {
+    fn can_gso(&self, segment_len: usize, _segment_count: usize) -> bool {
         segment_len >= self.as_ref().len()
     }
 


### PR DESCRIPTION
### Description of changes: 

From the BBR Congestion Control RFC §4.6.3:

> In order to amortize per-packet overheads involved in the sending process (host CPU, NIC processing, and interrupt processing delays), high-performance transport sender implementations (e.g., Linux TCP) often schedule an aggregate containing multiple packets (multiple SMSS) worth of data as a single quantum (using TSO, GSO, or other offload mechanisms). The BBR congestion control algorithm makes this control decision explicitly, dynamically calculating a quantum control parameter that specifies the maximum size of these transmission aggregates.

This change adds `send_quantum` to the `CongestionController` trait to allow congestion controllers like BBRv2 to influence the amount of data aggregated by GSO. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

