### PR TITLE
refactor(s2n-quic-transport): consolidate recovery manager interface

### DIFF
--- a/quic/s2n-quic-core/src/frame/ack.rs
+++ b/quic/s2n-quic-core/src/frame/ack.rs
@@ -115,7 +115,7 @@ impl<A: AckRanges> Ack<A> {
         self.ack_ranges.largest_acknowledged()
     }
 
-    pub fn into_pn_range_iter(
+    pub fn pn_range_iter(
         &self,
         space: PacketNumberSpace,
     ) -> impl Iterator<Item = PacketNumberRange> {

--- a/quic/s2n-quic-core/src/frame/ack.rs
+++ b/quic/s2n-quic-core/src/frame/ack.rs
@@ -1,7 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{frame::Tag, inet::ExplicitCongestionNotification, number::CheckedSub, varint::VarInt};
+use crate::{
+    frame::Tag,
+    inet::ExplicitCongestionNotification,
+    number::CheckedSub,
+    packet::number::{PacketNumberRange, PacketNumberSpace},
+    varint::VarInt,
+};
 use core::{
     convert::TryInto,
     ops::{RangeInclusive, SubAssign},
@@ -107,6 +113,16 @@ impl<A: AckRanges> Ack<A> {
 
     pub fn largest_acknowledged(&self) -> VarInt {
         self.ack_ranges.largest_acknowledged()
+    }
+
+    pub fn into_pn_range_iter(
+        &self,
+        space: PacketNumberSpace,
+    ) -> impl Iterator<Item = PacketNumberRange> {
+        self.ack_ranges().map(move |ack_range| {
+            let (start, end) = ack_range.into_inner();
+            PacketNumberRange::new(space.new_packet_number(start), space.new_packet_number(end))
+        })
     }
 }
 

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -10,7 +10,6 @@ use crate::{
     path::MINIMUM_MTU,
     recovery,
     recovery::manager::PtoState::RequiresTransmission,
-    space::into_pn_range_iter,
 };
 use core::{ops::RangeInclusive, time::Duration};
 use s2n_quic_core::{
@@ -2723,7 +2722,7 @@ fn helper_ack_packets_on_path(
     let largest_acked_packet_number = space.new_packet_number(frame.largest_acknowledged());
     let _ = manager.process_acks(
         datagram.timestamp,
-        into_pn_range_iter(frame.ack_ranges(), space),
+        frame.into_pn_range_iter(space),
         largest_acked_packet_number,
         frame.ack_delay(),
         frame.ecn_counts,

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -2722,7 +2722,7 @@ fn helper_ack_packets_on_path(
     let largest_acked_packet_number = space.new_packet_number(frame.largest_acknowledged());
     let _ = manager.process_acks(
         datagram.timestamp,
-        frame.into_pn_range_iter(space),
+        frame.pn_range_iter(space),
         largest_acked_packet_number,
         frame.ack_delay(),
         frame.ecn_counts,

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::into_pn_range_iter;
 use crate::{
     ack::{pending_ack_ranges::PendingAckRanges, AckManager},
     connection::{self, ConnectionTransmissionContext, ProcessingError},
@@ -803,7 +802,7 @@ impl<Config: endpoint::Config> PacketSpace<Config> for ApplicationSpace<Config> 
         let largest_acked_packet_number = space.new_packet_number(frame.largest_acknowledged());
         recovery_manager.process_acks(
             timestamp,
-            into_pn_range_iter(frame.ack_ranges(), space),
+            frame.into_pn_range_iter(space),
             largest_acked_packet_number,
             frame.ack_delay(),
             frame.ecn_counts,

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -802,7 +802,7 @@ impl<Config: endpoint::Config> PacketSpace<Config> for ApplicationSpace<Config> 
         let largest_acked_packet_number = space.new_packet_number(frame.largest_acknowledged());
         recovery_manager.process_acks(
             timestamp,
-            frame.into_pn_range_iter(space),
+            frame.pn_range_iter(space),
             largest_acked_packet_number,
             frame.ack_delay(),
             frame.ecn_counts,

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::into_pn_range_iter;
 use crate::{
     ack::{pending_ack_ranges::PendingAckRanges, AckManager},
     connection::{self, ConnectionTransmissionContext, ProcessingError},
@@ -589,12 +590,32 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
                 .expect("active path should be set"),
             path_manager,
         );
-        recovery_manager.on_pending_ack_ranges(
+
+        debug_assert!(
+            !pending_ack_ranges.is_empty(),
+            "pending_ack_ranges should be non-empty since connection indicated ack interest"
+        );
+
+        let largest_acked_packet_number = pending_ack_ranges
+            .max_value()
+            .expect("pending range should not be empty");
+        let result = recovery_manager.process_acks(
             timestamp,
-            pending_ack_ranges,
+            pending_ack_ranges.iter(),
+            largest_acked_packet_number,
+            pending_ack_ranges.ack_delay(),
+            pending_ack_ranges.ecn_counts(),
             &mut context,
             publisher,
-        )
+        );
+
+        // reset pending ack information after processing
+        //
+        // If there was an error during processing, the connection is closed
+        // so it should not matter if the queue is cleared.
+        pending_ack_ranges.reset_aggregate_info();
+
+        result
     }
 }
 
@@ -778,7 +799,17 @@ impl<Config: endpoint::Config> PacketSpace<Config> for ApplicationSpace<Config> 
         let (recovery_manager, mut context, _pending_ack_ranges) =
             self.recovery(handshake_status, local_id_registry, path_id, path_manager);
 
-        recovery_manager.on_ack_frame(timestamp, frame, &mut context, publisher)
+        let space = PacketNumberSpace::ApplicationData;
+        let largest_acked_packet_number = space.new_packet_number(frame.largest_acknowledged());
+        recovery_manager.process_acks(
+            timestamp,
+            into_pn_range_iter(frame.ack_ranges(), space),
+            largest_acked_packet_number,
+            frame.ack_delay(),
+            frame.ecn_counts,
+            &mut context,
+            publisher,
+        )
     }
 
     fn handle_connection_close_frame(

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::into_pn_range_iter;
 use crate::{
     ack::AckManager,
     connection::{self, ConnectionTransmissionContext, ProcessingError},
@@ -504,7 +505,18 @@ impl<Config: endpoint::Config> PacketSpace<Config> for HandshakeSpace<Config> {
         path.on_peer_validated();
         let (recovery_manager, mut context) =
             self.recovery(handshake_status, path_id, path_manager);
-        recovery_manager.on_ack_frame(timestamp, frame, &mut context, publisher)
+
+        let space = PacketNumberSpace::Handshake;
+        let largest_acked_packet_number = space.new_packet_number(frame.largest_acknowledged());
+        recovery_manager.process_acks(
+            timestamp,
+            into_pn_range_iter(frame.ack_ranges(), space),
+            largest_acked_packet_number,
+            frame.ack_delay(),
+            frame.ecn_counts,
+            &mut context,
+            publisher,
+        )
     }
 
     fn handle_connection_close_frame(

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -509,7 +509,7 @@ impl<Config: endpoint::Config> PacketSpace<Config> for HandshakeSpace<Config> {
         let largest_acked_packet_number = space.new_packet_number(frame.largest_acknowledged());
         recovery_manager.process_acks(
             timestamp,
-            frame.into_pn_range_iter(space),
+            frame.pn_range_iter(space),
             largest_acked_packet_number,
             frame.ack_delay(),
             frame.ecn_counts,

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::into_pn_range_iter;
 use crate::{
     ack::AckManager,
     connection::{self, ConnectionTransmissionContext, ProcessingError},
@@ -510,7 +509,7 @@ impl<Config: endpoint::Config> PacketSpace<Config> for HandshakeSpace<Config> {
         let largest_acked_packet_number = space.new_packet_number(frame.largest_acknowledged());
         recovery_manager.process_acks(
             timestamp,
-            into_pn_range_iter(frame.ack_ranges(), space),
+            frame.into_pn_range_iter(space),
             largest_acked_packet_number,
             frame.ack_delay(),
             frame.ecn_counts,

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::into_pn_range_iter;
 use crate::{
     ack::AckManager,
     connection::{self, ConnectionTransmissionContext, ProcessingError},
@@ -658,7 +657,7 @@ impl<Config: endpoint::Config> PacketSpace<Config> for InitialSpace<Config> {
         let largest_acked_packet_number = space.new_packet_number(frame.largest_acknowledged());
         recovery_manager.process_acks(
             timestamp,
-            into_pn_range_iter(frame.ack_ranges(), space),
+            frame.into_pn_range_iter(space),
             largest_acked_packet_number,
             frame.ack_delay(),
             frame.ecn_counts,

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -657,7 +657,7 @@ impl<Config: endpoint::Config> PacketSpace<Config> for InitialSpace<Config> {
         let largest_acked_packet_number = space.new_packet_number(frame.largest_acknowledged());
         recovery_manager.process_acks(
             timestamp,
-            frame.into_pn_range_iter(space),
+            frame.pn_range_iter(space),
             largest_acked_packet_number,
             frame.ack_delay(),
             frame.ecn_counts,

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -12,7 +12,6 @@ use crate::{
 use bytes::Bytes;
 use core::{
     fmt,
-    ops::RangeInclusive,
     task::{Poll, Waker},
 };
 use s2n_codec::DecoderBufferMut;
@@ -28,7 +27,7 @@ use s2n_quic_core::{
         RetireConnectionId, StopSending, StreamDataBlocked, StreamsBlocked,
     },
     inet::DatagramInfo,
-    packet::number::{PacketNumber, PacketNumberRange, PacketNumberSpace},
+    packet::number::{PacketNumber, PacketNumberSpace},
     time::{timer, Timestamp},
     transport,
     varint::VarInt,
@@ -931,14 +930,4 @@ pub trait PacketSpace<Config: endpoint::Config> {
 
         Ok(processed_packet)
     }
-}
-
-pub(crate) fn into_pn_range_iter(
-    iter: impl Iterator<Item = RangeInclusive<VarInt>>,
-    space: PacketNumberSpace,
-) -> impl Iterator<Item = PacketNumberRange> {
-    iter.map(move |ack_range| {
-        let (start, end) = ack_range.into_inner();
-        PacketNumberRange::new(space.new_packet_number(start), space.new_packet_number(end))
-    })
 }


### PR DESCRIPTION
### Description of changes: 
This PR consolidates the `on_ack_frame` and `on_pending_ack_ranges` api into a single `process_acks` api.

### Testing:
refactor

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

