### PR TITLE
feat(s2n-quic-core): BBRv2 bandwidth probing

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -3,15 +3,24 @@
 
 use crate::{
     counter::Counter,
-    recovery::{bandwidth, CongestionController, RttEstimator},
+    recovery::{
+        bandwidth, bandwidth::Bandwidth, bbr::probe_bw::CyclePhase, CongestionController,
+        RttEstimator,
+    },
     time::Timestamp,
 };
+use core::{
+    cmp::{max, min},
+    convert::TryInto,
+};
 use num_rational::Ratio;
+use num_traits::One;
 
 mod congestion;
 mod data_rate;
 mod data_volume;
 mod full_pipe;
+mod probe_bw;
 mod recovery;
 mod round;
 mod windowed_filter;
@@ -24,6 +33,17 @@ const LOSS_THRESH: Ratio<u32> = Ratio::new_raw(1, 50);
 //# The default multiplicative decrease to make upon each round trip during which
 //# the connection detects packet loss (the value is 0.7)
 const BETA: Ratio<u64> = Ratio::new_raw(7, 10);
+
+//= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#2.8
+//# The multiplicative factor to apply to BBR.inflight_hi when attempting to leave free headroom in
+//# the path (e.g. free space in the bottleneck buffer or free time slots in the bottleneck link)
+//# that can be used by cross traffic (the value is 0.85).
+const HEADROOM: Ratio<u64> = Ratio::new_raw(85, 100);
+
+//= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#2.8
+//# The minimal cwnd value BBR targets, to allow pipelining with TCP endpoints
+//# that follow an "ACK every other packet" delayed-ACK policy: 4 * SMSS.
+const MIN_PIPE_CWND_PACKETS: u16 = 4;
 
 /// A congestion controller that implements "Bottleneck Bandwidth and Round-trip propagation time"
 /// version 2 (BBRv2) as specified in <https://datatracker.ietf.org/doc/draft-cardwell-iccrg-bbr-congestion-control/>.
@@ -48,9 +68,10 @@ struct BbrCongestionController {
     cwnd: u32,
     recovery_state: recovery::State,
     congestion_state: congestion::State,
+    probe_bw_state: probe_bw::State,
     data_rate_model: data_rate::Model,
-    #[allow(dead_code)] // TODO: Remove when used
     data_volume_model: data_volume::Model,
+    max_datagram_size: u16,
 }
 
 type BytesInFlight = Counter<u32>;
@@ -139,6 +160,15 @@ impl CongestionController for BbrCongestionController {
             )
         }
 
+        if self.full_pipe_estimator.filled_pipe() {
+            self.adapt_upper_bounds(
+                self.bw_estimator.rate_sample(),
+                bytes_acknowledged,
+                ack_receive_time,
+            );
+            // TODO: if self.state == State::Probe_BW
+            self.update_probe_bw_cycle_phase(ack_receive_time);
+        }
         self.congestion_state
             .advance(self.bw_estimator.rate_sample());
     }
@@ -160,8 +190,8 @@ impl CongestionController for BbrCongestionController {
         self.recovery_state.on_congestion_event(event_time);
     }
 
-    fn on_mtu_update(&mut self, _max_data_size: u16) {
-        todo!()
+    fn on_mtu_update(&mut self, max_datagram_size: u16) {
+        self.max_datagram_size = max_datagram_size;
     }
 
     fn on_packet_discarded(&mut self, _bytes_sent: usize) {
@@ -170,5 +200,118 @@ impl CongestionController for BbrCongestionController {
 
     fn earliest_departure_time(&self) -> Option<Timestamp> {
         todo!()
+    }
+}
+
+impl BbrCongestionController {
+    /// The bandwidth-delay product
+    ///
+    /// Based on the current estimate of maximum sending bandwidth and minimum RTT
+    fn bdp(&self) -> u64 {
+        self.bdp_multiple(self.data_rate_model.bw(), Ratio::one())
+    }
+
+    /// Calculates a bandwidth-delay product using the supplied `Bandwidth` and `gain`
+    fn bdp_multiple(&self, bw: Bandwidth, gain: Ratio<u64>) -> u64 {
+        if let Some(min_rtt) = self.data_volume_model.min_rtt() {
+            (gain * (bw * min_rtt)).to_integer()
+        } else {
+            Self::initial_window(self.max_datagram_size).into()
+        }
+    }
+
+    /// How much data do we want in flight
+    ///
+    /// Based on the estimated BDP, unless congestion reduced the cwnd
+    fn target_inflight(&self) -> u32 {
+        self.bdp().min(self.cwnd as u64) as u32
+    }
+
+    /// The estimate of the volume of in-flight data required to fully utilize the bottleneck
+    /// bandwidth available to the flow, based on the BDP estimate (BBR.bdp), the aggregation
+    /// estimate (BBR.extra_acked), the offload budget (BBR.offload_budget), and BBRMinPipeCwnd.
+    #[allow(dead_code)] // TODO: Remove when used
+    fn max_inflight(&self) -> u64 {
+        let cwnd_gain = Ratio::one(); // TODO: get cwnd_gain from State
+        let bdp = self.bdp_multiple(self.data_rate_model.bw(), cwnd_gain);
+        let inflight = bdp + self.data_volume_model.extra_acked();
+        self.quantization_budget(inflight)
+    }
+
+    /// Inflight based on min RTT and the estimated bottleneck bandwidth
+    fn inflight(&self, bw: Bandwidth, gain: Ratio<u64>) -> u32 {
+        let inflight = self.bdp_multiple(bw, gain);
+        self.quantization_budget(inflight)
+            .try_into()
+            .unwrap_or(u32::MAX)
+    }
+
+    /// The volume of data that tries to leave free headroom in the bottleneck buffer or link for
+    /// other flows, for fairness convergence and lower RTTs and loss
+    fn inflight_with_headroom(&self) -> u32 {
+        if self.data_volume_model.inflight_hi() == u64::MAX {
+            return u32::MAX;
+        }
+
+        let headroom = max(
+            1,
+            (HEADROOM * self.data_volume_model.inflight_hi()).to_integer(),
+        );
+        max(
+            self.data_volume_model.inflight_hi() - headroom,
+            self.minimum_window() as u64,
+        )
+        .try_into()
+        .unwrap_or(u32::MAX) // TODO: change type
+    }
+
+    /// Calculates the quantization budget
+    fn quantization_budget(&self, inflight: u64) -> u64 {
+        //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.2
+        //# BBRQuantizationBudget(inflight)
+        //#   BBRUpdateOffloadBudget()
+        //#   inflight = max(inflight, BBR.offload_budget)
+        //#   inflight = max(inflight, BBRMinPipeCwnd)
+        //#   if (BBR.state == ProbeBW && BBR.cycle_idx == ProbeBW_UP)
+        //#     inflight += 2
+        //#   return inflight
+
+        let offload_budget = 1; // TODO: Track offload budget
+
+        let mut inflight = inflight
+            .max(offload_budget)
+            .max(self.minimum_window() as u64);
+
+        if self.probe_bw_state.cycle_phase() == CyclePhase::Up {
+            // TODO: Check BBR.state == ProbeBW
+            inflight += 2 * self.max_datagram_size as u64;
+        }
+
+        inflight
+    }
+
+    /// True if the amount of `lost_bytes` exceeds the BBR loss threshold
+    fn is_inflight_too_high(lost_bytes: u64, bytes_inflight: u32) -> bool {
+        lost_bytes > (LOSS_THRESH * bytes_inflight).to_integer() as u64
+    }
+
+    //= https://www.rfc-editor.org/rfc/rfc9002#section-7.2
+    //# Endpoints SHOULD use an initial congestion
+    //# window of ten times the maximum datagram size (max_datagram_size),
+    //# while limiting the window to the larger of 14,720 bytes or twice the
+    //# maximum datagram size.
+    #[inline]
+    fn initial_window(max_datagram_size: u16) -> u32 {
+        const INITIAL_WINDOW_LIMIT: u32 = 14720;
+        min(
+            10 * max_datagram_size as u32,
+            max(INITIAL_WINDOW_LIMIT, 2 * max_datagram_size as u32),
+        )
+    }
+
+    /// The minimal cwnd value BBR targets
+    #[inline]
+    fn minimum_window(&self) -> u32 {
+        (MIN_PIPE_CWND_PACKETS * self.max_datagram_size) as u32
     }
 }

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -8,7 +8,6 @@ use crate::{
         bandwidth, bandwidth::Bandwidth, bbr::probe_bw::CyclePhase, CongestionController,
         RttEstimator,
     },
-    recovery::{bandwidth, CongestionController, RttEstimator},
     time::Timestamp,
 };
 use core::{
@@ -129,7 +128,7 @@ impl CongestionController for BbrCongestionController {
         bytes_acknowledged: usize,
         newest_acked_packet_info: Self::PacketInfo,
         _rtt_estimator: &RttEstimator,
-        _random_generator: &mut Rnd,
+        random_generator: &mut Rnd,
         ack_receive_time: Timestamp,
     ) {
         self.bw_estimator.on_ack(
@@ -168,10 +167,11 @@ impl CongestionController for BbrCongestionController {
             self.adapt_upper_bounds(
                 self.bw_estimator.rate_sample(),
                 bytes_acknowledged,
+                random_generator,
                 ack_receive_time,
             );
             // TODO: if self.state == State::Probe_BW
-            self.update_probe_bw_cycle_phase(ack_receive_time);
+            self.update_probe_bw_cycle_phase(random_generator, ack_receive_time);
         }
         self.congestion_state
             .advance(self.bw_estimator.rate_sample());

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -157,7 +157,8 @@ impl CongestionController for BbrCongestionController {
                 self.bw_estimator.rate_sample(),
                 self.data_rate_model.max_bw(),
                 self.recovery_state.in_recovery(),
-            )
+            );
+            self.probe_bw_state.on_round_start();
         }
 
         if self.full_pipe_estimator.filled_pipe() {

--- a/quic/s2n-quic-core/src/recovery/bbr/data_rate.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/data_rate.rs
@@ -96,13 +96,9 @@ impl Model {
         }
     }
 
-    /// Updates `bw_hi` with the given `bw` if it exceeds the current `bw_hi`
+    /// Updates `bw_hi` with the given `bw`
     pub fn update_upper_bound(&mut self, bw: Bandwidth) {
-        if self.bw_hi == Bandwidth::MAX {
-            self.bw_hi = bw;
-        } else {
-            self.bw_hi = bw.max(self.bw_hi)
-        }
+        self.bw_hi = bw
     }
 
     /// Updates `bw_lo` with the given `bw` if it exceeds the current `bw_lo` * `bbr::BETA`
@@ -185,30 +181,6 @@ mod tests {
         // The sample is app limited so the max stays the same
         model.update_max_bw(rate_sample);
         assert_eq!(bw, model.max_bw());
-    }
-
-    #[test]
-    fn update_upper_bound() {
-        let mut model = Model::new();
-
-        let bw = Bandwidth::new(100, Duration::from_millis(10));
-
-        model.update_upper_bound(bw);
-
-        // We didn't have a valid bw_hi value yet, so the first sample is used
-        assert_eq!(bw, model.bw_hi());
-
-        let lower_bw = Bandwidth::new(50, Duration::from_millis(10));
-        model.update_upper_bound(lower_bw);
-
-        // The new sample is lower than bw_hi, so don't update bw_hi
-        assert_eq!(bw, model.bw_hi());
-
-        let higher_bw = Bandwidth::new(150, Duration::from_millis(10));
-        model.update_upper_bound(higher_bw);
-
-        // The new sample is higher than bw_hi, so update bw_hi
-        assert_eq!(higher_bw, model.bw_hi());
     }
 
     #[test]

--- a/quic/s2n-quic-core/src/recovery/bbr/data_volume.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/data_volume.rs
@@ -126,13 +126,9 @@ impl Model {
         self.extra_acked_filter.update(extra, round_count);
     }
 
-    /// Updates `inflight_hi` with the given `inflight_hi` if it exceeds the current `inflight_hi`
+    /// Updates `inflight_hi` with the given `inflight_hi`
     pub fn update_upper_bound(&mut self, inflight_hi: u64) {
-        if self.inflight_hi == u64::MAX {
-            self.inflight_hi = inflight_hi;
-        } else {
-            self.inflight_hi = inflight_hi.max(self.inflight_hi);
-        }
+        self.inflight_hi = inflight_hi;
     }
 
     /// Updates `inflight_lo` with the given `inflight_latest` if it exceeds
@@ -197,30 +193,6 @@ mod tests {
         // value is used as the extra acked (1600 bytes). 1700 remains the max extra acked.
         model.update_ack_aggregation(bw, 1700, 1600, 2, now);
         assert_eq!(1700, model.extra_acked());
-    }
-
-    #[test]
-    fn update_upper_bound() {
-        let now = NoopClock.get_time();
-        let mut model = Model::new(now);
-
-        let inflight_hi = 100;
-
-        model.update_upper_bound(inflight_hi);
-
-        // We didn't have a valid inflight_hi value yet, so the first sample is used
-        assert_eq!(inflight_hi, model.inflight_hi());
-
-        model.update_upper_bound(50);
-
-        // The new sample is lower than inflight_hi, so don't update inflight_hi
-        assert_eq!(inflight_hi, model.inflight_hi());
-
-        let inflight_hi = 150;
-        model.update_upper_bound(inflight_hi);
-
-        // The new sample is higher than inflight_hi, so update inflight_hi
-        assert_eq!(inflight_hi, model.inflight_hi());
     }
 
     #[test]

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
@@ -1,0 +1,432 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    recovery::{
+        bandwidth::{Bandwidth, RateSample},
+        bbr,
+        bbr::{congestion, data_rate, data_volume, round, BbrCongestionController},
+        CongestionController,
+    },
+    time::Timestamp,
+};
+use core::time::Duration;
+use num_rational::Ratio;
+use num_traits::One;
+
+const MAX_BW_PROBE_UP_ROUNDS: u8 = 30;
+
+/// Max number of packet-timed rounds to wait before probing for bandwidth
+const MAX_BW_PROBE_ROUNDS: u32 = 63;
+
+//= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3
+//# a BBR flow in ProbeBW mode cycles through the four
+//# Probe bw states - DOWN, CRUISE, REFILL, and UP
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CyclePhase {
+    /// Send slower than the network is delivering data, to reduce the amount of data in flight
+    Down,
+    /// Send at the same rate the network is delivering data
+    Cruise,
+    /// Try to fully utilize the network bottleneck without creating any significant queue pressure
+    Refill,
+    /// Probe for possible increases in available bandwidth
+    Up,
+}
+
+impl CyclePhase {
+    /// The dynamic gain factor used to scale BBR.bw to produce BBR.pacing_rate
+    pub fn pacing_gain(&self) -> Ratio<u64> {
+        //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.1
+        //# In the ProbeBW_DOWN phase of the cycle, a BBR flow pursues the deceleration tactic,
+        //# to try to send slower than the network is delivering data, to reduce the amount of data
+        //# in flight, with all of the standard motivations for the deceleration tactic (discussed
+        //# in "State Machine Tactics", above). It does this by switching to a BBR.pacing_gain of
+        //# 0.9, sending at 90% of BBR.bw.
+        const DOWN_PACING_GAIN: Ratio<u64> = Ratio::new_raw(9, 10);
+        //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.4
+        //# After ProbeBW_REFILL refills the pipe, ProbeBW_UP probes for possible increases in
+        //# available bandwidth by using a BBR.pacing_gain of 1.25, sending faster than the current
+        //# estimated available bandwidth.
+        const UP_PACING_GAIN: Ratio<u64> = Ratio::new_raw(5, 4);
+        //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.3
+        //# During ProbeBW_REFILL BBR uses a BBR.pacing_gain of 1.0, to send at a rate that
+        //# matches the current estimated available bandwidth
+
+        //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.2
+        //# In the ProbeBW_CRUISE phase of the cycle, a BBR flow pursues the "cruising" tactic
+        //# (discussed in "State Machine Tactics", above), attempting to send at the same rate
+        //# the network is delivering data. It tries to match the sending rate to the flow's
+        //# current available bandwidth, to try to achieve high utilization of the available
+        //# bandwidth without increasing queue pressure. It does this by switching to a
+        //# pacing_gain of 1.0, sending at 100% of BBR.bw. N
+        const CRUISE_REFILL_PACING_GAIN: Ratio<u64> = Ratio::new_raw(1, 1);
+
+        match self {
+            CyclePhase::Down => DOWN_PACING_GAIN,
+            CyclePhase::Cruise | CyclePhase::Refill => CRUISE_REFILL_PACING_GAIN,
+            CyclePhase::Up => UP_PACING_GAIN,
+        }
+    }
+}
+
+/// How the incoming ACK stream relates to our bandwidth probing
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum AckPhase {
+    /// not probing; not getting probe feedback
+    Init,
+    /// stopped probing; still getting feedback
+    ProbeStopping,
+    /// sending at est. bw to fill pipe
+    Refilling,
+    /// inflight rising to probe bw
+    ProbeStarting,
+    /// getting feedback from bw probing
+    ProbeFeedback,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct State {
+    /// The current mode for deciding how fast to send
+    cycle_phase: CyclePhase,
+    /// How the incoming ACK stream relates to our bandwidth probing
+    ack_phase: AckPhase,
+    /// A random duration to wait until probing for bandwidth
+    bw_probe_wait: Duration,
+    /// Packet-timed rounds since probed bw
+    rounds_since_bw_probe: u8,
+    /// Packets delivered per inflight_hi increment
+    bw_probe_up_cnt: u32,
+    /// Packets ACKed since inflight_hi increment
+    bw_probe_up_acks: u32,
+    /// cwnd-limited rounds in PROBE_UP
+    bw_probe_up_rounds: u8,
+    /// True if the rate samples reflect bandwidth probing
+    bw_probe_samples: bool,
+    /// Time of this cycle phase start
+    cycle_stamp: Option<Timestamp>,
+}
+
+impl State {
+    #[allow(dead_code)] // TODO: Remove when used
+    pub fn new() -> Self {
+        Self {
+            cycle_phase: CyclePhase::Down,
+            ack_phase: AckPhase::Init,
+            bw_probe_wait: Duration::ZERO,
+            rounds_since_bw_probe: 0,
+            bw_probe_up_cnt: 0,
+            bw_probe_up_acks: 0,
+            bw_probe_up_rounds: 0,
+            bw_probe_samples: false,
+            cycle_stamp: None,
+        }
+    }
+
+    /// Returns the current `probe_bw::CyclePhase`
+    pub fn cycle_phase(&self) -> CyclePhase {
+        self.cycle_phase
+    }
+
+    pub fn check_time_to_probe_bw(
+        &mut self,
+        target_inflight: u32,
+        max_data_size: u16,
+        now: Timestamp,
+    ) -> bool {
+        debug_assert!(
+            self.cycle_phase == CyclePhase::Down || self.cycle_phase == CyclePhase::Cruise
+        );
+
+        if self.has_elapsed_in_phase(self.bw_probe_wait, now)
+            || self.is_reno_coexistence_probe_time(target_inflight, max_data_size)
+        {
+            return true;
+        }
+        false
+    }
+
+    pub fn probe_inflight_hi_upward(
+        &mut self,
+        bytes_acknowledged: usize,
+        data_volume_model: &mut data_volume::Model,
+        cwnd: u32,
+        max_data_size: u16,
+        round_start: bool,
+    ) {
+        self.bw_probe_up_acks += bytes_acknowledged as u32;
+        if self.bw_probe_up_acks >= self.bw_probe_up_cnt {
+            let delta = self.bw_probe_up_acks / self.bw_probe_up_cnt;
+            self.bw_probe_up_acks -= delta * self.bw_probe_up_cnt;
+            let inflight_hi = data_volume_model.inflight_hi() + delta as u64;
+            data_volume_model.update_upper_bound(inflight_hi);
+        }
+        if round_start {
+            self.raise_inflight_hi_slope(cwnd, max_data_size);
+        }
+    }
+
+    /// Raise inflight_hi slope if appropriate
+    fn raise_inflight_hi_slope(&mut self, cwnd: u32, max_data_size: u16) {
+        //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.4
+        //# BBR takes an approach where the additive increase to BBR.inflight_hi
+        //# exponentially doubles each round trip
+        let growth_this_round = max_data_size << self.bw_probe_up_rounds;
+        self.bw_probe_up_rounds = (self.bw_probe_up_rounds + 1).min(MAX_BW_PROBE_UP_ROUNDS);
+        self.bw_probe_up_cnt = (cwnd / growth_this_round as u32).max(1);
+    }
+
+    fn has_elapsed_in_phase(&self, interval: Duration, now: Timestamp) -> bool {
+        self.cycle_stamp
+            .map_or(false, |cycle_stamp| now > cycle_stamp + interval)
+    }
+
+    fn is_reno_coexistence_probe_time(&self, target_inflight: u32, max_data_size: u16) -> bool {
+        let rounds = target_inflight.min(MAX_BW_PROBE_ROUNDS * max_data_size as u32);
+        self.rounds_since_bw_probe as u32 >= rounds
+    }
+
+    fn start_probe_bw_cruise(&mut self) {
+        debug_assert_eq!(self.cycle_phase, CyclePhase::Down);
+
+        self.cycle_phase = CyclePhase::Cruise
+    }
+
+    fn start_probe_bw_up(
+        &mut self,
+        round_counter: &mut round::Counter,
+        delivered_bytes: u64,
+        cwnd: u32,
+        max_data_size: u16,
+        now: Timestamp,
+    ) {
+        debug_assert_eq!(self.cycle_phase, CyclePhase::Refill);
+
+        self.bw_probe_samples = true;
+        self.ack_phase = AckPhase::ProbeStarting;
+        round_counter.set_round_end(delivered_bytes);
+        self.cycle_stamp = Some(now);
+        self.cycle_phase = CyclePhase::Up;
+        self.raise_inflight_hi_slope(cwnd, max_data_size);
+    }
+
+    fn start_probe_bw_refill(
+        &mut self,
+        data_volume_model: &mut data_volume::Model,
+        data_rate_model: &mut data_rate::Model,
+        round_counter: &mut round::Counter,
+        delivered_bytes: u64,
+    ) {
+        debug_assert!(
+            self.cycle_phase == CyclePhase::Down || self.cycle_phase == CyclePhase::Cruise
+        );
+
+        data_volume_model.reset_lower_bound();
+        data_rate_model.reset_lower_bound();
+        self.bw_probe_up_rounds = 0;
+        self.bw_probe_up_acks = 0;
+        self.ack_phase = AckPhase::Refilling;
+        round_counter.set_round_end(delivered_bytes);
+        self.cycle_phase = CyclePhase::Refill;
+    }
+
+    fn start_probe_bw_down(
+        &mut self,
+        congestion_state: &mut congestion::State,
+        round_counter: &mut round::Counter,
+        delivered_bytes: u64,
+        now: Timestamp,
+    ) {
+        congestion_state.reset();
+        self.bw_probe_up_cnt = u32::MAX;
+        // TODO: BBRPickProbeWait
+        self.cycle_stamp = Some(now);
+        self.ack_phase = AckPhase::ProbeStopping;
+        round_counter.set_round_end(delivered_bytes);
+        self.cycle_phase = CyclePhase::Down;
+    }
+
+    fn check_time_to_cruise(
+        &self,
+        bytes_in_flight: u32,
+        inflight_with_headroom: u32,
+        bdp: u32,
+    ) -> bool {
+        debug_assert_eq!(self.cycle_phase, CyclePhase::Down);
+
+        if bytes_in_flight > inflight_with_headroom {
+            return false; // not enough headroom
+        }
+        if bytes_in_flight <= bdp {
+            return true; // inflight <= estimated BDP
+        }
+        false
+    }
+}
+
+/// Methods related to the ProbeBW state
+impl BbrCongestionController {
+    pub fn update_probe_bw_cycle_phase(&mut self, now: Timestamp) {
+        let target_inflight = self.target_inflight();
+
+        // TODO: debug_assert(self.state == Probe_Bw, "only handling ProveBW states here")
+
+        match self.probe_bw_state.cycle_phase {
+            CyclePhase::Down | CyclePhase::Cruise => {
+                if self.probe_bw_state.check_time_to_probe_bw(
+                    target_inflight,
+                    self.max_datagram_size,
+                    now,
+                ) {
+                    self.probe_bw_state.start_probe_bw_refill(
+                        &mut self.data_volume_model,
+                        &mut self.data_rate_model,
+                        &mut self.round_counter,
+                        self.bw_estimator.delivered_bytes(),
+                    );
+                } else if self.probe_bw_state.cycle_phase == CyclePhase::Down
+                    && self.probe_bw_state.check_time_to_cruise(
+                        self.bytes_in_flight(),
+                        self.inflight_with_headroom(),
+                        self.inflight(self.data_rate_model.max_bw(), Ratio::one()),
+                    )
+                {
+                    self.probe_bw_state.start_probe_bw_cruise();
+                }
+            }
+            CyclePhase::Refill => {
+                // After one round of Refill, start Up
+                if self.round_counter.round_start() {
+                    self.probe_bw_state.start_probe_bw_up(
+                        &mut self.round_counter,
+                        self.bw_estimator.delivered_bytes(),
+                        self.cwnd,
+                        self.max_datagram_size,
+                        now,
+                    );
+                }
+            }
+            CyclePhase::Up => {
+                let min_rtt = self
+                    .data_volume_model
+                    .min_rtt()
+                    .expect("at least one RTT has passed");
+
+                if self.probe_bw_state.has_elapsed_in_phase(min_rtt, now)
+                    && self.bytes_in_flight()
+                        > self.inflight(
+                            self.data_rate_model.max_bw(),
+                            self.probe_bw_state.cycle_phase.pacing_gain(),
+                        )
+                {
+                    self.probe_bw_state.start_probe_bw_down(
+                        &mut self.congestion_state,
+                        &mut self.round_counter,
+                        self.bw_estimator.delivered_bytes(),
+                        now,
+                    );
+                }
+            }
+        }
+    }
+
+    pub fn adapt_upper_bounds(
+        &mut self,
+        rate_sample: RateSample,
+        bytes_acknowledged: usize,
+        now: Timestamp,
+    ) {
+        if !self.full_pipe_estimator.filled_pipe() {
+            return; // only handling steady-state behavior here
+        }
+
+        // TODO: let is_probe_bw = self.state == ProbeBw
+        let is_probe_bw = true;
+
+        if self.probe_bw_state.ack_phase == AckPhase::ProbeStarting
+            && self.round_counter.round_start()
+        {
+            // starting to get bw probing samples
+            self.probe_bw_state.ack_phase = AckPhase::ProbeFeedback;
+        }
+        if self.probe_bw_state.ack_phase == AckPhase::ProbeStopping
+            && self.round_counter.round_start()
+        {
+            self.probe_bw_state.bw_probe_samples = false;
+            self.probe_bw_state.ack_phase = AckPhase::Init;
+
+            if is_probe_bw && !rate_sample.is_app_limited {
+                self.data_rate_model.advance_max_bw_filter();
+            }
+        }
+        if !self.check_inflight_too_high(rate_sample, now) {
+            if self.data_volume_model.inflight_hi() == u64::MAX
+                || self.data_rate_model.bw_hi() == Bandwidth::MAX
+            {
+                // No upper bounds to raise
+                return;
+            }
+            self.data_volume_model
+                .update_upper_bound(rate_sample.bytes_in_flight as u64);
+            self.data_rate_model
+                .update_upper_bound(rate_sample.delivery_rate());
+
+            if self.probe_bw_state.cycle_phase == CyclePhase::Up
+                && self.is_congestion_limited()
+                && self.cwnd as u64 >= self.data_volume_model.inflight_hi()
+            {
+                self.probe_bw_state.probe_inflight_hi_upward(
+                    bytes_acknowledged,
+                    &mut self.data_volume_model,
+                    self.cwnd,
+                    self.max_datagram_size,
+                    self.round_counter.round_start(),
+                );
+            }
+        }
+    }
+
+    fn check_inflight_too_high(&mut self, rate_sample: RateSample, now: Timestamp) -> bool {
+        let inflight_too_high = BbrCongestionController::is_inflight_too_high(
+            rate_sample.lost_bytes,
+            rate_sample.bytes_in_flight,
+        );
+
+        if inflight_too_high && self.probe_bw_state.bw_probe_samples {
+            self.on_inflight_too_high(
+                rate_sample.is_app_limited,
+                rate_sample.bytes_in_flight,
+                self.target_inflight(),
+                now,
+            );
+        }
+
+        inflight_too_high
+    }
+
+    pub fn on_inflight_too_high(
+        &mut self,
+        is_app_limited: bool,
+        bytes_in_flight: u32,
+        target_inflight: u32,
+        now: Timestamp,
+    ) {
+        self.probe_bw_state.bw_probe_samples = false; // only react once per bw probe
+        if !is_app_limited {
+            // TODO: fix update_upper_bound
+            self.data_volume_model.update_upper_bound(
+                (bytes_in_flight as u64).max((bbr::BETA * target_inflight as u64).to_integer()),
+            )
+        }
+
+        // TODO: Check self.state == State::ProbeBw
+        if self.probe_bw_state.cycle_phase == CyclePhase::Up {
+            self.probe_bw_state.start_probe_bw_down(
+                &mut self.congestion_state,
+                &mut self.round_counter,
+                self.bw_estimator.delivered_bytes(),
+                now,
+            );
+        }
+    }
+}


### PR DESCRIPTION
### Description of changes: 

Implementation of the `ProbeBW` state machine and related methods described in the [BBRv2 draft RFC §4.3.3 ](https://www.ietf.org/archive/id/draft-cardwell-iccrg-bbr-congestion-control-02.html#name-probebw)

### Call-outs:

- There's a bit of a discrepancy between the type of `inflight_hi` (currently u64) and `bytes_in_flight`/`cwnd` (u32). I started trying to change `inflight_hi` but it was triggering too many changes for this PR, so I'll have to revisit that.
- The `update_upper_bound` methods in the `data_volume::Model` and `data_rate::Model` previously would not allow the bounds to be lowered, so I've fix them. I also noticed that the `bw_hi` value is never lowered from `Infinity` in the BBRv2 draft RFC, which would cause the `BBRAdaptUpperBounds` method specified in [§4.3.3.6](https://www.ietf.org/archive/id/draft-cardwell-iccrg-bbr-congestion-control-02.html#section-4.3.3.6) to never raise `inflight_hi` as well,  if the pseudocode were followed as written. I've based this implementation on the current Linux V2Alpha BBR2 branch, which doesn't have a `bw_hi` field equivalent to the one in the RFC. We may want to update this based on subsequent draft updates

### Testing:

Unit tests. I've held off on tests for the BbrCongestionController impl methods for now

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

