### PR TITLE
feat(netbench): Duplex connection mode

### DIFF
--- a/netbench/netbench/src/duplex.rs
+++ b/netbench/netbench/src/duplex.rs
@@ -76,7 +76,6 @@ impl<T: AsyncRead + AsyncWrite> Connection<T> {
                 Poll::Ready(result) => {
                     len += result? as u64;
                     self.to_send -= len;
-                    eprintln!("sent: {}", len);
                 }
                 _ => {}
             }
@@ -134,13 +133,11 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
     }
 
     fn poll_send(&mut self, owner: Owner, id: u64, bytes: u64, cx: &mut Context) -> Poll<Result<u64>> {
-        eprintln!("poll send: {}", bytes);
         self.to_send += bytes;
         Ok(bytes).into()
     }
 
     fn poll_receive(&mut self, owner: Owner, id: u64, bytes: u64, cx: &mut Context) -> Poll<Result<u64>> {
-        eprintln!("poll receive: {}", bytes);
         let len = (self.buffered_offset - self.received_offset).min(bytes);
 
         if len == 0 {

--- a/netbench/netbench/src/duplex.rs
+++ b/netbench/netbench/src/duplex.rs
@@ -19,7 +19,6 @@ pub struct Connection<T: AsyncRead + AsyncWrite> {
     inner: Pin<Box<T>>,
     stream_opened: bool,
     send_buffer: Vec<u8>,
-    read_buffer: [MaybeUninit<u8>; READ_BUFFER_SIZE],
 }
 
 impl<T: AsyncRead + AsyncWrite> Connection<T> {
@@ -29,7 +28,6 @@ impl<T: AsyncRead + AsyncWrite> Connection<T> {
             inner,
             stream_opened: false,
             send_buffer: vec![1; SEND_BUFFER_SIZE],
-            read_buffer: unsafe { MaybeUninit::uninit().assume_init() },
         }
     }
 
@@ -113,9 +111,14 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
         bytes: u64,
         cx: &mut Context,
     ) -> Poll<Result<u64>> {
+        let mut buf: [MaybeUninit<u8>; READ_BUFFER_SIZE] = unsafe {
+            MaybeUninit::uninit().assume_init()
+        };
+
         let mut received: u64 = 0;
         while received < bytes {
-            let mut buf = ReadBuf::uninit(&mut self.read_buffer);
+            let mut buf = ReadBuf::uninit(&mut buf);
+
             match self.inner.as_mut().poll_read(cx, &mut buf) {
                 Poll::Ready(_) => {
                     if buf.filled().is_empty() && self.stream_opened {

--- a/netbench/netbench/src/duplex.rs
+++ b/netbench/netbench/src/duplex.rs
@@ -1,0 +1,115 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{connection::Owner, Result};
+use bytes::Buf;
+use core::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+use futures::ready;
+use std::collections::{hash_map::Entry, HashMap, HashSet, VecDeque};
+use tokio::io::{AsyncRead, AsyncWrite};
+use s2n_quic_core::stream::testing::Data;
+
+#[derive(Debug)]
+pub struct Connection<T: AsyncRead + AsyncWrite> {
+    id: u64,
+    inner: Pin<Box<T>>,
+    stream_opened: bool,
+    to_send: u64,
+    to_receive: u64,
+}
+
+impl<T: AsyncRead + AsyncWrite> Connection<T> {
+    pub fn new(id: u64, inner: Pin<Box<T>>) -> Self {
+        Self {
+            id,
+            inner,
+            stream_opened: false,
+            to_send: 0,
+            to_receive: 0,
+        }
+    }
+
+    fn open_stream(&mut self) -> Result<()> {
+        if self.stream_opened {
+            return Err("cannot open more than one duplex stream at a time".into());
+        }
+
+        self.stream_opened = true;
+        Ok(())
+    }
+
+    fn close_stream(&mut self) -> Result<()> {
+        if !self.stream_opened {
+            return Err("attempted to close the stream which wasn't opened".into());
+        }
+
+        self.stream_opened = false;
+        Ok(())
+    }
+
+    fn write(&mut self, cx: &mut Context) -> Result<()> {
+        if self.inner.as_ref().is_write_vectored() {
+            eprintln!("is write vectored");
+        } else {
+            eprintln!("is not write vectored");
+        }
+        Ok(())
+    }
+
+    fn read(&mut self, cx: &mut Context) -> Result<()> {
+        Ok(())
+    }
+}
+
+impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
+    fn id(&self) -> u64 {
+        self.id
+    }
+
+    fn poll_open_bidirectional_stream(&mut self, id: u64, cx: &mut Context) -> Poll<Result<()>> {
+        self.open_stream().into()
+    }
+
+    fn poll_open_send_stream(&mut self, id: u64, cx: &mut Context) -> Poll<Result<()>> {
+        self.open_stream().into()
+    }
+
+    fn poll_accept_stream(&mut self, cx: &mut Context) -> Poll<Result<Option<u64>>> {
+        let id: u64 = 0;
+        match self.open_stream().into() {
+            Ok(()) => Ok(Some(id)).into(),
+            Err(err) => Err(err).into(),
+        }
+    }
+
+    fn poll_send(&mut self, owner: Owner, id: u64, bytes: u64, cx: &mut Context) -> Poll<Result<u64>> {
+        self.to_send += bytes;
+        Ok(bytes).into()
+    }
+
+    fn poll_receive(&mut self, owner: Owner, id: u64, bytes: u64, cx: &mut Context) -> Poll<Result<u64>> {
+        self.to_receive += bytes;
+        Ok(bytes).into()
+    }
+
+    fn poll_send_finish(&mut self, owner: Owner, id: u64, cx: &mut Context) -> Poll<Result<()>> {
+        todo!()
+    }
+
+    fn poll_receive_finish(&mut self, owner: Owner, id: u64, cx: &mut Context) -> Poll<Result<()>> {
+        todo!()
+    }
+
+    fn poll_progress(&mut self, cx: &mut Context) -> Poll<Result<()>> {
+        loop {
+            self.write(cx);
+        }
+    }
+
+    fn poll_finish(&mut self, cx: &mut Context) -> Poll<Result<()>> {
+        todo!()
+    }
+}

--- a/netbench/netbench/src/duplex.rs
+++ b/netbench/netbench/src/duplex.rs
@@ -78,7 +78,7 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
         _owner: Owner,
         _id: u64,
         bytes: u64,
-        cx: &mut Context
+        cx: &mut Context,
     ) -> Poll<Result<u64>> {
         let mut sent: u64 = 0;
         while sent < bytes {
@@ -111,7 +111,7 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
         _owner: Owner,
         _id: u64,
         bytes: u64,
-        cx: &mut Context
+        cx: &mut Context,
     ) -> Poll<Result<u64>> {
         let mut received: u64 = 0;
         while received < bytes {

--- a/netbench/netbench/src/duplex.rs
+++ b/netbench/netbench/src/duplex.rs
@@ -99,6 +99,10 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
             return Poll::Pending;
         }
 
+        if let Poll::Ready(res) = self.inner.as_mut().poll_flush(cx) {
+            res?;
+        }
+
         Ok(sent).into()
     }
 

--- a/netbench/netbench/src/duplex.rs
+++ b/netbench/netbench/src/duplex.rs
@@ -113,9 +113,8 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
         bytes: u64,
         cx: &mut Context,
     ) -> Poll<Result<u64>> {
-        let mut buf: [MaybeUninit<u8>; READ_BUFFER_SIZE] = unsafe {
-            MaybeUninit::uninit().assume_init()
-        };
+        let mut buf: [MaybeUninit<u8>; READ_BUFFER_SIZE] =
+            unsafe { MaybeUninit::uninit().assume_init() };
 
         let mut received: u64 = 0;
         while received < bytes {

--- a/netbench/netbench/src/duplex.rs
+++ b/netbench/netbench/src/duplex.rs
@@ -99,7 +99,6 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
             return Poll::Pending;
         }
 
-        cx.waker().wake_by_ref();
         if let Poll::Ready(res) = self.inner.as_mut().poll_flush(cx) {
             res?;
         }
@@ -135,7 +134,6 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
             return Poll::Pending;
         }
 
-        cx.waker().wake_by_ref();
         Ok(received).into()
     }
 

--- a/netbench/netbench/src/duplex.rs
+++ b/netbench/netbench/src/duplex.rs
@@ -7,7 +7,7 @@ use core::{
     task::{Context, Poll},
 };
 use futures::ready;
-use std::{io::IoSlice, mem::MaybeUninit};
+use std::mem::MaybeUninit;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 const READ_BUFFER_SIZE: usize = 100_000;
@@ -73,7 +73,13 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
         }
     }
 
-    fn poll_send(&mut self, _owner: Owner, _id: u64, bytes: u64, cx: &mut Context) -> Poll<Result<u64>> {
+    fn poll_send(
+        &mut self,
+        _owner: Owner,
+        _id: u64,
+        bytes: u64,
+        cx: &mut Context
+    ) -> Poll<Result<u64>> {
         let mut sent: u64 = 0;
         while sent < bytes {
             let to_send = (bytes - sent) as usize;
@@ -101,7 +107,13 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
         Ok(sent).into()
     }
 
-    fn poll_receive(&mut self, _owner: Owner, _id: u64, bytes: u64, cx: &mut Context) -> Poll<Result<u64>> {
+    fn poll_receive(
+        &mut self,
+        _owner: Owner,
+        _id: u64,
+        bytes: u64,
+        cx: &mut Context
+    ) -> Poll<Result<u64>> {
         let mut received: u64 = 0;
         while received < bytes {
             let mut buf = ReadBuf::uninit(&mut self.read_buffer);

--- a/netbench/netbench/src/duplex.rs
+++ b/netbench/netbench/src/duplex.rs
@@ -95,6 +95,10 @@ impl<T: AsyncRead + AsyncWrite> Connection<T> {
             cx.waker().wake_by_ref();
         }
 
+        if let Poll::Ready(res) = self.inner.as_mut().poll_flush(cx) {
+            res?;
+        }
+
         Ok(())
     }
 

--- a/netbench/netbench/src/duplex.rs
+++ b/netbench/netbench/src/duplex.rs
@@ -99,10 +99,6 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
             return Poll::Pending;
         }
 
-        if let Poll::Ready(res) = self.inner.as_mut().poll_flush(cx) {
-            res?;
-        }
-
         Ok(sent).into()
     }
 

--- a/netbench/netbench/src/duplex.rs
+++ b/netbench/netbench/src/duplex.rs
@@ -108,9 +108,6 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
             }
         } else {
             let to_send = &self.send_buffer[0..send_amount];
-            if let Poll::Ready(result) = self.inner.as_mut().poll_write(cx, to_send) {
-                return Ok(result? as u64).into();
-            }
             match self.inner.as_mut().poll_write(cx, to_send) {
                 Poll::Ready(result) => {
                     sent += result? as u64;

--- a/netbench/netbench/src/duplex.rs
+++ b/netbench/netbench/src/duplex.rs
@@ -97,8 +97,10 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
             return Poll::Pending;
         }
 
-        if let Poll::Ready(res) = self.inner.as_mut().poll_flush(cx) {
-            res?;
+        if sent == bytes {
+            if let Poll::Ready(res) = self.inner.as_mut().poll_flush(cx) {
+                res?;
+            }
         }
 
         Ok(sent).into()

--- a/netbench/netbench/src/duplex.rs
+++ b/netbench/netbench/src/duplex.rs
@@ -81,7 +81,7 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
             match self.inner.as_mut().poll_write_vectored(cx, &[to_send]) {
                 Poll::Ready(result) => {
                     sent += result? as u64;
-                },
+                }
                 Poll::Pending => {
                     return Poll::Pending;
                 }
@@ -91,7 +91,7 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
             match self.inner.as_mut().poll_write(cx, to_send) {
                 Poll::Ready(result) => {
                     sent += result? as u64;
-                },
+                }
                 Poll::Pending => {
                     return Poll::Pending;
                 }
@@ -121,11 +121,9 @@ impl<T: AsyncRead + AsyncWrite> super::Connection for Connection<T> {
                     cx.waker().wake_by_ref();
                 }
                 Ok(buf.filled().len() as u64).into()
-            },
-            Poll::Pending => {
-                Poll::Pending
-            },
-        }
+            }
+            Poll::Pending => Poll::Pending,
+        };
     }
 
     fn poll_send_finish(&mut self, _: Owner, _: u64, _: &mut Context) -> Poll<Result<()>> {

--- a/netbench/netbench/src/lib.rs
+++ b/netbench/netbench/src/lib.rs
@@ -11,9 +11,9 @@ mod driver;
 #[cfg(any(test, feature = "testing"))]
 pub mod testing;
 
+pub mod duplex;
 pub mod helper;
 pub mod multiplex;
-pub mod duplex;
 pub mod operation;
 #[cfg(feature = "s2n-quic")]
 pub mod s2n_quic;

--- a/netbench/netbench/src/lib.rs
+++ b/netbench/netbench/src/lib.rs
@@ -13,6 +13,7 @@ pub mod testing;
 
 pub mod helper;
 pub mod multiplex;
+pub mod duplex;
 pub mod operation;
 #[cfg(feature = "s2n-quic")]
 pub mod s2n_quic;


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.-->

Currently, Netbench has one implementation for the [Connection](https://github.com/aws/s2n-quic/blob/main/netbench/netbench/src/connection.rs) trait: [Multiplex](https://github.com/aws/s2n-quic/blob/main/netbench/netbench/src/multiplex.rs). This PR implements an additional connection, Duplex, which can be used for configurations with single streams. This connection reduces some of the performance overhead introduced in the implementation for application-level multiplexing.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

The change to drivers to enable this mode will be made in a separate PR.

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

