### PR TITLE
feat(s2n-quic): add on_ack_processed events

### DIFF
--- a/quic/s2n-quic-core/src/event.rs
+++ b/quic/s2n-quic-core/src/event.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{connection, endpoint};
-use core::{ops::Range, time::Duration};
+use core::{ops::RangeInclusive, time::Duration};
 
 mod generated;
 pub use generated::*;
@@ -74,13 +74,10 @@ impl<'a> IntoEvent<&'a str> for &'a str {
     }
 }
 
-impl<T> IntoEvent<Range<T>> for Range<T> {
+impl<T> IntoEvent<RangeInclusive<T>> for RangeInclusive<T> {
     #[inline]
-    fn into_event(self) -> Range<T> {
-        Range {
-            start: self.start,
-            end: self.end,
-        }
+    fn into_event(self) -> RangeInclusive<T> {
+        self
     }
 }
 

--- a/quic/s2n-quic-core/src/event.rs
+++ b/quic/s2n-quic-core/src/event.rs
@@ -74,6 +74,34 @@ impl<'a> IntoEvent<&'a str> for &'a str {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct Range<T: Copy> {
+    start: T,
+    end: T,
+}
+
+impl<T: Copy> Range<T> {
+    #[inline]
+    pub fn start(&self) -> T {
+        self.start
+    }
+
+    #[inline]
+    pub fn end(&self) -> T {
+        self.end
+    }
+}
+
+impl<T: IntoEvent<U> + Copy, U: Copy> IntoEvent<Range<U>> for core::ops::Range<T> {
+    #[inline]
+    fn into_event(self) -> Range<U> {
+        Range {
+            start: self.start.into_event(),
+            end: self.end.into_event(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Copy)]
 pub struct Timestamp(crate::time::Timestamp);
 

--- a/quic/s2n-quic-core/src/event.rs
+++ b/quic/s2n-quic-core/src/event.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{connection, endpoint};
-use core::time::Duration;
+use core::{ops::Range, time::Duration};
 
 mod generated;
 pub use generated::*;
@@ -74,30 +74,12 @@ impl<'a> IntoEvent<&'a str> for &'a str {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct Range<T: Copy> {
-    start: T,
-    end: T,
-}
-
-impl<T: Copy> Range<T> {
+impl<T> IntoEvent<Range<T>> for Range<T> {
     #[inline]
-    pub fn start(&self) -> T {
-        self.start
-    }
-
-    #[inline]
-    pub fn end(&self) -> T {
-        self.end
-    }
-}
-
-impl<T: IntoEvent<U> + Copy, U: Copy> IntoEvent<Range<U>> for core::ops::Range<T> {
-    #[inline]
-    fn into_event(self) -> Range<U> {
+    fn into_event(self) -> Range<T> {
         Range {
-            start: self.start.into_event(),
-            end: self.end.into_event(),
+            start: self.start,
+            end: self.end,
         }
     }
 }

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -321,11 +321,11 @@ pub mod api {
         #[doc = " When at `capacity`, the lowest packet_number range is dropped."]
         RxAckRangeDropped {
             #[doc = " The packet number range which was dropped"]
-            packet_number_range: crate::event::Range<u64>,
+            packet_number_range: core::ops::Range<u64>,
             #[doc = " The number of disjoint ranges the IntervalSet can store"]
-            capacity: u16,
+            capacity: usize,
             #[doc = " The store packet_number range in the IntervalSet"]
-            stored_range: crate::event::Range<u64>,
+            stored_range: core::ops::Range<u64>,
         },
     }
     #[derive(Clone, Debug)]
@@ -2461,7 +2461,7 @@ pub mod builder {
             #[doc = " The packet number range which was dropped"]
             packet_number_range: core::ops::Range<u64>,
             #[doc = " The number of disjoint ranges the IntervalSet can store"]
-            capacity: u16,
+            capacity: usize,
             #[doc = " The store packet_number range in the IntervalSet"]
             stored_range: core::ops::Range<u64>,
         },

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -321,11 +321,11 @@ pub mod api {
         #[doc = " When at `capacity`, the lowest packet_number range is dropped."]
         RxAckRangeDropped {
             #[doc = " The packet number range which was dropped"]
-            packet_number_range: core::ops::Range<u64>,
+            packet_number_range: core::ops::RangeInclusive<u64>,
             #[doc = " The number of disjoint ranges the IntervalSet can store"]
             capacity: usize,
             #[doc = " The store packet_number range in the IntervalSet"]
-            stored_range: core::ops::Range<u64>,
+            stored_range: core::ops::RangeInclusive<u64>,
         },
     }
     #[derive(Clone, Debug)]
@@ -2459,11 +2459,11 @@ pub mod builder {
         #[doc = " When at `capacity`, the lowest packet_number range is dropped."]
         RxAckRangeDropped {
             #[doc = " The packet number range which was dropped"]
-            packet_number_range: core::ops::Range<u64>,
+            packet_number_range: core::ops::RangeInclusive<u64>,
             #[doc = " The number of disjoint ranges the IntervalSet can store"]
             capacity: usize,
             #[doc = " The store packet_number range in the IntervalSet"]
-            stored_range: core::ops::Range<u64>,
+            stored_range: core::ops::RangeInclusive<u64>,
         },
     }
     impl IntoEvent<api::AckAction> for AckAction {

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -309,6 +309,27 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
+    pub enum AckAction {
+        #[non_exhaustive]
+        #[doc = " Ack range for received packets was dropped due to space constraints"]
+        #[doc = ""]
+        #[doc = " For the purpose of processing Acks, RX packet numbers are stored as"]
+        #[doc = " packet_number ranges in an IntervalSet; only lower and upper bounds"]
+        #[doc = " are stored instead of individual packet_numbers. Ranges are merged"]
+        #[doc = " when possible so only disjointed ranges are stored."]
+        #[doc = ""]
+        #[doc = " When at `capacity`, the lowest packet_number range is dropped."]
+        RxAckRangeDropped {
+            #[doc = " The packet number range which was dropped"]
+            packet_number_range: crate::event::Range<u64>,
+            #[doc = " The number of disjoint ranges the IntervalSet can store"]
+            capacity: u16,
+            #[doc = " The store packet_number range in the IntervalSet"]
+            stored_range: crate::event::Range<u64>,
+        },
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
     pub enum RetryDiscardReason<'a> {
         #[non_exhaustive]
         #[doc = " Received a Retry packet with SCID field equal to DCID field."]
@@ -525,6 +546,16 @@ pub mod api {
     }
     impl<'a> Event for Congestion<'a> {
         const NAME: &'static str = "recovery:congestion";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Events related to ACK processing"]
+    pub struct AckProcessed<'a> {
+        pub action: AckAction,
+        pub path: Path<'a>,
+    }
+    impl<'a> Event for AckProcessed<'a> {
+        const NAME: &'static str = "recovery:ack_processed";
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
@@ -1188,15 +1219,15 @@ pub mod api {
             use builder::PacketHeader;
             match packet_number.space() {
                 PacketNumberSpace::Initial => PacketHeader::Initial {
-                    number: packet_number.as_u64(),
+                    number: packet_number.into_event(),
                     version,
                 },
                 PacketNumberSpace::Handshake => PacketHeader::Handshake {
-                    number: packet_number.as_u64(),
+                    number: packet_number.into_event(),
                     version,
                 },
                 PacketNumberSpace::ApplicationData => PacketHeader::OneRtt {
-                    number: packet_number.as_u64(),
+                    number: packet_number.into_event(),
                 },
             }
         }
@@ -1427,6 +1458,17 @@ pub mod tracing {
             let id = context.id();
             let api::Congestion { path, source } = event;
             tracing :: event ! (target : "congestion" , parent : id , tracing :: Level :: DEBUG , path = tracing :: field :: debug (path) , source = tracing :: field :: debug (source));
+        }
+        #[inline]
+        fn on_ack_processed(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            _meta: &api::ConnectionMeta,
+            event: &api::AckProcessed,
+        ) {
+            let id = context.id();
+            let api::AckProcessed { action, path } = event;
+            tracing :: event ! (target : "ack_processed" , parent : id , tracing :: Level :: DEBUG , action = tracing :: field :: debug (action) , path = tracing :: field :: debug (path));
         }
         #[inline]
         fn on_packet_dropped(
@@ -2406,6 +2448,42 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
+    pub enum AckAction {
+        #[doc = " Ack range for received packets was dropped due to space constraints"]
+        #[doc = ""]
+        #[doc = " For the purpose of processing Acks, RX packet numbers are stored as"]
+        #[doc = " packet_number ranges in an IntervalSet; only lower and upper bounds"]
+        #[doc = " are stored instead of individual packet_numbers. Ranges are merged"]
+        #[doc = " when possible so only disjointed ranges are stored."]
+        #[doc = ""]
+        #[doc = " When at `capacity`, the lowest packet_number range is dropped."]
+        RxAckRangeDropped {
+            #[doc = " The packet number range which was dropped"]
+            packet_number_range: core::ops::Range<u64>,
+            #[doc = " The number of disjoint ranges the IntervalSet can store"]
+            capacity: u16,
+            #[doc = " The store packet_number range in the IntervalSet"]
+            stored_range: core::ops::Range<u64>,
+        },
+    }
+    impl IntoEvent<api::AckAction> for AckAction {
+        #[inline]
+        fn into_event(self) -> api::AckAction {
+            use api::AckAction::*;
+            match self {
+                Self::RxAckRangeDropped {
+                    packet_number_range,
+                    capacity,
+                    stored_range,
+                } => RxAckRangeDropped {
+                    packet_number_range: packet_number_range.into_event(),
+                    capacity: capacity.into_event(),
+                    stored_range: stored_range.into_event(),
+                },
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
     pub enum RetryDiscardReason<'a> {
         #[doc = " Received a Retry packet with SCID field equal to DCID field."]
         ScidEqualsDcid { cid: &'a [u8] },
@@ -2770,6 +2848,22 @@ pub mod builder {
             api::Congestion {
                 path: path.into_event(),
                 source: source.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Events related to ACK processing"]
+    pub struct AckProcessed<'a> {
+        pub action: AckAction,
+        pub path: Path<'a>,
+    }
+    impl<'a> IntoEvent<api::AckProcessed<'a>> for AckProcessed<'a> {
+        #[inline]
+        fn into_event(self) -> api::AckProcessed<'a> {
+            let AckProcessed { action, path } = self;
+            api::AckProcessed {
+                action: action.into_event(),
+                path: path.into_event(),
             }
         }
     }
@@ -3643,6 +3737,18 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
+        #[doc = "Called when the `AckProcessed` event is triggered"]
+        #[inline]
+        fn on_ack_processed(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            meta: &ConnectionMeta,
+            event: &AckProcessed,
+        ) {
+            let _ = context;
+            let _ = meta;
+            let _ = event;
+        }
         #[doc = "Called when the `PacketDropped` event is triggered"]
         #[inline]
         fn on_packet_dropped(
@@ -4194,6 +4300,16 @@ mod traits {
             (self.1).on_congestion(&mut context.1, meta, event);
         }
         #[inline]
+        fn on_ack_processed(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            meta: &ConnectionMeta,
+            event: &AckProcessed,
+        ) {
+            (self.0).on_ack_processed(&mut context.0, meta, event);
+            (self.1).on_ack_processed(&mut context.1, meta, event);
+        }
+        #[inline]
         fn on_packet_dropped(
             &mut self,
             context: &mut Self::ConnectionContext,
@@ -4698,6 +4814,8 @@ mod traits {
         fn on_recovery_metrics(&mut self, event: builder::RecoveryMetrics);
         #[doc = "Publishes a `Congestion` event to the publisher's subscriber"]
         fn on_congestion(&mut self, event: builder::Congestion);
+        #[doc = "Publishes a `AckProcessed` event to the publisher's subscriber"]
+        fn on_ack_processed(&mut self, event: builder::AckProcessed);
         #[doc = "Publishes a `PacketDropped` event to the publisher's subscriber"]
         fn on_packet_dropped(&mut self, event: builder::PacketDropped);
         #[doc = "Publishes a `KeyUpdate` event to the publisher's subscriber"]
@@ -4872,6 +4990,15 @@ mod traits {
             let event = event.into_event();
             self.subscriber
                 .on_congestion(self.context, &self.meta, &event);
+            self.subscriber
+                .on_connection_event(self.context, &self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_ack_processed(&mut self, event: builder::AckProcessed) {
+            let event = event.into_event();
+            self.subscriber
+                .on_ack_processed(self.context, &self.meta, &event);
             self.subscriber
                 .on_connection_event(self.context, &self.meta, &event);
             self.subscriber.on_event(&self.meta, &event);
@@ -5087,6 +5214,7 @@ pub mod testing {
         pub packet_lost: u32,
         pub recovery_metrics: u32,
         pub congestion: u32,
+        pub ack_processed: u32,
         pub packet_dropped: u32,
         pub key_update: u32,
         pub key_space_discarded: u32,
@@ -5155,6 +5283,7 @@ pub mod testing {
                 packet_lost: 0,
                 recovery_metrics: 0,
                 congestion: 0,
+                ack_processed: 0,
                 packet_dropped: 0,
                 key_update: 0,
                 key_space_discarded: 0,
@@ -5316,6 +5445,17 @@ pub mod testing {
             event: &api::Congestion,
         ) {
             self.congestion += 1;
+            if self.location.is_some() {
+                self.output.push(format!("{:?} {:?}", meta, event));
+            }
+        }
+        fn on_ack_processed(
+            &mut self,
+            _context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &api::AckProcessed,
+        ) {
+            self.ack_processed += 1;
             if self.location.is_some() {
                 self.output.push(format!("{:?} {:?}", meta, event));
             }
@@ -5644,6 +5784,7 @@ pub mod testing {
         pub packet_lost: u32,
         pub recovery_metrics: u32,
         pub congestion: u32,
+        pub ack_processed: u32,
         pub packet_dropped: u32,
         pub key_update: u32,
         pub key_space_discarded: u32,
@@ -5702,6 +5843,7 @@ pub mod testing {
                 packet_lost: 0,
                 recovery_metrics: 0,
                 congestion: 0,
+                ack_processed: 0,
                 packet_dropped: 0,
                 key_update: 0,
                 key_space_discarded: 0,
@@ -5887,6 +6029,13 @@ pub mod testing {
         }
         fn on_congestion(&mut self, event: builder::Congestion) {
             self.congestion += 1;
+            let event = event.into_event();
+            if self.location.is_some() {
+                self.output.push(format!("{:?}", event));
+            }
+        }
+        fn on_ack_processed(&mut self, event: builder::AckProcessed) {
+            self.ack_processed += 1;
             let event = event.into_event();
             if self.location.is_some() {
                 self.output.push(format!("{:?}", event));

--- a/quic/s2n-quic-core/src/packet/number/packet_number.rs
+++ b/quic/s2n-quic-core/src/packet/number/packet_number.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    event::IntoEvent,
     packet::number::{
         derive_truncation_range, packet_number_space::PacketNumberSpace,
         truncated_packet_number::TruncatedPacketNumber,
@@ -35,6 +36,12 @@ const PACKET_NUMBER_MASK: u64 = core::u64::MAX >> PACKET_SPACE_BITLEN;
 #[derive(Clone, Copy, Eq)]
 #[cfg_attr(any(test, feature = "generator"), derive(TypeGenerator))]
 pub struct PacketNumber(NonZeroU64);
+
+impl IntoEvent<u64> for PacketNumber {
+    fn into_event(self) -> u64 {
+        self.as_u64()
+    }
+}
 
 impl Default for PacketNumber {
     fn default() -> Self {

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -661,13 +661,11 @@ enum AckAction {
     /// When at `capacity`, the lowest packet_number range is dropped.
     RxAckRangeDropped {
         /// The packet number range which was dropped
-        #[builder(core::ops::Range<u64>)]
-        packet_number_range: crate::event::Range<u64>,
+        packet_number_range: core::ops::Range<u64>,
         /// The number of disjoint ranges the IntervalSet can store
-        capacity: u16,
+        capacity: usize,
         /// The store packet_number range in the IntervalSet
-        #[builder(core::ops::Range<u64>)]
-        stored_range: crate::event::Range<u64>,
+        stored_range: core::ops::Range<u64>,
     },
     // /// Acks were aggregated for delayed processing
     // AggregatePending {

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -661,11 +661,11 @@ enum AckAction {
     /// When at `capacity`, the lowest packet_number range is dropped.
     RxAckRangeDropped {
         /// The packet number range which was dropped
-        packet_number_range: core::ops::Range<u64>,
+        packet_number_range: core::ops::RangeInclusive<u64>,
         /// The number of disjoint ranges the IntervalSet can store
         capacity: usize,
         /// The store packet_number range in the IntervalSet
-        stored_range: core::ops::Range<u64>,
+        stored_range: core::ops::RangeInclusive<u64>,
     },
     // /// Acks were aggregated for delayed processing
     // AggregatePending {

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -502,15 +502,15 @@ impl builder::PacketHeader {
 
         match packet_number.space() {
             PacketNumberSpace::Initial => PacketHeader::Initial {
-                number: packet_number.as_u64(),
+                number: packet_number.into_event(),
                 version,
             },
             PacketNumberSpace::Handshake => PacketHeader::Handshake {
-                number: packet_number.as_u64(),
+                number: packet_number.into_event(),
                 version,
             },
             PacketNumberSpace::ApplicationData => PacketHeader::OneRtt {
-                number: packet_number.as_u64(),
+                number: packet_number.into_event(),
             },
         }
     }
@@ -648,6 +648,39 @@ enum PacketDropReason<'a> {
         reason: RetryDiscardReason<'a>,
         path: Path<'a>,
     },
+}
+
+enum AckAction {
+    /// Ack range for received packets was dropped due to space constraints
+    ///
+    /// For the purpose of processing Acks, RX packet numbers are stored as
+    /// packet_number ranges in an IntervalSet; only lower and upper bounds
+    /// are stored instead of individual packet_numbers. Ranges are merged
+    /// when possible so only disjointed ranges are stored.
+    ///
+    /// When at `capacity`, the lowest packet_number range is dropped.
+    RxAckRangeDropped {
+        /// The packet number range which was dropped
+        #[builder(core::ops::Range<u64>)]
+        packet_number_range: crate::event::Range<u64>,
+        /// The number of disjoint ranges the IntervalSet can store
+        capacity: u16,
+        /// The store packet_number range in the IntervalSet
+        #[builder(core::ops::Range<u64>)]
+        stored_range: crate::event::Range<u64>,
+    },
+    // /// Acks were aggregated for delayed processing
+    // AggregatePending {
+    //     ///  number of packet_numbers aggregated
+    //     count: u16,
+    // },
+    // /// Pending Acks were processed
+    // ProcessPending {
+    //     ///  number of packet_numbers acked
+    //     count: u16,
+    // },
+    // /// Acks aggregation failed due to space constraints
+    // AggregationPendingFailed,
 }
 
 enum RetryDiscardReason<'a> {

--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -102,6 +102,13 @@ struct Congestion<'a> {
     source: CongestionSource,
 }
 
+#[event("recovery:ack_processed")]
+/// Events related to ACK processing
+struct AckProcessed<'a> {
+    action: AckAction,
+    path: Path<'a>,
+}
+
 #[event("transport:packet_dropped")]
 /// Packet was dropped with the given reason
 struct PacketDropped<'a> {

--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -4,7 +4,7 @@
 use crate::{
     ack::{
         ack_eliciting_transmission::{AckElicitingTransmission, AckElicitingTransmissionSet},
-        ack_ranges::AckRanges,
+        ack_ranges::{AckRanges, AckRangesError},
         ack_transmission_state::AckTransmissionState,
     },
     contexts::WriteContext,
@@ -14,6 +14,11 @@ use crate::{
 use s2n_quic_core::{
     ack,
     counter::{Counter, Saturating},
+    event::{
+        self,
+        builder::{AckAction, AckProcessed},
+        IntoEvent as _,
+    },
     frame::{ack::EcnCounts, Ack, Ping},
     packet::number::{PacketNumber, PacketNumberSpace},
     time::{timer, Timer, Timestamp},
@@ -188,7 +193,12 @@ impl AckManager {
     }
 
     /// Called after an RX packet has been processed
-    pub fn on_processed_packet(&mut self, processed_packet: &ProcessedPacket) {
+    pub fn on_processed_packet<Pub: event::ConnectionPublisher>(
+        &mut self,
+        processed_packet: &ProcessedPacket,
+        path: event::builder::Path,
+        publisher: &mut Pub,
+    ) {
         let packet_number = processed_packet.packet_number;
         let now = processed_packet.datagram.timestamp;
 
@@ -212,7 +222,31 @@ impl AckManager {
         //
         // Most likely, this packet is very old and the contents have already
         // been retransmitted by the peer.
-        if self.ack_ranges.insert_packet_number(packet_number).is_err() {
+        if let Err(err) = self.ack_ranges.insert_packet_number(packet_number) {
+            match err {
+                AckRangesError::RangeInsertionFailed { min, max }
+                | AckRangesError::LowestRangeDropped { min, max } => {
+                    let start = self
+                        .ack_ranges
+                        .min_value()
+                        .expect("should be non empty")
+                        .into_event();
+                    let end = self
+                        .ack_ranges
+                        .max_value()
+                        .expect("should be non empty")
+                        .into_event();
+
+                    publisher.on_ack_processed(AckProcessed {
+                        action: AckAction::RxAckRangeDropped {
+                            packet_number_range: min.into_event()..max.into_event(),
+                            capacity: self.ack_ranges.intervals().count() as u16,
+                            stored_range: start..end,
+                        },
+                        path,
+                    });
+                }
+            };
             return;
         }
 
@@ -349,7 +383,10 @@ impl transmission::interest::Provider for AckManager {
 #[cfg(test)]
 mod tests {
     use super::{super::tests::*, *};
-    use crate::contexts::testing::{MockWriteContext, OutgoingFrameBuffer};
+    use crate::{
+        contexts::testing::{MockWriteContext, OutgoingFrameBuffer},
+        path::{path_event, testing::helper_path_server},
+    };
     use core::{
         iter::{empty, once},
         mem::size_of,
@@ -358,8 +395,10 @@ mod tests {
     use insta::assert_debug_snapshot;
     use s2n_quic_core::{
         ack, connection, endpoint,
+        event::testing::Publisher,
         frame::{ack_elicitation::AckElicitation, ping, Frame},
         inet::{DatagramInfo, ExplicitCongestionNotification},
+        path,
         time::{Clock, NoopClock},
     };
 
@@ -384,7 +423,13 @@ mod tests {
         assert!(!manager.transmission_state.is_active());
 
         // Trigger:
-        manager.on_processed_packet(&processed_packet);
+        let path = helper_path_server();
+        let path_id = path::Id::test_id();
+        manager.on_processed_packet(
+            &processed_packet,
+            path_event!(path, path_id),
+            &mut Publisher::snapshot(),
+        );
 
         // Expectation:
         assert!(manager.transmission_state.is_active());
@@ -403,7 +448,14 @@ mod tests {
         // Process a packet in an Ect0 datagram
         let pn = PacketNumberSpace::ApplicationData.new_packet_number(VarInt::from_u8(1));
         let datagram = helper_datagram_info(ExplicitCongestionNotification::Ect0);
-        manager.on_processed_packet(&ProcessedPacket::new(pn, &datagram));
+        let path = helper_path_server();
+        let path_id = path::Id::test_id();
+        let mut publisher = Publisher::snapshot();
+        manager.on_processed_packet(
+            &ProcessedPacket::new(pn, &datagram),
+            path_event!(path, path_id),
+            &mut publisher,
+        );
 
         assert_eq!(1, manager.ecn_counts.ect_0_count.as_u64());
         assert_eq!(0, manager.ecn_counts.ect_1_count.as_u64());
@@ -413,8 +465,17 @@ mod tests {
         let pn1 = PacketNumberSpace::ApplicationData.new_packet_number(VarInt::from_u8(2));
         let pn2 = PacketNumberSpace::ApplicationData.new_packet_number(VarInt::from_u8(3));
         let datagram = helper_datagram_info(ExplicitCongestionNotification::Ect1);
-        manager.on_processed_packet(&ProcessedPacket::new(pn1, &datagram));
-        manager.on_processed_packet(&ProcessedPacket::new(pn2, &datagram));
+
+        manager.on_processed_packet(
+            &ProcessedPacket::new(pn1, &datagram),
+            path_event!(path, path_id),
+            &mut publisher,
+        );
+        manager.on_processed_packet(
+            &ProcessedPacket::new(pn2, &datagram),
+            path_event!(path, path_id),
+            &mut publisher,
+        );
 
         assert_eq!(1, manager.ecn_counts.ect_0_count.as_u64());
         assert_eq!(2, manager.ecn_counts.ect_1_count.as_u64());
@@ -423,7 +484,11 @@ mod tests {
         // Process a packet in an Ce datagram
         let pn = PacketNumberSpace::ApplicationData.new_packet_number(VarInt::from_u8(4));
         let datagram = helper_datagram_info(ExplicitCongestionNotification::Ce);
-        manager.on_processed_packet(&ProcessedPacket::new(pn, &datagram));
+        manager.on_processed_packet(
+            &ProcessedPacket::new(pn, &datagram),
+            path_event!(path, path_id),
+            &mut publisher,
+        );
 
         assert_eq!(1, manager.ecn_counts.ect_0_count.as_u64());
         assert_eq!(2, manager.ecn_counts.ect_1_count.as_u64());
@@ -432,7 +497,11 @@ mod tests {
         // Process a packet in a NotEct datagram
         let pn = PacketNumberSpace::ApplicationData.new_packet_number(VarInt::from_u8(5));
         let datagram = helper_datagram_info(ExplicitCongestionNotification::NotEct);
-        manager.on_processed_packet(&ProcessedPacket::new(pn, &datagram));
+        manager.on_processed_packet(
+            &ProcessedPacket::new(pn, &datagram),
+            path_event!(path, path_id),
+            &mut publisher,
+        );
 
         assert_eq!(1, manager.ecn_counts.ect_0_count.as_u64());
         assert_eq!(2, manager.ecn_counts.ect_1_count.as_u64());

--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -240,7 +240,7 @@ impl AckManager {
                     publisher.on_ack_processed(AckProcessed {
                         action: AckAction::RxAckRangeDropped {
                             packet_number_range: min.into_event()..max.into_event(),
-                            capacity: self.ack_ranges.intervals().count() as u16,
+                            capacity: self.ack_ranges.interval_len(),
                             stored_range: start..end,
                         },
                         path,

--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -239,9 +239,9 @@ impl AckManager {
 
                     publisher.on_ack_processed(AckProcessed {
                         action: AckAction::RxAckRangeDropped {
-                            packet_number_range: min.into_event()..max.into_event(),
+                            packet_number_range: min.into_event()..=max.into_event(),
                             capacity: self.ack_ranges.interval_len(),
-                            stored_range: start..end,
+                            stored_range: start..=end,
                         },
                         path,
                     });

--- a/quic/s2n-quic-transport/src/ack/snapshots/quic__s2n-quic-transport__src__ack__ack_manager__events__activate.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/quic__s2n-quic-transport__src__ack__ack_manager__events__activate.snap
@@ -1,0 +1,7 @@
+---
+source: quic/s2n-quic-transport/src/ack/ack_manager.rs
+assertion_line: 430
+expression: ""
+
+---
+

--- a/quic/s2n-quic-transport/src/ack/snapshots/quic__s2n-quic-transport__src__ack__ack_manager__events__ecn_counts.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/quic__s2n-quic-transport__src__ack__ack_manager__events__ecn_counts.snap
@@ -1,0 +1,7 @@
+---
+source: quic/s2n-quic-transport/src/ack/ack_manager.rs
+assertion_line: 452
+expression: ""
+
+---
+

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -967,11 +967,18 @@ impl<Config: endpoint::Config> PacketSpace<Config> for ApplicationSpace<Config> 
         Ok(())
     }
 
-    fn on_processed_packet(
+    fn on_processed_packet<Pub: event::ConnectionPublisher>(
         &mut self,
         processed_packet: ProcessedPacket,
+        path_id: path::Id,
+        path: &Path<Config>,
+        publisher: &mut Pub,
     ) -> Result<(), transport::Error> {
-        self.ack_manager.on_processed_packet(&processed_packet);
+        self.ack_manager.on_processed_packet(
+            &processed_packet,
+            path_event!(path, path_id),
+            publisher,
+        );
         self.processed_packet_numbers
             .insert(processed_packet.packet_number)
             .expect("packet number was already checked");

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -524,11 +524,18 @@ impl<Config: endpoint::Config> PacketSpace<Config> for HandshakeSpace<Config> {
         Ok(())
     }
 
-    fn on_processed_packet(
+    fn on_processed_packet<Pub: event::ConnectionPublisher>(
         &mut self,
         processed_packet: ProcessedPacket,
+        path_id: path::Id,
+        path: &Path<Config>,
+        publisher: &mut Pub,
     ) -> Result<(), transport::Error> {
-        self.ack_manager.on_processed_packet(&processed_packet);
+        self.ack_manager.on_processed_packet(
+            &processed_packet,
+            path_event!(path, path_id),
+            publisher,
+        );
         self.processed_packet_numbers
             .insert(processed_packet.packet_number)
             .expect("packet number was already checked");

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -672,11 +672,18 @@ impl<Config: endpoint::Config> PacketSpace<Config> for InitialSpace<Config> {
         Ok(())
     }
 
-    fn on_processed_packet(
+    fn on_processed_packet<Pub: event::ConnectionPublisher>(
         &mut self,
         processed_packet: ProcessedPacket,
+        path_id: path::Id,
+        path: &Path<Config>,
+        publisher: &mut Pub,
     ) -> Result<(), transport::Error> {
-        self.ack_manager.on_processed_packet(&processed_packet);
+        self.ack_manager.on_processed_packet(
+            &processed_packet,
+            path_event!(path, path_id),
+            publisher,
+        );
         self.processed_packet_numbers
             .insert(processed_packet.packet_number)
             .expect("packet number was already checked");

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -679,9 +679,12 @@ pub trait PacketSpace<Config: endpoint::Config> {
     default_frame_handler!(handle_streams_blocked_frame, StreamsBlocked);
     default_frame_handler!(handle_new_token_frame, NewToken);
 
-    fn on_processed_packet(
+    fn on_processed_packet<Pub: event::ConnectionPublisher>(
         &mut self,
         processed_packet: ProcessedPacket,
+        path_id: path::Id,
+        path: &Path<Config>,
+        publisher: &mut Pub,
     ) -> Result<(), transport::Error>;
 
     // TODO: Reduce arguments, https://github.com/aws/s2n-quic/issues/312
@@ -925,7 +928,7 @@ pub trait PacketSpace<Config: endpoint::Config> {
         //# receipt by sending one or more ACK frames containing the packet
         //# number of the received packet.
 
-        self.on_processed_packet(processed_packet)?;
+        self.on_processed_packet(processed_packet, path_id, &path_manager[path_id], publisher)?;
 
         Ok(processed_packet)
     }

--- a/quic/s2n-quic/api.snap
+++ b/quic/s2n-quic/api.snap
@@ -1965,6 +1965,12 @@ struct s2n_quic::provider::event::disabled::Subscriber implements trait:
 struct s2n_quic::provider::event::disabled::Subscriber implements trait:
   impl std::panic::UnwindSafe for s2n_quic::provider::event::disabled::Subscriber
 
+module s2n_quic::provider::event::events exports enum:
+  s2n_quic::provider::event::events::AckAction
+
+module s2n_quic::provider::event::events exports struct:
+  s2n_quic::provider::event::events::AckProcessed
+
 module s2n_quic::provider::event::events exports struct:
   s2n_quic::provider::event::events::ActivePathUpdated
 
@@ -2177,6 +2183,81 @@ module s2n_quic::provider::event::events exports struct:
 
 module s2n_quic::provider::event::events exports struct:
   s2n_quic::provider::event::events::VersionInformation
+
+enum s2n_quic::provider::event::events::AckAction is non-exhaustive
+
+enum s2n_quic::provider::event::events::AckAction exports variant:
+  RxAckRangeDropped
+
+enum s2n_quic::provider::event::events::AckAction implements trait:
+  impl core::clone::Clone for s2n_quic::provider::event::events::AckAction
+
+enum s2n_quic::provider::event::events::AckAction implements trait:
+  impl core::fmt::Debug for s2n_quic::provider::event::events::AckAction
+
+enum s2n_quic::provider::event::events::AckAction implements trait:
+  impl core::marker::Send for s2n_quic::provider::event::events::AckAction
+
+enum s2n_quic::provider::event::events::AckAction implements trait:
+  impl core::marker::Sync for s2n_quic::provider::event::events::AckAction
+
+enum s2n_quic::provider::event::events::AckAction implements trait:
+  impl core::marker::Unpin for s2n_quic::provider::event::events::AckAction
+
+enum s2n_quic::provider::event::events::AckAction implements trait:
+  impl std::panic::RefUnwindSafe for s2n_quic::provider::event::events::AckAction
+
+enum s2n_quic::provider::event::events::AckAction implements trait:
+  impl std::panic::UnwindSafe for s2n_quic::provider::event::events::AckAction
+
+variant s2n_quic::provider::event::events::AckAction::RxAckRangeDropped is non-exhaustive
+
+variant s2n_quic::provider::event::events::AckAction::RxAckRangeDropped exports field:
+  capacity:
+  u16
+
+variant s2n_quic::provider::event::events::AckAction::RxAckRangeDropped exports field:
+  packet_number_range:
+  s2n_quic_core::event::Range<u64>
+
+variant s2n_quic::provider::event::events::AckAction::RxAckRangeDropped exports field:
+  stored_range:
+  s2n_quic_core::event::Range<u64>
+
+struct s2n_quic::provider::event::events::AckProcessed is non-exhaustive
+
+struct s2n_quic::provider::event::events::AckProcessed exports field:
+  action: s2n_quic::provider::event::events::AckAction
+
+struct s2n_quic::provider::event::events::AckProcessed implements trait:
+  impl<'a> core::clone::Clone for s2n_quic::provider::event::events::AckProcessed<'a>
+
+struct s2n_quic::provider::event::events::AckProcessed implements trait:
+  impl<'a> core::fmt::Debug for s2n_quic::provider::event::events::AckProcessed<'a>
+
+struct s2n_quic::provider::event::events::AckProcessed implements trait:
+  impl<'a> core::marker::Send for s2n_quic::provider::event::events::AckProcessed<'a>
+
+struct s2n_quic::provider::event::events::AckProcessed implements trait:
+  impl<'a> core::marker::Sync for s2n_quic::provider::event::events::AckProcessed<'a>
+
+struct s2n_quic::provider::event::events::AckProcessed implements trait:
+  impl<'a> core::marker::Unpin for s2n_quic::provider::event::events::AckProcessed<'a>
+
+struct s2n_quic::provider::event::events::AckProcessed implements trait:
+  impl<'a> s2n_quic::provider::event::Event for s2n_quic::provider::event::events::AckProcessed<'a>
+
+struct s2n_quic::provider::event::events::AckProcessed implements trait:
+  impl<'a> std::panic::RefUnwindSafe for s2n_quic::provider::event::events::AckProcessed<'a>
+
+struct s2n_quic::provider::event::events::AckProcessed implements trait:
+  impl<'a> std::panic::UnwindSafe for s2n_quic::provider::event::events::AckProcessed<'a>
+
+struct s2n_quic::provider::event::events::AckProcessed exports field:
+  path: s2n_quic::provider::event::events::Path<'a>
+
+struct s2n_quic::provider::event::events::AckProcessed exports constant:
+  pub const NAME: &'static str
 
 struct s2n_quic::provider::event::events::ActivePathUpdated is non-exhaustive
 

--- a/quic/s2n-quic/api.snap
+++ b/quic/s2n-quic/api.snap
@@ -2214,15 +2214,15 @@ variant s2n_quic::provider::event::events::AckAction::RxAckRangeDropped is non-e
 
 variant s2n_quic::provider::event::events::AckAction::RxAckRangeDropped exports field:
   capacity:
-  u16
+  usize
 
 variant s2n_quic::provider::event::events::AckAction::RxAckRangeDropped exports field:
   packet_number_range:
-  s2n_quic_core::event::Range<u64>
+  core::ops::range::Range<u64>
 
 variant s2n_quic::provider::event::events::AckAction::RxAckRangeDropped exports field:
   stored_range:
-  s2n_quic_core::event::Range<u64>
+  core::ops::range::Range<u64>
 
 struct s2n_quic::provider::event::events::AckProcessed is non-exhaustive
 


### PR DESCRIPTION
### Description of changes: 
This PR exposes specific error information from `AckRanges` and publishes them as events.

### Call-outs:
There are a few actions(commented out currently) which will be added in the future. But that is pending delayed ACK PR https://github.com/aws/s2n-quic/pull/1298

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

