### PR TITLE
feat: Add RandomGenerator to Congestion Controller

### DIFF
--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -73,3 +73,4 @@ harness = false
 [[test]]
 name = "recovery-simulation"
 path = "tests/recovery/simulation.rs"
+required-features = ["testing"]

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     counter::Counter,
+    random,
     recovery::{bandwidth, CongestionController, RttEstimator},
     time::Timestamp,
 };
@@ -100,12 +101,13 @@ impl CongestionController for BbrCongestionController {
         todo!()
     }
 
-    fn on_ack(
+    fn on_ack<Rnd: random::Generator>(
         &mut self,
         newest_acked_time_sent: Timestamp,
         bytes_acknowledged: usize,
         newest_acked_packet_info: Self::PacketInfo,
         _rtt_estimator: &RttEstimator,
+        _random_generator: &mut Rnd,
         ack_receive_time: Timestamp,
     ) {
         self.bw_estimator.on_ack(
@@ -143,12 +145,13 @@ impl CongestionController for BbrCongestionController {
             .advance(self.bw_estimator.rate_sample());
     }
 
-    fn on_packet_lost(
+    fn on_packet_lost<Rnd: random::Generator>(
         &mut self,
         lost_bytes: u32,
         _packet_info: Self::PacketInfo,
         _persistent_congestion: bool,
         new_loss_burst: bool,
+        _random_generator: &mut Rnd,
         timestamp: Timestamp,
     ) {
         self.bw_estimator.on_loss(lost_bytes as usize);

--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -5,6 +5,7 @@ use crate::{
     event::{api::SocketAddress, IntoEvent},
     inet,
     path::MINIMUM_MTU,
+    random,
     recovery::RttEstimator,
     time::Timestamp,
 };
@@ -82,12 +83,13 @@ pub trait CongestionController: 'static + Clone + Send + Debug {
     /// it is possible this method may be called multiple times for one acknowledgement. In either
     /// case, `newest_acked_time_sent` and `newest_acked_packet_info` represent the newest acknowledged
     /// packet contributing to `bytes_acknowledged`.
-    fn on_ack(
+    fn on_ack<Rnd: random::Generator>(
         &mut self,
         newest_acked_time_sent: Timestamp,
         bytes_acknowledged: usize,
         newest_acked_packet_info: Self::PacketInfo,
         rtt_estimator: &RttEstimator,
+        random_generator: &mut Rnd,
         ack_receive_time: Timestamp,
     );
 
@@ -96,12 +98,13 @@ pub trait CongestionController: 'static + Clone + Send + Debug {
     /// `new_loss_burst` is true if the lost packet is the first in a
     /// contiguous series of lost packets. This can be used for measuring or
     /// filtering out noise from burst losses.
-    fn on_packet_lost(
+    fn on_packet_lost<Rnd: random::Generator>(
         &mut self,
         lost_bytes: u32,
         packet_info: Self::PacketInfo,
         persistent_congestion: bool,
         new_loss_burst: bool,
+        random_generator: &mut Rnd,
         timestamp: Timestamp,
     );
 
@@ -185,22 +188,24 @@ pub mod testing {
 
             fn on_rtt_update(&mut self, _time_sent: Timestamp, _rtt_estimator: &RttEstimator) {}
 
-            fn on_ack(
+            fn on_ack<Rnd: random::Generator>(
                 &mut self,
                 _newest_acked_time_sent: Timestamp,
                 _sent_bytes: usize,
                 _newest_acked_packet_info: Self::PacketInfo,
                 _rtt_estimator: &RttEstimator,
+                _random_generator: &mut Rnd,
                 _ack_receive_time: Timestamp,
             ) {
             }
 
-            fn on_packet_lost(
+            fn on_packet_lost<Rnd: random::Generator>(
                 &mut self,
                 _lost_bytes: u32,
                 _packet_info: Self::PacketInfo,
                 _persistent_congestion: bool,
                 _new_loss_burst: bool,
+                _random_generator: &mut Rnd,
                 _timestamp: Timestamp,
             ) {
             }
@@ -300,23 +305,25 @@ pub mod testing {
                 self.on_rtt_update += 1
             }
 
-            fn on_ack(
+            fn on_ack<Rnd: random::Generator>(
                 &mut self,
                 _newest_acked_time_sent: Timestamp,
                 _sent_bytes: usize,
                 _newest_acked_packet_info: Self::PacketInfo,
                 _rtt_estimator: &RttEstimator,
+                _random_generator: &mut Rnd,
                 _ack_receive_time: Timestamp,
             ) {
                 self.on_packet_ack += 1;
             }
 
-            fn on_packet_lost(
+            fn on_packet_lost<Rnd: random::Generator>(
                 &mut self,
                 lost_bytes: u32,
                 _packet_info: Self::PacketInfo,
                 persistent_congestion: bool,
                 new_loss_burst: bool,
+                _random_generator: &mut Rnd,
                 _timestamp: Timestamp,
             ) {
                 self.bytes_in_flight = self.bytes_in_flight.saturating_sub(lost_bytes);

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     counter::Counter,
+    random,
     recovery::{
         congestion_controller::{self, CongestionController},
         cubic::{FastRetransmission::*, State::*},
@@ -239,12 +240,13 @@ impl CongestionController for CubicCongestionController {
     }
 
     #[inline]
-    fn on_ack(
+    fn on_ack<Rnd: random::Generator>(
         &mut self,
         newest_acked_time_sent: Timestamp,
         bytes_acknowledged: usize,
         _newest_acked_packet_info: Self::PacketInfo,
         rtt_estimator: &RttEstimator,
+        _random_generator: &mut Rnd,
         ack_receive_time: Timestamp,
     ) {
         self.bytes_in_flight
@@ -322,12 +324,13 @@ impl CongestionController for CubicCongestionController {
     }
 
     #[inline]
-    fn on_packet_lost(
+    fn on_packet_lost<Rnd: random::Generator>(
         &mut self,
         lost_bytes: u32,
         _packet_info: Self::PacketInfo,
         persistent_congestion: bool,
         _new_loss_burst: bool,
+        _random_generator: &mut Rnd,
         timestamp: Timestamp,
     ) {
         debug_assert!(lost_bytes > 0);

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -127,6 +127,7 @@ impl connection::Trait for TestConnection {
 
     fn on_pending_ack_ranges(
         &mut self,
+        _random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         _timestamp: Timestamp,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) -> Result<(), connection::Error> {

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -986,6 +986,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         self.space_manager.on_timeout(
             &mut self.local_id_registry,
             &mut self.path_manager,
+            random_generator,
             timestamp,
             &mut publisher,
         );
@@ -1051,6 +1052,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
     /// Process ACKs for the `Connection`.
     fn on_pending_ack_ranges(
         &mut self,
+        random_generator: &mut Config::RandomGenerator,
         timestamp: Timestamp,
         subscriber: &mut Config::EventSubscriber,
     ) -> Result<(), connection::Error> {
@@ -1066,6 +1068,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 path_id,
                 &mut self.path_manager,
                 &mut self.local_id_registry,
+                random_generator,
                 &mut publisher,
             )
             .map_err(|err| {

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -102,6 +102,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     /// Process pendings ACKs for the `Connection`.
     fn on_pending_ack_ranges(
         &mut self,
+        random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         timestamp: Timestamp,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) -> Result<(), connection::Error>;

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -1119,6 +1119,7 @@ mod tests {
             DEFAULT_MAX_MTU,
         );
         let now = NoopClock.get_time();
+        let random = &mut random::testing::Generator::default();
         path.on_validated();
 
         assert_eq!(
@@ -1140,7 +1141,7 @@ mod tests {
 
         // Lose a byte to enter recovery
         path.congestion_controller
-            .on_packet_lost(1, packet_info, false, false, now);
+            .on_packet_lost(1, packet_info, false, false, random, now);
         path.congestion_controller.requires_fast_retransmission = true;
 
         assert_eq!(
@@ -1154,6 +1155,7 @@ mod tests {
             packet_info,
             false,
             false,
+            random,
             now,
         );
         path.congestion_controller.requires_fast_retransmission = false;

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -366,6 +366,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         path_manager: &mut path::Manager<Config>,
         handshake_status: &mut HandshakeStatus,
         local_id_registry: &mut connection::LocalIdRegistry,
+        random_generator: &mut Config::RandomGenerator,
         timestamp: Timestamp,
         publisher: &mut Pub,
     ) {
@@ -379,7 +380,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
             path_manager,
         );
 
-        recovery_manager.on_timeout(timestamp, &mut context, publisher);
+        recovery_manager.on_timeout(timestamp, random_generator, &mut context, publisher);
 
         self.stream_manager.on_timeout(timestamp);
 
@@ -568,6 +569,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         pending_ack_ranges.extend(range, frame.ecn_counts, frame.ack_delay())
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn on_pending_ack_ranges<Pub: event::ConnectionPublisher>(
         &mut self,
         timestamp: Timestamp,
@@ -575,6 +577,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         path_manager: &mut path::Manager<Config>,
         handshake_status: &mut HandshakeStatus,
         local_id_registry: &mut connection::LocalIdRegistry,
+        random_generator: &mut Config::RandomGenerator,
         publisher: &mut Pub,
     ) -> Result<(), transport::Error> {
         debug_assert!(
@@ -587,6 +590,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         recovery_manager.on_pending_ack_ranges(
             timestamp,
             pending_ack_ranges,
+            random_generator,
             &mut context,
             publisher,
         )
@@ -743,6 +747,7 @@ impl<Config: endpoint::Config> PacketSpace<Config> for ApplicationSpace<Config> 
         path_manager: &mut path::Manager<Config>,
         handshake_status: &mut HandshakeStatus,
         local_id_registry: &mut connection::LocalIdRegistry,
+        random_generator: &mut Config::RandomGenerator,
         publisher: &mut Pub,
     ) -> Result<(), transport::Error> {
         let path = &mut path_manager[path_id];
@@ -754,7 +759,7 @@ impl<Config: endpoint::Config> PacketSpace<Config> for ApplicationSpace<Config> 
         // the ACKs immediately if insertion into PendingAckRanges fails
         //
         // self.update_pending_acks(&frame, &mut self.pending_ack_ranges)
-        recovery_manager.on_ack_frame(timestamp, frame, &mut context, publisher)
+        recovery_manager.on_ack_frame(timestamp, frame, random_generator, &mut context, publisher)
     }
 
     fn handle_connection_close_frame(

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -267,6 +267,7 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
         handshake_status: &HandshakeStatus,
         path_id: path::Id,
         path_manager: &mut path::Manager<Config>,
+        random_generator: &mut Config::RandomGenerator,
         timestamp: Timestamp,
         publisher: &mut Pub,
     ) {
@@ -274,7 +275,7 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
 
         let (recovery_manager, mut context) =
             self.recovery(handshake_status, path_id, path_manager);
-        recovery_manager.on_timeout(timestamp, &mut context, publisher);
+        recovery_manager.on_timeout(timestamp, random_generator, &mut context, publisher);
     }
 
     /// Called before the Handshake packet space is discarded
@@ -498,13 +499,14 @@ impl<Config: endpoint::Config> PacketSpace<Config> for HandshakeSpace<Config> {
         path_manager: &mut path::Manager<Config>,
         handshake_status: &mut HandshakeStatus,
         _local_id_registry: &mut connection::LocalIdRegistry,
+        random_generator: &mut Config::RandomGenerator,
         publisher: &mut Pub,
     ) -> Result<(), transport::Error> {
         let path = &mut path_manager[path_id];
         path.on_peer_validated();
         let (recovery_manager, mut context) =
             self.recovery(handshake_status, path_id, path_manager);
-        recovery_manager.on_ack_frame(timestamp, frame, &mut context, publisher)
+        recovery_manager.on_ack_frame(timestamp, frame, random_generator, &mut context, publisher)
     }
 
     fn handle_connection_close_frame(

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -314,6 +314,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
         handshake_status: &HandshakeStatus,
         path_id: path::Id,
         path_manager: &mut path::Manager<Config>,
+        random_generator: &mut Config::RandomGenerator,
         timestamp: Timestamp,
         publisher: &mut Pub,
     ) {
@@ -321,7 +322,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
 
         let (recovery_manager, mut context) =
             self.recovery(handshake_status, path_id, path_manager);
-        recovery_manager.on_timeout(timestamp, &mut context, publisher);
+        recovery_manager.on_timeout(timestamp, random_generator, &mut context, publisher);
     }
 
     /// Called before the Initial packet space is discarded
@@ -648,11 +649,12 @@ impl<Config: endpoint::Config> PacketSpace<Config> for InitialSpace<Config> {
         path_manager: &mut path::Manager<Config>,
         handshake_status: &mut HandshakeStatus,
         _local_id_registry: &mut connection::LocalIdRegistry,
+        random_generator: &mut Config::RandomGenerator,
         publisher: &mut Pub,
     ) -> Result<(), transport::Error> {
         let (recovery_manager, mut context) =
             self.recovery(handshake_status, path_id, path_manager);
-        recovery_manager.on_ack_frame(timestamp, frame, &mut context, publisher)
+        recovery_manager.on_ack_frame(timestamp, frame, random_generator, &mut context, publisher)
     }
 
     fn handle_connection_close_frame(

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -243,6 +243,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         &mut self,
         local_id_registry: &mut connection::LocalIdRegistry,
         path_manager: &mut path::Manager<Config>,
+        random_generator: &mut Config::RandomGenerator,
         timestamp: Timestamp,
         publisher: &mut Pub,
     ) {
@@ -257,6 +258,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
                 handshake_status,
                 path_id,
                 path_manager,
+                random_generator,
                 timestamp,
                 publisher,
             )
@@ -266,6 +268,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
                 handshake_status,
                 path_id,
                 path_manager,
+                random_generator,
                 timestamp,
                 publisher,
             )
@@ -275,6 +278,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
                 path_manager,
                 handshake_status,
                 local_id_registry,
+                random_generator,
                 timestamp,
                 publisher,
             )
@@ -451,6 +455,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         path_id: path::Id,
         path_manager: &mut path::Manager<Config>,
         local_id_registry: &mut connection::LocalIdRegistry,
+        random_generator: &mut Config::RandomGenerator,
         publisher: &mut Pub,
     ) -> Result<(), transport::Error> {
         debug_assert!(
@@ -470,6 +475,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
                 path_manager,
                 handshake_status,
                 local_id_registry,
+                random_generator,
                 publisher,
             )?;
         }
@@ -583,6 +589,7 @@ pub trait PacketSpace<Config: endpoint::Config> {
         path_manager: &mut path::Manager<Config>,
         handshake_status: &mut HandshakeStatus,
         local_id_registry: &mut connection::LocalIdRegistry,
+        random_generator: &mut Config::RandomGenerator,
         publisher: &mut Pub,
     ) -> Result<(), transport::Error>;
 
@@ -783,6 +790,7 @@ pub trait PacketSpace<Config: endpoint::Config> {
                         path_manager,
                         handshake_status,
                         local_id_registry,
+                        random_generator,
                         publisher,
                     )
                     .map_err(on_error)?;

--- a/scripts/recovery-sim
+++ b/scripts/recovery-sim
@@ -11,7 +11,7 @@ OUT=${1:-target/recovery-sim}
 mkdir -p $OUT
 OUT=$(realpath $OUT)
 
-RECOVERY_SIM_DIR=$OUT cargo test -p s2n-quic-core --test recovery-simulation -- --nocapture
+RECOVERY_SIM_DIR=$OUT cargo test -p s2n-quic-core --test recovery-simulation --features=testing -- --nocapture
 
 cd $OUT
 # Generate an html file with a directory listing of all recovery simulations. -P is used to only include


### PR DESCRIPTION
### Description of changes: 

Some congestion controllers (such as BBRv2) may wish to incorporate randomness into their algorithm to allow for better mixing and fairness with other flows. This change wires the `random::Generator` through to the `on_ack` and `on_packets_lost` methods in the Congestion Controller.

### Call-outs:

I originally added the `random::Generator` to the `RecoveryContext`, but this had two issues:
* `CongestionController::on_packet_sent` uses the `RecoveryContext`, so either I would have to stop it from using the `RecoveryContext` or wire the `random::Generator` through all the transmission code for no reason. 
* There are several places in the `recovery::Manager` where the `RecoveryContext` is mutably borrowed so that the congestion controller can be updated. When I added the `random::Generator` to the `RecoveryContext`, I ended up having to mutably borrow the `RecoveryContext` twice, which is not permitted. I couldn't find a work around for this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

