### PR TITLE
fix(s2n-quic-core): Allow for DSCP markings in the IP header

### DIFF
--- a/quic/s2n-quic-core/src/inet/ecn.rs
+++ b/quic/s2n-quic-core/src/inet/ecn.rs
@@ -77,12 +77,6 @@ impl Default for ExplicitCongestionNotification {
 impl ExplicitCongestionNotification {
     /// Create a ExplicitCongestionNotification from the ECN field in the IP header
     pub fn new(ecn_field: u8) -> Self {
-        debug_assert!(
-            ecn_field >> 2 == 0,
-            "{:#b} is not a valid ECN marking",
-            ecn_field
-        );
-
         match ecn_field & 0b11 {
             0b00 => ExplicitCongestionNotification::NotEct,
             0b01 => ExplicitCongestionNotification::Ect1,

--- a/quic/s2n-quic-core/src/inet/ecn.rs
+++ b/quic/s2n-quic-core/src/inet/ecn.rs
@@ -113,9 +113,23 @@ mod tests {
         }
     }
 
+    /// The most-significant 6 bits of the 8-bit traffic class field ECN markings are
+    /// read from are used for the differentiated services code point. This test
+    /// ensures we still parse ECN bits correctly even when the DSCP markings are present.
     #[test]
-    #[should_panic]
-    fn invalid_ecn() {
-        ExplicitCongestionNotification::new(4);
+    fn dscp_markings() {
+        for i in 0..u8::MAX {
+            for ecn in &[
+                ExplicitCongestionNotification::NotEct,
+                ExplicitCongestionNotification::Ect1,
+                ExplicitCongestionNotification::Ect0,
+                ExplicitCongestionNotification::Ce,
+            ] {
+                assert_eq!(
+                    *ecn,
+                    ExplicitCongestionNotification::new(i << 2 | *ecn as u8)
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
### Resolved issues:

resolves #1322

### Description of changes: 

The most-significant 6 bits of the 8-bit traffic class field ECN markings are read from are used for the differentiated services code point. Previously we were debug asserting these bits were always 0. This was too strict, as it is valid to set these bits, so this change removes the debug assertion.

### Testing:

Updated unit tests

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

