### PR TITLE
build(deps): update bolero to 0.7.0

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -17,7 +17,7 @@ checked_range_unsafe = []
 generator = ["bolero-generator"]
 
 [dependencies]
-bolero-generator = { version = "0.6", default-features = false, optional = true }
+bolero-generator = { version = "0.7", default-features = false, optional = true }
 byteorder = { version = "1.1", default-features = false }
 bytes = { version = "1", default-features = false, optional = true }
 zerocopy = "=0.6.0"

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -19,7 +19,7 @@ checked-counters = []
 event-tracing = ["tracing"]
 
 [dependencies]
-bolero-generator = { version = "0.6", default-features = false, optional = true }
+bolero-generator = { version = "0.7", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false }
 bytes = { version = "1", default-features = false }
 hex-literal = "0.3"
@@ -36,13 +36,18 @@ futures-test = { version = "0.3", optional = true } # For testing Waker interact
 once_cell = { version = "1", optional = true }
 
 [dev-dependencies]
-bolero = "0.6"
-bolero-generator = { version = "0.6", default-features = false }
+bolero = "0.7"
+bolero-generator = { version = "0.7", default-features = false }
 insta = "1"
 futures-test = "0.3"
 ip_network = "0.4"
 plotters = { version = "0.3", default-features = false, features = ["svg_backend", "line_series"] }
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
+
+# TODO remove this once this is fixed: https://github.com/model-checking/kani/issues/473
+[target.'cfg(kani)'.dependencies]
+bolero = "0.7"
+bolero-generator = "0.7"
 
 [[test]]
 name = "crypto"

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -24,7 +24,7 @@ zeroize = { version = "1", default-features = false, features = ["zeroize_derive
 [dev-dependencies]
 aes = "0.7"
 aes-gcm = "0.9"
-bolero = "0.6"
+bolero = "0.7"
 ctr = "0.8"
 ghash = "0.4"
 hex-literal = "0.3"

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -20,7 +20,7 @@ wipe = ["zeroize"]
 
 [dependencies]
 bach = { version = "0.0.6", optional = true }
-bolero-generator = { version = "0.6", default-features = false, optional = true }
+bolero-generator = { version = "0.7", default-features = false, optional = true }
 cfg-if = "1"
 errno = "0.2"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
@@ -36,8 +36,8 @@ libc = "0.2"
 
 [dev-dependencies]
 bach = { version = "0.0.6" }
-bolero = "0.6"
-bolero-generator = { version = "0.6", default-features = false }
+bolero = "0.7"
+bolero-generator = { version = "0.7", default-features = false }
 futures = { version = "0.3", features = ["std"] }
 insta = "1"
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -26,7 +26,7 @@ siphasher = "0.3"
 smallvec = { version = "1", default-features = false }
 
 [dev-dependencies]
-bolero = "0.6"
+bolero = "0.7"
 futures-test = "0.3" # For testing Waker interactions
 insta = "1"
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -63,7 +63,7 @@ zerocopy-derive = { version = "=0.3.0", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-bolero = { version = "0.6" }
+bolero = { version = "0.7" }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing", "event-tracing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
### Description of changes: 

This change updates to the latest bolero, which includes support for running harnesses as kani proofs. I've refactored the vectored copy test to be more friendly to kani as a demonstration of it working.

Depends on #1337 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

