### PR TITLE
fix(s2n-quic-transport): make periodic sync more frequent

### DIFF
--- a/quic/s2n-quic-core/src/counter.rs
+++ b/quic/s2n-quic-core/src/counter.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::number::{
-    CheckedAddAssign, CheckedSubAssign, SaturatingAddAssign, SaturatingSubAssign, UpcastFrom,
+    CheckedAddAssign, CheckedMulAssign, CheckedSubAssign, SaturatingAddAssign, SaturatingMulAssign,
+    SaturatingSubAssign, UpcastFrom,
 };
 use core::{cmp::Ordering, convert::TryFrom, marker::PhantomData, ops};
 
@@ -35,6 +36,11 @@ impl<T, Behavior> Counter<T, Behavior> {
     #[inline]
     pub const fn new(value: T) -> Self {
         Self(value, PhantomData)
+    }
+
+    #[inline]
+    pub fn set(&mut self, value: T) {
+        self.0 = value;
     }
 
     /// Tries to convert V to T and add it to the current counter value
@@ -116,6 +122,15 @@ assign_trait!(
     saturating_sub_assign,
     CheckedSubAssign,
     checked_sub_assign
+);
+
+assign_trait!(
+    MulAssign,
+    mul_assign,
+    SaturatingMulAssign,
+    saturating_mul_assign,
+    CheckedMulAssign,
+    checked_mul_assign
 );
 
 impl<T, B> UpcastFrom<Counter<T, B>> for T {


### PR DESCRIPTION
### Description of changes: 

The current `DATA_BLOCKED`, `STREAM_DATA_BLOCKED`, `STREAMS_BLOCKED` frames are sent 1 smoothed RTT before the idle timer expires. In testing, however, I've found this to be suboptimal and I don't think actually in line with the purpose of these frames. From [RFC9000 Section 4.1](https://www.rfc-editor.org/rfc/rfc9000#section-4.1):

> To keep the connection from closing, a sender that is flow control limited SHOULD periodically send a STREAM_DATA_BLOCKED or DATA_BLOCKED frame when it has no ack-eliciting packets in flight.

Since we likely don't have any bytes in flight when we're blocked by flow control, these frames are intended to act as a replacement for PTO, which only is armed when there are bytes in flight. This is important for when there's high loss on the connection and we may not have received the latest increase in flow control from the peer.

This change, instead, computes the base PTO duration on RTT updates and notifies all of the periodic sync components of the value. Each component has a backoff value that exponentially lengthens the period at which blocked frames are transmitted. In this way, these components act as their own PTO probe, ensuring the peer receives the blocked signal.

### Testing:

Running a few tests on main with high loss on the receiver results in the connection stalling quite quickly:

```tsv
send_throughput    receive_throughput
114.66Kbps      64bps
4.19Mbps        0bps
89.38Mbps       0bps
120.06Mbps      0bps
105.38Mbps      0bps
59.13Mbps       0bps
0bps    0bps
0bps    0bps
```

With these changes, the connection throughput survives a lot longer:

```tsv
send_throughput    receive_throughput
343.71Kbps      64bps
24.06Mbps       0bps
106.41Mbps      0bps
63.91Mbps       0bps
9.69Mbps        0bps
... snip 5 minutes ...
44.52Mbps       0bps
46.68Mbps       0bps
82.73Mbps       0bps
10.88Mbps       0bps
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

