### PR TITLE
build(s2n-quic-crypto): make the rust crypto implementations dev-depe…

### DIFF
--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -11,15 +11,11 @@ exclude = ["corpus.tar.gz"]
 
 [features]
 default = []
-testing = ["testing-oracles"]
-testing-oracles = ["aes", "aes-gcm", "ghash"]
+testing = []
 
 [dependencies]
-aes = { version = "0.7", optional = true }
-aes-gcm = { version = "0.9", optional = true }
 cfg-if = "1"
 lazy_static = "1"
-ghash = { version = "0.4", optional = true }
 ring = { version = "0.16", default-features = false }
 s2n-codec = { path = "../../common/s2n-codec", default-features = false, version = "=0.1.0" }
 s2n-quic-core = { path = "../s2n-quic-core", default-features = false, version = "=0.4.0" }

--- a/quic/s2n-quic-crypto/src/aes/testing.rs
+++ b/quic/s2n-quic-crypto/src/aes/testing.rs
@@ -32,7 +32,7 @@ macro_rules! aes_impl {
                     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
                     crate::aes::x86::testing::$name::implementations(&mut impls);
 
-                    #[cfg(any(test, feature = "aes"))]
+                    #[cfg(test)]
                     super::rust_crypto::$name::implementations(&mut impls);
 
                     impls
@@ -66,5 +66,5 @@ pub fn for_each_block<F: FnMut(&mut [u8; BLOCK_LEN])>(input: &mut [u8], mut f: F
     }
 }
 
-#[cfg(any(test, feature = "aes"))]
+#[cfg(test)]
 mod rust_crypto;

--- a/quic/s2n-quic-crypto/src/aesgcm/testing.rs
+++ b/quic/s2n-quic-crypto/src/aesgcm/testing.rs
@@ -34,7 +34,7 @@ macro_rules! aesgcm_impl {
 
                     crate::aesgcm::ring::$name::implementations(&mut impls);
 
-                    #[cfg(any(test, feature = "aes-gcm"))]
+                    #[cfg(test)]
                     super::rust_crypto::$name::implementations(&mut impls);
 
                     impls
@@ -57,5 +57,5 @@ pub use crate::{
 };
 pub type Key = Box<dyn Aead<Nonce = [u8; NONCE_LEN], Tag = [u8; TAG_LEN]>>;
 
-#[cfg(any(test, feature = "aes-gcm"))]
+#[cfg(test)]
 mod rust_crypto;

--- a/quic/s2n-quic-crypto/src/ghash/testing.rs
+++ b/quic/s2n-quic-crypto/src/ghash/testing.rs
@@ -31,7 +31,7 @@ lazy_static! {
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         super::x86::testing::implementations(&mut impls);
 
-        #[cfg(any(test, feature = "ghash"))]
+        #[cfg(test)]
         rust_crypto::implementations(&mut impls);
 
         impls
@@ -42,5 +42,5 @@ pub fn implementations() -> &'static [Implementation] {
     &*IMPLEMENTATIONS
 }
 
-#[cfg(any(test, feature = "ghash"))]
+#[cfg(test)]
 mod rust_crypto;


### PR DESCRIPTION
### Description of changes: 

Previously I was benchmarking our AES/GHASH implementations against the RustCrypto implementations, but I think the only interesting benchmark is against ring. Instead of including those, this change just moves them to dev-dependencies and uses them only for test oracles.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

