### PR TITLE
build(s2n-quic-crypto): update to the latest rust-crypto crates

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -15,6 +15,7 @@ skip-tree = [
     { name = "cuckoofilter" },
 
     # all of these are going to be just test dependencies
+    { name = "aes-gcm" },
     { name = "bolero" },
     { name = "criterion" },
     { name = "insta" },

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -22,10 +22,10 @@ s2n-quic-core = { path = "../s2n-quic-core", default-features = false, version =
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
 [dev-dependencies]
-aes = "0.7"
+aes = "0.8"
 aes-gcm = "0.9"
 bolero = "0.7"
-ctr = "0.8"
+ctr = "0.9"
 ghash = "0.4"
 hex-literal = "0.3"
 insta = "1"

--- a/quic/s2n-quic-crypto/src/aes/testing/rust_crypto.rs
+++ b/quic/s2n-quic-crypto/src/aes/testing/rust_crypto.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::aes::testing::{for_each_block, Aes};
-use aes::{Aes128, Aes256, BlockDecrypt, BlockEncrypt as _, NewBlockCipher as _};
+use aes::{
+    cipher::{BlockDecrypt, BlockEncrypt as _, KeyInit as _},
+    Aes128, Aes256,
+};
 
 macro_rules! impl_aes {
     ($name:ident, $lower:ident) => {


### PR DESCRIPTION
### Description of changes: 

Updating the dev-dependencies for s2n-quic-crypto.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

