### PR TITLE
fix(s2n-quic-platform): set don't fragment flag for IPv4 mapped IPv6 tx addresses

### DIFF
--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -163,19 +163,20 @@ impl Io {
         #[cfg(s2n_quic_platform_mtu_disc)]
         {
             use std::os::unix::io::AsRawFd;
-            if tx_addr.is_ipv4() {
-                // IP_PMTUDISC_PROBE setting will set the DF (Don't Fragment) flag
-                // while also ignoring the Path MTU. This means packets will not
-                // be fragmented, and the EMSGSIZE error will not be returned for
-                // packets larger than the Path MTU according to the kernel.
-                libc!(setsockopt(
-                    tx_socket.as_raw_fd(),
-                    libc::IPPROTO_IP,
-                    libc::IP_MTU_DISCOVER,
-                    &libc::IP_PMTUDISC_PROBE as *const _ as _,
-                    core::mem::size_of_val(&libc::IP_PMTUDISC_PROBE) as _,
-                ))?;
-            } else {
+
+            // IP_PMTUDISC_PROBE setting will set the DF (Don't Fragment) flag
+            // while also ignoring the Path MTU. This means packets will not
+            // be fragmented, and the EMSGSIZE error will not be returned for
+            // packets larger than the Path MTU according to the kernel.
+            libc!(setsockopt(
+                tx_socket.as_raw_fd(),
+                libc::IPPROTO_IP,
+                libc::IP_MTU_DISCOVER,
+                &libc::IP_PMTUDISC_PROBE as *const _ as _,
+                core::mem::size_of_val(&libc::IP_PMTUDISC_PROBE) as _,
+            ))?;
+
+            if tx_addr.is_ipv6() {
                 libc!(setsockopt(
                     tx_socket.as_raw_fd(),
                     libc::IPPROTO_IPV6,


### PR DESCRIPTION
### Description of changes: 

This change will always set the "don't fragment" flag for the IPv4 protocol, which is necessary for Path MTU probing to work correctly. Previously, if the tx address was an IPv4 mapped IPv6 address, only the setting for IPv6 would be set, which may not work on some systems. 

### Testing:

Tested locally

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

