### PR TITLE
fix: explicitly track MTU probes

### DIFF
--- a/quic/s2n-quic-core/src/recovery/sent_packets.rs
+++ b/quic/s2n-quic-core/src/recovery/sent_packets.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     frame::ack_elicitation::AckElicitation, inet::ExplicitCongestionNotification, path,
-    time::Timestamp,
+    time::Timestamp, transmission,
 };
 use core::convert::TryInto;
 
@@ -30,6 +30,8 @@ pub struct SentPacketInfo<PacketInfo> {
     pub path_id: path::Id,
     /// The ECN marker (if any) sent on the datagram that contained this packet
     pub ecn: ExplicitCongestionNotification,
+    /// Indicates if the packet was part of a probe transmission
+    pub transmission_mode: transmission::Mode,
     /// Additional packet metadata dictated by the congestion controller
     pub cc_packet_info: PacketInfo,
 }
@@ -43,6 +45,7 @@ impl<PacketInfo> SentPacketInfo<PacketInfo> {
         ack_elicitation: AckElicitation,
         path_id: path::Id,
         ecn: ExplicitCongestionNotification,
+        transmission_mode: transmission::Mode,
         cc_packet_info: PacketInfo,
     ) -> Self {
         debug_assert_eq!(
@@ -60,6 +63,7 @@ impl<PacketInfo> SentPacketInfo<PacketInfo> {
             ack_elicitation,
             path_id,
             ecn,
+            transmission_mode,
             cc_packet_info,
         }
     }
@@ -73,6 +77,7 @@ mod test {
         path,
         recovery::SentPacketInfo,
         time::{Clock, NoopClock},
+        transmission,
     };
 
     #[test]
@@ -85,6 +90,7 @@ mod test {
             AckElicitation::Eliciting,
             unsafe { path::Id::new(0) },
             ExplicitCongestionNotification::default(),
+            transmission::Mode::Normal,
             (),
         );
     }

--- a/quic/s2n-quic-core/src/transmission/mode.rs
+++ b/quic/s2n-quic-core/src/transmission/mode.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Mode {
     /// Loss recovery probing to detect lost packets
     LossRecoveryProbing,

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -188,12 +188,14 @@ impl<Config: endpoint::Config> Manager<Config> {
 
     //= https://www.rfc-editor.org/rfc/rfc9002#section-A.5
     //# After a packet is sent, information about the packet is stored.
+    #[allow(clippy::too_many_arguments)]
     pub fn on_packet_sent<Ctx: Context<Config>, Pub: event::ConnectionPublisher>(
         &mut self,
         packet_number: PacketNumber,
         outcome: transmission::Outcome,
         time_sent: Timestamp,
         ecn: ExplicitCongestionNotification,
+        transmission_mode: transmission::Mode,
         context: &mut Ctx,
         publisher: &mut Pub,
     ) {
@@ -229,6 +231,7 @@ impl<Config: endpoint::Config> Manager<Config> {
                 outcome.ack_elicitation,
                 path_id,
                 ecn,
+                transmission_mode,
                 cc_packet_info,
             ),
         );

--- a/quic/s2n-quic-transport/src/recovery/manager/persistent_congestion.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/persistent_congestion.rs
@@ -61,6 +61,15 @@ impl PersistentCongestionCalculator {
             return;
         }
 
+        // Check if this lost packet was an MTU probe
+        if packet_info.transmission_mode.is_mtu_probing() {
+            //= https://www.rfc-editor.org/rfc/rfc9000#section-14.4
+            //# Loss of a QUIC packet that is carried in a PMTU probe is therefore not a
+            //# reliable indication of congestion and SHOULD NOT trigger a congestion
+            //# control reaction; see Item 7 in Section 3 of [DPLPMTUD].
+            return;
+        }
+
         if let Some(current_period) = &mut self.current_period {
             // We are currently tracking a persistent congestion period
 

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__persistent_congestion_mtu_probe.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__persistent_congestion_mtu_probe.snap
@@ -1,0 +1,8 @@
+---
+source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
+expression: ""
+---
+PacketLost { packet_header: OneRtt { number: 1 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, bytes_lost: 1, is_mtu_probe: true }
+PacketLost { packet_header: OneRtt { number: 2 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, bytes_lost: 1, is_mtu_probe: false }
+Congestion { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, source: PacketLoss }
+RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 100ms, smoothed_rtt: 625ms, latest_rtt: 100ms, rtt_variance: 393.75ms, max_ack_delay: 10ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 1 }

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -116,6 +116,7 @@ fn on_packet_sent() {
             outcome,
             time_sent,
             ecn,
+            transmission::Mode::Normal,
             &mut context,
             &mut publisher,
         );
@@ -247,6 +248,7 @@ fn on_packet_sent_across_multiple_paths() {
         outcome,
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -292,6 +294,7 @@ fn on_packet_sent_across_multiple_paths() {
         outcome,
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -346,6 +349,7 @@ fn on_ack_frame() {
             },
             time_sent,
             ecn,
+            transmission::Mode::Normal,
             &mut context,
             &mut publisher,
         );
@@ -484,6 +488,7 @@ fn on_ack_frame() {
         },
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -553,6 +558,7 @@ fn process_new_acked_packets_update_pto_timer() {
         },
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -568,6 +574,7 @@ fn process_new_acked_packets_update_pto_timer() {
         },
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -666,6 +673,7 @@ fn process_new_acked_packets_congestion_controller() {
         },
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -681,6 +689,7 @@ fn process_new_acked_packets_congestion_controller() {
         },
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -790,6 +799,7 @@ fn process_new_acked_packets_pto_timer() {
         },
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -805,6 +815,7 @@ fn process_new_acked_packets_pto_timer() {
         },
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -840,6 +851,7 @@ fn process_new_acked_packets_pto_timer() {
         },
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -902,6 +914,7 @@ fn process_new_acked_packets_process_ecn() {
             },
             time_sent,
             ExplicitCongestionNotification::Ect0,
+            transmission::Mode::Normal,
             &mut context,
             &mut publisher,
         );
@@ -1002,6 +1015,7 @@ fn process_new_acked_packets_failed_ecn_validation_does_not_cause_congestion_eve
             },
             time_sent,
             ExplicitCongestionNotification::Ect0,
+            transmission::Mode::Normal,
             &mut context,
             &mut publisher,
         );
@@ -1058,6 +1072,7 @@ fn no_rtt_update_when_not_acknowledging_the_largest_acknowledged_packet() {
         },
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -1071,6 +1086,7 @@ fn no_rtt_update_when_not_acknowledging_the_largest_acknowledged_packet() {
         },
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -1147,6 +1163,7 @@ fn no_rtt_update_when_receiving_packet_on_different_path() {
         },
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -1160,6 +1177,7 @@ fn no_rtt_update_when_receiving_packet_on_different_path() {
         },
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -1261,6 +1279,7 @@ fn rtt_update_when_receiving_ack_from_multiple_paths() {
         },
         sent_time,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -1277,6 +1296,7 @@ fn rtt_update_when_receiving_ack_from_multiple_paths() {
         },
         sent_time,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -1350,6 +1370,7 @@ fn detect_and_remove_lost_packets() {
         outcome,
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -1380,6 +1401,7 @@ fn detect_and_remove_lost_packets() {
         outcome,
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -1391,6 +1413,7 @@ fn detect_and_remove_lost_packets() {
         outcome,
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -1402,6 +1425,7 @@ fn detect_and_remove_lost_packets() {
         outcome,
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -1525,6 +1549,7 @@ fn detect_lost_packets_persistent_congestion_path_aware() {
             outcome,
             now,
             ecn,
+            transmission::Mode::Normal,
             &mut context,
             &mut publisher,
         );
@@ -1538,6 +1563,7 @@ fn detect_lost_packets_persistent_congestion_path_aware() {
             outcome,
             now,
             ecn,
+            transmission::Mode::Normal,
             &mut context,
             &mut publisher,
         );
@@ -1551,6 +1577,7 @@ fn detect_lost_packets_persistent_congestion_path_aware() {
             outcome,
             now,
             ecn,
+            transmission::Mode::Normal,
             &mut context,
             &mut publisher,
         );
@@ -1666,6 +1693,7 @@ fn remove_lost_packets_persistent_congestion_path_aware() {
                 AckElicitation::Eliciting,
                 first_path_id,
                 ecn,
+                transmission::Mode::Normal,
                 Default::default(),
             ),
         ),
@@ -1678,6 +1706,7 @@ fn remove_lost_packets_persistent_congestion_path_aware() {
                 AckElicitation::Eliciting,
                 second_path_id,
                 ecn,
+                transmission::Mode::Normal,
                 Default::default(),
             ),
         ),
@@ -1747,6 +1776,7 @@ fn detect_and_remove_lost_packets_nothing_lost() {
         outcome,
         time_sent,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -1798,6 +1828,7 @@ fn detect_and_remove_lost_packets_mtu_probe() {
         outcome,
         time_sent,
         ecn,
+        transmission::Mode::MtuProbing,
         &mut context,
         &mut publisher,
     );
@@ -1856,6 +1887,7 @@ fn persistent_congestion() {
         outcome,
         time_zero,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -1866,6 +1898,7 @@ fn persistent_congestion() {
         outcome,
         time_zero + Duration::from_secs(1),
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -1890,6 +1923,7 @@ fn persistent_congestion() {
             outcome,
             time_zero + Duration::from_secs(t.into()),
             ecn,
+            transmission::Mode::Normal,
             &mut context,
             &mut publisher,
         );
@@ -1902,6 +1936,7 @@ fn persistent_congestion() {
         outcome,
         time_zero + Duration::from_secs(8),
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -1912,6 +1947,7 @@ fn persistent_congestion() {
         outcome,
         time_zero + Duration::from_secs(12),
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -1954,6 +1990,7 @@ fn persistent_congestion() {
         outcome,
         time_zero + Duration::from_secs(20),
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -2007,6 +2044,7 @@ fn persistent_congestion_multiple_periods() {
         outcome,
         time_zero,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -2017,6 +2055,7 @@ fn persistent_congestion_multiple_periods() {
         outcome,
         time_zero + Duration::from_secs(1),
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -2038,6 +2077,7 @@ fn persistent_congestion_multiple_periods() {
             outcome,
             time_zero + Duration::from_secs(t.into()),
             ecn,
+            transmission::Mode::Normal,
             &mut context,
             &mut publisher,
         );
@@ -2051,6 +2091,7 @@ fn persistent_congestion_multiple_periods() {
         outcome,
         time_zero + Duration::from_secs(8),
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -2061,6 +2102,7 @@ fn persistent_congestion_multiple_periods() {
         outcome,
         time_zero + Duration::from_secs(20),
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -2071,6 +2113,7 @@ fn persistent_congestion_multiple_periods() {
         outcome,
         time_zero + Duration::from_secs(30),
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -2130,6 +2173,7 @@ fn persistent_congestion_period_does_not_start_until_rtt_sample() {
         outcome,
         time_zero,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -2140,6 +2184,7 @@ fn persistent_congestion_period_does_not_start_until_rtt_sample() {
         outcome,
         time_zero + Duration::from_secs(10),
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -2150,6 +2195,7 @@ fn persistent_congestion_period_does_not_start_until_rtt_sample() {
         outcome,
         time_zero + Duration::from_secs(20),
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -2210,6 +2256,7 @@ fn persistent_congestion_not_ack_eliciting() {
         outcome,
         time_zero,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -2223,6 +2270,7 @@ fn persistent_congestion_not_ack_eliciting() {
         outcome,
         time_zero + Duration::from_secs(10),
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -2233,6 +2281,7 @@ fn persistent_congestion_not_ack_eliciting() {
         outcome,
         time_zero + Duration::from_secs(20),
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -2349,6 +2398,7 @@ fn update_pto_timer() {
         },
         now,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -2486,6 +2536,7 @@ fn on_timeout() {
         },
         now - Duration::from_secs(5),
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -2535,6 +2586,7 @@ fn on_timeout() {
             AckElicitation::Eliciting,
             unsafe { path::Id::new(0) },
             ecn,
+            transmission::Mode::Normal,
             Default::default(),
         ),
     );
@@ -2792,6 +2844,7 @@ fn probe_packets_count_towards_bytes_in_flight() {
         outcome,
         s2n_quic_platform::time::now(),
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );
@@ -2883,6 +2936,7 @@ fn packet_declared_lost_less_than_1_ms_from_loss_threshold() {
         outcome,
         sent_time,
         ecn,
+        transmission::Mode::Normal,
         &mut context,
         &mut publisher,
     );

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -2305,6 +2305,89 @@ fn persistent_congestion_not_ack_eliciting() {
     );
 }
 
+//= https://www.rfc-editor.org/rfc/rfc9000#section-14.4
+//= type=test
+//# Loss of a QUIC packet that is carried in a PMTU probe is therefore not a
+//# reliable indication of congestion and SHOULD NOT trigger a congestion
+//# control reaction; see Item 7 in Section 3 of [DPLPMTUD].
+#[test]
+fn persistent_congestion_mtu_probe() {
+    let space = PacketNumberSpace::ApplicationData;
+    let mut manager = Manager::new(space);
+    let mut path_manager = helper_generate_path_manager(Duration::from_millis(10));
+    let ecn = ExplicitCongestionNotification::default();
+    let mut context = MockContext::new(&mut path_manager);
+    let mut publisher = Publisher::snapshot();
+
+    let time_zero = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    context.path_mut().rtt_estimator.update_rtt(
+        Duration::from_millis(10),
+        Duration::from_millis(700),
+        s2n_quic_platform::time::now(),
+        true,
+        space,
+    );
+
+    let outcome = transmission::Outcome {
+        ack_elicitation: AckElicitation::Eliciting,
+        is_congestion_controlled: true,
+        bytes_sent: 1,
+        bytes_progressed: 0,
+    };
+
+    // t=0: Send packet #1 (app data)
+    manager.on_packet_sent(
+        space.new_packet_number(VarInt::from_u8(1)),
+        outcome,
+        time_zero,
+        ecn,
+        transmission::Mode::MtuProbing,
+        &mut context,
+        &mut publisher,
+    );
+
+    // t=10: Send packet #2 (app data)
+    manager.on_packet_sent(
+        space.new_packet_number(VarInt::from_u8(2)),
+        outcome,
+        time_zero + Duration::from_secs(10),
+        ecn,
+        transmission::Mode::Normal,
+        &mut context,
+        &mut publisher,
+    );
+
+    // t=20: Send packet #3 (app data)
+    manager.on_packet_sent(
+        space.new_packet_number(VarInt::from_u8(3)),
+        outcome,
+        time_zero + Duration::from_secs(20),
+        ecn,
+        transmission::Mode::Normal,
+        &mut context,
+        &mut publisher,
+    );
+
+    // t=20.1: Recv acknowledgement of #3
+    ack_packets(
+        3..=3,
+        time_zero + Duration::from_millis(20_100),
+        &mut context,
+        &mut manager,
+        None,
+        &mut publisher,
+    );
+
+    // There is no persistent congestion because the first packet in the potential
+    // persistent congestion period was an MTU probe and the remaining packets are
+    // not a long enough period to be considered persistent congestion.
+    assert_eq!(context.path().congestion_controller.on_packets_lost, 1);
+    assert_eq!(
+        context.path().congestion_controller.persistent_congestion,
+        Some(false)
+    );
+}
+
 //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.1
 //= type=test
 #[test]

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -226,6 +226,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
             outcome,
             context.timestamp,
             context.ecn,
+            context.transmission_mode,
             &mut recovery_context,
             context.publisher,
         );

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -166,6 +166,7 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
             outcome,
             time_sent,
             context.ecn,
+            context.transmission_mode,
             &mut recovery_context,
             context.publisher,
         );

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -212,6 +212,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
             outcome,
             time_sent,
             context.ecn,
+            context.transmission_mode,
             &mut recovery_context,
             context.publisher,
         );


### PR DESCRIPTION
### Description of changes: 

Previously we determined if a lost packet was an MTU probe if its sent bytes was greater than the current MTU. Since the MTU can decrease as part of the lost packet processing (due to a detected blackhole), this can cause some packets that were not actually MTU probes to be considered MTU probes as part of the OnPacketLost event. This change adds `transmission::Mode` to `SentPacketInfo` so we can explicitly track if a sent packet was an MTU probe. I've also used this information in the persistent congestion calculator to prevent MTU probes from being considered part of a persistent congestion period.

### Testing:

Existing tests and added a new test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

