### PR TITLE
fix(s2n-quic-transport): detach streams on drop

### DIFF
--- a/quic/s2n-quic-core/src/stream/ops.rs
+++ b/quic/s2n-quic-core/src/stream/ops.rs
@@ -271,7 +271,7 @@ pub mod rx {
         /// Optionally requests the peer to stop sending data with an error
         pub stop_sending: Option<application::Error>,
 
-        /// Marks the tx stream as detached, which makes the stream make progress, regardless of
+        /// Marks the rx stream as detached, which makes the stream make progress, regardless of
         /// application observations.
         pub detached: bool,
     }

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    client::Connect,
     provider::{
+        self,
         io::testing::{spawn, test, time::delay, Model},
         packet_interceptor::Loss,
     },
@@ -11,6 +13,8 @@ use crate::{
 use std::time::Duration;
 
 mod setup;
+use bytes::Bytes;
+use s2n_quic_platform::io::testing::primary;
 use setup::*;
 
 #[test]
@@ -98,4 +102,73 @@ fn interceptor_failure_test() {
             .with_rx_pass(1..4)
             .build(),
     )
+}
+
+/// Ensures streams with STOP_SENDING are properly cleaned up
+///
+/// See https://github.com/aws/s2n-quic/pull/1361
+#[test]
+fn stream_reset_test() {
+    let model = Model::default();
+    test(model, |handle| {
+        let mut server = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(SERVER_CERTS)?
+            .with_event(events())?
+            .with_limits(
+                // keep the stream limit low
+                provider::limits::Limits::default()
+                    .with_max_open_bidirectional_streams(1)
+                    .unwrap(),
+            )?
+            .start()?;
+        let server_addr = server.local_addr()?;
+
+        spawn(async move {
+            while let Some(mut connection) = server.accept().await {
+                spawn(async move {
+                    while let Some(mut stream) =
+                        connection.accept_bidirectional_stream().await.unwrap()
+                    {
+                        spawn(async move {
+                            // drain the receive stream
+                            while stream.receive().await.unwrap().is_some() {}
+
+                            // send data until the client resets the stream
+                            while stream.send(Bytes::from_static(&[42; 1024])).await.is_ok() {}
+                        });
+                    }
+                });
+            }
+        });
+
+        let client = build_client(handle)?;
+
+        primary::spawn(async move {
+            let connect = Connect::new(server_addr).with_server_name("localhost");
+            let mut connection = client.connect(connect).await.unwrap();
+
+            for mut remaining_chunks in 0usize..2 {
+                let mut stream = connection.open_bidirectional_stream().await.unwrap();
+
+                primary::spawn(async move {
+                    stream.send(Bytes::from_static(&[42])).await.unwrap();
+                    stream.finish().unwrap();
+
+                    loop {
+                        stream.receive().await.unwrap().unwrap();
+                        if let Some(next_value) = remaining_chunks.checked_sub(1) {
+                            remaining_chunks = next_value;
+                        } else {
+                            let _ = stream.stop_sending(123u8.into());
+                            break;
+                        }
+                    }
+                });
+            }
+        });
+
+        Ok(())
+    })
+    .unwrap();
 }

--- a/quic/s2n-quic/src/tests/setup.rs
+++ b/quic/s2n-quic/src/tests/setup.rs
@@ -105,6 +105,14 @@ pub fn client(handle: &Handle, server_addr: SocketAddr) -> Result {
     Ok(())
 }
 
+pub fn build_client(handle: &Handle) -> Result<Client> {
+    Ok(Client::builder()
+        .with_io(handle.builder().build().unwrap())?
+        .with_tls(certificates::CERT_PEM)?
+        .with_event(events())?
+        .start()?)
+}
+
 pub fn client_server(handle: &Handle) -> Result<SocketAddr> {
     let addr = server(handle)?;
     client(handle, addr)?;


### PR DESCRIPTION
### Description of changes: 

This change fixes a couple of issues with streams in terminal state:

#### Drop behavior

On drop, we now detach the application from the stream, to notify the s2n-quic endpoint that the stream is no longer reachable from the application and won't have any way to receive progress updates. This ensures streams continue to make progress, even without wakers. WIthout this, it's possible for a stream to get into a state where the application isn't able to observe any updates and the stream is never cleaned up.

https://github.com/aws/s2n-quic/blob/bfe6491b3189ed7802f6582d117afab504366909/quic/s2n-quic-transport/src/stream/api.rs#L66

https://github.com/aws/s2n-quic/blob/bfe6491b3189ed7802f6582d117afab504366909/quic/s2n-quic-transport/src/stream/api.rs#L73-L75

#### Stop sending behavior

In #1217, the behavior of STOP_SENDING was modified to finalize the stream once the application indicated it was no longer interested in reading the rest of the stream. This caused an issue when the peer transmitted a RESET_STREAM in response with an indicator of how many flow control credits it needed after closing it. This causes the data flow control credits to "leak" (not memory, but they just go unaccounted) on the peer and is unable to make more progress.

https://github.com/aws/s2n-quic/blob/bfe6491b3189ed7802f6582d117afab504366909/quic/s2n-quic-transport/src/stream/receive_stream.rs#L688

#### Single chunk receive

The receive stream implementation expects that when `.poll_receive()` is called and the last chunk is read, the application needs to do another read in order to transition the state to `final_state_observed`. The problem with this assumption is that in #1094 we added stream status caching which makes it impossible for the application to notify the stream that it read the status.

https://github.com/aws/s2n-quic/blob/bfe6491b3189ed7802f6582d117afab504366909/quic/s2n-quic-transport/src/stream/receive_stream.rs#L907-L908

### Testing:

I've added an integration test to show the fix working for the given scenario.

Using the added integration test with the code in main results in it timing out:

```
thread 'tests::stream_reset_test' panicked at 'called `Result::unwrap()` on an `Err` value:
  IdleTimerExpired { source: Location { file: "quic/s2n-quic-transport/src/connection/connection_impl.rs", line: 1012, col: 24 } }',
  quic/s2n-quic/src/tests.rs:128:72
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

