### PR TITLE
feat(s2n-quic-transport): add MtuUpdated event

### DIFF
--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -244,3 +244,10 @@ struct TxStreamProgress {
 pub struct KeepAliveTimerExpired {
     timeout: Duration,
 }
+
+#[event("connectivity:mtu_updated")]
+/// The maximum transmission unit (MTU) for the path has changed
+struct MtuUpdated {
+    path_id: u64,
+    mtu: u16,
+}

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -593,6 +593,11 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             },
         });
 
+        publisher.on_mtu_updated(event::builder::MtuUpdated {
+            path_id: path_manager.active_path_id().into_event(),
+            mtu: path_manager.active_path().mtu_controller.mtu() as u16,
+        });
+
         let wakeup_handle = Arc::from(parameters.wakeup_handle);
         let waker = Waker::from(wakeup_handle.clone());
         let mut connection = Self {

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -442,6 +442,11 @@ impl<Config: endpoint::Config> Manager<Config> {
             new: path_event!(path, new_path_id),
         });
 
+        publisher.on_mtu_updated(event::builder::MtuUpdated {
+            path_id: new_path_id.into_event(),
+            mtu: path.mtu_controller.mtu() as u16,
+        });
+
         // create a new path
         if new_path_idx < self.paths.len() {
             self.paths[new_path_idx] = path;

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__adding_new_path.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__adding_new_path.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__connection_migration_challenge_behavior.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__connection_migration_challenge_behavior.snap
@@ -1,7 +1,7 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 1, is_active: true } }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__connection_migration_new_path_abandon_timer.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__connection_migration_new_path_abandon_timer.snap
@@ -1,9 +1,8 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
-assertion_line: 1118
 expression: ""
-
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 1, is_active: true } }
 PathChallengeUpdated { path_challenge_status: Abandoned, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 0, is_active: true }, challenge_data: [123, 122, 121, 120, 127, 126, 125, 124] }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__connection_migration_use_max_ack_delay_from_active_path.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__connection_migration_use_max_ack_delay_from_active_path.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__limit_number_of_connection_migrations.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__limit_number_of_connection_migrations.snap
@@ -1,13 +1,16 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:1, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:1, remote_cid: 0x01, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:1, remote_cid: 0x01, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:1, remote_cid: 0x01, id: 1, is_active: true } }
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:1, remote_cid: 0x01, id: 1, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:2, remote_cid: 0x01, id: 2, is_active: false } }
+MtuUpdated { path_id: 2, mtu: 1200 }
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:1, remote_cid: 0x01, id: 1, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:2, remote_cid: 0x01, id: 2, is_active: true } }
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:2, remote_cid: 0x01, id: 2, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:3, remote_cid: 0x01, id: 3, is_active: false } }
+MtuUpdated { path_id: 3, mtu: 1200 }
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:2, remote_cid: 0x01, id: 2, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:3, remote_cid: 0x01, id: 3, is_active: true } }
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:3, remote_cid: 0x01, id: 3, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:4, remote_cid: 0x01, id: 4, is_active: false } }
+MtuUpdated { path_id: 4, mtu: 1200 }
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:3, remote_cid: 0x01, id: 3, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:4, remote_cid: 0x01, id: 4, is_active: true } }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__temporary_until_authenticated.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__temporary_until_authenticated.snap
@@ -1,9 +1,11 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.3:8001, remote_cid: 0x01, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.3:8001, remote_cid: 0x01, id: 1, is_active: true } }
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.3:8001, remote_cid: 0x01, id: 1, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 2, is_active: false } }
+MtuUpdated { path_id: 2, mtu: 1200 }

--- a/quic/s2n-quic-transport/src/path/mtu.rs
+++ b/quic/s2n-quic-transport/src/path/mtu.rs
@@ -10,7 +10,7 @@ use core::time::Duration;
 use s2n_codec::EncoderValue;
 use s2n_quic_core::{
     counter::{Counter, Saturating},
-    frame,
+    event, frame,
     inet::SocketAddress,
     packet::number::PacketNumber,
     path::{IPV4_MIN_HEADER_LEN, IPV6_MIN_HEADER_LEN, UDP_HEADER_LEN},
@@ -179,11 +179,12 @@ impl Controller {
     //# supported, this mechanism MAY also be used by DPLPMTUD to acknowledge
     //# reception of a probe packet.
     /// This method gets called when a packet delivery got acknowledged
-    pub fn on_packet_ack<CC: CongestionController>(
+    pub fn on_packet_ack<CC: CongestionController, Pub: event::ConnectionPublisher>(
         &mut self,
         packet_number: PacketNumber,
         sent_bytes: u16,
         congestion_controller: &mut CC,
+        publisher: &mut Pub,
     ) {
         if self.state == State::Disabled || !packet_number.space().is_application_data() {
             return;
@@ -225,12 +226,13 @@ impl Controller {
     //# robust in the case where probe packets are lost due to other
     //# reasons (including link transmission error, congestion).
     /// This method gets called when a packet loss is reported
-    pub fn on_packet_loss<CC: CongestionController>(
+    pub fn on_packet_loss<CC: CongestionController, Pub: event::ConnectionPublisher>(
         &mut self,
         packet_number: PacketNumber,
         lost_bytes: u16,
         now: Timestamp,
         congestion_controller: &mut CC,
+        publisher: &mut Pub,
     ) {
         // MTU probes are only sent in application data space
         if !packet_number.space().is_application_data() {
@@ -264,7 +266,7 @@ impl Controller {
                 }
 
                 if self.black_hole_counter > BLACK_HOLE_THRESHOLD {
-                    self.on_black_hole_detected(now, congestion_controller);
+                    self.on_black_hole_detected(now, congestion_controller, publisher);
                 }
             }
         }
@@ -364,10 +366,11 @@ impl Controller {
     }
 
     /// Called when an excessive number of packets larger than the BASE_PLPMTU have been lost
-    fn on_black_hole_detected<CC: CongestionController>(
+    fn on_black_hole_detected<CC: CongestionController, Pub: event::ConnectionPublisher>(
         &mut self,
         now: Timestamp,
         congestion_controller: &mut CC,
+        publisher: &mut Pub,
     ) {
         self.black_hole_counter = Default::default();
         self.largest_acked_mtu_sized_packet = None;
@@ -435,7 +438,7 @@ mod test {
     use super::*;
     use crate::contexts::testing::{MockWriteContext, OutgoingFrameBuffer};
     use s2n_quic_core::{
-        endpoint, frame::Frame, packet::number::PacketNumberSpace,
+        endpoint, event::testing::Publisher, frame::Frame, packet::number::PacketNumberSpace,
         recovery::congestion_controller::testing::mock::CongestionController,
         time::timer::Provider as _, varint::VarInt,
     };
@@ -555,11 +558,12 @@ mod test {
         let pn = pn(1);
         let mut cc = CongestionController::default();
         let now = now();
+        let mut publisher = Publisher::snapshot();
         controller.state = State::Searching(pn, now);
         controller.probed_size = BASE_PLPMTU;
         controller.max_probe_size = BASE_PLPMTU + PROBE_THRESHOLD * 2 - 1;
 
-        controller.on_packet_ack(pn, BASE_PLPMTU, &mut cc);
+        controller.on_packet_ack(pn, BASE_PLPMTU, &mut cc, &mut publisher);
 
         assert_eq!(
             BASE_PLPMTU + (max_udp_payload - BASE_PLPMTU) / 2,
@@ -591,9 +595,10 @@ mod test {
         let pn = pn(1);
         let mut cc = CongestionController::default();
         let now = now();
+        let mut publisher = Publisher::snapshot();
         controller.state = State::Searching(pn, now);
 
-        controller.on_packet_ack(pn, controller.probed_size, &mut cc);
+        controller.on_packet_ack(pn, controller.probed_size, &mut cc, &mut publisher);
 
         assert_eq!(1472 + (max_udp_payload - 1472) / 2, controller.probed_size);
         assert_eq!(1, cc.on_mtu_update);
@@ -618,9 +623,10 @@ mod test {
         let pn = pn(1);
         let mut cc = CongestionController::default();
         let now = now();
+        let mut publisher = Publisher::snapshot();
         controller.state = State::Searching(pn, now);
 
-        controller.on_packet_ack(pn, controller.probed_size, &mut cc);
+        controller.on_packet_ack(pn, controller.probed_size, &mut cc, &mut publisher);
 
         assert_eq!(1472 + (max_udp_payload - 1472) / 2, controller.probed_size);
         assert_eq!(1, cc.on_mtu_update);
@@ -633,16 +639,17 @@ mod test {
         let mut controller = new_controller(1500 + (PROBE_THRESHOLD * 2));
         let pnum = pn(3);
         let mut cc = CongestionController::default();
+        let mut publisher = Publisher::snapshot();
         controller.enable();
 
         controller.black_hole_counter += 1;
         // ack a packet smaller than the plpmtu
-        controller.on_packet_ack(pnum, controller.plpmtu - 1, &mut cc);
+        controller.on_packet_ack(pnum, controller.plpmtu - 1, &mut cc, &mut publisher);
         assert_eq!(controller.black_hole_counter, 1);
         assert_eq!(None, controller.largest_acked_mtu_sized_packet);
 
         // ack a packet the size of the plpmtu
-        controller.on_packet_ack(pnum, controller.plpmtu, &mut cc);
+        controller.on_packet_ack(pnum, controller.plpmtu, &mut cc, &mut publisher);
         assert_eq!(controller.black_hole_counter, 0);
         assert_eq!(Some(pnum), controller.largest_acked_mtu_sized_packet);
 
@@ -650,7 +657,7 @@ mod test {
 
         // ack an older packet
         let pnum_2 = pn(2);
-        controller.on_packet_ack(pnum_2, controller.plpmtu, &mut cc);
+        controller.on_packet_ack(pnum_2, controller.plpmtu, &mut cc, &mut publisher);
         assert_eq!(controller.black_hole_counter, 1);
         assert_eq!(Some(pnum), controller.largest_acked_mtu_sized_packet);
     }
@@ -660,12 +667,13 @@ mod test {
         let mut controller = new_controller(1500 + (PROBE_THRESHOLD * 2));
         let pnum = pn(3);
         let mut cc = CongestionController::default();
+        let mut publisher = Publisher::snapshot();
 
         controller.black_hole_counter += 1;
         controller.largest_acked_mtu_sized_packet = Some(pnum);
 
         let pn = pn(10);
-        controller.on_packet_ack(pn, controller.plpmtu, &mut cc);
+        controller.on_packet_ack(pn, controller.plpmtu, &mut cc, &mut publisher);
 
         assert_eq!(State::Disabled, controller.state);
         assert_eq!(controller.black_hole_counter, 1);
@@ -677,6 +685,7 @@ mod test {
         let mut controller = new_controller(1500 + (PROBE_THRESHOLD * 2));
         let pnum = pn(3);
         let mut cc = CongestionController::default();
+        let mut publisher = Publisher::snapshot();
         controller.enable();
 
         controller.black_hole_counter += 1;
@@ -685,7 +694,7 @@ mod test {
         // on_packet_ack will be called with packet numbers from Initial and Handshake space,
         // so it should not fail in this scenario.
         let pn = PacketNumberSpace::Handshake.new_packet_number(VarInt::from_u8(10));
-        controller.on_packet_ack(pn, controller.plpmtu, &mut cc);
+        controller.on_packet_ack(pn, controller.plpmtu, &mut cc, &mut publisher);
         assert_eq!(controller.black_hole_counter, 1);
         assert_eq!(Some(pnum), controller.largest_acked_mtu_sized_packet);
     }
@@ -702,10 +711,11 @@ mod test {
         let pn = pn(1);
         let mut cc = CongestionController::default();
         let now = now();
+        let mut publisher = Publisher::snapshot();
         controller.state = State::Searching(pn, now);
         let probed_size = controller.probed_size;
 
-        controller.on_packet_loss(pn, controller.probed_size, now, &mut cc);
+        controller.on_packet_loss(pn, controller.probed_size, now, &mut cc, &mut publisher);
 
         assert_eq!(0, cc.on_mtu_update);
         assert_eq!(max_udp_payload, controller.max_probe_size);
@@ -720,11 +730,12 @@ mod test {
         let pn = pn(1);
         let mut cc = CongestionController::default();
         let now = now();
+        let mut publisher = Publisher::snapshot();
         controller.state = State::Searching(pn, now);
         controller.probe_count = MAX_PROBES;
         assert_eq!(max_udp_payload, controller.max_probe_size);
 
-        controller.on_packet_loss(pn, controller.probed_size, now, &mut cc);
+        controller.on_packet_loss(pn, controller.probed_size, now, &mut cc, &mut publisher);
 
         assert_eq!(0, cc.on_mtu_update);
         assert_eq!(1472, controller.max_probe_size);
@@ -740,6 +751,7 @@ mod test {
         let mut controller = new_controller(1500);
         let mut cc = CongestionController::default();
         let now = now();
+        let mut publisher = Publisher::snapshot();
         controller.plpmtu = 1472;
         controller.enable();
 
@@ -747,14 +759,14 @@ mod test {
             let pn = pn(i as usize);
 
             // Losing a packet the size of the BASE_PLPMTU should not increase the black_hole_counter
-            controller.on_packet_loss(pn, BASE_PLPMTU, now, &mut cc);
+            controller.on_packet_loss(pn, BASE_PLPMTU, now, &mut cc, &mut publisher);
             assert_eq!(controller.black_hole_counter, i);
 
             // Losing a packet larger than the PLPMTU should not increase the black_hole_counter
-            controller.on_packet_loss(pn, controller.plpmtu + 1, now, &mut cc);
+            controller.on_packet_loss(pn, controller.plpmtu + 1, now, &mut cc, &mut publisher);
             assert_eq!(controller.black_hole_counter, i);
 
-            controller.on_packet_loss(pn, BASE_PLPMTU + 1, now, &mut cc);
+            controller.on_packet_loss(pn, BASE_PLPMTU + 1, now, &mut cc, &mut publisher);
             if i < BLACK_HOLE_THRESHOLD {
                 assert_eq!(controller.black_hole_counter, i + 1);
             }
@@ -776,11 +788,12 @@ mod test {
         let mut controller = new_controller(1500);
         let mut cc = CongestionController::default();
         let now = now();
+        let mut publisher = Publisher::snapshot();
 
         for i in 0..BLACK_HOLE_THRESHOLD + 1 {
             let pn = pn(i as usize);
             assert_eq!(controller.black_hole_counter, 0);
-            controller.on_packet_loss(pn, BASE_PLPMTU + 1, now, &mut cc);
+            controller.on_packet_loss(pn, BASE_PLPMTU + 1, now, &mut cc, &mut publisher);
         }
 
         assert_eq!(State::Disabled, controller.state);
@@ -792,6 +805,7 @@ mod test {
     fn on_packet_loss_not_application_space() {
         let mut controller = new_controller(1500);
         let mut cc = CongestionController::default();
+        let mut publisher = Publisher::snapshot();
 
         // test the loss in each state
         for state in vec![
@@ -805,7 +819,7 @@ mod test {
                 // on_packet_loss may be called with packet numbers from Initial and Handshake space
                 // so it should not fail in this scenario.
                 let pn = PacketNumberSpace::Initial.new_packet_number(VarInt::from_u8(i));
-                controller.on_packet_loss(pn, BASE_PLPMTU + 1, now(), &mut cc);
+                controller.on_packet_loss(pn, BASE_PLPMTU + 1, now(), &mut cc, &mut publisher);
                 assert_eq!(controller.black_hole_counter, 0);
                 assert_eq!(0, cc.on_mtu_update);
             }

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_ack_disabled_controller.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_ack_disabled_controller.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-transport/src/path/mtu.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_ack_not_application_space.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_ack_not_application_space.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-transport/src/path/mtu.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_ack_resets_black_hole_counter.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_ack_resets_black_hole_counter.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-transport/src/path/mtu.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_ack_search_requested.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_ack_search_requested.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-transport/src/path/mtu.rs
+expression: ""
+---
+MtuUpdated { path_id: 0, mtu: 1472 }

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_ack_within_threshold.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_ack_within_threshold.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-transport/src/path/mtu.rs
+expression: ""
+---
+MtuUpdated { path_id: 0, mtu: 1200 }

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_ack_within_threshold_of_max_plpmtu.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_ack_within_threshold_of_max_plpmtu.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-transport/src/path/mtu.rs
+expression: ""
+---
+MtuUpdated { path_id: 0, mtu: 1472 }

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_loss.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_loss.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-transport/src/path/mtu.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_loss_black_hole.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_loss_black_hole.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-transport/src/path/mtu.rs
+expression: ""
+---
+MtuUpdated { path_id: 0, mtu: 1200 }

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_loss_disabled_controller.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_loss_disabled_controller.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-transport/src/path/mtu.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_loss_max_probes.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_loss_max_probes.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-transport/src/path/mtu.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_loss_not_application_space.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mtu__events__on_packet_loss_not_application_space.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-transport/src/path/mtu.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -502,6 +502,7 @@ impl<Config: endpoint::Config> Manager<Config> {
                     packet_number,
                     acked_packet_info.sent_bytes,
                     &mut path.congestion_controller,
+                    acked_packet_info.path_id,
                     publisher,
                 );
                 path.ecn_controller
@@ -941,6 +942,7 @@ impl<Config: endpoint::Config> Manager<Config> {
                 sent_info.sent_bytes,
                 now,
                 &mut path.congestion_controller,
+                sent_info.path_id,
                 publisher,
             );
 

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -499,6 +499,7 @@ impl<Config: endpoint::Config> Manager<Config> {
                     packet_number,
                     acked_packet_info.sent_bytes,
                     &mut path.congestion_controller,
+                    publisher,
                 );
                 path.ecn_controller
                     .on_packet_ack(acked_packet_info.time_sent, acked_packet_info.ecn);
@@ -940,6 +941,7 @@ impl<Config: endpoint::Config> Manager<Config> {
                 sent_info.sent_bytes,
                 now,
                 &mut path.congestion_controller,
+                publisher,
             );
 
             let path_id = sent_info.path_id;

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__detect_lost_packets_persistent_congestion_path_aware.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__detect_lost_packets_persistent_congestion_path_aware.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__no_rtt_update_when_receiving_packet_on_different_path.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__no_rtt_update_when_receiving_packet_on_different_path.snap
@@ -1,8 +1,8 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false }, min_rtt: 333ms, smoothed_rtt: 333ms, latest_rtt: 333ms, rtt_variance: 166.5ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 0 }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 1.5s, smoothed_rtt: 1.5s, latest_rtt: 1.5s, rtt_variance: 750ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 256 }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__on_packet_sent.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__on_packet_sent.snap
@@ -1,7 +1,7 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }
 EcnStateChanged { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, state: Unknown }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__on_packet_sent_across_multiple_paths.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__on_packet_sent_across_multiple_paths.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_congestion_controller.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_congestion_controller.snap
@@ -1,8 +1,8 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 500ms, smoothed_rtt: 500ms, latest_rtt: 500ms, rtt_variance: 250ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 128 }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 500ms, smoothed_rtt: 500ms, latest_rtt: 500ms, rtt_variance: 250ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 128 }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_pto_timer.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_pto_timer.snap
@@ -1,8 +1,8 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 500ms, smoothed_rtt: 500ms, latest_rtt: 500ms, rtt_variance: 250ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 128 }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false }, min_rtt: 500ms, smoothed_rtt: 500ms, latest_rtt: 500ms, rtt_variance: 250ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 128 }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_update_pto_timer.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_update_pto_timer.snap
@@ -1,8 +1,8 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 500ms, smoothed_rtt: 500ms, latest_rtt: 500ms, rtt_variance: 250ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 128 }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 500ms, smoothed_rtt: 500ms, latest_rtt: 500ms, rtt_variance: 250ms, max_ack_delay: 100ms, pto_count: 1, congestion_window: 15000, bytes_in_flight: 128 }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__remove_lost_packets_persistent_congestion_path_aware.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__remove_lost_packets_persistent_congestion_path_aware.snap
@@ -1,9 +1,9 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }
 PacketLost { packet_header: OneRtt { number: 9 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: true }, bytes_lost: 1, is_mtu_probe: false }
 PacketLost { packet_header: OneRtt { number: 9 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false }, bytes_lost: 1, is_mtu_probe: false }
 Congestion { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false }, source: PacketLoss }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__rtt_update_when_receiving_ack_from_multiple_paths.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__rtt_update_when_receiving_ack_from_multiple_paths.snap
@@ -1,7 +1,7 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200 }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 700ms, smoothed_rtt: 700ms, latest_rtt: 700ms, rtt_variance: 350ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 128 }


### PR DESCRIPTION
### Description of changes: 

This change introduces an `MtuUpdated` event that is recorded whenever the MTU for a path changes, or when the path is initialized with the minimum QUIC MTU.

### Call-outs:

I used `path_id` instead of `Path` in the event since the recovery manager mutably borrows the path to call the MTU controller, so I wasn't able to pass a path event to the MTU controller as well.

### Testing:

Snapshot tests

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

