### PR TITLE
fix(netbench): allow local ip arg to be set from an environment variable

### DIFF
--- a/netbench/netbench-driver/src/lib.rs
+++ b/netbench/netbench-driver/src/lib.rs
@@ -69,7 +69,7 @@ pub struct Client {
     #[structopt(long, default_value = "netbench")]
     pub application_protocols: Vec<String>,
 
-    #[structopt(short, long, default_value = "::")]
+    #[structopt(short, long, default_value = "::", env = "LOCAL_IP")]
     pub local_ip: IpAddr,
 
     #[structopt(long, default_value = "0", env = "CLIENT_ID")]


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.-->

Currently, the local_ip argument for clients must be passed in with `--local-ip`. However, when running a driver with netbench collector, passing this argument is not possible. This PR allows for this argument to be set with the `LOCAL_IP` environment variable.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

None

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

