### PR TITLE
build(duvet): Add Github action for Duvet

### DIFF
--- a/.github/actions/duvet/README.md
+++ b/.github/actions/duvet/README.md
@@ -1,0 +1,60 @@
+# duvet-action
+
+This action builds and installs [Duvet](https://github.com/aws/s2n-quic/tree/main/common/duvet), generates a compliance report via a provided script, and publishes the result to an S3 bucket.
+
+# Usage
+
+### `report-script: ''`
+
+Path to a script that generates a Duvet report. See `duvet report --help` for more information about generating reports. The action expects the report to be generated to `report-path`.
+
+The script will be passed `github.sha` in the first argument, which can be used with the `--blob-link` Duvet argument.
+
+### `report-path: '''`
+
+Path to the output report generated in `report-script`. Defaults to `report.html` in the same directory that `report-script` is in.
+
+### `aws-access-key-id: ''`
+
+An AWS access key. The corresponding user must have S3 write permissions.
+
+### `aws-secret-access-key: ''`
+
+The AWS secret key.
+
+### `aws-s3-bucket-name: ''`
+
+The name of the destination S3 bucket which the report will be uploaded to.
+
+### `cdn: ''`
+
+An optional CDN which will prefix the published S3 URL in the `compliance / report` Github check.
+
+### `s2n-quic-dir: ''`
+
+Path to the directory where s2n-quic is cloned. Used for repositories other than s2n-quic, which first clone s2n-quic to call this action.
+
+
+## Example usage:
+
+```yml
+jobs:
+  duvet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3
+        with:
+          repository: aws/s2n-quic
+          path: ./s2n-quic
+          submodules: true
+      - uses: ./s2n-quic/.github/actions/duvet
+        with:
+          s2n-quic-dir: ./s2n-quic
+          report-script: compliance/generate_report.sh
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-s3-bucket-name: s2n-tls-ci-artifacts
+          aws-s3-region: us-west-2
+          cdn: https://d3fqnyekunr9xg.cloudfront.net
+```

--- a/.github/actions/duvet/action.yml
+++ b/.github/actions/duvet/action.yml
@@ -1,0 +1,105 @@
+name: 'Duvet'
+description: 'Uses Duvet to generate a compliance report and uploads it to S3'
+inputs:
+  report-script:
+    description: 'Path to script that generates a Duvet report'
+    required: true
+  report-path:
+    description: 'Path to generated Duvet report output'
+    required: false
+  aws-access-key-id:
+    description: 'AWS access key ID with S3 permissions'
+    required: true
+  aws-secret-access-key:
+    description: 'AWS secret key'
+    required: true
+  aws-s3-bucket-name:
+    description: 'Destination S3 bucket name for duvet reports'
+    required: true
+  aws-s3-region:
+    description: 'S3 bucket region'
+    required: true
+  cdn:
+    description: 'Prefix the S3 URL with a CDN'
+    required: false
+  s2n-quic-dir:
+    description: 'Path to the directory where s2n-quic is cloned'
+    default: ${{ github.workspace }}
+    required: false
+runs:
+  using: "composite"
+  steps:
+    - uses: actions-rs/toolchain@v1.0.7
+      id: toolchain
+      with:
+        toolchain: stable
+        override: true
+
+    - uses: camshaft/rust-cache@v1
+
+    - name: Clean up cache
+      working-directory: ${{ inputs.s2n-quic-dir }}
+      run: |
+        rm -f target/release/duvet
+        rm -f common/duvet/target/release/duvet
+      shell: bash
+
+    - name: Cache duvet
+      uses: actions/cache@v3.0.3
+      continue-on-error: true
+      with:
+        path: ${{ inputs.s2n-quic-dir }}/target/release/duvet
+        key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ github.job }}-duvet-${{ hashFiles(format('{0}/**/Cargo.lock', inputs.s2n-quic-dir)) }}-${{ hashFiles(format('{0}/common/duvet/**', inputs.s2n-quic-dir)) }}
+
+    - name: Install duvet
+      working-directory: ${{ inputs.s2n-quic-dir }}/common/duvet
+      run: |
+        if [ ! -f ../../target/release/duvet ]; then
+          mkdir -p ../../target/release
+          cargo build --release
+          cp target/release/duvet ../../target/release/duvet
+        fi
+        
+        echo "${{ inputs.s2n-quic-dir }}/target/release" >> $GITHUB_PATH
+      shell: bash
+
+    - name: Generate Duvet report
+      run: ${{ inputs.report-script }} ${{ github.sha }}
+      shell: bash
+
+    - uses: aws-actions/configure-aws-credentials@v1.6.1
+      if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key}}
+        aws-region: ${{ inputs.aws-s3-region }}
+
+    - name: Upload to S3
+      if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+      id: s3
+      run: |
+        if [ -n "${{ inputs.report-path }}" ]; then
+          REPORT_PATH="${{ inputs.report-path }}"
+        else
+          REPORT_PATH=$(dirname "${{ inputs.report-script }}")/report.html
+        fi
+        
+        TARGET="${{ github.sha }}/compliance.html"
+        aws s3 cp "$REPORT_PATH" "s3://${{ inputs.aws-s3-bucket-name }}/$TARGET" --acl private --follow-symlinks
+        
+        if [ -n "${{ inputs.cdn }}" ]; then
+          PREFIX="${{ inputs.cdn }}"
+        else
+          PREFIX="https://${{ inputs.aws-s3-bucket-name }}.s3.amazonaws.com"
+        fi
+        URL="$PREFIX/$TARGET"
+        
+        echo "::set-output name=URL::$URL"
+      shell: bash
+
+    - uses: ouzi-dev/commit-status-updater@v1.1.2
+      if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+      with:
+        name: "compliance / report"
+        status: "success"
+        url: ${{ steps.s3.outputs.URL }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,61 +311,15 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
-
-      - uses: actions-rs/toolchain@v1.0.7
-        id: toolchain
+      - uses: ./.github/actions/duvet
         with:
-          toolchain: stable
-          override: true
-
-      - uses: camshaft/rust-cache@v1
-
-      - name: Clean up cache
-        run: |
-          rm -f target/release/duvet
-          rm -f common/duvet/target/release/duvet
-
-      - name: Cache duvet
-        uses: actions/cache@v3.0.3
-        continue-on-error: true
-        with:
-          path: target/release/duvet
-          key: ${{ runner.os }}-${{ steps.toolchain.outputs.rustc_hash }}-${{ github.job }}-duvet-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('common/duvet/**') }}
-
-      - name: Build duvet
-        working-directory: common/duvet
-        run: |
-          if [ ! -f ../../target/release/duvet ]; then
-            mkdir -p ../../target/release
-            cargo build --release
-            cp target/release/duvet ../../target/release/duvet
-          fi
-
-      - name: Run duvet
-        run: ./scripts/compliance ${{ github.sha }}
-
-      - uses: aws-actions/configure-aws-credentials@v1.6.1
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
-        with:
+          report-script: ./scripts/compliance
+          report-path: ./target/compliance/report.html
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
-
-      - name: Upload to S3
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
-        id: s3
-        run: |
-          TARGET="${{ github.sha }}/compliance.html"
-          aws s3 cp target/compliance/report.html "s3://s2n-quic-ci-artifacts/$TARGET" --acl private --follow-symlinks
-          URL="$CDN/$TARGET"
-          echo "::set-output name=URL::$URL"
-
-      - uses: ouzi-dev/commit-status-updater@v1.1.2
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
-        with:
-          name: "compliance / report"
-          status: "success"
-          url: "${{ steps.s3.outputs.URL }}"
+          aws-s3-bucket-name: s2n-quic-ci-artifacts
+          aws-s3-region: us-west-1
+          cdn: $CDN
 
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.-->

Currently, s2n-quic generates Duvet reports in the ci.yml Github workflow. As a workflow, this functionality is restricted to s2n-quic only. This PR refactors this workflow into a new Duvet Github action, which allows for other repositories to clone s2n-quic and run Duvet in their CIs as well.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

None

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

