### PR TITLE
feat(s2n-quic-core): Add SlowStartExited event

### DIFF
--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -439,6 +439,8 @@ pub mod api {
         #[non_exhaustive]
         Ecn {},
         #[non_exhaustive]
+        Rtt {},
+        #[non_exhaustive]
         Other {},
     }
     #[derive(Clone, Debug)]
@@ -2726,6 +2728,7 @@ pub mod builder {
     pub enum SlowStartExitCause {
         PacketLoss,
         Ecn,
+        Rtt,
         Other,
     }
     impl IntoEvent<api::SlowStartExitCause> for SlowStartExitCause {
@@ -2735,6 +2738,7 @@ pub mod builder {
             match self {
                 Self::PacketLoss => PacketLoss {},
                 Self::Ecn => Ecn {},
+                Self::Rtt => Rtt {},
                 Self::Other => Other {},
             }
         }

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -435,12 +435,20 @@ pub mod api {
     #[doc = " The reason the slow start congestion controller state has been exited"]
     pub enum SlowStartExitCause {
         #[non_exhaustive]
+        #[doc = " A packet was determined lost"]
         PacketLoss {},
         #[non_exhaustive]
+        #[doc = " An Explicit Congestion Notification: Congestion Experienced marking was received"]
         Ecn {},
         #[non_exhaustive]
+        #[doc = " The round trip time estimate was updated"]
         Rtt {},
         #[non_exhaustive]
+        #[doc = " Slow Start exited due to a reason other than those above"]
+        #[doc = ""]
+        #[doc = " With the Cubic congestion controller, this reason is used after the initial exiting of"]
+        #[doc = " Slow Start, when the previously determined Slow Start threshold is exceed by the"]
+        #[doc = " congestion window."]
         Other {},
     }
     #[derive(Clone, Debug)]
@@ -2726,9 +2734,17 @@ pub mod builder {
     #[derive(Clone, Debug)]
     #[doc = " The reason the slow start congestion controller state has been exited"]
     pub enum SlowStartExitCause {
+        #[doc = " A packet was determined lost"]
         PacketLoss,
+        #[doc = " An Explicit Congestion Notification: Congestion Experienced marking was received"]
         Ecn,
+        #[doc = " The round trip time estimate was updated"]
         Rtt,
+        #[doc = " Slow Start exited due to a reason other than those above"]
+        #[doc = ""]
+        #[doc = " With the Cubic congestion controller, this reason is used after the initial exiting of"]
+        #[doc = " Slow Start, when the previously determined Slow Start threshold is exceed by the"]
+        #[doc = " congestion window."]
         Other,
     }
     impl IntoEvent<api::SlowStartExitCause> for SlowStartExitCause {

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -776,7 +776,7 @@ pub mod api {
         pub congestion_window: u32,
     }
     impl<'a> Event for SlowStartExited<'a> {
-        const NAME: &'static str = "connectivity:slow_start_exited";
+        const NAME: &'static str = "recovery:slow_start_exited";
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -432,6 +432,17 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
+    #[doc = " The reason the slow start congestion controller state has been exited"]
+    pub enum SlowStartExitCause {
+        #[non_exhaustive]
+        PacketLoss {},
+        #[non_exhaustive]
+        Ecn {},
+        #[non_exhaustive]
+        Other {},
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
     #[doc = " Application level protocol"]
     pub struct ApplicationProtocolInformation<'a> {
         pub chosen_application_protocol: &'a [u8],
@@ -755,6 +766,17 @@ pub mod api {
     }
     impl Event for MtuUpdated {
         const NAME: &'static str = "connectivity:mtu_updated";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " The slow start congestion controller state has been exited"]
+    pub struct SlowStartExited<'a> {
+        pub path: Path<'a>,
+        pub cause: SlowStartExitCause,
+        pub congestion_window: u32,
+    }
+    impl<'a> Event for SlowStartExited<'a> {
+        const NAME: &'static str = "connectivity:slow_start_exited";
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
@@ -1741,6 +1763,21 @@ pub mod tracing {
             tracing :: event ! (target : "mtu_updated" , parent : id , tracing :: Level :: DEBUG , path_id = tracing :: field :: debug (path_id) , mtu = tracing :: field :: debug (mtu));
         }
         #[inline]
+        fn on_slow_start_exited(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            _meta: &api::ConnectionMeta,
+            event: &api::SlowStartExited,
+        ) {
+            let id = context.id();
+            let api::SlowStartExited {
+                path,
+                cause,
+                congestion_window,
+            } = event;
+            tracing :: event ! (target : "slow_start_exited" , parent : id , tracing :: Level :: DEBUG , path = tracing :: field :: debug (path) , cause = tracing :: field :: debug (cause) , congestion_window = tracing :: field :: debug (congestion_window));
+        }
+        #[inline]
         fn on_version_information(
             &mut self,
             meta: &api::EndpointMeta,
@@ -2685,6 +2722,24 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
+    #[doc = " The reason the slow start congestion controller state has been exited"]
+    pub enum SlowStartExitCause {
+        PacketLoss,
+        Ecn,
+        Other,
+    }
+    impl IntoEvent<api::SlowStartExitCause> for SlowStartExitCause {
+        #[inline]
+        fn into_event(self) -> api::SlowStartExitCause {
+            use api::SlowStartExitCause::*;
+            match self {
+                Self::PacketLoss => PacketLoss {},
+                Self::Ecn => Ecn {},
+                Self::Other => Other {},
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
     #[doc = " Application level protocol"]
     pub struct ApplicationProtocolInformation<'a> {
         pub chosen_application_protocol: &'a [u8],
@@ -3246,6 +3301,28 @@ pub mod builder {
             api::MtuUpdated {
                 path_id: path_id.into_event(),
                 mtu: mtu.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " The slow start congestion controller state has been exited"]
+    pub struct SlowStartExited<'a> {
+        pub path: Path<'a>,
+        pub cause: SlowStartExitCause,
+        pub congestion_window: u32,
+    }
+    impl<'a> IntoEvent<api::SlowStartExited<'a>> for SlowStartExited<'a> {
+        #[inline]
+        fn into_event(self) -> api::SlowStartExited<'a> {
+            let SlowStartExited {
+                path,
+                cause,
+                congestion_window,
+            } = self;
+            api::SlowStartExited {
+                path: path.into_event(),
+                cause: cause.into_event(),
+                congestion_window: congestion_window.into_event(),
             }
         }
     }
@@ -4085,6 +4162,18 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
+        #[doc = "Called when the `SlowStartExited` event is triggered"]
+        #[inline]
+        fn on_slow_start_exited(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            meta: &ConnectionMeta,
+            event: &SlowStartExited,
+        ) {
+            let _ = context;
+            let _ = meta;
+            let _ = event;
+        }
         #[doc = "Called when the `VersionInformation` event is triggered"]
         #[inline]
         fn on_version_information(&mut self, meta: &EndpointMeta, event: &VersionInformation) {
@@ -4626,6 +4715,16 @@ mod traits {
             (self.1).on_mtu_updated(&mut context.1, meta, event);
         }
         #[inline]
+        fn on_slow_start_exited(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            meta: &ConnectionMeta,
+            event: &SlowStartExited,
+        ) {
+            (self.0).on_slow_start_exited(&mut context.0, meta, event);
+            (self.1).on_slow_start_exited(&mut context.1, meta, event);
+        }
+        #[inline]
         fn on_version_information(&mut self, meta: &EndpointMeta, event: &VersionInformation) {
             (self.0).on_version_information(meta, event);
             (self.1).on_version_information(meta, event);
@@ -4992,6 +5091,8 @@ mod traits {
         fn on_keep_alive_timer_expired(&mut self, event: builder::KeepAliveTimerExpired);
         #[doc = "Publishes a `MtuUpdated` event to the publisher's subscriber"]
         fn on_mtu_updated(&mut self, event: builder::MtuUpdated);
+        #[doc = "Publishes a `SlowStartExited` event to the publisher's subscriber"]
+        fn on_slow_start_exited(&mut self, event: builder::SlowStartExited);
         #[doc = r" Returns the QUIC version negotiated for the current connection, if any"]
         fn quic_version(&self) -> u32;
         #[doc = r" Returns the [`Subject`] for the current publisher"]
@@ -5332,6 +5433,15 @@ mod traits {
             self.subscriber.on_event(&self.meta, &event);
         }
         #[inline]
+        fn on_slow_start_exited(&mut self, event: builder::SlowStartExited) {
+            let event = event.into_event();
+            self.subscriber
+                .on_slow_start_exited(self.context, &self.meta, &event);
+            self.subscriber
+                .on_connection_event(self.context, &self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
         fn quic_version(&self) -> u32 {
             self.quic_version
         }
@@ -5381,6 +5491,7 @@ pub mod testing {
         pub tx_stream_progress: u32,
         pub keep_alive_timer_expired: u32,
         pub mtu_updated: u32,
+        pub slow_start_exited: u32,
         pub version_information: u32,
         pub endpoint_packet_sent: u32,
         pub endpoint_packet_received: u32,
@@ -5452,6 +5563,7 @@ pub mod testing {
                 tx_stream_progress: 0,
                 keep_alive_timer_expired: 0,
                 mtu_updated: 0,
+                slow_start_exited: 0,
                 version_information: 0,
                 endpoint_packet_sent: 0,
                 endpoint_packet_received: 0,
@@ -5840,6 +5952,17 @@ pub mod testing {
                 self.output.push(format!("{:?} {:?}", meta, event));
             }
         }
+        fn on_slow_start_exited(
+            &mut self,
+            _context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &api::SlowStartExited,
+        ) {
+            self.slow_start_exited += 1;
+            if self.location.is_some() {
+                self.output.push(format!("{:?} {:?}", meta, event));
+            }
+        }
         fn on_version_information(
             &mut self,
             meta: &api::EndpointMeta,
@@ -5974,6 +6097,7 @@ pub mod testing {
         pub tx_stream_progress: u32,
         pub keep_alive_timer_expired: u32,
         pub mtu_updated: u32,
+        pub slow_start_exited: u32,
         pub version_information: u32,
         pub endpoint_packet_sent: u32,
         pub endpoint_packet_received: u32,
@@ -6035,6 +6159,7 @@ pub mod testing {
                 tx_stream_progress: 0,
                 keep_alive_timer_expired: 0,
                 mtu_updated: 0,
+                slow_start_exited: 0,
                 version_information: 0,
                 endpoint_packet_sent: 0,
                 endpoint_packet_received: 0,
@@ -6363,6 +6488,13 @@ pub mod testing {
         }
         fn on_mtu_updated(&mut self, event: builder::MtuUpdated) {
             self.mtu_updated += 1;
+            let event = event.into_event();
+            if self.location.is_some() {
+                self.output.push(format!("{:?}", event));
+            }
+        }
+        fn on_slow_start_exited(&mut self, event: builder::SlowStartExited) {
+            self.slow_start_exited += 1;
             let event = event.into_event();
             if self.location.is_some() {
                 self.output.push(format!("{:?}", event));

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -119,7 +119,12 @@ impl CongestionController for BbrCongestionController {
             .on_packet_sent(*self.bytes_in_flight, app_limited, time_sent)
     }
 
-    fn on_rtt_update(&mut self, _time_sent: Timestamp, _rtt_estimator: &RttEstimator) {
+    fn on_rtt_update(
+        &mut self,
+        _time_sent: Timestamp,
+        _now: Timestamp,
+        _rtt_estimator: &RttEstimator,
+    ) {
         todo!()
     }
 

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -92,6 +92,10 @@ impl CongestionController for BbrCongestionController {
         todo!()
     }
 
+    fn is_slow_start(&self) -> bool {
+        todo!()
+    }
+
     fn requires_fast_retransmission(&self) -> bool {
         self.recovery_state.requires_fast_retransmission()
     }

--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -274,6 +274,7 @@ pub mod testing {
             pub requires_fast_retransmission: bool,
             pub loss_bursts: u32,
             pub app_limited: Option<bool>,
+            pub slow_start: bool,
         }
 
         impl Default for CongestionController {
@@ -291,6 +292,7 @@ pub mod testing {
                     requires_fast_retransmission: false,
                     loss_bursts: 0,
                     app_limited: None,
+                    slow_start: true,
                 }
             }
         }
@@ -311,7 +313,7 @@ pub mod testing {
             }
 
             fn is_slow_start(&self) -> bool {
-                false
+                self.slow_start
             }
 
             fn requires_fast_retransmission(&self) -> bool {
@@ -369,6 +371,7 @@ pub mod testing {
 
             fn on_congestion_event(&mut self, _event_time: Timestamp) {
                 self.congestion_events += 1;
+                self.slow_start = false;
             }
 
             fn on_mtu_update(&mut self, _max_data_size: u16) {

--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -52,6 +52,9 @@ pub trait CongestionController: 'static + Clone + Send + Debug {
     /// bytes in flight
     fn is_congestion_limited(&self) -> bool;
 
+    /// Returns `true` if the congestion controller is in the "Slow Start" state
+    fn is_slow_start(&self) -> bool;
+
     /// Returns `true` if the current state of the congestion controller
     /// requires a packet to be transmitted without respecting the
     /// available congestion window
@@ -182,6 +185,10 @@ pub mod testing {
                 false
             }
 
+            fn is_slow_start(&self) -> bool {
+                false
+            }
+
             fn requires_fast_retransmission(&self) -> bool {
                 false
             }
@@ -301,6 +308,10 @@ pub mod testing {
 
             fn is_congestion_limited(&self) -> bool {
                 self.requires_fast_retransmission || self.bytes_in_flight >= self.congestion_window
+            }
+
+            fn is_slow_start(&self) -> bool {
+                false
             }
 
             fn requires_fast_retransmission(&self) -> bool {

--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -82,7 +82,7 @@ pub trait CongestionController: 'static + Clone + Send + Debug {
 
     /// Invoked each time the round trip time is updated, which is whenever the
     /// newest acknowledged packet in an ACK frame is newly acknowledged
-    fn on_rtt_update(&mut self, time_sent: Timestamp, rtt_estimator: &RttEstimator);
+    fn on_rtt_update(&mut self, time_sent: Timestamp, now: Timestamp, rtt_estimator: &RttEstimator);
 
     /// Invoked when an acknowledgement of one or more previously unacknowledged packets is received
     ///
@@ -203,7 +203,13 @@ pub mod testing {
                 PacketInfo(())
             }
 
-            fn on_rtt_update(&mut self, _time_sent: Timestamp, _rtt_estimator: &RttEstimator) {}
+            fn on_rtt_update(
+                &mut self,
+                _time_sent: Timestamp,
+                _now: Timestamp,
+                _rtt_estimator: &RttEstimator,
+            ) {
+            }
 
             fn on_ack<Rnd: random::Generator>(
                 &mut self,
@@ -333,7 +339,12 @@ pub mod testing {
                 PacketInfo(())
             }
 
-            fn on_rtt_update(&mut self, _time_sent: Timestamp, _rtt_estimator: &RttEstimator) {
+            fn on_rtt_update(
+                &mut self,
+                _time_sent: Timestamp,
+                _now: Timestamp,
+                _rtt_estimator: &RttEstimator,
+            ) {
                 self.on_rtt_update += 1
             }
 

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -247,7 +247,12 @@ impl CongestionController for CubicCongestionController {
     }
 
     #[inline]
-    fn on_rtt_update(&mut self, time_sent: Timestamp, rtt_estimator: &RttEstimator) {
+    fn on_rtt_update(
+        &mut self,
+        time_sent: Timestamp,
+        now: Timestamp,
+        rtt_estimator: &RttEstimator,
+    ) {
         // Update the Slow Start algorithm each time the RTT
         // estimate is updated to find the slow start threshold.
         self.slow_start.on_rtt_update(
@@ -257,6 +262,19 @@ impl CongestionController for CubicCongestionController {
                 .expect("At least one packet must be sent to update RTT"),
             rtt_estimator.latest_rtt(),
         );
+
+        if self.is_slow_start() && self.congestion_window >= self.slow_start.threshold {
+            //= https://www.rfc-editor.org/rfc/rfc8312#section-4.8
+            //# In the case when CUBIC runs the hybrid slow start [HR08], it may exit
+            //# the first slow start without incurring any packet loss and thus W_max
+            //# is undefined.  In this special case, CUBIC switches to congestion
+            //# avoidance and increases its congestion window size using Eq. 1, where
+            //# t is the elapsed time since the beginning of the current congestion
+            //# avoidance, K is set to 0, and W_max is set to the congestion window
+            //# size at the beginning of the current congestion avoidance.
+            self.state = State::congestion_avoidance(now);
+            self.cubic.on_slow_start_exit(self.congestion_window);
+        }
     }
 
     #[inline]
@@ -327,14 +345,8 @@ impl CongestionController for CubicCongestionController {
                 .min(max_cwnd);
 
                 if self.congestion_window >= self.slow_start.threshold {
-                    //= https://www.rfc-editor.org/rfc/rfc8312#section-4.8
-                    //# In the case when CUBIC runs the hybrid slow start [HR08], it may exit
-                    //# the first slow start without incurring any packet loss and thus W_max
-                    //# is undefined.  In this special case, CUBIC switches to congestion
-                    //# avoidance and increases its congestion window size using Eq. 1, where
-                    //# t is the elapsed time since the beginning of the current congestion
-                    //# avoidance, K is set to 0, and W_max is set to the congestion window
-                    //# size at the beginning of the current congestion avoidance.
+                    // The congestion window has exceeded a previously determined slow start threshold
+                    // so transition to congestion avoidance and notify cubic of the slow start exit
                     self.state = State::congestion_avoidance(ack_receive_time);
                     self.cubic.on_slow_start_exit(self.congestion_window);
                 }

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -187,6 +187,11 @@ impl CongestionController for CubicCongestionController {
     }
 
     #[inline]
+    fn is_slow_start(&self) -> bool {
+        matches!(self.state, SlowStart)
+    }
+
+    #[inline]
     fn requires_fast_retransmission(&self) -> bool {
         matches!(self.state, Recovery(_, RequiresTransmission))
     }

--- a/quic/s2n-quic-core/src/recovery/cubic/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic/tests.rs
@@ -238,7 +238,9 @@ fn on_packet_sent() {
     //# distance networks.
 
     // Round one of hybrid slow start
-    cc.on_rtt_update(now, &rtt_estimator);
+    cc.on_rtt_update(now, now, &rtt_estimator);
+
+    assert!(cc.is_slow_start());
 
     // Latest RTT is 200ms
     rtt_estimator.update_rtt(
@@ -253,12 +255,18 @@ fn on_packet_sent() {
     cc.on_packet_sent(now + Duration::from_secs(20), 1, None, &rtt_estimator);
 
     assert_eq!(cc.bytes_in_flight, 2);
+    assert!(cc.is_slow_start());
 
     // Round two of hybrid slow start
     for _i in 1..=8 {
-        cc.on_rtt_update(now + Duration::from_secs(10), &rtt_estimator);
+        cc.on_rtt_update(
+            now + Duration::from_secs(10),
+            now + Duration::from_secs(10),
+            &rtt_estimator,
+        );
     }
 
+    assert!(!cc.is_slow_start());
     assert_delta!(cc.slow_start.threshold, 100_000.0, 0.001);
 }
 

--- a/quic/s2n-quic-core/src/recovery/cubic/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic/tests.rs
@@ -657,6 +657,7 @@ fn on_packet_lost_persistent_congestion() {
 
     cc.on_packet_lost(100, (), true, false, random, now);
 
+    assert!(cc.is_slow_start());
     assert_eq!(cc.state, SlowStart);
     assert_delta!(cc.congestion_window, cc.cubic.minimum_window(), 0.001);
     assert_delta!(cc.cubic.w_max, 0.0, 0.001);

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -768,5 +768,6 @@ enum PathChallengeStatus {
 enum SlowStartExitCause {
     PacketLoss,
     Ecn,
+    Rtt,
     Other,
 }

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -766,8 +766,16 @@ enum PathChallengeStatus {
 
 /// The reason the slow start congestion controller state has been exited
 enum SlowStartExitCause {
+    /// A packet was determined lost
     PacketLoss,
+    /// An Explicit Congestion Notification: Congestion Experienced marking was received
     Ecn,
+    /// The round trip time estimate was updated
     Rtt,
+    /// Slow Start exited due to a reason other than those above
+    ///
+    /// With the Cubic congestion controller, this reason is used after the initial exiting of
+    /// Slow Start, when the previously determined Slow Start threshold is exceed by the
+    /// congestion window.
     Other,
 }

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -763,3 +763,10 @@ enum PathChallengeStatus {
     Validated,
     Abandoned,
 }
+
+/// The reason the slow start congestion controller state has been exited
+enum SlowStartExitCause {
+    PacketLoss,
+    Ecn,
+    Other,
+}

--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -252,7 +252,7 @@ struct MtuUpdated {
     mtu: u16,
 }
 
-#[event("connectivity:slow_start_exited")]
+#[event("recovery:slow_start_exited")]
 /// The slow start congestion controller state has been exited
 struct SlowStartExited<'a> {
     path: Path<'a>,

--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -251,3 +251,11 @@ struct MtuUpdated {
     path_id: u64,
     mtu: u16,
 }
+
+#[event("connectivity:slow_start_exited")]
+/// The slow start congestion controller state has been exited
+struct SlowStartExited<'a> {
+    path: Path<'a>,
+    cause: SlowStartExitCause,
+    congestion_window: u32,
+}

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_process_ecn.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_process_ecn.snap
@@ -1,12 +1,12 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 EcnStateChanged { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, state: Unknown }
 PacketLost { packet_header: OneRtt { number: 1 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, bytes_lost: 128, is_mtu_probe: false }
 Congestion { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, source: PacketLoss }
 EcnStateChanged { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, state: Capable }
+SlowStartExited { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, cause: Ecn, congestion_window: 15000 }
 Congestion { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, source: Ecn }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 500ms, smoothed_rtt: 500ms, latest_rtt: 500ms, rtt_variance: 250ms, max_ack_delay: 10ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 1152 }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 500ms, smoothed_rtt: 500ms, latest_rtt: 500ms, rtt_variance: 187.5ms, max_ack_delay: 10ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 1152 }


### PR DESCRIPTION
### Description of changes: 

This change introduces a new event `SlowStartExited` that can be used to determine the timing, cause, and congestion window size at the time the "Slow Start" phase of the congestion controller is exited.

### Call-outs:

The slow start state may be re-entered (and subsequently exited) after persistent congestion is experienced, so applications that are not interested in recording `SlowStartExited` events after the initial slow start will need to ensure the metric is recorded only once per connection. 

### Testing:

Snapshot test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

