### PR TITLE
feat(s2n-quic-core): use random generator to determine next bandwidth probe in BBRv2

### DIFF
--- a/quic/s2n-quic-core/src/random.rs
+++ b/quic/s2n-quic-core/src/random.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use core::ops::RangeInclusive;
+
 /// A generator of random data. The two methods provide the same functionality for
 /// different use cases. One for "public" randomly generated data that may appear
 /// in the clear, and one for "private" data that should remain secret. This approach
@@ -14,6 +16,27 @@ pub trait Generator: 'static + Send {
     /// Fills `dest` with unpredictable bits that will only be
     /// used internally within the endpoint, remaining secret.
     fn private_random_fill(&mut self, dest: &mut [u8]);
+}
+
+/// Generates a random usize within the given inclusive range
+///
+/// NOTE: This will have slight bias towards the lower end of the range. Usages that
+/// require uniform sampling should implement rejection sampling or other methodologies
+/// and not copy this implementation.
+pub(crate) fn gen_range_biased<R: Generator>(
+    random_generator: &mut R,
+    range: RangeInclusive<usize>,
+) -> usize {
+    if range.start() == range.end() {
+        return *range.start();
+    }
+
+    let mut dest = [0; core::mem::size_of::<usize>()];
+    random_generator.public_random_fill(&mut dest);
+    let result = usize::from_le_bytes(dest);
+
+    let max_variance = (range.end() - range.start()).saturating_add(1);
+    range.start() + result % max_variance
 }
 
 #[cfg(any(test, feature = "testing"))]
@@ -43,5 +66,27 @@ pub mod testing {
 
             self.0 = self.0.wrapping_add(1)
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::random;
+
+    #[test]
+    #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
+    fn gen_range_biased_test() {
+        bolero::check!()
+            .with_type()
+            .cloned()
+            .for_each(|(seed, mut min, mut max)| {
+                if min > max {
+                    core::mem::swap(&mut min, &mut max);
+                }
+                let mut generator = random::testing::Generator(seed);
+                let result = random::gen_range_biased(&mut generator, min..=max);
+                assert!(result >= min);
+                assert!(result <= max);
+            });
     }
 }

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
@@ -303,17 +303,23 @@ impl State {
         self.cycle_phase = CyclePhase::Down;
     }
 
-    fn pick_probe_wait<Rnd: random::Generator>(&mut self, _random_generator: &mut Rnd) {
+    /// Randomly determine how long to wait before probing again
+    ///
+    /// Note: This uses a method for determining a number in a random range that has a very slight
+    ///       bias. In practice, this bias should not result in a detectable impact to BBR performance.
+    fn pick_probe_wait<Rnd: random::Generator>(&mut self, random_generator: &mut Rnd) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.5.3
         //# BBRPickProbeWait()
-
-        // TODO:
-        //     /* Decide random round-trip bound for wait: */
-        //     BBR.rounds_since_bw_probe = random_int_between(0, 1); /* 0 or 1 */
-        //     /* Decide the random wall clock bound for wait: */
-        //     BBR.bw_probe_wait = 2sec + random_float_between(0.0, 1.0) /* 0..1 sec */
-        self.rounds_since_bw_probe = Counter::default();
-        self.bw_probe_wait = Duration::from_secs(2);
+        //#    /* Decide random round-trip bound for wait: */
+        //#     BBR.rounds_since_bw_probe =
+        //#       random_int_between(0, 1); /* 0 or 1 */
+        //#     /* Decide the random wall clock bound for wait: */
+        //#     BBR.bw_probe_wait =
+        //#       2sec + random_float_between(0.0, 1.0) /* 0..1 sec */
+        self.rounds_since_bw_probe
+            .set(random::gen_range_biased(random_generator, 0..=1) as u8);
+        self.bw_probe_wait =
+            Duration::from_millis(random::gen_range_biased(random_generator, 2000..=3000) as u64);
     }
 }
 


### PR DESCRIPTION
### Description of changes: 

This change uses the random generator added to the congestion controller in #1317 to determine the next time for probing bandwidth in BBRv2.

### Call-outs:

I've moved the `gen_range_biased` method from the stateless reset code to `random.rs`, but made it `pub(crate)` to limit usage to just `s2n-quic-core`. I think that is reasonable to avoid duplicating this code, while still limiting usage of a potentially mis-usable method.  

### Testing:

Existing test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

