### PR TITLE
fix(s2n-quic-core): disable resetting congestion window after blackhole is detected.

### DIFF
--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -468,7 +468,7 @@ impl CongestionController for CubicCongestionController {
         if max_datagram_size < old_max_datagram_size {
             // leave this part for future developments of mtu mechanism.
             //
-            // As we currenty do not probe MTU until after the handshake is complete,
+            // As we currently do not probe MTU until after the handshake is complete,
             // resetting congestion window is not required here. Also, it can cause
             // adverse effects in the current logic.
         } else {

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -444,13 +444,6 @@ impl CongestionController for CubicCongestionController {
         self.slow_start.on_congestion_event(self.congestion_window);
     }
 
-    //= https://www.rfc-editor.org/rfc/rfc9002#section-7.2
-    //# If the maximum datagram size changes during the connection, the
-    //# initial congestion window SHOULD be recalculated with the new size.
-    //# If the maximum datagram size is decreased in order to complete the
-    //# handshake, the congestion window SHOULD be set to the new initial
-    //# congestion window.
-
     //= https://www.rfc-editor.org/rfc/rfc8899#section-3
     //# An update to the PLPMTU (or MPS) MUST NOT increase the congestion
     //# window measured in bytes [RFC4821].
@@ -459,19 +452,20 @@ impl CongestionController for CubicCongestionController {
     //# A PL that maintains the congestion window in terms of a limit to
     //# the number of outstanding fixed-size packets SHOULD adapt this
     //# limit to compensate for the size of the actual packets.
+
+    //= https://www.rfc-editor.org/rfc/rfc9002#section-7.2
+    //= type=exception
+    //= reason=The maximum datagram size remains at the minimum (1200 bytes) during the handshake
+    //# If the maximum datagram size is decreased in order to complete the
+    //# handshake, the congestion window SHOULD be set to the new initial
+    //# congestion window.
     #[inline]
     fn on_mtu_update(&mut self, max_datagram_size: u16) {
         let old_max_datagram_size = self.max_datagram_size;
         self.max_datagram_size = max_datagram_size;
         self.cubic.max_datagram_size = max_datagram_size;
 
-        if max_datagram_size < old_max_datagram_size {
-            // leave this part for future developments of mtu mechanism.
-            //
-            // As we currently do not probe MTU until after the handshake is complete,
-            // resetting congestion window is not required here. Also, it can cause
-            // adverse effects in the current logic.
-        } else {
+        if max_datagram_size > old_max_datagram_size {
             self.congestion_window =
                 (self.congestion_window / old_max_datagram_size as f32) * max_datagram_size as f32;
         }

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -466,8 +466,11 @@ impl CongestionController for CubicCongestionController {
         self.cubic.max_datagram_size = max_datagram_size;
 
         if max_datagram_size < old_max_datagram_size {
-            self.congestion_window =
-                CubicCongestionController::initial_window(max_datagram_size) as f32;
+            // leave this part for future developments of mtu mechanism.
+            //
+            // As we currenty do not probe MTU until after the handshake is complete,
+            // resetting congestion window is not required here. Also, it can cause
+            // adverse effects in the current logic.
         } else {
             self.congestion_window =
                 (self.congestion_window / old_max_datagram_size as f32) * max_datagram_size as f32;

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -445,6 +445,8 @@ impl CongestionController for CubicCongestionController {
     }
 
     //= https://www.rfc-editor.org/rfc/rfc8899#section-3
+    //= type=exception
+    //= reason=See https://github.com/aws/s2n-quic/issues/959
     //# An update to the PLPMTU (or MPS) MUST NOT increase the congestion
     //# window measured in bytes [RFC4821].
 
@@ -465,10 +467,8 @@ impl CongestionController for CubicCongestionController {
         self.max_datagram_size = max_datagram_size;
         self.cubic.max_datagram_size = max_datagram_size;
 
-        if max_datagram_size > old_max_datagram_size {
-            self.congestion_window =
-                (self.congestion_window / old_max_datagram_size as f32) * max_datagram_size as f32;
-        }
+        self.congestion_window =
+            (self.congestion_window / old_max_datagram_size as f32) * max_datagram_size as f32;
     }
 
     //= https://www.rfc-editor.org/rfc/rfc9002#section-6.4
@@ -519,6 +519,10 @@ impl CubicCongestionController {
     //# window of ten times the maximum datagram size (max_datagram_size),
     //# while limiting the window to the larger of 14,720 bytes or twice the
     //# maximum datagram size.
+
+    //= https://www.rfc-editor.org/rfc/rfc9002#section-7.2
+    //# If the maximum datagram size changes during the connection, the
+    //# initial congestion window SHOULD be recalculated with the new size.
     #[inline]
     fn initial_window(max_datagram_size: u16) -> u32 {
         const INITIAL_WINDOW_LIMIT: u32 = 14720;

--- a/quic/s2n-quic-core/src/recovery/cubic/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic/tests.rs
@@ -675,30 +675,6 @@ fn on_packet_lost_persistent_congestion() {
 
 //= https://www.rfc-editor.org/rfc/rfc9002#section-7.2
 //= type=test
-//# If the maximum datagram size is decreased in order to complete the
-//# handshake, the congestion window SHOULD be set to the new initial
-//# congestion window.
-/*
- * disable this tests until further developments for mtu probe mechanism
- *
-#[test]
-fn on_mtu_update_decrease() {
-    let mut cc = CubicCongestionController::new(10000);
-
-    cc.on_mtu_update(5000);
-    assert_eq!(cc.max_datagram_size, 5000);
-    assert_eq!(cc.cubic.max_datagram_size, 5000);
-
-    assert_delta!(
-        cc.congestion_window,
-        CubicCongestionController::initial_window(5000) as f32,
-        0.001
-    );
-}
-*/
-
-//= https://www.rfc-editor.org/rfc/rfc9002#section-7.2
-//= type=test
 //# If the maximum datagram size changes during the connection, the
 //# initial congestion window SHOULD be recalculated with the new size.
 

--- a/quic/s2n-quic-core/src/recovery/cubic/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic/tests.rs
@@ -678,6 +678,9 @@ fn on_packet_lost_persistent_congestion() {
 //# If the maximum datagram size is decreased in order to complete the
 //# handshake, the congestion window SHOULD be set to the new initial
 //# congestion window.
+/*
+ * disable this tests until further developments for mtu probe mechanism
+ *
 #[test]
 fn on_mtu_update_decrease() {
     let mut cc = CubicCongestionController::new(10000);
@@ -692,6 +695,7 @@ fn on_mtu_update_decrease() {
         0.001
     );
 }
+*/
 
 //= https://www.rfc-editor.org/rfc/rfc9002#section-7.2
 //= type=test


### PR DESCRIPTION
### Resolved issues:

This disables resetting congestion window when blackholes are detected through MTU probes. 
This is because we currently do not probe MTU until after the handshake is complete and 
this logic could lead to very poor performances when there're bursty packet losses

### Description of changes: 

* disable resetting congestion window after blackhole is detected in cubic.rs.
* disable test cases for it to avoid errors.

### Call-outs:

we should re-visit this part when we enhance mtu probe mechanism in the future.

### Testing:

Perform A/B tests between 2 instances and confirmed that there's no regression.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

