### PR TITLE
fix(s2n-quic-transport): fix clippy beta warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable, beta]
+        include:
+          - toolchain: stable
+            # fail on stable warnings
+            args: "-D warnings"
+          - toolchain: beta
+            # deriving Eq may break API compatibility so we disable it
+            # See https://github.com/rust-lang/rust-clippy/issues/9063
+            args: "-A derive_partial_eq_without_eq"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -86,7 +93,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: clippy
-          args: --all-features --all-targets -- -D warnings
+          args: --all-features --all-targets -- ${{ matrix.args }}
 
   udeps:
     runs-on: ubuntu-latest

--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -46,7 +46,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolchain: [stable, beta]
+        include:
+          - toolchain: stable
+            # fail on stable warnings
+            args: "-D warnings"
+          - toolchain: beta
+            # deriving Eq may break API compatibility so we disable it
+            # See https://github.com/rust-lang/rust-clippy/issues/9063
+            args: "-A derive_partial_eq_without_eq"
     steps:
       - uses: actions/checkout@v3
 
@@ -65,7 +72,7 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: clippy
-          args: --manifest-path netbench/Cargo.toml --all-features --all-targets -- -D warnings
+          args: --manifest-path netbench/Cargo.toml --all-features --all-targets -- ${{ matrix.args }}
 
   test:
     runs-on: ubuntu-latest

--- a/common/s2n-codec/src/decoder/value.rs
+++ b/common/s2n-codec/src/decoder/value.rs
@@ -104,13 +104,7 @@ decoder_value!(
         fn decode(buffer: Buffer) -> Result<Self> {
             let len = buffer.len();
             let (slice, buffer) = buffer.decode_slice(len)?;
-            // clippy changed identity_conversion to useless_conversion
-            // specify both for backwards compatibility
-            #[allow(
-                clippy::unknown_clippy_lints,
-                clippy::useless_conversion,
-                clippy::identity_conversion
-            )]
+            #[allow(clippy::useless_conversion)]
             let slice = slice.into();
             Ok((slice, buffer))
         }

--- a/netbench/netbench/src/operation.rs
+++ b/netbench/netbench/src/operation.rs
@@ -4,7 +4,7 @@
 use crate::units::{duration_format, Byte, Duration, Rate};
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum Connection {
     /// Pause for the specified duration before processing the next op
@@ -48,7 +48,7 @@ pub enum Connection {
     Scope { threads: Vec<Vec<Connection>> },
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum Client {
     /// Pause for the specified duration before processing the next op
@@ -74,7 +74,7 @@ pub enum Client {
     Scope { threads: Vec<Vec<Client>> },
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(rename_all = "snake_case")]
 pub enum Router {
     /// Pause for the specified duration before processing the next op

--- a/netbench/netbench/src/scenario/id.rs
+++ b/netbench/netbench/src/scenario/id.rs
@@ -4,7 +4,7 @@
 use core::fmt;
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize, Hash)]
 pub struct Id(String);
 
 impl Id {

--- a/netbench/netbench/src/units/rate.rs
+++ b/netbench/netbench/src/units/rate.rs
@@ -6,7 +6,7 @@ use core::fmt;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Clone, Copy, Debug, Default, PartialEq, Hash, Deserialize, Serialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub struct Rate {
     pub bytes: Byte,
     #[serde(with = "duration_format", rename = "period_ms")]

--- a/quic/s2n-quic-transport/src/connection/connection_container.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container.rs
@@ -562,7 +562,7 @@ impl<C: connection::Trait, L: connection::Lock<C>> InterestLists<C, L> {
     fn remove_node(&mut self, connection: &ConnectionNode<C, L>) {
         // And remove the Connection from all other interest lists it might be
         // part of.
-        let connection_ptr = &*connection as *const ConnectionNode<C, L>;
+        let connection_ptr = connection as *const ConnectionNode<C, L>;
 
         macro_rules! remove_connection_from_list {
             ($list_name:ident, $link_name:ident) => {

--- a/quic/s2n-quic-transport/src/interval_set/interval.rs
+++ b/quic/s2n-quic-transport/src/interval_set/interval.rs
@@ -346,7 +346,7 @@ impl IntervalBound for VarInt {
 
     #[inline]
     fn steps_between(&self, upper: &Self) -> usize {
-        <u64 as IntervalBound>::steps_between(&*self, &*upper)
+        <u64 as IntervalBound>::steps_between(self, upper)
     }
 
     #[inline]

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -404,14 +404,12 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
                 can_send_handshake,
                 early_connection_close
             );
-            let buffer = write_packet!(
+            write_packet!(
                 buffer,
                 application_mut,
                 can_send_application,
                 connection_close
-            );
-
-            buffer
+            )
         })
     }
 


### PR DESCRIPTION
### Description of changes: 

Clippy introduced a new lint in beta that checks to see if Eq can be derived if PartialEq is also derived. This is fine for applications but it makes ensuring backward-compatibility in libraries more fragile. If a field is added that doesn't implement Eq, then the derive would have to be removed, which could break existing callers.

This change adds an allow for the new lint globally, since I don't think it's very compelling.

See https://github.com/rust-lang/rust-clippy/issues/9063

I've also made beta clippy errors into warnings since it clutters up actual statuses every time clippy adds one of these things.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

