### PR TITLE
feat(s2n-quic): add with_max_open_local_bidirectional_streams with_max_open_remote_bidirectional_streams apis to limits

### DIFF
--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -52,6 +52,8 @@ pub struct Limits {
     pub(crate) bidirectional_remote_data_window: InitialMaxStreamDataBidiRemote,
     pub(crate) unidirectional_data_window: InitialMaxStreamDataUni,
     pub(crate) max_open_bidirectional_streams: InitialMaxStreamsBidi,
+    pub(crate) max_open_local_bidirectional_streams: Option<InitialMaxStreamsBidi>,
+    pub(crate) max_open_remote_bidirectional_streams: Option<InitialMaxStreamsBidi>,
     pub(crate) max_open_local_unidirectional_streams: InitialMaxStreamsUni,
     pub(crate) max_open_remote_unidirectional_streams: InitialMaxStreamsUni,
     pub(crate) max_ack_delay: MaxAckDelay,
@@ -89,6 +91,8 @@ impl Limits {
             bidirectional_remote_data_window: InitialMaxStreamDataBidiRemote::RECOMMENDED,
             unidirectional_data_window: InitialMaxStreamDataUni::RECOMMENDED,
             max_open_bidirectional_streams: InitialMaxStreamsBidi::RECOMMENDED,
+            max_open_local_bidirectional_streams: None,
+            max_open_remote_bidirectional_streams: None,
             max_open_local_unidirectional_streams: InitialMaxStreamsUni::RECOMMENDED,
             max_open_remote_unidirectional_streams: InitialMaxStreamsUni::RECOMMENDED,
             max_ack_delay: MaxAckDelay::RECOMMENDED,
@@ -120,11 +124,48 @@ impl Limits {
         unidirectional_data_window,
         u64
     );
-    setter!(
-        with_max_open_bidirectional_streams,
-        max_open_bidirectional_streams,
-        u64
-    );
+
+    /// Sets the max local and remote limits for bidi streams.
+    ///
+    /// The value `with_max_open_remote_bidirectional_streams` and
+    /// `with_max_open_local_bidirectional_streams` will be used instead
+    /// if set on the builder.
+    // Deprecate once the local and remote limits are used.
+    // #[deprecated(
+    //     since = "1.7.0",
+    //     note = "use with_max_open_remote_bidirectional_streams and with_max_open_local_bidirectional_streams instead"
+    // )]
+    pub fn with_max_open_bidirectional_streams(
+        mut self,
+        value: u64,
+    ) -> Result<Self, ValidationError> {
+        self.max_open_bidirectional_streams = value.try_into()?;
+        Ok(self)
+    }
+
+    /// Sets the max local limits for bidi streams
+    ///
+    /// The value set is used instead of `with_max_open_bidirectional_streams` when set.
+    #[doc(hidden)]
+    pub fn with_max_open_local_bidirectional_streams(
+        mut self,
+        value: u64,
+    ) -> Result<Self, ValidationError> {
+        self.max_open_local_bidirectional_streams = Some(value.try_into()?);
+        Ok(self)
+    }
+
+    /// Sets the max remote limits for bidi streams.
+    ///
+    /// The value set is used instead of `with_max_open_bidirectional_streams` when set.
+    #[doc(hidden)]
+    pub fn with_max_open_remote_bidirectional_streams(
+        mut self,
+        value: u64,
+    ) -> Result<Self, ValidationError> {
+        self.max_open_remote_bidirectional_streams = Some(value.try_into()?);
+        Ok(self)
+    }
     setter!(
         with_max_open_local_unidirectional_streams,
         max_open_local_unidirectional_streams,
@@ -170,10 +211,13 @@ impl Limits {
     }
 
     #[doc(hidden)]
-    pub const fn initial_flow_control_limits(&self) -> InitialFlowControlLimits {
+    pub fn initial_flow_control_limits(&self) -> InitialFlowControlLimits {
         InitialFlowControlLimits {
             stream_limits: self.initial_stream_limits(),
             max_data: self.data_window.as_varint(),
+            // TODO max_open_remote_bidirectional_streams is unused at the moment.
+            // Use it once the the stream controller is initiator aware.
+            // https://github.com/aws/s2n-quic/issues/1388
             max_streams_bidi: self.max_open_bidirectional_streams.as_varint(),
             max_streams_uni: self.max_open_remote_unidirectional_streams.as_varint(),
         }
@@ -188,12 +232,19 @@ impl Limits {
         }
     }
 
+    // TODO max_open_local_bidirectional_streams is unused at the moment. Use it
+    // once the the stream controller is initiator aware.
+    // https://github.com/aws/s2n-quic/issues/1388
     #[doc(hidden)]
-    pub const fn stream_limits(&self) -> stream::Limits {
+    pub fn stream_limits(&self) -> stream::Limits {
         stream::Limits {
             max_send_buffer_size: self.max_send_buffer_size,
             max_open_local_unidirectional_streams: self
                 .max_open_local_unidirectional_streams
+                .as_varint(),
+            max_open_local_bidirectional_streams: self
+                .max_open_local_bidirectional_streams
+                .unwrap_or(self.max_open_bidirectional_streams)
                 .as_varint(),
         }
     }

--- a/quic/s2n-quic-core/src/stream/limits.rs
+++ b/quic/s2n-quic-core/src/stream/limits.rs
@@ -17,6 +17,11 @@ pub struct Limits {
     /// is not communicated to the peer, it is only used for limiting
     /// concurrent streams opened locally by the application.
     pub max_open_local_unidirectional_streams: VarInt,
+    /// The maximum number of bidirectional streams that may
+    /// be opened concurrently by the local endpoint. This value
+    /// is not communicated to the peer, it is only used for limiting
+    /// concurrent streams opened locally by the application.
+    pub max_open_local_bidirectional_streams: VarInt,
 }
 
 impl Default for Limits {
@@ -29,5 +34,6 @@ impl Limits {
     pub const RECOMMENDED: Self = Self {
         max_send_buffer_size: DEFAULT_STREAM_MAX_SEND_BUFFER_SIZE,
         max_open_local_unidirectional_streams: InitialMaxStreamsUni::RECOMMENDED.as_varint(),
+        max_open_local_bidirectional_streams: InitialMaxStreamsUni::RECOMMENDED.as_varint(),
     };
 }

--- a/quic/s2n-quic-core/src/stream/limits.rs
+++ b/quic/s2n-quic-core/src/stream/limits.rs
@@ -1,7 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{transport::parameters::InitialMaxStreamsUni, varint::VarInt};
+use crate::{
+    transport::parameters::{InitialMaxStreamsBidi, InitialMaxStreamsUni, ValidationError},
+    varint::VarInt,
+};
 
 // TODO investigate a good default
 /// The default send buffer size for Streams
@@ -11,17 +14,17 @@ const DEFAULT_STREAM_MAX_SEND_BUFFER_SIZE: u32 = 512 * 1024;
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Limits {
     /// The maximum send buffer size for a Stream
-    pub max_send_buffer_size: u32,
+    pub max_send_buffer_size: LocalMaxSendBufferSize,
     /// The maximum number of unidirectional streams that may
     /// be opened concurrently by the local endpoint. This value
     /// is not communicated to the peer, it is only used for limiting
     /// concurrent streams opened locally by the application.
-    pub max_open_local_unidirectional_streams: VarInt,
+    pub max_open_local_unidirectional_streams: LocalUniDirectionalLimit,
     /// The maximum number of bidirectional streams that may
     /// be opened concurrently by the local endpoint. This value
     /// is not communicated to the peer, it is only used for limiting
     /// concurrent streams opened locally by the application.
-    pub max_open_local_bidirectional_streams: VarInt,
+    pub max_open_local_bidirectional_streams: LocalBiDirectionalLimit,
 }
 
 impl Default for Limits {
@@ -32,8 +35,74 @@ impl Default for Limits {
 
 impl Limits {
     pub const RECOMMENDED: Self = Self {
-        max_send_buffer_size: DEFAULT_STREAM_MAX_SEND_BUFFER_SIZE,
-        max_open_local_unidirectional_streams: InitialMaxStreamsUni::RECOMMENDED.as_varint(),
-        max_open_local_bidirectional_streams: InitialMaxStreamsUni::RECOMMENDED.as_varint(),
+        max_send_buffer_size: LocalMaxSendBufferSize::RECOMMENDED,
+        max_open_local_unidirectional_streams: LocalUniDirectionalLimit::RECOMMENDED,
+        max_open_local_bidirectional_streams: LocalBiDirectionalLimit::RECOMMENDED,
     };
+}
+
+macro_rules! local_limits {
+    ($name:ident($encodable_type:ty)) => {
+        #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+        pub struct $name($encodable_type);
+    };
+}
+
+macro_rules! varint_local_limits {
+    ($name:ident($encodable_type:ty)) => {
+        local_limits!($name($encodable_type));
+
+        impl $name {
+            pub const fn as_varint(self) -> VarInt {
+                self.0
+            }
+        }
+
+        impl TryFrom<u64> for $name {
+            type Error = ValidationError;
+
+            fn try_from(value: u64) -> Result<Self, Self::Error> {
+                let value = VarInt::new(value)?;
+                Ok(Self(value))
+            }
+        }
+    };
+}
+
+local_limits!(LocalMaxSendBufferSize(u32));
+
+impl LocalMaxSendBufferSize {
+    pub const RECOMMENDED: Self = Self(DEFAULT_STREAM_MAX_SEND_BUFFER_SIZE);
+
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+impl TryFrom<u32> for LocalMaxSendBufferSize {
+    type Error = ValidationError;
+
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
+        Ok(Self(value))
+    }
+}
+
+varint_local_limits!(LocalUniDirectionalLimit(VarInt));
+
+impl LocalUniDirectionalLimit {
+    pub const RECOMMENDED: Self = Self(InitialMaxStreamsUni::RECOMMENDED.as_varint());
+}
+
+varint_local_limits!(LocalBiDirectionalLimit(VarInt));
+
+impl LocalBiDirectionalLimit {
+    pub const RECOMMENDED: Self = Self(InitialMaxStreamsBidi::RECOMMENDED.as_varint());
+}
+
+// To maintain backwards API compatibility we need to convert from
+// `max_open_bidirectional_streams` to `max_open_local_bidirectional_streams`
+impl From<InitialMaxStreamsBidi> for LocalBiDirectionalLimit {
+    fn from(value: InitialMaxStreamsBidi) -> Self {
+        Self(value.as_varint())
+    }
 }

--- a/quic/s2n-quic-transport/src/stream/controller.rs
+++ b/quic/s2n-quic-transport/src/stream/controller.rs
@@ -79,7 +79,9 @@ impl Controller {
                 stream_id: StreamId::initial(local_endpoint_type, StreamType::Unidirectional),
                 outgoing: OutgoingController::new(
                     initial_peer_limits.max_streams_uni,
-                    stream_limits.max_open_local_unidirectional_streams,
+                    stream_limits
+                        .max_open_local_unidirectional_streams
+                        .as_varint(),
                 ),
                 incoming: IncomingController::new(initial_local_limits.max_streams_uni),
             },

--- a/quic/s2n-quic-transport/src/stream/manager.rs
+++ b/quic/s2n-quic-transport/src/stream/manager.rs
@@ -239,7 +239,7 @@ impl<S: StreamTrait> StreamManagerState<S> {
             initial_receive_window,
             desired_flow_control_window: initial_receive_window.as_u64() as u32,
             initial_send_window,
-            max_send_buffer_size: self.stream_limits.max_send_buffer_size,
+            max_send_buffer_size: self.stream_limits.max_send_buffer_size.as_u32(),
         }));
     }
 


### PR DESCRIPTION
### Resolved issues:
https://github.com/aws/s2n-quic/issues/1388

### Description of changes: 
The stream limits currently only excepts [with_max_open_bidirectional_streams](https://docs.rs/s2n-quic/latest/s2n_quic/provider/limits/struct.Limits.html#method.with_max_open_bidirectional_streams). This single value is used to configure both the local limits and also communicated to the peer via transport parameters. Setting separate limits is not possible.

This PR exposes two API calls (currently unused), with a local and remote options, which will replace the `with_max_open_bidirectional_streams` once the stream controller is initiator aware.

---
### API Behavior:
- `with_max_open_bidirectional_streams`: sets the local and remote limits
- if `max_open_local_bidirectional_streams` is called, that value is then used for local limits even if `with_max_open_bidirectional_streams` was also called (same applied to remote)
  - we therefore need a way to detect if `with_max_open_local_bidirectional_streams` is called.. hence `Option`

```
.with_max_open_bidirectional_streams(20)
// local_limit = 20
// remote_limit = 20
```

```
.with_max_open_bidirectional_streams(20)
.with_max_open_local_bidirectional_streams(50)
// local_limit = 50
// remote_limit = 20
```

```
.with_max_open_local_bidirectional_streams(50)
// local_limit = 50
// remote_limit = 100 // This is the default value for with_max_open_bidirectional_streams
```

### Testing:
There is no functional change in the PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

