### PR TITLE
fix(s2n-quic-core) F64 to usize Conversion

### DIFF
--- a/quic/s2n-quic-core/src/datagram/default.rs
+++ b/quic/s2n-quic-core/src/datagram/default.rs
@@ -369,8 +369,8 @@ impl Sender {
     ///
     /// Should be used to determine an appropriate datagram size that can be sent in
     /// this connection.
-    pub fn smoothed_packet_space(&self) -> f64 {
-        self.smoothed_packet_size
+    pub fn smoothed_packet_space(&self) -> usize {
+        self.smoothed_packet_size as usize
     }
 }
 
@@ -621,7 +621,7 @@ mod tests {
 
     #[test]
     fn record_capacity_stats() {
-        const SMOOTHED_PACKET_SPACE: f64 = 102.3193359375;
+        const SMOOTHED_PACKET_SPACE: usize = 102;
 
         let mut default_sender = Sender::builder().build().unwrap();
         default_sender.record_capacity_stats(100);

--- a/quic/s2n-quic-core/src/datagram/default.rs
+++ b/quic/s2n-quic-core/src/datagram/default.rs
@@ -621,6 +621,8 @@ mod tests {
 
     #[test]
     fn record_capacity_stats() {
+        // Here we test that record_capacity_stats() is working as expected. We use
+        // a precalculated const for the smoothed_packet_space value.
         const SMOOTHED_PACKET_SPACE: usize = 102;
 
         let mut default_sender = Sender::builder().build().unwrap();


### PR DESCRIPTION
### Resolved issues:

n/a

### Description of changes: 

It doesn't really make sense for this function to return a float since theres no such thing as a fractional byte. Changing to a usize.

### Call-outs:

n/a

### Testing:

test still passes

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

