### PR TITLE
ci: pin pyshark dependency

### DIFF
--- a/.github/interop/runner.patch
+++ b/.github/interop/runner.patch
@@ -162,7 +162,7 @@ index c2d6d1f..844bbd5 100644
  print("\nPulling the iperf endpoint...")
  os.system("docker pull martenseemann/quic-interop-iperf-endpoint")
 diff --git a/requirements.txt b/requirements.txt
-index fff6217..2ae6f9d 100644
+index fff6217..07a1506 100644
 --- a/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,4 @@
@@ -171,7 +171,7 @@ index fff6217..2ae6f9d 100644
  prettytable
 -pyshark
 \ No newline at end of file
-+pyshark==0.4.5
++pyshark==0.5.2
 \ No newline at end of file
 diff --git a/run.py b/run.py
 index fbd9515..aa8d6ed 100755
@@ -184,7 +184,7 @@ index fbd9515..aa8d6ed 100755
 -    sys.exit(main())
 +    main()
 diff --git a/testcases.py b/testcases.py
-index 99edfe0..0b8941a 100644
+index 2741a0d..5c0a862 100644
 --- a/testcases.py
 +++ b/testcases.py
 @@ -90,6 +90,10 @@ class TestCase(abc.ABC):
@@ -198,7 +198,7 @@ index 99edfe0..0b8941a 100644
      @staticmethod
      def scenario() -> str:
          """ Scenario for the ns3 simulator """
-@@ -1203,54 +1207,26 @@ class TestCasePortRebinding(TestCaseTransfer):
+@@ -1201,54 +1205,26 @@ class TestCasePortRebinding(TestCaseTransfer):
              logging.info("Server saw only a single client port in use; test broken?")
              return TestResult.FAILED
  
@@ -261,7 +261,7 @@ index 99edfe0..0b8941a 100644
                  if hasattr(p["quic"], "path_response.data")
              )
          )
-@@ -1532,6 +1508,10 @@ class MeasurementGoodput(Measurement):
+@@ -1445,6 +1421,10 @@ class MeasurementGoodput(Measurement):
      def testname(p: Perspective):
          return "transfer"
  
@@ -272,7 +272,7 @@ index 99edfe0..0b8941a 100644
      @staticmethod
      def abbreviation():
          return "G"
-@@ -1542,7 +1522,7 @@ class MeasurementGoodput(Measurement):
+@@ -1455,7 +1435,7 @@ class MeasurementGoodput(Measurement):
  
      @staticmethod
      def repetitions() -> int:
@@ -281,7 +281,21 @@ index 99edfe0..0b8941a 100644
  
      def get_paths(self):
          self._files = [self._generate_random_file(self.FILESIZE)]
-@@ -1615,8 +1595,8 @@ TESTCASES = [
+@@ -1469,12 +1449,7 @@ class MeasurementGoodput(Measurement):
+         if not self._check_version_and_files():
+             return TestResult.FAILED
+ 
+-        packets = self._client_trace().get_1rtt(Direction.FROM_SERVER)
+-        first, last = 0, 0
+-        for p in packets:
+-            if first == 0:
+-                first = p.sniff_time
+-            last = p.sniff_time
++        first, last = self._client_trace().get_start_end(Direction.FROM_SERVER)
+ 
+         if last - first == 0:
+             return TestResult.FAILED
+@@ -1528,8 +1503,8 @@ TESTCASES = [
      TestCaseChaCha20,
      TestCaseMultiplexing,
      TestCaseRetry,
@@ -292,10 +306,10 @@ index 99edfe0..0b8941a 100644
      TestCaseHTTP3,
      TestCaseBlackhole,
      TestCaseKeyUpdate,
-@@ -1628,11 +1608,9 @@ TESTCASES = [
+@@ -1540,11 +1515,9 @@ TESTCASES = [
+     TestCaseHandshakeCorruption,
      TestCaseTransferCorruption,
      TestCaseIPv6,
-     TestCaseV2,
 -    # The next three tests are disabled due to Wireshark not being able
 -    # to decrypt packets sent on the new path.
 -    # TestCasePortRebinding,
@@ -307,3 +321,34 @@ index 99edfe0..0b8941a 100644
  ]
  
  MEASUREMENTS = [
+diff --git a/trace.py b/trace.py
+index 215f25a..00759d4 100644
+--- a/trace.py
++++ b/trace.py
+@@ -125,10 +125,25 @@ class TraceAnalyzer:
+                 if layer.layer_name == "quic" and not hasattr(
+                     layer, "long_packet_type"
+                 ):
+-                    layer.sniff_time = packet.sniff_time
+                     packets.append(layer)
+         return packets
+ 
++    def get_start_end(self, direction: Direction = Direction.ALL) -> (int, int):
++        """ Get start and end time, one or both directions. """
++        start = 0
++        end = 0
++        for packet in self._get_packets(
++            self._get_direction_filter(direction) + "quic.header_form==0"
++        ):
++            for layer in packet.layers:
++                if layer.layer_name == "quic" and not hasattr(
++                    layer, "long_packet_type"
++                ):
++                    if start == 0:
++                        start = packet.sniff_time
++                    end = packet.sniff_time
++        return (start, end)
++
+     def get_vnp(self, direction: Direction = Direction.ALL) -> List:
+         return self._get_packets(
+             self._get_direction_filter(direction) + "quic.version==0"

--- a/.github/interop/runner.patch
+++ b/.github/interop/runner.patch
@@ -161,6 +161,18 @@ index c2d6d1f..844bbd5 100644
  
  print("\nPulling the iperf endpoint...")
  os.system("docker pull martenseemann/quic-interop-iperf-endpoint")
+diff --git a/requirements.txt b/requirements.txt
+index fff6217..2ae6f9d 100644
+--- a/requirements.txt
++++ b/requirements.txt
+@@ -1,4 +1,4 @@
+ pycrypto
+ termcolor
+ prettytable
+-pyshark
+\ No newline at end of file
++pyshark==0.4.6
+\ No newline at end of file
 diff --git a/run.py b/run.py
 index fbd9515..aa8d6ed 100755
 --- a/run.py
@@ -172,7 +184,7 @@ index fbd9515..aa8d6ed 100755
 -    sys.exit(main())
 +    main()
 diff --git a/testcases.py b/testcases.py
-index 2741a0d..a8d1e14 100644
+index 99edfe0..0b8941a 100644
 --- a/testcases.py
 +++ b/testcases.py
 @@ -90,6 +90,10 @@ class TestCase(abc.ABC):
@@ -186,7 +198,7 @@ index 2741a0d..a8d1e14 100644
      @staticmethod
      def scenario() -> str:
          """ Scenario for the ns3 simulator """
-@@ -1201,54 +1205,26 @@ class TestCasePortRebinding(TestCaseTransfer):
+@@ -1203,54 +1207,26 @@ class TestCasePortRebinding(TestCaseTransfer):
              logging.info("Server saw only a single client port in use; test broken?")
              return TestResult.FAILED
  
@@ -249,7 +261,7 @@ index 2741a0d..a8d1e14 100644
                  if hasattr(p["quic"], "path_response.data")
              )
          )
-@@ -1445,6 +1421,10 @@ class MeasurementGoodput(Measurement):
+@@ -1532,6 +1508,10 @@ class MeasurementGoodput(Measurement):
      def testname(p: Perspective):
          return "transfer"
  
@@ -260,7 +272,7 @@ index 2741a0d..a8d1e14 100644
      @staticmethod
      def abbreviation():
          return "G"
-@@ -1455,7 +1435,7 @@ class MeasurementGoodput(Measurement):
+@@ -1542,7 +1522,7 @@ class MeasurementGoodput(Measurement):
  
      @staticmethod
      def repetitions() -> int:
@@ -269,7 +281,7 @@ index 2741a0d..a8d1e14 100644
  
      def get_paths(self):
          self._files = [self._generate_random_file(self.FILESIZE)]
-@@ -1528,8 +1508,8 @@ TESTCASES = [
+@@ -1615,8 +1595,8 @@ TESTCASES = [
      TestCaseChaCha20,
      TestCaseMultiplexing,
      TestCaseRetry,
@@ -280,10 +292,10 @@ index 2741a0d..a8d1e14 100644
      TestCaseHTTP3,
      TestCaseBlackhole,
      TestCaseKeyUpdate,
-@@ -1540,11 +1520,9 @@ TESTCASES = [
-     TestCaseHandshakeCorruption,
+@@ -1628,11 +1608,9 @@ TESTCASES = [
      TestCaseTransferCorruption,
      TestCaseIPv6,
+     TestCaseV2,
 -    # The next three tests are disabled due to Wireshark not being able
 -    # to decrypt packets sent on the new path.
 -    # TestCasePortRebinding,

--- a/.github/interop/runner.patch
+++ b/.github/interop/runner.patch
@@ -171,7 +171,7 @@ index fff6217..2ae6f9d 100644
  prettytable
 -pyshark
 \ No newline at end of file
-+pyshark==0.4.6
++pyshark==0.4.5
 \ No newline at end of file
 diff --git a/run.py b/run.py
 index fbd9515..aa8d6ed 100755

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2022-04-12
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2022-07-10
   CDN: https://dnglbrstg7yg.cloudfront.net
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100

--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2022-04-12
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2022-07-10
   CDN: https://dnglbrstg7yg.cloudfront.net
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   # This kept breaking builds so we're pinning for now. We should do our best to keep
   # up with the changes, though.
-  INTEROP_RUNNER_REF: b21b8a55de227f665d2381f3e63174a83a3bc66c
+  INTEROP_RUNNER_REF: bdb2c815b8cfd70de4c2efb1bd278b1e87018ff8
   # This should be updated when updating wesleyrosenblum/quic-network-simulator
   NETWORK_SIMULATOR_REF: sha256:20abe0bed8c0e39e1d8750507b24295f7c978bdd7e05fa6f3a5afed4b76dc191
   IPERF_ENDPOINT_REF: sha256:cb50cc8019d45d9cad5faecbe46a3c21dd5e871949819a5175423755a9045106

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -19,7 +19,7 @@ env:
   # This should be updated when updating wesleyrosenblum/quic-network-simulator
   NETWORK_SIMULATOR_REF: sha256:20abe0bed8c0e39e1d8750507b24295f7c978bdd7e05fa6f3a5afed4b76dc191
   IPERF_ENDPOINT_REF: sha256:cb50cc8019d45d9cad5faecbe46a3c21dd5e871949819a5175423755a9045106
-  WIRESHARK_VERSION: 3.6.2
+  WIRESHARK_VERSION: 3.6.6
   CDN: https://dnglbrstg7yg.cloudfront.net
   LOG_URL: logs/latest/SERVER_CLIENT/TEST/index.html
   H3_SPEC_VERSION: v0.1.8

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -19,7 +19,7 @@ env:
   # This should be updated when updating wesleyrosenblum/quic-network-simulator
   NETWORK_SIMULATOR_REF: sha256:20abe0bed8c0e39e1d8750507b24295f7c978bdd7e05fa6f3a5afed4b76dc191
   IPERF_ENDPOINT_REF: sha256:cb50cc8019d45d9cad5faecbe46a3c21dd5e871949819a5175423755a9045106
-  WIRESHARK_VERSION: 3.6.6
+  WIRESHARK_VERSION: 3.6.2
   CDN: https://dnglbrstg7yg.cloudfront.net
   LOG_URL: logs/latest/SERVER_CLIENT/TEST/index.html
   H3_SPEC_VERSION: v0.1.8

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -15,15 +15,15 @@ env:
   RUST_BACKTRACE: 1
   # This kept breaking builds so we're pinning for now. We should do our best to keep
   # up with the changes, though.
-  INTEROP_RUNNER_REF: add48d0229f2c7a0093abd76c3b2b6c36ff47def
+  INTEROP_RUNNER_REF: b21b8a55de227f665d2381f3e63174a83a3bc66c
   # This should be updated when updating wesleyrosenblum/quic-network-simulator
   NETWORK_SIMULATOR_REF: sha256:20abe0bed8c0e39e1d8750507b24295f7c978bdd7e05fa6f3a5afed4b76dc191
   IPERF_ENDPOINT_REF: sha256:cb50cc8019d45d9cad5faecbe46a3c21dd5e871949819a5175423755a9045106
-  WIRESHARK_VERSION: 3.6.2
+  WIRESHARK_VERSION: 3.6.6
   CDN: https://dnglbrstg7yg.cloudfront.net
   LOG_URL: logs/latest/SERVER_CLIENT/TEST/index.html
   H3_SPEC_VERSION: v0.1.8
-  QUINN_REF: d8615d9c2bae9cca78471f8875a15911fd1f443b
+  QUINN_REF: 18f00de385b0edf49c3fcc169800c80d5dd3abf6
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100
   S2N_UNSTABLE_CRYPTO_OPT_RX: 100

--- a/.license-template
+++ b/.license-template
@@ -1,2 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -2,4 +2,3 @@ edition = "2018"
 format_macro_matchers = true
 imports_granularity = "Crate"
 use_field_init_shorthand = true
-license_template_path = "./.license-template"

--- a/scripts/interop/README.md
+++ b/scripts/interop/README.md
@@ -28,7 +28,7 @@
 ```
 git clone git@github.com:marten-seemann/quic-interop-runner.git
 cd quic-interop-runner
-gco cd62367f7cf98d16854551fdd8ef6a48ad89d53d
+gco b21b8a55de227f665d2381f3e63174a83a3bc66c
 
 cp <s2n-quic_proj_dir>.runner.patch .
 git apply --3way runner.patch # apply the current patch

--- a/scripts/interop/run
+++ b/scripts/interop/run
@@ -22,7 +22,7 @@ if [ ! -d $INTEROP_DIR ]; then
   git clone https://github.com/marten-seemann/quic-interop-runner $INTEROP_DIR
   # make sure to keep this up to date with the interop workflow
   cd $INTEROP_DIR
-  git checkout add48d0229f2c7a0093abd76c3b2b6c36ff47def
+  git checkout b21b8a55de227f665d2381f3e63174a83a3bc66c
   git apply --3way ../../.github/interop/runner.patch
   cd ../../
 fi

--- a/scripts/interop/run
+++ b/scripts/interop/run
@@ -22,7 +22,7 @@ if [ ! -d $INTEROP_DIR ]; then
   git clone https://github.com/marten-seemann/quic-interop-runner $INTEROP_DIR
   # make sure to keep this up to date with the interop workflow
   cd $INTEROP_DIR
-  git checkout b21b8a55de227f665d2381f3e63174a83a3bc66c
+  git checkout bdb2c815b8cfd70de4c2efb1bd278b1e87018ff8
   git apply --3way ../../.github/interop/runner.patch
   cd ../../
 fi


### PR DESCRIPTION
### Description of changes: 

pyshark recently published a few breaking changes, which in turn breaks the quic-interop-runner. This PR:

* Pins the pyshark version to the current
* Fixes the backward-incompatible API usage
* Updates the nightly toolchain to the latest
  * Removes the rustfmt license check (see https://github.com/rust-lang/rustfmt/issues/5103)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

