### PR TITLE
fix(s2n-quic-transport): make state dumping explicit and opt-in

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -72,7 +72,7 @@ jobs:
         mode: ["debug", "release"]
     # enable debug information
     env:
-      RUSTFLAGS: "-g --cfg s2n_internal_dev"
+      RUSTFLAGS: "-g --cfg s2n_internal_dev --cfg s2n_quic_dump_on_panic"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -217,7 +217,7 @@ impl<Config: endpoint::Config> EventContext<Config> {
     }
 }
 
-#[cfg(debug_assertions)]
+#[cfg(s2n_quic_dump_on_panic)]
 impl<Config: endpoint::Config> Drop for ConnectionImpl<Config> {
     fn drop(&mut self) {
         if std::thread::panicking() {


### PR DESCRIPTION
### Resolved issues:

Fixes #1392 

### Description of changes: 

Connection state dumping was useful with initial development. However, as applications begin to adopt s2n-quic, it adds noise to application tests and makes it difficult to figure out the actual cause.

This change preserves the ability to dump state, but make it opt-in at compile time with the `s2n_quic_dump_on_panic` flag.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

