### PR TITLE
deps(s2n-quic-tls): update s2n-tls to 0.0.9

### DIFF
--- a/netbench/netbench-driver/Cargo.toml
+++ b/netbench/netbench-driver/Cargo.toml
@@ -15,8 +15,8 @@ netbench = { version = "0.1", path = "../netbench" }
 probe = "0.3"
 s2n-quic = { path = "../../quic/s2n-quic", features = ["provider-tls-s2n"] }
 s2n-quic-core = { path = "../../quic/s2n-quic-core", features = ["testing"] }
-s2n-tls = { version = "0.0.8" }
-s2n-tls-tokio = { version = "0.0.8" }
+s2n-tls = { version = "=0.0.9" }
+s2n-tls-tokio = { version = "=0.0.9" }
 structopt = "0.3"
 tokio = { version = "1", features = ["io-util", "net", "time"] }
 tokio-native-tls = "0.3"

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-client.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-client.rs
@@ -3,7 +3,7 @@
 
 use netbench::{multiplex, scenario, Result};
 use netbench_driver::Allocator;
-use s2n_tls::raw::{
+use s2n_tls::{
     config::{Builder, Config},
     error::Error,
     security::DEFAULT_TLS13,

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
@@ -3,7 +3,7 @@
 
 use netbench::{multiplex, scenario, Result};
 use netbench_driver::Allocator;
-use s2n_tls::raw::{
+use s2n_tls::{
     config::{Builder, Config},
     error::Error,
     security::DEFAULT_TLS13,
@@ -71,7 +71,7 @@ impl Server {
         ) -> Result<()> {
             let connection = acceptor.accept(connection).await?;
             let server_name = connection
-                .get_ref()
+                .as_ref()
                 .server_name()
                 .ok_or("missing server name")?;
             let scenario = scenario.on_server_name(server_name)?;

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -20,10 +20,10 @@ libc = "0.2"
 s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.7.1", path = "../s2n-quic-core", default-features = false }
 s2n-quic-crypto = { version = "=0.7.1", path = "../s2n-quic-crypto", default-features = false }
-s2n-tls = { version = "=0.0.8", features = ["quic"] }
+s2n-tls = { version = "=0.0.9", features = ["quic"] }
 
 [target.'cfg(all(s2n_quic_unstable, s2n_quic_enable_pq_tls))'.dependencies]
-s2n-tls = { version = "=0.0.8", features = ["quic", "pq"] }
+s2n-tls = { version = "=0.0.9", features = ["quic", "pq"] }
 
 [dev-dependencies]
 checkers = "0.6"

--- a/quic/s2n-quic-tls/src/callback.rs
+++ b/quic/s2n-quic-tls/src/callback.rs
@@ -14,7 +14,7 @@ use s2n_quic_crypto::{
     ring::{aead, hkdf},
     Prk, SecretPair, Suite,
 };
-use s2n_tls::raw::{connection::Connection, error::Fallible, ffi::*};
+use s2n_tls::{connection::Connection, error::Fallible, ffi::*};
 
 /// The preallocated size of the outgoing buffer
 ///

--- a/quic/s2n-quic-tls/src/certificate.rs
+++ b/quic/s2n-quic-tls/src/certificate.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bytes::Bytes;
-use s2n_tls::raw::error::Error;
+use s2n_tls::error::Error;
 
 impl Format {
     pub fn as_pem(&self) -> Option<&[u8]> {

--- a/quic/s2n-quic-tls/src/client.rs
+++ b/quic/s2n-quic-tls/src/client.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use s2n_codec::EncoderValue;
 use s2n_quic_core::{application::ServerName, crypto::tls, endpoint};
-use s2n_tls::raw::{
+use s2n_tls::{
     config::{self, Config},
     enums::ClientAuthType,
     error::Error,

--- a/quic/s2n-quic-tls/src/keylog.rs
+++ b/quic/s2n-quic-tls/src/keylog.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use libc::{c_int, c_void};
-use s2n_tls::raw::ffi::*;
+use s2n_tls::ffi::*;
 use std::{
     fs::{File, OpenOptions},
     io::{BufWriter, Write},

--- a/quic/s2n-quic-tls/src/lib.rs
+++ b/quic/s2n-quic-tls/src/lib.rs
@@ -7,9 +7,9 @@
 static ALLOCATOR: checkers::Allocator = checkers::Allocator::system();
 
 #[cfg(all(s2n_quic_unstable, s2n_quic_enable_pq_tls))]
-static DEFAULT_POLICY: &s2n_tls::raw::security::Policy = &s2n_tls::raw::security::TESTING_PQ;
+static DEFAULT_POLICY: &s2n_tls::security::Policy = &s2n_tls::security::TESTING_PQ;
 #[cfg(not(all(s2n_quic_unstable, s2n_quic_enable_pq_tls)))]
-static DEFAULT_POLICY: &s2n_tls::raw::security::Policy = &s2n_tls::raw::security::DEFAULT_TLS13;
+static DEFAULT_POLICY: &s2n_tls::security::Policy = &s2n_tls::security::DEFAULT_TLS13;
 
 mod callback;
 mod keylog;
@@ -26,7 +26,7 @@ pub use server::Server;
 // Re-export the `ClientHelloHandler` and `Connection` to make it easier for users
 // to consume. This depends on experimental behavior in s2n-tls.
 #[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_client_hello")))]
-pub use s2n_tls::raw::{config::ClientHelloHandler, connection::Connection};
+pub use s2n_tls::{callbacks::ClientHelloCallback, connection::Connection};
 
 #[cfg(test)]
 mod tests;

--- a/quic/s2n-quic-tls/src/session.rs
+++ b/quic/s2n-quic-tls/src/session.rs
@@ -10,7 +10,7 @@ use s2n_quic_core::{
     endpoint, transport,
 };
 use s2n_quic_crypto::Suite;
-use s2n_tls::raw::{
+use s2n_tls::{
     config::Config,
     connection::Connection,
     enums::{Blinding, Mode},
@@ -99,7 +99,7 @@ impl tls::Session for Session {
             callback.set(&mut self.connection);
         }
 
-        let result = self.connection.negotiate().map_ok(|_| ());
+        let result = self.connection.poll_negotiate().map_ok(|_| ());
 
         callback.unset(&mut self.connection)?;
 

--- a/quic/s2n-quic-tls/src/tests.rs
+++ b/quic/s2n-quic-tls/src/tests.rs
@@ -15,8 +15,8 @@ use s2n_quic_core::{
     transport,
 };
 #[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_client_hello")))]
-use s2n_tls::raw::{config::ClientHelloHandler, connection::Connection};
-use s2n_tls::raw::{config::VerifyClientCertificateHandler, error::Error};
+use s2n_tls::{callbacks::ClientHelloCallback, connection::Connection};
+use s2n_tls::{callbacks::VerifyHostNameCallback, error::Error};
 use std::sync::Arc;
 
 pub struct MyClientHelloHandler {
@@ -34,8 +34,11 @@ impl MyClientHelloHandler {
 }
 
 #[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_client_hello")))]
-impl ClientHelloHandler for MyClientHelloHandler {
-    fn poll_client_hello(&self, _connection: &mut Connection) -> core::task::Poll<Result<(), ()>> {
+impl ClientHelloCallback for MyClientHelloHandler {
+    fn poll_client_hello(
+        &self,
+        _connection: &mut Connection,
+    ) -> core::task::Poll<Result<(), Error>> {
         if self.wait_counter.fetch_sub(1, Ordering::SeqCst) == 0 {
             self.done.store(true, Ordering::SeqCst);
             return Poll::Ready(Ok(()));
@@ -49,7 +52,7 @@ pub struct VerifyHostNameClientCertVerifier {
     host_name: String,
 }
 
-impl VerifyClientCertificateHandler for VerifyHostNameClientCertVerifier {
+impl VerifyHostNameCallback for VerifyHostNameClientCertVerifier {
     fn verify_host_name(&self, host_name: &str) -> bool {
         self.host_name == host_name
     }
@@ -65,7 +68,7 @@ impl VerifyHostNameClientCertVerifier {
 
 #[derive(Default)]
 pub struct RejectAllClientCertificatesHandler {}
-impl VerifyClientCertificateHandler for RejectAllClientCertificatesHandler {
+impl VerifyHostNameCallback for RejectAllClientCertificatesHandler {
     fn verify_host_name(&self, _host_name: &str) -> bool {
         false
     }
@@ -107,9 +110,7 @@ fn s2n_server_with_client_auth() -> Result<server::Server, Error> {
     server::Builder::default()
         .with_empty_trust_store()?
         .with_client_authentication()?
-        .with_verify_client_certificate_handler(VerifyHostNameClientCertVerifier::new(
-            "qlaws.qlaws",
-        ))?
+        .with_verify_host_name_callback(VerifyHostNameClientCertVerifier::new("qlaws.qlaws"))?
         .with_certificate(CERT_PEM, KEY_PEM)?
         .with_trusted_certificate(CERT_PEM)?
         .build()
@@ -119,7 +120,7 @@ fn s2n_server_with_client_auth_verifier_rejects_client_certs() -> Result<server:
     server::Builder::default()
         .with_empty_trust_store()?
         .with_client_authentication()?
-        .with_verify_client_certificate_handler(RejectAllClientCertificatesHandler::default())?
+        .with_verify_host_name_callback(RejectAllClientCertificatesHandler::default())?
         .with_certificate(CERT_PEM, KEY_PEM)?
         .with_trusted_certificate(CERT_PEM)?
         .build()


### PR DESCRIPTION
### Description of changes: 

This PR updates the s2n-tls version to 0.0.9

### Call-outs:

Some of the callback traits were renamed and needed to be changed. This does introduce a method rename on the builder so I've duplicated the function and added a `deprecated` attribute.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

