### PR TITLE
build: set rust-version in manifest

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -5,6 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/netbench/netbench-cli/Cargo.toml
+++ b/netbench/netbench-cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "netbench-cli"
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.60"
 license = "Apache-2.0"
 publish = false
 

--- a/netbench/netbench-collector/Cargo.toml
+++ b/netbench/netbench-collector/Cargo.toml
@@ -3,6 +3,7 @@ name = "netbench-collector"
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.60"
 license = "Apache-2.0"
 publish = false
 

--- a/netbench/netbench-driver/Cargo.toml
+++ b/netbench/netbench-driver/Cargo.toml
@@ -4,6 +4,7 @@ name = "netbench-driver"
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.60"
 license = "Apache-2.0"
 publish = false
 

--- a/netbench/netbench-scenarios/Cargo.toml
+++ b/netbench/netbench-scenarios/Cargo.toml
@@ -3,6 +3,7 @@ name = "netbench-scenarios"
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.60"
 license = "Apache-2.0"
 publish = false
 

--- a/netbench/netbench/Cargo.toml
+++ b/netbench/netbench/Cargo.toml
@@ -4,6 +4,7 @@ name = "netbench"
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.60"
 license = "Apache-2.0"
 publish = false
 

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -5,6 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -5,6 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-events/Cargo.toml
+++ b/quic/s2n-quic-events/Cargo.toml
@@ -4,6 +4,7 @@ name = "s2n-quic-events"
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 # This is a commit-time crate and should not be published
 publish = false

--- a/quic/s2n-quic-h3/Cargo.toml
+++ b/quic/s2n-quic-h3/Cargo.toml
@@ -4,6 +4,7 @@ name = "s2n-quic-h3"
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 # this contains an http3 implementation for testing purposes and should not be published
 publish = false

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -5,6 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -4,6 +4,7 @@ name = "s2n-quic-qns"
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 publish = false
 

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -5,6 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-sim/Cargo.toml
+++ b/quic/s2n-quic-sim/Cargo.toml
@@ -5,6 +5,7 @@ description = "A simulation environment for s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 publish = false
 

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -5,6 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -5,6 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -5,6 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -5,6 +5,7 @@ description = "A Rust implementation of the IETF QUIC protocol"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
+rust-version = "1.56"
 license = "Apache-2.0"
 # Exclude api.snap and corpus files when publishing to crates.io
 exclude = ["api.snap", "corpus.tar.gz"]


### PR DESCRIPTION
### Description of changes: 

Cargo added support to specify the MSRV in the manifest file so applications get an notification if the rust version is not supported. See https://doc.rust-lang.org/cargo/reference/manifest.html#the-rust-version-field

This PR adds the current MSRV to each of the Cargo.toml files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

