### PR TITLE
fix(s2n-quic-transport): enforce inclusive bound on stream limits

### DIFF
--- a/quic/s2n-quic-transport/src/stream/controller.rs
+++ b/quic/s2n-quic-transport/src/stream/controller.rs
@@ -597,14 +597,22 @@ impl IncomingController {
     }
 
     fn on_remote_open_stream(&mut self, stream_id: StreamId) -> Result<(), transport::Error> {
-        let max_stream_id = StreamId::nth(
+        let allowed_streams = self
+            // the limit of streams to open
+            .max_streams_sync
+            .latest_value()
+            .as_u64()
+            .checked_sub(1)
+            .ok_or(transport::Error::STREAM_LIMIT_ERROR)?;
+        // convert stream index into stream id
+        let max_allowed_stream_id = StreamId::nth(
             stream_id.initiator(),
             stream_id.stream_type(),
-            self.max_streams_sync.latest_value().as_u64(),
+            allowed_streams,
         )
         .expect("max_streams is limited to MAX_STREAMS_MAX_VALUE");
 
-        if stream_id > max_stream_id {
+        if stream_id > max_allowed_stream_id {
             //= https://www.rfc-editor.org/rfc/rfc9000#section-4.6
             //# Endpoints MUST NOT exceed the limit set by their peer.  An endpoint
             //# that receives a frame with a stream ID exceeding the limit it has

--- a/quic/s2n-quic-transport/src/stream/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/stream/manager/tests.rs
@@ -1164,13 +1164,11 @@ fn stream_limit_error_on_peer_open_stream_too_large() {
     for stream_type in [StreamType::Bidirectional, StreamType::Unidirectional] {
         let current_max_streams =
             manager.with_stream_controller(|ctrl| ctrl.max_streams_latest_value(stream_type));
+        // stream_id is 0-indexed
+        let current_max_streams = current_max_streams.as_u64() - 1;
 
-        let max_stream_id = StreamId::nth(
-            endpoint::Type::Client,
-            stream_type,
-            current_max_streams.as_u64(),
-        )
-        .unwrap();
+        let max_stream_id =
+            StreamId::nth(endpoint::Type::Client, stream_type, current_max_streams).unwrap();
 
         assert!(manager
             .with_stream_controller(|ctrl| ctrl.on_remote_open_stream(max_stream_id))


### PR DESCRIPTION
### Description of changes: 
There is a 1-of error when enforcing stream limits. This PR fixes the calculation

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

