### PR TITLE
build: remove testing crates in dockerfile build

### DIFF
--- a/quic/s2n-quic-qns/etc/Dockerfile.build
+++ b/quic/s2n-quic-qns/etc/Dockerfile.build
@@ -4,6 +4,8 @@ RUN cargo install cargo-chef --version 0.1.23
 COPY Cargo.toml /app
 COPY common /app/common
 COPY quic /app/quic
+# Don't include testing crates
+RUN rm -rf quic/s2n-quic-bench quic/s2n-quic-events quic/s2n-quic-sim
 RUN cargo chef prepare  --recipe-path recipe.json
 
 FROM rust:latest as cacher
@@ -23,6 +25,8 @@ RUN set -eux; \
 COPY Cargo.toml /app
 COPY common /app/common
 COPY quic /app/quic
+# Don't include testing crates
+RUN rm -rf quic/s2n-quic-bench quic/s2n-quic-events quic/s2n-quic-sim
 
 # Copy over the cached dependencies
 COPY --from=cacher /app/target target


### PR DESCRIPTION
### Description of changes: 

After merging #1346, the local interop Dockerfile included the `s2n-quic-sim` directory, which needs the `unstable-provider-io-testing` feature. This makes the container need unstable features and fails.

This fix removes the testing crates when building in the container, which removes the need to have unstable features.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

