### PR TITLE
feat(s2n-quic-core): implement BBRv2 state machine

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -86,27 +86,20 @@ impl State {
     /// The dynamic gain factor used to scale BBR.bw to produce BBR.pacing_rate
     pub fn pacing_gain(&self) -> Ratio<u64> {
         match self {
-            State::Startup => startup::STARTUP_PACING_GAIN,
-            State::Drain => drain::DRAIN_PACING_GAIN,
+            State::Startup => startup::PACING_GAIN,
+            State::Drain => drain::PACING_GAIN,
             State::ProbeBw(probe_bw_state) => probe_bw_state.cycle_phase().pacing_gain(),
-            State::ProbeRtt(_) => probe_rtt::PROBE_RTT_PACING_GAIN,
+            State::ProbeRtt(_) => probe_rtt::PACING_GAIN,
         }
     }
 
     /// The dynamic gain factor used to scale the estimated BDP to produce a congestion window (cwnd)
     pub fn cwnd_gain(&self) -> Ratio<u64> {
-        //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.2
-        //# BBREnterDrain():
-        //#     BBR.state = Drain
-        //#     BBR.pacing_gain = 1/BBRStartupCwndGain  /* pace slowly */
-        //#     BBR.cwnd_gain = BBRStartupCwndGain      /* maintain cwnd */
-        const DRAIN_CWND_GAIN: Ratio<u64> = startup::STARTUP_CWND_GAIN;
-
         match self {
-            State::Startup => startup::STARTUP_CWND_GAIN,
-            State::Drain => DRAIN_CWND_GAIN,
-            State::ProbeBw(_) => probe_bw::PROBE_BW_CWND_GAIN,
-            State::ProbeRtt(_) => probe_rtt::PROBE_RTT_CWND_GAIN,
+            State::Startup => startup::CWND_GAIN,
+            State::Drain => drain::CWND_GAIN,
+            State::ProbeBw(_) => probe_bw::CWND_GAIN,
+            State::ProbeRtt(_) => probe_rtt::CWND_GAIN,
         }
     }
 

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -265,7 +265,7 @@ impl CongestionController for BbrCongestionController {
             }
         }
 
-        self.check_probe_rtt(*self.bytes_in_flight, random_generator, ack_receive_time);
+        self.check_probe_rtt(random_generator, ack_receive_time);
         self.congestion_state
             .advance(self.bw_estimator.rate_sample());
     }

--- a/quic/s2n-quic-core/src/recovery/bbr/drain.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/drain.rs
@@ -14,14 +14,14 @@ use num_traits::One;
 //# pacing_gain well below 1.0, until any estimated queue has been drained. It uses a
 //# pacing_gain that is the inverse of the value used during Startup, chosen to try to
 //# drain the queue in one round
-pub(crate) const DRAIN_PACING_GAIN: Ratio<u64> = Ratio::new_raw(1, 2);
+pub(crate) const PACING_GAIN: Ratio<u64> = Ratio::new_raw(1, 2);
 
 //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.2
 //# BBREnterDrain():
 //#     BBR.state = Drain
 //#     BBR.pacing_gain = 1/BBRStartupCwndGain  /* pace slowly */
 //#     BBR.cwnd_gain = BBRStartupCwndGain      /* maintain cwnd */
-pub(crate) const DRAIN_CWND_GAIN: Ratio<u64> = startup::STARTUP_CWND_GAIN;
+pub(crate) const CWND_GAIN: Ratio<u64> = startup::CWND_GAIN;
 
 /// Methods related to the Drain state
 impl BbrCongestionController {

--- a/quic/s2n-quic-core/src/recovery/bbr/drain.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/drain.rs
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    random,
+    recovery::bbr::{startup, BbrCongestionController},
+    time::Timestamp,
+};
+use num_rational::Ratio;
+use num_traits::One;
+
+//= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.2
+//# In Drain, BBR aims to quickly drain any queue created in Startup by switching to a
+//# pacing_gain well below 1.0, until any estimated queue has been drained. It uses a
+//# pacing_gain that is the inverse of the value used during Startup, chosen to try to
+//# drain the queue in one round
+pub(crate) const DRAIN_PACING_GAIN: Ratio<u64> = Ratio::new_raw(1, 2);
+
+//= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.2
+//# BBREnterDrain():
+//#     BBR.state = Drain
+//#     BBR.pacing_gain = 1/BBRStartupCwndGain  /* pace slowly */
+//#     BBR.cwnd_gain = BBRStartupCwndGain      /* maintain cwnd */
+pub(crate) const DRAIN_CWND_GAIN: Ratio<u64> = startup::STARTUP_CWND_GAIN;
+
+/// Methods related to the Drain state
+impl BbrCongestionController {
+    /// Checks if the Drain state is done and enters `ProbeBw` if so
+    pub fn check_drain_done<Rnd: random::Generator>(
+        &mut self,
+        random_generator: &mut Rnd,
+        now: Timestamp,
+    ) {
+        //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.2
+        //# BBRCheckDrain():
+        //#   if (BBR.state == Drain and packets_in_flight <= BBRInflight(1.0))
+        //#     BBREnterProbeBW()  /* BBR estimates the queue was drained */
+        if self.state.is_drain()
+            && self.bytes_in_flight <= self.inflight(self.data_rate_model.bw(), Ratio::one())
+        {
+            self.enter_probe_bw(false, random_generator, now);
+        }
+    }
+}

--- a/quic/s2n-quic-core/src/recovery/bbr/full_pipe.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/full_pipe.rs
@@ -28,7 +28,6 @@ pub(crate) struct Estimator {
 
 impl Estimator {
     /// Returns true if BBR estimates that is has ever fully utilized its available bandwidth
-    #[allow(dead_code)] // TODO: Remove when used
     #[inline]
     pub fn filled_pipe(&self) -> bool {
         self.filled_pipe

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
@@ -25,7 +25,7 @@ const MAX_BW_PROBE_ROUNDS: u8 = 63;
 ///
 /// This value is defined in the table in
 /// https://www.ietf.org/archive/id/draft-cardwell-iccrg-bbr-congestion-control-02.html#section-4.6.1
-pub(crate) const PROBE_BW_CWND_GAIN: Ratio<u64> = Ratio::new_raw(2, 1);
+pub(crate) const CWND_GAIN: Ratio<u64> = Ratio::new_raw(2, 1);
 
 //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3
 //# a BBR flow in ProbeBW mode cycles through the four

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_rtt.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_rtt.rs
@@ -86,7 +86,6 @@ impl BbrCongestionController {
     /// Check if it is time to start probing for RTT changes, and enter the ProbeRtt state if so
     pub fn check_probe_rtt<Rnd: random::Generator>(
         &mut self,
-        bytes_in_flight: u32,
         random_generator: &mut Rnd,
         now: Timestamp,
     ) {
@@ -121,7 +120,7 @@ impl BbrCongestionController {
                 &mut self.bw_estimator,
                 &mut self.round_counter,
                 probe_rtt_cwnd,
-                bytes_in_flight,
+                *self.bytes_in_flight,
                 now,
             );
             if probe_rtt_state.is_done(now) {

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_rtt.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_rtt.rs
@@ -17,6 +17,16 @@ use num_rational::Ratio;
 //# holds inflight to BBRMinPipeCwnd or fewer packets: 200 ms.
 const PROBE_RTT_DURATION: Duration = Duration::from_millis(200);
 
+//= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.4.4
+//# BBREnterProbeRTT():
+//#     BBR.state = ProbeRTT
+//#     BBR.pacing_gain = 1
+pub(crate) const PROBE_RTT_PACING_GAIN: Ratio<u64> = Ratio::new_raw(1, 1);
+
+//= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#2.14.2
+//# A constant specifying the gain value for calculating the cwnd during ProbeRTT: 0.5
+pub(crate) const PROBE_RTT_CWND_GAIN: Ratio<u64> = Ratio::new_raw(1, 2);
+
 #[derive(Clone, Debug, Default)]
 pub(crate) struct State {
     timer: Timer,
@@ -166,8 +176,7 @@ impl BbrCongestionController {
         //#    probe_rtt_cwnd = max(probe_rtt_cwnd, BBRMinPipeCwnd)
         //#    return probe_rtt_cwnd#
 
-        let probe_rtt_cwnd_gain = Ratio::new(1u64, 2u64); // TODO State::ProbeRtt.cwnd_gain()
-        self.bdp_multiple(self.data_rate_model.bw(), probe_rtt_cwnd_gain)
+        self.bdp_multiple(self.data_rate_model.bw(), PROBE_RTT_CWND_GAIN)
             .try_into()
             .unwrap_or(u32::MAX)
             .max(self.minimum_window())

--- a/quic/s2n-quic-core/src/recovery/bbr/startup.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/startup.rs
@@ -7,12 +7,12 @@ use num_rational::Ratio;
 //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#2.6
 //# A constant specifying the minimum gain value for calculating the pacing rate that will
 //# allow the sending rate to double each round (4*ln(2) ~= 2.77)
-pub(crate) const STARTUP_PACING_GAIN: Ratio<u64> = Ratio::new_raw(277, 100);
+pub(crate) const PACING_GAIN: Ratio<u64> = Ratio::new_raw(277, 100);
 
 //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#2.6
 //# A constant specifying the minimum gain value for calculating the
 //# cwnd that will allow the sending rate to double each round (2.0)
-pub(crate) const STARTUP_CWND_GAIN: Ratio<u64> = Ratio::new_raw(2, 1);
+pub(crate) const CWND_GAIN: Ratio<u64> = Ratio::new_raw(2, 1);
 
 /// Methods related to the Startup state
 impl BbrCongestionController {


### PR DESCRIPTION
### Description of changes: 

This change implements the 4 BBRv2 states (Startup, Drain, ProbeBW, and ProbeRTT) and adds the transitions between them. I've also refactored things a bit to move the probe_rtt_state and the probe_bw_state into the `bbr::State` enum, and added more pseudocode citations from the draft RFC

### Testing:

TODO

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

