### PR TITLE
fix(s2n-quic-transport): make bidi stream controller initiator aware

### DIFF
--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -207,8 +207,12 @@ impl Limits {
         InitialFlowControlLimits {
             stream_limits: self.initial_stream_limits(),
             max_data: self.data_window.as_varint(),
-            max_streams_bidi: self.max_open_remote_bidirectional_streams.as_varint(),
-            max_streams_uni: self.max_open_remote_unidirectional_streams.as_varint(),
+            max_open_remote_bidirectional_streams: self
+                .max_open_remote_bidirectional_streams
+                .as_varint(),
+            max_open_remote_unidirectional_streams: self
+                .max_open_remote_unidirectional_streams
+                .as_varint(),
         }
     }
 

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -51,10 +51,9 @@ pub struct Limits {
     pub(crate) bidirectional_local_data_window: InitialMaxStreamDataBidiLocal,
     pub(crate) bidirectional_remote_data_window: InitialMaxStreamDataBidiRemote,
     pub(crate) unidirectional_data_window: InitialMaxStreamDataUni,
-    pub(crate) max_open_bidirectional_streams: InitialMaxStreamsBidi,
+    pub(crate) max_open_local_bidirectional_streams: stream::limits::LocalBidirectional,
     pub(crate) max_open_local_unidirectional_streams: stream::limits::LocalUnidirectional,
-    pub(crate) max_open_local_bidirectional_streams: Option<stream::limits::LocalBidirectional>,
-    pub(crate) max_open_remote_bidirectional_streams: Option<InitialMaxStreamsBidi>,
+    pub(crate) max_open_remote_bidirectional_streams: InitialMaxStreamsBidi,
     pub(crate) max_open_remote_unidirectional_streams: InitialMaxStreamsUni,
     pub(crate) max_ack_delay: MaxAckDelay,
     pub(crate) ack_delay_exponent: AckDelayExponent,
@@ -90,10 +89,9 @@ impl Limits {
             bidirectional_local_data_window: InitialMaxStreamDataBidiLocal::RECOMMENDED,
             bidirectional_remote_data_window: InitialMaxStreamDataBidiRemote::RECOMMENDED,
             unidirectional_data_window: InitialMaxStreamDataUni::RECOMMENDED,
-            max_open_bidirectional_streams: InitialMaxStreamsBidi::RECOMMENDED,
+            max_open_local_bidirectional_streams: stream::limits::LocalBidirectional::RECOMMENDED,
             max_open_local_unidirectional_streams: stream::limits::LocalUnidirectional::RECOMMENDED,
-            max_open_local_bidirectional_streams: None,
-            max_open_remote_bidirectional_streams: None,
+            max_open_remote_bidirectional_streams: InitialMaxStreamsBidi::RECOMMENDED,
             max_open_remote_unidirectional_streams: InitialMaxStreamsUni::RECOMMENDED,
             max_ack_delay: MaxAckDelay::RECOMMENDED,
             ack_delay_exponent: AckDelayExponent::RECOMMENDED,
@@ -125,41 +123,38 @@ impl Limits {
         u64
     );
 
-    /// Sets the max local and remote limits for bidi streams.
-    ///
-    /// The value `with_max_open_remote_bidirectional_streams` and
-    /// `with_max_open_local_bidirectional_streams` will be used instead
-    /// if set on the builder.
-    // TODO: Deprecate
+    /// Sets both the max local and remote limits for bidirectional streams.
+    #[deprecated(
+        note = "use with_max_open_local_bidirectional_streams and with_max_open_remote_bidirectional_streams instead"
+    )]
     pub fn with_max_open_bidirectional_streams(
         mut self,
         value: u64,
     ) -> Result<Self, ValidationError> {
-        self.max_open_bidirectional_streams = value.try_into()?;
+        self.max_open_local_bidirectional_streams = value.try_into()?;
+        self.max_open_remote_bidirectional_streams = value.try_into()?;
         Ok(self)
     }
 
-    /// Sets the max local limits for bidi streams
+    /// Sets the max local limits for bidirectional streams
     ///
     /// The value set is used instead of `with_max_open_bidirectional_streams` when set.
-    #[doc(hidden)]
     pub fn with_max_open_local_bidirectional_streams(
         mut self,
         value: u64,
     ) -> Result<Self, ValidationError> {
-        self.max_open_local_bidirectional_streams = Some(value.try_into()?);
+        self.max_open_local_bidirectional_streams = value.try_into()?;
         Ok(self)
     }
 
-    /// Sets the max remote limits for bidi streams.
+    /// Sets the max remote limits for bidirectional streams.
     ///
     /// The value set is used instead of `with_max_open_bidirectional_streams` when set.
-    #[doc(hidden)]
     pub fn with_max_open_remote_bidirectional_streams(
         mut self,
         value: u64,
     ) -> Result<Self, ValidationError> {
-        self.max_open_remote_bidirectional_streams = Some(value.try_into()?);
+        self.max_open_remote_bidirectional_streams = value.try_into()?;
         Ok(self)
     }
 
@@ -209,13 +204,10 @@ impl Limits {
 
     #[doc(hidden)]
     pub fn initial_flow_control_limits(&self) -> InitialFlowControlLimits {
-        let max_bidi_limit = self
-            .max_open_remote_bidirectional_streams
-            .unwrap_or(self.max_open_bidirectional_streams);
         InitialFlowControlLimits {
             stream_limits: self.initial_stream_limits(),
             max_data: self.data_window.as_varint(),
-            max_streams_bidi: max_bidi_limit.as_varint(),
+            max_streams_bidi: self.max_open_remote_bidirectional_streams.as_varint(),
             max_streams_uni: self.max_open_remote_unidirectional_streams.as_varint(),
         }
     }
@@ -234,9 +226,7 @@ impl Limits {
         stream::Limits {
             max_send_buffer_size: self.max_send_buffer_size,
             max_open_local_unidirectional_streams: self.max_open_local_unidirectional_streams,
-            max_open_local_bidirectional_streams: self
-                .max_open_local_bidirectional_streams
-                .unwrap_or_else(|| self.max_open_bidirectional_streams.into()),
+            max_open_local_bidirectional_streams: self.max_open_local_bidirectional_streams,
         }
     }
 

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -203,7 +203,7 @@ impl Limits {
     }
 
     #[doc(hidden)]
-    pub fn initial_flow_control_limits(&self) -> InitialFlowControlLimits {
+    pub const fn initial_flow_control_limits(&self) -> InitialFlowControlLimits {
         InitialFlowControlLimits {
             stream_limits: self.initial_stream_limits(),
             max_data: self.data_window.as_varint(),

--- a/quic/s2n-quic-core/src/stream/id.rs
+++ b/quic/s2n-quic-core/src/stream/id.rs
@@ -4,12 +4,15 @@
 //! Types and utilities around the QUIC Stream identifier
 
 use crate::{endpoint, stream::StreamType, varint::VarInt};
+#[cfg(any(test, feature = "generator"))]
+use bolero_generator::*;
 
 /// The ID of a stream.
 ///
 /// A stream ID is a 62-bit integer (0 to 2^62-1) that is unique for all streams
 /// on a connection.
 #[derive(PartialEq, Eq, PartialOrd, Ord, Debug, Copy, Clone, Hash)]
+#[cfg_attr(any(feature = "generator", test), derive(TypeGenerator))]
 pub struct StreamId(VarInt);
 
 // Stream IDs can be converted into `VarInt` and `u64`

--- a/quic/s2n-quic-core/src/stream/iter.rs
+++ b/quic/s2n-quic-core/src/stream/iter.rs
@@ -44,7 +44,7 @@ impl Iterator for StreamIter {
         }
 
         match self.start_stream_id.cmp(&self.max_stream_id) {
-            std::cmp::Ordering::Less => {
+            core::cmp::Ordering::Less => {
                 let ret = self.start_stream_id;
                 // The Stream ID can be expected to be valid, since `max_stream_id`
                 // is a valid `StreamId` and all IDs we iterate over are lower.
@@ -54,13 +54,13 @@ impl Iterator for StreamIter {
                     .expect("Expect a valid Stream ID");
                 Some(ret)
             }
-            std::cmp::Ordering::Equal => {
+            core::cmp::Ordering::Equal => {
                 // Avoid incrementing beyond `max_stream_id` and mark finished to
                 // to avoid returning max value again
                 self.finished = true;
                 Some(self.start_stream_id)
             }
-            std::cmp::Ordering::Greater => {
+            core::cmp::Ordering::Greater => {
                 debug_assert!(false, "The `new` method should verify valid ranges");
 
                 // finished

--- a/quic/s2n-quic-core/src/stream/iter.rs
+++ b/quic/s2n-quic-core/src/stream/iter.rs
@@ -1,0 +1,101 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::StreamId;
+#[cfg(any(test, feature = "generator"))]
+use bolero_generator::*;
+
+/// An Iterator over Stream Ids of a particular type.
+#[derive(Debug, Clone, Copy)]
+#[cfg_attr(any(feature = "generator", test), derive(TypeGenerator))]
+pub struct StreamIter {
+    start_stream_id: StreamId,
+    max_stream_id: StreamId,
+    finished: bool,
+}
+
+impl StreamIter {
+    #[inline]
+    pub fn new(start_stream_id: StreamId, max_stream_id: StreamId) -> Self {
+        debug_assert_eq!(start_stream_id.stream_type(), max_stream_id.stream_type());
+        debug_assert_eq!(start_stream_id.initiator(), max_stream_id.initiator());
+        debug_assert!(start_stream_id <= max_stream_id);
+
+        Self {
+            start_stream_id,
+            max_stream_id,
+            finished: false,
+        }
+    }
+
+    #[inline]
+    pub fn max_stream_id(self) -> StreamId {
+        self.max_stream_id
+    }
+}
+
+impl Iterator for StreamIter {
+    type Item = StreamId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // short circuit when finished
+        if self.finished {
+            return None;
+        }
+
+        match self.start_stream_id.cmp(&self.max_stream_id) {
+            std::cmp::Ordering::Less => {
+                let ret = self.start_stream_id;
+                // The Stream ID can be expected to be valid, since `max_stream_id`
+                // is a valid `StreamId` and all IDs we iterate over are lower.
+                self.start_stream_id = self
+                    .start_stream_id
+                    .next_of_type()
+                    .expect("Expect a valid Stream ID");
+                Some(ret)
+            }
+            std::cmp::Ordering::Equal => {
+                // Avoid incrementing beyond `max_stream_id` and mark finished to
+                // to avoid returning max value again
+                self.finished = true;
+                Some(self.start_stream_id)
+            }
+            std::cmp::Ordering::Greater => {
+                debug_assert!(false, "The `new` method should verify valid ranges");
+
+                // finished
+                self.finished = true;
+                None
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod fuzz_target {
+    use super::*;
+
+    #[test]
+    fn fuzz_builder() {
+        bolero::check!()
+            .with_type::<(StreamId, StreamId)>()
+            .cloned()
+            .for_each(|(min, max)| {
+                // enforce min <= max
+                if min > max {
+                    return;
+                }
+                // enforce same initiator type
+                if min.initiator() != max.initiator() {
+                    return;
+                }
+                // enforce same stream type
+                if min.stream_type() != max.stream_type() {
+                    return;
+                }
+
+                // All other combinations of min/max StreamId should be valid
+                StreamIter::new(min, max);
+            });
+    }
+}

--- a/quic/s2n-quic-core/src/stream/limits.rs
+++ b/quic/s2n-quic-core/src/stream/limits.rs
@@ -10,6 +10,10 @@ use crate::{
 /// The default send buffer size for Streams
 const DEFAULT_STREAM_MAX_SEND_BUFFER_SIZE: u32 = 512 * 1024;
 
+pub trait LocalLimits {
+    fn as_varint(&self) -> VarInt;
+}
+
 /// Per-stream limits
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Limits {
@@ -53,8 +57,8 @@ macro_rules! varint_local_limits {
     ($name:ident($encodable_type:ty)) => {
         local_limits!($name($encodable_type));
 
-        impl $name {
-            pub const fn as_varint(&self) -> VarInt {
+        impl LocalLimits for $name {
+            fn as_varint(&self) -> VarInt {
                 self.0
             }
         }

--- a/quic/s2n-quic-core/src/stream/limits.rs
+++ b/quic/s2n-quic-core/src/stream/limits.rs
@@ -58,6 +58,7 @@ macro_rules! varint_local_limits {
         local_limits!($name($encodable_type));
 
         impl LocalLimits for $name {
+            #[inline]
             fn as_varint(&self) -> VarInt {
                 self.0
             }
@@ -66,6 +67,7 @@ macro_rules! varint_local_limits {
         impl TryFrom<u64> for $name {
             type Error = ValidationError;
 
+            #[inline]
             fn try_from(value: u64) -> Result<Self, Self::Error> {
                 let value = VarInt::new(value)?;
                 Ok(Self(value))
@@ -79,6 +81,7 @@ local_limits!(MaxSendBufferSize(u32));
 impl MaxSendBufferSize {
     pub const RECOMMENDED: Self = Self(DEFAULT_STREAM_MAX_SEND_BUFFER_SIZE);
 
+    #[inline]
     pub fn as_u32(self) -> u32 {
         self.0
     }
@@ -87,6 +90,7 @@ impl MaxSendBufferSize {
 impl TryFrom<u32> for MaxSendBufferSize {
     type Error = ValidationError;
 
+    #[inline]
     fn try_from(value: u32) -> Result<Self, Self::Error> {
         Ok(Self(value))
     }

--- a/quic/s2n-quic-core/src/stream/mod.rs
+++ b/quic/s2n-quic-core/src/stream/mod.rs
@@ -3,6 +3,7 @@
 
 mod error;
 mod id;
+pub mod iter;
 pub mod limits;
 pub mod ops;
 mod type_;

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -1472,7 +1472,11 @@ impl<
             initial_max_stream_data_bidi_remote
         );
         load!(unidirectional_data_window, initial_max_stream_data_uni);
-        load!(max_open_bidirectional_streams, initial_max_streams_bidi);
+        load!(
+            max_open_remote_bidirectional_streams,
+            initial_max_streams_bidi
+        );
+
         load!(
             max_open_remote_unidirectional_streams,
             initial_max_streams_uni

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -1095,8 +1095,8 @@ optional_transport_parameter!(RetrySourceConnectionId);
 pub struct InitialFlowControlLimits {
     pub stream_limits: InitialStreamLimits,
     pub max_data: VarInt,
-    pub max_streams_bidi: VarInt,
-    pub max_streams_uni: VarInt,
+    pub max_open_remote_bidirectional_streams: VarInt,
+    pub max_open_remote_unidirectional_streams: VarInt,
 }
 
 /// Associated flow control limits from a set of TransportParameters
@@ -1150,8 +1150,8 @@ impl<
         InitialFlowControlLimits {
             stream_limits: self.stream_limits(),
             max_data: **initial_max_data,
-            max_streams_bidi: **initial_max_streams_bidi,
-            max_streams_uni: **initial_max_streams_uni,
+            max_open_remote_bidirectional_streams: **initial_max_streams_bidi,
+            max_open_remote_unidirectional_streams: **initial_max_streams_uni,
         }
     }
 

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1753,7 +1753,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
 
         space
             .stream_manager
-            .poll_open(stream_type, open_token, context)
+            .poll_open_local_stream(stream_type, open_token, context)
     }
 
     fn application_close(&mut self, error: Option<application::Error>) {

--- a/quic/s2n-quic-transport/src/stream/controller.rs
+++ b/quic/s2n-quic-transport/src/stream/controller.rs
@@ -18,23 +18,18 @@ use core::{
 use s2n_quic_core::{
     ack, endpoint,
     frame::MaxStreams,
-    stream,
-    stream::{StreamId, StreamType},
+    stream::{
+        self,
+        iter::StreamIter,
+        limits::{LocalBidirectional, LocalUnidirectional},
+        StreamId, StreamType,
+    },
     time::{timer, Timestamp},
     transport,
     transport::parameters::InitialFlowControlLimits,
 };
 
 pub use remote_initiated::MAX_STREAMS_SYNC_FRACTION;
-
-enum StreamDirection {
-    // A stream that both transmits and receives data
-    Bidirectional,
-    // A stream that transmits data (unidirectional)
-    Outgoing,
-    // A stream that receives data (unidirectional)
-    Incoming,
-}
 
 /// This component manages stream concurrency limits.
 ///
@@ -45,8 +40,10 @@ enum StreamDirection {
 #[derive(Debug)]
 pub struct Controller {
     local_endpoint_type: endpoint::Type,
-    bidi_controller: ControllerPair,
-    uni_controller: ControllerPair,
+    local_bidi_controller: LocalInitiated<LocalBidirectional>,
+    remote_bidi_controller: RemoteInitiated,
+    local_uni_controller: LocalInitiated<LocalUnidirectional>,
+    remote_uni_controller: RemoteInitiated,
 }
 
 impl Controller {
@@ -69,24 +66,16 @@ impl Controller {
     ) -> Self {
         Self {
             local_endpoint_type,
-            bidi_controller: ControllerPair {
-                stream_id: StreamId::initial(local_endpoint_type, StreamType::Bidirectional),
-                local_initiated: LocalInitiated::new(
-                    initial_peer_limits.max_streams_bidi,
-                    initial_local_limits.max_streams_bidi,
-                ),
-                remote_initiated: RemoteInitiated::new(initial_local_limits.max_streams_bidi),
-            },
-            uni_controller: ControllerPair {
-                stream_id: StreamId::initial(local_endpoint_type, StreamType::Unidirectional),
-                local_initiated: LocalInitiated::new(
-                    initial_peer_limits.max_streams_uni,
-                    stream_limits
-                        .max_open_local_unidirectional_streams
-                        .as_varint(),
-                ),
-                remote_initiated: RemoteInitiated::new(initial_local_limits.max_streams_uni),
-            },
+            local_bidi_controller: LocalInitiated::new(
+                initial_peer_limits.max_streams_bidi,
+                stream_limits.max_open_local_bidirectional_streams,
+            ),
+            remote_bidi_controller: RemoteInitiated::new(initial_local_limits.max_streams_bidi),
+            local_uni_controller: LocalInitiated::new(
+                initial_peer_limits.max_streams_uni,
+                stream_limits.max_open_local_unidirectional_streams,
+            ),
+            remote_uni_controller: RemoteInitiated::new(initial_local_limits.max_streams_uni),
         }
     }
 
@@ -94,97 +83,164 @@ impl Controller {
     /// which signals an increase in the available streams budget.
     pub fn on_max_streams(&mut self, frame: &MaxStreams) {
         match frame.stream_type {
-            StreamType::Bidirectional => self.bidi_controller.local_initiated.on_max_streams(frame),
-            StreamType::Unidirectional => self.uni_controller.local_initiated.on_max_streams(frame),
+            StreamType::Bidirectional => self.local_bidi_controller.on_max_streams(frame),
+            StreamType::Unidirectional => self.local_uni_controller.on_max_streams(frame),
         }
     }
 
     /// This method is called when the local application wishes to open a new stream.
     ///
+    /// This API requires that only one stream is opened per invocation and must be
+    /// called the next stream id of a type.
+    ///
     /// `Poll::Pending` is returned when there isn't available capacity to open a stream,
     /// either because of local initiated concurrency limits or the peer's stream limits.
     /// If `Poll::Pending` is returned, the waker in the given `context` will be woken
     /// when additional stream capacity becomes available.
-    pub fn poll_local_open_stream(
+    pub fn poll_open_local_stream(
         &mut self,
-        stream_type: StreamType,
+        stream_id: StreamId,
         open_tokens: &mut connection::OpenToken,
         context: &Context,
-    ) -> Poll<()> {
-        match stream_type {
+    ) -> Poll<StreamId> {
+        if cfg!(debug_assertions) {
+            match self.direction(stream_id) {
+                StreamDirection::RemoteInitiatedBidirectional
+                | StreamDirection::RemoteInitiatedUnidirectional => {
+                    panic!("should only be called for locally initiated streams")
+                }
+                _ => (),
+            }
+        }
+
+        let poll = match stream_id.stream_type() {
             StreamType::Bidirectional => self
-                .bidi_controller
-                .local_initiated
+                .local_bidi_controller
                 .poll_open_stream(&mut open_tokens.bidirectional, context),
             StreamType::Unidirectional => self
-                .uni_controller
-                .local_initiated
+                .local_uni_controller
                 .poll_open_stream(&mut open_tokens.unidirectional, context),
+        };
+
+        match poll {
+            Poll::Ready(_) => {
+                // only open streams if there is sufficient capacity based on limits
+                self.on_open_stream(stream_id);
+                Poll::Ready(stream_id)
+            }
+            Poll::Pending => Poll::Pending,
         }
     }
 
     /// This method is called when the remote peer wishes to open a new stream.
     ///
-    /// A `STREAM_LIMIT_ERROR` will be returned if the peer has exceeded the stream limits
-    /// that were communicated by transport parameters or MAX_STREAMS frames.
-    pub fn on_remote_open_stream(&mut self, stream_id: StreamId) -> Result<(), transport::Error> {
-        match stream_id.stream_type() {
-            StreamType::Bidirectional => self
-                .bidi_controller
-                .remote_initiated
-                .on_remote_open_stream(stream_id),
-            StreamType::Unidirectional => self
-                .uni_controller
-                .remote_initiated
-                .on_remote_open_stream(stream_id),
+    /// Opening a Stream also opens all lower Streams of the same type. Therefore
+    /// this function validates if there is enough capacity to open all streams.
+    ///
+    /// A `STREAM_LIMIT_ERROR` will be returned if the peer has exceeded the
+    /// stream limits that were communicated by transport parameters or
+    /// MAX_STREAMS frames.
+    pub fn on_open_remote_stream(
+        &mut self,
+        stream_iter: StreamIter,
+    ) -> Result<(), transport::Error> {
+        if cfg!(debug_assertions) {
+            match self.direction(stream_iter.max_stream_id()) {
+                StreamDirection::LocalInitiatedBidirectional
+                | StreamDirection::LocalInitiatedUnidirectional => {
+                    panic!("should only be called for remote initiated streams")
+                }
+                _ => (),
+            }
         }
+
+        // return early if there is not sufficient capacity based on limits
+        match stream_iter.max_stream_id().stream_type() {
+            StreamType::Bidirectional => self
+                .remote_bidi_controller
+                .on_remote_open_stream(stream_iter.max_stream_id())?,
+            StreamType::Unidirectional => self
+                .remote_uni_controller
+                .on_remote_open_stream(stream_iter.max_stream_id())?,
+        }
+
+        for stream_id in stream_iter {
+            self.on_open_stream(stream_id);
+        }
+        Ok(())
     }
 
-    /// This method is called whenever a stream is opened, regardless of which side initiated.
-    pub fn on_open_stream(&mut self, stream_id: StreamId) {
+    /// This method is called whenever a stream is opened, regardless of
+    /// which side initiated.
+    ///
+    /// The caller is responsible for performing stream capacity checks
+    /// prior to calling this function.
+    fn on_open_stream(&mut self, stream_id: StreamId) {
         match self.direction(stream_id) {
-            StreamDirection::Bidirectional => self.bidi_controller.on_open_stream(),
-            StreamDirection::Outgoing => self.uni_controller.local_initiated.on_open_stream(),
-            StreamDirection::Incoming => self.uni_controller.remote_initiated.on_open_stream(),
+            StreamDirection::LocalInitiatedBidirectional => {
+                self.local_bidi_controller.on_open_stream()
+            }
+            StreamDirection::RemoteInitiatedBidirectional => {
+                self.remote_bidi_controller.on_open_stream()
+            }
+            StreamDirection::LocalInitiatedUnidirectional => {
+                self.local_uni_controller.on_open_stream()
+            }
+            StreamDirection::RemoteInitiatedUnidirectional => {
+                self.remote_uni_controller.on_open_stream()
+            }
         }
     }
 
     /// This method is called whenever a stream is closed.
     pub fn on_close_stream(&mut self, stream_id: StreamId) {
         match self.direction(stream_id) {
-            StreamDirection::Bidirectional => self.bidi_controller.on_close_stream(),
-            StreamDirection::Outgoing => self.uni_controller.local_initiated.on_close_stream(),
-            StreamDirection::Incoming => self.uni_controller.remote_initiated.on_close_stream(),
+            StreamDirection::LocalInitiatedBidirectional => {
+                self.local_bidi_controller.on_close_stream()
+            }
+            StreamDirection::RemoteInitiatedBidirectional => {
+                self.remote_bidi_controller.on_close_stream()
+            }
+            StreamDirection::LocalInitiatedUnidirectional => {
+                self.local_uni_controller.on_close_stream()
+            }
+            StreamDirection::RemoteInitiatedUnidirectional => {
+                self.remote_uni_controller.on_close_stream()
+            }
         }
     }
 
     /// This method is called when the stream manager is closed. All wakers will be woken
     /// to unblock waiting tasks.
     pub fn close(&mut self) {
-        self.bidi_controller.close();
-        self.uni_controller.close();
+        self.local_bidi_controller.close();
+        self.remote_bidi_controller.close();
+        self.local_uni_controller.close();
+        self.remote_uni_controller.close();
     }
 
     /// This method is called when a packet delivery got acknowledged
     pub fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A) {
-        self.bidi_controller.on_packet_ack(ack_set);
-        self.uni_controller.on_packet_ack(ack_set);
+        self.local_bidi_controller.on_packet_ack(ack_set);
+        self.remote_bidi_controller.on_packet_ack(ack_set);
+        self.local_uni_controller.on_packet_ack(ack_set);
+        self.remote_uni_controller.on_packet_ack(ack_set);
     }
 
     /// This method is called when a packet loss is reported
     pub fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A) {
-        self.bidi_controller.on_packet_loss(ack_set);
-        self.uni_controller.on_packet_loss(ack_set);
+        self.local_bidi_controller.on_packet_loss(ack_set);
+        self.remote_bidi_controller.on_packet_loss(ack_set);
+        self.local_uni_controller.on_packet_loss(ack_set);
+        self.remote_uni_controller.on_packet_loss(ack_set);
     }
 
     /// Updates the period at which `STREAMS_BLOCKED` frames are sent to the peer
     /// if the application is blocked by peer limits.
     pub fn update_blocked_sync_period(&mut self, blocked_sync_period: Duration) {
-        self.bidi_controller
-            .local_initiated
+        self.local_bidi_controller
             .update_sync_period(blocked_sync_period);
-        self.uni_controller
-            .local_initiated
+        self.local_uni_controller
             .update_sync_period(blocked_sync_period);
     }
 
@@ -195,25 +251,33 @@ impl Controller {
             return Ok(());
         }
 
-        self.bidi_controller.on_transmit(context)?;
-        self.uni_controller.on_transmit(context)?;
+        // Only the stream_type from the StreamId is transmitted
+        let stream_id = StreamId::initial(self.local_endpoint_type, StreamType::Bidirectional);
+        self.local_bidi_controller.on_transmit(stream_id, context)?;
+        self.remote_bidi_controller
+            .on_transmit(stream_id, context)?;
+
+        // Only the stream_type from the StreamId is transmitted
+        let stream_id = StreamId::initial(self.local_endpoint_type, StreamType::Unidirectional);
+        self.remote_uni_controller.on_transmit(stream_id, context)?;
+        self.local_uni_controller.on_transmit(stream_id, context)?;
 
         Ok(())
     }
 
     /// Called when the connection timer expires
     pub fn on_timeout(&mut self, now: Timestamp) {
-        self.bidi_controller.on_timeout(now);
-        self.uni_controller.on_timeout(now);
+        self.local_bidi_controller.on_timeout(now);
+        self.local_uni_controller.on_timeout(now);
     }
 
     fn direction(&self, stream_id: StreamId) -> StreamDirection {
-        match stream_id.stream_type() {
-            StreamType::Bidirectional => StreamDirection::Bidirectional,
-            StreamType::Unidirectional if stream_id.initiator() == self.local_endpoint_type => {
-                StreamDirection::Outgoing
-            }
-            StreamType::Unidirectional => StreamDirection::Incoming,
+        let is_local_initiated = self.local_endpoint_type == stream_id.initiator();
+        match (is_local_initiated, stream_id.stream_type()) {
+            (true, StreamType::Bidirectional) => StreamDirection::LocalInitiatedBidirectional,
+            (true, StreamType::Unidirectional) => StreamDirection::LocalInitiatedUnidirectional,
+            (false, StreamType::Bidirectional) => StreamDirection::RemoteInitiatedBidirectional,
+            (false, StreamType::Unidirectional) => StreamDirection::RemoteInitiatedUnidirectional,
         }
     }
 }
@@ -221,8 +285,8 @@ impl Controller {
 impl timer::Provider for Controller {
     #[inline]
     fn timers<Q: timer::Query>(&self, query: &mut Q) -> timer::Result {
-        self.bidi_controller.timers(query)?;
-        self.uni_controller.timers(query)?;
+        self.local_bidi_controller.timers(query)?;
+        self.local_uni_controller.timers(query)?;
         Ok(())
     }
 }
@@ -234,85 +298,20 @@ impl transmission::interest::Provider for Controller {
         &self,
         query: &mut Q,
     ) -> transmission::interest::Result {
-        self.bidi_controller.transmission_interest(query)?;
-        self.uni_controller.transmission_interest(query)?;
+        self.local_bidi_controller.transmission_interest(query)?;
+        self.remote_bidi_controller.transmission_interest(query)?;
+        self.local_uni_controller.transmission_interest(query)?;
+        self.remote_uni_controller.transmission_interest(query)?;
         Ok(())
     }
 }
 
-/// The controller pair consists of both local_initiated and remote_initiated
-/// controllers that are both notified when a stream is opened, regardless
-/// of which side initiated the stream.
-#[derive(Debug)]
-struct ControllerPair {
-    stream_id: StreamId,
-    local_initiated: LocalInitiated,
-    remote_initiated: RemoteInitiated,
-}
-
-impl ControllerPair {
-    #[inline]
-    fn on_open_stream(&mut self) {
-        self.local_initiated.on_open_stream();
-        self.remote_initiated.on_open_stream();
-    }
-
-    #[inline]
-    fn on_close_stream(&mut self) {
-        self.local_initiated.on_close_stream();
-        self.remote_initiated.on_close_stream();
-    }
-
-    #[inline]
-    pub fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A) {
-        self.remote_initiated.on_packet_ack(ack_set);
-        self.local_initiated.on_packet_ack(ack_set);
-    }
-
-    #[inline]
-    pub fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A) {
-        self.remote_initiated.on_packet_loss(ack_set);
-        self.local_initiated.on_packet_loss(ack_set);
-    }
-
-    #[inline]
-    pub fn on_timeout(&mut self, now: Timestamp) {
-        self.local_initiated.on_timeout(now);
-    }
-
-    #[inline]
-    pub fn on_transmit<W: WriteContext>(&mut self, context: &mut W) -> Result<(), OnTransmitError> {
-        // Only the stream_type from the StreamId is transmitted
-        self.remote_initiated.on_transmit(self.stream_id, context)?;
-        self.local_initiated.on_transmit(self.stream_id, context)
-    }
-
-    /// This method is called when the stream manager is closed. All wakers will be woken
-    /// to unblock waiting tasks.
-    pub fn close(&mut self) {
-        self.local_initiated.close();
-        self.remote_initiated.close();
-    }
-}
-
-impl timer::Provider for ControllerPair {
-    #[inline]
-    fn timers<Q: timer::Query>(&self, query: &mut Q) -> timer::Result {
-        self.local_initiated.timers(query)?;
-        Ok(())
-    }
-}
-
-impl transmission::interest::Provider for ControllerPair {
-    #[inline]
-    fn transmission_interest<Q: transmission::interest::Query>(
-        &self,
-        query: &mut Q,
-    ) -> transmission::interest::Result {
-        self.remote_initiated.transmission_interest(query)?;
-        self.local_initiated.transmission_interest(query)?;
-        Ok(())
-    }
+#[derive(Debug, Copy, Clone)]
+enum StreamDirection {
+    LocalInitiatedBidirectional,
+    RemoteInitiatedBidirectional,
+    LocalInitiatedUnidirectional,
+    RemoteInitiatedUnidirectional,
 }
 
 #[cfg(test)]
@@ -321,24 +320,34 @@ mod tests {
     use s2n_quic_core::varint::VarInt;
 
     impl Controller {
-        pub fn available_outgoing_stream_capacity(&self, stream_type: StreamType) -> VarInt {
+        pub fn available_local_initiated_stream_capacity(&self, stream_type: StreamType) -> VarInt {
             match stream_type {
-                StreamType::Bidirectional => self
-                    .bidi_controller
-                    .local_initiated
-                    .available_stream_capacity(),
-                StreamType::Unidirectional => self
-                    .uni_controller
-                    .local_initiated
-                    .available_stream_capacity(),
+                StreamType::Bidirectional => self.local_bidi_controller.available_stream_capacity(),
+                StreamType::Unidirectional => self.local_uni_controller.available_stream_capacity(),
             }
         }
 
-        pub fn max_streams_latest_value(&self, stream_type: StreamType) -> VarInt {
+        pub fn remote_initiated_max_streams_latest_value(&self, stream_type: StreamType) -> VarInt {
             match stream_type {
-                StreamType::Bidirectional => self.bidi_controller.remote_initiated.latest_limit(),
-                StreamType::Unidirectional => self.uni_controller.remote_initiated.latest_limit(),
+                StreamType::Bidirectional => self.remote_bidi_controller.latest_limit(),
+                StreamType::Unidirectional => self.remote_uni_controller.latest_limit(),
+            }
+        }
+
+        pub fn available_remote_intiated_stream_capacity(&self, stream_type: StreamType) -> VarInt {
+            match stream_type {
+                StreamType::Bidirectional => {
+                    self.remote_initiated_max_streams_latest_value(stream_type)
+                        - self.remote_bidi_controller.open_stream_count()
+                }
+                StreamType::Unidirectional => {
+                    self.remote_initiated_max_streams_latest_value(stream_type)
+                        - self.remote_uni_controller.open_stream_count()
+                }
             }
         }
     }
 }
+
+#[cfg(test)]
+mod fuzz_target;

--- a/quic/s2n-quic-transport/src/stream/controller.rs
+++ b/quic/s2n-quic-transport/src/stream/controller.rs
@@ -19,12 +19,7 @@ use futures_core::ready;
 use s2n_quic_core::{
     ack, endpoint,
     frame::MaxStreams,
-    stream::{
-        self,
-        iter::StreamIter,
-        limits::{LocalBidirectional, LocalUnidirectional},
-        StreamId, StreamType,
-    },
+    stream::{self, iter::StreamIter, StreamId, StreamType},
     time::{timer, Timestamp},
     transport,
     transport::parameters::InitialFlowControlLimits,
@@ -41,9 +36,9 @@ pub use remote_initiated::MAX_STREAMS_SYNC_FRACTION;
 #[derive(Debug)]
 pub struct Controller {
     local_endpoint_type: endpoint::Type,
-    local_bidi_controller: LocalInitiated<LocalBidirectional>,
+    local_bidi_controller: LocalInitiated<stream::limits::LocalBidirectional>,
     remote_bidi_controller: RemoteInitiated,
-    local_uni_controller: LocalInitiated<LocalUnidirectional>,
+    local_uni_controller: LocalInitiated<stream::limits::LocalUnidirectional>,
     remote_uni_controller: RemoteInitiated,
 }
 
@@ -260,6 +255,7 @@ impl Controller {
         self.local_uni_controller.on_timeout(now);
     }
 
+    #[inline]
     fn direction(&self, stream_id: StreamId) -> StreamDirection {
         let is_local_initiated = self.local_endpoint_type == stream_id.initiator();
         match (is_local_initiated, stream_id.stream_type()) {

--- a/quic/s2n-quic-transport/src/stream/controller.rs
+++ b/quic/s2n-quic-transport/src/stream/controller.rs
@@ -67,15 +67,19 @@ impl Controller {
         Self {
             local_endpoint_type,
             local_bidi_controller: LocalInitiated::new(
-                initial_peer_limits.max_streams_bidi,
+                initial_peer_limits.max_open_remote_bidirectional_streams,
                 stream_limits.max_open_local_bidirectional_streams,
             ),
-            remote_bidi_controller: RemoteInitiated::new(initial_local_limits.max_streams_bidi),
+            remote_bidi_controller: RemoteInitiated::new(
+                initial_local_limits.max_open_remote_bidirectional_streams,
+            ),
             local_uni_controller: LocalInitiated::new(
-                initial_peer_limits.max_streams_uni,
+                initial_peer_limits.max_open_remote_unidirectional_streams,
                 stream_limits.max_open_local_unidirectional_streams,
             ),
-            remote_uni_controller: RemoteInitiated::new(initial_local_limits.max_streams_uni),
+            remote_uni_controller: RemoteInitiated::new(
+                initial_local_limits.max_open_remote_unidirectional_streams,
+            ),
         }
     }
 

--- a/quic/s2n-quic-transport/src/stream/controller/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/stream/controller/fuzz_target.rs
@@ -292,11 +292,10 @@ impl Model {
             };
 
         for stream_nth_idx in stream_nth_idx_iter {
-            let stream_id = StreamId::nth(stream_initiator, stream_type, stream_nth_idx).unwrap();
             let can_open = self.can_open_local(stream_type);
 
             let res = self.subject.poll_open_local_stream(
-                stream_id,
+                stream_type,
                 &mut token,
                 &Context::from_waker(&waker),
             );

--- a/quic/s2n-quic-transport/src/stream/controller/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/stream/controller/fuzz_target.rs
@@ -1,0 +1,532 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::ops::RangeInclusive;
+
+use super::*;
+use bolero::{check, generator::*};
+use futures_test::task::new_count_waker;
+use hashbrown::HashSet;
+use s2n_quic_core::varint::VarInt;
+
+#[derive(Debug)]
+struct Oracle {
+    local_endpoint_type: endpoint::Type,
+    initial_local_limits: InitialFlowControlLimits,
+    initial_remote_limits: InitialFlowControlLimits,
+
+    max_remote_bidi_opened_nth_idx: Option<u64>,
+    max_remote_uni_opened_nth_idx: Option<u64>,
+    max_local_bidi_opened_nth_idx: Option<u64>,
+    max_local_uni_opened_nth_idx: Option<u64>,
+
+    remote_bidi_open_idx_set: HashSet<u64>,
+    remote_uni_open_idx_set: HashSet<u64>,
+    local_bidi_open_idx_set: HashSet<u64>,
+    local_uni_open_idx_set: HashSet<u64>,
+}
+
+impl Oracle {
+    fn can_open_remote(&self, stream_type: StreamType, nth_idx: u64) -> bool {
+        // the count is +1 since streams are 0-indexed
+        let nth_cnt = nth_idx + 1;
+        let limit = self.remote_limit(stream_type);
+
+        nth_cnt <= limit
+    }
+
+    fn on_open_stream(
+        &mut self,
+        stream_initiator: endpoint::Type,
+        stream_type: StreamType,
+        nth_idx: u64,
+    ) {
+        match (stream_initiator == self.local_endpoint_type, stream_type) {
+            (true, StreamType::Bidirectional) => self.max_local_bidi_opened_nth_idx = Some(nth_idx),
+            (true, StreamType::Unidirectional) => self.max_local_uni_opened_nth_idx = Some(nth_idx),
+            (false, StreamType::Bidirectional) => {
+                self.max_remote_bidi_opened_nth_idx = Some(nth_idx)
+            }
+            (false, StreamType::Unidirectional) => {
+                self.max_remote_uni_opened_nth_idx = Some(nth_idx)
+            }
+        };
+
+        match (stream_initiator == self.local_endpoint_type, stream_type) {
+            (true, StreamType::Bidirectional) => self.local_bidi_open_idx_set.insert(nth_idx),
+            (true, StreamType::Unidirectional) => self.local_uni_open_idx_set.insert(nth_idx),
+            (false, StreamType::Bidirectional) => self.remote_bidi_open_idx_set.insert(nth_idx),
+            (false, StreamType::Unidirectional) => self.remote_uni_open_idx_set.insert(nth_idx),
+        };
+    }
+
+    // Returns the range of stream ids which can be opened.
+    //
+    // None is returned if no streams can be opened. None is returned if
+    // max_opened_nth_idx stream is > than the nth_idx stream requested. This
+    // is because opening a higher stream also opens the lower streams and we
+    // do not handle opening a closed stream.
+    fn open_stream_range(
+        &self,
+        stream_initiator: endpoint::Type,
+        stream_type: StreamType,
+        nth_idx: u64,
+    ) -> Option<RangeInclusive<u64>> {
+        let max_opened_nth_idx = match (stream_initiator == self.local_endpoint_type, stream_type) {
+            (true, StreamType::Bidirectional) => self.max_local_bidi_opened_nth_idx,
+            (true, StreamType::Unidirectional) => self.max_local_uni_opened_nth_idx,
+            (false, StreamType::Bidirectional) => self.max_remote_bidi_opened_nth_idx,
+            (false, StreamType::Unidirectional) => self.max_remote_uni_opened_nth_idx,
+        };
+
+        let stream_nth_idx_iter = if let Some(max_opened_nth_idx) = max_opened_nth_idx {
+            // idx already opened.. return
+            if max_opened_nth_idx >= nth_idx {
+                return None;
+            }
+
+            // +1 to get the next stream to open
+            max_opened_nth_idx + 1..=nth_idx
+        } else {
+            0..=nth_idx
+        };
+
+        Some(stream_nth_idx_iter)
+    }
+
+    fn can_close(
+        &self,
+        stream_initiator: endpoint::Type,
+        stream_type: StreamType,
+        nth_idx: u64,
+    ) -> bool {
+        match (stream_initiator == self.local_endpoint_type, stream_type) {
+            (true, StreamType::Bidirectional) => self.local_bidi_open_idx_set.contains(&nth_idx),
+            (true, StreamType::Unidirectional) => self.local_uni_open_idx_set.contains(&nth_idx),
+            (false, StreamType::Bidirectional) => self.remote_bidi_open_idx_set.contains(&nth_idx),
+            (false, StreamType::Unidirectional) => self.remote_uni_open_idx_set.contains(&nth_idx),
+        }
+    }
+
+    fn on_close_stream(
+        &mut self,
+        stream_initiator: endpoint::Type,
+        stream_type: StreamType,
+        nth_idx: u64,
+    ) {
+        match (stream_initiator == self.local_endpoint_type, stream_type) {
+            (true, StreamType::Bidirectional) => {
+                self.local_bidi_open_idx_set.take(&nth_idx).unwrap();
+            }
+            (true, StreamType::Unidirectional) => {
+                self.local_uni_open_idx_set.take(&nth_idx).unwrap();
+            }
+            (false, StreamType::Bidirectional) => {
+                self.remote_bidi_open_idx_set.take(&nth_idx).unwrap();
+                self.initial_local_limits.max_streams_bidi += 1;
+            }
+            (false, StreamType::Unidirectional) => {
+                self.remote_uni_open_idx_set.take(&nth_idx).unwrap();
+                self.initial_local_limits.max_streams_uni += 1;
+            }
+        };
+    }
+
+    fn remote_limit(&self, stream_type: StreamType) -> u64 {
+        match stream_type {
+            StreamType::Bidirectional => self.initial_local_limits.max_streams_bidi,
+            StreamType::Unidirectional => self.initial_local_limits.max_streams_uni,
+        }
+        .as_u64()
+    }
+
+    fn open_streams_count(&self, stream_initiator: endpoint::Type, stream_type: StreamType) -> u64 {
+        match (stream_initiator == self.local_endpoint_type, stream_type) {
+            (true, StreamType::Bidirectional) => self.local_bidi_open_idx_set.len() as u64,
+            (true, StreamType::Unidirectional) => self.local_uni_open_idx_set.len() as u64,
+            (false, StreamType::Bidirectional) => self.remote_bidi_open_idx_set.len() as u64,
+            (false, StreamType::Unidirectional) => self.remote_uni_open_idx_set.len() as u64,
+        }
+    }
+
+    fn on_max_stream_local(&mut self, maximum_streams: u8, direction: StreamDirection) {
+        match direction {
+            StreamDirection::LocalInitiatedBidirectional => {
+                if self.initial_remote_limits.max_streams_bidi.as_u64() < maximum_streams.into() {
+                    self.initial_remote_limits.max_streams_bidi = VarInt::from_u8(maximum_streams);
+                }
+            }
+            StreamDirection::LocalInitiatedUnidirectional => {
+                if self.initial_remote_limits.max_streams_uni.as_u64() < maximum_streams.into() {
+                    self.initial_remote_limits.max_streams_uni = VarInt::from_u8(maximum_streams);
+                }
+            }
+            StreamDirection::RemoteInitiatedBidirectional
+            | StreamDirection::RemoteInitiatedUnidirectional => {
+                panic!("should only be called for local endpoints")
+            }
+        };
+    }
+}
+
+#[derive(Debug)]
+struct Model {
+    oracle: Oracle,
+    subject: Controller,
+}
+
+impl Model {
+    fn new(local_endpoint_type: endpoint::Type, limits: Limits) -> Self {
+        let (initial_local_limits, initial_remote_limits, stream_limits) =
+            limits.as_controller_limits();
+
+        Model {
+            oracle: Oracle {
+                local_endpoint_type,
+                initial_local_limits,
+                initial_remote_limits,
+                max_remote_bidi_opened_nth_idx: None,
+                max_remote_uni_opened_nth_idx: None,
+                max_local_bidi_opened_nth_idx: None,
+                max_local_uni_opened_nth_idx: None,
+                remote_bidi_open_idx_set: HashSet::new(),
+                remote_uni_open_idx_set: HashSet::new(),
+                local_bidi_open_idx_set: HashSet::new(),
+                local_uni_open_idx_set: HashSet::new(),
+            },
+            subject: Controller::new(
+                local_endpoint_type,
+                initial_remote_limits,
+                initial_local_limits,
+                stream_limits,
+            ),
+        }
+    }
+
+    pub fn apply(&mut self, operation: &Operation) {
+        match operation {
+            Operation::OpenRemoteBidi { nth_idx } => {
+                self.on_open_remote(*nth_idx as u64, StreamType::Bidirectional)
+            }
+            Operation::OpenRemoteUni { nth_idx } => {
+                self.on_open_remote(*nth_idx as u64, StreamType::Unidirectional)
+            }
+            Operation::OpenLocalBidi { nth_idx } => {
+                self.on_open_local(*nth_idx as u64, StreamType::Bidirectional)
+            }
+            Operation::OpenLocalUni { nth_idx } => {
+                self.on_open_local(*nth_idx as u64, StreamType::Unidirectional)
+            }
+            Operation::CloseRemoteBidi { nth_idx } => {
+                self.on_close_remote(*nth_idx as u64, StreamType::Bidirectional)
+            }
+            Operation::CloseRemoteUni { nth_idx } => {
+                self.on_close_remote(*nth_idx as u64, StreamType::Unidirectional)
+            }
+            Operation::CloseLocalBidi { nth_idx } => {
+                self.on_close_local(*nth_idx as u64, StreamType::Bidirectional)
+            }
+            Operation::CloseLocalUni { nth_idx } => {
+                self.on_close_local(*nth_idx as u64, StreamType::Unidirectional)
+            }
+            Operation::MaxStreamLocalBidi { maximum_streams } => self.on_max_stream_local(
+                *maximum_streams,
+                StreamDirection::LocalInitiatedBidirectional,
+            ),
+            Operation::MaxStreamLocalUni { maximum_streams } => self.on_max_stream_local(
+                *maximum_streams,
+                StreamDirection::LocalInitiatedUnidirectional,
+            ),
+        }
+    }
+
+    fn on_max_stream_local(&mut self, maximum_streams: u8, direction: StreamDirection) {
+        let stream_type = match direction {
+            StreamDirection::LocalInitiatedBidirectional => StreamType::Bidirectional,
+            StreamDirection::LocalInitiatedUnidirectional => StreamType::Unidirectional,
+            StreamDirection::RemoteInitiatedBidirectional
+            | StreamDirection::RemoteInitiatedUnidirectional => panic!("dont expect"),
+        };
+        let frame = MaxStreams {
+            stream_type,
+            maximum_streams: VarInt::from_u32(maximum_streams.try_into().unwrap()),
+        };
+        self.subject.on_max_streams(&frame);
+        self.oracle.on_max_stream_local(maximum_streams, direction);
+    }
+
+    fn on_open_local(&mut self, nth_idx: u64, stream_type: StreamType) {
+        let (waker, _wake_counter) = new_count_waker();
+        let mut token = connection::OpenToken::new();
+
+        let stream_initiator = self.oracle.local_endpoint_type;
+
+        //-------------
+        let stream_nth_idx_iter =
+            match self
+                .oracle
+                .open_stream_range(stream_initiator, stream_type, nth_idx)
+            {
+                Some(val) => val,
+                None => return,
+            };
+
+        for stream_nth_idx in stream_nth_idx_iter {
+            let stream_id = StreamId::nth(stream_initiator, stream_type, stream_nth_idx).unwrap();
+            let can_open = self.can_open_local(stream_type);
+
+            let res = self.subject.poll_open_local_stream(
+                stream_id,
+                &mut token,
+                &Context::from_waker(&waker),
+            );
+
+            if can_open {
+                assert!(res.is_ready());
+                self.oracle
+                    .on_open_stream(stream_initiator, stream_type, stream_nth_idx);
+            } else {
+                assert!(res.is_pending())
+            }
+        }
+    }
+
+    fn on_open_remote(&mut self, nth_idx: u64, stream_type: StreamType) {
+        let stream_initiator = self.oracle.local_endpoint_type.peer_type();
+
+        //-------------
+        let stream_nth_idx_iter =
+            match self
+                .oracle
+                .open_stream_range(stream_initiator, stream_type, nth_idx)
+            {
+                Some(val) => val,
+                None => return,
+            };
+
+        let start_stream =
+            StreamId::nth(stream_initiator, stream_type, *stream_nth_idx_iter.start()).unwrap();
+        let end_stream =
+            StreamId::nth(stream_initiator, stream_type, *stream_nth_idx_iter.end()).unwrap();
+
+        let stream_iter = StreamIter::new(start_stream, end_stream);
+        let res = self.subject.on_open_remote_stream(stream_iter);
+
+        if self.can_open_remote(stream_type, nth_idx) {
+            for stream_nth_idx in stream_nth_idx_iter {
+                self.oracle
+                    .on_open_stream(stream_initiator, stream_type, stream_nth_idx);
+            }
+            res.unwrap();
+        } else {
+            res.expect_err("limits violated");
+        }
+    }
+
+    fn on_close_local(&mut self, nth_idx: u64, stream_type: StreamType) {
+        let stream_initiator = self.oracle.local_endpoint_type;
+
+        //-------------
+        if !self
+            .oracle
+            .can_close(stream_initiator, stream_type, nth_idx)
+        {
+            return;
+        }
+
+        self.oracle
+            .on_close_stream(stream_initiator, stream_type, nth_idx);
+        let stream_id = StreamId::nth(stream_initiator, stream_type, nth_idx).unwrap();
+        self.subject.on_close_stream(stream_id);
+    }
+
+    fn on_close_remote(&mut self, nth_idx: u64, stream_type: StreamType) {
+        let stream_initiator = self.oracle.local_endpoint_type.peer_type();
+
+        //-------------
+        if !self
+            .oracle
+            .can_close(stream_initiator, stream_type, nth_idx)
+        {
+            return;
+        }
+
+        self.oracle
+            .on_close_stream(stream_initiator, stream_type, nth_idx);
+        let stream_id = StreamId::nth(stream_initiator, stream_type, nth_idx).unwrap();
+        self.subject.on_close_stream(stream_id);
+    }
+
+    fn can_open_local(&self, stream_type: StreamType) -> bool {
+        let available_stream_capacity = self
+            .subject
+            .available_local_initiated_stream_capacity(stream_type);
+
+        available_stream_capacity > VarInt::from_u8(0)
+    }
+
+    fn can_open_remote(&self, stream_type: StreamType, nth_idx: u64) -> bool {
+        self.oracle.can_open_remote(stream_type, nth_idx)
+    }
+
+    /// Check that the subject and oracle match.
+    pub fn invariants(&self) {
+        // ---------
+        let mut stream_initiator = self.oracle.local_endpoint_type.peer_type();
+        let mut stream_type = StreamType::Bidirectional;
+        assert_eq!(
+            self.subject.remote_bidi_controller.open_stream_count(),
+            self.oracle
+                .open_streams_count(stream_initiator, stream_type)
+        );
+        assert_eq!(
+            self.subject
+                .remote_initiated_max_streams_latest_value(stream_type)
+                .as_u64(),
+            self.oracle.remote_limit(stream_type)
+        );
+
+        // ---------
+        stream_initiator = self.oracle.local_endpoint_type.peer_type();
+        stream_type = StreamType::Unidirectional;
+        assert_eq!(
+            self.subject.remote_uni_controller.open_stream_count(),
+            self.oracle
+                .open_streams_count(stream_initiator, stream_type)
+        );
+        assert_eq!(
+            self.subject
+                .remote_initiated_max_streams_latest_value(stream_type)
+                .as_u64(),
+            self.oracle.remote_limit(stream_type)
+        );
+
+        // ---------
+        stream_initiator = self.oracle.local_endpoint_type;
+        stream_type = StreamType::Bidirectional;
+        assert_eq!(
+            self.subject.local_bidi_controller.open_stream_count(),
+            self.oracle
+                .open_streams_count(stream_initiator, stream_type)
+        );
+        self.subject.local_bidi_controller.check_integrity();
+
+        // ---------
+        stream_initiator = self.oracle.local_endpoint_type;
+        stream_type = StreamType::Unidirectional;
+        assert_eq!(
+            self.subject.local_uni_controller.open_stream_count(),
+            self.oracle
+                .open_streams_count(stream_initiator, stream_type)
+        );
+        self.subject.local_uni_controller.check_integrity();
+    }
+}
+
+#[derive(Debug, TypeGenerator)]
+enum Operation {
+    // max_local_limit: max_remote_uni_stream (initial_local_limits)
+    // transmit: max_streams
+    OpenRemoteBidi { nth_idx: u8 },
+    CloseRemoteBidi { nth_idx: u8 },
+
+    // max_local_limit: max_remote_uni_stream (initial_local_limits)
+    // transmit: max_streams
+    OpenRemoteUni { nth_idx: u8 },
+    CloseRemoteUni { nth_idx: u8 },
+
+    // max_local_limit: max_local_bidi_stream
+    // peer_stream_limit: peer_max_bidi_stream (initial_remote_limits)
+    //
+    // limits: max_local_bidi_stream.min(peer_max_bidi_stream)
+    // transmit: streams_blocked
+    OpenLocalBidi { nth_idx: u8 },
+    CloseLocalBidi { nth_idx: u8 },
+    MaxStreamLocalBidi { maximum_streams: u8 },
+
+    // max_local_limit: max_local_uni_stream
+    // peer_stream_limit: peer_max_uni_stream (initial_remote_limits)
+    //
+    // limits: max_local_uni_stream.min(peer_max_uni_stream)
+    // transmit: streams_blocked
+    OpenLocalUni { nth_idx: u8 },
+    CloseLocalUni { nth_idx: u8 },
+    MaxStreamLocalUni { maximum_streams: u8 },
+}
+
+#[derive(Debug, TypeGenerator, Clone, Copy)]
+struct Limits {
+    // OpenRemoteBidi (initial_local_limits)
+    initial_local_max_remote_bidi: u8,
+
+    // OpenRemoteUni (initial_local_limits)
+    initial_local_max_remote_uni: u8,
+
+    // OpenLocalBidi (initial_remote_limits)
+    //  initial_remote_max_local_bidi.min(app_max_local_bidi)
+    initial_remote_max_local_bidi: u8,
+    app_max_local_bidi: u8,
+
+    // OpenLocalUni (initial_remote_limits)
+    //  initial_remote_max_local_uni.min(app_max_local_uni)
+    initial_remote_max_local_uni: u8,
+    app_max_local_uni: u8,
+}
+
+impl Limits {
+    fn as_controller_limits(
+        &self,
+    ) -> (
+        InitialFlowControlLimits,
+        InitialFlowControlLimits,
+        stream::Limits,
+    ) {
+        let mut initial_local_limits = InitialFlowControlLimits::default();
+        let mut initial_remote_limits = InitialFlowControlLimits::default();
+        let stream_limits = stream::Limits {
+            max_open_local_unidirectional_streams: (self.app_max_local_uni as u64)
+                .try_into()
+                .unwrap(),
+            max_open_local_bidirectional_streams: (self.app_max_local_bidi as u64)
+                .try_into()
+                .unwrap(),
+            ..Default::default()
+        };
+
+        // OpenRemoteBidi (initial_local_limits)
+        initial_local_limits.max_streams_bidi =
+            VarInt::from_u32(self.initial_local_max_remote_bidi.into());
+
+        // OpenRemoteUni (initial_local_limits)
+        initial_local_limits.max_streams_uni =
+            VarInt::from_u32(self.initial_local_max_remote_uni.into());
+
+        // OpenLocalBidi (initial_remote_limits)
+        //  initial_remote_max_local_bidi.min(app_max_local_bidi)
+        initial_remote_limits.max_streams_bidi =
+            VarInt::from_u32(self.initial_remote_max_local_bidi.into());
+
+        // OpenLocalUni (initial_remote_limits)
+        //  initial_remote_max_local_uni.min(app_max_local_uni)
+        initial_remote_limits.max_streams_uni =
+            VarInt::from_u32(self.initial_remote_max_local_uni.into());
+
+        (initial_local_limits, initial_remote_limits, stream_limits)
+    }
+}
+
+#[test]
+fn model_test() {
+    check!()
+        .with_type::<(Limits, Vec<Operation>)>()
+        .for_each(|(limits, operations)| {
+            let local_endpoint_type = endpoint::Type::Server;
+
+            let mut model = Model::new(local_endpoint_type, *limits);
+            for operation in operations.iter() {
+                model.apply(operation);
+            }
+
+            model.invariants();
+        })
+}

--- a/quic/s2n-quic-transport/src/stream/controller/local_initiated.rs
+++ b/quic/s2n-quic-transport/src/stream/controller/local_initiated.rs
@@ -86,6 +86,7 @@ impl<L: LocalLimits> LocalInitiated<L> {
             .update_sync_period(blocked_sync_period);
     }
 
+    #[inline]
     pub fn poll_open_stream(
         &mut self,
         open_token: &mut open_token::Token,
@@ -127,6 +128,7 @@ impl<L: LocalLimits> LocalInitiated<L> {
         Poll::Ready(())
     }
 
+    #[inline]
     pub fn on_open_stream(&mut self) {
         self.opened_streams += 1;
 
@@ -142,6 +144,7 @@ impl<L: LocalLimits> LocalInitiated<L> {
 
     /// The number of streams that may be opened by the local application, respecting both
     /// the local concurrent streams limit and the peer's stream limits.
+    #[inline]
     pub fn available_stream_capacity(&self) -> VarInt {
         let local_capacity = self
             .max_local_limit
@@ -151,6 +154,7 @@ impl<L: LocalLimits> LocalInitiated<L> {
     }
 
     /// The current number of streams that can be opened according to the peer's limits
+    #[inline]
     fn peer_capacity(&self) -> VarInt {
         self.peer_cumulative_stream_limit
             .saturating_sub(self.opened_streams)
@@ -180,6 +184,7 @@ impl<L: LocalLimits> LocalInitiated<L> {
     }
 
     /// Returns the number of streams currently open
+    #[inline]
     pub fn open_stream_count(&self) -> VarInt {
         self.opened_streams - self.closed_streams
     }

--- a/quic/s2n-quic-transport/src/stream/controller/local_initiated.rs
+++ b/quic/s2n-quic-transport/src/stream/controller/local_initiated.rs
@@ -16,7 +16,7 @@ use s2n_quic_core::{
     ack,
     frame::{MaxStreams, StreamsBlocked},
     packet::number::PacketNumber,
-    stream::StreamId,
+    stream::{limits::LocalLimits, StreamId},
     time::{timer, Timestamp},
     varint::VarInt,
 };
@@ -27,12 +27,12 @@ const WAKERS_INITIAL_CAPACITY: usize = 5;
 
 /// The LocalInitiated controller controls streams initiated locally
 #[derive(Debug)]
-pub(super) struct LocalInitiated {
+pub(super) struct LocalInitiated<L: LocalLimits> {
     /// The max stream limit specified by the local endpoint.
     ///
     /// Used to restrict the number of concurrent streams the local
     /// connection can open.
-    max_local_limit: VarInt,
+    max_local_limit: L,
     /// The cumulative stream limit specified by the remote endpoint.
     ///
     /// Can be updated when MAX_STREAMS frame is received.
@@ -49,8 +49,8 @@ pub(super) struct LocalInitiated {
     expired_token: open_token::Token,
 }
 
-impl LocalInitiated {
-    pub fn new(initial_peer_maximum_streams: VarInt, max_local_limit: VarInt) -> Self {
+impl<L: LocalLimits> LocalInitiated<L> {
+    pub fn new(initial_peer_maximum_streams: VarInt, max_local_limit: L) -> Self {
         Self {
             max_local_limit,
             peer_cumulative_stream_limit: initial_peer_maximum_streams,
@@ -145,6 +145,7 @@ impl LocalInitiated {
     pub fn available_stream_capacity(&self) -> VarInt {
         let local_capacity = self
             .max_local_limit
+            .as_varint()
             .saturating_sub(self.open_stream_count());
         local_capacity.min(self.peer_capacity())
     }
@@ -179,7 +180,7 @@ impl LocalInitiated {
     }
 
     /// Returns the number of streams currently open
-    fn open_stream_count(&self) -> VarInt {
+    pub fn open_stream_count(&self) -> VarInt {
         self.opened_streams - self.closed_streams
     }
 
@@ -227,14 +228,14 @@ impl LocalInitiated {
     }
 
     #[inline]
-    fn check_integrity(&self) {
+    pub fn check_integrity(&self) {
         if cfg!(debug_assertions) {
             assert!(
                 self.closed_streams <= self.opened_streams,
                 "Cannot close more streams than previously opened"
             );
             assert!(
-                self.open_stream_count() <= self.max_local_limit,
+                self.open_stream_count() <= self.max_local_limit.as_varint(),
                 "Cannot have more outgoing streams open concurrently than
                 the max_local_limit"
             );
@@ -242,7 +243,7 @@ impl LocalInitiated {
     }
 }
 
-impl timer::Provider for LocalInitiated {
+impl<L: LocalLimits> timer::Provider for LocalInitiated<L> {
     #[inline]
     fn timers<Q: timer::Query>(&self, query: &mut Q) -> timer::Result {
         self.streams_blocked_sync.timers(query)?;
@@ -250,7 +251,7 @@ impl timer::Provider for LocalInitiated {
     }
 }
 
-impl transmission::interest::Provider for LocalInitiated {
+impl<L: LocalLimits> transmission::interest::Provider for LocalInitiated<L> {
     #[inline]
     fn transmission_interest<Q: transmission::interest::Query>(
         &self,

--- a/quic/s2n-quic-transport/src/stream/controller/remote_initiated.rs
+++ b/quic/s2n-quic-transport/src/stream/controller/remote_initiated.rs
@@ -85,6 +85,7 @@ impl RemoteInitiated {
         Ok(())
     }
 
+    #[inline]
     pub fn on_open_stream(&mut self) {
         self.opened_streams += 1;
 
@@ -104,6 +105,7 @@ impl RemoteInitiated {
     }
 
     /// Returns the number of streams currently open
+    #[inline]
     pub fn open_stream_count(&self) -> VarInt {
         self.opened_streams - self.closed_streams
     }

--- a/quic/s2n-quic-transport/src/stream/controller/remote_initiated.rs
+++ b/quic/s2n-quic-transport/src/stream/controller/remote_initiated.rs
@@ -104,7 +104,7 @@ impl RemoteInitiated {
     }
 
     /// Returns the number of streams currently open
-    fn open_stream_count(&self) -> VarInt {
+    pub fn open_stream_count(&self) -> VarInt {
         self.opened_streams - self.closed_streams
     }
 

--- a/quic/s2n-quic-transport/src/stream/manager.rs
+++ b/quic/s2n-quic-transport/src/stream/manager.rs
@@ -29,7 +29,7 @@ use s2n_quic_core::{
         StopSending, StreamDataBlocked, StreamsBlocked,
     },
     packet::number::PacketNumberSpace,
-    stream::{ops, StreamId, StreamType},
+    stream::{iter::StreamIter, ops, StreamId, StreamType},
     time::{timer, Timestamp},
     transport::{self, parameters::InitialFlowControlLimits},
     varint::VarInt,
@@ -201,11 +201,11 @@ impl<S: StreamTrait> StreamManagerState<S> {
         result
     }
 
-    /// Opens the `Stream` with the given `StreamId`.
+    /// Inserts the `Stream` into the StreamContainer.
+    ///
     /// This method does not perform any validation whether it is allowed to
-    /// open the `Stream`, since the necessary validation depends on which side
-    /// opens the `Stream`.
-    fn open_stream(&mut self, stream_id: StreamId) {
+    /// open the `Stream`.
+    fn insert_stream(&mut self, stream_id: StreamId) {
         // The receive window is announced by us towards to the peer
         let initial_receive_window = self
             .initial_local_limits
@@ -228,8 +228,6 @@ impl<S: StreamTrait> StreamManagerState<S> {
             initial_receive_window <= VarInt::from_u32(core::u32::MAX),
             "Receive window must not exceed 32bit range"
         );
-
-        self.stream_controller.on_open_stream(stream_id);
 
         self.streams.insert_stream(S::new(StreamConfig {
             incoming_connection_flow_controller: self.incoming_connection_flow_controller.clone(),
@@ -278,25 +276,19 @@ impl<S: StreamTrait> StreamManagerState<S> {
                 //# that receives a frame with a stream ID exceeding the limit it has
                 //# sent MUST treat this as a connection error of type
                 //# STREAM_LIMIT_ERROR; see Section 11 for details on error handling.
-                self.stream_controller.on_remote_open_stream(stream_id)?;
+                let stream_iter = StreamIter::new(first_unopened_id, stream_id);
+
+                // Validate that there is enough capacity to open all streams.
+                self.stream_controller.on_open_remote_stream(stream_iter)?;
 
                 // We must create ALL streams which a lower Stream ID too:
-
+                //
                 //= https://www.rfc-editor.org/rfc/rfc9000#section-3.2
                 //# Before a stream is created, all streams of the same type with lower-
                 //# numbered stream IDs MUST be created.  This ensures that the creation
                 //# order for streams is consistent on both endpoints.
-
-                let mut stream_id_iter = first_unopened_id;
-                while stream_id_iter <= stream_id {
-                    self.open_stream(stream_id_iter);
-
-                    // The Stream ID can be expected to be valid, since we check upfront
-                    // whether the highest stream id (`stream_id`) is still valid,
-                    // and all IDs we iterate over are lower.
-                    stream_id_iter = stream_id_iter
-                        .next_of_type()
-                        .expect("Expect a valid Stream ID");
+                for stream_id in stream_iter {
+                    self.insert_stream(stream_id);
                 }
 
                 //= https://www.rfc-editor.org/rfc/rfc9000#section-2.1
@@ -330,6 +322,30 @@ impl<S: StreamTrait> StreamManagerState<S> {
         }
 
         Ok(())
+    }
+
+    fn poll_open_local_stream(
+        &mut self,
+        stream_id: StreamId,
+        open_token: &mut connection::OpenToken,
+        context: &Context,
+    ) -> Poll<Result<StreamId, connection::Error>> {
+        //= https://www.rfc-editor.org/rfc/rfc9000#section-4.6
+        //# Endpoints MUST NOT exceed the limit set by their peer.
+        //
+        //= https://www.rfc-editor.org/rfc/rfc9000#section-19.11
+        //# An endpoint MUST NOT open more streams than permitted by the current
+        //# stream limit set by its peer.
+        match self
+            .stream_controller
+            .poll_open_local_stream(stream_id, open_token, context)
+        {
+            Poll::Ready(stream_id) => {
+                self.insert_stream(stream_id);
+                Poll::Ready(Ok(stream_id))
+            }
+            Poll::Pending => Poll::Pending,
+        }
     }
 
     fn close(&mut self, error: connection::Error, flush: bool) {
@@ -532,7 +548,7 @@ impl<S: StreamTrait> AbstractStreamManager<S> {
         }
     }
 
-    /// Opens the next outgoing stream of a certain type
+    /// Opens the next local initiated stream of a certain type
     pub fn poll_open(
         &mut self,
         stream_type: StreamType,
@@ -544,21 +560,6 @@ impl<S: StreamTrait> AbstractStreamManager<S> {
             return Err(error).into();
         }
 
-        //= https://www.rfc-editor.org/rfc/rfc9000#section-4.6
-        //# Endpoints MUST NOT exceed the limit set by their peer.
-
-        //= https://www.rfc-editor.org/rfc/rfc9000#section-19.11
-        //# An endpoint MUST NOT open more streams than permitted by the current
-        //# stream limit set by its peer.
-        if self
-            .inner
-            .stream_controller
-            .poll_local_open_stream(stream_type, open_token, context)
-            .is_pending()
-        {
-            return Poll::Pending;
-        }
-
         let local_endpoint_type = self.inner.local_endpoint_type;
 
         let first_unopened_id = self
@@ -567,13 +568,19 @@ impl<S: StreamTrait> AbstractStreamManager<S> {
             .get_mut(local_endpoint_type, stream_type)
             .ok_or_else(connection::Error::stream_id_exhausted)?;
 
+        if self
+            .inner
+            .poll_open_local_stream(first_unopened_id, open_token, context)
+            .is_pending()
+        {
+            return Poll::Pending;
+        }
+
         // Increase the next utilized Stream ID
         *self
             .inner
             .next_stream_ids
             .get_mut(local_endpoint_type, stream_type) = first_unopened_id.next_of_type();
-
-        self.inner.open_stream(first_unopened_id);
 
         Ok(first_unopened_id).into()
     }

--- a/quic/s2n-quic-transport/src/stream/manager.rs
+++ b/quic/s2n-quic-transport/src/stream/manager.rs
@@ -310,7 +310,7 @@ impl<S: StreamTrait> StreamManagerState<S> {
                 }
             }
         } else {
-            // Check if the peer is sending us a frame for a Stream with
+            // Check if the peer is sending us a frame for a local initiated Stream with
             // a higher Stream ID than we ever used.
             // In this case the peer seems to be time-travelling and know about
             // Future Stream IDs we might use. We also will not accept this and

--- a/quic/s2n-quic-transport/src/stream/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/stream/manager/tests.rs
@@ -1321,7 +1321,7 @@ fn asymmetric_stream_limits_remote_initiated() {
 
                 // remote capacity assertion
                 let available_remote_stream_capacity = manager.with_stream_controller(|cntl| {
-                    cntl.available_remote_intiated_stream_capacity(stream_type)
+                    cntl.available_remote_initiated_stream_capacity(stream_type)
                 });
                 // Remote initiated streams capacity should be all used up
                 assert_eq!(
@@ -1402,7 +1402,7 @@ fn asymmetric_stream_limits_local_initiated() {
 
                 // remote capacity assertion
                 let available_remote_stream_capacity = manager.with_stream_controller(|cntl| {
-                    cntl.available_remote_intiated_stream_capacity(stream_type)
+                    cntl.available_remote_initiated_stream_capacity(stream_type)
                 });
                 // Local initiated streams do NOT use up the capacity for remote initiated streams
                 //

--- a/quic/s2n-quic-transport/src/stream/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/stream/manager/tests.rs
@@ -390,10 +390,11 @@ fn create_stream_manager(local_ep_type: endpoint::Type) -> AbstractStreamManager
     let initial_local_limits = create_default_initial_flow_control_limits();
     let initial_peer_limits = create_default_initial_flow_control_limits();
 
+    // set local limits high so that they are not a constraint
     let limits = ConnectionLimits::default()
-        .with_max_send_buffer_size(4096)
+        .with_max_open_local_bidirectional_streams(1000)
         .unwrap()
-        .with_max_open_local_unidirectional_streams(256)
+        .with_max_open_local_unidirectional_streams(1000)
         .unwrap();
 
     AbstractStreamManager::<MockStream>::new(
@@ -660,21 +661,27 @@ fn max_data_replenishes_connection_flow_control_window() {
 #[test]
 fn max_streams_replenishes_stream_control_capacity() {
     let mut manager = create_stream_manager(endpoint::Type::Server);
+    let (waker, _counter) = new_count_waker();
+    let mut token = connection::OpenToken::new();
 
     for stream_type in [StreamType::Bidirectional, StreamType::Unidirectional] {
-        let current_max_streams =
-            manager.with_stream_controller(|ctrl| ctrl.max_streams_latest_value(stream_type));
+        let current_max_streams = manager.with_stream_controller(|ctrl| {
+            ctrl.remote_initiated_max_streams_latest_value(stream_type)
+        });
 
         // Open and close up to the current max streams limit to ensure we are blocked on the
         // peer's max streams limit and not the local concurrent stream limit.
         for i in 0..*current_max_streams {
             let stream_id = StreamId::nth(endpoint::Type::Server, stream_type, i).unwrap();
-            manager.with_stream_controller(|ctrl| ctrl.on_open_stream(stream_id));
+            assert!(manager
+                .with_stream_controller(|ctrl| {
+                    ctrl.poll_open_local_stream(stream_id, &mut token, &Context::from_waker(&waker))
+                })
+                .is_ready());
+
             manager.with_stream_controller(|ctrl| ctrl.on_close_stream(stream_id));
         }
 
-        let (waker, _counter) = new_count_waker();
-        let mut token = connection::OpenToken::new();
         assert!(manager
             .poll_open(stream_type, &mut token, &Context::from_waker(&waker))
             .is_pending());
@@ -689,7 +696,7 @@ fn max_streams_replenishes_stream_control_capacity() {
             assert_eq!(
                 *additional_streams,
                 manager.with_stream_controller(
-                    |ctrl| ctrl.available_outgoing_stream_capacity(stream_type)
+                    |ctrl| ctrl.available_local_initiated_stream_capacity(stream_type)
                 )
             );
         }
@@ -711,8 +718,9 @@ fn peer_closing_streams_transmits_max_streams() {
     let mut manager = create_stream_manager(endpoint::Type::Server);
 
     for stream_type in [StreamType::Bidirectional, StreamType::Unidirectional] {
-        let current_max_streams =
-            manager.with_stream_controller(|ctrl| ctrl.max_streams_latest_value(stream_type));
+        let current_max_streams = manager.with_stream_controller(|ctrl| {
+            ctrl.remote_initiated_max_streams_latest_value(stream_type)
+        });
 
         // The peer opens up to the current max streams limit
         for i in 0..*current_max_streams {
@@ -818,7 +826,10 @@ fn send_streams_blocked_frame_when_blocked_by_peer() {
 
         assert_eq!(
             transmission::Interest::NewData,
-            manager.get_transmission_interest()
+            manager.get_transmission_interest(),
+            "stream_type:{:?} opened_streams:{}",
+            stream_type,
+            opened_streams
         );
 
         let mut frame_buffer = OutgoingFrameBuffer::new();
@@ -1162,8 +1173,9 @@ fn stream_limit_error_on_peer_open_stream_too_large() {
     let mut manager = create_stream_manager(endpoint::Type::Server);
 
     for stream_type in [StreamType::Bidirectional, StreamType::Unidirectional] {
-        let current_max_streams =
-            manager.with_stream_controller(|ctrl| ctrl.max_streams_latest_value(stream_type));
+        let current_max_streams = manager.with_stream_controller(|ctrl| {
+            ctrl.remote_initiated_max_streams_latest_value(stream_type)
+        });
         // stream_id is 0-indexed
         let current_max_streams = current_max_streams.as_u64() - 1;
 
@@ -1171,14 +1183,17 @@ fn stream_limit_error_on_peer_open_stream_too_large() {
             StreamId::nth(endpoint::Type::Client, stream_type, current_max_streams).unwrap();
 
         assert!(manager
-            .with_stream_controller(|ctrl| ctrl.on_remote_open_stream(max_stream_id))
+            .with_stream_controller(
+                |ctrl| ctrl.on_open_remote_stream(StreamIter::new(max_stream_id, max_stream_id))
+            )
             .is_ok());
 
         assert_eq!(
             Err(transport::Error::STREAM_LIMIT_ERROR),
-            manager.with_stream_controller(
-                |ctrl| ctrl.on_remote_open_stream(max_stream_id.next_of_type().unwrap())
-            )
+            manager.with_stream_controller(|ctrl| {
+                let open_id = max_stream_id.next_of_type().unwrap();
+                ctrl.on_open_remote_stream(StreamIter::new(open_id, open_id))
+            })
         );
     }
 }
@@ -1196,8 +1211,9 @@ fn blocked_on_local_concurrent_stream_limit() {
             })
             .is_ok());
 
-        let available_outgoing_stream_capacity = manager
-            .with_stream_controller(|ctrl| ctrl.available_outgoing_stream_capacity(stream_type));
+        let available_outgoing_stream_capacity = manager.with_stream_controller(|ctrl| {
+            ctrl.available_local_initiated_stream_capacity(stream_type)
+        });
 
         assert!(available_outgoing_stream_capacity < VarInt::from_u32(100_000));
 
@@ -1246,52 +1262,151 @@ fn blocked_on_local_concurrent_stream_limit() {
 }
 
 #[test]
-fn asymmetric_stream_limits() {
+fn asymmetric_stream_limits_remote_initiated() {
     let mut initial_local_limits = create_default_initial_flow_control_limits();
     let mut initial_peer_limits = create_default_initial_flow_control_limits();
 
-    let limits = ConnectionLimits::default()
-        .with_max_send_buffer_size(4096)
-        .unwrap()
-        .with_max_open_local_unidirectional_streams(256)
-        .unwrap();
+    for local_limit in 0..101 {
+        for peer_limit in 0..101 {
+            for stream_type in [StreamType::Bidirectional, StreamType::Unidirectional] {
+                let limits = ConnectionLimits::default()
+                    .with_max_open_local_bidirectional_streams(local_limit as u64)
+                    .unwrap()
+                    .with_max_open_local_unidirectional_streams(local_limit as u64)
+                    .unwrap();
 
-    for (local_limit, peer_limit) in &[(100, 5), (5, 100)] {
-        for stream_type in [StreamType::Bidirectional, StreamType::Unidirectional] {
-            initial_local_limits.max_streams_bidi = VarInt::from_u8(*local_limit);
-            initial_peer_limits.max_streams_bidi = VarInt::from_u8(*peer_limit);
-            initial_local_limits.max_streams_uni = VarInt::from_u8(*local_limit);
-            initial_peer_limits.max_streams_uni = VarInt::from_u8(*peer_limit);
+                initial_local_limits.max_streams_bidi = VarInt::from_u16(local_limit);
+                initial_peer_limits.max_streams_bidi = VarInt::from_u16(peer_limit);
+                initial_local_limits.max_streams_uni = VarInt::from_u16(local_limit);
+                initial_peer_limits.max_streams_uni = VarInt::from_u16(peer_limit);
 
-            let mut manager = AbstractStreamManager::<MockStream>::new(
-                &limits,
-                endpoint::Type::Server,
-                initial_local_limits,
-                initial_peer_limits,
-            );
+                let mut manager = AbstractStreamManager::<MockStream>::new(
+                    &limits,
+                    endpoint::Type::Server,
+                    initial_local_limits,
+                    initial_peer_limits,
+                );
 
-            // The peer opens streams up to the limit we have given them
-            for i in 0..*local_limit {
-                let stream_id =
-                    StreamId::nth(endpoint::Type::Client, stream_type, i as u64).unwrap();
+                // The peer opens streams up to the limit we have given them
+                for i in 0..local_limit {
+                    let stream_id =
+                        StreamId::nth(endpoint::Type::Client, stream_type, i as u64).unwrap();
+                    assert_eq!(
+                        Ok(()),
+                        manager.on_data(&stream_data(stream_id, VarInt::from_u32(0), &[], false))
+                    );
+                }
+
+                // local capacity assertion
+                let available_local_stream_capacity = manager.with_stream_controller(|cntl| {
+                    cntl.available_local_initiated_stream_capacity(stream_type)
+                });
+                // Remote initiated streams do NOT use up the capacity for local initiated streams
+                //
+                // Local endpoint did not open any streams so it should have the capacity based
+                // on peer and local limits.
+                let available_limit = local_limit.min(peer_limit);
                 assert_eq!(
-                    Ok(()),
-                    manager.on_data(&stream_data(stream_id, VarInt::from_u32(0), &[], false))
+                    VarInt::from_u16(available_limit),
+                    available_local_stream_capacity,
+                    "local_limit:{} peer_limit:{} stream_type:{:?}",
+                    local_limit,
+                    peer_limit,
+                    stream_type
+                );
+
+                // remote capacity assertion
+                let available_remote_stream_capacity = manager.with_stream_controller(|cntl| {
+                    cntl.available_remote_intiated_stream_capacity(stream_type)
+                });
+                // Remote initiated streams capacity should be all used up
+                assert_eq!(
+                    VarInt::from_u16(0),
+                    available_remote_stream_capacity,
+                    "local_limit:{} peer_limit:{} stream_type:{:?}",
+                    local_limit,
+                    peer_limit,
+                    stream_type
                 );
             }
+        }
+    }
+}
 
-            let available_outgoing_stream_capacity = manager.with_stream_controller(|cntl| {
-                cntl.available_outgoing_stream_capacity(stream_type)
-            });
+#[test]
+fn asymmetric_stream_limits_local_initiated() {
+    let mut initial_local_limits = create_default_initial_flow_control_limits();
+    let mut initial_peer_limits = create_default_initial_flow_control_limits();
+    let (accept_waker, _accept_wake_counter) = new_count_waker();
+    let mut token = connection::OpenToken::new();
 
-            if stream_type.is_bidirectional() {
-                // The peer opening bidirectional streams uses up the capacity for locally opening streams
-                assert_eq!(VarInt::from_u8(0), available_outgoing_stream_capacity);
-            } else {
-                // The peer opening incoming streams does not affect the capacity for opening outgoing streams
+    for local_limit in 0..101 {
+        for peer_limit in 0..101 {
+            for stream_type in [StreamType::Bidirectional, StreamType::Unidirectional] {
+                let limits = ConnectionLimits::default()
+                    .with_max_open_local_bidirectional_streams(local_limit as u64)
+                    .unwrap()
+                    .with_max_open_local_unidirectional_streams(local_limit as u64)
+                    .unwrap();
+
+                initial_local_limits.max_streams_bidi = VarInt::from_u16(local_limit);
+                initial_peer_limits.max_streams_bidi = VarInt::from_u16(peer_limit);
+                initial_local_limits.max_streams_uni = VarInt::from_u16(local_limit);
+                initial_peer_limits.max_streams_uni = VarInt::from_u16(peer_limit);
+
+                let mut manager = AbstractStreamManager::<MockStream>::new(
+                    &limits,
+                    endpoint::Type::Server,
+                    initial_local_limits,
+                    initial_peer_limits,
+                );
+
+                // Local endpoint opens streams up to the limit
+                let local_available_limit = local_limit.min(peer_limit);
+                for _ in 0..local_available_limit {
+                    let result = manager.poll_open(
+                        stream_type,
+                        &mut token,
+                        &Context::from_waker(&accept_waker),
+                    );
+                    assert!(
+                        result.is_ready(),
+                        "local_limit:{} peer_limit:{} stream_type:{:?}",
+                        local_limit,
+                        peer_limit,
+                        stream_type
+                    );
+                }
+
+                // local capacity assertion
+                let available_local_stream_capacity = manager.with_stream_controller(|cntl| {
+                    cntl.available_local_initiated_stream_capacity(stream_type)
+                });
+                // Local initiated streams capacity should be all used up
                 assert_eq!(
-                    VarInt::from_u8(*peer_limit),
-                    available_outgoing_stream_capacity
+                    VarInt::from_u16(0),
+                    available_local_stream_capacity,
+                    "local_limit:{} peer_limit:{} stream_type:{:?}",
+                    local_limit,
+                    peer_limit,
+                    stream_type
+                );
+
+                // remote capacity assertion
+                let available_remote_stream_capacity = manager.with_stream_controller(|cntl| {
+                    cntl.available_remote_intiated_stream_capacity(stream_type)
+                });
+                // Local initiated streams do NOT use up the capacity for remote initiated streams
+                //
+                // Remote endpoint did not open any streams so it should have the capacity that
+                // the local endpoint specified and sent in transport parameters
+                assert_eq!(
+                    VarInt::from_u16(local_limit),
+                    available_remote_stream_capacity,
+                    "local_limit:{} peer_limit:{} stream_type:{:?}",
+                    local_limit,
+                    peer_limit,
+                    stream_type
                 );
             }
         }

--- a/quic/s2n-quic-transport/src/stream/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/stream/manager/tests.rs
@@ -362,8 +362,8 @@ fn create_default_initial_flow_control_limits() -> InitialFlowControlLimits {
             max_data_uni: VarInt::from_u32(4096),
         },
         max_data: VarInt::from_u32(64 * 1024),
-        max_streams_bidi: VarInt::from_u32(128),
-        max_streams_uni: VarInt::from_u32(128),
+        max_open_remote_bidirectional_streams: VarInt::from_u32(128),
+        max_open_remote_unidirectional_streams: VarInt::from_u32(128),
     }
 }
 
@@ -1275,10 +1275,14 @@ fn asymmetric_stream_limits_remote_initiated() {
                     .with_max_open_local_unidirectional_streams(local_limit as u64)
                     .unwrap();
 
-                initial_local_limits.max_streams_bidi = VarInt::from_u16(local_limit);
-                initial_peer_limits.max_streams_bidi = VarInt::from_u16(peer_limit);
-                initial_local_limits.max_streams_uni = VarInt::from_u16(local_limit);
-                initial_peer_limits.max_streams_uni = VarInt::from_u16(peer_limit);
+                initial_local_limits.max_open_remote_bidirectional_streams =
+                    VarInt::from_u16(local_limit);
+                initial_peer_limits.max_open_remote_bidirectional_streams =
+                    VarInt::from_u16(peer_limit);
+                initial_local_limits.max_open_remote_unidirectional_streams =
+                    VarInt::from_u16(local_limit);
+                initial_peer_limits.max_open_remote_unidirectional_streams =
+                    VarInt::from_u16(peer_limit);
 
                 let mut manager = AbstractStreamManager::<MockStream>::new(
                     &limits,
@@ -1349,10 +1353,14 @@ fn asymmetric_stream_limits_local_initiated() {
                     .with_max_open_local_unidirectional_streams(local_limit as u64)
                     .unwrap();
 
-                initial_local_limits.max_streams_bidi = VarInt::from_u16(local_limit);
-                initial_peer_limits.max_streams_bidi = VarInt::from_u16(peer_limit);
-                initial_local_limits.max_streams_uni = VarInt::from_u16(local_limit);
-                initial_peer_limits.max_streams_uni = VarInt::from_u16(peer_limit);
+                initial_local_limits.max_open_remote_bidirectional_streams =
+                    VarInt::from_u16(local_limit);
+                initial_peer_limits.max_open_remote_bidirectional_streams =
+                    VarInt::from_u16(peer_limit);
+                initial_local_limits.max_open_remote_unidirectional_streams =
+                    VarInt::from_u16(local_limit);
+                initial_peer_limits.max_open_remote_unidirectional_streams =
+                    VarInt::from_u16(peer_limit);
 
                 let mut manager = AbstractStreamManager::<MockStream>::new(
                     &limits,

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -116,9 +116,9 @@ fn stream_reset_test() {
             .with_tls(SERVER_CERTS)?
             .with_event(events())?
             .with_limits(
-                // keep the stream limit low
                 provider::limits::Limits::default()
-                    .with_max_open_bidirectional_streams(1)
+                    // only allow 1 concurrent stream form the peer
+                    .with_max_open_local_bidirectional_streams(1)
                     .unwrap(),
             )?
             .start()?;
@@ -148,7 +148,7 @@ fn stream_reset_test() {
             let connect = Connect::new(server_addr).with_server_name("localhost");
             let mut connection = client.connect(connect).await.unwrap();
 
-            for mut remaining_chunks in 0usize..2 {
+            for mut remaining_chunks in 0usize..4 {
                 let mut stream = connection.open_bidirectional_stream().await.unwrap();
 
                 primary::spawn(async move {


### PR DESCRIPTION
### Description of changes: 
This PR introduces initiator aware stream controllers. With this we can track bidi local/remote streams separately, which makes it a bit easier to reason about.

Notable changes:
- The local_initiated controller is typed over the type of local_stream_limits (bidi vs uni), so the compiler can enforce correctness.
- The APIs for opening streams on the stream_controller now enforce checks at the time of opening the stream.

### Testing:
- fuzz testing
- unit tests

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

