### PR TITLE
feat(s2n-quic-core): Updating BBRv2 control parameters

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
@@ -39,7 +39,7 @@ impl Bandwidth {
     };
 
     /// Constructs a new `Bandwidth` with the given bytes per interval
-    pub fn new(bytes: u64, interval: Duration) -> Self {
+    pub const fn new(bytes: u64, interval: Duration) -> Self {
         if interval.is_zero() {
             Bandwidth::ZERO
         } else {
@@ -79,6 +79,20 @@ impl core::ops::Mul<Duration> for Bandwidth {
                 (self.bits_per_second / MICRO_BITS_PER_BYTE).saturating_mul(rhs.as_micros() as u64)
             }
         }
+    }
+}
+
+/// Divides a count of bytes represented as a u64 by the given `Bandwidth`
+///
+/// Since `Bandwidth` is a rate of bytes over a time period, this division
+/// results in a `Duration` being returned, representing how long a path
+/// with the given `Bandwidth` would take to transmit the given number of
+/// bytes.
+impl core::ops::Div<Bandwidth> for u64 {
+    type Output = Duration;
+
+    fn div(self, rhs: Bandwidth) -> Self::Output {
+        Duration::from_micros(self * MICRO_BITS_PER_BYTE / rhs.bits_per_second)
     }
 }
 

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
@@ -74,6 +74,17 @@ fn bandwidth_mul_overflow() {
     assert_eq!(result, 18446744073704000000 / 8 / 2);
 }
 
+#[test]
+fn u64_div_bandwidth() {
+    let bandwidth = Bandwidth::new(10_000, Duration::from_secs(1));
+    let bytes = 200_000;
+    assert_eq!(bytes / bandwidth, Duration::from_secs(20));
+
+    let bandwidth = Bandwidth::new(10_000, Duration::from_secs(1));
+    let bytes = 2_000;
+    assert_eq!(bytes / bandwidth, Duration::from_millis(200));
+}
+
 // first_sent_time and delivered_time typically hold values from recently acknowledged packets. However,
 // when  no packet has been sent yet, or there are no packets currently in flight, these values are initialized
 // with the time when a packet is sent. This test confirms first_sent_time and delivered_time are

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -707,6 +707,9 @@ impl BbrCongestionController {
         //# BBRModulateCwndForRecovery():
         //#   if (rs.newly_lost > 0)
         //#     cwnd = max(cwnd - rs.newly_lost, 1)
+
+        debug_assert_ne!(lost_bytes, 0);
+
         self.cwnd = self
             .cwnd
             .saturating_sub(lost_bytes)

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_rtt.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_rtt.rs
@@ -204,6 +204,8 @@ impl BbrCongestionController {
         //#    probe_rtt_cwnd = max(probe_rtt_cwnd, BBRMinPipeCwnd)
         //#    return probe_rtt_cwnd#
 
+        debug_assert!(self.state.is_probing_rtt());
+
         self.bdp_multiple(self.data_rate_model.bw(), probe_rtt::CWND_GAIN)
             .try_into()
             .unwrap_or(u32::MAX)


### PR DESCRIPTION
### Description of changes: 

This change updates the pacing rate, send quantum, and congestion window on each ACK in BBRv2.

### Call-outs:

There are a number of places I convert from a u64 to a u32 when dealing with inflight data functions. I'll follow up in a separate PR with making sure these methods are using the correct types.

### Testing:

Added a test for the bandwidth division, additional tests are TODO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

