### PR TITLE
ci: allow unicode license

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -42,6 +42,7 @@ allow = [
     "ISC",
     "MIT",
     "OpenSSL",
+    "Unicode-DFS-2016",
     "Zlib",
 ]
 


### PR DESCRIPTION
### Description of changes: 

This [`unicode-ident`](https://crates.io/crates/unicode-ident) crate recently added the Unicode license to the code, which breaks our current `cargo-deny` check. This change adds the license to the allow list.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

