### PR TITLE
feat(s2n-quic-tls): client hostname verify callback

### DIFF
--- a/quic/s2n-quic-tls/src/client.rs
+++ b/quic/s2n-quic-tls/src/client.rs
@@ -15,7 +15,6 @@ use s2n_tls::{
     enums::ClientAuthType,
     error::Error,
 };
-
 use std::sync::Arc;
 
 pub struct Client {

--- a/quic/s2n-quic-tls/src/client.rs
+++ b/quic/s2n-quic-tls/src/client.rs
@@ -10,10 +10,12 @@ use crate::{
 use s2n_codec::EncoderValue;
 use s2n_quic_core::{application::ServerName, crypto::tls, endpoint};
 use s2n_tls::{
+    callbacks::VerifyHostNameCallback,
     config::{self, Config},
     enums::ClientAuthType,
     error::Error,
 };
+
 use std::sync::Arc;
 
 pub struct Client {
@@ -115,6 +117,20 @@ impl Builder {
                 .expect("pem is currently the only certificate format supported"),
         )?;
         self.config.set_client_auth_type(ClientAuthType::Required)?;
+        Ok(self)
+    }
+
+    /// Set the host name verification callback.
+    ///
+    /// This will be invoked when a server certificate is presented during a TLS
+    /// handshake. If this function is invoked, the default server name validation
+    /// logic is disabled; this should only be used in very specific cases where normal
+    /// TLS hostname validation is not appropriate.
+    pub fn with_verify_host_name_callback<T: 'static + VerifyHostNameCallback>(
+        mut self,
+        handler: T,
+    ) -> Result<Self, Error> {
+        self.config.set_verify_host_callback(handler)?;
         Ok(self)
     }
 


### PR DESCRIPTION
### Resolved issues:

resolves #1408

### Description of changes: 

Add an option to configure a hostname verification callback on the
client side, analogous to the equivalent function on the server side.

### Call-outs:

Note that because the rust bindings don't support
configuring the callback on a per-connection basis, the verification
callback currently cannot be given the original server name that was
connected to, and must make its decision based solely on
client-creation-time context and the hostnames in the TLS certificate in
question.

In most cases where one would be implementing this callback, the
customer has custom logic for determining which hostnames to accept in
any case, so this may not be an issue, but in the future if s2n-tls rust
bindings expose this connection-specific verification call, a new trait
can be introduced to pass through the original server name, and a
blanket impl added to preserve source compatibility.

### Testing:

Additional unit testing. I've also tested it in our use-case application as well.