### PR TITLE
feat(s2n-quic-core): Handle loss and idle restart in BBRv2

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
@@ -166,6 +166,11 @@ impl Estimator {
         self.delivered_bytes
     }
 
+    /// Gets the total amount of data in bytes lost so far over the lifetime of the path
+    pub fn lost_bytes(&self) -> u64 {
+        self.lost_bytes
+    }
+
     /// Gets the latest [RateSample]
     pub fn rate_sample(&self) -> RateSample {
         self.rate_sample

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
@@ -176,6 +176,11 @@ impl Estimator {
         self.rate_sample
     }
 
+    /// Returns true if the path is currently in an application-limited period
+    pub fn is_app_limited(&self) -> bool {
+        self.app_limited_delivered_bytes.is_some()
+    }
+
     /// Called when a packet is transmitted
     pub fn on_packet_sent(
         &mut self,

--- a/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
@@ -66,8 +66,12 @@ impl State {
     }
 
     /// Resets the congestion signals
-    #[allow(dead_code)] // TODO: Remove when used
     pub fn reset(&mut self) {
+        //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.3
+        //# BBRResetCongestionSignals():
+        //#   BBR.loss_in_round = 0
+        //#   BBR.bw_latest = 0
+        //#   BBR.inflight_latest = 0
         self.loss_in_round = false;
         self.bw_latest = Bandwidth::ZERO;
         self.inflight_latest = 0;

--- a/quic/s2n-quic-core/src/recovery/bbr/data_rate.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/data_rate.rs
@@ -37,7 +37,7 @@ pub(crate) struct Model {
     //# The virtual time used by the BBR.max_bw filter window.
     cycle_count: core::num::Wrapping<u8>,
 }
-#[allow(dead_code)] // TODO: Remove when used
+
 impl Model {
     /// Constructs a new `data_rate::Model`
     pub fn new() -> Self {
@@ -97,6 +97,7 @@ impl Model {
     }
 
     /// Updates `bw_hi` with the given `bw`
+    #[allow(dead_code)] // TODO: See note in probe_bw.rs about updating bw_hi
     pub fn update_upper_bound(&mut self, bw: Bandwidth) {
         self.bw_hi = bw
     }
@@ -117,7 +118,10 @@ impl Model {
 
     /// Bounds `bw` to min(`max_bw`, `bw_lo`, `bw_hi)
     pub fn bound_bw_for_model(&mut self) {
-        self.bw = self.max_bw().min(self.bw_lo).min(self.bw_hi)
+        //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.3
+        //# BBRBoundBWForModel():
+        //#   BBR.bw = min(BBR.max_bw, BBR.bw_lo, BBR.bw_hi)
+        self.bw = self.max_bw().min(self.bw_lo()).min(self.bw_hi())
     }
 }
 

--- a/quic/s2n-quic-core/src/recovery/bbr/data_volume.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/data_volume.rs
@@ -145,6 +145,11 @@ impl Model {
     pub fn reset_lower_bound(&mut self) {
         self.inflight_lo = u64::MAX
     }
+
+    /// Sets the `extra_acked_interval_start` to the given `timestamp`
+    pub fn set_extra_acked_interval_start(&mut self, timestamp: Timestamp) {
+        self.extra_acked_interval_start = timestamp;
+    }
 }
 
 #[cfg(test)]

--- a/quic/s2n-quic-core/src/recovery/bbr/data_volume.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/data_volume.rs
@@ -44,7 +44,6 @@ pub(crate) struct Model {
     inflight_lo: u64,
 }
 
-#[allow(dead_code)] // TODO: Remove when used
 impl Model {
     /// Constructs a new `data_volume::Model`
     pub fn new(now: Timestamp) -> Self {

--- a/quic/s2n-quic-core/src/recovery/bbr/full_pipe.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/full_pipe.rs
@@ -10,6 +10,12 @@ use num_rational::Ratio;
 /// Estimator for determining if BBR has fully utilized its available bandwidth ("filled the pipe")
 #[derive(Debug, Default, Clone)]
 pub(crate) struct Estimator {
+    //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.1.2
+    //# BBRInitFullPipe():
+    //#  BBR.filled_pipe = false
+    //#  BBR.full_bw = 0
+    //#  BBR.full_bw_count = 0
+
     //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#2.13
     //# A boolean that records whether BBR estimates that it has ever
     //# fully utilized its available bandwidth ("filled the pipe").

--- a/quic/s2n-quic-core/src/recovery/bbr/recovery.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/recovery.rs
@@ -69,12 +69,12 @@ impl State {
     /// Called when a packet is transmitted
     #[inline]
     pub fn on_packet_sent(&mut self) {
-        if let State::Conservation(recovery_start_time, FastRetransmission::RequiresTransmission) =
+        if let State::Conservation(_, transmission @ FastRetransmission::RequiresTransmission) =
             self
         {
             // A packet has been sent since we entered recovery (fast retransmission)
             // so flip the state back to idle.
-            *self = State::Conservation(*recovery_start_time, FastRetransmission::Idle)
+            *transmission = FastRetransmission::Idle;
         }
     }
 
@@ -135,13 +135,13 @@ impl State {
 
     #[inline]
     pub fn on_packet_discarded(&mut self) {
-        if let State::Conservation(recovery_start_time, FastRetransmission::RequiresTransmission) =
+        if let State::Conservation(_, transmission @ FastRetransmission::RequiresTransmission) =
             self
         {
             // If any of the discarded packets were lost, they will no longer be retransmitted
             // so flip the Recovery status back to Idle so it is not waiting for a
             // retransmission that may never come.
-            *self = State::Conservation(*recovery_start_time, FastRetransmission::Idle)
+            *transmission = FastRetransmission::Idle;
         }
     }
 }

--- a/quic/s2n-quic-core/src/recovery/bbr/recovery.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/recovery.rs
@@ -46,7 +46,6 @@ pub(crate) enum State {
 
 impl State {
     /// True if packet conservation dynamics should be used to bound cwnd
-    #[allow(dead_code)] // TODO: Remove when used
     #[inline]
     pub fn packet_conservation(&self) -> bool {
         matches!(self, State::Conservation(_, _))

--- a/quic/s2n-quic-core/src/recovery/bbr/round.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/round.rs
@@ -10,6 +10,11 @@ use crate::recovery::bandwidth::PacketInfo;
 //# elapsed so far.
 #[derive(Clone, Debug, Default)]
 pub(crate) struct Counter {
+    //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.1
+    //# BBRInitRoundCounting():
+    //#   BBR.next_round_delivered = 0
+    //#   BBR.round_start = false
+    //#   BBR.round_count = 0
     /// The `delivered_bytes` at which the next round begins
     next_round_delivered_bytes: u64,
     /// True if the current ack being processed started a new round
@@ -45,7 +50,6 @@ impl Counter {
     }
 
     /// The number of rounds counted since initialization
-    #[allow(dead_code)] // TODO: Remove when used
     pub fn round_count(&self) -> u64 {
         self.round_count
     }


### PR DESCRIPTION
### Description of changes: 

This change implements the BBRv2 logic for handling packet loss, as well as resumption from idle. 

### Call-outs:

I've also cleaned up a few outstanding TODOs, as well as added a new one (#1412) for an optimization that we can do later if necessary

### Testing:

TODO

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

