### PR TITLE
fix(s2n-quic-core): Some Datagram Fixes

### DIFF
--- a/examples/unreliable-datagram/Cargo.toml
+++ b/examples/unreliable-datagram/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-s2n-quic = { version = "1", path = "../../quic/s2n-quic", features = ["unstable-provider-datagram", "provider-event-tracing"]}
+s2n-quic = { version = "1", path = "../../quic/s2n-quic", features = ["unstable-provider-datagram"]}
 s2n-quic-core = { path = "../../quic/s2n-quic-core" }
 tokio = { version = "1", features = ["full"] }
 bytes = { version = "1", default-features = false }

--- a/examples/unreliable-datagram/Cargo.toml
+++ b/examples/unreliable-datagram/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-s2n-quic = { version = "1", path = "../../quic/s2n-quic", features = ["unstable-provider-datagram"]}
+s2n-quic = { version = "1", path = "../../quic/s2n-quic", features = ["unstable-provider-datagram", "provider-event-tracing"]}
 s2n-quic-core = { path = "../../quic/s2n-quic-core" }
 tokio = { version = "1", features = ["full"] }
 bytes = { version = "1", default-features = false }

--- a/examples/unreliable-datagram/src/bin/datagram_receiver.rs
+++ b/examples/unreliable-datagram/src/bin/datagram_receiver.rs
@@ -4,7 +4,7 @@
 use core::task::Poll;
 use s2n_quic::{
     client::Connect,
-    provider::datagram::{default::Endpoint, default::Receiver},
+    provider::datagram::default::{Endpoint, Receiver},
     Client,
 };
 use std::{error::Error, net::SocketAddr};
@@ -38,26 +38,31 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let connect = Connect::new(addr).with_server_name("localhost");
     let mut connection = client.connect(connect).await?;
 
-    let recv_result = futures::future::poll_fn(|cx| {
-        // datagram_mut takes a closure which calls the requested datagram function. The type
-        // of the closure parameter should be either the datagram Sender type or the
-        // datagram Receiver type. The datagram_mut function will check this type against
-        // its stored datagram Sender and Receiver, and if the type matches, the requested
-        // function will execute. Here, that requested function is poll_recv_datagram.
-        match connection.datagram_mut(|recv: &mut Receiver| recv.poll_recv_datagram(cx)) {
-            // If the function is successfully called on the provider, it will return Poll<Bytes>.
-            // Here we send an Ok() to wrap around the Bytes so the poll_fn doesn't complain.
-            Ok(poll_value) => poll_value.map(|x| Ok(x)),
-            // The datagram_mut function may return a query error if it can't find the type
-            // referenced in the closure. Here we wrap the error in a Poll::Ready enum so the
-            // poll_fn doesn't complain.
-            Err(query_err) => return Poll::Ready(Err(query_err)),
-        }
-    })
-    .await;
-    if recv_result.is_ok() {
-        eprintln!("{:?}", recv_result.unwrap());
-    }
+    loop {
+        let recv_result = futures::future::poll_fn(|cx| {
+            // datagram_mut takes a closure which calls the requested datagram function. The type
+            // of the closure parameter should be either the datagram Sender type or the
+            // datagram Receiver type. The datagram_mut function will check this type against
+            // its stored datagram Sender and Receiver, and if the type matches, the requested
+            // function will execute. Here, that requested function is poll_recv_datagram.
+            match connection.datagram_mut(|recv: &mut Receiver| recv.poll_recv_datagram(cx)) {
+                // If the function is successfully called on the provider, it will return Poll<Bytes>.
+                // Here we send an Ok() to wrap around the Bytes so the poll_fn doesn't complain.
+                Ok(poll_value) => poll_value.map(|x| Ok(x)),
+                // The datagram_mut function may return a query error if it can't find the type
+                // referenced in the closure. Here we wrap the error in a Poll::Ready enum so the
+                // poll_fn doesn't complain.
+                Err(query_err) => return Poll::Ready(Err(query_err)),
+            }
+        })
+        .await;
 
-    Ok(())
+        match recv_result {
+            Ok(value) => eprintln!("RECV {:?}", value),
+            Err(err) => {
+                eprintln!("{:?}", err);
+                return Ok(());
+            }
+        }
+    }
 }

--- a/examples/unreliable-datagram/src/bin/datagram_receiver.rs
+++ b/examples/unreliable-datagram/src/bin/datagram_receiver.rs
@@ -65,5 +65,4 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
         }
     }
-    Ok(())
 }

--- a/examples/unreliable-datagram/src/bin/datagram_receiver.rs
+++ b/examples/unreliable-datagram/src/bin/datagram_receiver.rs
@@ -65,4 +65,5 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
         }
     }
+    Ok(())
 }

--- a/examples/unreliable-datagram/src/bin/datagram_sender.rs
+++ b/examples/unreliable-datagram/src/bin/datagram_sender.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 // Add datagrams to the send queue by passing in a closure that calls
                 // the desired datagram send function
                 let send_func = |x: &mut Sender| {
-                    match dbg!(x.send_datagram(Bytes::from_static(&[1, 2, 3]))) {
+                    match x.send_datagram(Bytes::from_static(&[1, 2, 3])) {
                         Ok(_) => {
                             // The datagram was successfully inserted into the send queue
                         }

--- a/examples/unreliable-datagram/src/bin/datagram_sender.rs
+++ b/examples/unreliable-datagram/src/bin/datagram_sender.rs
@@ -3,7 +3,7 @@
 
 use bytes::Bytes;
 use s2n_quic::{
-    provider::datagram::{default::Endpoint, default::Sender},
+    provider::datagram::default::{Endpoint, Sender},
     Server,
 };
 use std::error::Error;
@@ -38,22 +38,30 @@ async fn main() -> Result<(), Box<dyn Error>> {
         tokio::spawn(async move {
             eprintln!("Connection accepted from {:?}", connection.remote_addr());
 
-            // Add datagrams to the send queue by passing in a closure that calls
-            // the desired datagram send function
-            let send_func = |x: &mut Sender| {
-                match x.send_datagram(Bytes::from_static(&[1, 2, 3])) {
-                    Ok(_) => {
-                        // The datagram was successfully inserted into the send queue
+            loop {
+                // Add datagrams to the send queue by passing in a closure that calls
+                // the desired datagram send function
+                let send_func = |x: &mut Sender| {
+                    match dbg!(x.send_datagram(Bytes::from_static(&[1, 2, 3]))) {
+                        Ok(_) => {
+                            // The datagram was successfully inserted into the send queue
+                        }
+                        Err(err) => {
+                            eprintln!("{}", err);
+                            // An error was encountered while calling the send_datagram
+                            // method. Either the peer didn't advertise support for datagrams
+                            // or the send queue is at capacity.
+                        }
                     }
-                    Err(err) => {
-                        eprintln!("{}", err);
-                        // An error was encountered while calling the send_datagram
-                        // method. Either the peer didn't advertise support for datagrams
-                        // or the send queue is at capacity.
-                    }
+                };
+
+                if connection.datagram_mut(send_func).is_err() {
+                    eprintln!("closed");
+                    return;
                 }
-            };
-            let _ = connection.datagram_mut(send_func);
+
+                tokio::time::sleep(core::time::Duration::from_secs(1)).await;
+            }
         });
     }
 

--- a/quic/s2n-quic-core/src/datagram/default.rs
+++ b/quic/s2n-quic-core/src/datagram/default.rs
@@ -132,7 +132,7 @@ impl Receiver {
     ///   the caller should retry receiving after the [`Waker`](core::task::Waker) on the provided
     ///   [`Context`](core::task::Context) is notified.
     /// - `Poll::Ready(Datagram)` if there exists a datagram to be received.
-    /// - `Poll::Ready(Err)` if a connection error occurred and no more datagrams will be received.
+    /// - `Poll::Ready(DatagramError)` if a connection error occurred and no more datagrams will be received.
     pub fn poll_recv_datagram(&mut self, cx: &mut Context) -> Poll<Result<Bytes, DatagramError>> {
         if let Some(datagram) = self.queue.pop_front() {
             Poll::Ready(Ok(datagram))

--- a/quic/s2n-quic-core/src/datagram/default.rs
+++ b/quic/s2n-quic-core/src/datagram/default.rs
@@ -239,8 +239,11 @@ pub struct Datagram {
 #[non_exhaustive]
 #[derive(Debug, PartialEq)]
 pub enum DatagramError {
+    #[non_exhaustive]
     QueueAtCapacity,
+    #[non_exhaustive]
     ExceedsPeerTransportLimits,
+    #[non_exhaustive]
     ConnectionError { error: connection::Error },
 }
 

--- a/quic/s2n-quic-core/src/datagram/disabled.rs
+++ b/quic/s2n-quic-core/src/datagram/disabled.rs
@@ -29,8 +29,12 @@ impl Sender for DisabledSender {
     fn has_transmission_interest(&self) -> bool {
         false
     }
+
+    fn on_connection_error(&mut self, _error: crate::connection::Error) {}
 }
 
 impl Receiver for DisabledReceiver {
     fn on_datagram(&mut self, _datagram: &[u8]) {}
+
+    fn on_connection_error(&mut self, _error: crate::connection::Error) {}
 }

--- a/quic/s2n-quic-core/src/datagram/traits.rs
+++ b/quic/s2n-quic-core/src/datagram/traits.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::connection;
+
 /// The datagram endpoint trait provides a way to implement custom unreliable datagram
 /// sending and receiving logic. The Sender type should be implemented for custom
 /// sending behavior, and the Receiver type should be implemented for custom
@@ -53,8 +55,11 @@ impl PreConnectionInfo {
 }
 
 pub trait Receiver: 'static + Send {
-    // A callback that gives users direct access to datagrams as they are read off a packet
+    /// A callback that gives users direct access to datagrams as they are read off a packet
     fn on_datagram(&mut self, datagram: &[u8]);
+
+    /// A callback used to notify the application in the case of a connection error
+    fn on_connection_error(&mut self, error: connection::Error);
 }
 pub trait Sender: 'static + Send {
     /// A callback that allows users to write datagrams directly to the packet
@@ -64,6 +69,9 @@ pub trait Sender: 'static + Send {
     ///
     /// Use method to trigger the on_transmit callback
     fn has_transmission_interest(&self) -> bool;
+
+    /// A callback used to notify the application in the case of a connection error
+    fn on_connection_error(&mut self, error: connection::Error);
 }
 
 /// A packet will be available during the on_transmit callback. Use the methods

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1832,12 +1832,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
     #[inline]
     fn datagram_mut(&mut self, query: &mut dyn event::query::QueryMut) {
         if let Some((space, _)) = self.space_manager.application_mut() {
-            // Try to execute the query on the sender side. If that fails, try the receiver side.
-            match query.execute_mut(&mut space.datagram_manager.sender) {
-                event::query::ControlFlow::Continue => {
-                    query.execute_mut(&mut space.datagram_manager.receiver);
-                }
-                event::query::ControlFlow::Break => (),
+            if space.datagram_manager.datagram_mut(query).is_ready() {
+                self.wakeup_handle.wakeup();
             }
         }
     }


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

1. On the sending side, prevents datagrams from being sent if there exists some connection-level error.
2. On the poll receiving side, prevents waker from being cloned if there exists some connection-level error.
3. Includes tests for the above scenarios ^
4. Unreliable datagram example now sends and recvs in a loop.

### Call-outs:
### Testing:

Unit tests. Also datagrams can now be sent continuously and received continuously.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

