### PR TITLE
feat(s2n-quic-core): deprecate on_ack_processed event in favor of on_rx_ack_range_dropped

### DIFF
--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -2251,7 +2251,7 @@ pub mod builder {
             }
         }
     }
-    #[derive(Clone, Debug)]
+    #[derive(Copy, Clone, Debug)]
     pub struct Path<'a> {
         pub local_addr: SocketAddress<'a>,
         pub local_cid: ConnectionId<'a>,
@@ -2281,7 +2281,7 @@ pub mod builder {
             }
         }
     }
-    #[derive(Clone, Debug)]
+    #[derive(Copy, Clone, Debug)]
     pub struct ConnectionId<'a> {
         pub bytes: &'a [u8],
     }
@@ -2321,7 +2321,7 @@ pub mod builder {
             }
         }
     }
-    #[derive(Clone, Debug)]
+    #[derive(Copy, Clone, Debug)]
     pub enum SocketAddress<'a> {
         IpV4 { ip: &'a [u8; 4], port: u16 },
         IpV6 { ip: &'a [u8; 16], port: u16 },

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -55,8 +55,8 @@ pub mod api {
         pub connection_id: ConnectionId<'a>,
         pub stateless_reset_token: &'a [u8],
     }
+    #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[derive(Debug, Clone, Copy)]
     pub struct Path<'a> {
         pub local_addr: SocketAddress<'a>,
         pub local_cid: ConnectionId<'a>,
@@ -66,7 +66,7 @@ pub mod api {
         pub is_active: bool,
     }
     #[non_exhaustive]
-    #[derive(Clone, Copy)]
+    #[derive(Clone)]
     pub struct ConnectionId<'a> {
         pub bytes: &'a [u8],
     }
@@ -84,7 +84,7 @@ pub mod api {
         pub ce_count: u64,
     }
     #[non_exhaustive]
-    #[derive(Clone, Copy)]
+    #[derive(Clone)]
     pub enum SocketAddress<'a> {
         #[non_exhaustive]
         IpV4 { ip: &'a [u8; 4], port: u16 },
@@ -2251,7 +2251,7 @@ pub mod builder {
             }
         }
     }
-    #[derive(Copy, Clone, Debug)]
+    #[derive(Clone, Debug)]
     pub struct Path<'a> {
         pub local_addr: SocketAddress<'a>,
         pub local_cid: ConnectionId<'a>,
@@ -2281,7 +2281,7 @@ pub mod builder {
             }
         }
     }
-    #[derive(Copy, Clone, Debug)]
+    #[derive(Clone, Debug)]
     pub struct ConnectionId<'a> {
         pub bytes: &'a [u8],
     }
@@ -2321,7 +2321,7 @@ pub mod builder {
             }
         }
     }
-    #[derive(Copy, Clone, Debug)]
+    #[derive(Clone, Debug)]
     pub enum SocketAddress<'a> {
         IpV4 { ip: &'a [u8; 4], port: u16 },
         IpV6 { ip: &'a [u8; 16], port: u16 },

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -93,8 +93,6 @@ impl IntoEvent<bool> for &crate::transport::parameters::MigrationSupport {
     }
 }
 
-#[builder_derive(derive(Copy))]
-#[derive(Debug, Clone, Copy)]
 struct Path<'a> {
     local_addr: SocketAddress<'a>,
     local_cid: ConnectionId<'a>,
@@ -104,8 +102,7 @@ struct Path<'a> {
     is_active: bool,
 }
 
-#[derive(Clone, Copy)]
-#[builder_derive(derive(Copy))]
+#[derive(Clone)]
 struct ConnectionId<'a> {
     bytes: &'a [u8],
 }
@@ -138,8 +135,7 @@ impl_conn_id!(PeerId);
 impl_conn_id!(UnboundedId);
 impl_conn_id!(InitialId);
 
-#[derive(Clone, Copy)]
-#[builder_derive(derive(Copy))]
+#[derive(Clone)]
 enum SocketAddress<'a> {
     IpV4 { ip: &'a [u8; 4], port: u16 },
     IpV6 { ip: &'a [u8; 16], port: u16 },

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -93,6 +93,7 @@ impl IntoEvent<bool> for &crate::transport::parameters::MigrationSupport {
     }
 }
 
+#[builder_derive(derive(Copy))]
 struct Path<'a> {
     local_addr: SocketAddress<'a>,
     local_cid: ConnectionId<'a>,
@@ -103,6 +104,7 @@ struct Path<'a> {
 }
 
 #[derive(Clone)]
+#[builder_derive(derive(Copy))]
 struct ConnectionId<'a> {
     bytes: &'a [u8],
 }
@@ -136,6 +138,7 @@ impl_conn_id!(UnboundedId);
 impl_conn_id!(InitialId);
 
 #[derive(Clone)]
+#[builder_derive(derive(Copy))]
 enum SocketAddress<'a> {
     IpV4 { ip: &'a [u8; 4], port: u16 },
     IpV6 { ip: &'a [u8; 16], port: u16 },

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -93,6 +93,8 @@ impl IntoEvent<bool> for &crate::transport::parameters::MigrationSupport {
     }
 }
 
+#[builder_derive(derive(Copy))]
+#[derive(Debug, Clone, Copy)]
 struct Path<'a> {
     local_addr: SocketAddress<'a>,
     local_cid: ConnectionId<'a>,
@@ -102,7 +104,8 @@ struct Path<'a> {
     is_active: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
+#[builder_derive(derive(Copy))]
 struct ConnectionId<'a> {
     bytes: &'a [u8],
 }
@@ -135,7 +138,8 @@ impl_conn_id!(PeerId);
 impl_conn_id!(UnboundedId);
 impl_conn_id!(InitialId);
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
+#[builder_derive(derive(Copy))]
 enum SocketAddress<'a> {
     IpV4 { ip: &'a [u8; 4], port: u16 },
     IpV6 { ip: &'a [u8; 16], port: u16 },
@@ -714,6 +718,7 @@ enum PacketDropReason<'a> {
     },
 }
 
+#[deprecated(note = "use on_rx_ack_range_dropped event instead")]
 enum AckAction {
     /// Ack range for received packets was dropped due to space constraints
     ///

--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -104,10 +104,30 @@ struct Congestion<'a> {
 }
 
 #[event("recovery:ack_processed")]
+#[deprecated(note = "use on_rx_ack_range_dropped event instead")]
 /// Events related to ACK processing
 struct AckProcessed<'a> {
     action: AckAction,
     path: Path<'a>,
+}
+
+#[event("recovery:rx_ack_range_dropped")]
+/// Ack range for received packets was dropped due to space constraints
+///
+/// For the purpose of processing Acks, RX packet numbers are stored as
+/// packet_number ranges in an IntervalSet; only lower and upper bounds
+/// are stored instead of individual packet_numbers. Ranges are merged
+/// when possible so only disjointed ranges are stored.
+///
+/// When at `capacity`, the lowest packet_number range is dropped.
+struct RxAckRangeDropped<'a> {
+    path: Path<'a>,
+    /// The packet number range which was dropped
+    packet_number_range: core::ops::RangeInclusive<u64>,
+    /// The number of disjoint ranges the IntervalSet can store
+    capacity: usize,
+    /// The store packet_number range in the IntervalSet
+    stored_range: core::ops::RangeInclusive<u64>,
 }
 
 #[event("recovery:ack_range_received")]

--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -16,7 +16,7 @@ use s2n_quic_core::{
     counter::{Counter, Saturating},
     event::{
         self,
-        builder::{self, AckAction, AckProcessed},
+        builder::{AckAction, AckProcessed},
         IntoEvent as _,
     },
     frame::{ack::EcnCounts, Ack, Ping},
@@ -245,7 +245,7 @@ impl AckManager {
                         .expect("should be non empty")
                         .into_event();
 
-                    publisher.on_rx_ack_range_dropped(builder::RxAckRangeDropped {
+                    publisher.on_rx_ack_range_dropped(event::builder::RxAckRangeDropped {
                         path: path.clone(),
                         packet_number_range: min.into_event()..=max.into_event(),
                         capacity: self.ack_ranges.interval_len(),

--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -246,7 +246,7 @@ impl AckManager {
                         .into_event();
 
                     publisher.on_rx_ack_range_dropped(event::builder::RxAckRangeDropped {
-                        path: path.clone(),
+                        path,
                         packet_number_range: min.into_event()..=max.into_event(),
                         capacity: self.ack_ranges.interval_len(),
                         stored_range: start..=end,

--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -16,7 +16,7 @@ use s2n_quic_core::{
     counter::{Counter, Saturating},
     event::{
         self,
-        builder::{AckAction, AckProcessed},
+        builder::{self, AckAction, AckProcessed},
         IntoEvent as _,
     },
     frame::{ack::EcnCounts, Ack, Ping},
@@ -244,6 +244,13 @@ impl AckManager {
                         .max_value()
                         .expect("should be non empty")
                         .into_event();
+
+                    publisher.on_rx_ack_range_dropped(builder::RxAckRangeDropped {
+                        path,
+                        packet_number_range: min.into_event()..=max.into_event(),
+                        capacity: self.ack_ranges.interval_len(),
+                        stored_range: start..=end,
+                    });
 
                     publisher.on_ack_processed(AckProcessed {
                         action: AckAction::RxAckRangeDropped {

--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -246,7 +246,7 @@ impl AckManager {
                         .into_event();
 
                     publisher.on_rx_ack_range_dropped(builder::RxAckRangeDropped {
-                        path,
+                        path: path.clone(),
                         packet_number_range: min.into_event()..=max.into_event(),
                         capacity: self.ack_ranges.interval_len(),
                         stored_range: start..=end,


### PR DESCRIPTION
### Testing:

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

