### PR TITLE
s2n-quic-core: Lower inflight_lo based on ECN markings in BBRv2

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -387,7 +387,7 @@ impl CongestionController for BbrCongestionController {
         timestamp: Timestamp,
     ) {
         self.bw_estimator.on_loss(lost_bytes as usize);
-        if self.recovery_state.on_congestion_event(timestamp) {
+        if self.recovery_state.on_loss(timestamp) {
             // this congestion event caused the connection to enter recovery
             self.on_enter_fast_recovery();
         }
@@ -402,9 +402,8 @@ impl CongestionController for BbrCongestionController {
         self.handle_lost_packet(lost_bytes, packet_info, random_generator, timestamp);
     }
 
-    fn on_explicit_congestion(&mut self, ce_count: u64, event_time: Timestamp) {
+    fn on_explicit_congestion(&mut self, ce_count: u64, _event_time: Timestamp) {
         self.bw_estimator.on_explicit_congestion(ce_count);
-        self.recovery_state.on_congestion_event(event_time);
         self.ecn_state.on_explicit_congestion(ce_count);
     }
 

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -318,17 +318,8 @@ impl CongestionController for BbrCongestionController {
         //# BBRUpdateModelAndState():
         //#   BBRUpdateLatestDeliverySignals()
         //#   BBRUpdateCongestionSignals()
-        self.congestion_state.update(
-            // implements BBRUpdateLatestDeliverySignals() and BBRUpdateCongestionSignals()
-            newest_acked_packet_info,
-            self.bw_estimator.rate_sample(),
-            self.bw_estimator.delivered_bytes(),
-            &mut self.data_rate_model,
-            &mut self.data_volume_model,
-            self.state.is_probing_bw(),
-            self.cwnd,
-            self.ecn_state.alpha(),
-        );
+        // implements BBRUpdateLatestDeliverySignals() and BBRUpdateCongestionSignals()
+        self.update_latest_signals(newest_acked_packet_info);
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.2.3
         //# BBRUpdateACKAggregation()
         self.data_volume_model.update_ack_aggregation(

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -5,8 +5,10 @@ use crate::{
     counter::Counter,
     random,
     recovery::{
-        bandwidth, bandwidth::Bandwidth, bbr::probe_bw::CyclePhase, CongestionController,
-        RttEstimator,
+        bandwidth,
+        bandwidth::{Bandwidth, RateSample},
+        bbr::probe_bw::CyclePhase,
+        CongestionController, RttEstimator,
     },
     time::Timestamp,
 };
@@ -22,6 +24,7 @@ mod congestion;
 mod data_rate;
 mod data_volume;
 mod drain;
+mod ecn;
 mod full_pipe;
 mod probe_bw;
 mod probe_rtt;
@@ -33,10 +36,6 @@ mod windowed_filter;
 //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#2.8
 //# The maximum tolerated per-round-trip packet loss rate when probing for bandwidth (the default is 2%).
 const LOSS_THRESH: Ratio<u32> = Ratio::new_raw(1, 50);
-
-// The maximum tolerated ratio of packets containing ECN CE markings
-// Value from https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L2306
-const ECN_THRESH: Ratio<u64> = Ratio::new_raw(1, 2);
 
 //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#2.8
 //# The default multiplicative decrease to make upon each round trip during which
@@ -195,6 +194,7 @@ struct BbrCongestionController {
     prior_cwnd: u32,
     recovery_state: recovery::State,
     congestion_state: congestion::State,
+    ecn_state: ecn::State,
     data_rate_model: data_rate::Model,
     data_volume_model: data_volume::Model,
     max_datagram_size: u16,
@@ -301,6 +301,10 @@ impl CongestionController for BbrCongestionController {
             // This ack caused recovery to be exited
             self.on_exit_fast_recovery();
         }
+        if self.round_counter.round_start() {
+            self.ecn_state
+                .on_round_start(self.bw_estimator.delivered_bytes(), self.max_datagram_size);
+        }
 
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.2.3
         //# On every ACK, the BBR algorithm executes the following BBRUpdateOnACK() steps in order
@@ -323,6 +327,7 @@ impl CongestionController for BbrCongestionController {
             &mut self.data_volume_model,
             self.state.is_probing_bw(),
             self.cwnd,
+            self.ecn_state.alpha(),
         );
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.2.3
         //# BBRUpdateACKAggregation()
@@ -386,6 +391,8 @@ impl CongestionController for BbrCongestionController {
             // this congestion event caused the connection to enter recovery
             self.on_enter_fast_recovery();
         }
+        self.congestion_state
+            .on_packet_lost(self.bw_estimator.delivered_bytes());
         self.full_pipe_estimator.on_packet_lost(new_loss_burst);
         self.modulate_cwnd_for_recovery(lost_bytes);
 
@@ -398,6 +405,7 @@ impl CongestionController for BbrCongestionController {
     fn on_explicit_congestion(&mut self, ce_count: u64, event_time: Timestamp) {
         self.bw_estimator.on_explicit_congestion(ce_count);
         self.recovery_state.on_congestion_event(event_time);
+        self.ecn_state.on_explicit_congestion(ce_count);
     }
 
     fn on_mtu_update(&mut self, max_datagram_size: u16) {
@@ -465,6 +473,7 @@ impl BbrCongestionController {
             prior_cwnd: 0,
             recovery_state: recovery::State::Recovered,
             congestion_state: Default::default(),
+            ecn_state: Default::default(),
             data_rate_model: data_rate::Model::new(),
             // initialize extra_acked_interval_start and extra_acked_delivered
             data_volume_model: data_volume::Model::new(now),
@@ -662,14 +671,22 @@ impl BbrCongestionController {
     }
 
     /// True if the amount of loss or ECN CE markings exceed the BBR thresholds
-    fn is_inflight_too_high(&self) -> bool {
-        let rate_sample = self.bw_estimator.rate_sample();
-        Self::is_loss_too_high(rate_sample.lost_bytes, rate_sample.bytes_in_flight)
-            || Self::is_ecn_ce_too_high(
+    #[inline]
+    fn is_inflight_too_high(rate_sample: RateSample, max_datagram_size: u16) -> bool {
+        if Self::is_loss_too_high(rate_sample.lost_bytes, rate_sample.bytes_in_flight) {
+            return true;
+        }
+
+        if rate_sample.delivered_bytes > 0 {
+            let ecn_ce_ratio = ecn::ce_ratio(
                 rate_sample.ecn_ce_count,
                 rate_sample.delivered_bytes,
-                self.max_datagram_size,
-            )
+                max_datagram_size,
+            );
+            return ecn::is_ce_too_high(ecn_ce_ratio);
+        }
+
+        false
     }
 
     /// True if the amount of `lost_bytes` exceeds the BBR loss threshold
@@ -679,17 +696,6 @@ impl BbrCongestionController {
         //# IsInflightTooHigh()
         //#   return (rs.lost > rs.tx_in_flight * BBRLossThresh)
         lost_bytes > (LOSS_THRESH * bytes_inflight).to_integer() as u64
-    }
-
-    /// True if the `ecn_ce_count` exceeds the BBR ECN threshold
-    #[inline]
-    fn is_ecn_ce_too_high(ecn_ce_count: u64, delivered_bytes: u64, max_datagram_size: u16) -> bool {
-        // Estimate the number of bytes experiencing explicit congestion by multiplying
-        // the ecn_ce_count by max_datagram_size
-        let ecn_ce_bytes = ecn_ce_count.saturating_mul(max_datagram_size as u64);
-        let ecn_ce_threshold = (ECN_THRESH * delivered_bytes).to_integer();
-
-        ecn_ce_bytes > ecn_ce_threshold
     }
 
     //= https://www.rfc-editor.org/rfc/rfc9002#section-7.2

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -378,7 +378,7 @@ impl CongestionController for BbrCongestionController {
         timestamp: Timestamp,
     ) {
         self.bw_estimator.on_loss(lost_bytes as usize);
-        if self.recovery_state.on_loss(timestamp) {
+        if self.recovery_state.on_congestion_event(timestamp) {
             // this congestion event caused the connection to enter recovery
             self.on_enter_fast_recovery();
         }
@@ -393,10 +393,13 @@ impl CongestionController for BbrCongestionController {
         self.handle_lost_packet(lost_bytes, packet_info, random_generator, timestamp);
     }
 
-    fn on_explicit_congestion(&mut self, ce_count: u64, _event_time: Timestamp) {
+    fn on_explicit_congestion(&mut self, ce_count: u64, event_time: Timestamp) {
         self.bw_estimator.on_explicit_congestion(ce_count);
         self.ecn_state.on_explicit_congestion(ce_count);
         self.congestion_state.on_explicit_congestion();
+        if self.recovery_state.on_congestion_event(event_time) {
+            self.on_enter_fast_recovery();
+        }
     }
 
     fn on_mtu_update(&mut self, max_datagram_size: u16) {

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -396,6 +396,7 @@ impl CongestionController for BbrCongestionController {
     fn on_explicit_congestion(&mut self, ce_count: u64, _event_time: Timestamp) {
         self.bw_estimator.on_explicit_congestion(ce_count);
         self.ecn_state.on_explicit_congestion(ce_count);
+        self.congestion_state.on_explicit_congestion();
     }
 
     fn on_mtu_update(&mut self, max_datagram_size: u16) {

--- a/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
@@ -5,7 +5,6 @@ use crate::recovery::{
     bandwidth::{Bandwidth, PacketInfo, RateSample},
     bbr::{data_rate, data_volume, round, BbrCongestionController},
 };
-use num_rational::Ratio;
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct State {
@@ -37,7 +36,7 @@ impl State {
         data_volume_model: &mut data_volume::Model,
         is_probing_bw: bool,
         cwnd: u32,
-        ecn_alpha: Ratio<u64>,
+        ecn_alpha: f64,
     ) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.3
         //# BBRUpdateLatestDeliverySignals():
@@ -177,8 +176,6 @@ pub mod testing {
         },
         time::{Clock, NoopClock},
     };
-    use num_rational::Ratio;
-    use num_traits::One;
     use std::time::Duration;
 
     /// Asserts that the given `congestion::State` has been reset
@@ -220,7 +217,7 @@ pub mod testing {
             &mut data_volume_model,
             false,
             100,
-            Ratio::one(),
+            1.0,
         );
 
         state
@@ -232,7 +229,6 @@ mod tests {
     use super::*;
     use crate::time::{Clock, NoopClock};
     use core::time::Duration;
-    use num_traits::One;
 
     #[test]
     fn update() {
@@ -265,7 +261,7 @@ mod tests {
             &mut data_volume_model,
             false,
             100,
-            Ratio::one(),
+            1.0,
         );
 
         assert!(state.loss_round_counter.round_start());
@@ -297,7 +293,7 @@ mod tests {
             &mut data_volume_model,
             false,
             100,
-            Ratio::one(),
+            1.0,
         );
 
         assert!(!state.loss_round_counter.round_start());
@@ -321,7 +317,7 @@ mod tests {
             &mut data_volume_model,
             true, // we are probing bw, so lower bounds should not update
             100,
-            Ratio::one(),
+            1.0,
         );
 
         assert!(state.loss_round_counter.round_start());
@@ -361,7 +357,7 @@ mod tests {
             &mut data_volume::Model::new(now),
             false,
             100,
-            Ratio::one(),
+            1.0,
         );
 
         assert!(state.loss_round_counter.round_start());

--- a/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
@@ -28,7 +28,7 @@ impl State {
     ///
     /// Called near the start of ACK processing
     #[allow(clippy::too_many_arguments)]
-    pub fn update(
+    pub(super) fn update(
         &mut self,
         packet_info: PacketInfo,
         rate_sample: RateSample,
@@ -108,7 +108,7 @@ impl State {
     /// Initializes the congestion state for the next round
     ///
     /// Called near the end of ACK processing
-    pub fn advance(&mut self, rate_sample: RateSample) {
+    pub(super) fn advance(&mut self, rate_sample: RateSample) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.3
         //# BBRAdvanceLatestDeliverySignals():
         //#   if (BBR.loss_round_start)
@@ -121,7 +121,7 @@ impl State {
     }
 
     /// Resets the congestion signals
-    pub fn reset(&mut self) {
+    pub(super) fn reset(&mut self) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.3
         //# BBRResetCongestionSignals():
         //#   BBR.loss_in_round = 0
@@ -134,11 +134,17 @@ impl State {
     }
 
     #[inline]
-    pub fn on_packet_lost(&mut self, delivered_bytes: u64) {
+    pub(super) fn on_packet_lost(&mut self, delivered_bytes: u64) {
         if !self.loss_in_round {
             self.loss_round_counter.set_round_end(delivered_bytes);
         }
         self.loss_in_round = true;
+    }
+
+    #[inline]
+    /// Returns true if this is the beginning of a new loss round
+    pub(super) fn loss_round_start(&self) -> bool {
+        self.loss_round_counter.round_start()
     }
 }
 

--- a/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
@@ -72,9 +72,6 @@ impl State {
         }
 
         if self.loss_round_counter.round_start() {
-            // TODO: Check for ecn_in_round as in bbr2_adapt_lower_bounds
-            // See https://github.com/aws/s2n-quic/issues/1423
-
             if !is_probing_bw {
                 //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.3
                 //# BBRAdaptLowerBoundsFromCongestion():

--- a/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
@@ -139,6 +139,11 @@ impl State {
     }
 
     #[inline]
+    pub(super) fn on_explicit_congestion(&mut self) {
+        self.ecn_in_round = true;
+    }
+
+    #[inline]
     /// Returns true if this is the beginning of a new loss round
     pub(super) fn loss_round_start(&self) -> bool {
         self.loss_round_counter.round_start()

--- a/quic/s2n-quic-core/src/recovery/bbr/data_volume.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/data_volume.rs
@@ -5,6 +5,7 @@ use crate::{
     recovery::{
         bandwidth::Bandwidth,
         bbr::{
+            ecn::ECN_FACTOR,
             windowed_filter::{MinRttWindowedFilter, WindowedMaxFilter},
             BETA,
         },
@@ -12,6 +13,8 @@ use crate::{
     time::Timestamp,
 };
 use core::time::Duration;
+use num_rational::Ratio;
+use num_traits::One;
 
 //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#2.9.2
 //# The data volume model parameters together estimate both the volume of in-flight data required to
@@ -150,9 +153,19 @@ impl Model {
         self.inflight_hi = inflight_hi;
     }
 
-    /// Updates `inflight_lo` with the given `inflight_latest` if it exceeds
-    /// the current `inflight_lo` * `bbr::BETA`
-    pub fn update_lower_bound(&mut self, cwnd: u32, inflight_latest: u64) {
+    /// Updates `inflight_lo` according to if there is loss or ECN in the round
+    pub fn update_lower_bound(
+        &mut self,
+        cwnd: u32,
+        inflight_latest: u64,
+        loss_in_round: bool,
+        ecn_in_round: bool,
+        ecn_alpha: Ratio<u64>,
+    ) {
+        if !loss_in_round && !ecn_in_round {
+            return;
+        }
+
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.3
         //# if (BBR.inflight_lo == Infinity)
         //#     BBR.inflight_lo = cwnd
@@ -160,10 +173,22 @@ impl Model {
             self.inflight_lo = cwnd as u64;
         }
 
-        //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.3
-        //# BBR.inflight_lo = max(BBR.inflight_latest,
-        //#                       BBRBeta * BBR.infligh_lo)
-        self.inflight_lo = inflight_latest.max((BETA * self.inflight_lo).to_integer());
+        // Update inflight_lo to the lower of the values determined when loss_in_round or ecn_in_round
+        // Based on https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L1618
+        let ecn_inflight_lo = if ecn_in_round {
+            ((Ratio::one() - (ecn_alpha * ECN_FACTOR)) * self.inflight_lo).to_integer()
+        } else {
+            u64::MAX
+        };
+
+        if loss_in_round {
+            //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.3
+            //# BBR.inflight_lo = max(BBR.inflight_latest,
+            //#                       BBRBeta * BBR.infligh_lo)
+            self.inflight_lo = inflight_latest.max((BETA * self.inflight_lo).to_integer());
+        }
+
+        self.inflight_lo = self.inflight_lo.min(ecn_inflight_lo);
     }
 
     /// Resets `inflight_lo` to its initial value
@@ -232,25 +257,37 @@ mod tests {
         let now = NoopClock.get_time();
         let mut model = Model::new(now);
 
-        model.update_lower_bound(1000, 100);
+        model.update_lower_bound(1000, 100, true, false, Ratio::one());
 
         // We didn't have a valid inflight_lo value yet, and the given inflight_latest is lower than cwnd * BETA,
         // so inflight_lo is set to cwnd * BETA
         assert_eq!((BETA * 1000).to_integer(), model.inflight_lo());
 
-        model.update_upper_bound(50);
-
-        // The new sample is lower than inflight_lo, so don't update inflight_lo
-        assert_eq!((BETA * 1000).to_integer(), model.inflight_lo());
-
-        let inflight_lo = 1500;
-        model.update_lower_bound(1000, inflight_lo);
+        let inflight_latest = 1500;
+        model.update_lower_bound(1000, inflight_latest, true, false, Ratio::one());
 
         // The new sample is higher than inflight_lo, so update inflight_lo
-        assert_eq!(inflight_lo, model.inflight_lo());
+        assert_eq!(inflight_latest, model.inflight_lo());
+
+        let ecn_alpha = Ratio::new(4, 5);
+        model.update_lower_bound(1000, inflight_latest, false, true, ecn_alpha);
+
+        // There was ecn_in_round, so lower inflight_lo according to ecn_alpha
+        // (1 - 4/5 * 1/3) * 1500 = 1100
+        assert_eq!(1100, model.inflight_lo());
 
         // Resetting the lower bound sets inflight_lo to u64::MAX
         model.reset_lower_bound();
         assert_eq!(u64::MAX, model.inflight_lo());
+
+        // There is both ECN and Loss in the round, but the Loss reduced value is lower, so use the Loss value
+        model.update_lower_bound(1500, 100, true, true, ecn_alpha);
+        assert_eq!(1050, model.inflight_lo());
+
+        model.reset_lower_bound();
+
+        // There is both ECN and Loss in the round, but the Loss reduced value is higher, so use the ECN value
+        model.update_lower_bound(1500, 1200, true, true, ecn_alpha);
+        assert_eq!(1100, model.inflight_lo());
     }
 }

--- a/quic/s2n-quic-core/src/recovery/bbr/ecn.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/ecn.rs
@@ -90,6 +90,10 @@ pub(super) fn is_ce_too_high(ce_ratio: f64) -> bool {
     ce_ratio > ECN_THRESH
 }
 
+/// Calculates the new ECN alpha value
+///
+/// Based on `bbr2_update_ecn_alpha` from the Linux TCP BBRv2 implementation
+/// See https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L1392
 #[inline]
 fn calculate_alpha(alpha: f64, ce_ratio: f64) -> f64 {
     ((1.0 - ECN_ALPHA_GAIN) * alpha + ECN_ALPHA_GAIN * ce_ratio).min(1.0)

--- a/quic/s2n-quic-core/src/recovery/bbr/ecn.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/ecn.rs
@@ -25,7 +25,7 @@ pub(crate) struct State {
     /// Weighted average ratio of ECN CE marked packets with `ECN_ALPHA_GAIN` applied
     alpha: Ratio<u64>,
     /// True if the ECN CE count over the current round trip was too high
-    ecn_ce_too_high: bool,
+    ce_too_high: bool,
 }
 
 impl Default for State {
@@ -34,7 +34,7 @@ impl Default for State {
             ce_count_in_round: 0,
             round_start_delivered_bytes: 0,
             alpha: Ratio::one(),
-            ecn_ce_too_high: false,
+            ce_too_high: false,
         }
     }
 }
@@ -46,9 +46,13 @@ impl State {
         let delivered_bytes_in_round = delivered_bytes - self.round_start_delivered_bytes;
         // update alpha
         if delivered_bytes_in_round > 0 {
-            let ce_ratio = ce_ratio(self.ce_count_in_round, delivered_bytes, max_datagram_size);
+            let ce_ratio = ce_ratio(
+                self.ce_count_in_round,
+                delivered_bytes_in_round,
+                max_datagram_size,
+            );
             self.alpha = calculate_alpha(self.alpha, ce_ratio);
-            self.ecn_ce_too_high = is_ce_too_high(ce_ratio);
+            self.ce_too_high = is_ce_too_high(ce_ratio);
         }
 
         self.round_start_delivered_bytes = delivered_bytes;
@@ -63,8 +67,8 @@ impl State {
 
     /// Returns true if the ECN CE ratio over the latest round was too high
     #[inline]
-    pub(super) fn ecn_ce_too_high(&self) -> bool {
-        self.ecn_ce_too_high
+    pub(super) fn is_ce_too_high_in_round(&self) -> bool {
+        self.ce_too_high
     }
 
     /// Returns the ECN alpha value
@@ -87,7 +91,7 @@ pub(super) fn ce_ratio(
     Ratio::new(ecn_ce_bytes, delivered_bytes)
 }
 
-/// True if the `ecn_ce_ratio` exceeds the BBR ECN threshold
+/// True if the given ECN `ce_ratio` exceeds the BBR ECN threshold
 #[inline]
 pub(super) fn is_ce_too_high(ce_ratio: Ratio<u64>) -> bool {
     ce_ratio > ECN_THRESH
@@ -100,5 +104,60 @@ fn calculate_alpha(alpha: Ratio<u64>, ce_ratio: Ratio<u64>) -> Ratio<u64> {
 
 #[cfg(test)]
 mod tests {
-    // TODO
+    use super::*;
+    use crate::{path::MINIMUM_MTU, recovery::bbr::ecn};
+
+    #[test]
+    fn on_round_start() {
+        let mut state = ecn::State::default();
+        assert_eq!(Ratio::one(), state.alpha());
+
+        let delivered_bytes = 1000;
+        state.on_round_start(delivered_bytes, MINIMUM_MTU);
+
+        // No ECN CE yet and alpha is currently at the initial value of 1,
+        // so alpha is just 1 - alpha gain
+        assert_eq!(Ratio::one() - ECN_ALPHA_GAIN, state.alpha());
+        assert!(!state.is_ce_too_high_in_round());
+        assert_eq!(delivered_bytes, state.round_start_delivered_bytes);
+
+        state.on_explicit_congestion(10);
+        assert_eq!(10, state.ce_count_in_round);
+
+        let alpha = state.alpha();
+        let prev_delivered = delivered_bytes;
+        // 20 packets delivered, 10 of which were ECN CE marked
+        let delivered_bytes = prev_delivered + 20 * MINIMUM_MTU as u64;
+
+        state.on_round_start(delivered_bytes, MINIMUM_MTU);
+
+        assert_eq!(
+            (Ratio::one() - ECN_ALPHA_GAIN) * alpha + ECN_ALPHA_GAIN * Ratio::new(1, 2),
+            state.alpha()
+        );
+        // ECN ce count is not above the 50% `ECN_THRESH`
+        assert!(!state.is_ce_too_high_in_round());
+        assert_eq!(delivered_bytes, state.round_start_delivered_bytes);
+        // ce count is reset
+        assert_eq!(0, state.ce_count_in_round);
+
+        state.on_explicit_congestion(11);
+        assert_eq!(11, state.ce_count_in_round);
+
+        let alpha = state.alpha();
+        let prev_delivered = delivered_bytes;
+        let delivered_bytes = prev_delivered + 20 * MINIMUM_MTU as u64;
+
+        // 20 packets delivered, 11 of which were ECN CE marked
+        state.on_round_start(delivered_bytes, MINIMUM_MTU);
+
+        assert_eq!(
+            (Ratio::one() - ECN_ALPHA_GAIN) * alpha + ECN_ALPHA_GAIN * Ratio::new(11, 20),
+            state.alpha()
+        );
+        // ECN ce count is above the 50% `ECN_THRESH`
+        assert!(state.is_ce_too_high_in_round());
+        assert_eq!(delivered_bytes, state.round_start_delivered_bytes);
+        assert_eq!(0, state.ce_count_in_round);
+    }
 }

--- a/quic/s2n-quic-core/src/recovery/bbr/ecn.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/ecn.rs
@@ -1,0 +1,104 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use num_rational::Ratio;
+use num_traits::One;
+
+// Gain factor for ECN CE mark ratio samples
+// Value from https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L2290
+const ECN_ALPHA_GAIN: Ratio<u64> = Ratio::new_raw(1, 16);
+
+// The maximum tolerated ratio of packets containing ECN CE markings
+// Value from https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L2306
+const ECN_THRESH: Ratio<u64> = Ratio::new_raw(1, 2);
+
+// On ECN CE markings, cut inflight_lo to (1 - ECN_FACTOR * ecn_alpha)
+// Value from https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L2301
+pub(super) const ECN_FACTOR: Ratio<u64> = Ratio::new_raw(1, 3);
+
+#[derive(Clone, Debug)]
+pub(crate) struct State {
+    /// The amount of explicit congestion experienced packets in the current round trip
+    ce_count_in_round: u64,
+    /// The amount of bytes delivered in the current round trip
+    round_start_delivered_bytes: u64,
+    /// Weighted average ratio of ECN CE marked packets with `ECN_ALPHA_GAIN` applied
+    alpha: Ratio<u64>,
+    /// True if the ECN CE count over the current round trip was too high
+    ecn_ce_too_high: bool,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        Self {
+            ce_count_in_round: 0,
+            round_start_delivered_bytes: 0,
+            alpha: Ratio::one(),
+            ecn_ce_too_high: false,
+        }
+    }
+}
+
+impl State {
+    /// Called on each new BBR round
+    #[inline]
+    pub(super) fn on_round_start(&mut self, delivered_bytes: u64, max_datagram_size: u16) {
+        let delivered_bytes_in_round = delivered_bytes - self.round_start_delivered_bytes;
+        // update alpha
+        if delivered_bytes_in_round > 0 {
+            let ce_ratio = ce_ratio(self.ce_count_in_round, delivered_bytes, max_datagram_size);
+            self.alpha = calculate_alpha(self.alpha, ce_ratio);
+            self.ecn_ce_too_high = is_ce_too_high(ce_ratio);
+        }
+
+        self.round_start_delivered_bytes = delivered_bytes;
+        self.ce_count_in_round = 0;
+    }
+
+    /// Called each time explicit congestion is recorded
+    #[inline]
+    pub(super) fn on_explicit_congestion(&mut self, ce_count: u64) {
+        self.ce_count_in_round += ce_count;
+    }
+
+    /// Returns true if the ECN CE ratio over the latest round was too high
+    #[inline]
+    pub(super) fn ecn_ce_too_high(&self) -> bool {
+        self.ecn_ce_too_high
+    }
+
+    /// Returns the ECN alpha value
+    #[inline]
+    pub(super) fn alpha(&self) -> Ratio<u64> {
+        self.alpha
+    }
+}
+
+/// Calculate the ratio of ECN CE marked bytes to overall delivered bytes
+#[inline]
+pub(super) fn ce_ratio(
+    ecn_ce_count: u64,
+    delivered_bytes: u64,
+    max_datagram_size: u16,
+) -> Ratio<u64> {
+    // Estimate the number of bytes experiencing explicit congestion by multiplying
+    // the ecn_ce_count by max_datagram_size
+    let ecn_ce_bytes = ecn_ce_count.saturating_mul(max_datagram_size as u64);
+    Ratio::new(ecn_ce_bytes, delivered_bytes)
+}
+
+/// True if the `ecn_ce_ratio` exceeds the BBR ECN threshold
+#[inline]
+pub(super) fn is_ce_too_high(ce_ratio: Ratio<u64>) -> bool {
+    ce_ratio > ECN_THRESH
+}
+
+#[inline]
+fn calculate_alpha(alpha: Ratio<u64>, ce_ratio: Ratio<u64>) -> Ratio<u64> {
+    ((Ratio::one() - ECN_ALPHA_GAIN) * alpha + ECN_ALPHA_GAIN * ce_ratio).min(Ratio::one())
+}
+
+#[cfg(test)]
+mod tests {
+    // TODO
+}

--- a/quic/s2n-quic-core/src/recovery/bbr/full_pipe.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/full_pipe.rs
@@ -30,8 +30,6 @@ pub(crate) struct Estimator {
     loss_bursts: Counter<u8, Saturating>,
     /// The number of rounds where the ECN CE markings exceed ECN_THRESH
     ecn_ce_rounds: Counter<u8, Saturating>,
-    /// True if BBR was in fast recovery in the last round
-    in_recovery_last_round: bool,
 }
 
 impl Estimator {

--- a/quic/s2n-quic-core/src/recovery/bbr/full_pipe.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/full_pipe.rs
@@ -127,8 +127,8 @@ impl Estimator {
         self.full_bw_count >= BANDWIDTH_PLATEAU_ROUND_COUNT
     }
 
-    /// Determines if inflight has been too high (due to either loss or ECN markings) for enough
-    /// round trips to estimate the available bandwidth has been fully utilized.
+    /// Determines if inflight has been too high (due to either loss or ECN markings) and enough
+    /// distinct loss bursts have been observed to estimate the available bandwidth has been fully utilized.
     #[inline]
     fn excessive_inflight(
         &mut self,
@@ -143,6 +143,11 @@ impl Estimator {
         //#    *  The loss rate over the time scale of a single full round trip exceeds BBRLossThresh (2%).
         //#    *  There are at least BBRStartupFullLossCnt=3 discontiguous sequence ranges lost in that round trip.
         const STARTUP_FULL_LOSS_COUNT: u8 = 3;
+
+        //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.1.3
+        //= type=exception
+        //= reason=The BBRv2 RFC reference to "fast recovery" here is more applicable to TCP.
+        //#    *  The connection has been in fast recovery for at least one full round trip.
 
         // The BBRv2 RFC reference to "fast recovery" here seems more applicable to TCP, rather than
         // QUIC. Instead, we just consider the loss rate and number of loss bursts over the round trip.

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
@@ -889,7 +889,7 @@ mod tests {
         let now = NoopClock.get_time();
         let mut data_volume_model = data_volume::Model::new(now);
         let mut data_rate_model = data_rate::Model::new();
-        data_volume_model.update_lower_bound(12000, 12000, true, false, Ratio::one());
+        data_volume_model.update_lower_bound(12000, 12000, true, false, 1.0);
         data_rate_model.update_lower_bound(Bandwidth::ZERO);
 
         state.ack_phase = AckPhase::ProbeStopping;

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
@@ -569,7 +569,7 @@ impl BbrCongestionController {
             self.update_ack_phase(rate_sample);
         }
 
-        if self.is_inflight_too_high() {
+        if Self::is_inflight_too_high(rate_sample, self.max_datagram_size) {
             if self.bw_probe_samples {
                 // Inflight is too high and the sample is from bandwidth probing: lower inflight downward
                 self.on_inflight_too_high(
@@ -889,7 +889,7 @@ mod tests {
         let now = NoopClock.get_time();
         let mut data_volume_model = data_volume::Model::new(now);
         let mut data_rate_model = data_rate::Model::new();
-        data_volume_model.update_lower_bound(12000, 12000);
+        data_volume_model.update_lower_bound(12000, 12000, true, false, Ratio::one());
         data_rate_model.update_lower_bound(Bandwidth::ZERO);
 
         state.ack_phase = AckPhase::ProbeStopping;

--- a/quic/s2n-quic-core/src/recovery/bbr/recovery.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/recovery.rs
@@ -108,11 +108,11 @@ impl State {
         false
     }
 
-    /// Called when packet loss occurs
+    /// Called when a congestion event occurs (packet loss or ECN CE count increase)
     ///
-    /// Returns `true` if the packet loss caused recovery to be entered
+    /// Returns `true` if the congestion event caused recovery to be entered
     #[inline]
-    pub fn on_loss(&mut self, now: Timestamp) -> bool {
+    pub fn on_congestion_event(&mut self, now: Timestamp) -> bool {
         match self {
             State::Recovered => {
                 //= https://www.rfc-editor.org/rfc/rfc9002#section-7.3.2
@@ -190,8 +190,8 @@ mod tests {
         assert!(!state.on_ack(true, now));
         assert_eq!(state, State::Recovered);
 
-        // Packet loss moves Recovered to Conservation
-        assert!(state.on_loss(now));
+        // Congestion event moves Recovered to Conservation
+        assert!(state.on_congestion_event(now));
         assert_eq!(
             state,
             State::Conservation(now, FastRetransmission::RequiresTransmission)
@@ -208,16 +208,16 @@ mod tests {
 
         // Congestion moves the recovery start time forward
         let now = now + Duration::from_secs(5);
-        assert!(!state.on_loss(now));
+        assert!(!state.on_congestion_event(now));
         assert_eq!(state, State::Conservation(now, FastRetransmission::Idle));
 
         // Ack received that starts a new round moves Conservation to Growth
         assert!(!state.on_ack(true, now));
         assert_eq!(state, State::Growth(now));
 
-        // Packet loss moves the recovery start time forward
+        // Congestion moves the recovery start time forward
         let now = now + Duration::from_secs(10);
-        assert!(!state.on_loss(now));
+        assert!(!state.on_congestion_event(now));
         assert_eq!(state, State::Growth(now));
 
         // Ack for a packet sent before the recovery start time does not exit recovery

--- a/quic/s2n-quic-core/src/recovery/bbr/startup.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/startup.rs
@@ -46,11 +46,8 @@ impl BbrCongestionController {
         }
 
         if self.congestion_state.loss_round_start() {
-            self.full_pipe_estimator.on_loss_round_start(
-                self.bw_estimator.rate_sample(),
-                self.recovery_state.in_recovery(),
-                self.max_datagram_size,
-            )
+            self.full_pipe_estimator
+                .on_loss_round_start(self.bw_estimator.rate_sample(), self.max_datagram_size)
         }
 
         if self.state.is_startup() && self.full_pipe_estimator.filled_pipe() {

--- a/quic/s2n-quic-core/src/recovery/bbr/startup.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/startup.rs
@@ -41,7 +41,7 @@ impl BbrCongestionController {
             self.full_pipe_estimator.on_round_start(
                 self.bw_estimator.rate_sample(),
                 self.data_rate_model.max_bw(),
-                self.ecn_state.ecn_ce_too_high(),
+                self.ecn_state.is_ce_too_high_in_round(),
             );
         }
 

--- a/quic/s2n-quic-core/src/recovery/bbr/startup.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/startup.rs
@@ -46,6 +46,10 @@ impl BbrCongestionController {
         }
 
         if self.congestion_state.loss_round_start() {
+            // Excessive inflight is checked at the end of a loss round, not a regular round, as done
+            // in tcp_bbr2.c/bbr2_check_loss_too_high_in_startup
+            //
+            // See https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L2133
             self.full_pipe_estimator
                 .on_loss_round_start(self.bw_estimator.rate_sample(), self.max_datagram_size)
         }

--- a/quic/s2n-quic-core/src/recovery/bbr/startup.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/startup.rs
@@ -41,13 +41,20 @@ impl BbrCongestionController {
             self.full_pipe_estimator.on_round_start(
                 self.bw_estimator.rate_sample(),
                 self.data_rate_model.max_bw(),
-                self.recovery_state.in_recovery(),
                 self.ecn_state.ecn_ce_too_high(),
-                self.max_datagram_size,
             );
-            if self.state.is_startup() && self.full_pipe_estimator.filled_pipe() {
-                self.enter_drain();
-            }
+        }
+
+        if self.congestion_state.loss_round_start() {
+            self.full_pipe_estimator.on_loss_round_start(
+                self.bw_estimator.rate_sample(),
+                self.recovery_state.in_recovery(),
+                self.max_datagram_size,
+            )
+        }
+
+        if self.state.is_startup() && self.full_pipe_estimator.filled_pipe() {
+            self.enter_drain();
         }
     }
 }

--- a/quic/s2n-quic-core/src/recovery/bbr/startup.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/startup.rs
@@ -42,6 +42,7 @@ impl BbrCongestionController {
                 self.bw_estimator.rate_sample(),
                 self.data_rate_model.max_bw(),
                 self.recovery_state.in_recovery(),
+                self.ecn_state.ecn_ce_too_high(),
                 self.max_datagram_size,
             );
             if self.state.is_startup() && self.full_pipe_estimator.filled_pipe() {


### PR DESCRIPTION
### Resolved issues:

resolves #1423

### Description of changes: 

This change implements lowering of the `inflight_lo` data volume parameter in response to ECN congestion experienced (CE) signals. The implementation is based on the Linux TCP BBRv2 implementation, specifically [bbr2_update_ecn_alpha](https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L1392) and [bbr2_adapt_lower_bounds](https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L1630). Effectively a weight average of the ratio of packets marked with the ECN CE marking is updated on every BBR round. That value (`alpha`) is used to reduce `inflight_lo`. `inflight_lo` may also be reduced when packet loss occurs. The lower of the ECN `inflight_lo` and packet loss `inflight_lo` is ultimately used.

### Call-outs:

I've included some other related changes in this PR as well that bring the code more in line with the TCP implementation, as well as simplify some things:

- The end of the "loss round" that the `loss_round_counter` in `congestion::State` tracks is extended when loss first occurs in a round. 
- I've removed the use of `is_recovery` when determining if we should exit startup due to loss. I believe this requirement is more suited to TCP, and the Chromium implementation doesn't follow it
- The check in the `full_pipe::Estimator` for exiting based on loss is now called at the end of a loss round, instead of a regular round. I also check for the ECN rate of the latest Rate Sample. Both these changes are is inline with the TCP implementation. 
- I've added a third check in `full_pipe::Estimator` that lets startup be exited when the ECN CE ratio over the entire round exceeds the `ECN_THRESH`. This is based on the [Linux TCP implementation](https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L1372)

### Testing:

Added some unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

