### PR TITLE
test(s2n-quic): add integration test for tokio AsyncRead and AsyncWrite

### DIFF
--- a/quic/s2n-quic/src/stream/receive.rs
+++ b/quic/s2n-quic/src/stream/receive.rs
@@ -343,7 +343,7 @@ macro_rules! impl_receive_stream_trait {
             ) -> core::task::Poll<std::io::Result<()>> {
                 use bytes::Bytes;
 
-                if buf.capacity() == 0 {
+                if buf.remaining() == 0 {
                     return Ok(()).into();
                 }
 

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -5,7 +5,7 @@ use crate::{
     client::Connect,
     provider::{
         self,
-        io::testing::{spawn, test, time::delay, Model},
+        io::testing::{rand, spawn, test, time::delay, Model},
         packet_interceptor::Loss,
     },
     Server,
@@ -16,6 +16,7 @@ mod setup;
 use bytes::Bytes;
 use s2n_quic_platform::io::testing::primary;
 use setup::*;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[test]
 fn client_server_test() {
@@ -165,6 +166,68 @@ fn stream_reset_test() {
                         }
                     }
                 });
+            }
+        });
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+/// Ensures tokio `AsyncRead` implementation functions properly
+///
+/// See https://github.com/aws/s2n-quic/issues/1427
+#[test]
+fn tokio_read_exact_test() {
+    let model = Model::default();
+    test(model, |handle| {
+        let server_addr = server(handle)?;
+
+        let client = build_client(handle)?;
+
+        // send 5000 bytes
+        const LEN: usize = 5000;
+
+        primary::spawn(async move {
+            let connect = Connect::new(server_addr).with_server_name("localhost");
+            let mut connection = client.connect(connect).await.unwrap();
+            let stream = connection.open_bidirectional_stream().await.unwrap();
+            let (mut recv, mut send) = stream.split();
+
+            primary::spawn(async move {
+                let mut read_len = 0;
+                let mut buf = [0u8; 1000];
+                // try to read from the stream until we read LEN bytes
+                while read_len < LEN {
+                    let max_len = buf.len().min(LEN - read_len);
+                    // generate a random amount of bytes to read
+                    let len = rand::gen_range(1..=max_len);
+
+                    let buf = &mut buf[0..len];
+                    recv.read_exact(buf).await.unwrap();
+
+                    // record the amount that was read
+                    read_len += len;
+                }
+                assert_eq!(read_len, LEN);
+            });
+
+            let mut write_len = 0;
+            let mut buf = &[42u8; LEN][..];
+            while !buf.is_empty() {
+                // split the `buf` until it's empty
+                let chunk_len = write_len.min(buf.len());
+                let (chunk, remaining) = buf.split_at(chunk_len);
+
+                // ensure the chunk is written to the stream
+                send.write_all(chunk).await.unwrap();
+
+                buf = remaining;
+                // slowly increase the size of the chunks written
+                write_len += 1;
+
+                // by slowing the rate at which we send, we exercise the receiver's buffering logic in `read_exact`
+                delay(Duration::from_millis(10)).await;
             }
         });
 


### PR DESCRIPTION
### Resolved issues:

resolves #1427, extends #1429 

### Description of changes: 

This change adds an integration test for the recently fixed `tokio::io::AsyncRead` implementation.

### Testing:

If #1429 is reverted, this integration test fails, showing that it's an effective test in preventing a regression.

```
thread 'tests::tokio_read_exact_test' panicked at 'buf.len() must fit in remaining()', ~/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/io/read_buf.rs:245:9
stack backtrace:
   0: std::panicking::begin_panic
             at /rustc/59eed8a2aac0230a8b53e89d4e99d55912ba6b35/library/std/src/panicking.rs:543:12
   1: tokio::io::read_buf::ReadBuf::put_slice
             at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/io/read_buf.rs:245:9
   2: <s2n_quic::stream::receive::ReceiveStream as tokio::io::async_read::AsyncRead>::poll_read
             at ./src/stream/receive.rs:371:21
   3: <&mut T as tokio::io::async_read::AsyncRead>::poll_read
             at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/io/async_read.rs:67:13
   4: <tokio::io::util::read_exact::ReadExact<A> as core::future::future::Future>::poll
             at ~/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.19.2/src/io/util/read_exact.rs:60:24
   5: s2n_quic::tests::tokio_read_exact_test::{{closure}}::{{closure}}::{{closure}}
             at ./src/tests.rs:208:21
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

