### PR TITLE
feat(s2n-quic-core): Add limit values for Blocked frame events 

### DIFF
--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -149,11 +149,17 @@ pub mod api {
         #[non_exhaustive]
         MaxStreams { stream_type: StreamType, value: u64 },
         #[non_exhaustive]
-        DataBlocked {},
+        DataBlocked { data_limit: u64 },
         #[non_exhaustive]
-        StreamDataBlocked {},
+        StreamDataBlocked {
+            stream_id: u64,
+            stream_data_limit: u64,
+        },
         #[non_exhaustive]
-        StreamsBlocked { stream_type: StreamType },
+        StreamsBlocked {
+            stream_type: StreamType,
+            stream_limit: u64,
+        },
         #[non_exhaustive]
         NewConnectionId {},
         #[non_exhaustive]
@@ -1285,18 +1291,24 @@ pub mod api {
     }
     impl IntoEvent<builder::Frame> for &crate::frame::DataBlocked {
         fn into_event(self) -> builder::Frame {
-            builder::Frame::DataBlocked {}
+            builder::Frame::DataBlocked {
+                data_limit: self.data_limit.as_u64(),
+            }
         }
     }
     impl IntoEvent<builder::Frame> for &crate::frame::StreamDataBlocked {
         fn into_event(self) -> builder::Frame {
-            builder::Frame::StreamDataBlocked {}
+            builder::Frame::StreamDataBlocked {
+                stream_id: self.stream_id.as_u64(),
+                stream_data_limit: self.stream_data_limit.as_u64(),
+            }
         }
     }
     impl IntoEvent<builder::Frame> for &crate::frame::StreamsBlocked {
         fn into_event(self) -> builder::Frame {
             builder::Frame::StreamsBlocked {
                 stream_type: self.stream_type.into_event(),
+                stream_limit: self.stream_limit.as_u64(),
             }
         }
     }
@@ -2405,10 +2417,16 @@ pub mod builder {
             stream_type: StreamType,
             value: u64,
         },
-        DataBlocked,
-        StreamDataBlocked,
+        DataBlocked {
+            data_limit: u64,
+        },
+        StreamDataBlocked {
+            stream_id: u64,
+            stream_data_limit: u64,
+        },
         StreamsBlocked {
             stream_type: StreamType,
+            stream_limit: u64,
         },
         NewConnectionId,
         RetireConnectionId,
@@ -2481,10 +2499,22 @@ pub mod builder {
                     stream_type: stream_type.into_event(),
                     value: value.into_event(),
                 },
-                Self::DataBlocked => DataBlocked {},
-                Self::StreamDataBlocked => StreamDataBlocked {},
-                Self::StreamsBlocked { stream_type } => StreamsBlocked {
+                Self::DataBlocked { data_limit } => DataBlocked {
+                    data_limit: data_limit.into_event(),
+                },
+                Self::StreamDataBlocked {
+                    stream_id,
+                    stream_data_limit,
+                } => StreamDataBlocked {
+                    stream_id: stream_id.into_event(),
+                    stream_data_limit: stream_data_limit.into_event(),
+                },
+                Self::StreamsBlocked {
+                    stream_type,
+                    stream_limit,
+                } => StreamsBlocked {
                     stream_type: stream_type.into_event(),
+                    stream_limit: stream_limit.into_event(),
                 },
                 Self::NewConnectionId => NewConnectionId {},
                 Self::RetireConnectionId => RetireConnectionId {},

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -344,10 +344,18 @@ enum Frame {
         stream_type: StreamType,
         value: u64,
     },
-    DataBlocked,
-    StreamDataBlocked,
+    DataBlocked {
+        stream_type: StreamType,
+        data_limit: u64,
+    },
+    StreamDataBlocked {
+        stream_type: StreamType,
+        stream_id: u64,
+        stream_data_limit: u64,
+    },
     StreamsBlocked {
         stream_type: StreamType,
+        stream_limit: u64
     },
     NewConnectionId,
     RetireConnectionId,
@@ -440,13 +448,20 @@ impl IntoEvent<builder::Frame> for &crate::frame::MaxStreams {
 
 impl IntoEvent<builder::Frame> for &crate::frame::DataBlocked {
     fn into_event(self) -> builder::Frame {
-        builder::Frame::DataBlocked {}
+        builder::Frame::DataBlocked {
+            stream_type: self.stream_type.into_event(),
+            data_limit: self.data_limit.as_u64(),
+        }
     }
 }
 
 impl IntoEvent<builder::Frame> for &crate::frame::StreamDataBlocked {
     fn into_event(self) -> builder::Frame {
-        builder::Frame::StreamDataBlocked {}
+        builder::Frame::StreamDataBlocked {
+            stream_type: self.stream_type.into_event(),
+            stream_id: self.stream_id.as_u64(),
+            stream_data_limit: self.stream_data_limit.as_u64(),
+        }
     }
 }
 
@@ -454,6 +469,7 @@ impl IntoEvent<builder::Frame> for &crate::frame::StreamsBlocked {
     fn into_event(self) -> builder::Frame {
         builder::Frame::StreamsBlocked {
             stream_type: self.stream_type.into_event(),
+            stream_limit: self.stream_limit.as_u64(),
         }
     }
 }

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -345,11 +345,9 @@ enum Frame {
         value: u64,
     },
     DataBlocked {
-        stream_type: StreamType,
         data_limit: u64,
     },
     StreamDataBlocked {
-        stream_type: StreamType,
         stream_id: u64,
         stream_data_limit: u64,
     },
@@ -449,7 +447,6 @@ impl IntoEvent<builder::Frame> for &crate::frame::MaxStreams {
 impl IntoEvent<builder::Frame> for &crate::frame::DataBlocked {
     fn into_event(self) -> builder::Frame {
         builder::Frame::DataBlocked {
-            stream_type: self.stream_type.into_event(),
             data_limit: self.data_limit.as_u64(),
         }
     }
@@ -458,7 +455,6 @@ impl IntoEvent<builder::Frame> for &crate::frame::DataBlocked {
 impl IntoEvent<builder::Frame> for &crate::frame::StreamDataBlocked {
     fn into_event(self) -> builder::Frame {
         builder::Frame::StreamDataBlocked {
-            stream_type: self.stream_type.into_event(),
             stream_id: self.stream_id.as_u64(),
             stream_data_limit: self.stream_data_limit.as_u64(),
         }


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Currently Block frame events (DataBlocked, StreamDataBlocked and StreamsBlocked) contain no fields that describe by the frame was sent. This PR adds limit values to to these events

### Call-outs:

N/A

### Testing:

`cargo test` succeeds.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

