### PR TITLE
refactor(s2n-quic-core): represent Bandwidth as nanos per byte

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
@@ -38,6 +38,8 @@ pub struct PacketInfo {
 /// of data (nanoseconds per byte, in this case). This allows for some of the  
 /// math operations needed on `Bandwidth` to avoid division, while reducing the
 /// likelihood of panicking due to overflow.
+///
+/// The maximum (non-infinite) value that can be represented is 1 GB/second.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Bandwidth {
     nanos_per_byte: u64,

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
@@ -30,6 +30,14 @@ pub struct PacketInfo {
     pub is_app_limited: bool,
 }
 
+/// Represents a rate at which data is transferred
+///
+/// While bandwidth is typically thought of as an amount of data over a fixed
+/// amount of time (bytes per second, for example), in this case we internally
+/// represent bandwidth as the inverse: an amount of time to send a fixed amount
+/// of data (nanoseconds per byte, in this case). This allows for some of the  
+/// math operations needed on `Bandwidth` to avoid division, while reducing the
+/// likelihood of panicking due to overflow.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct Bandwidth {
     nanos_per_byte: u64,

--- a/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
@@ -315,7 +315,7 @@ mod tests {
             loss_round_counter: Default::default(),
             loss_in_round: true,
             inflight_latest: 100,
-            bw_latest: Bandwidth::MAX,
+            bw_latest: Bandwidth::INFINITY,
         };
 
         state.reset();

--- a/quic/s2n-quic-core/src/recovery/bbr/data_rate.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/data_rate.rs
@@ -48,8 +48,8 @@ impl Model {
 
         Self {
             max_bw_filter: WindowedMaxFilter::new(MAX_BW_FILTER_LEN),
-            bw_hi: Bandwidth::MAX,
-            bw_lo: Bandwidth::MAX,
+            bw_hi: Bandwidth::INFINITY,
+            bw_lo: Bandwidth::INFINITY,
             bw: Bandwidth::ZERO,
             cycle_count: Default::default(),
         }
@@ -121,7 +121,7 @@ impl Model {
         //# BBRInitLowerBounds():
         //#   if (BBR.bw_lo == Infinity)
         //#     BBR.bw_lo = BBR.max_bw
-        if self.bw_lo == Bandwidth::MAX {
+        if self.bw_lo == Bandwidth::INFINITY {
             self.bw_lo = self.max_bw()
         }
 
@@ -137,7 +137,7 @@ impl Model {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.3
         //# BBRResetLowerBounds():
         //#   BBR.bw_lo       = Infinity
-        self.bw_lo = Bandwidth::MAX
+        self.bw_lo = Bandwidth::INFINITY
     }
 
     /// Bounds `bw` to min(`max_bw`, `bw_lo`, `bw_hi)
@@ -160,8 +160,8 @@ mod tests {
 
         assert_eq!(Bandwidth::ZERO, model.max_bw());
         assert_eq!(Bandwidth::ZERO, model.bw());
-        assert_eq!(Bandwidth::MAX, model.bw_hi());
-        assert_eq!(Bandwidth::MAX, model.bw_lo());
+        assert_eq!(Bandwidth::INFINITY, model.bw_hi());
+        assert_eq!(Bandwidth::INFINITY, model.bw_lo());
     }
 
     #[test]
@@ -246,7 +246,7 @@ mod tests {
 
         // Resetting the lower bound sets bw_lo to Bandwidth::MAX
         model.reset_lower_bound();
-        assert_eq!(Bandwidth::MAX, model.bw_lo());
+        assert_eq!(Bandwidth::INFINITY, model.bw_lo());
     }
 
     #[test]

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
@@ -905,7 +905,7 @@ mod tests {
         assert_eq!(CyclePhase::Refill, state.cycle_phase());
         // Lower bounds are reset
         assert_eq!(u64::MAX, data_volume_model.inflight_lo());
-        assert_eq!(Bandwidth::MAX, data_rate_model.bw_lo());
+        assert_eq!(Bandwidth::INFINITY, data_rate_model.bw_lo());
 
         assert_eq!(0, state.bw_probe_up_rounds);
         assert_eq!(0, state.bw_probe_up_acks);


### PR DESCRIPTION
### Description of changes: 

This change refactors the `Bandwidth` type used by BBRv2 to internally represent bandwidth as the number of nanoseconds to send 1 byte of data, rather than how many bits can be sent in a second. This allows for some of the division operations to be replaced with multiplication.

### Testing:

Unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

