### PR TITLE
fix(s2n-quic-core): various BBRv2 fixes

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -18,7 +18,7 @@ use core::{
     time::Duration,
 };
 use num_rational::Ratio;
-use num_traits::One;
+use num_traits::{Inv, One};
 
 mod congestion;
 mod data_rate;
@@ -247,6 +247,8 @@ impl CongestionController for BbrCongestionController {
         app_limited: Option<bool>,
         _rtt_estimator: &RttEstimator,
     ) -> Self::PacketInfo {
+        let prior_bytes_in_flight = *self.bytes_in_flight;
+
         if sent_bytes > 0 {
             self.recovery_state.on_packet_sent();
 
@@ -262,7 +264,7 @@ impl CongestionController for BbrCongestionController {
         }
 
         self.bw_estimator
-            .on_packet_sent(*self.bytes_in_flight, app_limited, time_sent)
+            .on_packet_sent(prior_bytes_in_flight, app_limited, time_sent)
     }
 
     fn on_rtt_update(
@@ -390,6 +392,9 @@ impl CongestionController for BbrCongestionController {
         random_generator: &mut Rnd,
         timestamp: Timestamp,
     ) {
+        debug_assert!(lost_bytes > 0);
+
+        self.bytes_in_flight -= lost_bytes;
         self.bw_estimator.on_loss(lost_bytes as usize);
         if self.recovery_state.on_congestion_event(timestamp) {
             // this congestion event caused the connection to enter recovery
@@ -577,16 +582,16 @@ impl BbrCongestionController {
             return u32::MAX;
         }
 
-        let headroom = max(
-            1,
-            (HEADROOM * self.data_volume_model.inflight_hi()).to_integer(),
-        );
-        max(
-            self.data_volume_model.inflight_hi() - headroom,
-            self.minimum_window() as u64,
-        )
-        .try_into()
-        .unwrap_or(u32::MAX) // TODO: change type
+        // The RFC pseudocode mistakenly subtracts headroom (representing 85% of inflight_hi)
+        // from inflight_hi, resulting a reduction to 15% of inflight_hi. Since the intention is
+        // to reduce inflight_hi to 85% of inflight_hi, we can just multiply by `HEADROOM`.
+        // See https://groups.google.com/g/bbr-dev/c/xmley7VkeoE/m/uXDlnxiuCgAJ
+        let inflight_with_headroom = (HEADROOM * self.data_volume_model.inflight_hi())
+            .to_integer()
+            .try_into()
+            .unwrap_or(u32::MAX);
+
+        inflight_with_headroom.max(self.minimum_window())
     }
 
     /// Calculates the quantization budget
@@ -943,7 +948,7 @@ impl BbrCongestionController {
 
         if Self::is_loss_too_high(lost_since_transmit as u64, packet_info.bytes_in_flight) {
             let inflight_hi_from_lost_packet =
-                self.inflight_hi_from_lost_packet(lost_bytes, lost_since_transmit, packet_info);
+                Self::inflight_hi_from_lost_packet(lost_bytes, lost_since_transmit, packet_info);
             self.on_inflight_too_high(
                 packet_info.is_app_limited,
                 packet_info.bytes_in_flight,
@@ -956,7 +961,6 @@ impl BbrCongestionController {
 
     /// Returns the prefix of packet where losses exceeded `LOSS_THRESH`
     fn inflight_hi_from_lost_packet(
-        &self,
         size: u32,
         lost_since_transmit: u32,
         packet_info: <BbrCongestionController as CongestionController>::PacketInfo,
@@ -982,8 +986,12 @@ impl BbrCongestionController {
         let inflight_prev = packet_info.bytes_in_flight - size;
         // What was lost before this packet?
         let lost_prev = lost_since_transmit - size;
-        let lost_prefix =
-            ((LOSS_THRESH * inflight_prev - lost_prev) / (Ratio::one() - LOSS_THRESH)).to_integer();
+        // BBRLossThresh * inflight_prev - lost_prev
+        let loss_budget = (LOSS_THRESH * inflight_prev)
+            .to_integer()
+            .saturating_sub(lost_prev);
+        // Multiply by the inverse of 1 - LOSS_THRESH instead of dividing
+        let lost_prefix = ((Ratio::one() - LOSS_THRESH).inv() * loss_budget).to_integer();
         // At what inflight value did losses cross BBRLossThresh?
         inflight_prev + lost_prefix
     }
@@ -1067,3 +1075,6 @@ impl congestion_controller::Endpoint for Endpoint {
         BbrCongestionController::new(path_info.max_datagram_size)
     }
 }
+
+#[cfg(test)]
+mod tests;

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_rtt.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_rtt.rs
@@ -206,8 +206,6 @@ impl BbrCongestionController {
         //#    probe_rtt_cwnd = max(probe_rtt_cwnd, BBRMinPipeCwnd)
         //#    return probe_rtt_cwnd#
 
-        debug_assert!(self.state.is_probing_rtt());
-
         self.bdp_multiple(self.data_rate_model.bw(), probe_rtt::CWND_GAIN)
             .try_into()
             .unwrap_or(u32::MAX)

--- a/quic/s2n-quic-core/src/recovery/bbr/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/tests.rs
@@ -1,0 +1,59 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    path::MINIMUM_MTU,
+    recovery::{bandwidth::PacketInfo, bbr::BbrCongestionController},
+    time::{Clock, NoopClock},
+};
+
+//= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.2
+//= type=test
+//# BBRInflightHiFromLostPacket(rs, packet):
+//#   size = packet.size
+//#   /* What was in flight before this packet? */
+//#   inflight_prev = rs.tx_in_flight - size
+//#   /* What was lost before this packet? */
+//#   lost_prev = rs.lost - size
+//#   lost_prefix = (BBRLossThresh * inflight_prev - lost_prev) /
+//#                 (1 - BBRLossThresh)
+//#   /* At what inflight value did losses cross BBRLossThresh? */
+//#   inflight = inflight_prev + lost_prefix
+//#   return inflight
+#[test]
+fn inflight_hi_from_lost_packet() {
+    let now = NoopClock.get_time();
+    let packet_info = PacketInfo {
+        delivered_bytes: 0,
+        delivered_time: now,
+        lost_bytes: 0,
+        ecn_ce_count: 0,
+        first_sent_time: now,
+        bytes_in_flight: 3000,
+        is_app_limited: false,
+    };
+
+    let inflight_prev = packet_info.bytes_in_flight - MINIMUM_MTU as u32;
+    assert_eq!(inflight_prev, 1800);
+
+    // lost prefix = (BBRLossThresh * inflight_prev - lost_prev) / (1 - BBRLossThresh)
+    // lost prefix = (1/50 * 1800 - (1210 - 1200)) / (1 - 1/50) = ~26
+    assert_eq!(
+        inflight_prev + 26,
+        BbrCongestionController::inflight_hi_from_lost_packet(
+            MINIMUM_MTU as u32,
+            1210,
+            packet_info
+        )
+    );
+
+    // lost prefix is zero since LOSS_THRESH * 1800 < 3000 - 1200
+    assert_eq!(
+        inflight_prev,
+        BbrCongestionController::inflight_hi_from_lost_packet(
+            MINIMUM_MTU as u32,
+            3000,
+            packet_info
+        )
+    );
+}


### PR DESCRIPTION
### Description of changes: 

This change resolves a few panics and other issues found while performing some basic testing of BBRv2.

Fixes:
* `bandwidth::Estimator::on_packet_sent` was expecting the `bytes_in_flight` from before the current packet was transmitted, in order to initialize `first_sent_time` and `delivered_time`. Previously, the `bytes_in_flight` value from after the packet was sent was used, resulting in those fields not being initialized and a panic occuring
* `bytes_in_flight` was not being decremented when a packet was lost
* The calculation of `inflight_with_headroom` accurately follows the draft RFC, but the draft RFC mistakenly reduces inflight_hi to 15%, instead of the intended 85%, see https://groups.google.com/g/bbr-dev/c/xmley7VkeoE/m/uXDlnxiuCgAJ
* `inflight_hi_from_lost_packet` subtracts `lost_prev` from `LOSS_THRESH * inflight_prev`, which may underflow. I've replaced this with a `saturating_sub`, which necessitated refactoring some of this method.
* the assertion `debug_assert!(self.state.is_probing_rtt());` in `probe_rtt_cwnd` was failing since this method is called prior to checking `state.is_probing_rtt()` to avoid borrow issues. I've removed the assertion
* AckPhase was previously prohibited from transitioning from `ProbeFeedback` to `ProbeStopping`. This is a valid transition, so I've added it to the `transition_to` assertion.
* `update_ack_phase` was transitioning from `ProbeStopping` to `Init`, which is not valid. I've removed that transition, and prohibitied it in `AckPhase::transition_to`
* The `RateSample` in `bandwidth::Estimator` had invalid `lost_bytes` and `ecn_ce_count`, as those fields were previously only updated when loss or ECN CE was encountered. If the previous sampling interval had loss/ECN CE and the current sampling interval did not, those values would still reflect the prior sampling interval's loss/ECN CE. I've made a change to update those fields on every ack.

### Testing:

Added/modified some unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

