### PR TITLE
feat(s2n-quic-core): congestion controller fuzz tests

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -983,7 +983,7 @@ impl BbrCongestionController {
         // the required information directly.
 
         // What was in flight before this packet?
-        let inflight_prev = packet_info.bytes_in_flight - size;
+        let inflight_prev = packet_info.bytes_in_flight.saturating_sub(size);
         // What was lost before this packet?
         let lost_prev = lost_since_transmit - size;
         // BBRLossThresh * inflight_prev - lost_prev

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -983,6 +983,8 @@ impl BbrCongestionController {
         // the required information directly.
 
         // What was in flight before this packet?
+        // Note: The TCP BBRv2 impl treats a negative inflight_prev as an error case
+        // see https://github.com/aws/s2n-quic/issues/1456
         let inflight_prev = packet_info.bytes_in_flight.saturating_sub(size);
         // What was lost before this packet?
         let lost_prev = lost_since_transmit - size;

--- a/quic/s2n-quic-core/src/recovery/bbr/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/tests.rs
@@ -56,4 +56,28 @@ fn inflight_hi_from_lost_packet() {
             packet_info
         )
     );
+
+    // Test losing the first sent packet when nothing is inflight yet
+    let packet_info = PacketInfo {
+        delivered_bytes: 0,
+        delivered_time: now,
+        lost_bytes: 0,
+        ecn_ce_count: 0,
+        first_sent_time: now,
+        bytes_in_flight: 0,
+        is_app_limited: false,
+    };
+
+    // inflight_prev = 0 since bytes_in_flight when the lost packet was sent was 0
+    let inflight_prev = 0;
+
+    // lost prefix is zero since inflight_prev = 0
+    assert_eq!(
+        inflight_prev,
+        BbrCongestionController::inflight_hi_from_lost_packet(
+            MINIMUM_MTU as u32,
+            MINIMUM_MTU as u32,
+            packet_info
+        )
+    );
 }

--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -400,3 +400,6 @@ pub mod testing {
         }
     }
 }
+
+#[cfg(test)]
+mod fuzz_target;

--- a/quic/s2n-quic-core/src/recovery/congestion_controller/corpus.tar.gz
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller/corpus.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d5feaaccf2c956cc74f455d687e76ef27b017fda34698aad8ccb698cbd6ca6c
+size 156860

--- a/quic/s2n-quic-core/src/recovery/congestion_controller/fuzz_target.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller/fuzz_target.rs
@@ -1,0 +1,223 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    packet::number::PacketNumberSpace,
+    path::MINIMUM_MTU,
+    random,
+    recovery::{
+        bbr::BbrCongestionController, CongestionController, CubicCongestionController, RttEstimator,
+    },
+    time::{testing::Clock, Clock as _, Timestamp},
+};
+use bolero::{check, generator::*};
+use core::time::Duration;
+use std::collections::VecDeque;
+
+struct SentPacketInfo<PacketInfo> {
+    sent_bytes: u16,
+    time_sent: Timestamp,
+    cc_packet_info: PacketInfo,
+}
+
+#[derive(Debug, TypeGenerator)]
+enum Operation {
+    IncrementTime {
+        /// The milli-second value by which to increase the timestamp
+        millis: u16,
+    },
+    PacketSent {
+        #[generator(1..=255)]
+        count: u8,
+        #[generator(1200..=9000)]
+        bytes_sent: u16,
+        app_limited: Option<bool>,
+    },
+    RttUpdated {
+        #[generator(1..=2000)]
+        millis: u64,
+    },
+    AckReceived {
+        #[generator(1..=255)]
+        count: u8,
+    },
+    PacketLost,
+    ExplicitCongestion {
+        #[generator(1..=255)]
+        ce_count: u64,
+    },
+    MtuUpdated {
+        #[generator(1200..=9000)]
+        mtu: u16,
+    },
+    PacketDiscarded,
+}
+
+struct Model<CC: CongestionController> {
+    /// The congestion controller being fuzzed
+    subject: CC,
+    /// Tracks packets inflight
+    sent_packets: VecDeque<SentPacketInfo<CC::PacketInfo>>,
+    /// The round trip time estimator
+    rtt_estimator: RttEstimator,
+    /// A monotonically increasing timestamp
+    timestamp: Timestamp,
+}
+
+impl<CC: CongestionController> Model<CC> {
+    fn new(congestion_controller: CC) -> Self {
+        Self {
+            subject: congestion_controller,
+            sent_packets: VecDeque::new(),
+            rtt_estimator: RttEstimator::default(),
+            timestamp: Clock::default().get_time(),
+        }
+    }
+
+    fn apply<Rnd: random::Generator>(&mut self, operation: &Operation, rng: &mut Rnd) {
+        match operation {
+            Operation::IncrementTime { millis } => {
+                self.timestamp += Duration::from_millis(*millis as u64);
+            }
+            Operation::PacketSent {
+                count,
+                bytes_sent,
+                app_limited,
+            } => {
+                self.on_packet_sent(*count, *bytes_sent, *app_limited);
+            }
+            Operation::RttUpdated { millis } => self.on_rtt_updated(Duration::from_millis(*millis)),
+            Operation::AckReceived { count } => {
+                self.on_ack_received(*count, rng);
+            }
+            Operation::PacketLost => {
+                self.on_packet_lost(rng);
+            }
+            Operation::ExplicitCongestion { ce_count } => self.on_explicit_congestion(*ce_count),
+            Operation::MtuUpdated { mtu } => self.on_mtu_updated(*mtu),
+            Operation::PacketDiscarded => self.on_packet_discarded(),
+        }
+    }
+
+    fn on_packet_sent(&mut self, count: u8, bytes_sent: u16, app_limited: Option<bool>) {
+        for _ in 0..count {
+            let packet_info = self.subject.on_packet_sent(
+                self.timestamp,
+                bytes_sent as usize,
+                app_limited,
+                &self.rtt_estimator,
+            );
+            self.sent_packets.push_back(SentPacketInfo {
+                sent_bytes: bytes_sent,
+                time_sent: self.timestamp,
+                cc_packet_info: packet_info,
+            });
+        }
+    }
+
+    fn on_ack_received<Rnd: random::Generator>(&mut self, count: u8, rng: &mut Rnd) {
+        for _ in 0..count {
+            if let Some(sent_packet_info) = self.sent_packets.pop_front() {
+                self.subject.on_ack(
+                    sent_packet_info.time_sent,
+                    sent_packet_info.sent_bytes as usize,
+                    sent_packet_info.cc_packet_info,
+                    &self.rtt_estimator,
+                    rng,
+                    self.timestamp,
+                );
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn on_packet_lost<Rnd: random::Generator>(&mut self, rng: &mut Rnd) {
+        if let Some(sent_packet_info) = self.sent_packets.pop_front() {
+            self.subject.on_packet_lost(
+                sent_packet_info.sent_bytes as u32,
+                sent_packet_info.cc_packet_info,
+                false,
+                false,
+                rng,
+                self.timestamp,
+            );
+        }
+    }
+
+    fn on_rtt_updated(&mut self, rtt: Duration) {
+        if let Some(sent_packet_info) = self.sent_packets.front() {
+            self.rtt_estimator.update_rtt(
+                Duration::ZERO,
+                rtt,
+                self.timestamp,
+                false,
+                PacketNumberSpace::Initial,
+            );
+            self.subject.on_rtt_update(
+                sent_packet_info.time_sent,
+                self.timestamp,
+                &self.rtt_estimator,
+            );
+        }
+    }
+
+    fn on_explicit_congestion(&mut self, ce_count: u64) {
+        let ce_count = ce_count.min(self.sent_packets.len() as u64);
+        self.subject
+            .on_explicit_congestion(ce_count, self.timestamp)
+    }
+
+    fn on_packet_discarded(&mut self) {
+        if let Some(sent_packet_info) = self.sent_packets.pop_front() {
+            self.subject
+                .on_packet_discarded(sent_packet_info.sent_bytes as usize)
+        }
+    }
+
+    fn on_mtu_updated(&mut self, mtu: u16) {
+        self.subject.on_mtu_update(mtu)
+    }
+
+    fn invariants(&self) {
+        let bytes_in_flight: u32 = self
+            .sent_packets
+            .iter()
+            .map(|sent_packet_info| sent_packet_info.sent_bytes as u32)
+            .sum();
+
+        assert_eq!(bytes_in_flight, self.subject.bytes_in_flight());
+    }
+}
+
+#[test]
+fn cubic_fuzz() {
+    check!()
+        .with_generator((MINIMUM_MTU..=9000, 0..255, gen::<Vec<Operation>>()))
+        .for_each(|(max_datagram_size, seed, operations)| {
+            let mut model = Model::new(CubicCongestionController::new(*max_datagram_size));
+            let mut rng = random::testing::Generator(*seed);
+
+            for operation in operations.iter() {
+                model.apply(operation, &mut rng);
+            }
+
+            model.invariants();
+        });
+}
+
+#[test]
+fn bbr_fuzz() {
+    check!()
+        .with_generator((MINIMUM_MTU..=9000, 0..255, gen::<Vec<Operation>>()))
+        .for_each(|(max_datagram_size, seed, operations)| {
+            let mut model = Model::new(BbrCongestionController::new(*max_datagram_size));
+            let mut rng = random::testing::Generator(*seed);
+
+            for operation in operations.iter() {
+                model.apply(operation, &mut rng);
+            }
+
+            model.invariants();
+        });
+}

--- a/quic/s2n-quic-core/src/recovery/congestion_controller/fuzz_target.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller/fuzz_target.rs
@@ -210,6 +210,7 @@ impl<CC: CongestionController> Model<CC> {
     }
 }
 
+#[cfg_attr(miri, ignore)]
 #[test]
 fn cubic_fuzz() {
     check!()
@@ -226,6 +227,7 @@ fn cubic_fuzz() {
         });
 }
 
+#[cfg_attr(miri, ignore)]
 #[test]
 fn bbr_fuzz() {
     check!()

--- a/quic/s2n-quic-core/src/recovery/hybrid_slow_start.rs
+++ b/quic/s2n-quic-core/src/recovery/hybrid_slow_start.rs
@@ -26,7 +26,7 @@ pub struct HybridSlowStart {
 
 /// Minimum slow start threshold in multiples of the max_datagram_size.
 /// Defined as "hystart_low_window" in tcp_cubic.c
-const LOW_SSTHRESH: u16 = 16;
+const LOW_SSTHRESH: f32 = 16.0;
 /// Factor for dividing the RTT to determine the threshold. Defined in tcp_cubic.c (not a constant)
 //= https://tools.ietf.org/id/draft-ietf-tcpm-hystartplusplus-04.txt#section-4.2
 //#   o  RttThresh = clamp(MIN_RTT_THRESH, lastRoundMinRTT / 8, MAX_RTT_THRESH)
@@ -190,7 +190,7 @@ impl HybridSlowStart {
     }
 
     fn low_ssthresh(&self) -> f32 {
-        (LOW_SSTHRESH * self.max_datagram_size) as f32
+        LOW_SSTHRESH * self.max_datagram_size as f32
     }
 
     #[cfg(feature = "std")]

--- a/quic/s2n-quic-core/src/recovery/mod.rs
+++ b/quic/s2n-quic-core/src/recovery/mod.rs
@@ -31,4 +31,4 @@ mod sent_packets;
 //= tracking-issue=1073
 //# A sender with knowledge that the network path to the
 //# receiver can absorb larger bursts MAY use a higher limit.
-pub const MAX_BURST_PACKETS: u16 = 10;
+pub const MAX_BURST_PACKETS: u32 = 10;

--- a/quic/s2n-quic-core/src/recovery/pacing.rs
+++ b/quic/s2n-quic-core/src/recovery/pacing.rs
@@ -79,7 +79,7 @@ impl Pacer {
             } else {
                 self.next_packet_departure_time = Some(now + INITIAL_INTERVAL);
             }
-            self.capacity = Counter::new((MAX_BURST_PACKETS * max_datagram_size) as u32);
+            self.capacity = Counter::new(MAX_BURST_PACKETS * max_datagram_size as u32);
         }
 
         self.capacity -= bytes_sent as u32;
@@ -106,7 +106,7 @@ impl Pacer {
 
         // `MAX_BURST_PACKETS` is incorporated into the formula since we are trying to spread
         // bursts of packets evenly over time.
-        let packet_size = (MAX_BURST_PACKETS * max_datagram_size) as u32;
+        let packet_size = MAX_BURST_PACKETS * max_datagram_size as u32;
 
         //= https://www.rfc-editor.org/rfc/rfc9002#section-7.7
         //# A perfectly paced sender spreads packets exactly evenly over time.

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -1209,7 +1209,7 @@ fn no_rtt_update_when_receiving_packet_on_different_path() {
     // clear the cc counts
     context.path_mut().congestion_controller.on_rtt_update = 0;
 
-    // Ack packet 0 on diffent path as it was sent.. expect no rtt update
+    // Ack packet 0 on different path as it was sent.. expect no rtt update
     let ack_receive_time = time_sent + Duration::from_millis(500);
     helper_ack_packets_on_path(
         0..=0,


### PR DESCRIPTION
### Description of changes: 

This change introduces fuzz tests for the Cubic and BBR congestion controller. The fuzz tests simulate a series of packets being sent, acked, lost, etc and verify that no panics are encountered and that the bytes in flight count is correct.

### Call-outs:

I also included a few fixes for issues I found during some initial fuzzing:
* An underflow in BBR when the first packet sent is lost
* Overflows in hybrid slow start and the default pacer when the MTU is set to a value > 6553 bytes

### Testing:

Ran fuzz tests for ~20 minutes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

