### PR TITLE
ci: fix clippy warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,13 +68,8 @@ jobs:
         include:
           - toolchain: stable
             # fail on stable warnings
-            # deriving Eq may break API compatibility so we disable it
-            # See https://github.com/rust-lang/rust-clippy/issues/9063
-            args: "-D warnings -A clippy::derive_partial_eq_without_eq"
+            args: "-D warnings"
           - toolchain: beta
-            # deriving Eq may break API compatibility so we disable it
-            # See https://github.com/rust-lang/rust-clippy/issues/9063
-            args: "-A clippy::derive_partial_eq_without_eq"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -95,7 +90,9 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: clippy
-          args: --all-features --all-targets -- ${{ matrix.args }}
+          # deriving Eq may break API compatibility so we disable it
+          # See https://github.com/rust-lang/rust-clippy/issues/9063
+          args: --all-features --all-targets -- -A clippy::derive_partial_eq_without_eq ${{ matrix.args }}
 
   udeps:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,11 +70,11 @@ jobs:
             # fail on stable warnings
             # deriving Eq may break API compatibility so we disable it
             # See https://github.com/rust-lang/rust-clippy/issues/9063
-            args: "-D warnings -A derive_partial_eq_without_eq"
+            args: "-D warnings -A clippy::derive_partial_eq_without_eq"
           - toolchain: beta
             # deriving Eq may break API compatibility so we disable it
             # See https://github.com/rust-lang/rust-clippy/issues/9063
-            args: "-A derive_partial_eq_without_eq"
+            args: "-A clippy::derive_partial_eq_without_eq"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,9 @@ jobs:
         include:
           - toolchain: stable
             # fail on stable warnings
-            args: "-D warnings"
+            # deriving Eq may break API compatibility so we disable it
+            # See https://github.com/rust-lang/rust-clippy/issues/9063
+            args: "-D warnings -A derive_partial_eq_without_eq"
           - toolchain: beta
             # deriving Eq may break API compatibility so we disable it
             # See https://github.com/rust-lang/rust-clippy/issues/9063

--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -53,7 +53,7 @@ jobs:
           - toolchain: beta
             # deriving Eq may break API compatibility so we disable it
             # See https://github.com/rust-lang/rust-clippy/issues/9063
-            args: "-A derive_partial_eq_without_eq"
+            args: "-A clippy::derive_partial_eq_without_eq"
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -51,9 +51,6 @@ jobs:
             # fail on stable warnings
             args: "-D warnings"
           - toolchain: beta
-            # deriving Eq may break API compatibility so we disable it
-            # See https://github.com/rust-lang/rust-clippy/issues/9063
-            args: "-A clippy::derive_partial_eq_without_eq"
     steps:
       - uses: actions/checkout@v3
 
@@ -72,7 +69,9 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: clippy
-          args: --manifest-path netbench/Cargo.toml --all-features --all-targets -- ${{ matrix.args }}
+          # deriving Eq may break API compatibility so we disable it
+          # See https://github.com/rust-lang/rust-clippy/issues/9063
+          args: --manifest-path netbench/Cargo.toml --all-features --all-targets -- -A clippy::derive_partial_eq_without_eq ${{ matrix.args }}
 
   test:
     runs-on: ubuntu-latest

--- a/common/docdiff/Cargo.toml
+++ b/common/docdiff/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 anyhow = "1"
 duct = "0.13"
 glob = "0.3"
-insta = "1"
+insta = { version = "1", features = ["json"] }
 once_cell = "1"
 rayon = "1"
 scraper = "0.12"

--- a/common/duvet/Cargo.toml
+++ b/common/duvet/Cargo.toml
@@ -24,7 +24,7 @@ url = "2"
 v_jsonescape = "0.6"
 
 [dev-dependencies]
-insta = "1"
+insta = { version = "1", features = ["json"] }
 
 [workspace]
 members = ["."]

--- a/netbench/netbench/Cargo.toml
+++ b/netbench/netbench/Cargo.toml
@@ -31,5 +31,5 @@ tokio = { version = "1", features = ["net", "time"] }
 
 [dev-dependencies]
 futures-test = "0.3"
-insta = "1"
+insta = { version = "1", features = ["json"] }
 tokio = { version = "1", features = ["io-util", "net", "test-util", "time"] }

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -25,7 +25,7 @@ byteorder = { version = "1", default-features = false }
 bytes = { version = "1", default-features = false }
 hex-literal = "0.3"
 # used for event snapshot testing - needs an internal API so we require a minimum version
-insta = { version = ">=1.12", optional = true }
+insta = { version = ">=1.12", features = ["json"], optional = true }
 num-rational = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }
@@ -39,7 +39,7 @@ once_cell = { version = "1", optional = true }
 [dev-dependencies]
 bolero = "0.7"
 bolero-generator = { version = "0.7", default-features = false }
-insta = "1"
+insta = { version = "1", features = ["json"] }
 futures-test = "0.3"
 ip_network = "0.4"
 plotters = { version = "0.3", default-features = false, features = ["svg_backend", "line_series"] }

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -29,7 +29,7 @@ bolero = "0.7"
 ctr = "0.9"
 ghash = "0.4"
 hex-literal = "0.3"
-insta = "1"
+insta = { version = "1", features = ["json"] }
 pretty-hex = "0.3"
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -40,6 +40,6 @@ bach = { version = "0.0.6" }
 bolero = "0.7"
 bolero-generator = { version = "0.7", default-features = false }
 futures = { version = "0.3", features = ["std"] }
-insta = "1"
+insta = { version = "1", features = ["json"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -19,5 +19,5 @@ s2n-quic-core = { version = "=0.10.0", path = "../s2n-quic-core", default-featur
 s2n-quic-crypto = { version = "=0.10.0", path = "../s2n-quic-crypto", default-features = false }
 
 [dev-dependencies]
-insta = "1"
+insta = { version = "1", features = ["json"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -29,7 +29,7 @@ smallvec = { version = "1", default-features = false }
 [dev-dependencies]
 bolero = "0.7"
 futures-test = "0.3" # For testing Waker interactions
-insta = "1"
+insta = { version = "1", features = ["json"] }
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }


### PR DESCRIPTION
### Description of changes: 

The clippy lint `derive_partial_eq_without_eq`, which we previously ignore for the Beta CI in #1390, is now in the stable version of Rust, as of [Rust 1.63.0](https://github.com/rust-lang/rust-clippy/blob/master/CHANGELOG.md#rust-163). This change updates the CI to ignore this lint for both stable and beta. 

In addition, Insta requires the `json` feature in order to avoid warnings when using the `assert_json_snapshot!` macro, so I've added that feature as well.

### Call-outs:

Once Rust 1.63.0 is our MSRV, then we should be able to add ignoring `derive_partial_eq_without_eq` to `clippy.toml`

### Testing:

The CI for this PR tests this

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

