### PR TITLE
refactor(s2n-quic-core): add inline to BBR methods

### DIFF
--- a/quic/s2n-quic-core/src/datagram/traits.rs
+++ b/quic/s2n-quic-core/src/datagram/traits.rs
@@ -54,6 +54,12 @@ impl PreConnectionInfo {
     }
 }
 
+impl Default for PreConnectionInfo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Allows users to configure the behavior of receiving datagrams.
 pub trait Receiver: 'static + Send {
     /// A callback that gives users direct access to datagrams as they are read off a packet

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
@@ -280,11 +280,11 @@ impl Estimator {
         self.delivered_bytes += bytes_acknowledged as u64;
         self.delivered_time = Some(now);
 
+        let is_app_limited_period_over =
+            |app_limited_bytes| self.delivered_bytes > app_limited_bytes;
         if self
             .app_limited_delivered_bytes
-            .map_or(false, |app_limited_bytes| {
-                self.delivered_bytes > app_limited_bytes
-            })
+            .map_or(false, is_app_limited_period_over)
         {
             // Clear app-limited field if bubble is ACKed and gone
             self.app_limited_delivered_bytes = None;

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -217,14 +217,17 @@ type BytesInFlight = Counter<u32>;
 impl CongestionController for BbrCongestionController {
     type PacketInfo = bandwidth::PacketInfo;
 
+    #[inline]
     fn congestion_window(&self) -> u32 {
         self.cwnd
     }
 
+    #[inline]
     fn bytes_in_flight(&self) -> u32 {
         *self.bytes_in_flight
     }
 
+    #[inline]
     fn is_congestion_limited(&self) -> bool {
         let available_congestion_window = self
             .congestion_window()
@@ -232,14 +235,17 @@ impl CongestionController for BbrCongestionController {
         available_congestion_window < self.max_datagram_size as u32
     }
 
+    #[inline]
     fn is_slow_start(&self) -> bool {
         self.state.is_startup()
     }
 
+    #[inline]
     fn requires_fast_retransmission(&self) -> bool {
         self.recovery_state.requires_fast_retransmission()
     }
 
+    #[inline]
     fn on_packet_sent(
         &mut self,
         time_sent: Timestamp,
@@ -267,6 +273,7 @@ impl CongestionController for BbrCongestionController {
             .on_packet_sent(prior_bytes_in_flight, app_limited, time_sent)
     }
 
+    #[inline]
     fn on_rtt_update(
         &mut self,
         _time_sent: Timestamp,
@@ -276,6 +283,7 @@ impl CongestionController for BbrCongestionController {
         // BBRUpdateMinRTT() called in `on_ack`
     }
 
+    #[inline]
     fn on_ack<Rnd: random::Generator>(
         &mut self,
         newest_acked_time_sent: Timestamp,
@@ -383,6 +391,7 @@ impl CongestionController for BbrCongestionController {
         }
     }
 
+    #[inline]
     fn on_packet_lost<Rnd: random::Generator>(
         &mut self,
         lost_bytes: u32,
@@ -411,6 +420,7 @@ impl CongestionController for BbrCongestionController {
         self.handle_lost_packet(lost_bytes, packet_info, random_generator, timestamp);
     }
 
+    #[inline]
     fn on_explicit_congestion(&mut self, ce_count: u64, event_time: Timestamp) {
         self.bw_estimator.on_explicit_congestion(ce_count);
         self.ecn_state.on_explicit_congestion(ce_count);
@@ -420,10 +430,12 @@ impl CongestionController for BbrCongestionController {
         }
     }
 
+    #[inline]
     fn on_mtu_update(&mut self, max_datagram_size: u16) {
         self.max_datagram_size = max_datagram_size;
     }
 
+    #[inline]
     fn on_packet_discarded(&mut self, bytes_sent: usize) {
         self.bytes_in_flight
             .try_sub(bytes_sent)
@@ -431,10 +443,12 @@ impl CongestionController for BbrCongestionController {
         self.recovery_state.on_packet_discarded();
     }
 
+    #[inline]
     fn earliest_departure_time(&self) -> Option<Timestamp> {
         self.next_departure_time
     }
 
+    #[inline]
     fn send_quantum(&self) -> Option<usize> {
         Some(self.send_quantum)
     }
@@ -500,11 +514,13 @@ impl BbrCongestionController {
     /// The bandwidth-delay product
     ///
     /// Based on the current estimate of maximum sending bandwidth and minimum RTT
+    #[inline]
     fn bdp(&self) -> u64 {
         self.bdp_multiple(self.data_rate_model.bw(), Ratio::one())
     }
 
     /// Calculates a bandwidth-delay product using the supplied `Bandwidth` and `gain`
+    #[inline]
     fn bdp_multiple(&self, bw: Bandwidth, gain: Ratio<u64>) -> u64 {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.2
         //# BBRBDPMultiple(gain):
@@ -523,6 +539,7 @@ impl BbrCongestionController {
     /// How much data do we want in flight
     ///
     /// Based on the estimated BDP, unless congestion reduced the cwnd
+    #[inline]
     fn target_inflight(&self) -> u32 {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.5.3
         //# BBRTargetInflight()
@@ -536,6 +553,7 @@ impl BbrCongestionController {
     ///
     /// Based on the BDP estimate (BBR.bdp), the aggregation estimate (BBR.extra_acked), the
     /// offload budget (BBR.offload_budget), and BBRMinPipeCwnd.
+    #[inline]
     fn max_inflight(&self) -> u64 {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.2
         //# BBRUpdateMaxInflight()
@@ -553,6 +571,7 @@ impl BbrCongestionController {
     }
 
     /// Inflight based on min RTT and the estimated bottleneck bandwidth
+    #[inline]
     fn inflight(&self, bw: Bandwidth, gain: Ratio<u64>) -> u32 {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.2
         //# BBRInflight(gain)
@@ -569,6 +588,7 @@ impl BbrCongestionController {
 
     /// The volume of data that tries to leave free headroom in the bottleneck buffer or link for
     /// other flows, for fairness convergence and lower RTTs and loss
+    #[inline]
     fn inflight_with_headroom(&self) -> u32 {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.6
         //# BBRInflightWithHeadroom()
@@ -595,6 +615,7 @@ impl BbrCongestionController {
     }
 
     /// Calculates the quantization budget
+    #[inline]
     fn quantization_budget(&self, inflight: u64) -> u64 {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.2
         //# BBRQuantizationBudget(inflight)
@@ -731,6 +752,7 @@ impl BbrCongestionController {
     }
 
     /// Updates the congestion window based on the latest model
+    #[inline]
     fn set_cwnd(&mut self, newly_acked: usize) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.6
         //# BBRSetCwnd():
@@ -792,6 +814,7 @@ impl BbrCongestionController {
     }
 
     /// Returns the maximum congestion window bound by recent congestion
+    #[inline]
     fn bound_cwnd_for_model(&self) -> u32 {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.7
         //# BBRBoundCwndForModel():
@@ -830,6 +853,7 @@ impl BbrCongestionController {
     }
 
     /// Saves the last-known good congestion window (the latest cwnd unmodulated by loss recovery or ProbeRTT)
+    #[inline]
     fn save_cwnd(&mut self) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.4
         //# BBRSaveCwnd()
@@ -846,6 +870,7 @@ impl BbrCongestionController {
     }
 
     /// Restores the last-known good congestion window (the latest cwnd unmodulated by loss recovery or ProbeRTT)
+    #[inline]
     fn restore_cwnd(&mut self) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.4
         //# BBRRestoreCwnd()
@@ -920,6 +945,7 @@ impl BbrCongestionController {
         self.try_fast_path = false;
     }
 
+    #[inline]
     fn handle_lost_packet<Rnd: random::Generator>(
         &mut self,
         lost_bytes: u32,
@@ -960,6 +986,7 @@ impl BbrCongestionController {
     }
 
     /// Returns the prefix of packet where losses exceeded `LOSS_THRESH`
+    #[inline]
     fn inflight_hi_from_lost_packet(
         size: u32,
         lost_since_transmit: u32,

--- a/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
@@ -165,6 +165,7 @@ impl State {
 impl BbrCongestionController {
     /// Updates delivery and congestion signals according to
     /// BBRUpdateLatestDeliverySignals() and BBRUpdateCongestionSignals()
+    #[inline]
     pub(super) fn update_latest_signals(&mut self, packet_info: PacketInfo) {
         self.congestion_state.update(
             packet_info,

--- a/quic/s2n-quic-core/src/recovery/bbr/drain.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/drain.rs
@@ -26,6 +26,7 @@ pub(crate) const CWND_GAIN: Ratio<u64> = startup::CWND_GAIN;
 /// Methods related to the Drain state
 impl BbrCongestionController {
     /// Enter the `Drain` state
+    #[inline]
     pub(super) fn enter_drain(&mut self) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.2
         //# BBREnterDrain():
@@ -40,6 +41,7 @@ impl BbrCongestionController {
     }
 
     /// Checks if the `Drain` state is done and enters `ProbeBw` if so
+    #[inline]
     pub(super) fn check_drain_done<Rnd: random::Generator>(
         &mut self,
         random_generator: &mut Rnd,

--- a/quic/s2n-quic-core/src/recovery/bbr/ecn.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/ecn.rs
@@ -102,19 +102,19 @@ fn calculate_alpha(alpha: f64, ce_ratio: f64) -> f64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{path::MINIMUM_MTU, recovery::bbr::ecn};
+    use crate::{assert_delta, path::MINIMUM_MTU, recovery::bbr::ecn};
 
     #[test]
     fn on_round_start() {
         let mut state = ecn::State::default();
-        assert_eq!(1.0, state.alpha());
+        assert_delta!(1.0, state.alpha(), 0.0001);
 
         let delivered_bytes = 1000;
         state.on_round_start(delivered_bytes, MINIMUM_MTU);
 
         // No ECN CE yet and alpha is currently at the initial value of 1,
         // so alpha is just 1 - alpha gain
-        assert_eq!(1.0 - ECN_ALPHA_GAIN, state.alpha());
+        assert_delta!(1.0 - ECN_ALPHA_GAIN, state.alpha(), 0.0001);
         assert!(!state.is_ce_too_high_in_round());
         assert_eq!(delivered_bytes, state.round_start_delivered_bytes);
 
@@ -128,9 +128,10 @@ mod tests {
 
         state.on_round_start(delivered_bytes, MINIMUM_MTU);
 
-        assert_eq!(
+        assert_delta!(
             (1.0 - ECN_ALPHA_GAIN) * alpha + ECN_ALPHA_GAIN * 0.5,
-            state.alpha()
+            state.alpha(),
+            0.0001
         );
         // ECN ce count is not above the 50% `ECN_THRESH`
         assert!(!state.is_ce_too_high_in_round());
@@ -148,9 +149,10 @@ mod tests {
         // 20 packets delivered, 11 of which were ECN CE marked
         state.on_round_start(delivered_bytes, MINIMUM_MTU);
 
-        assert_eq!(
+        assert_delta!(
             (1.0 - ECN_ALPHA_GAIN) * alpha + ECN_ALPHA_GAIN * 11.0 / 20.0,
-            state.alpha()
+            state.alpha(),
+            0.0001
         );
         // ECN ce count is above the 50% `ECN_THRESH`
         assert!(state.is_ce_too_high_in_round());

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
@@ -403,6 +403,7 @@ impl BbrCongestionController {
     ///
     /// If `cruise_immediately` is true, `CyclePhase::Cruise` will be entered immediately
     /// after entering `CyclePhase::Down`
+    #[inline]
     pub(super) fn enter_probe_bw<Rnd: random::Generator>(
         &mut self,
         cruise_immediately: bool,
@@ -432,6 +433,7 @@ impl BbrCongestionController {
     }
 
     /// Transition the current Probe BW cycle phase if necessary
+    #[inline]
     pub(super) fn update_probe_bw_cycle_phase<Rnd: random::Generator>(
         &mut self,
         random_generator: &mut Rnd,
@@ -547,6 +549,7 @@ impl BbrCongestionController {
     }
 
     /// Adapt the upper bounds lower or higher depending on the loss rate
+    #[inline]
     pub(super) fn adapt_upper_bounds<Rnd: random::Generator>(
         &mut self,
         bytes_acknowledged: usize,
@@ -632,6 +635,7 @@ impl BbrCongestionController {
     }
 
     /// Update AckPhase and advance the Max BW filter if necessary
+    #[inline]
     fn update_ack_phase(&mut self, rate_sample: RateSample) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.6
         //#   if (BBR.ack_phase == ACKS_PROBE_STARTING and BBR.round_start)
@@ -667,6 +671,7 @@ impl BbrCongestionController {
     }
 
     /// Called when loss indicates the current inflight amount is too high
+    #[inline]
     pub(super) fn on_inflight_too_high<Rnd: random::Generator>(
         &mut self,
         is_app_limited: bool,
@@ -705,6 +710,7 @@ impl BbrCongestionController {
     }
 
     /// Returns true if it is time to transition from `Down` to `Cruise`
+    #[inline]
     fn is_time_to_cruise(&self) -> bool {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.6
         //# BBRCheckTimeToCruise())

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_rtt.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_rtt.rs
@@ -84,6 +84,7 @@ impl State {
 /// Methods related to the `ProbeRtt` state
 impl BbrCongestionController {
     /// Check if it is time to start probing for RTT changes, and enter the ProbeRtt state if so
+    #[inline]
     pub(super) fn check_probe_rtt<Rnd: random::Generator>(
         &mut self,
         random_generator: &mut Rnd,
@@ -147,6 +148,7 @@ impl BbrCongestionController {
     }
 
     /// Exits the `ProbeRtt` state
+    #[inline]
     pub(super) fn exit_probe_rtt<Rnd: random::Generator>(
         &mut self,
         random_generator: &mut Rnd,
@@ -199,6 +201,7 @@ impl BbrCongestionController {
     }
 
     /// Returns the congestion window that should be used during the `ProbeRTT` state
+    #[inline]
     pub(super) fn probe_rtt_cwnd(&self) -> u32 {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.5
         //# BBRProbeRTTCwnd():

--- a/quic/s2n-quic-core/src/recovery/bbr/startup.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/startup.rs
@@ -17,6 +17,7 @@ pub(crate) const CWND_GAIN: Ratio<u64> = Ratio::new_raw(2, 1);
 /// Methods related to the Startup state
 impl BbrCongestionController {
     /// Enter the `Startup` state
+    #[inline]
     pub(super) fn enter_startup(&mut self) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.1.1
         //# BBREnterStartup():
@@ -32,6 +33,7 @@ impl BbrCongestionController {
     }
 
     /// Checks if the `Startup` state is done and enters `Drain` if so
+    #[inline]
     pub(super) fn check_startup_done(&mut self) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.1.1
         //# BBRCheckStartupDone():

--- a/quic/s2n-quic-core/src/recovery/hybrid_slow_start.rs
+++ b/quic/s2n-quic-core/src/recovery/hybrid_slow_start.rs
@@ -3,6 +3,8 @@
 
 use crate::time::Timestamp;
 use core::time::Duration;
+#[cfg(not(feature = "std"))]
+use num_traits::Float as _;
 
 /// An implementation of the Hybrid Slow Start algorithm described in
 /// "Hybrid Slow Start for High-Bandwidth and Long-Distance Networks"

--- a/quic/s2n-quic-core/src/recovery/hybrid_slow_start.rs
+++ b/quic/s2n-quic-core/src/recovery/hybrid_slow_start.rs
@@ -174,7 +174,7 @@ impl HybridSlowStart {
     /// should be called from on_packet_ack
     pub fn cwnd_increment(&self, sent_bytes: usize) -> f32 {
         if cfg!(debug_assertions) && !self.use_hystart_plus_plus {
-            assert_eq!(self.ss_growth_divisor, 1.0);
+            assert!((self.ss_growth_divisor - 1.0).abs() < f32::EPSILON);
         }
         (sent_bytes as f32) / self.ss_growth_divisor
     }

--- a/quic/s2n-quic-crypto/src/aes/testing.rs
+++ b/quic/s2n-quic-crypto/src/aes/testing.rs
@@ -27,7 +27,10 @@ macro_rules! aes_impl {
 
             lazy_static! {
                 static ref IMPLEMENTATIONS: Vec<Implementation> = {
+                    #[cfg(any(target_arch = "x86", target_arch = "x86_64", test))]
                     let mut impls = vec![];
+                    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", test)))]
+                    let impls = vec![];
 
                     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
                     crate::aes::x86::testing::$name::implementations(&mut impls);

--- a/quic/s2n-quic-crypto/src/aes/testing.rs
+++ b/quic/s2n-quic-crypto/src/aes/testing.rs
@@ -27,16 +27,13 @@ macro_rules! aes_impl {
 
             lazy_static! {
                 static ref IMPLEMENTATIONS: Vec<Implementation> = {
-                    #[cfg(any(target_arch = "x86", target_arch = "x86_64", test))]
-                    let mut impls = vec![];
-                    #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", test)))]
                     let impls = vec![];
 
                     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-                    crate::aes::x86::testing::$name::implementations(&mut impls);
+                    let impls = crate::aes::x86::testing::$name::implementations(impls);
 
                     #[cfg(test)]
-                    super::rust_crypto::$name::implementations(&mut impls);
+                    let impls = super::rust_crypto::$name::implementations(impls);
 
                     impls
                 };

--- a/quic/s2n-quic-crypto/src/aes/testing/rust_crypto.rs
+++ b/quic/s2n-quic-crypto/src/aes/testing/rust_crypto.rs
@@ -31,7 +31,7 @@ macro_rules! impl_aes {
             use super::*;
             use crate::aes::testing::$lower::Implementation;
 
-            pub fn implementations(impls: &mut Vec<Implementation>) {
+            pub fn implementations(mut impls: Vec<Implementation>) -> Vec<Implementation> {
                 impls.push(Implementation {
                     name: "RustCrypto",
                     new: |key| {
@@ -39,6 +39,7 @@ macro_rules! impl_aes {
                         Box::new(aes)
                     },
                 });
+                impls
             }
         }
     };

--- a/quic/s2n-quic-crypto/src/aes/x86/testing.rs
+++ b/quic/s2n-quic-crypto/src/aes/x86/testing.rs
@@ -68,13 +68,14 @@ macro_rules! impl_aes {
                 }
             }
 
-            pub fn implementations(impls: &mut Vec<Implementation>) {
+            pub fn implementations(mut impls: Vec<Implementation>) -> Vec<Implementation> {
                 Avx2::call_supported(|| {
                     impls.push(Implementation {
                         name: "s2n_quic/avx2",
                         new: |key| Box::new(<Impl<Avx2>>::new(key)),
                     });
                 });
+                impls
             }
         }
     };

--- a/quic/s2n-quic-crypto/src/aesgcm/generic.rs
+++ b/quic/s2n-quic-crypto/src/aesgcm/generic.rs
@@ -29,6 +29,7 @@ where
     C: Ctr,
     G: GHash,
 {
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     #[inline(always)]
     pub fn new(aes: A, ghash: G) -> Self {
         Self {

--- a/quic/s2n-quic-crypto/src/ghash.rs
+++ b/quic/s2n-quic-crypto/src/ghash.rs
@@ -10,11 +10,13 @@ pub mod x86;
 pub mod testing;
 
 pub const TAG_LEN: usize = 16;
+#[cfg(any(target_arch = "x86", target_arch = "x86_64", test))]
 pub const KEY_LEN: usize = 16;
 
 pub trait Constructor {
     type GHash: GHash;
 
+    #[cfg(any(target_arch = "x86", target_arch = "x86_64", test))]
     fn create(&self, key: [u8; KEY_LEN]) -> Self::GHash;
 }
 

--- a/quic/s2n-quic-crypto/src/ghash/testing.rs
+++ b/quic/s2n-quic-crypto/src/ghash/testing.rs
@@ -26,7 +26,10 @@ pub trait GHash {
 
 lazy_static! {
     static ref IMPLEMENTATIONS: Vec<Implementation> = {
+        #[cfg(any(target_arch = "x86", target_arch = "x86_64", test))]
         let mut impls = vec![];
+        #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", test)))]
+        let impls = vec![];
 
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
         super::x86::testing::implementations(&mut impls);

--- a/quic/s2n-quic-crypto/src/ghash/testing.rs
+++ b/quic/s2n-quic-crypto/src/ghash/testing.rs
@@ -26,16 +26,13 @@ pub trait GHash {
 
 lazy_static! {
     static ref IMPLEMENTATIONS: Vec<Implementation> = {
-        #[cfg(any(target_arch = "x86", target_arch = "x86_64", test))]
-        let mut impls = vec![];
-        #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", test)))]
         let impls = vec![];
 
         #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-        super::x86::testing::implementations(&mut impls);
+        let impls = super::x86::testing::implementations(impls);
 
         #[cfg(test)]
-        rust_crypto::implementations(&mut impls);
+        let impls = rust_crypto::implementations(impls);
 
         impls
     };

--- a/quic/s2n-quic-crypto/src/ghash/testing/rust_crypto.rs
+++ b/quic/s2n-quic-crypto/src/ghash/testing/rust_crypto.rs
@@ -22,9 +22,10 @@ impl GHash for Impl {
     }
 }
 
-pub fn implementations(impls: &mut Vec<Implementation>) {
+pub fn implementations(mut impls: Vec<Implementation>) -> Vec<Implementation> {
     impls.push(Implementation {
         name: "RustCrypto",
         new: |key| Box::new(Impl::new(&key.into())),
     });
+    impls
 }

--- a/quic/s2n-quic-crypto/src/ghash/x86/testing.rs
+++ b/quic/s2n-quic-crypto/src/ghash/x86/testing.rs
@@ -53,7 +53,7 @@ where
     }
 }
 
-pub fn implementations(impls: &mut Vec<Implementation>) {
+pub fn implementations(mut impls: Vec<Implementation>) -> Vec<Implementation> {
     Avx2::call_supported(|| {
         impls.push(Implementation {
             name: "s2n_quic/std/avx2",
@@ -77,4 +77,5 @@ pub fn implementations(impls: &mut Vec<Implementation>) {
             },
         });
     });
+    impls
 }

--- a/quic/s2n-quic-sim/src/stats.rs
+++ b/quic/s2n-quic-sim/src/stats.rs
@@ -750,9 +750,9 @@ impl FromStr for Filter {
 
     fn from_str(filter: &str) -> Result<Self, Self::Err> {
         let (query, op, value): (_, Op, _) = if let Some((q, v)) = filter.split_once("!=") {
-            (q, |a, b| a != b, v)
+            (q, |a, b| (a - b).abs() > f64::EPSILON, v)
         } else if let Some((q, v)) = filter.split_once("==") {
-            (q, |a, b| a == b, v)
+            (q, |a, b| (a - b).abs() < f64::EPSILON, v)
         } else if let Some((q, v)) = filter.split_once(">=") {
             (q, |a, b| a >= b, v)
         } else if let Some((q, v)) = filter.split_once('>') {
@@ -762,7 +762,7 @@ impl FromStr for Filter {
         } else if let Some((q, v)) = filter.split_once('<') {
             (q, |a, b| a < b, v)
         } else if let Some((q, v)) = filter.split_once('=') {
-            (q, |a, b| a == b, v)
+            (q, |a, b| (a - b).abs() < f64::EPSILON, v)
         } else {
             (filter, |a, _b| a != 0.0, "0")
         };


### PR DESCRIPTION
### Description of changes: 

This change adds the `#[inline]` compiler suggestion to BBR methods to improve performance

### Call-outs:

I've also fixed some new Clippy issues I noticed failing, and resolved some compilation warnings on ARM targets

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

