### PR TITLE
fix(s2n-quic-transport): notify peer of locally-created receive streams

### DIFF
--- a/quic/s2n-quic-transport/src/stream/controller/remote_initiated.rs
+++ b/quic/s2n-quic-transport/src/stream/controller/remote_initiated.rs
@@ -111,6 +111,11 @@ impl RemoteInitiated {
     }
 
     #[inline]
+    pub fn total_open_stream_count(&self) -> VarInt {
+        self.opened_streams
+    }
+
+    #[inline]
     pub fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A) {
         self.max_streams_sync.on_packet_ack(ack_set)
     }

--- a/quic/s2n-quic-transport/src/sync/once_sync.rs
+++ b/quic/s2n-quic-transport/src/sync/once_sync.rs
@@ -59,6 +59,11 @@ impl<T: Copy + Clone + Eq + PartialEq, S: ValueToFrameWriter<T>> OnceSync<T, S> 
         }
     }
 
+    /// Forces transmission of the given value.
+    pub fn force_delivery(&mut self, value: T) {
+        self.delivery = DeliveryState::Requested(value);
+    }
+
     /// Stop to synchronize the value to the peer
     #[inline]
     pub fn stop_sync(&mut self) {

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -235,3 +235,59 @@ fn tokio_read_exact_test() {
     })
     .unwrap();
 }
+
+/// Ensures the peer is notified of locally-created streams
+///
+/// # Client expectations
+/// * The client connects to the server
+/// * The client opens a bidirectional stream
+/// * The client reads 100 bytes from the newly created stream
+///
+/// # Server expectations
+/// * The server accepts a new connection
+/// * The server accepts a new bidirectional stream
+/// * The server writes 100 bytes to the newly accepted stream
+///
+/// Unless the client notifies the server of the stream creation, the connection
+/// is dead-locked and will timeout.
+///
+/// See https://github.com/aws/s2n-quic/issues/1464
+#[test]
+fn local_stream_open_notify_test() {
+    let model = Model::default();
+    test(model, |handle| {
+        let mut server = build_server(handle)?;
+        let server_addr = server.local_addr()?;
+
+        // send 100 bytes
+        const LEN: usize = 100;
+
+        spawn(async move {
+            while let Some(mut conn) = server.accept().await {
+                while let Ok(Some(mut stream)) = conn.accept_bidirectional_stream().await {
+                    primary::spawn(async move {
+                        stream.send(vec![42; LEN].into()).await.unwrap();
+                    });
+                }
+            }
+        });
+
+        let client = build_client(handle)?;
+
+        primary::spawn(async move {
+            let connect = Connect::new(server_addr).with_server_name("localhost");
+            let mut connection = client.connect(connect).await.unwrap();
+            let mut stream = connection.open_bidirectional_stream().await.unwrap();
+
+            let mut recv_len = 0;
+            while let Ok(Some(chunk)) = stream.receive().await {
+                recv_len += chunk.len();
+            }
+
+            assert_eq!(LEN, recv_len);
+        });
+
+        Ok(())
+    })
+    .unwrap();
+}

--- a/quic/s2n-quic/src/tests/setup.rs
+++ b/quic/s2n-quic/src/tests/setup.rs
@@ -73,12 +73,16 @@ pub fn server(handle: &Handle) -> Result<SocketAddr> {
     })
 }
 
-pub fn client(handle: &Handle, server_addr: SocketAddr) -> Result {
-    let client = Client::builder()
+pub fn build_server(handle: &Handle) -> Result<Server> {
+    Ok(Server::builder()
         .with_io(handle.builder().build().unwrap())?
-        .with_tls(certificates::CERT_PEM)?
+        .with_tls(SERVER_CERTS)?
         .with_event(events())?
-        .start()?;
+        .start()?)
+}
+
+pub fn client(handle: &Handle, server_addr: SocketAddr) -> Result {
+    let client = build_client(handle)?;
 
     primary::spawn(async move {
         let connect = Connect::new(server_addr).with_server_name("localhost");


### PR DESCRIPTION
### Resolved issues:

resolves #1464 

### Description of changes: 

The current stream behavior when opening a stream locally is to wait to send a `STREAM` until we have data to send to the peer. This causes a dead-lock on a connection when the local endpoint creates a stream and immediately calls `receive` on it. The peer isn't aware of the stream and won't know to send data. The connection will eventually time out as a result.

This fix adds a `open_notify` sender which sends an empty `STREAM` frame with `len = 0, offset = 0` at the creation of a local stream that can receive (basically a locally-created, bidirectional stream). If the local application opens another bidirectional stream, the previous frame transmission will be cancelled and a new transmission will be started. This prevents an empty frame being transmitted for each new stream, since the peer will automatically create all of the streams lower than the maximum.

### Call-outs:

This does mean we send an empty `STREAM` frame when the application opens a stream; worst case being one frame for every locally-initiated, bidirectional stream. However, I believe this to be acceptable since the peer can set up the stream sooner in anticipation of receiving data on it. Also empty STREAM frames are quite small, ranging from 4 to 7 bytes, depending on the size of the stream ID.

### Testing:

I've added an integration test that establishes a connection, opens a stream, and waits to receive data on the stream. Without the fix, the test fails:

```
   0.050233213s s2n_quic:server:conn: connection_closed: error=IdleTimerExpired { source: Location { file: "s2n-quic/quic/s2n-quic-transport/src/connection/connection_impl.rs", line: 1038, col: 24 } } id=0
   0.050381142s s2n_quic:client: platform_event_loop_wakeup: timeout_expired=true rx_ready=false tx_ready=false application_wakeup=false
   0.050510013s s2n_quic:client:conn: connection_closed: error=IdleTimerExpired { source: Location { file: "s2n-quic/quic/s2n-quic-transport/src/connection/connection_impl.rs", line: 1038, col: 24 } } id=0
thread 'tests::local_stream_open_notify_test' panicked at 'assertion failed: `(left == right)`
  left: `100`,
 right: `0`', quic/s2n-quic/src/tests.rs:287:13
```

With the fix, the test succeeds:

```
...
test tests::local_stream_open_notify_test ... ok
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

