### PR TITLE
refactor(s2n-quic-core): use dyn random::Generator instead of static dispatch

### DIFF
--- a/quic/s2n-quic-core/src/packet/retry.rs
+++ b/quic/s2n-quic-core/src/packet/retry.rs
@@ -116,11 +116,11 @@ pub type EncryptedRetry<'a> = Retry<'a>;
 pub type CleartextRetry<'a> = Retry<'a>;
 
 impl<'a> Retry<'a> {
-    pub fn encode_packet<T: token::Format, C: RetryKey, R: random::Generator>(
+    pub fn encode_packet<T: token::Format, C: RetryKey>(
         remote_address: &SocketAddress,
         packet: &ProtectedInitial,
         local_connection_id: &connection::LocalId,
-        random: &mut R,
+        random: &mut dyn random::Generator,
         token_format: &mut T,
         packet_buf: &mut [u8],
     ) -> Option<Range<usize>> {

--- a/quic/s2n-quic-core/src/packet/stateless_reset.rs
+++ b/quic/s2n-quic-core/src/packet/stateless_reset.rs
@@ -35,11 +35,11 @@ pub fn min_indistinguishable_packet_len(max_tag_len: usize) -> usize {
 }
 
 /// Encodes a stateless reset packet into the given packet buffer.
-pub fn encode_packet<R: random::Generator>(
+pub fn encode_packet(
     token: stateless_reset::Token,
     max_tag_len: usize,
     triggering_packet_len: usize,
-    random_generator: &mut R,
+    random_generator: &mut dyn random::Generator,
     packet_buf: &mut [u8],
 ) -> Option<usize> {
     //= https://www.rfc-editor.org/rfc/rfc9000#section-10.3
@@ -100,8 +100,8 @@ pub fn encode_packet<R: random::Generator>(
 
 /// Fills the given buffer with a random amount of random data at least of the
 /// given `min_len`. Returns the length of the unpredictable bits that were generated.
-fn generate_unpredictable_bits<R: random::Generator>(
-    random_generator: &mut R,
+fn generate_unpredictable_bits(
+    random_generator: &mut dyn random::Generator,
     min_len: usize,
     buffer: &mut [u8],
 ) -> usize {

--- a/quic/s2n-quic-core/src/random.rs
+++ b/quic/s2n-quic-core/src/random.rs
@@ -23,7 +23,7 @@ pub trait Generator: 'static + Send {
 /// NOTE: This will have slight bias towards the lower end of the range. Usages that
 /// require uniform sampling should implement rejection sampling or other methodologies
 /// and not copy this implementation.
-pub(crate) fn gen_range_biased<R: Generator>(
+pub(crate) fn gen_range_biased<R: Generator + ?Sized>(
     random_generator: &mut R,
     range: RangeInclusive<usize>,
 ) -> usize {

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -284,13 +284,13 @@ impl CongestionController for BbrCongestionController {
     }
 
     #[inline]
-    fn on_ack<Rnd: random::Generator>(
+    fn on_ack(
         &mut self,
         newest_acked_time_sent: Timestamp,
         bytes_acknowledged: usize,
         newest_acked_packet_info: Self::PacketInfo,
         rtt_estimator: &RttEstimator,
-        random_generator: &mut Rnd,
+        random_generator: &mut dyn random::Generator,
         ack_receive_time: Timestamp,
     ) {
         self.bytes_in_flight
@@ -392,13 +392,13 @@ impl CongestionController for BbrCongestionController {
     }
 
     #[inline]
-    fn on_packet_lost<Rnd: random::Generator>(
+    fn on_packet_lost(
         &mut self,
         lost_bytes: u32,
         packet_info: Self::PacketInfo,
         _persistent_congestion: bool,
         new_loss_burst: bool,
-        random_generator: &mut Rnd,
+        random_generator: &mut dyn random::Generator,
         timestamp: Timestamp,
     ) {
         debug_assert!(lost_bytes > 0);
@@ -946,11 +946,11 @@ impl BbrCongestionController {
     }
 
     #[inline]
-    fn handle_lost_packet<Rnd: random::Generator>(
+    fn handle_lost_packet(
         &mut self,
         lost_bytes: u32,
         packet_info: <BbrCongestionController as CongestionController>::PacketInfo,
-        random_generator: &mut Rnd,
+        random_generator: &mut dyn random::Generator,
         now: Timestamp,
     ) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.2

--- a/quic/s2n-quic-core/src/recovery/bbr/drain.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/drain.rs
@@ -42,9 +42,9 @@ impl BbrCongestionController {
 
     /// Checks if the `Drain` state is done and enters `ProbeBw` if so
     #[inline]
-    pub(super) fn check_drain_done<Rnd: random::Generator>(
+    pub(super) fn check_drain_done(
         &mut self,
-        random_generator: &mut Rnd,
+        random_generator: &mut dyn random::Generator,
         now: Timestamp,
     ) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.2

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
@@ -350,12 +350,12 @@ impl State {
     }
 
     /// Start the `Down` cycle phase
-    fn start_down<Rnd: random::Generator>(
+    fn start_down(
         &mut self,
         congestion_state: &mut congestion::State,
         round_counter: &mut round::Counter,
         delivered_bytes: u64,
-        random_generator: &mut Rnd,
+        random_generator: &mut dyn random::Generator,
         now: Timestamp,
     ) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.6
@@ -381,7 +381,7 @@ impl State {
     ///
     /// Note: This uses a method for determining a number in a random range that has a very slight
     ///       bias. In practice, this bias should not result in a detectable impact to BBR performance.
-    fn pick_probe_wait<Rnd: random::Generator>(&mut self, random_generator: &mut Rnd) {
+    fn pick_probe_wait(&mut self, random_generator: &mut dyn random::Generator) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.5.3
         //# BBRPickProbeWait()
         //#    /* Decide random round-trip bound for wait: */
@@ -404,10 +404,10 @@ impl BbrCongestionController {
     /// If `cruise_immediately` is true, `CyclePhase::Cruise` will be entered immediately
     /// after entering `CyclePhase::Down`
     #[inline]
-    pub(super) fn enter_probe_bw<Rnd: random::Generator>(
+    pub(super) fn enter_probe_bw(
         &mut self,
         cruise_immediately: bool,
-        random_generator: &mut Rnd,
+        random_generator: &mut dyn random::Generator,
         now: Timestamp,
     ) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.6
@@ -434,9 +434,9 @@ impl BbrCongestionController {
 
     /// Transition the current Probe BW cycle phase if necessary
     #[inline]
-    pub(super) fn update_probe_bw_cycle_phase<Rnd: random::Generator>(
+    pub(super) fn update_probe_bw_cycle_phase(
         &mut self,
-        random_generator: &mut Rnd,
+        random_generator: &mut dyn random::Generator,
         now: Timestamp,
     ) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.6
@@ -550,10 +550,10 @@ impl BbrCongestionController {
 
     /// Adapt the upper bounds lower or higher depending on the loss rate
     #[inline]
-    pub(super) fn adapt_upper_bounds<Rnd: random::Generator>(
+    pub(super) fn adapt_upper_bounds(
         &mut self,
         bytes_acknowledged: usize,
-        random_generator: &mut Rnd,
+        random_generator: &mut dyn random::Generator,
         now: Timestamp,
     ) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.6
@@ -672,12 +672,12 @@ impl BbrCongestionController {
 
     /// Called when loss indicates the current inflight amount is too high
     #[inline]
-    pub(super) fn on_inflight_too_high<Rnd: random::Generator>(
+    pub(super) fn on_inflight_too_high(
         &mut self,
         is_app_limited: bool,
         bytes_in_flight: u32,
         target_inflight: u32,
-        random_generator: &mut Rnd,
+        random_generator: &mut dyn random::Generator,
         now: Timestamp,
     ) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.2

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_rtt.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_rtt.rs
@@ -85,9 +85,9 @@ impl State {
 impl BbrCongestionController {
     /// Check if it is time to start probing for RTT changes, and enter the ProbeRtt state if so
     #[inline]
-    pub(super) fn check_probe_rtt<Rnd: random::Generator>(
+    pub(super) fn check_probe_rtt(
         &mut self,
-        random_generator: &mut Rnd,
+        random_generator: &mut dyn random::Generator,
         now: Timestamp,
     ) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.4.4
@@ -149,9 +149,9 @@ impl BbrCongestionController {
 
     /// Exits the `ProbeRtt` state
     #[inline]
-    pub(super) fn exit_probe_rtt<Rnd: random::Generator>(
+    pub(super) fn exit_probe_rtt(
         &mut self,
-        random_generator: &mut Rnd,
+        random_generator: &mut dyn random::Generator,
         now: Timestamp,
     ) {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.4.4

--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -90,13 +90,13 @@ pub trait CongestionController: 'static + Clone + Send + Debug {
     /// it is possible this method may be called multiple times for one acknowledgement. In either
     /// case, `newest_acked_time_sent` and `newest_acked_packet_info` represent the newest acknowledged
     /// packet contributing to `bytes_acknowledged`.
-    fn on_ack<Rnd: random::Generator>(
+    fn on_ack(
         &mut self,
         newest_acked_time_sent: Timestamp,
         bytes_acknowledged: usize,
         newest_acked_packet_info: Self::PacketInfo,
         rtt_estimator: &RttEstimator,
-        random_generator: &mut Rnd,
+        random_generator: &mut dyn random::Generator,
         ack_receive_time: Timestamp,
     );
 
@@ -105,13 +105,13 @@ pub trait CongestionController: 'static + Clone + Send + Debug {
     /// `new_loss_burst` is true if the lost packet is the first in a
     /// contiguous series of lost packets. This can be used for measuring or
     /// filtering out noise from burst losses.
-    fn on_packet_lost<Rnd: random::Generator>(
+    fn on_packet_lost(
         &mut self,
         lost_bytes: u32,
         packet_info: Self::PacketInfo,
         persistent_congestion: bool,
         new_loss_burst: bool,
-        random_generator: &mut Rnd,
+        random_generator: &mut dyn random::Generator,
         timestamp: Timestamp,
     );
 
@@ -212,24 +212,24 @@ pub mod testing {
             ) {
             }
 
-            fn on_ack<Rnd: random::Generator>(
+            fn on_ack(
                 &mut self,
                 _newest_acked_time_sent: Timestamp,
                 _sent_bytes: usize,
                 _newest_acked_packet_info: Self::PacketInfo,
                 _rtt_estimator: &RttEstimator,
-                _random_generator: &mut Rnd,
+                _random_generator: &mut dyn random::Generator,
                 _ack_receive_time: Timestamp,
             ) {
             }
 
-            fn on_packet_lost<Rnd: random::Generator>(
+            fn on_packet_lost(
                 &mut self,
                 _lost_bytes: u32,
                 _packet_info: Self::PacketInfo,
                 _persistent_congestion: bool,
                 _new_loss_burst: bool,
-                _random_generator: &mut Rnd,
+                _random_generator: &mut dyn random::Generator,
                 _timestamp: Timestamp,
             ) {
             }
@@ -349,25 +349,25 @@ pub mod testing {
                 self.on_rtt_update += 1
             }
 
-            fn on_ack<Rnd: random::Generator>(
+            fn on_ack(
                 &mut self,
                 _newest_acked_time_sent: Timestamp,
                 _sent_bytes: usize,
                 _newest_acked_packet_info: Self::PacketInfo,
                 _rtt_estimator: &RttEstimator,
-                _random_generator: &mut Rnd,
+                _random_generator: &mut dyn random::Generator,
                 _ack_receive_time: Timestamp,
             ) {
                 self.on_packet_ack += 1;
             }
 
-            fn on_packet_lost<Rnd: random::Generator>(
+            fn on_packet_lost(
                 &mut self,
                 lost_bytes: u32,
                 _packet_info: Self::PacketInfo,
                 persistent_congestion: bool,
                 new_loss_burst: bool,
-                _random_generator: &mut Rnd,
+                _random_generator: &mut dyn random::Generator,
                 _timestamp: Timestamp,
             ) {
                 self.bytes_in_flight = self.bytes_in_flight.saturating_sub(lost_bytes);

--- a/quic/s2n-quic-core/src/recovery/congestion_controller/fuzz_target.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller/fuzz_target.rs
@@ -75,7 +75,7 @@ impl<CC: CongestionController> Model<CC> {
         }
     }
 
-    fn apply<Rnd: random::Generator>(&mut self, operation: &Operation, rng: &mut Rnd) {
+    fn apply(&mut self, operation: &Operation, rng: &mut dyn random::Generator) {
         match operation {
             Operation::IncrementTime { millis } => {
                 self.timestamp += Duration::from_millis(*millis as u64);
@@ -115,12 +115,12 @@ impl<CC: CongestionController> Model<CC> {
         }
     }
 
-    fn on_ack_received<Rnd: random::Generator>(
+    fn on_ack_received(
         &mut self,
         index: u8,
         count: u8,
         rtt: Duration,
-        rng: &mut Rnd,
+        rng: &mut dyn random::Generator,
     ) {
         let index = (index as usize).min(self.sent_packets.len().saturating_sub(1));
         let mut rtt_updated = false;
@@ -151,7 +151,7 @@ impl<CC: CongestionController> Model<CC> {
         }
     }
 
-    fn on_packet_lost<Rnd: random::Generator>(&mut self, index: u8, rng: &mut Rnd) {
+    fn on_packet_lost(&mut self, index: u8, rng: &mut dyn random::Generator) {
         let index = (index as usize).min(self.sent_packets.len().saturating_sub(1));
 
         // Report the packet at the random `index` as lost

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -278,13 +278,13 @@ impl CongestionController for CubicCongestionController {
     }
 
     #[inline]
-    fn on_ack<Rnd: random::Generator>(
+    fn on_ack(
         &mut self,
         newest_acked_time_sent: Timestamp,
         bytes_acknowledged: usize,
         _newest_acked_packet_info: Self::PacketInfo,
         rtt_estimator: &RttEstimator,
-        _random_generator: &mut Rnd,
+        _random_generator: &mut dyn random::Generator,
         ack_receive_time: Timestamp,
     ) {
         self.bytes_in_flight_hi = self.bytes_in_flight_hi.max(self.bytes_in_flight);
@@ -378,13 +378,13 @@ impl CongestionController for CubicCongestionController {
     }
 
     #[inline]
-    fn on_packet_lost<Rnd: random::Generator>(
+    fn on_packet_lost(
         &mut self,
         lost_bytes: u32,
         _packet_info: Self::PacketInfo,
         persistent_congestion: bool,
         _new_loss_burst: bool,
-        _random_generator: &mut Rnd,
+        _random_generator: &mut dyn random::Generator,
         timestamp: Timestamp,
     ) {
         debug_assert!(lost_bytes > 0);

--- a/quic/s2n-quic-crypto/src/retry.rs
+++ b/quic/s2n-quic-crypto/src/retry.rs
@@ -101,7 +101,7 @@ mod tests {
             }
         {
             let local_conn_id = connection::LocalId::try_from_bytes(&retry::example::SCID).unwrap();
-            if let Some(range) = packet::retry::Retry::encode_packet::<_, RetryKey, _>(
+            if let Some(range) = packet::retry::Retry::encode_packet::<_, RetryKey>(
                 &remote_address,
                 &packet,
                 &local_conn_id,
@@ -151,7 +151,7 @@ mod tests {
             //# Connection ID field of the packet sent by the client.
             let local_conn_id =
                 connection::LocalId::try_from_bytes(&retry::example::ODCID).unwrap();
-            assert!(packet::retry::Retry::encode_packet::<_, RetryKey, _>(
+            assert!(packet::retry::Retry::encode_packet::<_, RetryKey>(
                 &remote_address,
                 &packet,
                 &local_conn_id,

--- a/quic/s2n-quic-transport/src/connection/connection_id_mapper.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_id_mapper.rs
@@ -27,7 +27,7 @@ pub struct HashState {
 
 impl HashState {
     /// Generates hash state by using the given random generator to produce random keys.
-    fn new<R: random::Generator>(random_generator: &mut R) -> HashState {
+    fn new(random_generator: &mut dyn random::Generator) -> HashState {
         let mut k0 = [0u8; core::mem::size_of::<u64>()];
         let mut k1 = [0u8; core::mem::size_of::<u64>()];
 
@@ -197,7 +197,7 @@ pub(crate) struct ConnectionIdMapperState {
 }
 
 impl ConnectionIdMapperState {
-    fn new<R: random::Generator>(random_generator: &mut R) -> Self {
+    fn new(random_generator: &mut dyn random::Generator) -> Self {
         Self {
             local_id_map: LocalIdMap::new(HashState::new(random_generator)),
             stateless_reset_map: StatelessResetMap::new(HashState::new(random_generator)),
@@ -219,8 +219,8 @@ pub struct ConnectionIdMapper {
 
 impl ConnectionIdMapper {
     /// Creates a new `ConnectionIdMapper`
-    pub fn new<R: random::Generator>(
-        random_generator: &mut R,
+    pub fn new(
+        random_generator: &mut dyn random::Generator,
         endpoint_type: endpoint::Type,
     ) -> Self {
         Self {

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -370,7 +370,6 @@ impl<Cfg: Config> Endpoint<Cfg> {
                 self.retry_dispatch.queue::<
                     _,
                     <<<Cfg as Config>::TLSEndpoint as tls::Endpoint>::Session as CryptoSuite>::RetryKey,
-                    _,
                 >(
                     header.path,
                     packet,

--- a/quic/s2n-quic-transport/src/endpoint/retry.rs
+++ b/quic/s2n-quic-transport/src/endpoint/retry.rs
@@ -35,16 +35,15 @@ impl<Path: path::Handle> Dispatch<Path> {
         }
     }
 
-    #[allow(dead_code)]
-    pub fn queue<T: token::Format, C: RetryKey, R: random::Generator>(
+    pub fn queue<T: token::Format, C: RetryKey>(
         &mut self,
         path_handle: Path,
         packet: &packet::initial::ProtectedInitial,
         local_connection_id: connection::LocalId,
-        random: &mut R,
+        random: &mut dyn random::Generator,
         token_format: &mut T,
     ) {
-        if let Some(transmission) = Transmission::new::<_, C, _>(
+        if let Some(transmission) = Transmission::new::<_, C>(
             path_handle,
             packet,
             local_connection_id,
@@ -101,15 +100,15 @@ impl<Path: path::Handle> core::fmt::Debug for Transmission<Path> {
 }
 
 impl<Path: path::Handle> Transmission<Path> {
-    pub fn new<T: token::Format, C: RetryKey, R: random::Generator>(
+    pub fn new<T: token::Format, C: RetryKey>(
         path: Path,
         packet: &packet::initial::ProtectedInitial,
         local_connection_id: connection::LocalId,
-        random: &mut R,
+        random: &mut dyn random::Generator,
         token_format: &mut T,
     ) -> Option<Self> {
         let mut packet_buf = [0u8; MINIMUM_MTU as usize];
-        let packet_range = packet::retry::Retry::encode_packet::<_, C, _>(
+        let packet_range = packet::retry::Retry::encode_packet::<_, C>(
             &path.remote_address(),
             packet,
             &local_connection_id,

--- a/quic/s2n-quic-transport/src/endpoint/stateless_reset.rs
+++ b/quic/s2n-quic-transport/src/endpoint/stateless_reset.rs
@@ -26,13 +26,13 @@ impl<Path: path::Handle> Dispatch<Path> {
         }
     }
 
-    pub fn queue<R: random::Generator>(
+    pub fn queue(
         &mut self,
         path: Path,
         token: stateless_reset::Token,
         max_tag_len: usize,
         triggering_packet_len: usize,
-        random_generator: &mut R,
+        random_generator: &mut dyn random::Generator,
     ) {
         if let Some(transmission) = Transmission::new(
             path,
@@ -89,12 +89,12 @@ impl<Handle: path::Handle> core::fmt::Debug for Transmission<Handle> {
 }
 
 impl<Path: path::Handle> Transmission<Path> {
-    pub fn new<R: random::Generator>(
+    pub fn new(
         path: Path,
         token: stateless_reset::Token,
         max_tag_len: usize,
         triggering_packet_len: usize,
-        random_generator: &mut R,
+        random_generator: &mut dyn random::Generator,
     ) -> Option<Self> {
         let mut packet_buf = [0u8; MINIMUM_MTU as usize];
 

--- a/quic/s2n-quic-transport/src/path/ecn.rs
+++ b/quic/s2n-quic-transport/src/path/ecn.rs
@@ -97,11 +97,11 @@ impl Controller {
     }
 
     /// Called when the connection timer expires
-    pub fn on_timeout<Rnd: random::Generator, Pub: event::ConnectionPublisher>(
+    pub fn on_timeout<Pub: event::ConnectionPublisher>(
         &mut self,
         now: Timestamp,
         path: event::builder::Path,
-        random_generator: &mut Rnd,
+        random_generator: &mut dyn random::Generator,
         rtt: Duration,
         publisher: &mut Pub,
     ) {
@@ -169,8 +169,8 @@ impl Controller {
     /// bias in the resulting count, but does not result in any reduction in security for this
     /// usage. Other usages that require uniform sampling should implement rejection sampling or
     /// other methodologies and not copy this implementation.
-    fn next_ce_packet_duration<Rnd: random::Generator>(
-        random_generator: &mut Rnd,
+    fn next_ce_packet_duration(
+        random_generator: &mut dyn random::Generator,
         rtt: Duration,
     ) -> Duration {
         let mut bytes = [0; core::mem::size_of::<u16>()];

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -21,7 +21,7 @@ use s2n_quic_core::{
         migration::{self, Validator as _},
         Handle as _, Id, MaxMtu,
     },
-    random::Generator as _,
+    random,
     recovery::{
         congestion_controller::{self, Endpoint as _},
         RttEstimator,
@@ -88,7 +88,7 @@ impl<Config: endpoint::Config> Manager<Config> {
     fn update_active_path<Pub: event::ConnectionPublisher>(
         &mut self,
         new_path_id: Id,
-        random_generator: &mut Config::RandomGenerator,
+        random_generator: &mut dyn random::Generator,
         publisher: &mut Pub,
     ) -> Result<(), transport::Error> {
         debug_assert!(new_path_id != path_id(self.active));
@@ -458,7 +458,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         Ok((new_path_id, unblocked))
     }
 
-    fn set_challenge(&mut self, path_id: Id, random_generator: &mut Config::RandomGenerator) {
+    fn set_challenge(&mut self, path_id: Id, random_generator: &mut dyn random::Generator) {
         //= https://www.rfc-editor.org/rfc/rfc9000#section-8.2.1
         //# The endpoint MUST use unpredictable data in every PATH_CHALLENGE
         //# frame so that it can associate the peer's response with the
@@ -594,7 +594,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         path_id: Id,
         source_connection_id: Option<PeerId>,
         path_validation_probing: path_validation::Probe,
-        random_generator: &mut Config::RandomGenerator,
+        random_generator: &mut dyn random::Generator,
         publisher: &mut Pub,
     ) -> Result<(), transport::Error> {
         //= https://www.rfc-editor.org/rfc/rfc9000#section-7.2
@@ -715,7 +715,7 @@ impl<Config: endpoint::Config> Manager<Config> {
     pub fn on_timeout<Pub: event::ConnectionPublisher>(
         &mut self,
         timestamp: Timestamp,
-        random_generator: &mut Config::RandomGenerator,
+        random_generator: &mut dyn random::Generator,
         publisher: &mut Pub,
     ) -> Result<(), connection::Error> {
         for (id, path) in self.paths.iter_mut().enumerate() {

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -224,11 +224,11 @@ impl<Config: endpoint::Config> Path<Config> {
     }
 
     #[inline]
-    pub fn on_timeout<Rnd: random::Generator, Pub: event::ConnectionPublisher>(
+    pub fn on_timeout<Pub: event::ConnectionPublisher>(
         &mut self,
         timestamp: Timestamp,
         path_id: Id,
-        random_generator: &mut Rnd,
+        random_generator: &mut dyn random::Generator,
         publisher: &mut Pub,
     ) {
         self.challenge

--- a/scripts/sim
+++ b/scripts/sim
@@ -7,7 +7,7 @@ if [ ! -f target/release/s2n-quic-sim ]; then
   cargo build --release --bin s2n-quic-sim
 fi
 
-if [ ! "$@" ]; then
+if [[ -z "$@" ]]; then
   ./target/release/s2n-quic-sim batch quic/s2n-quic-sim/plans/*.toml
 else
   ./target/release/s2n-quic-sim $@


### PR DESCRIPTION
### Description of changes: 

This change updates usage of `random::Generator` in several locations to use dynamic dispatch over static dispatch. This is preferable in these cases, as the generator is rarely used and inlining the actual rng implementation wouldn't really enable any optimizations. This also means all of the functions that are generic over the `random::Generator`, can be generated at compile time of `s2n-quic-core` and `s2n-quic-transport`, rather than instantiation of a `s2n-quic` `Client` or `Server`. This _should_ help with compile times and final binary sizes.

### Testing:

Since this is just a type change, all of the existing tests should catch any issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

