### PR TITLE
ci: don't require ECN to pass for ngtcp2

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -233,9 +233,7 @@
     "msquic": [],
     "mvfst": [],
     "neqo": [],
-    "ngtcp2": [
-      "client"
-    ],
+    "ngtcp2": [],
     "picoquic": [
       "client"
     ],


### PR DESCRIPTION
### Description of changes: 

ECN interop testing no longer works with ngtcp2 as of https://github.com/ngtcp2/ngtcp2/pull/521. This change causes ngtcp2 MTU probes to not be marked with ECN-Capable markings, which the ECN interop test requires on all packets. 

This change makes it so ECN interop tests with ngtcp2 are no longer required.

### Call-outs:

We could potentially work around this by setting the `max_udp_payload_size` transport parameter to 1200, but we don't currently expose this setting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

