### PR TITLE
Revert "ci: don't require ECN to pass for ngtcp2"

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -233,7 +233,9 @@
     "msquic": [],
     "mvfst": [],
     "neqo": [],
-    "ngtcp2": [],
+    "ngtcp2": [
+      "client"
+    ],
     "picoquic": [
       "client"
     ],


### PR DESCRIPTION
Reverts aws/s2n-quic#1469

ngtcp2 fixed the issue with ECN interop in https://github.com/ngtcp2/ngtcp2/pull/525