### PR TITLE
fix(s2n-quic-core): congestion controller fuzz improvements and fixes

### DIFF
--- a/quic/s2n-quic-core/src/recovery/congestion_controller/__fuzz__/recovery__congestion_controller__fuzz_target__bbr/corpus.tar.gz
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller/__fuzz__/recovery__congestion_controller__fuzz_target__bbr/corpus.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:22ce06946953ce829d10b350ac74f3753e0a7b96e19924c6a7cc5459e9ee2f88
-size 48098
+oid sha256:da4b22df1b425ca4b5a0f8a7307f6a9ed1f8211abd34ae851c36d25fe7bb6ce1
+size 260431

--- a/quic/s2n-quic-core/src/recovery/congestion_controller/__fuzz__/recovery__congestion_controller__fuzz_target__bbr/corpus.tar.gz
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller/__fuzz__/recovery__congestion_controller__fuzz_target__bbr/corpus.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:22ce06946953ce829d10b350ac74f3753e0a7b96e19924c6a7cc5459e9ee2f88
+size 48098

--- a/quic/s2n-quic-core/src/recovery/congestion_controller/__fuzz__/recovery__congestion_controller__fuzz_target__cubic/corpus.tar.gz
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller/__fuzz__/recovery__congestion_controller__fuzz_target__cubic/corpus.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2869cad79d9c341660e92e4ed02bc37eb98faeea42ecf7decac0fe7df2d4142d
+size 43021

--- a/quic/s2n-quic-core/src/recovery/congestion_controller/corpus.tar.gz
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller/corpus.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8d5feaaccf2c956cc74f455d687e76ef27b017fda34698aad8ccb698cbd6ca6c
-size 156860

--- a/quic/s2n-quic-core/src/recovery/congestion_controller/fuzz_target.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller/fuzz_target.rs
@@ -101,17 +101,22 @@ impl<CC: CongestionController> Model<CC> {
 
     fn on_packet_sent(&mut self, count: u8, bytes_sent: u16, app_limited: Option<bool>) {
         for _ in 0..count {
-            let packet_info = self.subject.on_packet_sent(
-                self.timestamp,
-                bytes_sent as usize,
-                app_limited,
-                &self.rtt_estimator,
-            );
-            self.sent_packets.push_back(SentPacketInfo {
-                sent_bytes: bytes_sent,
-                time_sent: self.timestamp,
-                cc_packet_info: packet_info,
-            });
+            if !self.subject.is_congestion_limited()
+                || self.subject.requires_fast_retransmission()
+                || bytes_sent == 0
+            {
+                let packet_info = self.subject.on_packet_sent(
+                    self.timestamp,
+                    bytes_sent as usize,
+                    app_limited,
+                    &self.rtt_estimator,
+                );
+                self.sent_packets.push_back(SentPacketInfo {
+                    sent_bytes: bytes_sent,
+                    time_sent: self.timestamp,
+                    cc_packet_info: packet_info,
+                });
+            }
         }
     }
 


### PR DESCRIPTION
### Description of changes: 

The fuzz test corpus files for the congestion controller fuzz tests were not organized properly, meaning they were not being used during execution of the fuzz tests or in coverage reporting. This change fixes the corpus files to keep them separated into individual directories.

While running the fuzz tests for a longer period, an issue was found when the Bandwidth reaches the maximum limit of 1GB/sec. To handle this, I've updated several usages of bandwidth to perform saturating multiplication or saturating addition. 

In addition, I've updated the fuzz test to not send packets when congestion limits, to more accurately match how the congestion controller is used by the recovery manager.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

