### PR TITLE
fix x86 compilation for s2n-quic-crypto

### DIFF
--- a/quic/s2n-quic-crypto/src/arch.rs
+++ b/quic/s2n-quic-crypto/src/arch.rs
@@ -5,7 +5,7 @@ use cfg_if::cfg_if;
 
 cfg_if! {
     if #[cfg(target_arch = "x86")] {
-        pub use core::arch::x86::::*;
+        pub use core::arch::x86::*;
         mod x86;
         pub use x86::*;
     } else if #[cfg(target_arch = "x86_64")] {


### PR DESCRIPTION
Rust really should catch weird stuff like this even if it's disabled with a macro...

### Resolved issues:

### Description of changes: 

It only fixes a typo in the source code

### Call-outs:

### Testing:

There's no changes except fixing a typo, so no testing is necessary. Perhaps an x86 CI pipeline should be added.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

