### PR TITLE
Extending AEAD confidentiality limits

### DIFF
--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -26,6 +26,7 @@ bytes = { version = "1", default-features = false }
 hex-literal = "0.3"
 # used for event snapshot testing - needs an internal API so we require a minimum version
 insta = { version = ">=1.12", features = ["json"], optional = true }
+lazy_static = "1"
 num-rational = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }

--- a/quic/s2n-quic-core/src/crypto/application/limited.rs
+++ b/quic/s2n-quic-core/src/crypto/application/limited.rs
@@ -3,6 +3,17 @@
 
 use crate::{crypto::OneRttKey, path::MaxMtu};
 
+use std::sync::Mutex;
+
+lazy_static::lazy_static! {
+    pub static ref MAX_MTU: Mutex<MaxMtu> = Mutex::new(MaxMtu::default());
+}
+
+#[inline]
+pub fn set_global_max_mtu(max_mtu: u16) {
+    *MAX_MTU.lock().unwrap() = MaxMtu::try_from(max_mtu).unwrap();
+}
+
 //= https://www.rfc-editor.org/rfc/rfc9001#section-6.6
 //# Endpoints MUST count the number of encrypted packets for each set of
 //# keys.

--- a/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__aes128_gcm__confidentiality_tls_aes_128_gcm_sha256_test.snap
+++ b/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__aes128_gcm__confidentiality_tls_aes_128_gcm_sha256_test.snap
@@ -1,6 +1,13 @@
 ---
 source: quic/s2n-quic-crypto/src/cipher_suite.rs
-assertion_line: 288
-expression: "u64::pow(2, 23)"
+expression: AEAD_AES_GCM_CONFIDENTIALITY_LIMIT
 ---
-8388608
+AeadConfidentialityLimit {
+    default_confidentiality_limit: 8388608,
+    restricted_confidentiality_limit: Some(
+        RestrictedAeadConfidentialityLimit {
+            packet_size_limit: 2048,
+            confidentiality_limit: 268435456,
+        },
+    ),
+}

--- a/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__aes256_gcm__confidentiality_tls_aes_256_gcm_sha384_test.snap
+++ b/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__aes256_gcm__confidentiality_tls_aes_256_gcm_sha384_test.snap
@@ -1,6 +1,13 @@
 ---
 source: quic/s2n-quic-crypto/src/cipher_suite.rs
-assertion_line: 251
-expression: "u64::pow(2, 23)"
+expression: AEAD_AES_GCM_CONFIDENTIALITY_LIMIT
 ---
-8388608
+AeadConfidentialityLimit {
+    default_confidentiality_limit: 8388608,
+    restricted_confidentiality_limit: Some(
+        RestrictedAeadConfidentialityLimit {
+            packet_size_limit: 2048,
+            confidentiality_limit: 268435456,
+        },
+    ),
+}

--- a/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__chacha20_poly1305__confidentiality_tls_chacha20_poly1305_sha256_test.snap
+++ b/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__chacha20_poly1305__confidentiality_tls_chacha20_poly1305_sha256_test.snap
@@ -1,6 +1,8 @@
 ---
 source: quic/s2n-quic-crypto/src/cipher_suite.rs
-assertion_line: 271
-expression: "u64::pow(2, 62)"
+expression: AEAD_CHACHA20_CONFIDENTIALITY_LIMIT
 ---
-4611686018427387904
+AeadConfidentialityLimit {
+    default_confidentiality_limit: 4611686018427387904,
+    restricted_confidentiality_limit: None,
+}

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -58,6 +58,7 @@ mod version;
 // exports
 pub use config::{Config, Context};
 pub use packet_buffer::Buffer as PacketBuffer;
+use s2n_quic_core::crypto::limited::set_global_max_mtu;
 pub use s2n_quic_core::endpoint::*;
 
 const DEFAULT_MAX_PEERS: usize = 1024;
@@ -262,6 +263,7 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
 
     #[inline]
     fn set_max_mtu(&mut self, max_mtu: MaxMtu) {
+        set_global_max_mtu(max_mtu.into());
         self.max_mtu = max_mtu
     }
 


### PR DESCRIPTION
### Resolved issues:

Partially addresses https://github.com/aws/s2n-quic/issues/322. 

### Description of changes: 

[RFC9001 ](https://www.rfc-editor.org/rfc/rfc9001#name-limits-on-aead-usage) specifies that AEAD confidentiality limits MAY be reduced if the packet size is limited. This PR attempts to address this using a global variable MAX_MTU (yuck). This does not attempt to limit the AEAD integrity limits as such limits are enforced on packet decryption; s2n-quic has no way of knowing whether the sender limited their packet sizes.

### Call-outs:

I tried solving this with a global variable. Global variables make me nervous but I was struggling to find an alternative where the `Key` trait could be privy to max_mtu/Limit information. This may not be the best solution; requesting feedback to see if this is worth pursuing.

### Testing:

* Added supported unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

