### PR TITLE
fix(s2n-quic-core): add BBR unit tests and fix handle_lost_packet

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -978,7 +978,6 @@ impl BbrCongestionController {
                 Self::inflight_hi_from_lost_packet(lost_bytes, lost_since_transmit, packet_info);
             self.on_inflight_too_high(
                 packet_info.is_app_limited,
-                packet_info.bytes_in_flight,
                 inflight_hi_from_lost_packet,
                 random_generator,
                 now,

--- a/quic/s2n-quic-core/src/recovery/bbr/data_volume.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/data_volume.rs
@@ -210,6 +210,11 @@ impl Model {
     pub fn set_extra_acked_interval_start(&mut self, timestamp: Timestamp) {
         self.extra_acked_interval_start = Some(timestamp);
     }
+
+    #[cfg(test)]
+    pub fn set_extra_acked_for_test(&mut self, sample: u64, round_count: u64) {
+        self.extra_acked_filter.update(sample, round_count);
+    }
 }
 
 #[cfg(test)]

--- a/quic/s2n-quic-core/src/recovery/bbr/drain.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/drain.rs
@@ -14,6 +14,15 @@ use num_traits::One;
 //# pacing_gain well below 1.0, until any estimated queue has been drained. It uses a
 //# pacing_gain that is the inverse of the value used during Startup, chosen to try to
 //# drain the queue in one round
+
+// The wording above is somewhat ambiguous over whether the drain pacing_gain should be
+// the inverse of the startup pacing_gain or startup cwnd_gain. However, the citation below
+// makes it clear it is the inverse of the startup cwnd_gain. This is also supported
+// by the following derivation:
+// https://github.com/google/bbr/blob/master/Documentation/startup/gain/analysis/bbr_drain_gain.pdf
+
+//= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.2
+//#     BBR.pacing_gain = 1/BBRStartupCwndGain  /* pace slowly */
 pub(crate) const PACING_GAIN: Ratio<u64> = Ratio::new_raw(1, 2);
 
 //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.2

--- a/quic/s2n-quic-core/src/recovery/bbr/full_pipe.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/full_pipe.rs
@@ -195,6 +195,11 @@ impl Estimator {
             self.loss_bursts += 1;
         }
     }
+
+    #[cfg(test)]
+    pub fn set_filled_pipe_for_test(&mut self, filled_pipe: bool) {
+        self.filled_pipe = filled_pipe;
+    }
 }
 
 #[cfg(test)]

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
@@ -398,7 +398,14 @@ impl State {
 
     #[cfg(test)]
     pub fn set_cycle_phase_for_test(&mut self, cycle_phase: CyclePhase) {
-        self.cycle_phase = cycle_phase
+        self.cycle_phase = cycle_phase;
+
+        match cycle_phase {
+            CyclePhase::Down => self.ack_phase = AckPhase::ProbeStopping,
+            CyclePhase::Refill => self.ack_phase = AckPhase::Refilling,
+            CyclePhase::Up => self.ack_phase = AckPhase::ProbeStarting,
+            CyclePhase::Cruise => {}
+        }
     }
 }
 
@@ -596,7 +603,6 @@ impl BbrCongestionController {
                 self.on_inflight_too_high(
                     rate_sample.is_app_limited,
                     rate_sample.bytes_in_flight,
-                    self.target_inflight(),
                     random_generator,
                     now,
                 );
@@ -681,7 +687,6 @@ impl BbrCongestionController {
         &mut self,
         is_app_limited: bool,
         bytes_in_flight: u32,
-        target_inflight: u32,
         random_generator: &mut dyn random::Generator,
         now: Timestamp,
     ) {
@@ -697,7 +702,8 @@ impl BbrCongestionController {
         self.bw_probe_samples = false; // only react once per bw probe
         if !is_app_limited {
             self.data_volume_model.update_upper_bound(
-                (bytes_in_flight as u64).max((bbr::BETA * target_inflight as u64).to_integer()),
+                (bytes_in_flight as u64)
+                    .max((bbr::BETA * self.target_inflight() as u64).to_integer()),
             )
         }
 

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
@@ -395,6 +395,11 @@ impl State {
         self.bw_probe_wait =
             Duration::from_millis(random::gen_range_biased(random_generator, 2000..=3000) as u64);
     }
+
+    #[cfg(test)]
+    pub fn set_cycle_phase_for_test(&mut self, cycle_phase: CyclePhase) {
+        self.cycle_phase = cycle_phase
+    }
 }
 
 /// Methods related to the ProbeBW state

--- a/quic/s2n-quic-core/src/recovery/bbr/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/tests.rs
@@ -2,10 +2,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    assert_delta,
     path::MINIMUM_MTU,
-    recovery::{bandwidth::PacketInfo, bbr::BbrCongestionController},
+    random,
+    recovery::{
+        bandwidth::PacketInfo,
+        bbr::{probe_rtt, BbrCongestionController, State},
+    },
     time::{Clock, NoopClock},
 };
+use num_traits::{Inv, ToPrimitive};
 
 //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.2
 //= type=test
@@ -79,5 +85,80 @@ fn inflight_hi_from_lost_packet() {
             MINIMUM_MTU as u32,
             packet_info
         )
+    );
+}
+
+#[test]
+fn pacing_cwnd_gain() {
+    //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#2.6
+    //= type=test
+    //# A constant specifying the minimum gain value for calculating the pacing rate that will
+    //# allow the sending rate to double each round (4*ln(2) ~= 2.77)
+    assert_delta!(State::Startup.pacing_gain().to_f32().unwrap(), 2.77, 0.001);
+
+    //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#2.6
+    //= type=test
+    //# A constant specifying the minimum gain value for calculating the
+    //# cwnd that will allow the sending rate to double each round (2.0)
+    assert_delta!(State::Startup.cwnd_gain().to_f32().unwrap(), 2.0, 0.001);
+
+    //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.2
+    //= type=test
+    //# In Drain, BBR aims to quickly drain any queue created in Startup by switching to a
+    //# pacing_gain well below 1.0, until any estimated queue has been drained. It uses a
+    //# pacing_gain that is the inverse of the value used during Startup, chosen to try to
+    //# drain the queue in one round
+
+    //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.2
+    //= type=test
+    //# BBREnterDrain():
+    //#     BBR.state = Drain
+    //#     BBR.pacing_gain = 1/BBRStartupCwndGain  /* pace slowly */
+    //#     BBR.cwnd_gain = BBRStartupCwndGain      /* maintain cwnd */
+    assert_eq!(State::Drain.pacing_gain(), State::Startup.cwnd_gain().inv());
+    assert_eq!(State::Drain.cwnd_gain(), State::Startup.cwnd_gain());
+
+    let mut bbr = BbrCongestionController::new(MINIMUM_MTU);
+    let now = NoopClock.get_time();
+    bbr.enter_drain();
+    bbr.enter_probe_bw(false, &mut random::testing::Generator::default(), now);
+    assert!(bbr.state.is_probing_bw());
+
+    // ProbeBw cwnd gain from https://www.ietf.org/archive/id/draft-cardwell-iccrg-bbr-congestion-control-02.html#section-4.6.1
+    assert_delta!(bbr.state.cwnd_gain().to_f32().unwrap(), 2.0, 0.001);
+
+    //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.1
+    //= type=test
+    //# In the ProbeBW_DOWN phase of the cycle, a BBR flow pursues the deceleration tactic,
+    //# to try to send slower than the network is delivering data, to reduce the amount of data
+    //# in flight, with all of the standard motivations for the deceleration tactic (discussed
+    //# in "State Machine Tactics", above). It does this by switching to a BBR.pacing_gain of
+    //# 0.9, sending at 90% of BBR.bw.
+    assert_delta!(bbr.state.pacing_gain().to_f32().unwrap(), 0.9, 0.001);
+
+    //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.4.4
+    //= type=test
+    //# BBREnterProbeRTT():
+    //#     BBR.state = ProbeRTT
+    //#     BBR.pacing_gain = 1
+    assert_delta!(
+        State::ProbeRtt(probe_rtt::State::default())
+            .pacing_gain()
+            .to_f32()
+            .unwrap(),
+        1.0,
+        0.001
+    );
+
+    //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#2.14.2
+    //= type=test
+    //# A constant specifying the gain value for calculating the cwnd during ProbeRTT: 0.5
+    assert_delta!(
+        State::ProbeRtt(probe_rtt::State::default())
+            .cwnd_gain()
+            .to_f32()
+            .unwrap(),
+        0.5,
+        0.001
     );
 }

--- a/quic/s2n-quic-core/src/recovery/bbr/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/tests.rs
@@ -628,6 +628,29 @@ fn save_cwnd() {
     assert_eq!(2000, bbr.prior_cwnd);
 }
 
+//= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.4
+//= type=test
+//# BBRRestoreCwnd()
+//#   cwnd = max(cwnd, BBR.prior_cwnd)
+#[test]
+fn restore_cwnd() {
+    let mut bbr = BbrCongestionController::new(MINIMUM_MTU);
+
+    bbr.prior_cwnd = 1000;
+    bbr.cwnd = 2000;
+
+    bbr.restore_cwnd();
+
+    assert_eq!(2000, bbr.cwnd);
+
+    bbr.prior_cwnd = 2000;
+    bbr.cwnd = 1000;
+
+    bbr.restore_cwnd();
+
+    assert_eq!(2000, bbr.cwnd);
+}
+
 /// Helper method to move the given BBR congestion controller into the
 /// ProbeBW state with the given CyclePhase
 fn enter_probe_bw_state(bbr: &mut BbrCongestionController, cycle_phase: CyclePhase) {

--- a/quic/s2n-quic-core/src/recovery/bbr/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/tests.rs
@@ -651,6 +651,26 @@ fn restore_cwnd() {
     assert_eq!(2000, bbr.cwnd);
 }
 
+//= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.4
+//= type=test
+//# BBRModulateCwndForRecovery():
+//#   if (rs.newly_lost > 0)
+//#     cwnd = max(cwnd - rs.newly_lost, 1)
+#[test]
+fn modulate_cwnd_for_recovery() {
+    let mut bbr = BbrCongestionController::new(MINIMUM_MTU);
+
+    bbr.cwnd = 100_000;
+
+    bbr.modulate_cwnd_for_recovery(1000);
+    assert_eq!(99_000, bbr.congestion_window());
+
+    // Don't drop below the minimum window
+    bbr.cwnd = bbr.minimum_window();
+    bbr.modulate_cwnd_for_recovery(1000);
+    assert_eq!(bbr.minimum_window(), bbr.congestion_window());
+}
+
 /// Helper method to move the given BBR congestion controller into the
 /// ProbeBW state with the given CyclePhase
 fn enter_probe_bw_state(bbr: &mut BbrCongestionController, cycle_phase: CyclePhase) {

--- a/quic/s2n-quic-core/src/recovery/bbr/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/tests.rs
@@ -305,6 +305,27 @@ fn max_inflight() {
 
 //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.2
 //= type=test
+//# BBRInflight(gain)
+//#   inflight = BBRBDPMultiple(gain)
+//#   return BBRQuantizationBudget(inflight)
+#[test]
+fn inflight() {
+    let mut bbr = BbrCongestionController::new(MINIMUM_MTU);
+    let now = NoopClock.get_time();
+
+    // Set an RTT so min_rtt is populated
+    let rtt = Duration::from_millis(100);
+    bbr.data_volume_model.update_min_rtt(rtt, now);
+    assert_eq!(Some(rtt), bbr.data_volume_model.min_rtt());
+
+    let bandwidth = Bandwidth::new(2000, Duration::from_millis(1));
+    // bdp = 2000bytes/ms * 100ms = 200000bytes
+    // max_inflight = quantization_budget(200000) = 200000
+    assert_eq!(200000, bbr.inflight(bandwidth, Ratio::one()));
+}
+
+//= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.2
+//= type=test
 //# BBRQuantizationBudget(inflight)
 //#   BBRUpdateOffloadBudget()
 //#   inflight = max(inflight, BBR.offload_budget)

--- a/quic/s2n-quic-core/src/recovery/bbr/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/tests.rs
@@ -481,3 +481,50 @@ fn set_next_departure_time() {
         bbr.earliest_departure_time()
     );
 }
+
+#[test]
+fn is_inflight_too_high() {
+    let rate_sample = RateSample {
+        lost_bytes: 3,
+        bytes_in_flight: 100,
+        ..Default::default()
+    };
+    // loss rate higher than 2% threshold
+    assert!(BbrCongestionController::is_inflight_too_high(
+        rate_sample,
+        MINIMUM_MTU
+    ));
+
+    let rate_sample = RateSample {
+        lost_bytes: 2,
+        bytes_in_flight: 100,
+        ..Default::default()
+    };
+    // loss rate <= 2% threshold
+    assert!(!BbrCongestionController::is_inflight_too_high(
+        rate_sample,
+        MINIMUM_MTU
+    ));
+
+    let rate_sample = RateSample {
+        delivered_bytes: 100 * MINIMUM_MTU as u64,
+        ecn_ce_count: 51,
+        ..Default::default()
+    };
+    // ecn rate higher than 50% threshold
+    assert!(BbrCongestionController::is_inflight_too_high(
+        rate_sample,
+        MINIMUM_MTU
+    ));
+
+    let rate_sample = RateSample {
+        delivered_bytes: 100 * MINIMUM_MTU as u64,
+        ecn_ce_count: 50,
+        ..Default::default()
+    };
+    // ecn rate <= 50% threshold
+    assert!(!BbrCongestionController::is_inflight_too_high(
+        rate_sample,
+        MINIMUM_MTU
+    ));
+}

--- a/quic/s2n-quic-core/src/recovery/bbr/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/tests.rs
@@ -287,6 +287,24 @@ fn target_inflight() {
 
 //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.2
 //= type=test
+//# BBRUpdateMaxInflight()
+//#   BBRUpdateAggregationBudget()
+//#   inflight = BBRBDPMultiple(BBR.cwnd_gain)
+//#   inflight += BBR.extra_acked
+//#   BBR.max_inflight = BBRQuantizationBudget(inflight)
+#[test]
+fn max_inflight() {
+    let mut bbr = BbrCongestionController::new(MINIMUM_MTU);
+
+    bbr.data_volume_model.set_extra_acked_for_test(1000, 0);
+    // bdp = initial_window = 12000 since min_rtt is not populated
+    // inflight = bdp + extra_acked = 13000
+    // max_inflight = quantization_budget(13000) = 3 * MAX_SEND_QUANTUM = 192000
+    assert_eq!(192000, bbr.max_inflight());
+}
+
+//= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.2
+//= type=test
 //# BBRQuantizationBudget(inflight)
 //#   BBRUpdateOffloadBudget()
 //#   inflight = max(inflight, BBR.offload_budget)


### PR DESCRIPTION
### Description of changes: 

This change adds more unit test coverage for BBRv2. While adding a unit test for `fn handle_lost_packet` I found a bug in the function. I've included the fix for that in this change as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

