### PR TITLE
fix(s2n-quic-core): adjust BBR congestion window on MTU update

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bbr/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/tests.rs
@@ -1017,6 +1017,19 @@ fn control_update_required() {
     assert!(!bbr.control_update_required(model_updated, Some(Duration::from_millis(100))));
 }
 
+#[test]
+fn on_mtu_update() {
+    let mut mtu = 5000;
+    let mut bbr = BbrCongestionController::new(mtu);
+    bbr.cwnd = 100_000;
+
+    mtu = 10000;
+    bbr.on_mtu_update(mtu);
+
+    assert_eq!(bbr.max_datagram_size, mtu);
+    assert_eq!(bbr.cwnd, 200_000);
+}
+
 /// Helper method to move the given BBR congestion controller into the
 /// ProbeBW state with the given CyclePhase
 fn enter_probe_bw_state(bbr: &mut BbrCongestionController, cycle_phase: CyclePhase) {


### PR DESCRIPTION
### Description of changes: 

This change updates the behavior of BBR to match that of CUBIC when the MTU of a path is updated, specifically the size of the congestion window in bytes is updated to reflect the new maximum datagram size, to keep the size of the congestion window in packets constant. 

### Call-outs:

This is not necessarily compliant with the QUIC RFC (see #959), however it is necessary to have BBR on an even footing with CUBIC while we are evaluating both.

### Testing:

Added unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

