### PR TITLE
fix(s2n-quic-core): bug fix for multiplicative_decrease in cubic

### DIFF
--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -742,7 +742,7 @@ impl Cubic {
     // This does not change the units of the congestion window
     #[inline]
     fn multiplicative_decrease(&mut self, cwnd: f32) -> f32 {
-        self.w_max = self.bytes_to_packets(cwnd);
+        self.w_max = self.bytes_to_packets(cwnd).max(self.bytes_to_packets(self.minimum_window()));
 
         //= https://www.rfc-editor.org/rfc/rfc8312#section-4.6
         //# To speed up this bandwidth release by

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -742,7 +742,9 @@ impl Cubic {
     // This does not change the units of the congestion window
     #[inline]
     fn multiplicative_decrease(&mut self, cwnd: f32) -> f32 {
-        self.w_max = self.bytes_to_packets(cwnd).max(self.bytes_to_packets(self.minimum_window()));
+        self.w_max = self
+            .bytes_to_packets(cwnd)
+            .max(self.bytes_to_packets(self.minimum_window()));
 
         //= https://www.rfc-editor.org/rfc/rfc8312#section-4.6
         //# To speed up this bandwidth release by


### PR DESCRIPTION
### Resolved issues:

This is probably a very rare case, but when w_max < 2MSS && w_max < w_last_max, cwnd_start will be larger than w_max.
This means w.max - cwnd_start will be negative, which can cause crash when K is calculated.

### Description of changes: 

* we should make sure w_max should not be less than 2MSS. As minimal cwnd is 2MSS, I believe it doesn't make sense w_max is lower than 2MSS.

### Testing:

Perform A/B tests between 2 instances and confirmed that there's no regression.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.