### PR TITLE
Remember Cubic's w_last_max correctly

### DIFF
--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -772,10 +772,12 @@ impl Cubic {
         //# time for the new flow to catch up to its congestion window size.
         let w_max = self.w_max;
         if w_max < self.w_last_max {
+            self.w_last_max = w_max;
             self.w_max = (w_max * (1.0 + BETA_CUBIC) / 2.0)
                 .max(self.bytes_to_packets(self.minimum_window()));
+        } else {
+            self.w_last_max = w_max;
         }
-        self.w_last_max = w_max;
 
         let cwnd_start = (cwnd * BETA_CUBIC).max(self.minimum_window());
 


### PR DESCRIPTION
Per RFC https://www.rfc-editor.org/rfc/rfc8312#section-4.6,  a flow remembers the last value of W_max before
it updates W_max for the current congestion event.

After clippy fixes in #685, it seems the `w_max` is first updated before  `w_last_max`, which may lead to reducing `w_max` more often when this fast convergence congestion code path hits.

(1.0 + BETA_CUBIC) / 2.0 =  (1+0.7) / 2 = 0.85 is the w_max multiplier

### Resolved issues:

resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.-->

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

