### PR TITLE
fix(s2n-quic-transport): cancel ack_delay_timer after ACK transmission

### DIFF
--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -130,6 +130,9 @@ impl AckManager {
             "`on_transmit_complete` was called when `should_transmit` is false"
         );
 
+        // if we transmitted something no need to wake up again to transmit the same thing
+        self.ack_delay_timer.cancel();
+
         let mut is_ack_eliciting = context.ack_elicitation().is_ack_eliciting();
 
         if !is_ack_eliciting {

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__client_sending_test.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__client_sending_test.snap
@@ -1,8 +1,7 @@
 ---
 source: quic/s2n-quic-transport/src/ack/ack_manager.rs
-assertion_line: 552
+assertion_line: 644
 expression: "Simulation{network:\n               Network{client:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(25),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),\n                       server:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(25),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            empty()).into(),},\n           events: empty().collect(),\n           delay: Duration::from_millis(0),}.run()"
-
 ---
 Report {
     client: EndpointReport {
@@ -10,40 +9,40 @@ Report {
             {
                 PacketNumber(
                     ApplicationData,
-                    19,
+                    16,
                 )..=PacketNumber(
                     ApplicationData,
-                    19,
+                    16,
                 ),
             },
         ),
-        total_transmissions: 101,
+        total_transmissions: 100,
         ack_eliciting_transmissions: 100,
-        ack_transmissions: 20,
+        ack_transmissions: 16,
         congested_transmissions: 0,
         dropped_transmissions: 0,
         delayed_transmissions: 0,
-        processed_transmissions: 101,
+        processed_transmissions: 100,
     },
     server: EndpointReport {
         pending_ack_ranges: AckRanges(
             {
                 PacketNumber(
                     ApplicationData,
-                    100,
+                    90,
                 )..=PacketNumber(
                     ApplicationData,
-                    100,
+                    99,
                 ),
             },
         ),
-        total_transmissions: 20,
-        ack_eliciting_transmissions: 4,
-        ack_transmissions: 20,
+        total_transmissions: 17,
+        ack_eliciting_transmissions: 3,
+        ack_transmissions: 17,
         congested_transmissions: 0,
         dropped_transmissions: 0,
         delayed_transmissions: 0,
-        processed_transmissions: 20,
+        processed_transmissions: 17,
     },
-    iterations: 122,
+    iterations: 118,
 }

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__delayed_client_sending_test.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__delayed_client_sending_test.snap
@@ -1,8 +1,7 @@
 ---
 source: quic/s2n-quic-transport/src/ack/ack_manager.rs
-assertion_line: 585
+assertion_line: 677
 expression: "Simulation{network:\n               Network{client:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(25),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),\n                       server:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(25),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            empty()).into(),},\n           events: empty().collect(),\n           delay: Duration::from_millis(100),}.run()"
-
 ---
 Report {
     client: EndpointReport {
@@ -10,40 +9,40 @@ Report {
             {
                 PacketNumber(
                     ApplicationData,
-                    11,
+                    10,
                 )..=PacketNumber(
                     ApplicationData,
-                    19,
+                    16,
                 ),
             },
         ),
-        total_transmissions: 102,
+        total_transmissions: 101,
         ack_eliciting_transmissions: 100,
-        ack_transmissions: 13,
+        ack_transmissions: 11,
         congested_transmissions: 0,
         dropped_transmissions: 0,
         delayed_transmissions: 0,
-        processed_transmissions: 102,
+        processed_transmissions: 101,
     },
     server: EndpointReport {
         pending_ack_ranges: AckRanges(
             {
                 PacketNumber(
                     ApplicationData,
-                    100,
+                    90,
                 )..=PacketNumber(
                     ApplicationData,
-                    101,
+                    100,
                 ),
             },
         ),
-        total_transmissions: 20,
-        ack_eliciting_transmissions: 4,
-        ack_transmissions: 20,
+        total_transmissions: 17,
+        ack_eliciting_transmissions: 3,
+        ack_transmissions: 17,
         congested_transmissions: 0,
         dropped_transmissions: 0,
         delayed_transmissions: 0,
-        processed_transmissions: 20,
+        processed_transmissions: 17,
     },
     iterations: 127,
 }

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__high_latency_test.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__high_latency_test.snap
@@ -1,8 +1,7 @@
 ---
 source: quic/s2n-quic-transport/src/ack/ack_manager.rs
-assertion_line: 619
+assertion_line: 711
 expression: "Simulation{network:\n               Network{client:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(25),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),\n                       server:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(100),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),},\n           events: empty().collect(),\n           delay: Duration::from_millis(1000),}.run()"
-
 ---
 Report {
     client: EndpointReport {
@@ -10,40 +9,40 @@ Report {
             {
                 PacketNumber(
                     ApplicationData,
-                    100,
+                    90,
                 )..=PacketNumber(
                     ApplicationData,
-                    115,
+                    112,
                 ),
             },
         ),
-        total_transmissions: 123,
-        ack_eliciting_transmissions: 104,
-        ack_transmissions: 23,
+        total_transmissions: 119,
+        ack_eliciting_transmissions: 103,
+        ack_transmissions: 19,
         congested_transmissions: 0,
         dropped_transmissions: 0,
         delayed_transmissions: 0,
-        processed_transmissions: 123,
+        processed_transmissions: 119,
     },
     server: EndpointReport {
         pending_ack_ranges: AckRanges(
             {
                 PacketNumber(
                     ApplicationData,
-                    119,
+                    100,
                 )..=PacketNumber(
                     ApplicationData,
-                    122,
+                    118,
                 ),
             },
         ),
-        total_transmissions: 116,
-        ack_eliciting_transmissions: 103,
-        ack_transmissions: 16,
+        total_transmissions: 113,
+        ack_eliciting_transmissions: 102,
+        ack_transmissions: 13,
         congested_transmissions: 0,
         dropped_transmissions: 0,
         delayed_transmissions: 0,
-        processed_transmissions: 116,
+        processed_transmissions: 113,
     },
-    iterations: 238,
+    iterations: 233,
 }

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__lossy_network_test.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__lossy_network_test.snap
@@ -1,8 +1,7 @@
 ---
 source: quic/s2n-quic-transport/src/ack/ack_manager.rs
-assertion_line: 653
+assertion_line: 745
 expression: "Simulation{network:\n               Network{client:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(25),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),\n                       server:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(100),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),},\n           events:\n               once(NetworkEvent::Pass).cycle().take(4).chain(once(NetworkEvent::Drop)).collect(),\n           delay: Duration::from_millis(0),}.run()"
-
 ---
 Report {
     client: EndpointReport {
@@ -45,5 +44,5 @@ Report {
         delayed_transmissions: 0,
         processed_transmissions: 80,
     },
-    iterations: 181,
+    iterations: 180,
 }


### PR DESCRIPTION
### Description of changes: 

I noticed while looking at tracing logs that we were waking up to send an ACK even though we had already sent one with a STREAM frame. Digging into it, I noticed we weren't cancelling the `ack_delay_timer` after transmitting an ACK frame which resulted in redundant packets being transmitted. This change, instead, cancels the timer.

### Testing:

The simulation snapshots were updated which all show the improvement in the number of transmitted packets between peers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

