### PR TITLE
fix(s2n-quic-transport): denormalize ACK interest for CID registries

### DIFF
--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -187,12 +187,14 @@ impl Limits {
     // internal APIs
 
     #[doc(hidden)]
+    #[inline]
     pub fn load_peer<A, B, C, D>(&mut self, peer_parameters: &TransportParameters<A, B, C, D>) {
         self.max_idle_timeout
             .load_peer(&peer_parameters.max_idle_timeout);
     }
 
     #[doc(hidden)]
+    #[inline]
     pub const fn ack_settings(&self) -> ack::Settings {
         ack::Settings {
             ack_delay_exponent: self.ack_delay_exponent.as_u8(),
@@ -203,6 +205,7 @@ impl Limits {
     }
 
     #[doc(hidden)]
+    #[inline]
     pub const fn initial_flow_control_limits(&self) -> InitialFlowControlLimits {
         InitialFlowControlLimits {
             stream_limits: self.initial_stream_limits(),
@@ -217,6 +220,7 @@ impl Limits {
     }
 
     #[doc(hidden)]
+    #[inline]
     pub const fn initial_stream_limits(&self) -> InitialStreamLimits {
         InitialStreamLimits {
             max_data_bidi_local: self.bidirectional_local_data_window.as_varint(),
@@ -226,6 +230,7 @@ impl Limits {
     }
 
     #[doc(hidden)]
+    #[inline]
     pub fn stream_limits(&self) -> stream::Limits {
         stream::Limits {
             max_send_buffer_size: self.max_send_buffer_size,
@@ -235,16 +240,19 @@ impl Limits {
     }
 
     #[doc(hidden)]
+    #[inline]
     pub fn max_idle_timeout(&self) -> Option<Duration> {
         self.max_idle_timeout.as_duration()
     }
 
     #[doc(hidden)]
+    #[inline]
     pub fn max_handshake_duration(&self) -> Duration {
         self.max_handshake_duration
     }
 
     #[doc(hidden)]
+    #[inline]
     pub fn max_keep_alive_period(&self) -> Duration {
         self.max_keep_alive_period
     }

--- a/quic/s2n-quic-core/src/lib.rs
+++ b/quic/s2n-quic-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod frame;
 pub mod havoc;
 pub mod inet;
 pub mod io;
+pub mod memo;
 pub mod number;
 pub mod packet;
 pub mod path;

--- a/quic/s2n-quic-core/src/memo.rs
+++ b/quic/s2n-quic-core/src/memo.rs
@@ -1,0 +1,172 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::{cell::Cell, fmt};
+
+/// A datastructure that [memoizes](https://wikipedia.org/wiki/Memoization) a query function
+///
+/// This can be used for when queries rarely change and can potentially be expensive or on hot
+/// code paths. After the `input` is mutated, the query value should be `clear`ed to signal that
+/// the function needs to be executed again.
+///
+/// In debug mode the `get` call will always run the query and assert that the values match.
+#[derive(Clone)]
+pub struct Memo<T: Copy, Input, Check = DefaultConsistencyCheck> {
+    value: Cell<Option<T>>,
+    query: fn(&Input) -> T,
+    check: Check,
+}
+
+impl<T: Copy + fmt::Debug, Input, Check> fmt::Debug for Memo<T, Input, Check> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("Memo").field(&self.value.get()).finish()
+    }
+}
+
+impl<T: Copy + PartialEq + fmt::Debug, Input, Check: ConsistencyCheck> Memo<T, Input, Check> {
+    /// Creates a new `Memo` over a query function
+    #[inline]
+    pub fn new(query: fn(&Input) -> T) -> Self {
+        Self {
+            value: Cell::new(None),
+            query,
+            check: Check::default(),
+        }
+    }
+
+    /// Returns the current value of the query function, which may be cached
+    #[inline]
+    #[track_caller]
+    pub fn get(&self, input: &Input) -> T {
+        if let Some(value) = self.value.get() {
+            // make sure the values match
+            self.check.check_consistency(value, input, self.query);
+            return value;
+        }
+
+        let value = (self.query)(input);
+        self.value.set(Some(value));
+        value
+    }
+
+    /// Clears the cached value of the query function
+    #[inline]
+    pub fn clear(&self) {
+        self.value.set(None);
+    }
+
+    /// Asserts that the cached value reflects the current query result in debug mode
+    #[inline]
+    #[track_caller]
+    pub fn check_consistency(&self, input: &Input) {
+        if cfg!(debug_assertions) {
+            // `get` will assert the value matches the query internally
+            let _ = self.get(input);
+        }
+    }
+}
+
+/// Trait to configure consistency checking behavior
+pub trait ConsistencyCheck: Clone + Default {
+    /// Called when the `Memo` struct has a cached value
+    ///
+    /// An implementation can assert that the `cache` value matches the current `query` result
+    fn check_consistency<T: PartialEq + fmt::Debug, Input>(
+        &self,
+        cache: T,
+        input: &Input,
+        query: fn(&Input) -> T,
+    );
+}
+
+#[derive(Copy, Clone, Default)]
+pub struct ConsistencyCheckAlways;
+
+impl ConsistencyCheck for ConsistencyCheckAlways {
+    #[inline]
+    fn check_consistency<T: PartialEq + fmt::Debug, Input>(
+        &self,
+        actual: T,
+        input: &Input,
+        query: fn(&Input) -> T,
+    ) {
+        let expected = query(input);
+        assert_eq!(expected, actual);
+    }
+}
+
+#[derive(Copy, Clone, Default)]
+pub struct ConsistencyCheckNever;
+
+impl ConsistencyCheck for ConsistencyCheckNever {
+    #[inline]
+    fn check_consistency<T: PartialEq + fmt::Debug, Input>(
+        &self,
+        _cache: T,
+        _input: &Input,
+        _query: fn(&Input) -> T,
+    ) {
+        // noop
+    }
+}
+
+#[cfg(debug_assertions)]
+pub type DefaultConsistencyCheck = ConsistencyCheckAlways;
+#[cfg(not(debug_assertions))]
+pub type DefaultConsistencyCheck = ConsistencyCheckNever;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug, Default)]
+    struct Input<Value> {
+        value: Value,
+        should_query: bool,
+    }
+
+    #[test]
+    fn memo_test() {
+        let memo = Memo::<u64, Input<_>, ConsistencyCheckNever>::new(|input| {
+            assert!(
+                input.should_query,
+                "query was called when it wasn't expected"
+            );
+            input.value
+        });
+
+        assert_eq!(
+            memo.get(&Input {
+                value: 1,
+                should_query: true,
+            }),
+            1
+        );
+
+        assert_eq!(
+            memo.get(&Input {
+                value: 2,
+                should_query: false,
+            }),
+            1
+        );
+
+        memo.clear();
+
+        assert_eq!(
+            memo.get(&Input {
+                value: 3,
+                should_query: true,
+            }),
+            3
+        );
+
+        assert_eq!(
+            memo.get(&Input {
+                value: 4,
+                should_query: false,
+            }),
+            3
+        );
+    }
+}

--- a/quic/s2n-quic-core/src/time/timer.rs
+++ b/quic/s2n-quic-core/src/time/timer.rs
@@ -59,6 +59,13 @@ impl Timer {
     }
 }
 
+impl From<Option<Timestamp>> for Timer {
+    #[inline]
+    fn from(expiration: Option<Timestamp>) -> Self {
+        Self { expiration }
+    }
+}
+
 /// Returned when a `Query` wants to end a timer query
 #[derive(Clone, Copy, Debug, Default)]
 pub struct QueryBreak;

--- a/quic/s2n-quic-transport/src/connection/peer_id_registry/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/peer_id_registry/tests.rs
@@ -146,7 +146,7 @@ fn active_connection_id_limit_must_be_at_least_2() {
         2,
         reg.registered_ids
             .iter()
-            .filter(|id_info| id_info.status.is_active())
+            .filter(|id_info| id_info.is_active())
             .count()
     );
 }


### PR DESCRIPTION
### Description of changes: 

I was doing perf measurements on light loads with infrequent send/recv and the ACK processing/interest queries in the CID registries was showing up quite a bit. This is because on every event we iterate through the whole list of registered CIDs, even if none of them are waiting for an ACK signal or have transmission interest.

This change, instead, denormalizes values on the struct itself and that's checked before iterating through the list. It is done through a new `Memo` struct that I added.

### Testing:

I've updated the `check_consistency` method to include making sure that the field _always_ reflects the current state of each one of the CIDs. This check is performed (in debug mode) on each mutation of the data structure, which means all of the existing tests will catch any issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

