### PR TITLE
fix(s2n-quic-transport): optimize at_amplification_limit function

### DIFF
--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -435,11 +435,18 @@ impl<Config: endpoint::Config> Path<Config> {
     //# A PL MUST NOT send a datagram (other than a probe
     //# packet) with a size at the PL that is larger than the current
     //# PLPMTU.
+
+    /// Clamps payload sizes to the current MTU for the path
+    ///
+    /// # Panics
+    ///
+    /// Panics if this is called when the path is amplification limited
     #[inline]
     pub fn clamp_mtu(&self, requested_size: usize, transmission_mode: transmission::Mode) -> usize {
-        if self.at_amplification_limit() {
-            return 0;
-        }
+        debug_assert!(
+            !self.at_amplification_limit(),
+            "amplication limits should be checked before clamping MTU values"
+        );
 
         requested_size.min(self.mtu(transmission_mode))
     }

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -445,7 +445,7 @@ impl<Config: endpoint::Config> Path<Config> {
     pub fn clamp_mtu(&self, requested_size: usize, transmission_mode: transmission::Mode) -> usize {
         debug_assert!(
             !self.at_amplification_limit(),
-            "amplication limits should be checked before clamping MTU values"
+            "amplification limits should be checked before clamping MTU values"
         );
 
         requested_size.min(self.mtu(transmission_mode))

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -1018,8 +1018,7 @@ mod tests {
 
             path.on_bytes_transmitted(1);
             // Verify we can't transmit any more bytes
-            assert_eq!(path.clamp_mtu(1, transmission_mode), 0);
-            assert_eq!(path.clamp_mtu(10, transmission_mode), 0);
+            assert!(path.at_amplification_limit());
 
             path.on_bytes_received(1);
             // Verify we can transmit up to 3 more bytes
@@ -1086,21 +1085,13 @@ mod tests {
     }
 
     #[test]
+    #[should_panic]
     fn clamp_mtu_when_tx_more_than_rx() {
         let mut path = testing::helper_path_server();
         let mtu = 1472;
         let probed_size = 1500;
         path.mtu_controller = mtu::testing::test_controller(mtu, probed_size);
 
-        assert_eq!(0, path.clamp_mtu(10000, transmission::Mode::Normal));
-
-        path.on_bytes_received(1);
-        assert_eq!(
-            path.mtu_controller.mtu(),
-            path.clamp_mtu(10000, transmission::Mode::Normal)
-        );
-
-        path.on_bytes_transmitted(100);
         assert_eq!(0, path.clamp_mtu(10000, transmission::Mode::Normal));
     }
 


### PR DESCRIPTION
### Description of changes: 

The logic in `at_amplication_limit` was a bit confusing and needlessly complicated. This PR simplifies it a bit, which also helps perf, since this is called on every single packet we send. I've also fixed the documentation to be a bit clearer.

### Testing:

The existing tests show that the behavior is preserved.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

