### PR TITLE
fix(s2n-quic-platform): only zeroize buffers on drop

### DIFF
--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -11,13 +11,12 @@ license = "Apache-2.0"
 exclude = ["corpus.tar.gz"]
 
 [features]
-default = ["std", "tokio-runtime", "wipe"]
+default = ["std", "tokio-runtime"]
 std = ["s2n-quic-core/std", "socket2", "lazy_static"]
 testing = ["std", "generator", "futures/std", "io-testing"] # Testing allows to overwrite the system time
 io-testing = ["bach"]
 generator = ["bolero-generator", "s2n-quic-core/generator"]
 tokio-runtime = ["futures", "pin-project", "tokio"]
-wipe = ["zeroize"]
 
 [dependencies]
 bach = { version = "0.0.6", optional = true }
@@ -30,7 +29,7 @@ pin-project = { version = "1", optional = true }
 s2n-quic-core = { version = "=0.10.1", path = "../s2n-quic-core", default-features = false }
 socket2 = { version = "0.4", features = ["all"], optional = true }
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt", "time"], optional = true }
-zeroize = { version = "1", default-features = false, optional = true }
+zeroize = { version = "1", default-features = false }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"

--- a/quic/s2n-quic-platform/src/buffer/vec.rs
+++ b/quic/s2n-quic-platform/src/buffer/vec.rs
@@ -70,3 +70,10 @@ impl DerefMut for VecBuffer {
         self.region.as_mut()
     }
 }
+
+impl Drop for VecBuffer {
+    fn drop(&mut self) {
+        // The buffer could contain sensitive data so release it before freeing the memory
+        zeroize::Zeroize::zeroize(&mut self.region[..]);
+    }
+}

--- a/quic/s2n-quic-platform/src/message/queue.rs
+++ b/quic/s2n-quic-platform/src/message/queue.rs
@@ -11,7 +11,6 @@ pub use slice::Slice;
 
 pub type Free<'a, M> = Slice<'a, M, behavior::Free>;
 pub type Occupied<'a, M> = Slice<'a, M, behavior::Occupied>;
-pub type OccupiedWipe<'a, M> = Slice<'a, M, behavior::OccupiedWipe>;
 
 use crate::message;
 use core::fmt;
@@ -142,23 +141,6 @@ impl<Ring: message::Ring> Queue<Ring> {
             primary: &mut self.occupied,
             secondary: &mut self.free,
             behavior: behavior::Occupied { mtu },
-            max_gso,
-            gso_segment: None,
-            local_address: &self.local_address,
-        }
-    }
-
-    /// Returns a slice of all of the `occupied` messages
-    ///
-    /// The messages will be wiped on release.
-    pub fn occupied_wipe_mut(&mut self) -> OccupiedWipe<Ring::Message> {
-        let mtu = self.mtu();
-        let max_gso = self.max_gso();
-        Slice {
-            messages: self.ring.as_mut_slice(),
-            primary: &mut self.occupied,
-            secondary: &mut self.free,
-            behavior: behavior::OccupiedWipe { mtu },
             max_gso,
             gso_segment: None,
             local_address: &self.local_address,

--- a/quic/s2n-quic-platform/src/socket/mmsg.rs
+++ b/quic/s2n-quic-platform/src/socket/mmsg.rs
@@ -231,8 +231,8 @@ impl<B: Buffer> Queue<B> {
         }
     }
 
-    pub fn rx_queue(&mut self) -> queue::OccupiedWipe<Message> {
-        self.0.occupied_wipe_mut()
+    pub fn rx_queue(&mut self) -> queue::Occupied<Message> {
+        self.0.occupied_mut()
     }
 
     pub fn tx_queue(&mut self) -> queue::Free<Message> {

--- a/quic/s2n-quic-platform/src/socket/msg.rs
+++ b/quic/s2n-quic-platform/src/socket/msg.rs
@@ -231,8 +231,8 @@ impl<B: Buffer> Queue<B> {
         Ok(count)
     }
 
-    pub fn rx_queue(&mut self) -> queue::OccupiedWipe<Message> {
-        self.0.occupied_wipe_mut()
+    pub fn rx_queue(&mut self) -> queue::Occupied<Message> {
+        self.0.occupied_mut()
     }
 
     pub fn tx_queue(&mut self) -> queue::Free<Message> {

--- a/quic/s2n-quic-platform/src/socket/std.rs
+++ b/quic/s2n-quic-platform/src/socket/std.rs
@@ -173,8 +173,8 @@ impl<B: Buffer> Queue<B> {
         Ok(count)
     }
 
-    pub fn rx_queue(&mut self) -> queue::OccupiedWipe<Message> {
-        self.0.occupied_wipe_mut()
+    pub fn rx_queue(&mut self) -> queue::Occupied<Message> {
+        self.0.occupied_mut()
     }
 
     pub fn tx_queue(&mut self) -> queue::Free<Message> {


### PR DESCRIPTION
### Description of changes: 

On main, we currently spend about 10% of CPU cycles zeroizing packet receive buffers when receiving a lot of data. This is expensive because the `zeroize` crate does a [volatile write per byte](https://github.com/RustCrypto/utils/blob/193e7ad59ec81317bafbdbd9f9014b3dc89f9935/zeroize/src/lib.rs#L771-L784).

I believe we should change this to instead zeroize on buffer drop, since the thing we care about the most is zeroizing the packet buffers before we release them to the allocator. This completely removes any overhead when receiving a bunch of packets.

### Testing:

#### Before

[
![](https://dnglbrstg7yg.cloudfront.net/e5ae19ff115a09d29a8b041728393df85f0b69ea/perf/s2n-quic-client-s2n-quic-server/1000MB-down-0MB-up.client.svg)
](https://dnglbrstg7yg.cloudfront.net/e5ae19ff115a09d29a8b041728393df85f0b69ea/perf/s2n-quic-client-s2n-quic-server/1000MB-down-0MB-up.client.svg)

#### After
[
![](https://dnglbrstg7yg.cloudfront.net/54fc7542f8ca58c4b4434d1ddd3fe947dc1ceb21/perf/s2n-quic-client-s2n-quic-server/1000MB-down-0MB-up.client.svg)
](https://dnglbrstg7yg.cloudfront.net/54fc7542f8ca58c4b4434d1ddd3fe947dc1ceb21/perf/s2n-quic-client-s2n-quic-server/1000MB-down-0MB-up.client.svg)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

