### PR TITLE
fix(s2n-quic-core): check weighted_average difference based on weight in nanos

### DIFF
--- a/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
@@ -728,10 +728,17 @@ mod test {
 
                 let weight = 8;
 
-                // assert that the unoptimized version matches the optimized to the millisecond
+                // perform the unoptimized version
                 let expected = ((weight - 1) as u32 * a) / weight + b / weight;
                 let actual = super::weighted_average(a, b, weight as _);
-                assert_eq!(expected.as_millis(), actual.as_millis());
+
+                // assert that the unoptimized result matches the optimized to the nearest `weight` nanos
+                assert!(
+                    super::abs_difference(expected.as_nanos(), actual.as_nanos()) as u32 <= weight,
+                    "expected: {:?}; actual: {:?}",
+                    expected,
+                    actual
+                );
             })
     }
 }


### PR DESCRIPTION
### Description of changes: 

In #1491, I added a test to make sure the optimized `weighted_average` matches the unoptimized version. My test asserted the values matched to the nearest milliseconds. The problem with this approach is the result may be on the line of a full millisecond, which will get rounded down in one case and not the other:

```
======================== Test Failure ========================

BOLERO_RANDOM_SEED=13710580805818456088

Input: 
(
    655509357,
    3219434504,
)

Error: 
panicked at 'assertion failed: `(left == right)`
  left: `976`,
 right: `975`', quic\s2n-quic-core\src\recovery\rtt_estimator.rs:734:17
```

The fix is to instead take the `abs_difference` in nanos and assert that it's within the `weight`, which is precisely the amount of precision lost in our optimized, overflow-free version.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

