### PR TITLE
test(s2n-quic-transport): add a bolero harness for interval_set insert

### DIFF
--- a/quic/s2n-quic-transport/src/interval_set/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/interval_set/fuzz_target.rs
@@ -98,6 +98,20 @@ fn interval_set_test() {
     );
 }
 
+#[test]
+#[cfg_attr(kani, kani::proof, kani::unwind(2))]
+fn interval_set_inset_range_test() {
+    // Generate valid ranges (lb <= ub)
+    let gen = gen::<(i32, i32, i32)>().filter_gen(|(a, b, _c)| a <= b);
+
+    check!().with_generator(gen).for_each(|(lb, ub, elem)| {
+        let mut set: IntervalSet<i32> = IntervalSet::new();
+        let range = lb..=ub;
+        assert!(set.insert(range.clone()).is_ok());
+        assert_eq!(range.contains(&elem), set.contains(&elem));
+    });
+}
+
 fn process_operation(
     OperationTest { limit, operations }: &OperationTest,
 ) -> (Oracle, IntervalSet<RangeBound>) {


### PR DESCRIPTION
### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.-->

Add a bolero-based test that checks range insertion for `interval_set`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

