### PR TITLE
test(s2n-quic-transport) Adds proof for try_merge_receive_buffers

### DIFF
--- a/quic/s2n-quic-transport/src/buffer/receive_buffer.rs
+++ b/quic/s2n-quic-transport/src/buffer/receive_buffer.rs
@@ -657,3 +657,16 @@ impl StreamReceiveBuffer {
         *self = StreamReceiveBuffer::with_buffer_size(self.buffer_size)
     }
 }
+
+#[test]
+#[cfg_attr(kani, kani::proof)]
+fn try_merge_receive_buffers() {
+    let mut buffer = StreamReceiveBuffer::new();
+    let index: usize = kani::any();
+    kani::assume(index < usize::MAX);
+    let slot_pos: SlotPosition = SlotPosition {
+        offset: kani::any(),
+        index,
+    };
+    buffer.try_merge_receive_buffers(slot_pos, kani::any(), kani::any());
+}


### PR DESCRIPTION
### Resolved issues:

N/A
### Description of changes: 

Kani proof for try_merge_receive_buffers function.

### Call-outs:

Notice I had to add an assert that index is smaller than a max usize. I ~think~ this is a reasonable assumption, but lmk if it is not. Also, I did not use a bolero macro for this? Let me know if I should actually try to make this into a bolero proof.

### Testing:

Proof passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

