### PR TITLE
testing: kani test for packet number map

### DIFF
--- a/quic/s2n-quic-core/src/packet/number/map.rs
+++ b/quic/s2n-quic-core/src/packet/number/map.rs
@@ -770,26 +770,20 @@ mod tests {
             .for_each(|ops| model(ops))
     }
 
-
     #[test]
-    #[cfg_attr(kani, kani::proof, kani::unwind(9))]
-    fn kani_test() {
-        // Confirm that a 
-        let gen = gen::<VarInt>();
+    #[cfg_attr(kani, kani::proof, kani::unwind(9), kani::solver(kissat))]
+    fn insert_value() {
+        // Confirm that a value is inserted
+        check!().with_type().cloned().for_each(|pn| {
+            let space = PacketNumberSpace::ApplicationData;
+            let mut map = Map::default();
+            assert!(map.is_empty());
+            let pn = space.new_packet_number(pn);
 
-        check!()
-            .with_generator(gen)
-            .cloned()
-            .for_each(|pn| {
-                let space = PacketNumberSpace::ApplicationData;
-                let mut map = Map::default();
-                assert!(map.is_empty());
-                let pn = space.new_packet_number(pn);
+            map.insert(pn, ());
 
-                map.insert(pn, ());
-
-                assert!(map.get(pn).is_some());
-                assert!(!map.is_empty());
-            });
+            assert!(map.get(pn).is_some());
+            assert!(!map.is_empty());
+        });
     }
 }

--- a/quic/s2n-quic-core/src/packet/number/map.rs
+++ b/quic/s2n-quic-core/src/packet/number/map.rs
@@ -769,4 +769,27 @@ mod tests {
             .with_type::<Vec<Operation>>()
             .for_each(|ops| model(ops))
     }
+
+
+    #[test]
+    #[cfg_attr(kani, kani::proof, kani::unwind(9))]
+    fn kani_test() {
+        // Confirm that a 
+        let gen = gen::<VarInt>();
+
+        check!()
+            .with_generator(gen)
+            .cloned()
+            .for_each(|pn| {
+                let space = PacketNumberSpace::ApplicationData;
+                let mut map = Map::default();
+                assert!(map.is_empty());
+                let pn = space.new_packet_number(pn);
+
+                map.insert(pn, ());
+
+                assert!(map.get(pn).is_some());
+                assert!(!map.is_empty());
+            });
+    }
 }


### PR DESCRIPTION
Adds a kani proof. Note that this takes approx 30 min on my mac to run.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

