### PR TITLE
test(s2n-quic-core) Kani proofs for VarInt + Random

### DIFF
--- a/quic/s2n-quic-core/src/random.rs
+++ b/quic/s2n-quic-core/src/random.rs
@@ -75,8 +75,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
-    #[cfg_attr(kani, kani::proof)] 
-    #[cfg_attr(kani, kani::unwind(10))]
+    #[cfg_attr(kani, kani::proof, kani::unwind(10))]
     fn gen_range_biased_test() {
         bolero::check!()
             .with_type()

--- a/quic/s2n-quic-core/src/random.rs
+++ b/quic/s2n-quic-core/src/random.rs
@@ -75,6 +75,8 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
+    #[cfg_attr(kani, kani::proof)] 
+    #[cfg_attr(kani, kani::unwind(10))]
     fn gen_range_biased_test() {
         bolero::check!()
             .with_type()

--- a/quic/s2n-quic-core/src/slice.rs
+++ b/quic/s2n-quic-core/src/slice.rs
@@ -88,7 +88,7 @@ where
     count
 }
 
-#[cfg(any(test, kani))]
+#[cfg(test)]
 mod tests {
     use super::*;
     use bolero::{check, generator::*};

--- a/quic/s2n-quic-core/src/varint/tests.rs
+++ b/quic/s2n-quic-core/src/varint/tests.rs
@@ -69,6 +69,19 @@ sequence_test!(two_byte_sequence_test([0x7b, 0xbd], 15293));
 
 sequence_test!(one_byte_sequence_test([0x25], 37));
 
+//= https://www.rfc-editor.org/rfc/rfc9000#section-16
+//= type=test
+// # +======+========+=============+=======================+
+// # | 2MSB | Length | Usable Bits | Range                 |
+// # +======+========+=============+=======================+
+// # | 00   | 1      | 6           | 0-63                  |
+// # +------+--------+-------------+-----------------------+
+// # | 01   | 2      | 14          | 0-16383               |
+// # +------+--------+-------------+-----------------------+
+// # | 10   | 4      | 30          | 0-1073741823          |
+// # +------+--------+-------------+-----------------------+
+// # | 11   | 8      | 62          | 0-4611686018427387903 |
+// # +------+--------+-------------+-----------------------+
 #[test]
 #[cfg_attr(miri, ignore)]
 #[cfg_attr(kani, kani::proof)]
@@ -77,10 +90,6 @@ fn kani_one_byte_sequence_test() {
         .with_type()
         .cloned()
         .for_each(|mut first_byte: u8| {
-            //= https://www.rfc-editor.org/rfc/rfc9000#section-16
-            //= type=test
-            //# One byte sequences have the first two MSBs encoded as 00; the
-            //# last six bits are the usable values.
             first_byte &= 0x3f;
             let byte_sequence = [first_byte];
             let expected = VarInt::new(first_byte as u64).unwrap();
@@ -103,10 +112,6 @@ fn kani_two_byte_sequence_test() {
         .with_generator(g)
         .cloned()
         .for_each(|(mut first_byte, second_byte)| {
-            //= https://www.rfc-editor.org/rfc/rfc9000#section-16
-            //= type=test
-            //# two byte sequences have the first two msbs encoded as 01; the
-            //# last 14 bits are the usable values.
             first_byte = (first_byte & 0x3f) | 0x40;
             let byte_sequence = [first_byte, second_byte];
             let expected_val = u16::from_be_bytes([first_byte & 0x3f, second_byte]);
@@ -131,10 +136,6 @@ fn kani_four_byte_sequence_test() {
         .with_generator(g)
         .cloned()
         .for_each(|(mut first_byte, second_byte, third_byte)| {
-            //= https://www.rfc-editor.org/rfc/rfc9000#section-16
-            //= type=test
-            //# Four byte sequences have the first two MSBs encoded as 10; the
-            //# last 30 bits are the usable values.
             first_byte = (first_byte & 0x3f) | 0x80;
             let byte_sequence = [first_byte, second_byte, third_byte, 0xff];
             let expected_val: u32 =

--- a/quic/s2n-quic-core/src/varint/tests.rs
+++ b/quic/s2n-quic-core/src/varint/tests.rs
@@ -161,10 +161,6 @@ fn kani_eight_byte_sequence_test() {
         .with_generator(g)
         .cloned()
         .for_each(|(mut first_byte, second_byte, third_byte, fourth_byte)| {
-            //= https://www.rfc-editor.org/rfc/rfc9000#section-16
-            //= type=test
-            //# Eight byte sequences have the first two MSBs encoded as 11; the
-            //# last 62 bits are the usable values.
             first_byte = (first_byte & 0x3f) | 0xc0;
             let byte_sequence = [
                 first_byte,

--- a/quic/s2n-quic-core/src/varint/tests.rs
+++ b/quic/s2n-quic-core/src/varint/tests.rs
@@ -4,8 +4,7 @@
 use super::*;
 use crate::varint::VarInt;
 use bolero::check;
-use s2n_codec::assert_codec_round_trip_bytes;
-use s2n_codec::assert_codec_round_trip_value;
+use s2n_codec::{assert_codec_round_trip_bytes, assert_codec_round_trip_value};
 
 #[test]
 #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time

--- a/quic/s2n-quic-core/src/varint/tests.rs
+++ b/quic/s2n-quic-core/src/varint/tests.rs
@@ -68,3 +68,87 @@ sequence_test!(four_byte_sequence_test(
 sequence_test!(two_byte_sequence_test([0x7b, 0xbd], 15293));
 
 sequence_test!(one_byte_sequence_test([0x25], 37));
+
+mod tests {
+    use super::*;
+    use s2n_codec::assert_codec_round_trip_value;
+
+    #[cfg(kani)]
+    #[kani::proof]
+    fn kani_one_byte_sequence_test() {
+        // https://www.rfc-editor.org/rfc/rfc9000#section-16
+        // One byte sequences have the first two MSBs encoded as 00; the
+        // last six bits are the usable values.
+        let first_byte: u8 = kani::any::<u8>() & 0x3f;
+        let byte_sequence = [first_byte];
+        let expected = VarInt::new(first_byte as u64).unwrap();
+        let actual_bytes = assert_codec_round_trip_value!(VarInt, expected);
+        assert_eq!(&byte_sequence[..], &actual_bytes[..]);
+    }
+
+    #[cfg(kani)]
+    #[kani::proof]
+    fn kani_two_byte_sequence_test() {
+        // https://www.rfc-editor.org/rfc/rfc9000#section-16
+        // Two byte sequences have the first two MSBs encoded as 01; the
+        // last 14 bits are the usable values.
+        let first_byte: u8 = (kani::any::<u8>() & 0x2f) | 0x40;
+        let second_byte: u8 = kani::any();
+        // The s2n-quic implementation always chooses the smallest encoding possible.
+        // This means if we wish to test two-byte sequences, we need to encode a number
+        // that is > 63.
+        kani::assume(second_byte > 63);
+        let byte_sequence = [first_byte, second_byte];
+        let expected_val: u64 = (((first_byte & 0x3f) as u64) << 8) | (second_byte as u64);
+        assert!(expected_val <= 16383);
+        let expected = VarInt::new(expected_val).unwrap();
+        let actual_bytes = assert_codec_round_trip_value!(VarInt, expected);
+        assert_eq!(&byte_sequence[..], &actual_bytes[..]);
+    }
+
+    #[cfg(kani)]
+    #[kani::proof]
+    fn kani_four_byte_sequence_test() {
+        // https://www.rfc-editor.org/rfc/rfc9000#section-16
+        // Four byte sequences have the first two MSBs encoded as 10; the
+        // last 30 bits are the usable values.
+        let first_byte: u8 = (kani::any::<u8>() & 0x3f) | 0x80;
+        let second_byte: u8 = kani::any();
+        // The s2n-quic implementation always chooses the smallest encoding possible.
+        // This means if we wish to test the four-byte sequences, we need to encode a number
+        // that is > 16383 or 0b0011 1111 1111 1111.
+        let third_byte: u8 = kani::any();
+        kani::assume(third_byte > 0x3f);
+        let byte_sequence = [first_byte, second_byte, third_byte, 0xff];
+        let expected_val: u64 = (((first_byte & 0x3f) as u64) << 24) 
+            | (second_byte as u64) << 16 | (third_byte as u64) << 8 | 0xff;
+        assert!(expected_val <= 1073741823);
+        let expected = VarInt::new(expected_val).unwrap();
+        let actual_bytes = assert_codec_round_trip_value!(VarInt, expected);
+        assert_eq!(&byte_sequence[..], &actual_bytes[..]);
+    }
+
+    #[cfg(kani)]
+    #[kani::proof]
+    fn kani_eight_byte_sequence_test() {
+        // https://www.rfc-editor.org/rfc/rfc9000#section-16
+        // Eight byte sequences have the first two MSBs encoded as 11; the
+        // last 62 bits are the usable values.
+        let first_byte: u8 = (kani::any::<u8>() & 0x3f) | 0xc0;
+        let second_byte: u8 = kani::any();
+        // The s2n-quic implementation always chooses the smallest encoding possible.
+        // This means if we wish to test eight-byte sequences, we need to encode a number
+        // that is > 1073741823 or 0b0011 1111 1111 1111 1111 1111 1111 1111
+        let third_byte: u8 = kani::any();
+        let fourth_byte: u8 = kani::any();
+        kani::assume(fourth_byte > 0x3f);
+        let byte_sequence = [first_byte, second_byte, third_byte, fourth_byte, 0xff, 0xff, 0xff, 0xff];
+        let expected_val: u64 = (((first_byte & 0x3f) as u64) << 56) 
+            | (second_byte as u64) << 48 | (third_byte as u64) << 40 | (fourth_byte as u64) << 32 
+            | (0xff << 24) | (0xff << 16) | (0xff << 8) | 0xff;
+        assert!(expected_val <= 4611686018427387903);
+        let expected = VarInt::new(expected_val).unwrap();
+        let actual_bytes = assert_codec_round_trip_value!(VarInt, expected);
+        assert_eq!(&byte_sequence[..], &actual_bytes[..]);
+    }
+}

--- a/quic/s2n-quic-core/src/varint/tests.rs
+++ b/quic/s2n-quic-core/src/varint/tests.rs
@@ -5,6 +5,7 @@ use super::*;
 use crate::varint::VarInt;
 use bolero::check;
 use s2n_codec::assert_codec_round_trip_bytes;
+use s2n_codec::assert_codec_round_trip_value;
 
 #[test]
 #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
@@ -69,86 +70,125 @@ sequence_test!(two_byte_sequence_test([0x7b, 0xbd], 15293));
 
 sequence_test!(one_byte_sequence_test([0x25], 37));
 
-mod tests {
-    use super::*;
-    use s2n_codec::assert_codec_round_trip_value;
+#[test]
+#[cfg_attr(miri, ignore)]
+#[cfg_attr(kani, kani::proof)]
+fn kani_one_byte_sequence_test() {
+    bolero::check!()
+        .with_type()
+        .cloned()
+        .for_each(|mut first_byte: u8| {
+            //= https://www.rfc-editor.org/rfc/rfc9000#section-16
+            //= type=test
+            //# One byte sequences have the first two MSBs encoded as 00; the
+            //# last six bits are the usable values.
+            first_byte &= 0x3f;
+            let byte_sequence = [first_byte];
+            let expected = VarInt::new(first_byte as u64).unwrap();
+            let actual_bytes = assert_codec_round_trip_value!(VarInt, expected);
+            assert_eq!(&byte_sequence[..], &actual_bytes[..]);
+        });
+}
 
-    #[cfg(kani)]
-    #[kani::proof]
-    fn kani_one_byte_sequence_test() {
-        // https://www.rfc-editor.org/rfc/rfc9000#section-16
-        // One byte sequences have the first two MSBs encoded as 00; the
-        // last six bits are the usable values.
-        let first_byte: u8 = kani::any::<u8>() & 0x3f;
-        let byte_sequence = [first_byte];
-        let expected = VarInt::new(first_byte as u64).unwrap();
-        let actual_bytes = assert_codec_round_trip_value!(VarInt, expected);
-        assert_eq!(&byte_sequence[..], &actual_bytes[..]);
-    }
+#[test]
+#[cfg_attr(miri, ignore)]
+#[cfg_attr(kani, kani::proof)]
+fn kani_two_byte_sequence_test() {
+    // the s2n-quic implementation always chooses the smallest encoding possible.
+    // this means if we wish to test two-byte sequences, we need to encode a number
+    // that is > 63.
+    let g = gen::<(u8, u8)>().filter_gen(|(_, b)| *b > 63);
 
-    #[cfg(kani)]
-    #[kani::proof]
-    fn kani_two_byte_sequence_test() {
-        // https://www.rfc-editor.org/rfc/rfc9000#section-16
-        // Two byte sequences have the first two MSBs encoded as 01; the
-        // last 14 bits are the usable values.
-        let first_byte: u8 = (kani::any::<u8>() & 0x2f) | 0x40;
-        let second_byte: u8 = kani::any();
-        // The s2n-quic implementation always chooses the smallest encoding possible.
-        // This means if we wish to test two-byte sequences, we need to encode a number
-        // that is > 63.
-        kani::assume(second_byte > 63);
-        let byte_sequence = [first_byte, second_byte];
-        let expected_val: u64 = (((first_byte & 0x3f) as u64) << 8) | (second_byte as u64);
-        assert!(expected_val <= 16383);
-        let expected = VarInt::new(expected_val).unwrap();
-        let actual_bytes = assert_codec_round_trip_value!(VarInt, expected);
-        assert_eq!(&byte_sequence[..], &actual_bytes[..]);
-    }
+    bolero::check!()
+        .with_type::<(u8, u8)>()
+        .with_generator(g)
+        .cloned()
+        .for_each(|(mut first_byte, second_byte)| {
+            //= https://www.rfc-editor.org/rfc/rfc9000#section-16
+            //= type=test
+            //# two byte sequences have the first two msbs encoded as 01; the
+            //# last 14 bits are the usable values.
+            first_byte = (first_byte & 0x3f) | 0x40;
+            let byte_sequence = [first_byte, second_byte];
+            let expected_val = u16::from_be_bytes([first_byte & 0x3f, second_byte]);
+            assert!(expected_val <= 16383);
+            let expected = VarInt::new(expected_val as u64).unwrap();
+            let actual_bytes = assert_codec_round_trip_value!(VarInt, expected);
+            assert_eq!(&byte_sequence[..], &actual_bytes[..]);
+        });
+}
 
-    #[cfg(kani)]
-    #[kani::proof]
-    fn kani_four_byte_sequence_test() {
-        // https://www.rfc-editor.org/rfc/rfc9000#section-16
-        // Four byte sequences have the first two MSBs encoded as 10; the
-        // last 30 bits are the usable values.
-        let first_byte: u8 = (kani::any::<u8>() & 0x3f) | 0x80;
-        let second_byte: u8 = kani::any();
-        // The s2n-quic implementation always chooses the smallest encoding possible.
-        // This means if we wish to test the four-byte sequences, we need to encode a number
-        // that is > 16383 or 0b0011 1111 1111 1111.
-        let third_byte: u8 = kani::any();
-        kani::assume(third_byte > 0x3f);
-        let byte_sequence = [first_byte, second_byte, third_byte, 0xff];
-        let expected_val: u64 = (((first_byte & 0x3f) as u64) << 24) 
-            | (second_byte as u64) << 16 | (third_byte as u64) << 8 | 0xff;
-        assert!(expected_val <= 1073741823);
-        let expected = VarInt::new(expected_val).unwrap();
-        let actual_bytes = assert_codec_round_trip_value!(VarInt, expected);
-        assert_eq!(&byte_sequence[..], &actual_bytes[..]);
-    }
+#[test]
+#[cfg_attr(miri, ignore)]
+#[cfg_attr(kani, kani::proof)]
+fn kani_four_byte_sequence_test() {
+    // The s2n-quic implementation always chooses the smallest encoding possible.
+    // This means if we wish to test the four-byte sequences, we need to encode a number
+    // that is > 16383 or 0b0011 1111 1111 1111.
+    let g = gen::<(u8, u8, u8)>().filter_gen(|(_, _, c)| *c > 0x3f);
 
-    #[cfg(kani)]
-    #[kani::proof]
-    fn kani_eight_byte_sequence_test() {
-        // https://www.rfc-editor.org/rfc/rfc9000#section-16
-        // Eight byte sequences have the first two MSBs encoded as 11; the
-        // last 62 bits are the usable values.
-        let first_byte: u8 = (kani::any::<u8>() & 0x3f) | 0xc0;
-        let second_byte: u8 = kani::any();
-        // The s2n-quic implementation always chooses the smallest encoding possible.
-        // This means if we wish to test eight-byte sequences, we need to encode a number
-        // that is > 1073741823 or 0b0011 1111 1111 1111 1111 1111 1111 1111
-        let third_byte: u8 = kani::any();
-        let fourth_byte: u8 = kani::any();
-        kani::assume(fourth_byte > 0x3f);
-        let byte_sequence = [first_byte, second_byte, third_byte, fourth_byte, 0xff, 0xff, 0xff, 0xff];
-        let expected_val: u64 = (((first_byte & 0x3f) as u64) << 56) 
-            | (second_byte as u64) << 48 | (third_byte as u64) << 40 | (fourth_byte as u64) << 32 
-            | (0xff << 24) | (0xff << 16) | (0xff << 8) | 0xff;
-        assert!(expected_val <= 4611686018427387903);
-        let expected = VarInt::new(expected_val).unwrap();
-        let actual_bytes = assert_codec_round_trip_value!(VarInt, expected);
-        assert_eq!(&byte_sequence[..], &actual_bytes[..]);
-    }
+    bolero::check!()
+        .with_type::<(u8, u8, u8)>()
+        .with_generator(g)
+        .cloned()
+        .for_each(|(mut first_byte, second_byte, third_byte)| {
+            //= https://www.rfc-editor.org/rfc/rfc9000#section-16
+            //= type=test
+            //# Four byte sequences have the first two MSBs encoded as 10; the
+            //# last 30 bits are the usable values.
+            first_byte = (first_byte & 0x3f) | 0x80;
+            let byte_sequence = [first_byte, second_byte, third_byte, 0xff];
+            let expected_val: u32 =
+                u32::from_be_bytes([first_byte & 0x3f, second_byte, third_byte, 0xff]);
+            assert!(expected_val <= 1073741823);
+            let expected = VarInt::new(expected_val as u64).unwrap();
+            let actual_bytes = assert_codec_round_trip_value!(VarInt, expected);
+            assert_eq!(&byte_sequence[..], &actual_bytes[..]);
+        });
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+#[cfg_attr(kani, kani::proof)]
+fn kani_eight_byte_sequence_test() {
+    // The s2n-quic implementation always chooses the smallest encoding possible.
+    // This means if we wish to test eight-byte sequences, we need to encode a number
+    // that is > 1073741823 or 0b0011 1111 1111 1111 1111 1111 1111 1111
+    let g = gen::<(u8, u8, u8, u8)>().filter_gen(|(_, _, _, d)| *d > 0x3f);
+
+    bolero::check!()
+        .with_type::<(u8, u8, u8, u8)>()
+        .with_generator(g)
+        .cloned()
+        .for_each(|(mut first_byte, second_byte, third_byte, fourth_byte)| {
+            //= https://www.rfc-editor.org/rfc/rfc9000#section-16
+            //= type=test
+            //# Eight byte sequences have the first two MSBs encoded as 11; the
+            //# last 62 bits are the usable values.
+            first_byte = (first_byte & 0x3f) | 0xc0;
+            let byte_sequence = [
+                first_byte,
+                second_byte,
+                third_byte,
+                fourth_byte,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+            ];
+            let expected_val: u64 = u64::from_be_bytes([
+                first_byte & 0x3f,
+                second_byte,
+                third_byte,
+                fourth_byte,
+                0xff,
+                0xff,
+                0xff,
+                0xff,
+            ]);
+            assert!(expected_val <= 4611686018427387903);
+            let expected = VarInt::new(expected_val).unwrap();
+            let actual_bytes = assert_codec_round_trip_value!(VarInt, expected);
+            assert_eq!(&byte_sequence[..], &actual_bytes[..]);
+        });
 }


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

* Added Kani hook for a `random` test harness
* Added Kani test harness for `VarInt`

### Call-outs:

### Testing:

Kani proof passes. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

