### PR TITLE
fix(s2n-quic-core): don't reduce lower bounds during BBR startup

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -146,9 +146,28 @@ impl State {
         false
     }
 
+    /// True if the current state is ProbeBw and the CyclePhase is `Refill`
+    fn is_probing_bw_refill(&self) -> bool {
+        if let State::ProbeBw(probe_bw_state) = self {
+            return probe_bw_state.cycle_phase() == CyclePhase::Refill;
+        }
+        false
+    }
+
     /// True if the current state is ProbeRtt
     fn is_probing_rtt(&self) -> bool {
         matches!(self, State::ProbeRtt(_))
+    }
+
+    /// True if BBR is accelerating sending in order to probe for bandwidth
+    ///
+    /// Note: This is not the same as `is_probing_bw`, as states other than
+    ///       `State::ProbingBw` are also considered as probing for bandwidth
+    ///       and not every `ProbingBw` sub-state is actually probing.
+    ///
+    /// See https://github.com/google/bbr/blob/a23c4bb59e0c5a505fc0f5cc84c4d095a64ed361/net/ipv4/tcp_bbr2.c#L1348
+    fn is_probing_for_bandwidth(&self) -> bool {
+        self.is_startup() || self.is_probing_bw_up() || self.is_probing_bw_refill()
     }
 
     /// Transition to the given `new_state`

--- a/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
@@ -34,7 +34,7 @@ impl State {
         delivered_bytes: u64,
         data_rate_model: &mut data_rate::Model,
         data_volume_model: &mut data_volume::Model,
-        is_probing_bw: bool,
+        is_probing_for_bandwidth: bool,
         cwnd: u32,
         ecn_alpha: f64,
     ) {
@@ -71,7 +71,10 @@ impl State {
         }
 
         if self.loss_round_counter.round_start() {
-            if !is_probing_bw {
+            //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.3
+            //# When not explicitly accelerating to probe for bandwidth (Drain, ProbeRTT,
+            //# ProbeBW_DOWN, ProbeBW_CRUISE), BBR responds to loss by slowing down to some extent.
+            if !is_probing_for_bandwidth {
                 //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.3
                 //# BBRAdaptLowerBoundsFromCongestion():
                 //#   if (BBRIsProbingBW())
@@ -173,7 +176,7 @@ impl BbrCongestionController {
             self.bw_estimator.delivered_bytes(),
             &mut self.data_rate_model,
             &mut self.data_volume_model,
-            self.state.is_probing_bw(),
+            self.state.is_probing_for_bandwidth(),
             self.cwnd,
             self.ecn_state.alpha(),
         );


### PR DESCRIPTION
### Description of changes: 

This change fixes the behavior of BBR during Startup so that when loss is encountered during Startup, the short term data volume and data rate bounds are not updated. The original code assumed the `BBRIsProbingBW()` function mentioned (but not defined) in the [BBR RFC](https://www.ietf.org/archive/id/draft-cardwell-iccrg-bbr-congestion-control-02.html#section-4.5.6.3) should return true only if BBR is in the ProbeBW state. After looking at the [TCP Linux BBR implementation](https://github.com/google/bbr/blob/a23c4bb59e0c5a505fc0f5cc84c4d095a64ed361/net/ipv4/tcp_bbr2.c#L1348) and the [Chromium implementation](https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quiche/quic/core/congestion_control/bbr2_startup.h;l=40;drc=f97e7e130b02a0fee5a06aa9cdf25d3a0a3715d0;bpv=0;bpt=0), this is not correct. 

The text at the beginning section 4.5.6.3 also makes this clear:
> When not explicitly accelerating to probe for bandwidth (Drain, ProbeRTT, ProbeBW_DOWN, ProbeBW_CRUISE), BBR responds to loss by slowing down to some extent.

### Testing:

Added a unit test


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

