### PR TITLE
fix(s2n-quic-core): remove modulate cwnd for recovery in BBR

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bbr/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/tests.rs
@@ -517,31 +517,6 @@ fn bound_cwnd_for_model() {
     assert_eq!(4800, bbr.bound_cwnd_for_model());
 }
 
-//= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.4
-//= type=test
-//#   if (BBR.packet_conservation)
-//#     cwnd = max(cwnd, packets_in_flight + rs.newly_acked)
-#[test]
-fn set_cwnd_packet_conservation() {
-    let mut bbr = BbrCongestionController::new(MINIMUM_MTU);
-    let now = NoopClock.get_time();
-    assert_eq!(36_000, bbr.max_inflight());
-
-    bbr.recovery_state.on_congestion_event(now);
-    assert!(bbr.recovery_state.packet_conservation());
-
-    bbr.cwnd = 12_000;
-    bbr.bytes_in_flight = Counter::new(12_500);
-    bbr.set_cwnd(1000);
-    assert_eq!(13_500, bbr.cwnd);
-
-    bbr.cwnd = 14_000;
-    bbr.set_cwnd(1000);
-    assert_eq!(14_000, bbr.cwnd);
-
-    assert!(!bbr.try_fast_path);
-}
-
 //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.6
 //= type=test
 //#     if (BBR.filled_pipe)
@@ -720,25 +695,6 @@ fn restore_cwnd() {
     bbr.restore_cwnd();
 
     assert_eq!(2000, bbr.cwnd);
-}
-
-//= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.4
-//= type=test
-//# BBRModulateCwndForRecovery():
-//#   if (rs.newly_lost > 0)
-//#     cwnd = max(cwnd - rs.newly_lost, 1)
-#[test]
-fn modulate_cwnd_for_recovery() {
-    let mut bbr = BbrCongestionController::new(MINIMUM_MTU);
-    bbr.cwnd = 100_000;
-
-    bbr.modulate_cwnd_for_recovery(1000);
-    assert_eq!(99_000, bbr.congestion_window());
-
-    // Don't drop below the minimum window
-    bbr.cwnd = bbr.minimum_window();
-    bbr.modulate_cwnd_for_recovery(1000);
-    assert_eq!(bbr.minimum_window(), bbr.congestion_window());
 }
 
 //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.6.4.4


### PR DESCRIPTION
### Description of changes: 

The BBR draft RFC contains pseudocode showing the congestion window being decreased when packets are determined to be lost:

```
BBRModulateCwndForRecovery():
    if (rs.newly_lost > 0)
      cwnd = max(cwnd - rs.newly_lost, 1)
    if (BBR.packet_conservation)
      cwnd = max(cwnd, packets_in_flight + rs.newly_acked)
```

This pseudocode has been in the RFC in the 00 draft, which was a specification for BBRv1. Looking at the Chromium and TCP Linux implementations of BBRv2, this pseudocode is not in those implementations. I do see the implementation in the BBRv1 implementations ([Chromium](https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quiche/quic/core/congestion_control/bbr_sender.cc;l=794) | [TCP](https://github.com/torvalds/linux/blob/master/net/ipv4/tcp_bbr.c#L479)). This leads me to believe that this pseudocode is left over from BBRv1 and has not been revised properly for BBRv2. Thus, this PR removes this function.

Running the Monte Carlo simulations with this updated code shows some improvement in connection duration:

Before:
<img width="686" alt="Screen Shot 2022-09-27 at 11 25 16 AM" src="https://user-images.githubusercontent.com/55108558/192606693-d9f691ba-3b42-4fca-a200-9c80ba1cc915.png">

After:
<img width="725" alt="Screen Shot 2022-09-26 at 11 48 01 AM" src="https://user-images.githubusercontent.com/55108558/192606010-6e9cac66-d613-4832-bafd-94ff9bd52596.png">

### Call-outs:

Now that this code is removed, there is no longer any actual use of the `packet_conservation` state in `recovery.rs`. I've left that code as is though, in anticipation that there will be further revisions of the BBR RFC that will make use of it.

### Testing:

Local testing and monte carlo simulations

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

