### PR TITLE
fix(s2n-quic-transport): make Ack + Padding packets not congestion controlled

### DIFF
--- a/quic/s2n-quic-core/src/frame/congestion_controlled.rs
+++ b/quic/s2n-quic-core/src/frame/congestion_controlled.rs
@@ -31,7 +31,23 @@ impl CongestionControlled for crate::frame::MaxStreamData {}
 impl CongestionControlled for crate::frame::MaxStreams {}
 impl CongestionControlled for crate::frame::NewConnectionId<'_> {}
 impl CongestionControlled for crate::frame::NewToken<'_> {}
-impl CongestionControlled for crate::frame::Padding {}
+impl CongestionControlled for crate::frame::Padding {
+    //= https://www.rfc-editor.org/rfc/rfc9002#section-2
+    //= type=exception
+    //= reason=https://github.com/aws/s2n-quic/pull/1514
+    //# Packets are considered in flight when they are ack-eliciting or contain a PADDING frame
+
+    //= https://www.rfc-editor.org/rfc/rfc9002#section-3
+    //= type=exception
+    //= reason=https://github.com/aws/s2n-quic/pull/1514
+    //# PADDING frames cause packets to contribute toward bytes in
+    //# flight without directly causing an acknowledgment to be sent.
+
+    #[inline]
+    fn is_congestion_controlled(&self) -> bool {
+        false
+    }
+}
 impl CongestionControlled for crate::frame::PathChallenge<'_> {}
 impl CongestionControlled for crate::frame::PathResponse<'_> {}
 impl CongestionControlled for crate::frame::Ping {}

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -155,6 +155,9 @@ pub struct CubicCongestionController {
     //# Packets only containing ACK frames do not count toward
     //# bytes_in_flight to ensure congestion control does not impede
     //# congestion feedback.
+
+    // ACK + PADDING packets do not contribute to bytes_in_flight
+    // See https://github.com/aws/s2n-quic/pull/1514
     bytes_in_flight: BytesInFlight,
     time_of_last_sent_packet: Option<Timestamp>,
     under_utilized: bool,

--- a/quic/s2n-quic-transport/src/transmission/mod.rs
+++ b/quic/s2n-quic-transport/src/transmission/mod.rs
@@ -102,24 +102,12 @@ impl<'a, 'sub, Config: endpoint::Config, P: Payload> PacketPayloadEncoder
             // if we've only got a few bytes left in the buffer may as well pad it to full
             // capacity
             let remaining_capacity = context.buffer.remaining_capacity();
-            let min_indistinguishable_packet_len =
-                stateless_reset::min_indistinguishable_packet_len(tag_len);
-            if remaining_capacity < min_indistinguishable_packet_len {
+            if remaining_capacity < stateless_reset::min_indistinguishable_packet_len(tag_len) {
                 length = remaining_capacity;
             }
 
             if length > 0 {
-                let is_congestion_controlled = context.outcome.is_congestion_controlled;
-                // Use `write_frame_forced` to bypass congestion controller checks
-                // since we still want to send this packet despite Padding being
-                // congestion controlled.
-                context.write_frame_forced(&Padding { length });
-                if length < min_indistinguishable_packet_len {
-                    // Restore previous `is_congestion_controlled` value as we don't want Padding
-                    // alone to cause a small, non-congestion controlled packet (such as an Ack-only
-                    // packet) to become congestion controlled.
-                    context.outcome.is_congestion_controlled = is_congestion_controlled;
-                }
+                context.write_frame(&Padding { length });
             }
 
             {


### PR DESCRIPTION
### Description of changes: 

Currently, it is almost impossible for s2n-quic to construct a packet that is not congestion controlled, despite this statement from the RFC:

> Packets only containing ACK frames do not count toward bytes_in_flight to ensure congestion control does not impede congestion feedback.

This is because we enforce a [minimum indistinguishable packet len](https://github.com/aws/s2n-quic/blob/a904cdf3bc9a991474e76a58a6570f61d7092c4b/quic/s2n-quic-core/src/packet/stateless_reset.rs#L33) that ends up being 53 bytes. Since an Ack frame is often less than 53 bytes, we add padding, which then makes the whole packet count against congestion control:

> PADDING frames cause packets to contribute toward bytes in flight without directly causing an acknowledgment to be sent.

The result is that we seem to almost always have at least 53 bytes in flight (due to the ack delay timer), even during application idle periods. This has consequence for BBR in that it prevents BBR from performing some [specific actions](https://www.ietf.org/archive/id/draft-cardwell-iccrg-bbr-congestion-control-02.html#section-4.4.3) it is supposed to take when resuming from idle, since it specifically checks for bytes_in_flight == 0.

This change makes it so that packets that were not congestion-controlled prior to adding a small amount of padding, continue to be not congestion-controlled after padding.

### Testing:

Local testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

