### PR TITLE
fix(s2n-quic-core): allow cwnd to grow past max_inflight while less than 2 * initial_cwnd

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -751,8 +751,13 @@ impl BbrCongestionController {
                 cwnd = max_inflight;
                 self.try_fast_path = true;
             }
-        } else if cwnd < max_inflight || self.bw_estimator.delivered_bytes() < initial_cwnd as u64 {
+        } else if cwnd < max_inflight
+            || self.bw_estimator.delivered_bytes() < 2 * initial_cwnd as u64
+        {
             // cwnd has room to grow, or so little data has been delivered that max_inflight should not be used
+            // The Linux TCP BBRv2 implementation and Chromium BBRv2 implementation both use 2 * initial_cwnd here
+            // See https://github.com/google/bbr/blob/1ee29b79317a3028ed1fcd85cb46da009f45de00/net/ipv4/tcp_bbr2.c#L931
+            // and https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quiche/quic/core/congestion_control/bbr2_sender.cc;l=404;bpv=1;bpt=1
             cwnd += newly_acked as u32;
         } else {
             self.try_fast_path = true;

--- a/quic/s2n-quic-core/src/recovery/bbr/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/tests.rs
@@ -556,12 +556,12 @@ fn set_cwnd_not_filled_pipe() {
     bbr.set_cwnd(1000);
     assert_eq!(13_000, bbr.cwnd);
 
-    // cwnd > BBR.max_inflight, but C.delivered < InitialCwnd
+    // cwnd > BBR.max_inflight, but C.delivered < 2 * InitialCwnd
     bbr.cwnd = 40_000;
     bbr.set_cwnd(1000);
     assert_eq!(41_000, bbr.cwnd);
 
-    // Set C.delivered > InitialCwnd
+    // Set C.delivered > 2 * InitialCwnd
     let packet_info = PacketInfo {
         delivered_bytes: 0,
         delivered_time: now,
@@ -572,7 +572,7 @@ fn set_cwnd_not_filled_pipe() {
         is_app_limited: false,
     };
     bbr.bw_estimator.on_ack(
-        BbrCongestionController::initial_window(MINIMUM_MTU) as usize + 1,
+        2 * BbrCongestionController::initial_window(MINIMUM_MTU) as usize + 1,
         now,
         packet_info,
         now,


### PR DESCRIPTION
### Description of changes: 

The BBRv2 RFC specifies that during startup, the congestion window may grow beyond `max_inflight` as long as the amount of delivered data has not exceeded the initial congestion window. Both the [Linux TCP](https://github.com/google/bbr/blob/1ee29b79317a3028ed1fcd85cb46da009f45de00/net/ipv4/tcp_bbr2.c#L931) and [Chromium](https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quiche/quic/core/congestion_control/bbr2_sender.cc;l=404;bpv=1;bpt=1) implementations extend that to 2 * the initial congestion window. This allows for a longer period where more accurate bandwidth estimates can be measured for determining how to limit the congestion window.

### Testing:

Updated unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

