### PR TITLE
feat(s2n-quic-qns): add /_perf path handling

### DIFF
--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -17,9 +17,6 @@ env:
   # This should be occasionally updated.
   RUST_NIGHTLY_TOOLCHAIN: nightly-2022-09-15
   CDN: https://dnglbrstg7yg.cloudfront.net
-  # enable unstable features for testing
-  S2N_UNSTABLE_CRYPTO_OPT_TX: 100
-  S2N_UNSTABLE_CRYPTO_OPT_RX: 100
 
 jobs:
   rustfmt:
@@ -183,13 +180,13 @@ jobs:
 
       - name: Run server
         run: |
-          sudo SCENARIO=$SCENARIO ./netbench-collector \
+          sudo SCENARIO=$SCENARIO S2N_UNSTABLE_CRYPTO_OPT_TX=1 S2N_UNSTABLE_CRYPTO_OPT_RX=1 ./netbench-collector \
             ./netbench-driver-${{ matrix.driver }}-server > results/${{ matrix.scenario }}/${{ matrix.driver }}/server.json &
 
       - name: Run client
         run: |
           export SERVER_0=localhost:4433
-          sudo SCENARIO=$SCENARIO SERVER_0=$SERVER_0 ./netbench-collector \
+          sudo SCENARIO=$SCENARIO SERVER_0=$SERVER_0 S2N_UNSTABLE_CRYPTO_OPT_TX=1 S2N_UNSTABLE_CRYPTO_OPT_RX=1 ./netbench-collector \
             ./netbench-driver-${{ matrix.driver }}-client > results/${{ matrix.scenario }}/${{ matrix.driver }}/client.json
 
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -23,7 +23,7 @@ env:
   CDN: https://dnglbrstg7yg.cloudfront.net
   LOG_URL: logs/latest/SERVER_CLIENT/TEST/index.html
   H3_SPEC_VERSION: v0.1.8
-  QUINN_REF: 18f00de385b0edf49c3fcc169800c80d5dd3abf6
+  QUINN_REF: 6e4bcbb2fcb57ced2ef261c9662521c5baf37f3c
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100
   S2N_UNSTABLE_CRYPTO_OPT_RX: 100

--- a/quic/s2n-quic-qns/benchmark/client/Dockerfile.build
+++ b/quic/s2n-quic-qns/benchmark/client/Dockerfile.build
@@ -7,7 +7,7 @@ RUN apt-get update; \
      apt-get install -y git;
 
 RUN git clone https://github.com/quinn-rs/quinn.git .; \
-     git checkout 730fdaf723eef125c175fbcdba1ac3fe3324f7ce;
+     git checkout 6e4bcbb2fcb57ced2ef261c9662521c5baf37f3c;
 RUN cargo chef prepare  --recipe-path recipe.json
 
 FROM rust:latest as cacher
@@ -24,7 +24,7 @@ ARG release="true"
 # copy quinn sources
 RUN git init; \
      git remote add origin https://github.com/quinn-rs/quinn; \
-     git fetch origin 730fdaf723eef125c175fbcdba1ac3fe3324f7ce; \
+     git fetch origin 6e4bcbb2fcb57ced2ef261c9662521c5baf37f3c; \
      git reset --hard FETCH_HEAD;
 
 # Copy over the cached dependencies

--- a/quic/s2n-quic-qns/src/server/h09.rs
+++ b/quic/s2n-quic-qns/src/server/h09.rs
@@ -56,7 +56,7 @@ async fn handle_stream(stream: BidirectionalStream, www_dir: Arc<Path>) -> Resul
     let (rx_stream, mut tx_stream) = stream.split();
     let path = read_request(rx_stream).await?;
 
-    if let Some(amount) = path.strip_prefix("/_perf/").and_then(|v| v.parse().ok()) {
+    if let Some(amount) = path.strip_prefix("_perf/").and_then(|v| v.parse().ok()) {
         return handle_perf_stream(amount, tx_stream).await;
     }
 
@@ -149,6 +149,7 @@ fn parse_h09_request(chunks: &[Bytes], path: &mut String, is_open: bool) -> Resu
             Some(b'.') => path.push('.'),
             Some(b'/') => path.push('/'),
             Some(b'-') => path.push('-'),
+            Some(b'_') => path.push('_'),
             Some(b'\n' | b'\r') => return Ok(true),
             // https://www.w3.org/Protocols/HTTP/AsImplemented.html
             // > The document address will consist of a single word (ie no spaces).

--- a/scripts/perf/build
+++ b/scripts/perf/build
@@ -19,7 +19,7 @@ if [ ! -f target/perf/quinn/bin/perf_client ] || [ ! -f target/perf/quinn/bin/pe
   mkdir -p target/perf/quinn
   cargo +stable install \
     --git https://github.com/quinn-rs/quinn \
-    --rev 4395b969a69b9e39bef1333e44312bf2548d4e1c \
+    --rev 6e4bcbb2fcb57ced2ef261c9662521c5baf37f3c \
     --bin perf_client \
     --bin perf_server \
     --root target/perf/quinn \
@@ -27,7 +27,7 @@ if [ ! -f target/perf/quinn/bin/perf_client ] || [ ! -f target/perf/quinn/bin/pe
     perf
 fi
 
-RUSTFLAGS="-g" cargo \
+RUSTFLAGS="-g --cfg s2n_quic_unstable" cargo \
   +stable \
   build \
   --bin s2n-quic-qns \

--- a/scripts/perf/test
+++ b/scripts/perf/test
@@ -32,6 +32,8 @@ SERVER=$SERVER \
   TMP_DIR=$TMP_DIR \
   OUT_DIR=$OUT_DIR \
   TEST=$TEST \
+  S2N_UNSTABLE_CRYPTO_OPT_TX=1 \
+  S2N_UNSTABLE_CRYPTO_OPT_RX=1 \
   ultraman start --no-timestamp true
 
 function report() {


### PR DESCRIPTION
### Description of changes: 

This change adds a `/_perf/{bytes}` handler to the interop server. This will allow a client to request a certain number of bytes without the file having to exist.

### Call-outs:

I've also:
* fixed the `bench` job by updating quinn to the latest version.
* Fixed the perf script build
* Passed the optimized crypto environment variable flags to commands with `sudo`, as they're not automatically inherited

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

