### PR TITLE
feat(s2n-quic-core): add congestion control events

### DIFF
--- a/quic/s2n-quic-core/src/event.rs
+++ b/quic/s2n-quic-core/src/event.rs
@@ -53,6 +53,7 @@ ident_into_event!(
     i64,
     usize,
     isize,
+    f32,
     Duration,
     bool,
     connection::Error,

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -864,12 +864,12 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     #[doc = " The slow start congestion controller state has been exited"]
-    pub struct SlowStartExited<'a> {
-        pub path: Path<'a>,
+    pub struct SlowStartExited {
+        pub path_id: u64,
         pub cause: SlowStartExitCause,
         pub congestion_window: u32,
     }
-    impl<'a> Event for SlowStartExited<'a> {
+    impl Event for SlowStartExited {
         const NAME: &'static str = "recovery:slow_start_exited";
     }
     #[derive(Clone, Debug)]
@@ -1939,11 +1939,11 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::SlowStartExited {
-                path,
+                path_id,
                 cause,
                 congestion_window,
             } = event;
-            tracing :: event ! (target : "slow_start_exited" , parent : id , tracing :: Level :: DEBUG , path = tracing :: field :: debug (path) , cause = tracing :: field :: debug (cause) , congestion_window = tracing :: field :: debug (congestion_window));
+            tracing :: event ! (target : "slow_start_exited" , parent : id , tracing :: Level :: DEBUG , path_id = tracing :: field :: debug (path_id) , cause = tracing :: field :: debug (cause) , congestion_window = tracing :: field :: debug (congestion_window));
         }
         #[inline]
         fn on_version_information(
@@ -3666,21 +3666,21 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     #[doc = " The slow start congestion controller state has been exited"]
-    pub struct SlowStartExited<'a> {
-        pub path: Path<'a>,
+    pub struct SlowStartExited {
+        pub path_id: u64,
         pub cause: SlowStartExitCause,
         pub congestion_window: u32,
     }
-    impl<'a> IntoEvent<api::SlowStartExited<'a>> for SlowStartExited<'a> {
+    impl IntoEvent<api::SlowStartExited> for SlowStartExited {
         #[inline]
-        fn into_event(self) -> api::SlowStartExited<'a> {
+        fn into_event(self) -> api::SlowStartExited {
             let SlowStartExited {
-                path,
+                path_id,
                 cause,
                 congestion_window,
             } = self;
             api::SlowStartExited {
-                path: path.into_event(),
+                path_id: path_id.into_event(),
                 cause: cause.into_event(),
                 congestion_window: congestion_window.into_event(),
             }

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{event, recovery::congestion_controller::Publisher, time::Timestamp};
+use crate::{recovery::congestion_controller::Publisher, time::Timestamp};
 use core::{
     cmp::{max, Ordering},
     time::Duration,
@@ -281,13 +281,13 @@ impl Estimator {
     //# rate sample based on a snapshot of connection delivery information from the time
     //# at which the packet was last transmitted.
     /// Called for each acknowledgement of one or more packets
-    pub fn on_ack<Pub: event::ConnectionPublisher>(
+    pub fn on_ack<Pub: Publisher>(
         &mut self,
         bytes_acknowledged: usize,
         newest_acked_time_sent: Timestamp,
         newest_acked_packet_info: PacketInfo,
         now: Timestamp,
-        publisher: &mut Publisher<Pub>,
+        publisher: &mut Pub,
     ) {
         self.delivered_bytes += bytes_acknowledged as u64;
         self.delivered_time = Some(now);

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__app_limited.snap
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__app_limited.snap
@@ -2,5 +2,5 @@
 source: quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
 expression: ""
 ---
-DeliveryRateUpdated { path_id: 0, bytes_per_second: 1500 }
-DeliveryRateUpdated { path_id: 0, bytes_per_second: 1501 }
+DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 1s, delivered_bytes: 1500, lost_bytes: 100, ecn_ce_count: 5, is_app_limited: false, prior_delivered_bytes: 15000, bytes_in_flight: 1500, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 1500 } }
+DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 1s, delivered_bytes: 1501, lost_bytes: 100, ecn_ce_count: 5, is_app_limited: false, prior_delivered_bytes: 15000, bytes_in_flight: 1500, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 1501 } }

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__app_limited.snap
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__app_limited.snap
@@ -1,0 +1,6 @@
+---
+source: quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
+expression: ""
+---
+DeliveryRateUpdated { path_id: 0, bytes_per_second: 1500 }
+DeliveryRateUpdated { path_id: 0, bytes_per_second: 1501 }

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__on_packet_ack_implausible_ack_rate.snap
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__on_packet_ack_implausible_ack_rate.snap
@@ -2,5 +2,5 @@
 source: quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
 expression: ""
 ---
-DeliveryRateUpdated { path_id: 0, bytes_per_second: 375 }
-DeliveryRateUpdated { path_id: 0, bytes_per_second: 300 }
+DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 4s, delivered_bytes: 1500, lost_bytes: 0, ecn_ce_count: 0, is_app_limited: false, prior_delivered_bytes: 0, bytes_in_flight: 0, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 375 } }
+DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 5s, delivered_bytes: 1500, lost_bytes: 0, ecn_ce_count: 0, is_app_limited: false, prior_delivered_bytes: 1500, bytes_in_flight: 1500, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 300 } }

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__on_packet_ack_implausible_ack_rate.snap
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__on_packet_ack_implausible_ack_rate.snap
@@ -1,0 +1,6 @@
+---
+source: quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
+expression: ""
+---
+DeliveryRateUpdated { path_id: 0, bytes_per_second: 375 }
+DeliveryRateUpdated { path_id: 0, bytes_per_second: 300 }

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__on_packet_ack_rate_sample.snap
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__on_packet_ack_rate_sample.snap
@@ -1,0 +1,7 @@
+---
+source: quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
+expression: ""
+---
+DeliveryRateUpdated { path_id: 0, bytes_per_second: 20150 }
+DeliveryRateUpdated { path_id: 0, bytes_per_second: 272 }
+DeliveryRateUpdated { path_id: 0, bytes_per_second: 409 }

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__on_packet_ack_rate_sample.snap
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__on_packet_ack_rate_sample.snap
@@ -2,6 +2,6 @@
 source: quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
 expression: ""
 ---
-DeliveryRateUpdated { path_id: 0, bytes_per_second: 20150 }
-DeliveryRateUpdated { path_id: 0, bytes_per_second: 272 }
-DeliveryRateUpdated { path_id: 0, bytes_per_second: 409 }
+DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 10s, delivered_bytes: 201500, lost_bytes: 150, ecn_ce_count: 15, is_app_limited: false, prior_delivered_bytes: 0, bytes_in_flight: 0, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 20150 } }
+DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 11s, delivered_bytes: 3000, lost_bytes: 0, ecn_ce_count: 0, is_app_limited: true, prior_delivered_bytes: 200000, bytes_in_flight: 3000, prior_lost_bytes: 150, prior_ecn_ce_count: 15, delivery_rate_bytes_per_second: 272 } }
+DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 11s, delivered_bytes: 4500, lost_bytes: 0, ecn_ce_count: 0, is_app_limited: true, prior_delivered_bytes: 200000, bytes_in_flight: 3000, prior_lost_bytes: 150, prior_ecn_ce_count: 15, delivery_rate_bytes_per_second: 409 } }

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use crate::recovery::congestion_controller::PathPublisher;
 use crate::{
-    path,
+    event, path,
     time::{Clock, NoopClock},
 };
 
@@ -142,7 +143,7 @@ fn on_packet_sent() {
 #[test]
 fn app_limited() {
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let first_sent_time = NoopClock.get_time();
     let delivered_time = first_sent_time + Duration::from_secs(1);
     let mut bw_estimator = Estimator {
@@ -206,7 +207,7 @@ fn app_limited() {
 #[test]
 fn on_packet_ack_rate_sample() {
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let t0 = NoopClock.get_time() + Duration::from_secs(60);
     let t1 = t0 + Duration::from_secs(1);
     let t2 = t0 + Duration::from_secs(2);
@@ -347,7 +348,7 @@ fn on_packet_ack_rate_sample() {
 #[test]
 fn on_packet_ack_implausible_ack_rate() {
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let t0 = NoopClock.get_time();
     let mut bw_estimator = Estimator::default();
 

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::recovery::congestion_controller::PathPublisher;
 use crate::{
     event, path,
+    recovery::congestion_controller::PathPublisher,
     time::{Clock, NoopClock},
 };
 

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::time::{Clock, NoopClock};
+use crate::{
+    path,
+    time::{Clock, NoopClock},
+};
 
 #[test]
 fn bandwidth() {
@@ -138,6 +141,8 @@ fn on_packet_sent() {
 
 #[test]
 fn app_limited() {
+    let mut publisher = event::testing::Publisher::snapshot();
+    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
     let first_sent_time = NoopClock.get_time();
     let delivered_time = first_sent_time + Duration::from_secs(1);
     let mut bw_estimator = Estimator {
@@ -176,18 +181,32 @@ fn app_limited() {
     };
 
     // Acknowledge all the bytes that were inflight when the app-limited period began
-    bw_estimator.on_ack(1500, delivered_time, packet_info, delivered_time);
+    bw_estimator.on_ack(
+        1500,
+        delivered_time,
+        packet_info,
+        delivered_time,
+        &mut publisher,
+    );
     // Still app_limited, since we need bytes to be acknowledged after the app limited period
     assert_eq!(Some(1500 + 15000), bw_estimator.app_limited_delivered_bytes);
 
     // Acknowledge one more byte
-    bw_estimator.on_ack(1, delivered_time, packet_info, delivered_time);
+    bw_estimator.on_ack(
+        1,
+        delivered_time,
+        packet_info,
+        delivered_time,
+        &mut publisher,
+    );
     // Now the app limited period is over
     assert_eq!(None, bw_estimator.app_limited_delivered_bytes);
 }
 
 #[test]
 fn on_packet_ack_rate_sample() {
+    let mut publisher = event::testing::Publisher::snapshot();
+    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
     let t0 = NoopClock.get_time() + Duration::from_secs(60);
     let t1 = t0 + Duration::from_secs(1);
     let t2 = t0 + Duration::from_secs(2);
@@ -207,7 +226,7 @@ fn on_packet_ack_rate_sample() {
 
     let now = t0 + Duration::from_secs(10);
     let delivered_bytes = bw_estimator.delivered_bytes;
-    bw_estimator.on_ack(1500, t0, packet_1, now);
+    bw_estimator.on_ack(1500, t0, packet_1, now, &mut publisher);
 
     assert_eq!(bw_estimator.delivered_bytes, delivered_bytes + 1500);
     assert_eq!(bw_estimator.delivered_time, Some(now));
@@ -247,7 +266,7 @@ fn on_packet_ack_rate_sample() {
     // Ack a newer packet
     let now = now + Duration::from_secs(1);
     let delivered_bytes = bw_estimator.delivered_bytes;
-    bw_estimator.on_ack(1500, t2, packet_3, now);
+    bw_estimator.on_ack(1500, t2, packet_3, now, &mut publisher);
 
     assert_eq!(bw_estimator.delivered_bytes, delivered_bytes + 1500);
     assert_eq!(bw_estimator.delivered_time, Some(now));
@@ -283,7 +302,7 @@ fn on_packet_ack_rate_sample() {
     // Ack an older packet
     let now = now + Duration::from_secs(1);
     let delivered_bytes = bw_estimator.delivered_bytes;
-    bw_estimator.on_ack(1500, t1, packet_2, now);
+    bw_estimator.on_ack(1500, t1, packet_2, now, &mut publisher);
 
     assert_eq!(bw_estimator.delivered_bytes, delivered_bytes + 1500);
     assert_eq!(bw_estimator.delivered_time, Some(now));
@@ -327,19 +346,27 @@ fn on_packet_ack_rate_sample() {
 //# by capping the delivery rate sample to be no higher than the send rate.
 #[test]
 fn on_packet_ack_implausible_ack_rate() {
+    let mut publisher = event::testing::Publisher::snapshot();
+    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
     let t0 = NoopClock.get_time();
     let mut bw_estimator = Estimator::default();
 
     // A packet is sent and acknowledged 4 seconds later
     let packet_info = bw_estimator.on_packet_sent(0, Some(false), t0);
     let t4 = t0 + Duration::from_secs(4);
-    bw_estimator.on_ack(1500, t0, packet_info, t4);
+    bw_estimator.on_ack(1500, t0, packet_info, t4, &mut publisher);
 
     // A packet is sent and acknowledged 1 second later
     let t5 = t0 + Duration::from_secs(5);
     let packet_info = bw_estimator.on_packet_sent(1500, Some(false), t5);
     let now = t0 + Duration::from_secs(6);
-    bw_estimator.on_ack(1500, t0 + Duration::from_secs(5), packet_info, now);
+    bw_estimator.on_ack(
+        1500,
+        t0 + Duration::from_secs(5),
+        packet_info,
+        now,
+        &mut publisher,
+    );
 
     let send_elapsed = t5 - packet_info.first_sent_time;
     let ack_elapsed = now - packet_info.delivered_time;
@@ -387,4 +414,13 @@ fn on_explicit_congestion() {
 
     assert_eq!(8, bw_estimator.ecn_ce_count);
     assert_eq!(8, bw_estimator.rate_sample.ecn_ce_count);
+}
+
+#[test]
+fn as_bytes_per_second() {
+    let bandwidth = Bandwidth::new(10_000, Duration::from_secs(1));
+
+    assert_eq!(10_000, bandwidth.as_bytes_per_second());
+    assert_eq!(0, Bandwidth::ZERO.as_bytes_per_second());
+    assert_eq!(u64::MAX, Bandwidth::INFINITY.as_bytes_per_second());
 }

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -251,14 +251,6 @@ impl CongestionController for BbrCongestionController {
     }
 
     #[inline]
-    fn is_slow_start(&self) -> bool {
-        // BBR may enter and exit the ProbeRtt state while still slow starting
-        // so the full pipe estimator, which is only filled once per connection,
-        // provides a more accurate view on whether BBR is still slow starting.
-        !self.full_pipe_estimator.filled_pipe()
-    }
-
-    #[inline]
     fn requires_fast_retransmission(&self) -> bool {
         self.recovery_state.requires_fast_retransmission()
     }

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -313,7 +313,7 @@ impl CongestionController for BbrCongestionController {
         rtt_estimator: &RttEstimator,
         random_generator: &mut dyn random::Generator,
         ack_receive_time: Timestamp,
-        _publisher: &mut Publisher<Pub>,
+        publisher: &mut Publisher<Pub>,
     ) {
         self.bytes_in_flight
             .try_sub(bytes_acknowledged)
@@ -372,7 +372,7 @@ impl CongestionController for BbrCongestionController {
             //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.2.3
             //# BBRCheckStartupDone()
             //# BBRCheckDrain()
-            self.check_startup_done();
+            self.check_startup_done(publisher);
         }
         self.check_drain_done(random_generator, ack_receive_time);
 

--- a/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__pacing__events__one_rtt.snap
+++ b/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__pacing__events__one_rtt.snap
@@ -1,0 +1,6 @@
+---
+source: quic/s2n-quic-core/src/recovery/bbr/pacing.rs
+expression: ""
+---
+PacingRateUpdated { path_id: 0, bytes_per_second: 2747252, burst_size: 12000, pacing_gain: 2.77 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 2747252, burst_size: 12000, pacing_gain: 2.77 }

--- a/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__pacing__events__set_pacing_rate.snap
+++ b/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__pacing__events__set_pacing_rate.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/bbr/pacing.rs
+expression: ""
+---
+PacingRateUpdated { path_id: 0, bytes_per_second: 1237623, burst_size: 12000, pacing_gain: 1.25 }

--- a/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__startup__events__check_startup_done.snap
+++ b/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__startup__events__check_startup_done.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/bbr/startup.rs
+expression: ""
+---
+SlowStartExited { path_id: 0, cause: Other, congestion_window: 12000 }

--- a/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__startup__events__check_startup_done_filled_pipe_on_loss_round_start.snap
+++ b/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__startup__events__check_startup_done_filled_pipe_on_loss_round_start.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/bbr/startup.rs
+expression: ""
+---
+SlowStartExited { path_id: 0, cause: Other, congestion_window: 12000 }

--- a/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__startup__events__check_startup_done_filled_pipe_on_round_start.snap
+++ b/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__startup__events__check_startup_done_filled_pipe_on_round_start.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/bbr/startup.rs
+expression: ""
+---
+SlowStartExited { path_id: 0, cause: Other, congestion_window: 12000 }

--- a/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__tests__events__handle_restart_from_idle.snap
+++ b/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__tests__events__handle_restart_from_idle.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/bbr/tests.rs
+expression: ""
+---
+PacingRateUpdated { path_id: 0, bytes_per_second: 100000000, burst_size: 12000, pacing_gain: 1.0 }

--- a/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__tests__events__on_mtu_update.snap
+++ b/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__tests__events__on_mtu_update.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/bbr/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__tests__events__set_cwnd_not_filled_pipe.snap
+++ b/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__tests__events__set_cwnd_not_filled_pipe.snap
@@ -2,4 +2,4 @@
 source: quic/s2n-quic-core/src/recovery/bbr/tests.rs
 expression: ""
 ---
-DeliveryRateUpdated { path_id: 0, bytes_per_second: 0 }
+DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 0ns, delivered_bytes: 24001, lost_bytes: 0, ecn_ce_count: 0, is_app_limited: false, prior_delivered_bytes: 0, bytes_in_flight: 0, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 0 } }

--- a/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__tests__events__set_cwnd_not_filled_pipe.snap
+++ b/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__tests__events__set_cwnd_not_filled_pipe.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/bbr/tests.rs
+expression: ""
+---
+DeliveryRateUpdated { path_id: 0, bytes_per_second: 0 }

--- a/quic/s2n-quic-core/src/recovery/bbr/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/tests.rs
@@ -11,7 +11,7 @@ use crate::{
         bandwidth::{Bandwidth, PacketInfo, RateSample},
         bbr,
         bbr::{probe_bw::CyclePhase, probe_rtt, BbrCongestionController, State, State::ProbeRtt},
-        congestion_controller::Publisher,
+        congestion_controller::PathPublisher,
         CongestionController,
     },
     time::{Clock, NoopClock},
@@ -550,7 +550,7 @@ fn set_cwnd_filled_pipe() {
 fn set_cwnd_not_filled_pipe() {
     let mut bbr = BbrCongestionController::new(MINIMUM_MTU);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time();
     assert_eq!(36_000, bbr.max_inflight());
 
@@ -851,7 +851,7 @@ fn handle_lost_packet() {
 fn handle_restart_from_idle() {
     let mut bbr = BbrCongestionController::new(MINIMUM_MTU);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time();
     let pacing_rate = bbr.pacer.pacing_rate();
 
@@ -1014,7 +1014,7 @@ fn on_mtu_update() {
     let mut mtu = 5000;
     let mut bbr = BbrCongestionController::new(mtu);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
 
     bbr.cwnd = 100_000;
 

--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -77,9 +77,6 @@ pub trait CongestionController: 'static + Clone + Send + Debug {
     /// bytes in flight
     fn is_congestion_limited(&self) -> bool;
 
-    /// Returns `true` if the congestion controller is in the "Slow Start" state
-    fn is_slow_start(&self) -> bool;
-
     /// Returns `true` if the current state of the congestion controller
     /// requires a packet to be transmitted without respecting the
     /// available congestion window
@@ -235,10 +232,6 @@ pub mod testing {
                 false
             }
 
-            fn is_slow_start(&self) -> bool {
-                false
-            }
-
             fn requires_fast_retransmission(&self) -> bool {
                 false
             }
@@ -387,10 +380,6 @@ pub mod testing {
 
             fn is_congestion_limited(&self) -> bool {
                 self.requires_fast_retransmission || self.bytes_in_flight >= self.congestion_window
-            }
-
-            fn is_slow_start(&self) -> bool {
-                self.slow_start
             }
 
             fn requires_fast_retransmission(&self) -> bool {

--- a/quic/s2n-quic-core/src/recovery/congestion_controller/fuzz_target.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller/fuzz_target.rs
@@ -8,7 +8,7 @@ use crate::{
     path::MINIMUM_MTU,
     random,
     recovery::{
-        bbr::BbrCongestionController, congestion_controller::Publisher, CongestionController,
+        bbr::BbrCongestionController, congestion_controller::PathPublisher, CongestionController,
         CubicCongestionController, RttEstimator,
     },
     time::{testing::Clock, Clock as _, Timestamp},
@@ -104,7 +104,7 @@ impl<CC: CongestionController> Model<CC> {
 
     fn on_packet_sent(&mut self, count: u8, bytes_sent: u16, app_limited: Option<bool>) {
         let mut publisher = event::testing::Publisher::no_snapshot();
-        let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+        let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
 
         for _ in 0..count {
             if !self.subject.is_congestion_limited()
@@ -135,7 +135,7 @@ impl<CC: CongestionController> Model<CC> {
         rng: &mut dyn random::Generator,
     ) {
         let mut publisher = event::testing::Publisher::no_snapshot();
-        let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+        let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
         let index = (index as usize).min(self.sent_packets.len().saturating_sub(1));
         let mut rtt_updated = false;
 
@@ -168,7 +168,7 @@ impl<CC: CongestionController> Model<CC> {
 
     fn on_packet_lost(&mut self, index: u8, rng: &mut dyn random::Generator) {
         let mut publisher = event::testing::Publisher::no_snapshot();
-        let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+        let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
         let index = (index as usize).min(self.sent_packets.len().saturating_sub(1));
 
         // Report the packet at the random `index` as lost
@@ -190,7 +190,7 @@ impl<CC: CongestionController> Model<CC> {
 
     fn on_rtt_updated(&mut self, time_sent: Timestamp, rtt: Duration) {
         let mut publisher = event::testing::Publisher::no_snapshot();
-        let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+        let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
 
         self.rtt_estimator.update_rtt(
             Duration::ZERO,
@@ -209,7 +209,7 @@ impl<CC: CongestionController> Model<CC> {
 
     fn on_explicit_congestion(&mut self, ce_count: u64) {
         let mut publisher = event::testing::Publisher::no_snapshot();
-        let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+        let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
         let ce_count = ce_count.min(self.sent_packets.len() as u64);
         self.subject
             .on_explicit_congestion(ce_count, self.timestamp, &mut publisher)
@@ -217,7 +217,7 @@ impl<CC: CongestionController> Model<CC> {
 
     fn on_packet_discarded(&mut self) {
         let mut publisher = event::testing::Publisher::no_snapshot();
-        let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+        let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
         if let Some(sent_packet_info) = self.sent_packets.pop_front() {
             self.subject
                 .on_packet_discarded(sent_packet_info.sent_bytes as usize, &mut publisher)
@@ -226,7 +226,7 @@ impl<CC: CongestionController> Model<CC> {
 
     fn on_mtu_updated(&mut self, mtu: u16) {
         let mut publisher = event::testing::Publisher::no_snapshot();
-        let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+        let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
         self.subject.on_mtu_update(mtu, &mut publisher)
     }
 

--- a/quic/s2n-quic-core/src/recovery/congestion_controller/fuzz_target.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller/fuzz_target.rs
@@ -2,11 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    event,
     packet::number::PacketNumberSpace,
+    path,
     path::MINIMUM_MTU,
     random,
     recovery::{
-        bbr::BbrCongestionController, CongestionController, CubicCongestionController, RttEstimator,
+        bbr::BbrCongestionController, congestion_controller::Publisher, CongestionController,
+        CubicCongestionController, RttEstimator,
     },
     time::{testing::Clock, Clock as _, Timestamp},
 };
@@ -100,6 +103,9 @@ impl<CC: CongestionController> Model<CC> {
     }
 
     fn on_packet_sent(&mut self, count: u8, bytes_sent: u16, app_limited: Option<bool>) {
+        let mut publisher = event::testing::Publisher::no_snapshot();
+        let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+
         for _ in 0..count {
             if !self.subject.is_congestion_limited()
                 || self.subject.requires_fast_retransmission()
@@ -110,6 +116,7 @@ impl<CC: CongestionController> Model<CC> {
                     bytes_sent as usize,
                     app_limited,
                     &self.rtt_estimator,
+                    &mut publisher,
                 );
                 self.sent_packets.push_back(SentPacketInfo {
                     sent_bytes: bytes_sent,
@@ -127,6 +134,8 @@ impl<CC: CongestionController> Model<CC> {
         rtt: Duration,
         rng: &mut dyn random::Generator,
     ) {
+        let mut publisher = event::testing::Publisher::no_snapshot();
+        let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
         let index = (index as usize).min(self.sent_packets.len().saturating_sub(1));
         let mut rtt_updated = false;
 
@@ -148,6 +157,7 @@ impl<CC: CongestionController> Model<CC> {
                         &self.rtt_estimator,
                         rng,
                         self.timestamp,
+                        &mut publisher,
                     );
                 }
             } else {
@@ -157,6 +167,8 @@ impl<CC: CongestionController> Model<CC> {
     }
 
     fn on_packet_lost(&mut self, index: u8, rng: &mut dyn random::Generator) {
+        let mut publisher = event::testing::Publisher::no_snapshot();
+        let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
         let index = (index as usize).min(self.sent_packets.len().saturating_sub(1));
 
         // Report the packet at the random `index` as lost
@@ -170,12 +182,16 @@ impl<CC: CongestionController> Model<CC> {
                     false,
                     rng,
                     self.timestamp,
+                    &mut publisher,
                 );
             }
         }
     }
 
     fn on_rtt_updated(&mut self, time_sent: Timestamp, rtt: Duration) {
+        let mut publisher = event::testing::Publisher::no_snapshot();
+        let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+
         self.rtt_estimator.update_rtt(
             Duration::ZERO,
             rtt,
@@ -183,25 +199,35 @@ impl<CC: CongestionController> Model<CC> {
             false,
             PacketNumberSpace::Initial,
         );
-        self.subject
-            .on_rtt_update(time_sent, self.timestamp, &self.rtt_estimator);
+        self.subject.on_rtt_update(
+            time_sent,
+            self.timestamp,
+            &self.rtt_estimator,
+            &mut publisher,
+        );
     }
 
     fn on_explicit_congestion(&mut self, ce_count: u64) {
+        let mut publisher = event::testing::Publisher::no_snapshot();
+        let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
         let ce_count = ce_count.min(self.sent_packets.len() as u64);
         self.subject
-            .on_explicit_congestion(ce_count, self.timestamp)
+            .on_explicit_congestion(ce_count, self.timestamp, &mut publisher)
     }
 
     fn on_packet_discarded(&mut self) {
+        let mut publisher = event::testing::Publisher::no_snapshot();
+        let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
         if let Some(sent_packet_info) = self.sent_packets.pop_front() {
             self.subject
-                .on_packet_discarded(sent_packet_info.sent_bytes as usize)
+                .on_packet_discarded(sent_packet_info.sent_bytes as usize, &mut publisher)
         }
     }
 
     fn on_mtu_updated(&mut self, mtu: u16) {
-        self.subject.on_mtu_update(mtu)
+        let mut publisher = event::testing::Publisher::no_snapshot();
+        let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+        self.subject.on_mtu_update(mtu, &mut publisher)
     }
 
     fn invariants(&self) {

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -208,7 +208,7 @@ impl CongestionController for CubicCongestionController {
         bytes_sent: usize,
         app_limited: Option<bool>,
         rtt_estimator: &RttEstimator,
-        _publisher: &mut Publisher<Pub>,
+        publisher: &mut Publisher<Pub>,
     ) {
         if bytes_sent == 0 {
             // Packet was not congestion controlled
@@ -247,6 +247,7 @@ impl CongestionController for CubicCongestionController {
             self.congestion_window(),
             self.max_datagram_size,
             self.state.is_slow_start(),
+            publisher,
         );
     }
 

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -3,7 +3,9 @@
 
 use crate::{
     counter::Counter,
-    event, random,
+    event,
+    event::builder::SlowStartExitCause,
+    random,
     recovery::{
         congestion_controller::{self, CongestionController, Publisher},
         cubic::{FastRetransmission::*, State::*},
@@ -73,6 +75,11 @@ impl State {
 
             timing.app_limited_time = Some(timestamp);
         }
+    }
+
+    /// Returns true if the state is `SlowStart`
+    fn is_slow_start(&self) -> bool {
+        matches!(self, SlowStart)
     }
 }
 
@@ -256,7 +263,7 @@ impl CongestionController for CubicCongestionController {
         time_sent: Timestamp,
         now: Timestamp,
         rtt_estimator: &RttEstimator,
-        _publisher: &mut Publisher<Pub>,
+        publisher: &mut Publisher<Pub>,
     ) {
         // Update the Slow Start algorithm each time the RTT
         // estimate is updated to find the slow start threshold.
@@ -268,7 +275,8 @@ impl CongestionController for CubicCongestionController {
             rtt_estimator.latest_rtt(),
         );
 
-        if self.is_slow_start() && self.congestion_window >= self.slow_start.threshold {
+        if self.state.is_slow_start() && self.congestion_window >= self.slow_start.threshold {
+            publisher.on_slow_start_exited(SlowStartExitCause::Rtt, self.congestion_window());
             //= https://www.rfc-editor.org/rfc/rfc8312#section-4.8
             //# In the case when CUBIC runs the hybrid slow start [HR08], it may exit
             //# the first slow start without incurring any packet loss and thus W_max
@@ -291,7 +299,7 @@ impl CongestionController for CubicCongestionController {
         rtt_estimator: &RttEstimator,
         _random_generator: &mut dyn random::Generator,
         ack_receive_time: Timestamp,
-        _publisher: &mut Publisher<Pub>,
+        publisher: &mut Publisher<Pub>,
     ) {
         self.bytes_in_flight_hi = self.bytes_in_flight_hi.max(self.bytes_in_flight);
         self.bytes_in_flight
@@ -353,6 +361,8 @@ impl CongestionController for CubicCongestionController {
                 if self.congestion_window >= self.slow_start.threshold {
                     // The congestion window has exceeded a previously determined slow start threshold
                     // so transition to congestion avoidance and notify cubic of the slow start exit
+                    publisher
+                        .on_slow_start_exited(SlowStartExitCause::Other, self.congestion_window());
                     self.state = State::congestion_avoidance(ack_receive_time);
                     self.cubic.on_slow_start_exit(self.congestion_window);
                 }
@@ -392,11 +402,17 @@ impl CongestionController for CubicCongestionController {
         _new_loss_burst: bool,
         _random_generator: &mut dyn random::Generator,
         timestamp: Timestamp,
-        _publisher: &mut Publisher<Pub>,
+        publisher: &mut Publisher<Pub>,
     ) {
         debug_assert!(lost_bytes > 0);
 
         self.bytes_in_flight -= lost_bytes;
+
+        if matches!(self.state, State::SlowStart) && !persistent_congestion {
+            publisher
+                .on_slow_start_exited(SlowStartExitCause::PacketLoss, self.congestion_window());
+        }
+
         self.on_congestion_event(timestamp);
 
         //= https://www.rfc-editor.org/rfc/rfc9002#section-7.6.2
@@ -416,8 +432,12 @@ impl CongestionController for CubicCongestionController {
         &mut self,
         _ce_count: u64,
         event_time: Timestamp,
-        _publisher: &mut Publisher<Pub>,
+        publisher: &mut Publisher<Pub>,
     ) {
+        if matches!(self.state, State::SlowStart) {
+            publisher.on_slow_start_exited(SlowStartExitCause::Ecn, self.congestion_window());
+        }
+
         //= https://www.rfc-editor.org/rfc/rfc9002#section-7.1
         //# If a path has been validated to support Explicit Congestion
         //# Notification (ECN) [RFC3168] [RFC8311], QUIC treats a Congestion

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__congestion_avoidance_after_fast_convergence.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__congestion_avoidance_after_fast_convergence.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+SlowStartExited { path_id: 0, cause: PacketLoss, congestion_window: 80000 }

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__congestion_avoidance_after_idle_period.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__congestion_avoidance_after_idle_period.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_mtu_update_increase.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_mtu_update_increase.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_ack_congestion_avoidance.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_ack_congestion_avoidance.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_ack_congestion_avoidance_max_cwnd.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_ack_congestion_avoidance_max_cwnd.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_ack_limited.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_ack_limited.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_ack_recovery.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_ack_recovery.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_ack_recovery_to_congestion_avoidance.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_ack_recovery_to_congestion_avoidance.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_ack_slow_start_to_congestion_avoidance.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_ack_slow_start_to_congestion_avoidance.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+SlowStartExited { path_id: 0, cause: Other, congestion_window: 10100 }

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_ack_utilized_then_under_utilized.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_ack_utilized_then_under_utilized.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+PacingRateUpdated { path_id: 0, bytes_per_second: 1200480, burst_size: 50000, pacing_gain: 2.0 }

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_discarded.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_discarded.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_lost.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_lost.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+SlowStartExited { path_id: 0, cause: PacketLoss, congestion_window: 100000 }

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_lost_already_in_recovery.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_lost_already_in_recovery.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_lost_below_minimum_window.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_lost_below_minimum_window.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_lost_persistent_congestion.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_lost_persistent_congestion.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_sent.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_sent.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+SlowStartExited { path_id: 0, cause: Rtt, congestion_window: 100000 }

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_sent_application_limited.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_sent_application_limited.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_sent_fast_retransmission.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_sent_fast_retransmission.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_sent_none_application_limited.snap
+++ b/quic/s2n-quic-core/src/recovery/cubic/snapshots/quic__s2n-quic-core__src__recovery__cubic__tests__events__on_packet_sent_none_application_limited.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/cubic/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/cubic/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic/tests.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 use super::*;
 use crate::{
+    event,
     packet::number::PacketNumberSpace,
     path,
-    recovery::congestion_controller::Publisher,
+    recovery::congestion_controller::PathPublisher,
     time::{Clock, NoopClock},
 };
 use core::time::Duration;
@@ -213,7 +214,7 @@ fn minimum_window_equals_two_times_max_datagram_size() {
 fn on_packet_sent() {
     let mut cc = CubicCongestionController::new(1000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let mut rtt_estimator = RttEstimator::default();
     let now = NoopClock.get_time();
 
@@ -291,7 +292,7 @@ fn on_packet_sent() {
 fn on_packet_sent_application_limited() {
     let mut cc = CubicCongestionController::new(1000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let rtt_estimator = RttEstimator::default();
     let now = NoopClock.get_time();
 
@@ -345,7 +346,7 @@ fn on_packet_sent_application_limited() {
 fn on_packet_sent_none_application_limited() {
     let mut cc = CubicCongestionController::new(1000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let rtt_estimator = RttEstimator::default();
     let now = NoopClock.get_time();
 
@@ -398,7 +399,7 @@ fn on_packet_sent_none_application_limited() {
 fn on_packet_sent_fast_retransmission() {
     let mut cc = CubicCongestionController::new(1000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let rtt_estimator = RttEstimator::default();
     let now = NoopClock.get_time();
 
@@ -427,7 +428,7 @@ fn on_packet_sent_fast_retransmission() {
 fn congestion_avoidance_after_idle_period() {
     let mut cc = CubicCongestionController::new(1000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time();
     let rtt_estimator = &RttEstimator::default();
     let random = &mut random::testing::Generator::default();
@@ -527,7 +528,7 @@ fn congestion_avoidance_after_fast_convergence() {
     let max_datagram_size = 1200;
     let mut cc = CubicCongestionController::new(max_datagram_size);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time();
     let random = &mut random::testing::Generator::default();
     cc.bytes_in_flight = BytesInFlight::new(100);
@@ -640,7 +641,7 @@ fn congestion_avoidance_max_cwnd() {
 fn on_packet_lost() {
     let mut cc = CubicCongestionController::new(1000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time();
     let random = &mut random::testing::Generator::default();
     cc.congestion_window = 100_000.0;
@@ -681,7 +682,7 @@ fn on_packet_lost() {
 fn on_packet_lost_below_minimum_window() {
     let mut cc = CubicCongestionController::new(1000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time();
     let random = &mut random::testing::Generator::default();
     cc.congestion_window = cc.cubic.minimum_window();
@@ -705,7 +706,7 @@ fn on_packet_lost_below_minimum_window() {
 fn on_packet_lost_already_in_recovery() {
     let mut cc = CubicCongestionController::new(1000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time();
     let random = &mut random::testing::Generator::default();
     cc.congestion_window = 10000.0;
@@ -731,7 +732,7 @@ fn on_packet_lost_already_in_recovery() {
 fn on_packet_lost_persistent_congestion() {
     let mut cc = CubicCongestionController::new(1000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time();
     let random = &mut random::testing::Generator::default();
     cc.congestion_window = 10000.0;
@@ -765,7 +766,7 @@ fn on_mtu_update_increase() {
     let cwnd_in_bytes = cwnd_in_packets / mtu as f32;
     let mut cc = CubicCongestionController::new(mtu);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     cc.congestion_window = cwnd_in_packets;
 
     mtu = 10000;
@@ -790,7 +791,7 @@ fn on_mtu_update_increase() {
 fn on_packet_discarded() {
     let mut cc = CubicCongestionController::new(5000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     cc.bytes_in_flight = BytesInFlight::new(10000);
 
     cc.on_packet_discarded(1000, &mut publisher);
@@ -816,7 +817,7 @@ fn on_packet_discarded() {
 fn on_packet_ack_limited() {
     let mut cc = CubicCongestionController::new(5000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time();
     let random = &mut random::testing::Generator::default();
     cc.congestion_window = 100_000.0;
@@ -856,7 +857,7 @@ fn on_packet_ack_limited() {
 fn on_packet_ack_timestamp_regression() {
     let mut cc = CubicCongestionController::new(5000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time() + Duration::from_secs(1);
     let rtt_estimator = RttEstimator::default();
     let random = &mut random::testing::Generator::default();
@@ -891,7 +892,7 @@ fn on_packet_ack_timestamp_regression() {
 fn on_packet_ack_utilized_then_under_utilized() {
     let mut cc = CubicCongestionController::new(5000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time();
     let mut rtt_estimator = RttEstimator::default();
     let random = &mut random::testing::Generator::default();
@@ -960,7 +961,7 @@ fn on_packet_ack_utilized_then_under_utilized() {
 fn on_packet_ack_congestion_avoidance_max_cwnd() {
     let mut cc = CubicCongestionController::new(5000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time();
     let mut rtt_estimator = RttEstimator::default();
     let random = &mut random::testing::Generator::default();
@@ -988,7 +989,7 @@ fn on_packet_ack_congestion_avoidance_max_cwnd() {
 fn on_packet_ack_recovery_to_congestion_avoidance() {
     let mut cc = CubicCongestionController::new(5000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time();
     let random = &mut random::testing::Generator::default();
 
@@ -1019,7 +1020,7 @@ fn on_packet_ack_recovery_to_congestion_avoidance() {
 fn on_packet_ack_slow_start_to_congestion_avoidance() {
     let mut cc = CubicCongestionController::new(5000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time();
     let random = &mut random::testing::Generator::default();
 
@@ -1056,7 +1057,7 @@ fn on_packet_ack_slow_start_to_congestion_avoidance() {
 fn on_packet_ack_recovery() {
     let mut cc = CubicCongestionController::new(5000);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time();
     let random = &mut random::testing::Generator::default();
 
@@ -1085,7 +1086,7 @@ fn on_packet_ack_congestion_avoidance() {
     let mut cc = CubicCongestionController::new(max_datagram_size);
     let mut cc2 = CubicCongestionController::new(max_datagram_size);
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let now = NoopClock.get_time();
     let random = &mut random::testing::Generator::default();
 

--- a/quic/s2n-quic-core/src/recovery/cubic/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic/tests.rs
@@ -250,7 +250,7 @@ fn on_packet_sent() {
     // Round one of hybrid slow start
     cc.on_rtt_update(now, now, &rtt_estimator, &mut publisher);
 
-    assert!(cc.is_slow_start());
+    assert!(cc.state.is_slow_start());
 
     // Latest RTT is 200ms
     rtt_estimator.update_rtt(
@@ -271,7 +271,7 @@ fn on_packet_sent() {
     );
 
     assert_eq!(cc.bytes_in_flight, 2);
-    assert!(cc.is_slow_start());
+    assert!(cc.state.is_slow_start());
 
     // Round two of hybrid slow start
     for _i in 1..=8 {
@@ -283,7 +283,7 @@ fn on_packet_sent() {
         );
     }
 
-    assert!(!cc.is_slow_start());
+    assert!(!cc.state.is_slow_start());
     assert_delta!(cc.slow_start.threshold, 100_000.0, 0.001);
 }
 
@@ -740,7 +740,7 @@ fn on_packet_lost_persistent_congestion() {
 
     cc.on_packet_lost(100, (), true, false, random, now, &mut publisher);
 
-    assert!(cc.is_slow_start());
+    assert!(cc.state.is_slow_start());
     assert_eq!(cc.state, SlowStart);
     assert_delta!(cc.congestion_window, cc.cubic.minimum_window(), 0.001);
     assert_delta!(cc.cubic.w_max, 0.0, 0.001);

--- a/quic/s2n-quic-core/src/recovery/pacing.rs
+++ b/quic/s2n-quic-core/src/recovery/pacing.rs
@@ -3,7 +3,6 @@
 
 use crate::{
     counter::{Counter, Saturating},
-    event,
     recovery::{
         bandwidth::Bandwidth, congestion_controller::Publisher, RttEstimator, MAX_BURST_PACKETS,
     },
@@ -46,7 +45,7 @@ impl Pacer {
     /// Called when each packet has been written
     #[allow(clippy::too_many_arguments)]
     #[inline]
-    pub fn on_packet_sent<Pub: event::ConnectionPublisher>(
+    pub fn on_packet_sent<Pub: Publisher>(
         &mut self,
         now: Timestamp,
         bytes_sent: usize,
@@ -54,7 +53,7 @@ impl Pacer {
         congestion_window: u32,
         max_datagram_size: u16,
         slow_start: bool,
-        publisher: &mut Publisher<Pub>,
+        publisher: &mut Pub,
     ) {
         if rtt_estimator.smoothed_rtt() < MINIMUM_PACING_RTT {
             return;
@@ -89,12 +88,12 @@ impl Pacer {
 
     // Recalculate the interval between bursts of paced packets
     #[inline]
-    fn interval<Pub: event::ConnectionPublisher>(
+    fn interval<Pub: Publisher>(
         rtt: Duration,
         congestion_window: u32,
         max_datagram_size: u16,
         slow_start: bool,
-        publisher: &mut Publisher<Pub>,
+        publisher: &mut Pub,
     ) -> Duration {
         debug_assert_ne!(congestion_window, 0);
 

--- a/quic/s2n-quic-core/src/recovery/pacing/__fuzz__/recovery__pacing__tests__interval_differential/corpus.tar.gz
+++ b/quic/s2n-quic-core/src/recovery/pacing/__fuzz__/recovery__pacing__tests__interval_differential/corpus.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:88a4061a1a1d0c6a891e95e27d4022f5c20a1a6035b7853caa68bb7b2cfebe18
+size 5588

--- a/quic/s2n-quic-core/src/recovery/pacing/snapshots/quic__s2n-quic-core__src__recovery__pacing__tests__events__earliest_departure_time.snap
+++ b/quic/s2n-quic-core/src/recovery/pacing/snapshots/quic__s2n-quic-core__src__recovery__pacing__tests__events__earliest_departure_time.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/pacing/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/pacing/snapshots/quic__s2n-quic-core__src__recovery__pacing__tests__events__earliest_departure_time_before_now.snap
+++ b/quic/s2n-quic-core/src/recovery/pacing/snapshots/quic__s2n-quic-core__src__recovery__pacing__tests__events__earliest_departure_time_before_now.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/pacing/tests.rs
+expression: ""
+---
+PacingRateUpdated { path_id: 0, bytes_per_second: 450450, burst_size: 12000, pacing_gain: 1.25 }

--- a/quic/s2n-quic-core/src/recovery/pacing/snapshots/quic__s2n-quic-core__src__recovery__pacing__tests__events__on_packet_sent_large_bytes_sent.snap
+++ b/quic/s2n-quic-core/src/recovery/pacing/snapshots/quic__s2n-quic-core__src__recovery__pacing__tests__events__on_packet_sent_large_bytes_sent.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/pacing/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-core/src/recovery/pacing/snapshots/quic__s2n-quic-core__src__recovery__pacing__tests__events__post_slow_start.snap
+++ b/quic/s2n-quic-core/src/recovery/pacing/snapshots/quic__s2n-quic-core__src__recovery__pacing__tests__events__post_slow_start.snap
@@ -1,0 +1,16 @@
+---
+source: quic/s2n-quic-core/src/recovery/pacing/tests.rs
+expression: ""
+---
+PacingRateUpdated { path_id: 0, bytes_per_second: 450450, burst_size: 12000, pacing_gain: 1.25 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 450450, burst_size: 12000, pacing_gain: 1.25 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 450450, burst_size: 12000, pacing_gain: 1.25 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 450450, burst_size: 12000, pacing_gain: 1.25 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 450450, burst_size: 12000, pacing_gain: 1.25 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 450450, burst_size: 12000, pacing_gain: 1.25 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 450450, burst_size: 12000, pacing_gain: 1.25 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 450450, burst_size: 12000, pacing_gain: 1.25 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 450450, burst_size: 12000, pacing_gain: 1.25 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 450450, burst_size: 12000, pacing_gain: 1.25 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 450450, burst_size: 12000, pacing_gain: 1.25 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 450450, burst_size: 12000, pacing_gain: 1.25 }

--- a/quic/s2n-quic-core/src/recovery/pacing/snapshots/quic__s2n-quic-core__src__recovery__pacing__tests__events__slow_start.snap
+++ b/quic/s2n-quic-core/src/recovery/pacing/snapshots/quic__s2n-quic-core__src__recovery__pacing__tests__events__slow_start.snap
@@ -1,0 +1,24 @@
+---
+source: quic/s2n-quic-core/src/recovery/pacing/tests.rs
+expression: ""
+---
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }
+PacingRateUpdated { path_id: 0, bytes_per_second: 720980, burst_size: 12000, pacing_gain: 2.0 }

--- a/quic/s2n-quic-core/src/recovery/pacing/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/pacing/tests.rs
@@ -2,27 +2,41 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    event,
     packet::number::PacketNumberSpace,
+    path,
     path::MINIMUM_MTU,
     recovery::{
+        congestion_controller::Publisher,
         pacing::{Pacer, INITIAL_INTERVAL, N, SLOW_START_N},
-        RttEstimator,
+        RttEstimator, MAX_BURST_PACKETS,
     },
     time::{Clock, NoopClock, Timestamp},
 };
+use bolero::{check, generator::*};
 use core::time::Duration;
 use num_traits::ToPrimitive;
 
 #[test]
 fn earliest_departure_time() {
     let mut pacer = Pacer::default();
+    let mut publisher = event::testing::Publisher::snapshot();
+    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
     assert_eq!(None, pacer.next_packet_departure_time);
 
     let now = NoopClock.get_time();
     let rtt = RttEstimator::default();
     let cwnd = 12000;
 
-    pacer.on_packet_sent(now, MINIMUM_MTU as usize, &rtt, cwnd, MINIMUM_MTU, false);
+    pacer.on_packet_sent(
+        now,
+        MINIMUM_MTU as usize,
+        &rtt,
+        cwnd,
+        MINIMUM_MTU,
+        false,
+        &mut publisher,
+    );
 
     // The initial interval is added for the second packet
     assert_eq!(
@@ -34,12 +48,22 @@ fn earliest_departure_time() {
 #[test]
 fn on_packet_sent_large_bytes_sent() {
     let mut pacer = Pacer::default();
+    let mut publisher = event::testing::Publisher::snapshot();
+    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
 
     let now = NoopClock.get_time();
     let rtt = RttEstimator::default();
     let cwnd = 12000;
 
-    pacer.on_packet_sent(now, usize::MAX, &rtt, cwnd, MINIMUM_MTU, false);
+    pacer.on_packet_sent(
+        now,
+        usize::MAX,
+        &rtt,
+        cwnd,
+        MINIMUM_MTU,
+        false,
+        &mut publisher,
+    );
 
     assert_eq!(
         Some(now + INITIAL_INTERVAL),
@@ -61,12 +85,14 @@ fn test_one_rtt(slow_start: bool) {
     let mut pacer = Pacer::default();
     let now = NoopClock.get_time();
     let rtt = RttEstimator::default();
+    let mut publisher = event::testing::Publisher::snapshot();
+    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
 
     let cwnd = MINIMUM_MTU as u32 * 100;
     let n = if slow_start {
-        SLOW_START_N.0.to_f32().unwrap()
+        SLOW_START_N.to_f32().unwrap()
     } else {
-        N.0.to_f32().unwrap()
+        N.to_f32().unwrap()
     };
     // If in slow start we should be sending 2X the cwnd in one RTT,
     // otherwise we should be sending 1.25X the cwnd.
@@ -80,6 +106,7 @@ fn test_one_rtt(slow_start: bool) {
         cwnd,
         MINIMUM_MTU,
         slow_start,
+        &mut publisher,
     );
     assert_eq!(
         Some(now + INITIAL_INTERVAL),
@@ -101,6 +128,7 @@ fn test_one_rtt(slow_start: bool) {
             cwnd,
             MINIMUM_MTU,
             slow_start,
+            &mut publisher,
         );
         sent_bytes += MINIMUM_MTU as u32;
     }
@@ -115,10 +143,20 @@ fn earliest_departure_time_before_now() {
     let mut pacer = Pacer::default();
     let now = NoopClock.get_time();
     let rtt = RttEstimator::default();
+    let mut publisher = event::testing::Publisher::snapshot();
+    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
 
     let cwnd = MINIMUM_MTU as u32 * 100;
     loop {
-        pacer.on_packet_sent(now, MINIMUM_MTU as usize, &rtt, cwnd, MINIMUM_MTU, false);
+        pacer.on_packet_sent(
+            now,
+            MINIMUM_MTU as usize,
+            &rtt,
+            cwnd,
+            MINIMUM_MTU,
+            false,
+            &mut publisher,
+        );
         if pacer.capacity == 0 {
             break;
         }
@@ -132,7 +170,15 @@ fn earliest_departure_time_before_now() {
     // next interval. Since the timestamp we pass in is after the next interval, the earliest departure time
     // becomes the new "now".
     let now = now + Duration::from_secs(1);
-    pacer.on_packet_sent(now, MINIMUM_MTU as usize, &rtt, cwnd, MINIMUM_MTU, false);
+    pacer.on_packet_sent(
+        now,
+        MINIMUM_MTU as usize,
+        &rtt,
+        cwnd,
+        MINIMUM_MTU,
+        false,
+        &mut publisher,
+    );
     assert_eq!(Some(now), pacer.earliest_departure_time());
 }
 
@@ -188,6 +234,75 @@ fn interval_change() {
     assert!(new_interval < interval);
 }
 
+/// This test aims to compare the rate based implementation of pacing with the inter-packet interval
+/// based implementation of pacing described in RFC 9002. Due to rounding issues while multiplying
+/// and dividing, the two implementations do not match exactly, so this test asserts that the
+/// two implementations differ by less than 1.1 ms.
+#[test]
+#[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
+fn interval_differential_test() {
+    check!()
+        .with_generator((1_000_000..u32::MAX, 1..u32::MAX, gen(), gen()))
+        .cloned()
+        .for_each(|(rtt, congestion_window, max_datagram_size, slow_start)| {
+            let mut publisher = event::testing::Publisher::no_snapshot();
+            let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+            let rtt = Duration::from_nanos(rtt as _);
+            let actual = Pacer::interval(
+                rtt,
+                congestion_window,
+                max_datagram_size,
+                slow_start,
+                &mut publisher,
+            );
+
+            let expected = rfc_interval(rtt, congestion_window, max_datagram_size, slow_start);
+
+            assert!(
+                abs_difference(actual, expected) < Duration::from_nanos(1_100_000),
+                "expected: {:?}; actual: {:?}",
+                expected,
+                actual
+            );
+        });
+}
+
+//= https://www.rfc-editor.org/rfc/rfc9002#section-7.7
+//= type=test
+//# A perfectly paced sender spreads packets exactly evenly over time.
+//# For a window-based congestion controller, such as the one in this
+//# document, that rate can be computed by averaging the congestion
+//# window over the RTT. Expressed as a rate in units of bytes per time,
+//# where congestion_window is in bytes:
+//#
+//# rate = N * congestion_window / smoothed_rtt
+//#
+//# Or expressed as an inter-packet interval in units of time:
+//#
+//# interval = ( smoothed_rtt * packet_size / congestion_window ) / N
+//(rtt_estimator.smoothed_rtt() * packet_size / congestion_window) / n
+fn rfc_interval(
+    rtt: Duration,
+    congestion_window: u32,
+    max_datagram_size: u16,
+    slow_start: bool,
+) -> Duration {
+    let packet_size = MAX_BURST_PACKETS * max_datagram_size as u32;
+    let result = rtt * packet_size / congestion_window;
+    let n = if slow_start { SLOW_START_N } else { N };
+
+    // Divide by n by multiplying by the inverse
+    result * *n.denom() as u32 / *n.numer() as u32
+}
+
+fn abs_difference(a: Duration, b: Duration) -> Duration {
+    if a > b {
+        a - b
+    } else {
+        b - a
+    }
+}
+
 // Calls `on_packet_sent` until the earliest departure time has increased, and returns the interval
 // between the new earliest departure time and the original earliest departure time
 fn get_interval(
@@ -198,6 +313,8 @@ fn get_interval(
     max_datagram_size: u16,
     slow_start: bool,
 ) -> Duration {
+    let mut publisher = event::testing::Publisher::no_snapshot();
+    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
     let starting_departure_time = pacer.earliest_departure_time().unwrap_or(now);
 
     loop {
@@ -208,6 +325,7 @@ fn get_interval(
             congestion_window,
             max_datagram_size,
             slow_start,
+            &mut publisher,
         );
         if let Some(departure_time) = pacer.earliest_departure_time() {
             if departure_time > starting_departure_time {

--- a/quic/s2n-quic-core/src/recovery/pacing/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/pacing/tests.rs
@@ -7,7 +7,7 @@ use crate::{
     path,
     path::MINIMUM_MTU,
     recovery::{
-        congestion_controller::Publisher,
+        congestion_controller::PathPublisher,
         pacing::{Pacer, INITIAL_INTERVAL, N, SLOW_START_N},
         RttEstimator, MAX_BURST_PACKETS,
     },
@@ -21,7 +21,7 @@ use num_traits::ToPrimitive;
 fn earliest_departure_time() {
     let mut pacer = Pacer::default();
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     assert_eq!(None, pacer.next_packet_departure_time);
 
     let now = NoopClock.get_time();
@@ -49,7 +49,7 @@ fn earliest_departure_time() {
 fn on_packet_sent_large_bytes_sent() {
     let mut pacer = Pacer::default();
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
 
     let now = NoopClock.get_time();
     let rtt = RttEstimator::default();
@@ -86,7 +86,7 @@ fn test_one_rtt(slow_start: bool) {
     let now = NoopClock.get_time();
     let rtt = RttEstimator::default();
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
 
     let cwnd = MINIMUM_MTU as u32 * 100;
     let n = if slow_start {
@@ -144,7 +144,7 @@ fn earliest_departure_time_before_now() {
     let now = NoopClock.get_time();
     let rtt = RttEstimator::default();
     let mut publisher = event::testing::Publisher::snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
 
     let cwnd = MINIMUM_MTU as u32 * 100;
     loop {
@@ -251,7 +251,7 @@ fn interval_differential_test() {
         .cloned()
         .for_each(|(rtt, congestion_window, max_datagram_size, slow_start)| {
             let mut publisher = event::testing::Publisher::no_snapshot();
-            let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+            let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
             let rtt = Duration::from_nanos(rtt as _);
             let actual = Pacer::interval(
                 rtt,
@@ -319,7 +319,7 @@ fn get_interval(
     slow_start: bool,
 ) -> Duration {
     let mut publisher = event::testing::Publisher::no_snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
     let starting_departure_time = pacer.earliest_departure_time().unwrap_or(now);
 
     loop {

--- a/quic/s2n-quic-core/src/recovery/pacing/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/pacing/tests.rs
@@ -242,7 +242,12 @@ fn interval_change() {
 #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
 fn interval_differential_test() {
     check!()
-        .with_generator((1_000_000..u32::MAX, 1..u32::MAX, gen(), gen()))
+        .with_generator((
+            1_000_000..u32::MAX, // RTT ranges from 1ms to ~4sec
+            2400..u32::MAX, // congestion window ranges from the minimum window (2 * MINIMUM_MTU) to u32::MAX
+            MINIMUM_MTU..=9000, // max_datagram_size ranges from MINIMUM_MTU to 9000
+            gen(),
+        ))
         .cloned()
         .for_each(|(rtt, congestion_window, max_datagram_size, slow_start)| {
             let mut publisher = event::testing::Publisher::no_snapshot();

--- a/quic/s2n-quic-core/src/recovery/simulation.rs
+++ b/quic/s2n-quic-core/src/recovery/simulation.rs
@@ -8,7 +8,7 @@ use crate::{
     path::MINIMUM_MTU,
     random,
     recovery::{
-        congestion_controller::Publisher, CongestionController, CubicCongestionController,
+        congestion_controller::PathPublisher, CongestionController, CubicCongestionController,
         RttEstimator,
     },
     time::{Clock, NoopClock, Timestamp},
@@ -223,7 +223,7 @@ fn minimum_window<CC: CongestionController>(
     let rtt_estimator = RttEstimator::default();
     let random = &mut random::testing::Generator::default();
     let mut publisher = event::testing::Publisher::no_snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
 
     let packet_info = congestion_controller.on_packet_sent(
         time_zero,
@@ -299,7 +299,7 @@ fn simulate_constant_rtt<CC: CongestionController>(
     let mut rtt_estimator = RttEstimator::default();
     let random = &mut random::testing::Generator::default();
     let mut publisher = event::testing::Publisher::no_snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
 
     // Update the rtt with 200 ms
     rtt_estimator.update_rtt(
@@ -376,7 +376,7 @@ fn send_and_ack<CC: CongestionController>(
     let earliest_ack_receive_time = ack_receive_time - Duration::from_millis(50);
     let sending_full_cwnd = bytes as u32 == congestion_controller.congestion_window();
     let mut publisher = event::testing::Publisher::no_snapshot();
-    let mut publisher = Publisher::new(&mut publisher, path::Id::test_id());
+    let mut publisher = PathPublisher::new(&mut publisher, path::Id::test_id());
 
     let mut packet_info = None;
 

--- a/quic/s2n-quic-core/src/recovery/snapshots/s2n_quic_core__recovery__simulation__AppLimited1MB-CubicCongestionController.snap
+++ b/quic/s2n-quic-core/src/recovery/snapshots/s2n_quic_core__recovery__simulation__AppLimited1MB-CubicCongestionController.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-core/src/recovery/simulation.rs
-assertion_line: 149
 expression: self
 ---
 Simulation {
@@ -88,7 +87,7 @@ Simulation {
          77: pkts: 728,
          78: pkts: 737,
          79: pkts: 747,
-         80: pkts: 758,
+         80: pkts: 757,
          81: pkts: 768,
          82: pkts: 780,
          83: pkts: 792,

--- a/quic/s2n-quic-core/src/recovery/snapshots/s2n_quic_core__recovery__simulation__Lossat3MB-CubicCongestionController.snap
+++ b/quic/s2n-quic-core/src/recovery/snapshots/s2n_quic_core__recovery__simulation__Lossat3MB-CubicCongestionController.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-core/src/recovery/simulation.rs
-assertion_line: 149
 expression: self
 ---
 Simulation {
@@ -33,7 +32,7 @@ Simulation {
          22: pkts: 2165,
          23: pkts: 2189,
          24: pkts: 2211,
-         25: pkts: 2232,
+         25: pkts: 2233,
          26: pkts: 2253,
          27: pkts: 2273,
          28: pkts: 2291,
@@ -117,7 +116,7 @@ Simulation {
         106: pkts: 2689,
         107: pkts: 2700,
         108: pkts: 2713,
-        109: pkts: 2725,
+        109: pkts: 2726,
         110: pkts: 2739,
         111: pkts: 2754,
         112: pkts: 2769,

--- a/quic/s2n-quic-core/src/recovery/snapshots/s2n_quic_core__recovery__simulation__Lossat3MBand2_75MB-CubicCongestionController.snap
+++ b/quic/s2n-quic-core/src/recovery/snapshots/s2n_quic_core__recovery__simulation__Lossat3MBand2_75MB-CubicCongestionController.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-core/src/recovery/simulation.rs
-assertion_line: 149
 expression: self
 ---
 Simulation {
@@ -33,7 +32,7 @@ Simulation {
          22: pkts: 2165,
          23: pkts: 2189,
          24: pkts: 2211,
-         25: pkts: 2232,
+         25: pkts: 2233,
          26: pkts: 2253,
          27: pkts: 2273,
          28: pkts: 2291,

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -353,7 +353,7 @@ enum Frame {
     },
     StreamsBlocked {
         stream_type: StreamType,
-        stream_limit: u64
+        stream_limit: u64,
     },
     NewConnectionId,
     RetireConnectionId,
@@ -856,4 +856,28 @@ enum MtuUpdatedCause {
     ProbeAcknowledged,
     /// A blackhole was detected
     Blackhole,
+}
+
+/// A bandwidth delivery rate estimate with associated metadata
+struct RateSample {
+    /// The length of the sampling interval
+    interval: Duration,
+    /// The amount of data in bytes marked as delivered over the sampling interval
+    delivered_bytes: u64,
+    /// The amount of data in bytes marked as lost over the sampling interval
+    lost_bytes: u64,
+    /// The number of packets marked as explicit congestion experienced over the sampling interval
+    ecn_ce_count: u64,
+    /// [PacketInfo::is_app_limited] from the most recent acknowledged packet
+    is_app_limited: bool,
+    /// [PacketInfo::delivered_bytes] from the most recent acknowledged packet
+    prior_delivered_bytes: u64,
+    /// [PacketInfo::bytes_in_flight] from the most recent acknowledged packet
+    bytes_in_flight: u32,
+    /// [PacketInfo::lost_bytes] from the most recent acknowledged packet
+    prior_lost_bytes: u64,
+    /// [PacketInfo::ecn_ce_count] from the most recent acknowledged packet
+    prior_ecn_ce_count: u64,
+    /// The delivery rate for this rate sample
+    delivery_rate_bytes_per_second: u64,
 }

--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -289,3 +289,21 @@ struct SlowStartExited {
     cause: SlowStartExitCause,
     congestion_window: u32,
 }
+
+#[event("recovery:delivery_rate_updated")]
+/// The delivery rate has been updated
+/// Note: This event is only recorded for congestion controllers that support
+///       bandwidth estimates, such as BBR
+struct DeliveryRateUpdated {
+    path_id: u64,
+    bytes_per_second: u64,
+}
+
+#[event("recovery:pacing_rate_updated")]
+/// The pacing rate has been updated
+struct PacingRateUpdated {
+    path_id: u64,
+    bytes_per_second: u64,
+    burst_size: u32,
+    pacing_gain: f32,
+}

--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -284,8 +284,8 @@ struct MtuUpdated {
 
 #[event("recovery:slow_start_exited")]
 /// The slow start congestion controller state has been exited
-struct SlowStartExited<'a> {
-    path: Path<'a>,
+struct SlowStartExited {
+    path_id: u64,
     cause: SlowStartExitCause,
     congestion_window: u32,
 }

--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -290,13 +290,13 @@ struct SlowStartExited {
     congestion_window: u32,
 }
 
-#[event("recovery:delivery_rate_updated")]
-/// The delivery rate has been updated
+#[event("recovery:delivery_rate_sampled")]
+/// A new delivery rate sample has been generated
 /// Note: This event is only recorded for congestion controllers that support
 ///       bandwidth estimates, such as BBR
-struct DeliveryRateUpdated {
+struct DeliveryRateSampled {
     path_id: u64,
-    bytes_per_second: u64,
+    rate_sample: RateSample,
 }
 
 #[event("recovery:pacing_rate_updated")]

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1637,7 +1637,13 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             .on_retry_packet(retry_source_connection_id);
 
         if let Some((space, _handshake_status)) = self.space_manager.initial_mut() {
-            space.on_retry_packet(path, &retry_source_connection_id, packet.retry_token);
+            space.on_retry_packet(
+                path,
+                path_id,
+                &retry_source_connection_id,
+                packet.retry_token,
+                &mut publisher,
+            );
         }
 
         Ok(())

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -1121,7 +1121,7 @@ mod tests {
         let random = &mut random::testing::Generator::default();
         let mut publisher = event::testing::Publisher::snapshot();
         let mut publisher =
-            congestion_controller::Publisher::new(&mut publisher, path::Id::test_id());
+            congestion_controller::PathPublisher::new(&mut publisher, path::Id::test_id());
         path.on_validated();
 
         assert_eq!(

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -1119,6 +1119,9 @@ mod tests {
         );
         let now = NoopClock.get_time();
         let random = &mut random::testing::Generator::default();
+        let mut publisher = event::testing::Publisher::snapshot();
+        let mut publisher =
+            congestion_controller::Publisher::new(&mut publisher, path::Id::test_id());
         path.on_validated();
 
         assert_eq!(
@@ -1132,6 +1135,7 @@ mod tests {
             path.congestion_controller.congestion_window() as usize,
             None,
             &path.rtt_estimator,
+            &mut publisher,
         );
 
         assert_eq!(
@@ -1140,8 +1144,15 @@ mod tests {
         );
 
         // Lose a byte to enter recovery
-        path.congestion_controller
-            .on_packet_lost(1, packet_info, false, false, random, now);
+        path.congestion_controller.on_packet_lost(
+            1,
+            packet_info,
+            false,
+            false,
+            random,
+            now,
+            &mut publisher,
+        );
         path.congestion_controller.requires_fast_retransmission = true;
 
         assert_eq!(
@@ -1157,6 +1168,7 @@ mod tests {
             false,
             random,
             now,
+            &mut publisher,
         );
         path.congestion_controller.requires_fast_retransmission = false;
 

--- a/quic/s2n-quic-transport/src/path/mtu.rs
+++ b/quic/s2n-quic-transport/src/path/mtu.rs
@@ -212,7 +212,7 @@ impl Controller {
                 // A new MTU has been confirmed, notify the congestion controller
                 congestion_controller.on_mtu_update(
                     self.plpmtu,
-                    &mut congestion_controller::Publisher::new(publisher, path_id),
+                    &mut congestion_controller::PathPublisher::new(publisher, path_id),
                 );
 
                 publisher.on_mtu_updated(event::builder::MtuUpdated {
@@ -394,7 +394,7 @@ impl Controller {
         self.plpmtu = BASE_PLPMTU;
         congestion_controller.on_mtu_update(
             BASE_PLPMTU,
-            &mut congestion_controller::Publisher::new(publisher, path_id),
+            &mut congestion_controller::PathPublisher::new(publisher, path_id),
         );
         // Cancel any current probes
         self.state = State::SearchComplete;

--- a/quic/s2n-quic-transport/src/path/mtu.rs
+++ b/quic/s2n-quic-transport/src/path/mtu.rs
@@ -5,6 +5,7 @@ use crate::{
     contexts::WriteContext,
     path,
     path::{MaxMtu, MINIMUM_MTU},
+    recovery::congestion_controller,
     transmission,
 };
 use core::time::Duration;
@@ -209,7 +210,10 @@ impl Controller {
             if packet_number == probe_packet_number {
                 self.plpmtu = self.probed_size;
                 // A new MTU has been confirmed, notify the congestion controller
-                congestion_controller.on_mtu_update(self.plpmtu);
+                congestion_controller.on_mtu_update(
+                    self.plpmtu,
+                    &mut congestion_controller::Publisher::new(publisher, path_id),
+                );
 
                 publisher.on_mtu_updated(event::builder::MtuUpdated {
                     path_id: path_id.into_event(),
@@ -388,7 +392,10 @@ impl Controller {
         self.largest_acked_mtu_sized_packet = None;
         // Reset the plpmtu back to the BASE_PLPMTU and notify the congestion controller
         self.plpmtu = BASE_PLPMTU;
-        congestion_controller.on_mtu_update(BASE_PLPMTU);
+        congestion_controller.on_mtu_update(
+            BASE_PLPMTU,
+            &mut congestion_controller::Publisher::new(publisher, path_id),
+        );
         // Cancel any current probes
         self.state = State::SearchComplete;
         // Arm the PMTU raise timer to try a larger MTU again after a cooling off period

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mod__events__transmission_constraint_test.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mod__events__transmission_constraint_test.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-transport/src/path/mod.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -12,11 +12,7 @@ use crate::{
 };
 use core::{cmp::max, time::Duration};
 use s2n_quic_core::{
-    event::{
-        self,
-        builder::{CongestionSource, SlowStartExitCause},
-        IntoEvent,
-    },
+    event::{self, builder::CongestionSource, IntoEvent},
     frame,
     frame::ack::EcnCounts,
     inet::ExplicitCongestionNotification,
@@ -556,8 +552,6 @@ impl<Config: endpoint::Config> Manager<Config> {
                 largest_acked_packet_number.space(),
             );
 
-            let slow_start = path.congestion_controller.is_slow_start();
-            let congestion_window = path.congestion_controller.congestion_window();
             // Update the congestion controller with the latest RTT estimate
             path.congestion_controller.on_rtt_update(
                 largest_newly_acked_info.time_sent,
@@ -568,14 +562,6 @@ impl<Config: endpoint::Config> Manager<Config> {
                     largest_newly_acked_info.path_id,
                 ),
             );
-            if slow_start && !path.congestion_controller.is_slow_start() {
-                let path_id = largest_newly_acked_info.path_id;
-                publisher.on_slow_start_exited(event::builder::SlowStartExited {
-                    path: path_event!(path, path_id),
-                    cause: SlowStartExitCause::Rtt,
-                    congestion_window,
-                });
-            }
 
             // Notify components the RTT estimate was updated
             context.on_rtt_update();
@@ -616,8 +602,6 @@ impl<Config: endpoint::Config> Manager<Config> {
             if acked_packet_info.path_id == current_path_id {
                 current_path_acked_bytes += sent_bytes;
             } else if sent_bytes > 0 {
-                let slow_start = path.congestion_controller.is_slow_start();
-                let congestion_window = path.congestion_controller.congestion_window();
                 path.congestion_controller.on_ack(
                     acked_packet_info.time_sent,
                     sent_bytes,
@@ -630,14 +614,6 @@ impl<Config: endpoint::Config> Manager<Config> {
                         acked_packet_info.path_id,
                     ),
                 );
-                if slow_start && !path.congestion_controller.is_slow_start() {
-                    let path_id = acked_packet_info.path_id;
-                    publisher.on_slow_start_exited(event::builder::SlowStartExited {
-                        path: path_event!(path, path_id),
-                        cause: SlowStartExitCause::Other,
-                        congestion_window,
-                    });
-                }
             }
 
             //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.1
@@ -683,8 +659,6 @@ impl<Config: endpoint::Config> Manager<Config> {
         let path = context.path_mut();
 
         if current_path_acked_bytes > 0 {
-            let slow_start = path.congestion_controller.is_slow_start();
-            let congestion_window = path.congestion_controller.congestion_window();
             path.congestion_controller.on_ack(
                 largest_newly_acked.time_sent,
                 current_path_acked_bytes,
@@ -694,14 +668,6 @@ impl<Config: endpoint::Config> Manager<Config> {
                 timestamp,
                 &mut congestion_controller::Publisher::new(publisher, current_path_id),
             );
-            if slow_start && !path.congestion_controller.is_slow_start() {
-                publisher.on_slow_start_exited(event::builder::SlowStartExited {
-                    path: path_event!(path, current_path_id),
-                    cause: SlowStartExitCause::Other,
-                    congestion_window,
-                });
-            }
-
             self.update_pto_timer(path, timestamp, is_handshake_confirmed);
         }
     }
@@ -729,8 +695,6 @@ impl<Config: endpoint::Config> Manager<Config> {
         );
 
         if let ValidationOutcome::CongestionExperienced(ce_count) = outcome {
-            let slow_start = context.path().congestion_controller.is_slow_start();
-            let congestion_window = context.path().congestion_controller.congestion_window();
             //= https://www.rfc-editor.org/rfc/rfc9002#section-7.1
             //# If a path has been validated to support Explicit Congestion
             //# Notification (ECN) [RFC3168] [RFC8311], QUIC treats a Congestion
@@ -744,14 +708,6 @@ impl<Config: endpoint::Config> Manager<Config> {
                     timestamp,
                     &mut congestion_controller::Publisher::new(publisher, path_id),
                 );
-            if slow_start && !context.path().congestion_controller.is_slow_start() {
-                let path = context.path();
-                publisher.on_slow_start_exited(event::builder::SlowStartExited {
-                    path: path_event!(path, path_id),
-                    cause: SlowStartExitCause::Ecn,
-                    congestion_window,
-                });
-            }
             let path = context.path();
             publisher.on_congestion(event::builder::Congestion {
                 path: path_event!(path, path_id),
@@ -971,8 +927,6 @@ impl<Config: endpoint::Config> Manager<Config> {
                     &mut congestion_controller::Publisher::new(publisher, sent_info.path_id),
                 );
             } else if sent_info.sent_bytes > 0 {
-                let slow_start = path.congestion_controller.is_slow_start();
-                let congestion_window = path.congestion_controller.congestion_window();
                 path.congestion_controller.on_packet_lost(
                     sent_info.sent_bytes as u32,
                     sent_info.cc_packet_info,
@@ -982,14 +936,6 @@ impl<Config: endpoint::Config> Manager<Config> {
                     now,
                     &mut congestion_controller::Publisher::new(publisher, sent_info.path_id),
                 );
-                if slow_start && !path.congestion_controller.is_slow_start() {
-                    let path_id = sent_info.path_id;
-                    publisher.on_slow_start_exited(event::builder::SlowStartExited {
-                        path: path_event!(path, path_id),
-                        cause: SlowStartExitCause::PacketLoss,
-                        congestion_window,
-                    });
-                }
                 is_congestion_event = true;
             }
 

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -148,7 +148,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         }
         path.congestion_controller.on_packet_discarded(
             discarded_bytes,
-            &mut congestion_controller::Publisher::new(publisher, path_id),
+            &mut congestion_controller::PathPublisher::new(publisher, path_id),
         );
 
         *self = Self::new(self.space);
@@ -231,7 +231,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             congestion_controlled_bytes,
             app_limited,
             &path.rtt_estimator,
-            &mut congestion_controller::Publisher::new(publisher, path_id),
+            &mut congestion_controller::PathPublisher::new(publisher, path_id),
         );
 
         self.sent_packets.insert(
@@ -557,7 +557,7 @@ impl<Config: endpoint::Config> Manager<Config> {
                 largest_newly_acked_info.time_sent,
                 timestamp,
                 &path.rtt_estimator,
-                &mut congestion_controller::Publisher::new(
+                &mut congestion_controller::PathPublisher::new(
                     publisher,
                     largest_newly_acked_info.path_id,
                 ),
@@ -609,7 +609,7 @@ impl<Config: endpoint::Config> Manager<Config> {
                     &path.rtt_estimator,
                     random_generator,
                     timestamp,
-                    &mut congestion_controller::Publisher::new(
+                    &mut congestion_controller::PathPublisher::new(
                         publisher,
                         acked_packet_info.path_id,
                     ),
@@ -666,7 +666,7 @@ impl<Config: endpoint::Config> Manager<Config> {
                 &path.rtt_estimator,
                 random_generator,
                 timestamp,
-                &mut congestion_controller::Publisher::new(publisher, current_path_id),
+                &mut congestion_controller::PathPublisher::new(publisher, current_path_id),
             );
             self.update_pto_timer(path, timestamp, is_handshake_confirmed);
         }
@@ -706,7 +706,7 @@ impl<Config: endpoint::Config> Manager<Config> {
                 .on_explicit_congestion(
                     ce_count.as_u64(),
                     timestamp,
-                    &mut congestion_controller::Publisher::new(publisher, path_id),
+                    &mut congestion_controller::PathPublisher::new(publisher, path_id),
                 );
             let path = context.path();
             publisher.on_congestion(event::builder::Congestion {
@@ -752,7 +752,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         }
         path.congestion_controller.on_packet_discarded(
             discarded_bytes,
-            &mut congestion_controller::Publisher::new(publisher, path_id),
+            &mut congestion_controller::PathPublisher::new(publisher, path_id),
         );
     }
 
@@ -924,7 +924,7 @@ impl<Config: endpoint::Config> Manager<Config> {
                 //# unnecessary reduction of the sending rate.
                 path.congestion_controller.on_packet_discarded(
                     sent_info.sent_bytes as usize,
-                    &mut congestion_controller::Publisher::new(publisher, sent_info.path_id),
+                    &mut congestion_controller::PathPublisher::new(publisher, sent_info.path_id),
                 );
             } else if sent_info.sent_bytes > 0 {
                 path.congestion_controller.on_packet_lost(
@@ -934,7 +934,7 @@ impl<Config: endpoint::Config> Manager<Config> {
                     new_loss_burst,
                     random_generator,
                     now,
-                    &mut congestion_controller::Publisher::new(publisher, sent_info.path_id),
+                    &mut congestion_controller::PathPublisher::new(publisher, sent_info.path_id),
                 );
                 is_congestion_event = true;
             }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_process_ecn.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_process_ecn.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
-assertion_line: 920
 expression: ""
 ---
 EcnStateChanged { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, state: Unknown }
@@ -8,7 +7,6 @@ AckRangeReceived { packet_header: OneRtt { number: 2 }, path: Path { local_addr:
 PacketLost { packet_header: OneRtt { number: 1 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, bytes_lost: 128, is_mtu_probe: false }
 Congestion { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, source: PacketLoss }
 EcnStateChanged { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, state: Capable }
-SlowStartExited { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, cause: Ecn, congestion_window: 15000 }
 Congestion { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, source: Ecn }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 500ms, smoothed_rtt: 500ms, latest_rtt: 500ms, rtt_variance: 250ms, max_ack_delay: 10ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 1152, congestion_limited: false }
 AckRangeReceived { packet_header: OneRtt { number: 6 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, ack_range: 6..=10 }

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -87,11 +87,13 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
     ///
     /// Reset the TLS stack and recover state when the first Retry packet is processed.
     /// Also regenerate the Initial keys based on the new retry_source_connection_id.
-    pub fn on_retry_packet(
+    pub fn on_retry_packet<Pub: event::ConnectionPublisher>(
         &mut self,
         path: &mut path::Path<Config>,
+        path_id: path::Id,
         retry_source_connection_id: &PeerId,
         retry_token: &[u8],
+        publisher: &mut Pub,
     ) {
         debug_assert!(Config::ENDPOINT_TYPE.is_client());
         self.retry_token = retry_token.to_vec();
@@ -116,7 +118,8 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
 
         // Reset the recovery state; discarding any previous Initial packets that
         // might have been sent/lost.
-        self.recovery_manager.on_retry_packet(path);
+        self.recovery_manager
+            .on_retry_packet(path, path_id, publisher);
     }
 
     /// Returns true if the packet number has already been processed


### PR DESCRIPTION
### Resolved issues:

resolves #1519

### Description of changes: 

This change introduces a `congestion_controller::Publisher` that is passed to all mutating congestion controller methods, to allow for each congestion controller to emit events internally. This publisher wraps an `event::ConnectionPublisher` to provide the necessary context and increase ease of use within a congestion controller. 

The `SlowStartExited` event has been moved from being emitted by the `recovery::Manager` to inside the Cubic and BBR congestion controllers. This necessitated changing the `path` member of this event to just `path_id`. 

Two new events are also added as part of this PR:
* `DeliveryRateSampled`: This event is emitted when ever BBR updates its estimation of the delivery rate of the current path. Since Cubic does not use delivery rate estimation, this event is not emitted for the Cubic congestion controller.
* `PacingRateUpdate`: This event is emitted when the pacing rate that both Cubic or BBR use for pacing out sending packets is updated. To simplify the recording of this metric, the Cubic pacer has been refactored to utilize the `Bandwidth` struct to define the pacing rate.

### Call-outs:

The `SlowStartExited` event has been changed to use `path_id` instead of `path`, as the congestion controller is owned by the path, making it difficult to include the entire path type in the event. This is technically a breaking change, though this event is new enough that it is unlikely to be in use yet.

### Testing:

I added a differential fuzz test for the refactoring of the Cubic pacing logic to test that the new logic differs from the old logic by less than 1.1 ms. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

