### PR TITLE
fix(s2n-quic-core): Initialize BBR pacing rate on first RTT sample

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__pacing__events__initialize_pacing_rate.snap
+++ b/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__pacing__events__initialize_pacing_rate.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/bbr/pacing.rs
+expression: ""
+---
+PacingRateUpdated { path_id: 0, bytes_per_second: 384024, burst_size: 12000, pacing_gain: 2.77 }

--- a/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__pacing__events__one_rtt.snap
+++ b/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__pacing__events__one_rtt.snap
@@ -3,4 +3,3 @@ source: quic/s2n-quic-core/src/recovery/bbr/pacing.rs
 expression: ""
 ---
 PacingRateUpdated { path_id: 0, bytes_per_second: 2747252, burst_size: 12000, pacing_gain: 2.77 }
-PacingRateUpdated { path_id: 0, bytes_per_second: 2747252, burst_size: 12000, pacing_gain: 2.77 }


### PR DESCRIPTION
### Description of changes: 

The [BBR draft RFC](https://www.ietf.org/archive/id/draft-cardwell-iccrg-bbr-congestion-control-02.html#section-4.6.2-5) and current BBR implementation initialize pacing rate based on a nominal bandwidth calculation that ends up being about 33MB/s. Since the pacing rate does not decrease while in slow start, this very high initial pacing value could lead to bursts and potential packet loss. 

Following the [TCP Linux BBR implementation](https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L666-L667), this change will initialize the pacing rate a second time, when the first real RTT sample is measured. 

### Testing:

Added unit test, and local testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

