### PR TITLE
ci: add kani task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -647,3 +647,31 @@ jobs:
           ./scripts/typos --format json | tee /tmp/typos.json | jq -rs '.[] | "::error file=\(.path),line=\(.line_num),col=\(.byte_offset)::\(.typo) should be \"" + (.corrections // [] | join("\" or \"") + "\"")'
           cat /tmp/typos.json
           ! grep -q '[^[:space:]]' /tmp/typos.json
+
+  kani:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - uses: camshaft/install@v1
+        with:
+          crate: kani-verifier
+          version: 0.11.0
+          bins: kani,cargo-kani
+
+      - name: Kani setup
+        run: cargo-kani setup
+
+      - name: Kani run
+        run: |
+          cd quic/s2n-quic-core
+          cargo kani --tests --enable-unstable --mir-linker

--- a/quic/s2n-quic-core/src/packet/number/sliding_window.rs
+++ b/quic/s2n-quic-core/src/packet/number/sliding_window.rs
@@ -277,7 +277,7 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(kani, kani::proof)]
+    #[cfg_attr(kani, kani::proof, kani::unwind(2))]
     #[cfg_attr(miri, ignore)] // this test is too expensive for miri
     fn insert_test() {
         // Make sure the two packet numbers are not the same

--- a/quic/s2n-quic-core/src/packet/number/tests.rs
+++ b/quic/s2n-quic-core/src/packet/number/tests.rs
@@ -10,7 +10,7 @@ use bolero::{check, generator::*};
 use s2n_codec::{testing::encode, DecoderBuffer};
 
 #[test]
-#[cfg_attr(kani, kani::proof)]
+#[cfg_attr(kani, kani::proof, kani::unwind(5))]
 fn round_trip() {
     check!()
         .with_generator(
@@ -160,7 +160,7 @@ fn rfc_decoder(largest_pn: u64, truncated_pn: u64, pn_nbits: usize) -> u64 {
 }
 
 #[test]
-#[cfg_attr(kani, kani::proof)]
+#[cfg_attr(kani, kani::proof, kani::unwind(5))]
 fn truncate_expand_test() {
     check!()
         .with_type()
@@ -175,7 +175,7 @@ fn truncate_expand_test() {
 }
 
 #[test]
-#[cfg_attr(kani, kani::proof)]
+#[cfg_attr(kani, kani::proof, kani::unwind(5))]
 fn rfc_differential_test() {
     check!()
         .with_type()
@@ -207,7 +207,7 @@ fn rfc_differential_test() {
 }
 
 #[test]
-#[cfg_attr(kani, kani::proof)]
+#[cfg_attr(kani, kani::proof, kani::unwind(5))]
 fn example_test() {
     macro_rules! example {
         ($largest:expr, $truncated:expr, $expected:expr) => {{

--- a/quic/s2n-quic-core/src/slice.rs
+++ b/quic/s2n-quic-core/src/slice.rs
@@ -152,9 +152,9 @@ mod tests {
 
     const LEN: usize = if cfg!(kani) { 2 } else { 32 };
 
-    #[cfg_attr(not(kani), test)]
-    #[cfg_attr(kani, kani::proof)]
-    #[cfg_attr(kani, kani::unwind(5))]
+    #[test]
+    #[cfg(any(not(kani), kani_slow))]
+    #[cfg_attr(kani, kani::proof, kani::unwind(5))]
     #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
     fn vectored_copy_fuzz_test() {
         check!()


### PR DESCRIPTION
### Description of changes: 

This change adds a Kani CI task for running all of our kani harnesses. [Task link](https://github.com/aws/s2n-quic/actions/runs/3222849352/jobs/5272343920)

### Call-outs:

I've added `unwind` values to all of the harnesses to prevent kani from endlessly unwinding if it can't figure out the bounds. I've also gated the vectored copy harness behind a `cfg(kani_slow)` as it currently takes around 30 minutes to verify.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

