### PR TITLE
fix(s2n-quic-core): add missing fields on loading limits into TPs

### DIFF
--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -619,26 +619,6 @@ pub const fn compute_data_window(mbps: u64, rtt: Duration, rtt_count: u64) -> Va
     VarInt::from_u32(window as u32)
 }
 
-#[test]
-fn compute_data_window_test() {
-    assert_eq!(
-        *compute_data_window(150, Duration::from_millis(10), 1),
-        187_500
-    );
-    assert_eq!(
-        *compute_data_window(150, Duration::from_millis(10), 2),
-        375_000
-    );
-    assert_eq!(
-        *compute_data_window(150, Duration::from_millis(100), 2),
-        3_750_000
-    );
-    assert_eq!(
-        *compute_data_window(1500, Duration::from_millis(100), 2),
-        37_500_000
-    );
-}
-
 impl InitialMaxData {
     /// Tuned for 150Mbps with a 100ms RTT
     pub const RECOMMENDED: Self = Self(compute_data_window(150, Duration::from_millis(100), 2));
@@ -1464,6 +1444,7 @@ impl<
             };
         }
 
+        load!(max_idle_timeout, max_idle_timeout);
         load!(max_ack_delay, max_ack_delay);
         load!(data_window, initial_max_data);
         load!(
@@ -1485,154 +1466,8 @@ impl<
             initial_max_streams_uni
         );
         load!(max_ack_delay, max_ack_delay);
+        load!(ack_delay_exponent, ack_delay_exponent);
         load!(max_active_connection_ids, active_connection_id_limit);
         load!(max_datagram_frame_size, max_datagram_frame_size);
-    }
-}
-
-#[cfg(test)]
-mod snapshot_tests {
-    use super::*;
-    use s2n_codec::assert_codec_round_trip_value;
-
-    macro_rules! default_transport_parameter_test {
-        ($endpoint_params:ident) => {
-            let default_value = $endpoint_params::default();
-
-            #[cfg(not(miri))] // snapshot tests don't work on miri
-            insta::assert_debug_snapshot!(
-                concat!(stringify!($endpoint_params), "__default"),
-                default_value
-            );
-            // Tests that a transport parameter will not be sent if it is set
-            // to its default value defined in the rfc.
-            let encoded_output: Vec<u8> =
-                assert_codec_round_trip_value!($endpoint_params, default_value);
-            let expected_output: Vec<u8> = vec![];
-            assert_eq!(
-                encoded_output, expected_output,
-                "Default parameters should be empty"
-            );
-        };
-    }
-
-    #[test]
-    fn default_server_snapshot_test() {
-        default_transport_parameter_test!(ServerTransportParameters);
-    }
-
-    #[test]
-    fn default_client_snapshot_test() {
-        default_transport_parameter_test!(ClientTransportParameters);
-    }
-
-    fn server_transport_parameters() -> ServerTransportParameters {
-        // pick a value that isn't the default for any of the params
-        let integer_value = VarInt::from_u8(42);
-
-        ServerTransportParameters {
-            max_idle_timeout: integer_value.try_into().unwrap(),
-            max_udp_payload_size: MaxUdpPayloadSize::new(1500u16).unwrap(),
-            initial_max_data: integer_value.try_into().unwrap(),
-            initial_max_stream_data_bidi_local: integer_value.try_into().unwrap(),
-            initial_max_stream_data_bidi_remote: integer_value.try_into().unwrap(),
-            initial_max_stream_data_uni: integer_value.try_into().unwrap(),
-            initial_max_streams_bidi: integer_value.try_into().unwrap(),
-            initial_max_streams_uni: integer_value.try_into().unwrap(),
-            max_datagram_frame_size: MaxDatagramFrameSize::new(0u16).unwrap(),
-            ack_delay_exponent: 2u8.try_into().unwrap(),
-            max_ack_delay: integer_value.try_into().unwrap(),
-            migration_support: MigrationSupport::Disabled,
-            active_connection_id_limit: integer_value.try_into().unwrap(),
-            original_destination_connection_id: Some(
-                [1, 2, 3, 4, 5, 6, 7, 8][..].try_into().unwrap(),
-            ),
-            stateless_reset_token: Some([2; 16].into()),
-            preferred_address: Some(PreferredAddress {
-                ipv4_address: Some(SocketAddressV4::new([127, 0, 0, 1], 1337)),
-                ipv6_address: None,
-                connection_id: [4, 5, 6, 7][..].try_into().unwrap(),
-                stateless_reset_token: [1; 16].into(),
-            }),
-            initial_source_connection_id: Some([1, 2, 3, 4][..].try_into().unwrap()),
-            retry_source_connection_id: Some([1, 2, 3, 4][..].try_into().unwrap()),
-        }
-    }
-
-    #[test]
-    fn server_snapshot_test() {
-        let value = server_transport_parameters();
-        let encoded_output = assert_codec_round_trip_value!(ServerTransportParameters, value);
-
-        #[cfg(not(miri))] // snapshot tests don't work on miri
-        insta::assert_debug_snapshot!("server_snapshot_test", encoded_output);
-
-        let _ = encoded_output;
-    }
-
-    fn client_transport_parameters() -> ClientTransportParameters {
-        // pick a value that isn't the default for any of the params
-        let integer_value = VarInt::from_u8(42);
-
-        ClientTransportParameters {
-            max_idle_timeout: integer_value.try_into().unwrap(),
-            max_udp_payload_size: MaxUdpPayloadSize::new(1500u16).unwrap(),
-            initial_max_data: integer_value.try_into().unwrap(),
-            initial_max_stream_data_bidi_local: integer_value.try_into().unwrap(),
-            initial_max_stream_data_bidi_remote: integer_value.try_into().unwrap(),
-            initial_max_stream_data_uni: integer_value.try_into().unwrap(),
-            initial_max_streams_bidi: integer_value.try_into().unwrap(),
-            initial_max_streams_uni: integer_value.try_into().unwrap(),
-            max_datagram_frame_size: MaxDatagramFrameSize::new(0u16).unwrap(),
-            ack_delay_exponent: 2u8.try_into().unwrap(),
-            max_ack_delay: integer_value.try_into().unwrap(),
-            migration_support: MigrationSupport::Disabled,
-            active_connection_id_limit: integer_value.try_into().unwrap(),
-            original_destination_connection_id: Default::default(),
-            stateless_reset_token: Default::default(),
-            preferred_address: Default::default(),
-            initial_source_connection_id: Some([1, 2, 3, 4][..].try_into().unwrap()),
-            retry_source_connection_id: Default::default(),
-        }
-    }
-
-    #[test]
-    fn client_snapshot_test() {
-        let value = client_transport_parameters();
-        let encoded_output = assert_codec_round_trip_value!(ClientTransportParameters, value);
-
-        #[cfg(not(miri))] // snapshot tests don't work on miri
-        insta::assert_debug_snapshot!("client_snapshot_test", encoded_output);
-
-        let _ = encoded_output;
-    }
-
-    //= https://www.rfc-editor.org/rfc/rfc9000#section-7.4.2
-    //= type=test
-    //# An endpoint MUST ignore transport parameters that it does
-    //# not support.
-    #[test]
-    fn ignore_unknown_parameter() {
-        use s2n_codec::EncoderBuffer;
-
-        let value = client_transport_parameters();
-
-        // Reserved parameters have tags of the form 31 * N + 27
-        // We inject one at the end
-        let mut buffer = vec![0; 32 * 1024];
-        let mut encoder = EncoderBuffer::new(&mut buffer);
-
-        encoder.encode(&value);
-
-        let id1: TransportParameterId = VarInt::from_u16(31 * 2 + 27);
-        encoder.encode(&id1);
-        encoder.encode_with_len_prefix::<TransportParameterLength, _>(&());
-
-        let (encoded, _) = encoder.split_off();
-        let decoder = DecoderBuffer::new(encoded);
-        let (decoded_params, remaining) =
-            ClientTransportParameters::decode(decoder).expect("Decoding succeeds");
-        assert_eq!(value, decoded_params);
-        assert_eq!(0, remaining.len());
     }
 }

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__ClientTransportParameters__default.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__ClientTransportParameters__default.snap
@@ -1,0 +1,79 @@
+---
+source: quic/s2n-quic-core/src/transport/parameters/tests.rs
+assertion_line: 55
+expression: default_value
+---
+TransportParameters {
+    max_idle_timeout: MaxIdleTimeout(
+        VarInt(
+            0,
+        ),
+    ),
+    max_udp_payload_size: MaxUdpPayloadSize(
+        VarInt(
+            65527,
+        ),
+    ),
+    initial_max_data: InitialMaxData(
+        VarInt(
+            0,
+        ),
+    ),
+    initial_max_stream_data_bidi_local: InitialMaxStreamDataBidiLocal(
+        VarInt(
+            0,
+        ),
+    ),
+    initial_max_stream_data_bidi_remote: InitialMaxStreamDataBidiRemote(
+        VarInt(
+            0,
+        ),
+    ),
+    initial_max_stream_data_uni: InitialMaxStreamDataUni(
+        VarInt(
+            0,
+        ),
+    ),
+    initial_max_streams_bidi: InitialMaxStreamsBidi(
+        VarInt(
+            0,
+        ),
+    ),
+    initial_max_streams_uni: InitialMaxStreamsUni(
+        VarInt(
+            0,
+        ),
+    ),
+    max_datagram_frame_size: MaxDatagramFrameSize(
+        VarInt(
+            0,
+        ),
+    ),
+    ack_delay_exponent: AckDelayExponent(
+        3,
+    ),
+    max_ack_delay: MaxAckDelay(
+        VarInt(
+            25,
+        ),
+    ),
+    migration_support: Enabled,
+    active_connection_id_limit: ActiveConnectionIdLimit(
+        VarInt(
+            2,
+        ),
+    ),
+    original_destination_connection_id: DisabledParameter(
+        PhantomData,
+    ),
+    stateless_reset_token: DisabledParameter(
+        PhantomData,
+    ),
+    preferred_address: DisabledParameter(
+        PhantomData,
+    ),
+    initial_source_connection_id: None,
+    retry_source_connection_id: DisabledParameter(
+        PhantomData,
+    ),
+}

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__ServerTransportParameters__default.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__ServerTransportParameters__default.snap
@@ -1,8 +1,7 @@
 ---
-source: quic/s2n-quic-core/src/transport/parameters/mod.rs
-assertion_line: 1542
+source: quic/s2n-quic-core/src/transport/parameters/tests.rs
+assertion_line: 50
 expression: default_value
-
 ---
 TransportParameters {
     max_idle_timeout: MaxIdleTimeout(
@@ -64,17 +63,9 @@ TransportParameters {
             2,
         ),
     ),
-    original_destination_connection_id: DisabledParameter(
-        PhantomData,
-    ),
-    stateless_reset_token: DisabledParameter(
-        PhantomData,
-    ),
-    preferred_address: DisabledParameter(
-        PhantomData,
-    ),
+    original_destination_connection_id: None,
+    stateless_reset_token: None,
+    preferred_address: None,
     initial_source_connection_id: None,
-    retry_source_connection_id: DisabledParameter(
-        PhantomData,
-    ),
+    retry_source_connection_id: None,
 }

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__client_snapshot_test.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__client_snapshot_test.snap
@@ -1,8 +1,7 @@
 ---
-source: quic/s2n-quic-core/src/transport/parameters/mod.rs
-assertion_line: 1633
+source: quic/s2n-quic-core/src/transport/parameters/tests.rs
+assertion_line: 132
 expression: encoded_output
-
 ---
 [
     1,

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__load_client_limits.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__load_client_limits.snap
@@ -1,13 +1,12 @@
 ---
-source: quic/s2n-quic-core/src/transport/parameters/mod.rs
-assertion_line: 1537
-expression: default_value
-
+source: quic/s2n-quic-core/src/transport/parameters/tests.rs
+assertion_line: 154
+expression: params
 ---
 TransportParameters {
     max_idle_timeout: MaxIdleTimeout(
         VarInt(
-            0,
+            30000,
         ),
     ),
     max_udp_payload_size: MaxUdpPayloadSize(
@@ -17,32 +16,32 @@ TransportParameters {
     ),
     initial_max_data: InitialMaxData(
         VarInt(
-            0,
+            3750000,
         ),
     ),
     initial_max_stream_data_bidi_local: InitialMaxStreamDataBidiLocal(
         VarInt(
-            0,
+            3750000,
         ),
     ),
     initial_max_stream_data_bidi_remote: InitialMaxStreamDataBidiRemote(
         VarInt(
-            0,
+            3750000,
         ),
     ),
     initial_max_stream_data_uni: InitialMaxStreamDataUni(
         VarInt(
-            0,
+            3750000,
         ),
     ),
     initial_max_streams_bidi: InitialMaxStreamsBidi(
         VarInt(
-            0,
+            100,
         ),
     ),
     initial_max_streams_uni: InitialMaxStreamsUni(
         VarInt(
-            0,
+            100,
         ),
     ),
     max_datagram_frame_size: MaxDatagramFrameSize(
@@ -64,9 +63,17 @@ TransportParameters {
             2,
         ),
     ),
-    original_destination_connection_id: None,
-    stateless_reset_token: None,
-    preferred_address: None,
+    original_destination_connection_id: DisabledParameter(
+        PhantomData,
+    ),
+    stateless_reset_token: DisabledParameter(
+        PhantomData,
+    ),
+    preferred_address: DisabledParameter(
+        PhantomData,
+    ),
     initial_source_connection_id: None,
-    retry_source_connection_id: None,
+    retry_source_connection_id: DisabledParameter(
+        PhantomData,
+    ),
 }

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__load_server_limits.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__load_server_limits.snap
@@ -1,0 +1,71 @@
+---
+source: quic/s2n-quic-core/src/transport/parameters/tests.rs
+assertion_line: 147
+expression: params
+---
+TransportParameters {
+    max_idle_timeout: MaxIdleTimeout(
+        VarInt(
+            30000,
+        ),
+    ),
+    max_udp_payload_size: MaxUdpPayloadSize(
+        VarInt(
+            65527,
+        ),
+    ),
+    initial_max_data: InitialMaxData(
+        VarInt(
+            3750000,
+        ),
+    ),
+    initial_max_stream_data_bidi_local: InitialMaxStreamDataBidiLocal(
+        VarInt(
+            3750000,
+        ),
+    ),
+    initial_max_stream_data_bidi_remote: InitialMaxStreamDataBidiRemote(
+        VarInt(
+            3750000,
+        ),
+    ),
+    initial_max_stream_data_uni: InitialMaxStreamDataUni(
+        VarInt(
+            3750000,
+        ),
+    ),
+    initial_max_streams_bidi: InitialMaxStreamsBidi(
+        VarInt(
+            100,
+        ),
+    ),
+    initial_max_streams_uni: InitialMaxStreamsUni(
+        VarInt(
+            100,
+        ),
+    ),
+    max_datagram_frame_size: MaxDatagramFrameSize(
+        VarInt(
+            0,
+        ),
+    ),
+    ack_delay_exponent: AckDelayExponent(
+        3,
+    ),
+    max_ack_delay: MaxAckDelay(
+        VarInt(
+            25,
+        ),
+    ),
+    migration_support: Enabled,
+    active_connection_id_limit: ActiveConnectionIdLimit(
+        VarInt(
+            2,
+        ),
+    ),
+    original_destination_connection_id: None,
+    stateless_reset_token: None,
+    preferred_address: None,
+    initial_source_connection_id: None,
+    retry_source_connection_id: None,
+}

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__server_snapshot_test.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__server_snapshot_test.snap
@@ -1,8 +1,7 @@
 ---
-source: quic/s2n-quic-core/src/transport/parameters/mod.rs
-assertion_line: 1596
+source: quic/s2n-quic-core/src/transport/parameters/tests.rs
+assertion_line: 95
 expression: encoded_output
-
 ---
 [
     1,

--- a/quic/s2n-quic-core/src/transport/parameters/tests.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/tests.rs
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::transport::parameters::{ClientTransportParameters, ServerTransportParameters};
+use super::*;
 use bolero::check;
-use s2n_codec::assert_codec_round_trip_bytes;
+use s2n_codec::{assert_codec_round_trip_bytes, assert_codec_round_trip_value};
 
 #[test]
 #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
@@ -19,4 +19,183 @@ fn round_trip() {
             assert_codec_round_trip_bytes!(ServerTransportParameters, input[1..]);
         }
     });
+}
+
+macro_rules! default_transport_parameter_test {
+    ($endpoint_params:ident) => {
+        let default_value = $endpoint_params::default();
+
+        #[cfg(not(miri))] // snapshot tests don't work on miri
+        insta::assert_debug_snapshot!(
+            concat!(stringify!($endpoint_params), "__default"),
+            default_value
+        );
+        // Tests that a transport parameter will not be sent if it is set
+        // to its default value defined in the rfc.
+        let encoded_output: Vec<u8> =
+            assert_codec_round_trip_value!($endpoint_params, default_value);
+        let expected_output: Vec<u8> = vec![];
+        assert_eq!(
+            encoded_output, expected_output,
+            "Default parameters should be empty"
+        );
+    };
+}
+
+#[test]
+fn default_server_snapshot_test() {
+    default_transport_parameter_test!(ServerTransportParameters);
+}
+
+#[test]
+fn default_client_snapshot_test() {
+    default_transport_parameter_test!(ClientTransportParameters);
+}
+
+fn server_transport_parameters() -> ServerTransportParameters {
+    // pick a value that isn't the default for any of the params
+    let integer_value = VarInt::from_u8(42);
+
+    ServerTransportParameters {
+        max_idle_timeout: integer_value.try_into().unwrap(),
+        max_udp_payload_size: MaxUdpPayloadSize::new(1500u16).unwrap(),
+        initial_max_data: integer_value.try_into().unwrap(),
+        initial_max_stream_data_bidi_local: integer_value.try_into().unwrap(),
+        initial_max_stream_data_bidi_remote: integer_value.try_into().unwrap(),
+        initial_max_stream_data_uni: integer_value.try_into().unwrap(),
+        initial_max_streams_bidi: integer_value.try_into().unwrap(),
+        initial_max_streams_uni: integer_value.try_into().unwrap(),
+        max_datagram_frame_size: MaxDatagramFrameSize::new(0u16).unwrap(),
+        ack_delay_exponent: 2u8.try_into().unwrap(),
+        max_ack_delay: integer_value.try_into().unwrap(),
+        migration_support: MigrationSupport::Disabled,
+        active_connection_id_limit: integer_value.try_into().unwrap(),
+        original_destination_connection_id: Some([1, 2, 3, 4, 5, 6, 7, 8][..].try_into().unwrap()),
+        stateless_reset_token: Some([2; 16].into()),
+        preferred_address: Some(PreferredAddress {
+            ipv4_address: Some(SocketAddressV4::new([127, 0, 0, 1], 1337)),
+            ipv6_address: None,
+            connection_id: [4, 5, 6, 7][..].try_into().unwrap(),
+            stateless_reset_token: [1; 16].into(),
+        }),
+        initial_source_connection_id: Some([1, 2, 3, 4][..].try_into().unwrap()),
+        retry_source_connection_id: Some([1, 2, 3, 4][..].try_into().unwrap()),
+    }
+}
+
+#[test]
+fn server_snapshot_test() {
+    let value = server_transport_parameters();
+    let encoded_output = assert_codec_round_trip_value!(ServerTransportParameters, value);
+
+    #[cfg(not(miri))] // snapshot tests don't work on miri
+    insta::assert_debug_snapshot!("server_snapshot_test", encoded_output);
+
+    let _ = encoded_output;
+}
+
+fn client_transport_parameters() -> ClientTransportParameters {
+    // pick a value that isn't the default for any of the params
+    let integer_value = VarInt::from_u8(42);
+
+    ClientTransportParameters {
+        max_idle_timeout: integer_value.try_into().unwrap(),
+        max_udp_payload_size: MaxUdpPayloadSize::new(1500u16).unwrap(),
+        initial_max_data: integer_value.try_into().unwrap(),
+        initial_max_stream_data_bidi_local: integer_value.try_into().unwrap(),
+        initial_max_stream_data_bidi_remote: integer_value.try_into().unwrap(),
+        initial_max_stream_data_uni: integer_value.try_into().unwrap(),
+        initial_max_streams_bidi: integer_value.try_into().unwrap(),
+        initial_max_streams_uni: integer_value.try_into().unwrap(),
+        max_datagram_frame_size: MaxDatagramFrameSize::new(0u16).unwrap(),
+        ack_delay_exponent: 2u8.try_into().unwrap(),
+        max_ack_delay: integer_value.try_into().unwrap(),
+        migration_support: MigrationSupport::Disabled,
+        active_connection_id_limit: integer_value.try_into().unwrap(),
+        original_destination_connection_id: Default::default(),
+        stateless_reset_token: Default::default(),
+        preferred_address: Default::default(),
+        initial_source_connection_id: Some([1, 2, 3, 4][..].try_into().unwrap()),
+        retry_source_connection_id: Default::default(),
+    }
+}
+
+#[test]
+fn client_snapshot_test() {
+    let value = client_transport_parameters();
+    let encoded_output = assert_codec_round_trip_value!(ClientTransportParameters, value);
+
+    #[cfg(not(miri))] // snapshot tests don't work on miri
+    insta::assert_debug_snapshot!("client_snapshot_test", encoded_output);
+
+    let _ = encoded_output;
+}
+
+#[test]
+fn load_server_limits() {
+    let limits = crate::connection::limits::Limits::default();
+    let mut params = ServerTransportParameters::default();
+    params.load_limits(&limits);
+
+    #[cfg(not(miri))]
+    insta::assert_debug_snapshot!("load_server_limits", params);
+}
+
+#[test]
+fn load_client_limits() {
+    let limits = crate::connection::limits::Limits::default();
+    let mut params = ClientTransportParameters::default();
+    params.load_limits(&limits);
+
+    #[cfg(not(miri))]
+    insta::assert_debug_snapshot!("load_client_limits", params);
+}
+
+//= https://www.rfc-editor.org/rfc/rfc9000#section-7.4.2
+//= type=test
+//# An endpoint MUST ignore transport parameters that it does
+//# not support.
+#[test]
+fn ignore_unknown_parameter() {
+    use s2n_codec::EncoderBuffer;
+
+    let value = client_transport_parameters();
+
+    // Reserved parameters have tags of the form 31 * N + 27
+    // We inject one at the end
+    let mut buffer = vec![0; 32 * 1024];
+    let mut encoder = EncoderBuffer::new(&mut buffer);
+
+    encoder.encode(&value);
+
+    let id1: TransportParameterId = VarInt::from_u16(31 * 2 + 27);
+    encoder.encode(&id1);
+    encoder.encode_with_len_prefix::<TransportParameterLength, _>(&());
+
+    let (encoded, _) = encoder.split_off();
+    let decoder = DecoderBuffer::new(encoded);
+    let (decoded_params, remaining) =
+        ClientTransportParameters::decode(decoder).expect("Decoding succeeds");
+    assert_eq!(value, decoded_params);
+    assert_eq!(0, remaining.len());
+}
+
+#[test]
+fn compute_data_window_test() {
+    assert_eq!(
+        *compute_data_window(150, Duration::from_millis(10), 1),
+        187_500
+    );
+    assert_eq!(
+        *compute_data_window(150, Duration::from_millis(10), 2),
+        375_000
+    );
+    assert_eq!(
+        *compute_data_window(150, Duration::from_millis(100), 2),
+        3_750_000
+    );
+    assert_eq!(
+        *compute_data_window(1500, Duration::from_millis(100), 2),
+        37_500_000
+    );
 }


### PR DESCRIPTION
### Description of changes: 

We currently have a couple of missing loads for copying the connection limits into transport parameters. This makes it effectively impossible for us to communicate the correct `max_idle_timeout` and `ack_delay_exponent` value to the peer.

This change adds the missing loads.

### Testing:

I've also added a couple of snapshot tests to show the fix is now working and prevent a similar issue from happening in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

