### PR TITLE
fix(s2n-quic-core): BBR app-limited fixes

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
@@ -250,6 +250,7 @@ impl Estimator {
     pub fn on_packet_sent(
         &mut self,
         bytes_in_flight: u32,
+        sent_bytes: usize,
         app_limited: Option<bool>,
         now: Timestamp,
     ) -> PacketInfo {
@@ -274,8 +275,8 @@ impl Estimator {
             self.delivered_time = Some(now);
         }
 
-        if app_limited.unwrap_or(false) {
-            self.on_app_limited(bytes_in_flight);
+        if app_limited.unwrap_or(true) {
+            self.on_app_limited(bytes_in_flight.saturating_add(sent_bytes as u32));
         }
 
         PacketInfo {

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__app_limited.snap
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__app_limited.snap
@@ -2,5 +2,5 @@
 source: quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
 expression: ""
 ---
-DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 1s, delivered_bytes: 1500, lost_bytes: 100, ecn_ce_count: 5, is_app_limited: false, prior_delivered_bytes: 15000, bytes_in_flight: 1500, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 1500 } }
-DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 1s, delivered_bytes: 1501, lost_bytes: 100, ecn_ce_count: 5, is_app_limited: false, prior_delivered_bytes: 15000, bytes_in_flight: 1500, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 1501 } }
+DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 1s, delivered_bytes: 2600, lost_bytes: 100, ecn_ce_count: 5, is_app_limited: false, prior_delivered_bytes: 15000, bytes_in_flight: 1500, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 2600 } }
+DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 1s, delivered_bytes: 2601, lost_bytes: 100, ecn_ce_count: 5, is_app_limited: false, prior_delivered_bytes: 15000, bytes_in_flight: 1500, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 2601 } }

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
@@ -92,7 +92,7 @@ fn on_packet_sent_timestamp_initialization() {
     let mut bw_estimator = Estimator::default();
 
     // Test that first_sent_time and delivered_time are updated on the first sent packet
-    let packet_info = bw_estimator.on_packet_sent(0, None, t0);
+    let packet_info = bw_estimator.on_packet_sent(0, 0, None, t0);
     assert_eq!(t0, packet_info.first_sent_time);
     assert_eq!(t0, packet_info.delivered_time);
     assert_eq!(Some(t0), bw_estimator.first_sent_time);
@@ -100,7 +100,7 @@ fn on_packet_sent_timestamp_initialization() {
 
     // Test that first_sent_time and delivered_time are not updated if packets are in flight
     let t1 = t0 + Duration::from_secs(1);
-    let packet_info = bw_estimator.on_packet_sent(1500, None, t1);
+    let packet_info = bw_estimator.on_packet_sent(1500, 0, None, t1);
     assert_eq!(t0, packet_info.first_sent_time);
     assert_eq!(t0, packet_info.delivered_time);
     assert_eq!(Some(t0), bw_estimator.first_sent_time);
@@ -108,7 +108,7 @@ fn on_packet_sent_timestamp_initialization() {
 
     // Test that first_sent_time and delivered_time are updated after an idle period
     let t2 = t0 + Duration::from_secs(2);
-    let packet_info = bw_estimator.on_packet_sent(0, None, t2);
+    let packet_info = bw_estimator.on_packet_sent(0, 0, None, t2);
     assert_eq!(t2, packet_info.first_sent_time);
     assert_eq!(t2, packet_info.delivered_time);
     assert_eq!(Some(t2), bw_estimator.first_sent_time);
@@ -129,7 +129,7 @@ fn on_packet_sent() {
         rate_sample: Default::default(),
     };
 
-    let packet_info = bw_estimator.on_packet_sent(500, Some(true), first_sent_time);
+    let packet_info = bw_estimator.on_packet_sent(500, 100, Some(true), first_sent_time);
     assert_eq!(first_sent_time, packet_info.first_sent_time);
     assert_eq!(delivered_time, packet_info.delivered_time);
     assert_eq!(15000, packet_info.delivered_bytes);
@@ -137,7 +137,10 @@ fn on_packet_sent() {
     assert_eq!(5, packet_info.ecn_ce_count);
     assert!(packet_info.is_app_limited);
     assert_eq!(500, packet_info.bytes_in_flight);
-    assert_eq!(Some(500 + 15000), bw_estimator.app_limited_delivered_bytes);
+    assert_eq!(
+        Some(500 + 15000 + 100),
+        bw_estimator.app_limited_delivered_bytes
+    );
 }
 
 #[test]
@@ -157,19 +160,28 @@ fn app_limited() {
     };
 
     // Packet is sent while app-limited, starting the app limited period
-    let packet_info = bw_estimator.on_packet_sent(1500, Some(true), first_sent_time);
+    let packet_info = bw_estimator.on_packet_sent(1500, 100, Some(true), first_sent_time);
     assert!(packet_info.is_app_limited);
-    assert_eq!(Some(1500 + 15000), bw_estimator.app_limited_delivered_bytes);
+    assert_eq!(
+        Some(1500 + 15000 + 100),
+        bw_estimator.app_limited_delivered_bytes
+    );
 
     // Packet is sent while not app-limited, but the app limited continues until all previous bytes in flight have been acknowledged
-    let packet_info = bw_estimator.on_packet_sent(500, Some(false), first_sent_time);
+    let packet_info = bw_estimator.on_packet_sent(500, 100, Some(false), first_sent_time);
     assert!(packet_info.is_app_limited);
-    assert_eq!(Some(1500 + 15000), bw_estimator.app_limited_delivered_bytes);
+    assert_eq!(
+        Some(1500 + 15000 + 100),
+        bw_estimator.app_limited_delivered_bytes
+    );
 
-    // Packet is sent while app-limited is not determined, but the app limited continues until all previous bytes in flight have been acknowledged
-    let packet_info = bw_estimator.on_packet_sent(500, None, first_sent_time);
+    // Packet is sent while app-limited is not determined, this should default to app-limited
+    let packet_info = bw_estimator.on_packet_sent(2500, 100, None, first_sent_time);
     assert!(packet_info.is_app_limited);
-    assert_eq!(Some(1500 + 15000), bw_estimator.app_limited_delivered_bytes);
+    assert_eq!(
+        Some(2500 + 15000 + 100),
+        bw_estimator.app_limited_delivered_bytes
+    );
 
     let packet_info = PacketInfo {
         delivered_bytes: bw_estimator.delivered_bytes,
@@ -183,14 +195,17 @@ fn app_limited() {
 
     // Acknowledge all the bytes that were inflight when the app-limited period began
     bw_estimator.on_ack(
-        1500,
+        2600,
         delivered_time,
         packet_info,
         delivered_time,
         &mut publisher,
     );
     // Still app_limited, since we need bytes to be acknowledged after the app limited period
-    assert_eq!(Some(1500 + 15000), bw_estimator.app_limited_delivered_bytes);
+    assert_eq!(
+        Some(2500 + 100 + 15000),
+        bw_estimator.app_limited_delivered_bytes
+    );
 
     // Acknowledge one more byte
     bw_estimator.on_ack(
@@ -215,15 +230,15 @@ fn on_packet_ack_rate_sample() {
 
     // Send three packets. In between each send, other packets were acknowledged, lost or had ECN CE,
     // and thus the delivered_bytes amount, lost_bytes amount, and ecn ce count is increased.
-    let packet_1 = bw_estimator.on_packet_sent(0, Some(false), t0);
+    let packet_1 = bw_estimator.on_packet_sent(0, 100, Some(false), t0);
     bw_estimator.delivered_bytes = 100000;
     bw_estimator.lost_bytes = 100;
     bw_estimator.ecn_ce_count = 5;
-    let packet_2 = bw_estimator.on_packet_sent(1500, Some(true), t1);
+    let packet_2 = bw_estimator.on_packet_sent(1500, 100, Some(true), t1);
     bw_estimator.delivered_bytes = 200000;
     bw_estimator.lost_bytes = 150;
     bw_estimator.ecn_ce_count = 15;
-    let packet_3 = bw_estimator.on_packet_sent(3000, Some(false), t2);
+    let packet_3 = bw_estimator.on_packet_sent(3000, 100, Some(false), t2);
 
     let now = t0 + Duration::from_secs(10);
     let delivered_bytes = bw_estimator.delivered_bytes;
@@ -353,13 +368,13 @@ fn on_packet_ack_implausible_ack_rate() {
     let mut bw_estimator = Estimator::default();
 
     // A packet is sent and acknowledged 4 seconds later
-    let packet_info = bw_estimator.on_packet_sent(0, Some(false), t0);
+    let packet_info = bw_estimator.on_packet_sent(0, 100, Some(false), t0);
     let t4 = t0 + Duration::from_secs(4);
     bw_estimator.on_ack(1500, t0, packet_info, t4, &mut publisher);
 
     // A packet is sent and acknowledged 1 second later
     let t5 = t0 + Duration::from_secs(5);
-    let packet_info = bw_estimator.on_packet_sent(1500, Some(false), t5);
+    let packet_info = bw_estimator.on_packet_sent(1500, 100, Some(false), t5);
     let now = t0 + Duration::from_secs(6);
     bw_estimator.on_ack(
         1500,

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
@@ -412,6 +412,25 @@ fn on_packet_loss() {
 
     assert_eq!(750, bw_estimator.lost_bytes);
     assert_eq!(750, bw_estimator.rate_sample.lost_bytes);
+
+    bw_estimator.on_app_limited(1000);
+    bw_estimator.on_loss(250);
+    assert_eq!(Some(750), bw_estimator.app_limited_delivered_bytes);
+
+    bw_estimator.on_loss(1000);
+    assert_eq!(Some(0), bw_estimator.app_limited_delivered_bytes);
+}
+
+#[test]
+fn on_packet_discarded() {
+    let mut bw_estimator = Estimator::default();
+
+    bw_estimator.on_app_limited(1000);
+    bw_estimator.on_packet_discarded(250);
+    assert_eq!(Some(750), bw_estimator.app_limited_delivered_bytes);
+
+    bw_estimator.on_packet_discarded(1000);
+    assert_eq!(Some(0), bw_estimator.app_limited_delivered_bytes);
 }
 
 #[test]

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -282,7 +282,7 @@ impl CongestionController for BbrCongestionController {
         }
 
         self.bw_estimator
-            .on_packet_sent(prior_bytes_in_flight, app_limited, time_sent)
+            .on_packet_sent(prior_bytes_in_flight, sent_bytes, app_limited, time_sent)
     }
 
     #[inline]

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -492,6 +492,7 @@ impl CongestionController for BbrCongestionController {
         self.bytes_in_flight
             .try_sub(bytes_sent)
             .expect("bytes sent should not exceed u32::MAX");
+        self.bw_estimator.on_packet_discarded(bytes_sent);
         self.recovery_state.on_packet_discarded();
     }
 


### PR DESCRIPTION
### Description of changes: 

This change includes three fixes to ensure BBR properly marks the connection as application limited:

* If the `app_limited` designation is not provided to BBR (i.e. app_limited = None), the delivery rate estimator will default to considering this app-limited, rather than not app-limited. `app_limited` is only `None` for the Initial and Handshake spaces, when it is more likely than not that the application is not fully utilizing the congestion window. Because the consequences of not considering the connection app-limited can be severe in BBR, it is safer to conservatively consider the connection app-limited in this case.
* When a packet is sent while app_limited, the `bandwith::estimator` marks the connection as app-limited until all the bytes in flight are acknowledged as delivered to the peer. The previous code was not considering the bytes in the packet currently being transmitted as part of the bytes in flight, resulting in the app-limited period ending slightly too early. This change fixes that.
* When a packet is lost or discarded, those bytes will never be delivered. Therefore, the `app_limited_delivered_bytes` that the bandwidth estimator uses for tracking application limited periods should be moved earlier, to account for the less expected delivered bytes.

### Testing:

Updated/added unit tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

