### PR TITLE
fix(s2n-quic-transport): correctly handle 32-bit platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,9 @@ jobs:
           - rust: stable
             os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
+          - rust: stable
+            os: ubuntu-latest
+            target: i686-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v3
         with:

--- a/common/s2n-codec/src/zerocopy.rs
+++ b/common/s2n-codec/src/zerocopy.rs
@@ -71,11 +71,11 @@ macro_rules! zerocopy_value_codec {
 
         impl $crate::EncoderValue for $name {
             fn encoding_size(&self) -> usize {
-                core::mem::size_of::<Self>()
+                core::mem::size_of::<$name>()
             }
 
             fn encoding_size_for_encoder<E: $crate::Encoder>(&self, _encoder: &E) -> usize {
-                core::mem::size_of::<Self>()
+                core::mem::size_of::<$name>()
             }
 
             fn encode<E: $crate::Encoder>(&self, encoder: &mut E) {
@@ -85,11 +85,11 @@ macro_rules! zerocopy_value_codec {
 
         impl<'a> $crate::EncoderValue for &'a $name {
             fn encoding_size(&self) -> usize {
-                core::mem::size_of::<Self>()
+                core::mem::size_of::<$name>()
             }
 
             fn encoding_size_for_encoder<E: $crate::Encoder>(&self, _encoder: &E) -> usize {
-                ::core::mem::size_of::<Self>()
+                ::core::mem::size_of::<$name>()
             }
 
             fn encode<E: $crate::Encoder>(&self, encoder: &mut E) {
@@ -99,11 +99,11 @@ macro_rules! zerocopy_value_codec {
 
         impl<'a> $crate::EncoderValue for &'a mut $name {
             fn encoding_size(&self) -> usize {
-                core::mem::size_of::<Self>()
+                core::mem::size_of::<$name>()
             }
 
             fn encoding_size_for_encoder<E: $crate::Encoder>(&self, _encoder: &E) -> usize {
-                ::core::mem::size_of::<Self>()
+                ::core::mem::size_of::<$name>()
             }
 
             fn encode<E: $crate::Encoder>(&self, encoder: &mut E) {

--- a/quic/s2n-quic-core/src/packet/interceptor/loss.rs
+++ b/quic/s2n-quic-core/src/packet/interceptor/loss.rs
@@ -6,8 +6,8 @@ use core::ops::Range;
 
 #[derive(Debug)]
 struct Direction {
-    loss: Range<usize>,
-    pass: Range<usize>,
+    loss: Range<u64>,
+    pass: Range<u64>,
     mode: Mode,
 }
 
@@ -15,7 +15,7 @@ impl Default for Direction {
     fn default() -> Self {
         Self {
             loss: 0..0,
-            pass: usize::MAX..usize::MAX,
+            pass: u64::MAX..u64::MAX,
             mode: Mode::Loss { remaining: 0 },
         }
     }
@@ -63,7 +63,7 @@ impl Direction {
     }
 
     #[inline]
-    fn gen_range<R: havoc::Random>(range: &Range<usize>, random: &mut R) -> usize {
+    fn gen_range<R: havoc::Random>(range: &Range<u64>, random: &mut R) -> u64 {
         if range.start == range.end {
             return range.start;
         }
@@ -74,8 +74,8 @@ impl Direction {
 
 #[derive(Debug)]
 enum Mode {
-    Loss { remaining: usize },
-    Pass { remaining: usize },
+    Loss { remaining: u64 },
+    Pass { remaining: u64 },
 }
 
 #[derive(Debug, Default)]
@@ -97,22 +97,22 @@ where
         }
     }
 
-    pub fn with_tx_pass(mut self, range: Range<usize>) -> Self {
+    pub fn with_tx_pass(mut self, range: Range<u64>) -> Self {
         self.tx.pass = range;
         self
     }
 
-    pub fn with_tx_loss(mut self, range: Range<usize>) -> Self {
+    pub fn with_tx_loss(mut self, range: Range<u64>) -> Self {
         self.tx.loss = range;
         self
     }
 
-    pub fn with_rx_pass(mut self, range: Range<usize>) -> Self {
+    pub fn with_rx_pass(mut self, range: Range<u64>) -> Self {
         self.rx.pass = range;
         self
     }
 
-    pub fn with_rx_loss(mut self, range: Range<usize>) -> Self {
+    pub fn with_rx_loss(mut self, range: Range<u64>) -> Self {
         self.rx.loss = range;
         self
     }

--- a/quic/s2n-quic-platform/build.rs
+++ b/quic/s2n-quic-platform/build.rs
@@ -27,6 +27,11 @@ fn main() -> Result<(), Error> {
             supports("pktinfo");
             supports("tos");
         }
+        "android" => {
+            supports("mtu_disc");
+            supports("pktinfo");
+            supports("tos");
+        }
         _ => {
             // TODO others
         }

--- a/quic/s2n-quic-platform/src/io/testing.rs
+++ b/quic/s2n-quic-platform/src/io/testing.rs
@@ -46,7 +46,7 @@ pub mod rand {
         }
 
         #[inline]
-        fn gen_range(&mut self, range: core::ops::Range<usize>) -> usize {
+        fn gen_range(&mut self, range: core::ops::Range<u64>) -> u64 {
             gen_range(range)
         }
     }
@@ -196,6 +196,8 @@ impl<N: Network> bach::executor::Environment for Env<N> {
         while let Some(time) = self.time.advance() {
             let _ = time;
             if self.time.wake() > 0 {
+                // if a task has woken, then reset the stall count
+                self.stalled_iterations = 0;
                 break;
             }
         }

--- a/quic/s2n-quic-platform/src/message/cmsg.rs
+++ b/quic/s2n-quic-platform/src/message/cmsg.rs
@@ -256,7 +256,7 @@ mod tests {
     use core::mem::zeroed;
 
     #[test]
-    #[cfg_attr(target_os = "linux", ignore)] // the linux implementation currently has an integer overflow on garbage data
+    #[cfg_attr(any(target_os = "linux", target_os = "android"), ignore)] // the linux implementation currently has an integer overflow on garbage data
     fn iter_test() {
         check!().for_each(|cmsg| {
             let mut msghdr = unsafe { zeroed::<libc::msghdr>() };

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -17,7 +17,6 @@ cfg-if = "1"
 futures = "0.3"
 http = "0.2"
 humansize = "1"
-mimalloc = { version = "0.1", default-features = false }
 openssl-sys = { version = "0.9", features = ["vendored"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-h3 = { path = "../s2n-quic-h3" }
@@ -32,6 +31,10 @@ s2n-quic = { path = "../s2n-quic", features = ["provider-event-tracing", "provid
 
 [target.'cfg(not(unix))'.dependencies]
 s2n-quic = { path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-rustls"] }
+
+# the mimalloc build is currently broken on android
+[target.'cfg(not(target_os = "android"))'.dependencies]
+mimalloc = { version = "0.1", default-features = false }
 
 # we don't use openssl-sys directly; it's just here to pin and vendor in dev
 [package.metadata.cargo-udeps.ignore]

--- a/quic/s2n-quic-qns/src/main.rs
+++ b/quic/s2n-quic-qns/src/main.rs
@@ -18,6 +18,7 @@ mod tls;
 /// Do not change it without updating it elsewhere
 const CRASH_ERROR_MESSAGE: &str = "The s2n-quic-qns application shut down unexpectedly";
 
+#[cfg(not(target_os = "android"))]
 #[global_allocator]
 static ALLOC: mimalloc::MiMalloc = mimalloc::MiMalloc;
 

--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -406,7 +406,6 @@ mod tests {
     };
     use core::{
         iter::{empty, once},
-        mem::size_of,
         time::Duration,
     };
     use insta::assert_debug_snapshot;
@@ -635,7 +634,11 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn size_of_snapshots() {
+        use core::mem::size_of;
+        use insta::assert_debug_snapshot;
+
         assert_debug_snapshot!("AckManager", size_of::<AckManager>());
     }
 

--- a/quic/s2n-quic-transport/src/ack/ack_ranges.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_ranges.rs
@@ -284,6 +284,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn size_of_snapshots() {
         use core::mem::size_of;
         use insta::assert_debug_snapshot;

--- a/quic/s2n-quic-transport/src/ack/ack_transmission_state.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_transmission_state.rs
@@ -307,6 +307,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(target_pointer_width = "64")]
     fn size_of_snapshots() {
         use core::mem::size_of;
         use insta::assert_debug_snapshot;

--- a/quic/s2n-quic/src/tests/setup.rs
+++ b/quic/s2n-quic/src/tests/setup.rs
@@ -141,7 +141,7 @@ impl havoc::Random for Random {
         self.fill_bytes(bytes);
     }
 
-    fn gen_range(&mut self, range: std::ops::Range<usize>) -> usize {
+    fn gen_range(&mut self, range: std::ops::Range<u64>) -> u64 {
         self.inner.gen_range(range)
     }
 }


### PR DESCRIPTION
### Resolved issues:

closes #1485 

### Description of changes: 

This change adds 32-bit platform to our CI and fixes the issues found while compiling and running the tests. This includes

* Using u64 instead of usize in a few places
* Ignoring the snapshot tests on 32bit platform
* Adding `target_os = "android"` to a few places.

### Call-outs:

The android test run currently fails. That will need to be added in another PR.

### Testing:

The tests were executed locally and in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

