### PR TITLE
ci: ignore bach dependency in cargo-deny

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -4,7 +4,6 @@ unmaintained = "deny"
 notice = "deny"
 yanked = "deny"
 ignore = [
-    "RUSTSEC-2021-0127", # criterion (a test dependency) uses cbor for encoding
     "RUSTSEC-2021-0139", # criterion, structopt, and tracing-subscriber (test dependencies) use ansi_term
     "RUSTSEC-2022-0041", # bolero (a test dependency) needs to update its libtest-mimic dependency
 ]
@@ -18,6 +17,7 @@ skip-tree = [
 
     # all of these are going to be just test dependencies
     { name = "aes-gcm" },
+    { name = "bach" },
     { name = "bolero" },
     { name = "criterion" },
     { name = "insta" },


### PR DESCRIPTION
### Description of changes: 

Cargo deny starting complaining about duplicate versions of the `windows-sys` crate. This is due to the `parking_lot` dependency in bach. As such, I've added `bach` to the list of ignored dependencies since it'll always be a test dependency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

