### PR TITLE
fix(s2n-quic-core): Limit time in BBR ProbeBW_DOWN to min rtt

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
@@ -723,11 +723,9 @@ impl BbrCongestionController {
     /// Returns true if it is time to transition from `Down` to `Cruise`
     #[inline]
     fn is_time_to_cruise(&self, now: Timestamp) -> bool {
-        if let bbr::State::ProbeBw(ref probe_bw_state) = self.state {
-            let min_rtt = self
-                .data_volume_model
-                .min_rtt()
-                .expect("at least one RTT has passed");
+        if let (bbr::State::ProbeBw(probe_bw_state), Some(min_rtt)) =
+            (&self.state, self.data_volume_model.min_rtt())
+        {
             // Chromium and Linux TCP both limit the time spent in ProbeBW_Down to min_rtt
             // See https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L1982-L1981
             //  and https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quiche/quic/core/congestion_control/bbr2_probe_bw.cc;l=276

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
@@ -494,7 +494,7 @@ impl BbrCongestionController {
 
         let target_inflight = self.target_inflight();
         let inflight = self.inflight(self.data_rate_model.max_bw(), self.state.pacing_gain());
-        let time_to_cruise = self.is_time_to_cruise();
+        let time_to_cruise = self.is_time_to_cruise(now);
 
         if let bbr::State::ProbeBw(ref mut probe_bw_state) = self.state {
             let prior_cycle_phase = probe_bw_state.cycle_phase();
@@ -722,7 +722,20 @@ impl BbrCongestionController {
 
     /// Returns true if it is time to transition from `Down` to `Cruise`
     #[inline]
-    fn is_time_to_cruise(&self) -> bool {
+    fn is_time_to_cruise(&self, now: Timestamp) -> bool {
+        if let bbr::State::ProbeBw(ref probe_bw_state) = self.state {
+            let min_rtt = self
+                .data_volume_model
+                .min_rtt()
+                .expect("at least one RTT has passed");
+            // Chromium and Linux TCP both limit the time spent in ProbeBW_Down to min_rtt
+            // See https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L1982-L1981
+            //  and https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quiche/quic/core/congestion_control/bbr2_probe_bw.cc;l=276
+            if probe_bw_state.has_elapsed_in_phase(min_rtt, now) {
+                return true;
+            }
+        }
+
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.3.6
         //# BBRCheckTimeToCruise())
         //#   if (inflight > BBRInflightWithHeadroom())


### PR DESCRIPTION
### Description of changes: 
The ProbeBW_Down BBRv2 state cuts the pacing rate to 90% of maximum bandwidth. The Chromium and Linux TCP implementations of BBRv2 limit the time spent in the ProbeBW_Down state to min_rtt:
* [Linux TCP](https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L1982-L1981)
* [Chromium](https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quiche/quic/core/congestion_control/bbr2_probe_bw.cc;l=276)

This change follows these implementations and will restrict time spent in the ProbeBW_Down state to the minimum RTT.

### Call-outs:

The Chromium implementation is more strict than the TCP Linux implementation in exiting this state, as the Linux implementation still requires inflight to be less than inflight_with_headroom. This change follows the Chromium implementation, though we can revisit this if fairness becomes an issue.

### Testing:

Local testing

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

