### PR TITLE
fix(s2n-quic-core): implement std Error for other error types

### DIFF
--- a/quic/s2n-quic-core/src/application/error.rs
+++ b/quic/s2n-quic-core/src/application/error.rs
@@ -7,7 +7,7 @@ use crate::{
     frame::ConnectionClose,
     varint::{VarInt, VarIntError},
 };
-use core::{convert::TryFrom, ops};
+use core::{convert::TryFrom, fmt, ops};
 
 //= https://www.rfc-editor.org/rfc/rfc9000#section-20.2
 //# The management of application error codes is left to application
@@ -18,9 +18,18 @@ use core::{convert::TryFrom, ops};
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Error(VarInt);
 
-impl core::fmt::Debug for Error {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
+impl fmt::Debug for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "application::Error({})", self.0.as_u64())
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "QUIC application error code: {}", self.0.as_u64())
     }
 }
 

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -251,6 +251,9 @@ impl From<core::convert::Infallible> for ValidationError {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for ValidationError {}
+
 /// Creates a transport parameter struct with the inner codec type
 macro_rules! transport_parameter {
     ($name:ident($encodable_type:ty), $tag:expr) => {

--- a/quic/s2n-quic-core/src/varint/mod.rs
+++ b/quic/s2n-quic-core/src/varint/mod.rs
@@ -3,6 +3,7 @@
 
 use core::{
     convert::{TryFrom, TryInto},
+    fmt,
     ops::Deref,
 };
 use s2n_codec::{decoder_value, Encoder, EncoderValue};
@@ -44,6 +45,15 @@ pub const MAX_VARINT_VALUE: u64 = 4_611_686_018_427_387_903;
 
 #[derive(Debug)]
 pub struct VarIntError;
+
+impl fmt::Display for VarIntError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "varint range exceeded")
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for VarIntError {}
 
 // https://godbolt.org/z/ToTvPD
 #[inline(always)]
@@ -110,8 +120,8 @@ fn encoding_size(x: u64) -> usize {
 #[cfg_attr(any(feature = "generator", test), derive(TypeGenerator))]
 pub struct VarInt(#[cfg_attr(any(feature = "generator", test), generator(Self::GENERATOR))] u64);
 
-impl core::fmt::Display for VarInt {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+impl fmt::Display for VarInt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.0.fmt(f)
     }
 }

--- a/quic/s2n-quic/src/provider/congestion_controller.rs
+++ b/quic/s2n-quic/src/provider/congestion_controller.rs
@@ -13,7 +13,8 @@ pub trait Provider {
     fn start(self) -> Result<Self::Endpoint, Self::Error>;
 }
 
-pub use s2n_quic_core::recovery::{bbr::Endpoint as Bbr, cubic::Endpoint as Default};
+pub use s2n_quic_core::recovery::{bbr::Endpoint as Bbr, cubic::Endpoint as Cubic};
+pub type Default = Cubic;
 
 impl_provider_utils!();
 


### PR DESCRIPTION
### Description of changes: 

I noticed that when configuring connection limits I wasn't able to convert validation errors into `Box<dyn std::error::Error>`. So I did a scan of all of the errors in `s2n-quic-core` and implemented `std::error::Error` for all of the error types that were missing it.

### Call-outs:

I included a change to make it easier to switch the default congestion controller in code. It's a super small, but unrelated, change. Didn't seem worth opening a PR just for that 😄.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

