### PR TITLE
fix(s2n-quic-core): record total bytes in flight in PacketInfo

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
@@ -249,7 +249,7 @@ impl Estimator {
     /// Called when a packet is transmitted
     pub fn on_packet_sent(
         &mut self,
-        bytes_in_flight: u32,
+        prior_bytes_in_flight: u32,
         sent_bytes: usize,
         app_limited: Option<bool>,
         now: Timestamp,
@@ -270,13 +270,15 @@ impl Estimator {
         //#   P.delivered_time  = C.delivered_time
         //#   P.delivered       = C.delivered
         //#   P.is_app_limited  = (C.app_limited != 0)
-        if bytes_in_flight == 0 {
+        if prior_bytes_in_flight == 0 {
             self.first_sent_time = Some(now);
             self.delivered_time = Some(now);
         }
 
+        let bytes_in_flight = prior_bytes_in_flight.saturating_add(sent_bytes as u32);
+
         if app_limited.unwrap_or(true) {
-            self.on_app_limited(bytes_in_flight.saturating_add(sent_bytes as u32));
+            self.on_app_limited(bytes_in_flight);
         }
 
         PacketInfo {

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__on_packet_ack_implausible_ack_rate.snap
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__on_packet_ack_implausible_ack_rate.snap
@@ -2,5 +2,5 @@
 source: quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
 expression: ""
 ---
-DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 4s, delivered_bytes: 1500, lost_bytes: 0, ecn_ce_count: 0, is_app_limited: false, prior_delivered_bytes: 0, bytes_in_flight: 0, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 375 } }
-DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 5s, delivered_bytes: 1500, lost_bytes: 0, ecn_ce_count: 0, is_app_limited: false, prior_delivered_bytes: 1500, bytes_in_flight: 1500, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 300 } }
+DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 4s, delivered_bytes: 1500, lost_bytes: 0, ecn_ce_count: 0, is_app_limited: false, prior_delivered_bytes: 0, bytes_in_flight: 100, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 375 } }
+DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 5s, delivered_bytes: 1500, lost_bytes: 0, ecn_ce_count: 0, is_app_limited: false, prior_delivered_bytes: 1500, bytes_in_flight: 1600, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 300 } }

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__on_packet_ack_rate_sample.snap
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/snapshots/quic__s2n-quic-core__src__recovery__bandwidth__estimator__tests__events__on_packet_ack_rate_sample.snap
@@ -2,6 +2,6 @@
 source: quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
 expression: ""
 ---
-DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 10s, delivered_bytes: 201500, lost_bytes: 150, ecn_ce_count: 15, is_app_limited: false, prior_delivered_bytes: 0, bytes_in_flight: 0, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 20150 } }
-DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 11s, delivered_bytes: 3000, lost_bytes: 0, ecn_ce_count: 0, is_app_limited: true, prior_delivered_bytes: 200000, bytes_in_flight: 3000, prior_lost_bytes: 150, prior_ecn_ce_count: 15, delivery_rate_bytes_per_second: 272 } }
-DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 11s, delivered_bytes: 4500, lost_bytes: 0, ecn_ce_count: 0, is_app_limited: true, prior_delivered_bytes: 200000, bytes_in_flight: 3000, prior_lost_bytes: 150, prior_ecn_ce_count: 15, delivery_rate_bytes_per_second: 409 } }
+DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 10s, delivered_bytes: 201500, lost_bytes: 150, ecn_ce_count: 15, is_app_limited: false, prior_delivered_bytes: 0, bytes_in_flight: 100, prior_lost_bytes: 0, prior_ecn_ce_count: 0, delivery_rate_bytes_per_second: 20150 } }
+DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 11s, delivered_bytes: 3000, lost_bytes: 0, ecn_ce_count: 0, is_app_limited: true, prior_delivered_bytes: 200000, bytes_in_flight: 3100, prior_lost_bytes: 150, prior_ecn_ce_count: 15, delivery_rate_bytes_per_second: 272 } }
+DeliveryRateSampled { path_id: 0, rate_sample: RateSample { interval: 11s, delivered_bytes: 4500, lost_bytes: 0, ecn_ce_count: 0, is_app_limited: true, prior_delivered_bytes: 200000, bytes_in_flight: 3100, prior_lost_bytes: 150, prior_ecn_ce_count: 15, delivery_rate_bytes_per_second: 409 } }

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator/tests.rs
@@ -136,7 +136,7 @@ fn on_packet_sent() {
     assert_eq!(100, packet_info.lost_bytes);
     assert_eq!(5, packet_info.ecn_ce_count);
     assert!(packet_info.is_app_limited);
-    assert_eq!(500, packet_info.bytes_in_flight);
+    assert_eq!(500 + 100, packet_info.bytes_in_flight);
     assert_eq!(
         Some(500 + 15000 + 100),
         bw_estimator.app_limited_delivered_bytes


### PR DESCRIPTION
### Description of changes: 

The `bytes_in_flight` value recorded in the `PacketInfo` used by BBR's delivery rate estimator should reflect the total amount of data in flight including the packet currently being transmitted. This follows the delivery rate estimation implementation in TCP: https://github.com/google/bbr/blob/7636a4ccf0f51e69a1e37bff97851dff0d344919/net/ipv4/tcp_rate.c#L43

### Testing:

Updated unit test

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

