### PR TITLE
feat(netbench): add support for profiling

### DIFF
--- a/netbench/netbench-collector/src/generic.rs
+++ b/netbench/netbench-collector/src/generic.rs
@@ -17,9 +17,12 @@ pub fn run(args: &Args) -> Result<()> {
 
     let driver = &args.driver;
     let interval = args.interval;
-    let scenario = &args.scenario;
+    let scenario_path = &args.scenario;
+    let scenario = args.scenario()?;
 
-    command.env("TRACE", "disabled").env("SCENARIO", scenario);
+    command
+        .env("TRACE", "disabled")
+        .env("SCENARIO", scenario_path);
 
     let mut proc = command.spawn()?;
     let info = Proc::new(proc.id());
@@ -27,7 +30,8 @@ pub fn run(args: &Args) -> Result<()> {
     Initialize {
         pid: proc.id() as _,
         driver: driver.to_string(),
-        scenario: scenario.to_string(),
+        scenario: scenario_path.to_string(),
+        traces: scenario.traces.to_vec(),
         ..Default::default()
     }
     .print()?;

--- a/netbench/netbench-collector/src/main.rs
+++ b/netbench/netbench-collector/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use netbench::{units::parse_duration, Result};
+use netbench::{scenario::Scenario, units::parse_duration, Result};
 use std::time::Duration;
 use structopt::StructOpt;
 
@@ -18,6 +18,12 @@ pub struct Args {
 
     #[structopt(long, short, parse(try_from_str=parse_duration), default_value = "1s")]
     pub interval: Duration,
+}
+
+impl Args {
+    pub fn scenario(&self) -> Result<Scenario> {
+        Scenario::open(std::path::Path::new(&self.scenario))
+    }
 }
 
 fn main() -> Result<()> {

--- a/netbench/netbench-collector/src/netbench.bt
+++ b/netbench/netbench-collector/src/netbench.bt
@@ -49,6 +49,13 @@ usdt:{{bin}}:netbench__accept
   @A=count();
 }
 
+usdt:{{bin}}:netbench__profile
+/pid==cpid/
+{
+  @p[arg1]=stats(arg2);
+  @P[arg1]=hist(arg2);
+}
+
 uprobe:{{libc}}:malloc
 /pid==cpid/
 {
@@ -124,6 +131,12 @@ i:ms:{{interval_ms}} {
 
   print(@A);
   clear(@A);
+
+  print(@p);
+  clear(@p);
+
+  print(@P);
+  clear(@P);
 
   print("===");
 }

--- a/netbench/netbench-driver/src/bin/netbench-driver-native-tls-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-native-tls-server.rs
@@ -45,6 +45,11 @@ impl Server {
         let mut conn_id = 0;
         loop {
             let (connection, _addr) = server.accept().await?;
+
+            if !self.opts.nagle {
+                let _ = connection.set_nodelay(true);
+            }
+
             let scenario = scenario.clone();
             let id = conn_id;
             conn_id += 1;

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
@@ -46,6 +46,11 @@ impl Server {
         let mut conn_id = 0;
         loop {
             let (connection, _addr) = server.accept().await?;
+
+            if !self.opts.nagle {
+                let _ = connection.set_nodelay(true);
+            }
+
             let scenario = scenario.clone();
             let id = conn_id;
             conn_id += 1;

--- a/netbench/netbench-driver/src/bin/netbench-driver-tcp-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-tcp-server.rs
@@ -39,6 +39,11 @@ impl Server {
         let mut conn_id = 0;
         loop {
             let (connection, _addr) = server.accept().await?;
+
+            if !self.opts.nagle {
+                let _ = connection.set_nodelay(true);
+            }
+
             let scenario = scenario.clone();
             let id = conn_id;
             conn_id += 1;

--- a/netbench/netbench-driver/src/lib.rs
+++ b/netbench/netbench-driver/src/lib.rs
@@ -43,6 +43,9 @@ pub struct Server {
 
     #[structopt(env = "SCENARIO")]
     pub scenario: Scenario,
+
+    #[structopt(long)]
+    pub nagle: bool,
 }
 
 impl Server {
@@ -89,6 +92,9 @@ pub struct Client {
 
     #[structopt(env = "SCENARIO")]
     pub scenario: Scenario,
+
+    #[structopt(long)]
+    pub nagle: bool,
 }
 
 impl Client {

--- a/netbench/netbench-scenarios/src/config.rs
+++ b/netbench/netbench-scenarios/src/config.rs
@@ -209,3 +209,27 @@ macro_rules! try_from_value {
 
 try_from_value!(Byte, "BYTES");
 try_from_value!(Rate, "RATE");
+
+impl<T: TryFromValue> TryFromValue for Vec<T> {
+    const VALUE_NAME: &'static str = T::VALUE_NAME;
+
+    fn try_from_value(value: &Override) -> Result<Self> {
+        let mut out = vec![];
+        if let Override::String(v) = value {
+            for value in v.split(',') {
+                let value = value.trim();
+                let value = Override::String(value.to_owned());
+                out.push(T::try_from_value(&value)?);
+            }
+        }
+        Ok(out)
+    }
+
+    fn display(&self) -> String {
+        let mut out = vec![];
+        for value in self {
+            out.push(value.display());
+        }
+        out.join(",")
+    }
+}

--- a/netbench/netbench-scenarios/src/main.rs
+++ b/netbench/netbench-scenarios/src/main.rs
@@ -1,4 +1,4 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-netbench_scenarios::scenarios!(connect, request_response);
+netbench_scenarios::scenarios!(connect, ping, request_response);

--- a/netbench/netbench-scenarios/src/ping.rs
+++ b/netbench/netbench-scenarios/src/ping.rs
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use netbench_scenarios::prelude::*;
+
+config!({
+    /// The number of concurrent connections to create
+    let connections: u64 = 1;
+
+    /// The number of concurrent streams to ping on
+    let streams: u64 = 1;
+
+    /// The amount of time to spend pinging for each size
+    let time: Duration = 15.seconds();
+
+    /// The amount of data to send in each ping
+    let size: Vec<Byte> = vec![
+        1000.bytes(),
+        10_000.bytes(),
+        100_000.bytes(),
+        1_000_000.bytes(),
+    ];
+});
+
+pub fn scenario(config: Config) -> Scenario {
+    let Config {
+        connections,
+        streams,
+        size: sizes,
+        time,
+    } = config;
+
+    Scenario::build(|scenario| {
+        let server = scenario.create_server();
+
+        scenario.create_client(|client| {
+            for size in sizes.iter().copied() {
+                let ping = format!("ping {}", size);
+                let pong = format!("pong {}", size);
+                client.scope(|client| {
+                    for _ in 0..connections {
+                        client.spawn(|client| {
+                            client.connect_to(&server, |conn| {
+                                conn.scope(|conn| {
+                                    for _ in 0..streams {
+                                        conn.spawn(|conn| {
+                                            conn.open_bidirectional_stream(
+                                                |local| {
+                                                    local.iterate(time, |local| {
+                                                        local.profile(&ping, |local| {
+                                                            local.send(size);
+                                                            local.receive(size);
+                                                        });
+                                                    });
+                                                },
+                                                |remote| {
+                                                    remote.iterate(time, |remote| {
+                                                        remote.profile(&pong, |remote| {
+                                                            remote.receive(size);
+                                                            remote.send(size);
+                                                        });
+                                                    });
+                                                },
+                                            );
+                                        });
+                                    }
+                                });
+                            });
+                        });
+                    }
+                });
+            }
+        });
+    })
+}

--- a/netbench/netbench/src/scenario/builder.rs
+++ b/netbench/netbench/src/scenario/builder.rs
@@ -21,6 +21,62 @@ macro_rules! trace {
                 .push(crate::operation::Connection::Trace { trace_id });
             self
         }
+
+        pub fn profile<F: FnOnce(&mut Self)>(&mut self, name: &str, f: F) -> &mut Self {
+            let trace_id = self.state.trace(name);
+            let mut builder = self.child_scope();
+            f(&mut builder);
+            let operations = builder.finish_scope();
+
+            self.ops.push(crate::operation::Connection::Profile {
+                trace_id,
+                operations,
+            });
+
+            self
+        }
+    };
+}
+
+macro_rules! iterate {
+    () => {
+        pub fn iterate<I: Into<crate::operation::IterateValue>, F: FnOnce(&mut Self)>(
+            &mut self,
+            count: I,
+            f: F,
+        ) -> &mut Self {
+            let mut builder = self.child_scope();
+            f(&mut builder);
+            let mut operations = builder.finish_scope();
+
+            let count = count.into();
+
+            if operations.is_empty() || count.is_zero() {
+                return self;
+            }
+
+            let mut trace_id = None;
+
+            // optimize out nested iterate/profile statements
+            if operations.len() == 1 {
+                if let Some(crate::operation::Connection::Profile {
+                    trace_id: child_id,
+                    operations: child,
+                }) = operations.get_mut(0)
+                {
+                    trace_id = Some(*child_id);
+                    operations = core::mem::take(child);
+                }
+            }
+
+            self.ops.push(crate::operation::Connection::Iterate {
+                value: count,
+                operations,
+                trace_id,
+            });
+
+            self
+        }
     };
 }
 

--- a/netbench/netbench/src/scenario/builder/connection.rs
+++ b/netbench/netbench/src/scenario/builder/connection.rs
@@ -51,6 +51,10 @@ impl<E: Endpoint> Builder<E> {
         }
     }
 
+    fn child_scope(&self) -> Self {
+        Self::new(self.state.clone())
+    }
+
     pub fn checkpoint<Location>(
         &self,
     ) -> (
@@ -63,6 +67,7 @@ impl<E: Endpoint> Builder<E> {
     sync!(E, Local);
     sleep!();
     trace!();
+    iterate!();
 
     pub fn scope<F: FnOnce(&mut Scope<E>)>(&mut self, f: F) -> &mut Self {
         let mut scope = Scope::new(self.state.clone());

--- a/netbench/netbench/src/scenario/builder/stream.rs
+++ b/netbench/netbench/src/scenario/builder/stream.rs
@@ -68,6 +68,7 @@ impl<Endpoint, Location> Stream<Endpoint, Location> {
     sync!(Endpoint, Location);
     sleep!();
     trace!();
+    iterate!();
 
     pub(crate) fn new(id: u64, state: connection::State) -> Self {
         Self {
@@ -77,6 +78,14 @@ impl<Endpoint, Location> Stream<Endpoint, Location> {
             endpoint: PhantomData,
             location: PhantomData,
         }
+    }
+
+    fn child_scope(&self) -> Self {
+        Self::new(self.id, self.state.clone())
+    }
+
+    fn finish_scope(self) -> Vec<op::Connection> {
+        self.ops
     }
 
     pub fn concurrently<
@@ -117,6 +126,7 @@ impl<Endpoint, Location> SendStream<Endpoint, Location> {
     sync!(Endpoint, Location);
     sleep!();
     trace!();
+    iterate!();
 
     pub(crate) fn new(id: u64, state: connection::State) -> Self {
         Self {
@@ -126,6 +136,14 @@ impl<Endpoint, Location> SendStream<Endpoint, Location> {
             endpoint: PhantomData,
             location: PhantomData,
         }
+    }
+
+    fn child_scope(&self) -> Self {
+        Self::new(self.id, self.state.clone())
+    }
+
+    fn finish_scope(self) -> Vec<op::Connection> {
+        self.ops
     }
 
     pub(crate) fn finish(mut self) -> Vec<op::Connection> {
@@ -148,6 +166,7 @@ impl<Endpoint, Location> ReceiveStream<Endpoint, Location> {
     sync!(Endpoint, Location);
     sleep!();
     trace!();
+    iterate!();
 
     pub(crate) fn new(id: u64, state: connection::State) -> Self {
         Self {
@@ -157,6 +176,14 @@ impl<Endpoint, Location> ReceiveStream<Endpoint, Location> {
             endpoint: PhantomData,
             location: PhantomData,
         }
+    }
+
+    fn child_scope(&self) -> Self {
+        Self::new(self.id, self.state.clone())
+    }
+
+    fn finish_scope(self) -> Vec<op::Connection> {
+        self.ops
     }
 
     pub(crate) fn finish(mut self) -> Vec<op::Connection> {

--- a/netbench/netbench/src/stats.rs
+++ b/netbench/netbench/src/stats.rs
@@ -25,6 +25,8 @@ pub struct Initialize {
     pub driver: String,
     pub scenario: String,
     pub start_time: SystemTime,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub traces: Vec<String>,
 }
 
 impl Default for Initialize {
@@ -34,6 +36,7 @@ impl Default for Initialize {
             driver: Default::default(),
             scenario: Default::default(),
             start_time: std::time::SystemTime::now(),
+            traces: vec![],
         }
     }
 }
@@ -72,6 +75,8 @@ pub struct Stats {
     pub send: HashMap<StreamId, Stat>,
     #[serde(default, skip_serializing_if = "is_default")]
     pub receive: HashMap<StreamId, Stat>,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub profiles: HashMap<u64, Histogram>,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -80,6 +85,27 @@ pub struct Stat {
     pub count: u64,
     #[serde(default, skip_serializing_if = "is_default")]
     pub total: u64,
+}
+
+impl Stat {
+    pub fn average(&self) -> f64 {
+        self.total as f64 / self.count as f64
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Histogram {
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub stat: Stat,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub buckets: Vec<Bucket>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Bucket {
+    pub lower: u64,
+    pub upper: u64,
+    pub count: u64,
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash, PartialOrd, Ord)]

--- a/netbench/netbench/src/trace/usdt.rs
+++ b/netbench/netbench/src/trace/usdt.rs
@@ -71,6 +71,17 @@ impl Trace for Usdt {
     }
 
     #[inline(never)]
+    fn profile(&mut self, now: Timestamp, id: u64, time: Duration) {
+        probe!(
+            netbench,
+            netbench__profile,
+            self.connection_id,
+            id,
+            time.as_micros() as u64
+        );
+    }
+
+    #[inline(never)]
     fn park(&mut self, _now: Timestamp, id: u64) {
         probe!(netbench, netbench__park, self.connection_id, id);
     }
@@ -87,7 +98,7 @@ impl Trace for Usdt {
             netbench__connect,
             self.connection_id,
             id,
-            time.as_nanos() as u64
+            time.as_micros() as u64
         );
     }
 }


### PR DESCRIPTION
### Description of changes: 

This change adds profiling capabilities to netbench. To demonstrate the functionality, I've added a `ping` scenario that sends a configurable payload to the server, which then responds with the same size. It loops for 15s on each payload and averages the latency.

On the GitHub Actions servers s2n-quic appears to be quite competitive. With high RTT s2n-quic has some latency issues around 100k payloads, but does well at the other sizes.

### Call outs

I ran into [nagle issues](https://en.m.wikipedia.org/wiki/Nagle%27s_algorithm) while testing TCP-based drivers so those all disable it by default, with a CLI option to enable it.

### Testing:

#### localhost

 ##### CPU
![ping-cpu](https://user-images.githubusercontent.com/799311/197087699-cd6618ef-bf7b-414e-bfc9-877970f66ad4.png)
##### Ping Latency (1k payload)
![ping1k](https://user-images.githubusercontent.com/799311/197087709-d4e33e1d-6520-49ce-a0c0-b5d60df268d6.png)
##### Ping Latency (10k payload)
![ping10k](https://user-images.githubusercontent.com/799311/197087721-5419ffc2-238d-42f8-a63c-b9dd16079b7c.png)
##### Ping Latency (100k payload)
![ping100k](https://user-images.githubusercontent.com/799311/197087739-de2ab3c0-14e8-4ff6-ad0f-241555e7303d.png)
##### Ping Latency (1M payload)
![ping1M](https://user-images.githubusercontent.com/799311/197087750-0e381425-a45f-44db-a64e-2c88a56e708a.png)

#### 100ms RTT

##### Ping Latency (1k payload)
![visualization(13)](https://user-images.githubusercontent.com/799311/197298379-5e48830e-0c64-488d-add7-880e47da24b4.png)


##### Ping Latency (10k payload)
![visualization(12)](https://user-images.githubusercontent.com/799311/197298282-f0ebe628-f6b7-4636-a79f-867a3bdb8f86.png)

##### Ping Latency (100k payload)
![visualization(9)](https://user-images.githubusercontent.com/799311/197298318-4d10d326-97ea-4983-bd92-236be968ed36.png)


##### Ping Latency (1M payload)
![visualization(11)](https://user-images.githubusercontent.com/799311/197298335-63c7956a-797b-49dc-9be3-6cb55b700404.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

