### PR TITLE
fix(s2n-quic-core): use loss burst count when checking inflight in BBRv2

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -9,7 +9,10 @@ use crate::{
     recovery::{
         bandwidth,
         bandwidth::{Bandwidth, RateSample},
-        bbr::{pacing::Pacer, probe_bw::CyclePhase},
+        bbr::{
+            pacing::Pacer,
+            probe_bw::{CyclePhase, PROBE_BW_FULL_LOSS_COUNT},
+        },
         congestion_controller,
         congestion_controller::Publisher,
         CongestionController, RttEstimator,
@@ -23,7 +26,6 @@ use core::{
 };
 use num_rational::Ratio;
 use num_traits::{CheckedMul, Inv, One};
-use crate::recovery::bbr::probe_bw::PROBE_BW_FULL_LOSS_COUNT;
 
 mod congestion;
 mod data_rate;

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -23,6 +23,7 @@ use core::{
 };
 use num_rational::Ratio;
 use num_traits::{CheckedMul, Inv, One};
+use crate::recovery::bbr::probe_bw::PROBE_BW_FULL_LOSS_COUNT;
 
 mod congestion;
 mod data_rate;
@@ -466,8 +467,7 @@ impl CongestionController for BbrCongestionController {
             self.on_enter_fast_recovery();
         }
         self.congestion_state
-            .on_packet_lost(self.bw_estimator.delivered_bytes());
-        self.full_pipe_estimator.on_packet_lost(new_loss_burst);
+            .on_packet_lost(self.bw_estimator.delivered_bytes(), new_loss_burst);
 
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.2.4
         //# BBRUpdateOnLoss(packet):
@@ -718,8 +718,18 @@ impl BbrCongestionController {
 
     /// True if the amount of loss or ECN CE markings exceed the BBR thresholds
     #[inline]
-    fn is_inflight_too_high(rate_sample: RateSample, max_datagram_size: u16) -> bool {
-        if Self::is_loss_too_high(rate_sample.lost_bytes, rate_sample.bytes_in_flight) {
+    fn is_inflight_too_high(
+        rate_sample: RateSample,
+        max_datagram_size: u16,
+        loss_bursts: u8,
+        loss_burst_limit: u8,
+    ) -> bool {
+        if Self::is_loss_too_high(
+            rate_sample.lost_bytes,
+            rate_sample.bytes_in_flight,
+            loss_bursts,
+            loss_burst_limit,
+        ) {
             return true;
         }
 
@@ -735,13 +745,20 @@ impl BbrCongestionController {
         false
     }
 
-    /// True if the amount of `lost_bytes` exceeds the BBR loss threshold
+    /// True if the amount of `lost_bytes` exceeds the BBR loss threshold and the count of loss
+    /// bursts is greater than or equal to the loss burst limit
     #[inline]
-    fn is_loss_too_high(lost_bytes: u64, bytes_inflight: u32) -> bool {
+    fn is_loss_too_high(
+        lost_bytes: u64,
+        bytes_inflight: u32,
+        loss_bursts: u8,
+        loss_burst_limit: u8,
+    ) -> bool {
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.5.6.2
         //# IsInflightTooHigh()
         //#   return (rs.lost > rs.tx_in_flight * BBRLossThresh)
-        lost_bytes > (LOSS_THRESH * bytes_inflight).to_integer() as u64
+        loss_bursts >= loss_burst_limit
+            && lost_bytes > (LOSS_THRESH * bytes_inflight).to_integer() as u64
     }
 
     //= https://www.rfc-editor.org/rfc/rfc9002#section-7.2
@@ -972,7 +989,12 @@ impl BbrCongestionController {
             .try_into()
             .unwrap_or(u32::MAX);
 
-        if Self::is_loss_too_high(lost_since_transmit as u64, packet_info.bytes_in_flight) {
+        if Self::is_loss_too_high(
+            lost_since_transmit as u64,
+            packet_info.bytes_in_flight,
+            self.congestion_state.loss_bursts_in_round(),
+            PROBE_BW_FULL_LOSS_COUNT,
+        ) {
             let inflight_hi_from_lost_packet =
                 Self::inflight_hi_from_lost_packet(lost_bytes, lost_since_transmit, packet_info);
             self.on_inflight_too_high(

--- a/quic/s2n-quic-core/src/recovery/bbr/full_pipe.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/full_pipe.rs
@@ -159,6 +159,15 @@ impl Estimator {
         // This is more in line with the Chromium BBRv2 implementation.
         // See: https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quiche/quic/core/congestion_control/bbr2_startup.cc;l=104
 
+        if loss_bursts_in_round < STARTUP_FULL_LOSS_COUNT {
+            // is_inflight_too_high returns true when ECN CE markings exceed the threshold, even
+            // if the loss burst count is below the threshold. During startup, excessive ECN CE
+            // is separately checked over multiple rounds, so return immediately if we have
+            // not seen enough loss bursts. This follows the Linux TCP BBRv2 implementation
+            // See https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L2150
+            return false;
+        }
+
         BbrCongestionController::is_inflight_too_high(
             rate_sample,
             max_datagram_size,
@@ -253,20 +262,13 @@ mod tests {
             ..Default::default()
         };
 
-        // Only 2 loss bursts, not enough to be considered excessive loss
-        fp_estimator.on_packet_lost(true);
-        fp_estimator.on_packet_lost(true);
-
-        fp_estimator.on_loss_round_start(rate_sample, MINIMUM_MTU);
+        // Only 7 loss bursts, not enough to be considered excessive loss
+        fp_estimator.on_loss_round_start(rate_sample, 7, MINIMUM_MTU);
         // The pipe has not been filled yet since there were only 2 loss bursts
         assert!(!fp_estimator.filled_pipe());
 
         // 3 loss bursts, enough to be considered excessive loss
-        fp_estimator.on_packet_lost(true);
-        fp_estimator.on_packet_lost(true);
-        fp_estimator.on_packet_lost(true);
-
-        fp_estimator.on_loss_round_start(rate_sample, MINIMUM_MTU);
+        fp_estimator.on_loss_round_start(rate_sample, 8, MINIMUM_MTU);
         // The pipe has been filled due to loss
         assert!(fp_estimator.filled_pipe());
     }
@@ -283,23 +285,10 @@ mod tests {
             ..Default::default()
         };
 
-        // In recovery the first round
-        fp_estimator.on_loss_round_start(rate_sample, MINIMUM_MTU);
+        // Only 7 loss bursts, not enough to be considered excessive loss
+        fp_estimator.on_loss_round_start(rate_sample, 7, MINIMUM_MTU);
 
-        // Only 2 loss bursts, not enough to be considered excessive loss
-        fp_estimator.on_packet_lost(true);
-        fp_estimator.on_packet_lost(true);
-
-        fp_estimator.on_loss_round_start(rate_sample, MINIMUM_MTU);
-        // The pipe has not been filled yet since there were only 2 loss bursts
-        assert!(!fp_estimator.filled_pipe());
-
-        // 3 loss bursts, enough to be considered excessive loss
-        fp_estimator.on_packet_lost(true);
-        fp_estimator.on_packet_lost(true);
-        fp_estimator.on_packet_lost(true);
-
-        fp_estimator.on_loss_round_start(rate_sample, MINIMUM_MTU);
+        fp_estimator.on_loss_round_start(rate_sample, 8, MINIMUM_MTU);
         // The pipe has been filled due to ECN
         assert!(fp_estimator.filled_pipe());
     }
@@ -315,16 +304,8 @@ mod tests {
             lost_bytes: 2,
             ..Default::default()
         };
-
-        // In recovery the first round
-        fp_estimator.on_loss_round_start(rate_sample, MINIMUM_MTU);
-
-        // 3 loss bursts, enough to be considered excessive loss
-        fp_estimator.on_packet_lost(true);
-        fp_estimator.on_packet_lost(true);
-        fp_estimator.on_packet_lost(true);
-
-        fp_estimator.on_loss_round_start(rate_sample, MINIMUM_MTU);
+        // 8 loss bursts, enough to be considered excessive loss
+        fp_estimator.on_loss_round_start(rate_sample, 8, MINIMUM_MTU);
         // The pipe has not been filled yet since the loss rate was not high enough
         assert!(!fp_estimator.filled_pipe());
     }

--- a/quic/s2n-quic-core/src/recovery/bbr/full_pipe.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/full_pipe.rs
@@ -147,6 +147,9 @@ impl Estimator {
         //= type=exception
         //= reason=Chromium and Linux TCP BBRv2 both use 8 lost bursts in a round trip
         //#    *  There are at least BBRStartupFullLossCnt=3 discontiguous sequence ranges lost in that round trip.
+
+        // See https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L2325-L2329
+        // and https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quiche/quic/core/quic_protocol_flags_list.h;l=135;bpv=1;bpt=0
         const STARTUP_FULL_LOSS_COUNT: u8 = 8;
 
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.3.1.3

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
@@ -24,6 +24,11 @@ const MAX_BW_PROBE_UP_ROUNDS: u8 = 30;
 /// Max number of packet-timed rounds to wait before probing for bandwidth
 const MAX_BW_PROBE_ROUNDS: u8 = 63;
 
+/// The number of discontiguous bursts of loss required before inflight_hi is lowered
+/// Value from:
+/// https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quiche/quic/core/quic_protocol_flags_list.h;l=139;bpv=1;bpt=0
+pub(super) const PROBE_BW_FULL_LOSS_COUNT: u8 = 2;
+
 /// Cwnd gain used in the Probe BW state
 ///
 /// This value is defined in the table in
@@ -627,7 +632,12 @@ impl BbrCongestionController {
             self.update_ack_phase(rate_sample);
         }
 
-        if Self::is_inflight_too_high(rate_sample, self.max_datagram_size) {
+        if Self::is_inflight_too_high(
+            rate_sample,
+            self.max_datagram_size,
+            self.congestion_state.loss_bursts_in_round(),
+            PROBE_BW_FULL_LOSS_COUNT,
+        ) {
             if self.bw_probe_samples {
                 // Inflight is too high and the sample is from bandwidth probing: lower inflight downward
                 self.on_inflight_too_high(

--- a/quic/s2n-quic-core/src/recovery/bbr/startup.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/startup.rs
@@ -186,9 +186,9 @@ mod tests {
         // Set loss to be too high, which would cause the full pipe estimator to be filled
         bbr.bw_estimator.on_loss(1000);
         // 3 loss bursts must occur for the pipe to be full
-        bbr.full_pipe_estimator.on_packet_lost(true);
-        bbr.full_pipe_estimator.on_packet_lost(true);
-        bbr.full_pipe_estimator.on_packet_lost(true);
+        bbr.congestion_state.on_packet_lost(100, true);
+        bbr.congestion_state.on_packet_lost(100, true);
+        bbr.congestion_state.on_packet_lost(100, true);
         assert!(!bbr.congestion_state.loss_round_start());
         bbr.check_startup_done(&mut publisher);
 

--- a/quic/s2n-quic-core/src/recovery/bbr/startup.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/startup.rs
@@ -60,8 +60,11 @@ impl BbrCongestionController {
             // in tcp_bbr2.c/bbr2_check_loss_too_high_in_startup
             //
             // See https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L2133
-            self.full_pipe_estimator
-                .on_loss_round_start(self.bw_estimator.rate_sample(), self.max_datagram_size)
+            self.full_pipe_estimator.on_loss_round_start(
+                self.bw_estimator.rate_sample(),
+                self.congestion_state.loss_bursts_in_round(),
+                self.max_datagram_size,
+            )
         }
 
         if self.state.is_startup() && self.full_pipe_estimator.filled_pipe() {

--- a/quic/s2n-quic-core/src/recovery/bbr/startup.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/startup.rs
@@ -185,10 +185,11 @@ mod tests {
 
         // Set loss to be too high, which would cause the full pipe estimator to be filled
         bbr.bw_estimator.on_loss(1000);
-        // 3 loss bursts must occur for the pipe to be full
-        bbr.congestion_state.on_packet_lost(100, true);
-        bbr.congestion_state.on_packet_lost(100, true);
-        bbr.congestion_state.on_packet_lost(100, true);
+        bbr.bw_estimator.set_delivered_bytes_for_test(100);
+        // 8 loss bursts must occur for the pipe to be full
+        for _ in 0..8 {
+            bbr.congestion_state.on_packet_lost(100, true);
+        }
         assert!(!bbr.congestion_state.loss_round_start());
         bbr.check_startup_done(&mut publisher);
 

--- a/quic/s2n-quic-core/src/recovery/bbr/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/tests.rs
@@ -983,7 +983,7 @@ fn model_update_required() {
     assert!(!bbr.model_update_required());
 
     // loss in round
-    bbr.congestion_state.on_packet_lost(100);
+    bbr.congestion_state.on_packet_lost(100, false);
     assert!(bbr.model_update_required());
     bbr.congestion_state.reset();
     assert!(!bbr.model_update_required());

--- a/quic/s2n-quic-core/src/recovery/bbr/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/tests.rs
@@ -440,10 +440,20 @@ fn is_inflight_too_high() {
         bytes_in_flight: 100,
         ..Default::default()
     };
-    // loss rate higher than 2% threshold
+    // loss rate higher than 2% threshold and loss bursts = limit
     assert!(BbrCongestionController::is_inflight_too_high(
         rate_sample,
-        MINIMUM_MTU
+        MINIMUM_MTU,
+        2,
+        2
+    ));
+
+    // loss rate higher than 2% threshold but loss bursts < limit
+    assert!(!BbrCongestionController::is_inflight_too_high(
+        rate_sample,
+        MINIMUM_MTU,
+        1,
+        2
     ));
 
     let rate_sample = RateSample {
@@ -454,7 +464,9 @@ fn is_inflight_too_high() {
     // loss rate <= 2% threshold
     assert!(!BbrCongestionController::is_inflight_too_high(
         rate_sample,
-        MINIMUM_MTU
+        MINIMUM_MTU,
+        2,
+        2
     ));
 
     let rate_sample = RateSample {
@@ -465,7 +477,9 @@ fn is_inflight_too_high() {
     // ecn rate higher than 50% threshold
     assert!(BbrCongestionController::is_inflight_too_high(
         rate_sample,
-        MINIMUM_MTU
+        MINIMUM_MTU,
+        0,
+        2
     ));
 
     let rate_sample = RateSample {
@@ -476,7 +490,9 @@ fn is_inflight_too_high() {
     // ecn rate <= 50% threshold
     assert!(!BbrCongestionController::is_inflight_too_high(
         rate_sample,
-        MINIMUM_MTU
+        MINIMUM_MTU,
+        0,
+        2,
     ));
 }
 
@@ -792,6 +808,9 @@ fn handle_lost_packet() {
     };
 
     enter_probe_bw_state(&mut bbr, CyclePhase::Up, &mut publisher);
+    // Two lost bursts to trigger inflight being too high
+    bbr.congestion_state.on_packet_lost(500, true);
+    bbr.congestion_state.on_packet_lost(500, true);
     bbr.handle_lost_packet(
         1000,
         lost_packet,
@@ -834,6 +853,9 @@ fn handle_lost_packet() {
         .update_min_rtt(Duration::from_millis(10), now);
     bbr.data_rate_model.update_max_bw(rate_sample);
     bbr.data_rate_model.bound_bw_for_model();
+    // Two lost bursts to trigger inflight being too high
+    bbr.congestion_state.on_packet_lost(500, true);
+    bbr.congestion_state.on_packet_lost(500, true);
 
     bbr.handle_lost_packet(
         1000,
@@ -983,7 +1005,7 @@ fn model_update_required() {
     assert!(!bbr.model_update_required());
 
     // loss in round
-    bbr.congestion_state.on_packet_lost(100, false);
+    bbr.congestion_state.on_packet_lost(100, true);
     assert!(bbr.model_update_required());
     bbr.congestion_state.reset();
     assert!(!bbr.model_update_required());


### PR DESCRIPTION
### Description of changes: 

This change introduces some additional requirements for exiting slow start and setting the `inflight_hi` model bound.

In the Chromium BBRv2 implementation, `inflight_hi` is not lowered unless 2 bursts of loss are recorded during a round ([source](https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quiche/quic/core/quic_protocol_flags_list.h;l=139;bpv=1;bpt=0)). In addition, both the Chromium and Linux TCP BBRv2 implementations require 8 bursts of loss to exit Startup, as opposed to the 3 described in the draft RFC ([Chromium](https://source.chromium.org/chromium/chromium/src/+/main:net/third_party/quiche/src/quiche/quic/core/quic_protocol_flags_list.h;l=135;bpv=1;bpt=0) | [TCP](https://github.com/google/bbr/blob/1a45fd4faf30229a3d3116de7bfe9d2f933d3562/net/ipv4/tcp_bbr2.c#L2325-L2329)).

### Testing:
_Note: These results include an additional change to remove the fast recovery cwnd reduction, that will come in a followup PR_

Before:
<img width="449" alt="Screen Shot 2022-10-19 at 7 09 46 PM" src="https://user-images.githubusercontent.com/55108558/196839968-7093ee7c-e0a6-4d4f-a4f8-3bc349863bf8.png">

After:
<img width="428" alt="Screen Shot 2022-10-20 at 2 40 04 PM" src="https://user-images.githubusercontent.com/55108558/197080716-6bf14589-cbbf-44f7-b50d-cd6e102d57ee.png">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

