### PR TITLE
ci: update kani to 0.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -668,7 +668,7 @@ jobs:
       - uses: camshaft/install@v1
         with:
           crate: kani-verifier
-          version: 0.11.0
+          version: 0.13.0
           bins: kani,cargo-kani
 
       - name: Kani setup
@@ -677,4 +677,4 @@ jobs:
       - name: Kani run
         run: |
           cd quic/s2n-quic-core
-          cargo kani --tests --enable-unstable --mir-linker
+          cargo kani --tests

--- a/common/s2n-codec/src/decoder/mod.rs
+++ b/common/s2n-codec/src/decoder/mod.rs
@@ -424,6 +424,11 @@ pub enum DecoderError {
 use core::fmt;
 impl fmt::Display for DecoderError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // https://github.com/model-checking/kani/issues/1767#issuecomment-1275449305
+        if cfg!(kani) {
+            return Ok(());
+        }
+
         match self {
             Self::UnexpectedEof(len) => write!(f, "unexpected eof: {}", len),
             Self::UnexpectedBytes(len) => write!(f, "unexpected bytes: {}", len),

--- a/common/s2n-codec/src/testing/mod.rs
+++ b/common/s2n-codec/src/testing/mod.rs
@@ -6,14 +6,7 @@ pub use crate::{
     EncoderBuffer, EncoderLenEstimator, EncoderValue,
 };
 
-#[derive(Clone, Debug)]
-pub struct Error(String);
-
-impl From<DecoderError> for Error {
-    fn from(err: DecoderError) -> Self {
-        Self(err.to_string())
-    }
-}
+pub type Error = DecoderError;
 
 #[macro_export]
 macro_rules! assert_codec_round_trip_value {
@@ -153,10 +146,20 @@ macro_rules! assert_codec_round_trip_sample_file {
     }};
 }
 
+#[cfg(not(kani))]
 macro_rules! ensure {
-    ($expr:expr, $message:expr $(, $format:expr)*) => {
+    ($expr:expr, $message:expr $(,)?) => {
         if !($expr) {
-            return Err(Error(format!($message $(, $format)*)));
+            return Err($crate::testing::Error::InvariantViolation($message));
+        }
+    };
+}
+
+#[cfg(kani)]
+macro_rules! ensure {
+    ($expr:expr, $message:expr $(,)?) => {
+        if !($expr) {
+            return Err($crate::testing::Error::InvariantViolation($message));
         }
     };
 }
@@ -191,9 +194,7 @@ pub fn ensure_decoding_matches<'a, T: DecoderValue<'a> + PartialEq + core::fmt::
     let (actual_value, remaining) = decode(expected_bytes)?;
     ensure!(
         expected_value == &actual_value,
-        "mut decodings do not match:\n expected: {:?}\n   actual: {:?}",
-        expected_value,
-        actual_value
+        "mut decodings do not match",
     );
     remaining.ensure_empty()?;
     Ok(())
@@ -213,9 +214,7 @@ pub fn ensure_decoding_mut_matches<'a, T: DecoderValueMut<'a> + PartialEq + core
     let (actual_value, remaining) = decode_mut(expected_bytes)?;
     ensure!(
         expected_value == &actual_value,
-        "mut decodings do not match:\n expected: {:?}\n   actual: {:?}",
-        expected_value,
-        actual_value
+        "mut decodings do not match",
     );
     remaining.ensure_empty()?;
     Ok(())

--- a/common/s2n-codec/src/testing/mod.rs
+++ b/common/s2n-codec/src/testing/mod.rs
@@ -146,16 +146,6 @@ macro_rules! assert_codec_round_trip_sample_file {
     }};
 }
 
-#[cfg(not(kani))]
-macro_rules! ensure {
-    ($expr:expr, $message:expr $(,)?) => {
-        if !($expr) {
-            return Err($crate::testing::Error::InvariantViolation($message));
-        }
-    };
-}
-
-#[cfg(kani)]
 macro_rules! ensure {
     ($expr:expr, $message:expr $(,)?) => {
         if !($expr) {


### PR DESCRIPTION
### Description of changes: 

This change updates the kani version in CI to 0.13.

### Call-outs:

To work around this issue described in https://github.com/model-checking/kani/issues/1767, I've applied the suggested fix: https://github.com/model-checking/kani/issues/1767#issuecomment-1275449305. We should be able to revert these changes once it is addressed upstream.

The mir-linker was also enabled by default so I removed that flag. 

### Testing:

I tested both locally and in [ci](https://github.com/aws/s2n-quic/actions/runs/3314584782/jobs/5474060658).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

