### PR TITLE
feat(netbench): include connect time metrics in report

### DIFF
--- a/netbench/netbench-cli/src/report.rs
+++ b/netbench/netbench-cli/src/report.rs
@@ -93,6 +93,7 @@ impl Report {
                     accept,
                     send,
                     receive,
+                    connect_time,
                     profiles,
                 } = event?;
 
@@ -194,6 +195,25 @@ impl Report {
                     );
                 }
 
+                {
+                    let mut y = connect_time.average();
+
+                    if !f64::is_normal(y) {
+                        y = 0.0;
+                    }
+
+                    // convert micros to seconds
+                    y /= 1_000_000.0;
+
+                    stats_table.push(Row {
+                        x,
+                        y,
+                        pid,
+                        stat: Stat::ConnectTime as _,
+                        stream_id: None,
+                    });
+                }
+
                 for (trace_id, hist) in profiles {
                     let trace = &traces[trace_id as usize];
                     let trace_id = if let Some(id) = trace_ids.iter().position(|v| v == trace) {
@@ -207,7 +227,10 @@ impl Report {
                     // offset the stat id with the built-in names
                     let stat = Stat::NAMES.len() as u64 + trace_id;
 
-                    let y = hist.stat.average();
+                    let mut y = hist.stat.average();
+                    if !f64::is_normal(y) {
+                        y = 0.0;
+                    }
 
                     // convert micros to seconds
                     let y = y / 1_000_000.0;
@@ -391,6 +414,7 @@ stat!(
         ContextSwitches = "context-switches",
         Syscalls = "syscalls",
         Connections = "connections",
+        ConnectTime = "connect-time",
         Accept = "accept (streams)",
         AllocBytes = "alloc (bytes)",
         AllocCount = "alloc (count)",

--- a/netbench/netbench-collector/src/bpftrace.rs
+++ b/netbench/netbench-collector/src/bpftrace.rs
@@ -107,6 +107,7 @@ impl Report {
         stat!("S", syscalls);
         stat!("O", connections);
         stat!("A", accept);
+        stat!("h", connect_time);
 
         macro_rules! try_map {
             ($prefix:literal, $on_value:expr) => {
@@ -190,6 +191,7 @@ impl Report {
             allocs: current.allocs,
             reallocs: current.reallocs,
             deallocs: current.deallocs,
+            connect_time: current.connect_time,
             send: core::mem::take(&mut self.send),
             receive: core::mem::take(&mut self.receive),
             profiles: core::mem::take(&mut self.profiles),

--- a/netbench/netbench-collector/src/netbench.bt
+++ b/netbench/netbench-collector/src/netbench.bt
@@ -41,6 +41,7 @@ usdt:{{bin}}:netbench__connect
 /pid==cpid/
 {
   @O=count();
+  @h=stats(arg2);
 }
 
 usdt:{{bin}}:netbench__accept
@@ -137,6 +138,9 @@ i:ms:{{interval_ms}} {
 
   print(@P);
   clear(@P);
+
+  print(@h);
+  clear(@h);
 
   print("===");
 }

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-quic-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-quic-server.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use netbench::{scenario, Result};
+use netbench::{scenario, timer::Timestamp, Result, Timer};
 use netbench_driver::Allocator;
 use s2n_quic::{provider::io, Connection};
 use std::{collections::HashSet, sync::Arc};
@@ -30,7 +30,7 @@ impl Server {
         let scenario = self.opts.scenario();
         let trace = self.opts.trace();
 
-        let mut server = self.server()?;
+        let mut server = self.server(trace.clone())?;
 
         while let Some(connection) = server.accept().await {
             let scenario = scenario.clone();
@@ -63,7 +63,7 @@ impl Server {
         }
     }
 
-    fn server(&self) -> Result<s2n_quic::Server> {
+    fn server(&self, trace: impl netbench::Trace + Send + 'static) -> Result<s2n_quic::Server> {
         let (certificate, private_key) = self.opts.certificate();
         let certificate = certificate.pem.as_str();
         let private_key = private_key.pem.as_str();
@@ -88,9 +88,53 @@ impl Server {
         let server = s2n_quic::Server::builder()
             .with_io(io)?
             .with_tls(tls)?
+            .with_event(EventTracer::new(trace))?
             .start()
             .unwrap();
 
         Ok(server)
+    }
+}
+
+struct EventTracer<T> {
+    trace: T,
+    timer: netbench::timer::Tokio,
+}
+
+impl<T> EventTracer<T> {
+    fn new(trace: T) -> Self {
+        Self {
+            trace,
+            timer: Default::default(),
+        }
+    }
+}
+
+impl<T: 'static + Send + netbench::Trace> s2n_quic::provider::event::Subscriber for EventTracer<T> {
+    type ConnectionContext = Timestamp;
+
+    #[inline]
+    fn create_connection_context(
+        &mut self,
+        _meta: &s2n_quic::provider::event::events::ConnectionMeta,
+        _info: &s2n_quic::provider::event::ConnectionInfo,
+    ) -> Timestamp {
+        self.timer.now()
+    }
+
+    #[inline]
+    fn on_handshake_status_updated(
+        &mut self,
+        start: &mut Timestamp,
+        meta: &s2n_quic::provider::event::events::ConnectionMeta,
+        event: &s2n_quic::provider::event::events::HandshakeStatusUpdated,
+    ) {
+        use s2n_quic::provider::event::events::HandshakeStatus;
+
+        // record the difference of when we started the connection and completed the handshake
+        if let HandshakeStatus::Complete { .. } = event.status {
+            let now = self.timer.now();
+            self.trace.connect(now, meta.id, now - *start)
+        }
     }
 }

--- a/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-s2n-tls-server.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use netbench::{duplex, multiplex, scenario, Driver, Result};
+use netbench::{duplex, multiplex, scenario, Driver, Result, Timer};
 use netbench_driver::Allocator;
 use s2n_tls::{
     config::{Builder, Config},
@@ -74,7 +74,14 @@ impl Server {
             mut trace: impl netbench::Trace,
             config: Option<multiplex::Config>,
         ) -> Result<()> {
+            let mut timer = netbench::timer::Tokio::default();
+            let before = timer.now();
+
             let connection = acceptor.accept(connection).await?;
+
+            let now = timer.now();
+            trace.connect(now, conn_id, now - before);
+
             let server_name = connection
                 .as_ref()
                 .server_name()
@@ -84,7 +91,6 @@ impl Server {
             let connection = Box::pin(connection);
 
             let mut checkpoints = HashSet::new();
-            let mut timer = netbench::timer::Tokio::default();
 
             if let Some(config) = config {
                 let conn = multiplex::Connection::new(conn_id, connection, config);

--- a/netbench/netbench-driver/src/bin/netbench-driver-tcp-server.rs
+++ b/netbench/netbench-driver/src/bin/netbench-driver-tcp-server.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use netbench::{multiplex, scenario, Result};
+use netbench::{multiplex, scenario, Result, Timer};
 use netbench_driver::Allocator;
 use std::{collections::HashSet, sync::Arc};
 use structopt::StructOpt;
@@ -64,6 +64,11 @@ impl Server {
             config: Option<multiplex::Config>,
             (rx_buffer, tx_buffer): (usize, usize),
         ) -> Result<()> {
+            let mut timer = netbench::timer::Tokio::default();
+
+            // TCP servers don't have a connect time
+            trace.connect(timer.now(), conn_id, Default::default());
+
             let connection = io::BufStream::with_capacity(rx_buffer, tx_buffer, connection);
             let mut connection = Box::pin(connection);
 
@@ -74,7 +79,6 @@ impl Server {
                 .ok_or("invalid connection id")?;
 
             let mut checkpoints = HashSet::new();
-            let mut timer = netbench::timer::Tokio::default();
 
             if let Some(config) = config {
                 let conn = netbench::Driver::new(

--- a/netbench/netbench/src/stats.rs
+++ b/netbench/netbench/src/stats.rs
@@ -72,6 +72,8 @@ pub struct Stats {
     #[serde(default, skip_serializing_if = "is_default")]
     pub deallocs: Stat,
     #[serde(default, skip_serializing_if = "is_default")]
+    pub connect_time: Stat,
+    #[serde(default, skip_serializing_if = "is_default")]
     pub send: HashMap<StreamId, Stat>,
     #[serde(default, skip_serializing_if = "is_default")]
     pub receive: HashMap<StreamId, Stat>,

--- a/netbench/netbench/src/trace/usdt.rs
+++ b/netbench/netbench/src/trace/usdt.rs
@@ -72,13 +72,8 @@ impl Trace for Usdt {
 
     #[inline(never)]
     fn profile(&mut self, now: Timestamp, id: u64, time: Duration) {
-        probe!(
-            netbench,
-            netbench__profile,
-            self.connection_id,
-            id,
-            time.as_micros() as u64
-        );
+        let time = time.as_micros() as u64;
+        probe!(netbench, netbench__profile, self.connection_id, id, time);
     }
 
     #[inline(never)]
@@ -93,12 +88,7 @@ impl Trace for Usdt {
 
     #[inline(never)]
     fn connect(&mut self, _now: Timestamp, id: u64, time: Duration) {
-        probe!(
-            netbench,
-            netbench__connect,
-            self.connection_id,
-            id,
-            time.as_micros() as u64
-        );
+        let time = time.as_micros() as u64;
+        probe!(netbench, netbench__connect, self.connection_id, id, time);
     }
 }


### PR DESCRIPTION
### Description of changes: 

This change adds connect time reporting to netbench. The trace event was already there; just needed to wire it up to the bpftrace module.


### Call-outs:

Originally the metric was only implemented on the client but I went ahead and added it to the server drivers to make the report generic.

### Testing:

I ran the `connect` scenario over my LAN between two hosts.

![visualization(16)](https://user-images.githubusercontent.com/799311/198143682-968028f3-118f-4fea-bf8f-7c052d3141ed.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

