### PR TITLE
Use Kani action in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,23 +658,8 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions-rs/toolchain@v1.0.7
-        id: toolchain
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-
-      - uses: camshaft/install@v1
-        with:
-          crate: kani-verifier
-          version: 0.13.0
-          bins: kani,cargo-kani
-
-      - name: Kani setup
-        run: cargo-kani setup
-
       - name: Kani run
-        run: |
-          cd quic/s2n-quic-core
-          cargo kani --tests
+        uses: model-checking/kani-github-action@v0.13
+        with:
+          working-directory: quic/s2n-quic-core
+          args: --tests


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Currently, quic uses a hardcoded install script to run Kani in CI.  Change to use the new kani action.

### Call-outs:

This CI is tagged to a particular version of kani.  Changes to this version will require updating the CI action used.

### Testing:

This is a CI change. Testing is on the PR itself.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

