### PR TITLE
feat(s2n-quic-tls): add config loader trait

### DIFF
--- a/quic/s2n-quic-tls/src/lib.rs
+++ b/quic/s2n-quic-tls/src/lib.rs
@@ -40,6 +40,13 @@ impl<T: FnMut(ConnectionContext) -> Config + Send + 'static> ConfigLoader for T 
     }
 }
 
+impl ConfigLoader for Box<dyn ConfigLoader> {
+    #[inline]
+    fn load(&mut self, cx: ConnectionContext) -> Config {
+        (**self).load(cx)
+    }
+}
+
 mod callback;
 mod keylog;
 mod params;

--- a/quic/s2n-quic-tls/src/tests.rs
+++ b/quic/s2n-quic-tls/src/tests.rs
@@ -319,3 +319,20 @@ fn run<S: Endpoint, C: Endpoint>(
 ) {
     run_result(server, client, client_hello_cb_done).unwrap();
 }
+
+#[test]
+fn config_loader() {
+    use crate::{ConfigLoader, Server};
+
+    let server = Server::default();
+
+    // make sure the loader can be a static type
+    let server: Server<Server> = Server::from_loader(server);
+
+    // make sure the loader can be a dynamic type
+    let server: Box<dyn ConfigLoader> = Box::new(server);
+    let mut server: Server<Box<dyn ConfigLoader>> = Server::from_loader(server);
+
+    // make sure the server can actually create a session
+    let _ = server.new_server_session(&1);
+}


### PR DESCRIPTION
### Resolved issues:

resolves #1533. resolves #1407.

### Description of changes: 

This change adds a `ConfigLoader` trait to the s2n-quic-tls crate. This allows applications to define the behavior for loading s2n-tls config objects per connection. Specifically this enables the ability to rotate certificates, as the trust store is tied to `Config`s.

### Call-outs:

This does include a potentially sharp edge of the config needing to be in a valid state for it to be accepted. This includes:

* setting a security policy that supports TLS 1.3
* enabling QUIC support
* setting at least one application protocol

If these requirements aren't met, the connection will fail at runtime. Luckily, the `Server` and `Client` structs implement the `ConfigLoader` themselves so they can be used to correctly construct a valid config.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

