### PR TITLE
test(s2n-quic-core): reduce const instruction counts

### DIFF
--- a/quic/s2n-quic-core/src/stream/testing.rs
+++ b/quic/s2n-quic-core/src/stream/testing.rs
@@ -15,7 +15,7 @@ static DATA: Bytes = {
     const INNER: [u8; DATA_LEN] = {
         let mut data = [0; DATA_LEN];
         let mut idx = 0;
-        while idx < data.len() {
+        while idx < DATA_LEN {
             data[idx] = idx as u8;
             idx += 1;
         }

--- a/quic/s2n-quic-core/src/transport/parameters/disabled_parameter.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/disabled_parameter.rs
@@ -2,11 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{TransportParameter, TransportParameterId, TransportParameterValidator};
-use core::marker::PhantomData;
+use core::{fmt, marker::PhantomData};
 
 /// Struct for marking a field as disabled for a given endpoint type
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub struct DisabledParameter<T>(PhantomData<T>);
+
+impl<T> fmt::Debug for DisabledParameter<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "DisabledParameter")
+    }
+}
 
 impl<T> Default for DisabledParameter<T> {
     fn default() -> Self {

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__ClientTransportParameters__default.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__ClientTransportParameters__default.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/tests.rs
-assertion_line: 55
 expression: default_value
 ---
 TransportParameters {
@@ -63,17 +62,9 @@ TransportParameters {
             2,
         ),
     ),
-    original_destination_connection_id: DisabledParameter(
-        PhantomData,
-    ),
-    stateless_reset_token: DisabledParameter(
-        PhantomData,
-    ),
-    preferred_address: DisabledParameter(
-        PhantomData,
-    ),
+    original_destination_connection_id: DisabledParameter,
+    stateless_reset_token: DisabledParameter,
+    preferred_address: DisabledParameter,
     initial_source_connection_id: None,
-    retry_source_connection_id: DisabledParameter(
-        PhantomData,
-    ),
+    retry_source_connection_id: DisabledParameter,
 }

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__load_client_limits.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__load_client_limits.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/tests.rs
-assertion_line: 154
 expression: params
 ---
 TransportParameters {
@@ -63,17 +62,9 @@ TransportParameters {
             2,
         ),
     ),
-    original_destination_connection_id: DisabledParameter(
-        PhantomData,
-    ),
-    stateless_reset_token: DisabledParameter(
-        PhantomData,
-    ),
-    preferred_address: DisabledParameter(
-        PhantomData,
-    ),
+    original_destination_connection_id: DisabledParameter,
+    stateless_reset_token: DisabledParameter,
+    preferred_address: DisabledParameter,
     initial_source_connection_id: None,
-    retry_source_connection_id: DisabledParameter(
-        PhantomData,
-    ),
+    retry_source_connection_id: DisabledParameter,
 }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -66,7 +66,7 @@ zerocopy-derive = { version = "=0.3.0", optional = true }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-bolero = { version = "0.7" }
+bolero = { version = "0.8" }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing", "event-tracing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
### Description of changes: 

This fixes a few things after the most recent rust beta was released:

* There seems to have been a change in how const instructions were counted and resulted in the static stream data to fail (see https://github.com/rust-lang/rust/issues/103814). I was able to get around this issue by replacing `data.len()` with `DATA_LEN`.
* The `derive(Debug)` for `PhantomData` now includes the inner `T` in its output. This breaks our snapshot tests so I've implemented a manual debug where it caused issues

### Call-outs:

I also noticed that the `s2n-quic` crate had not updated its `bolero` dependency as part of #1552. I've also done that here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

