### PR TITLE
test(s2n-quic-core): disable miri for interval set tests

### DIFF
--- a/quic/s2n-quic-core/src/interval_set/tests.rs
+++ b/quic/s2n-quic-core/src/interval_set/tests.rs
@@ -73,6 +73,7 @@ macro_rules! assert_set_eq {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
 fn interval_set_test() {
     check!().with_type().for_each(
         |(initial_ops, union_ops, difference_ops, intersection_ops)| {
@@ -100,6 +101,7 @@ fn interval_set_test() {
 
 #[test]
 #[cfg_attr(kani, kani::proof, kani::unwind(2))]
+#[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
 fn interval_set_inset_range_test() {
     // Generate valid ranges (lb <= ub)
     let gen = gen::<(i32, i32, i32)>().filter_gen(|(a, b, _c)| a <= b);


### PR DESCRIPTION
### Description of changes: 

The IntervalSet tests seem to be too expensive for miri. Ignoring these seems to make the miri CI more reliable.

### Testing:

The CI tests now pass. Hopefully this fixes it moving forward.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

