### PR TITLE
chore: release 1.12.0

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-codec"
-version = "0.1.0"
+version = "0.2.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-core"
-version = "0.12.0"
+version = "0.13.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -28,7 +28,7 @@ hex-literal = "0.3"
 insta = { version = ">=1.12", features = ["json"], optional = true }
 num-rational = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
-s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }
+s2n-codec = { version = "=0.2.0", path = "../../common/s2n-codec", default-features = false }
 subtle = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }
 zerocopy = "=0.6.0"

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-crypto"
-version = "0.12.0"
+version = "0.13.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -18,8 +18,8 @@ testing = []
 cfg-if = "1"
 lazy_static = "1"
 ring = { version = "0.16", default-features = false }
-s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.12.0", path = "../s2n-quic-core", default-features = false }
+s2n-codec = { version = "=0.2.0", path = "../../common/s2n-codec", default-features = false }
+s2n-quic-core = { version = "=0.13.0", path = "../s2n-quic-core", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["zeroize_derive"] }
 
 [dev-dependencies]

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-platform"
-version = "0.12.0"
+version = "0.13.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -26,7 +26,7 @@ errno = "0.2"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 lazy_static = { version = "1", optional = true }
 pin-project = { version = "1", optional = true }
-s2n-quic-core = { version = "=0.12.0", path = "../s2n-quic-core", default-features = false }
+s2n-quic-core = { version = "=0.13.0", path = "../s2n-quic-core", default-features = false }
 socket2 = { version = "0.4", features = ["all"], optional = true }
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt", "time"], optional = true }
 zeroize = { version = "1", default-features = false }

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-rustls"
-version = "0.12.0"
+version = "0.13.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -14,9 +14,9 @@ exclude = ["corpus.tar.gz"]
 bytes = { version = "1", default-features = false }
 rustls = { version = "0.20", features = ["quic"] }
 rustls-pemfile = "1"
-s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.12.0", path = "../s2n-quic-core", default-features = false }
-s2n-quic-crypto = { version = "=0.12.0", path = "../s2n-quic-crypto", default-features = false }
+s2n-codec = { version = "=0.2.0", path = "../../common/s2n-codec", default-features = false }
+s2n-quic-core = { version = "=0.13.0", path = "../s2n-quic-core", default-features = false }
+s2n-quic-crypto = { version = "=0.13.0", path = "../s2n-quic-crypto", default-features = false }
 
 [dev-dependencies]
 insta = { version = "1", features = ["json"] }

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-tls-default"
-version = "0.12.0"
+version = "0.13.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 exclude = ["corpus.tar.gz"]
 
 [target.'cfg(unix)'.dependencies]
-s2n-quic-tls = { version = "=0.12.0", path = "../s2n-quic-tls" }
+s2n-quic-tls = { version = "=0.13.0", path = "../s2n-quic-tls" }
 
 [target.'cfg(not(unix))'.dependencies]
-s2n-quic-rustls = { version = "=0.12.0", path = "../s2n-quic-rustls" }
+s2n-quic-rustls = { version = "=0.13.0", path = "../s2n-quic-rustls" }

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-tls"
-version = "0.12.0"
+version = "0.13.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -17,9 +17,9 @@ unstable_client_hello = []
 bytes = { version = "1", default-features = false }
 errno = "0.2"
 libc = "0.2"
-s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.12.0", path = "../s2n-quic-core", default-features = false }
-s2n-quic-crypto = { version = "=0.12.0", path = "../s2n-quic-crypto", default-features = false }
+s2n-codec = { version = "=0.2.0", path = "../../common/s2n-codec", default-features = false }
+s2n-quic-core = { version = "=0.13.0", path = "../s2n-quic-core", default-features = false }
+s2n-quic-crypto = { version = "=0.13.0", path = "../s2n-quic-crypto", default-features = false }
 s2n-tls = { version = "=0.0.17", features = ["quic"] }
 
 [target.'cfg(all(s2n_quic_unstable, s2n_quic_enable_pq_tls))'.dependencies]

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-transport"
-version = "0.12.0"
+version = "0.13.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -21,8 +21,8 @@ futures-core = { version = "0.3", default-features = false, features = ["alloc"]
 hashbrown = "0.12"
 intrusive-collections = "0.9"
 once_cell = "1"
-s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
-s2n-quic-core = { version = "=0.12.0", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
+s2n-codec = { version = "=0.2.0", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
+s2n-quic-core = { version = "=0.13.0", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
 siphasher = "0.3"
 smallvec = { version = "1", default-features = false }
 

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic"
-version = "1.11.0"
+version = "1.12.0"
 description = "A Rust implementation of the IETF QUIC protocol"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -53,13 +53,13 @@ hash_hasher = { version = "2", optional = true }
 rand = "0.8"
 rand_chacha = "0.3"
 ring = { version = "0.16", optional = true, default-features = false }
-s2n-codec = { version = "=0.1.0", path = "../../common/s2n-codec" }
-s2n-quic-core = { version = "=0.12.0", path = "../s2n-quic-core" }
-s2n-quic-platform = { version = "=0.12.0", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
-s2n-quic-rustls = { version = "=0.12.0", path = "../s2n-quic-rustls", optional = true }
-s2n-quic-tls = { version = "=0.12.0", path = "../s2n-quic-tls", optional = true }
-s2n-quic-tls-default = { version = "=0.12.0", path = "../s2n-quic-tls-default", optional = true }
-s2n-quic-transport = { version = "=0.12.0", path = "../s2n-quic-transport" }
+s2n-codec = { version = "=0.2.0", path = "../../common/s2n-codec" }
+s2n-quic-core = { version = "=0.13.0", path = "../s2n-quic-core" }
+s2n-quic-platform = { version = "=0.13.0", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
+s2n-quic-rustls = { version = "=0.13.0", path = "../s2n-quic-rustls", optional = true }
+s2n-quic-tls = { version = "=0.13.0", path = "../s2n-quic-tls", optional = true }
+s2n-quic-tls-default = { version = "=0.13.0", path = "../s2n-quic-tls-default", optional = true }
+s2n-quic-transport = { version = "=0.13.0", path = "../s2n-quic-transport" }
 tokio = { version = "1", default-features = false }
 zerocopy = { version = "=0.6.0", optional = true }
 zerocopy-derive = { version = "=0.3.0", optional = true }


### PR DESCRIPTION
### Description of changes: 

Bumping version numbers for the 1.12.0 release

### Call-outs:

The following crates were [changed since the 1.11.0 release](https://github.com/aws/s2n-quic/compare/v1.11.0...main):
- common/s2n-codec
- s2n-quic-core
- s2n-quic-crypto
- s2n-quic-platform
- s2n-quic-tls
- s2n-quic-transport
- s2n-quic

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

