### PR TITLE
ci: CI fixes

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -5,7 +5,6 @@ notice = "deny"
 yanked = "deny"
 ignore = [
     "RUSTSEC-2021-0139", # criterion, structopt, and tracing-subscriber (test dependencies) use ansi_term
-    "RUSTSEC-2022-0041", # bolero (a test dependency) needs to update its libtest-mimic dependency
 ]
 
 [bans]
@@ -21,6 +20,7 @@ skip-tree = [
     { name = "bolero" },
     { name = "criterion" },
     { name = "insta" },
+    { name = "heck" },
 ]
 
 [sources]

--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -27,7 +27,6 @@ skip-tree = [
     { name = "s2n-quic-h3" },
     { name = "s2n-quic-qns" },
     { name = "s2n-quic-sim" },
-    { name = "s2n" },
 ]
 
 [sources]

--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -20,7 +20,14 @@ skip-tree = [
     { name = "bolero" },
     { name = "criterion" },
     { name = "insta" },
-    { name = "heck" },
+
+    # Ignore duplicate dependencies in private s2n-quic crates
+    { name = "s2n-quic-bench" },
+    { name = "s2n-quic-events" },
+    { name = "s2n-quic-h3" },
+    { name = "s2n-quic-qns" },
+    { name = "s2n-quic-sim" },
+    { name = "s2n" },
 ]
 
 [sources]

--- a/netbench/netbench/src/scenario/id.rs
+++ b/netbench/netbench/src/scenario/id.rs
@@ -28,7 +28,7 @@ impl Hasher {
     pub fn finish(self) -> Id {
         use sha2::Digest;
         let hash = self.hash.finalize();
-        let out = base64::encode_config(&hash, base64::URL_SAFE_NO_PAD);
+        let out = base64::encode_config(hash, base64::URL_SAFE_NO_PAD);
         // '_' is not allowed in DNS names
         let out = out.replace('_', "-");
         Id(out)


### PR DESCRIPTION
### Description of changes: 

This PR fixes the following clippy error:
https://github.com/aws/s2n-quic/actions/runs/3422661099/jobs/5700329160

```
error: the borrowed expression implements the required traits
Error:   --> netbench/src/scenario/id.rs:31:41
   |
31 |         let out = base64::encode_config(&hash, base64::URL_SAFE_NO_PAD);
   |                                         ^^^^^ help: change this to: `hash`
   |
   = note: `-D clippy::needless-borrow` implied by `-D warnings`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
```

And fixes the following duplicate dependency error by ignoring duplicate dependencies in private s2n-quic crates.
https://github.com/aws/s2n-quic/actions/runs/3422661100/jobs/5700327679
```
warning[A007]: advisory was not encountered
  ┌─ /github/workspace/.github/config/cargo-deny.toml:[8](https://github.com/aws/s2n-quic/actions/runs/3422661100/jobs/5700327679#step:5:9):5
  │
8 │     "RUSTSEC-2022-0041", # bolero (a test dependency) needs to update its libtest-mimic dependency
  │     ^^^^^^^^^^^^^^^^^^^ no crate matched advisory criteria

error[B004]: found 2 duplicate entries for crate 'heck'
   ┌─ /github/workspace/Cargo.lock:82:1
   │  
82 │ ╭ heck 0.3.3 registry+https://github.com/rust-lang/crates.io-index
83 │ │ heck 0.4.0 registry+https://github.com/rust-lang/crates.io-index
   │ ╰────────────────────────────────────────────────────────────────^ lock entries
   │  
   = heck v0.3.3
     └── structopt-derive v0.4.[18](https://github.com/aws/s2n-quic/actions/runs/3422661100/jobs/5700327679#step:5:19)
         └── structopt v0.3.26
             ├── s2n-quic-qns v0.1.0
             └── s2n-quic-sim v0.1.0
   = heck v0.4.0
     └── s2n-quic-events v0.1.0

advisories ok, bans FAILED, licenses ok, sources ok
```

### Testing:

- Clippy should succeed in CI.
- The dependencies check should succeed in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

