### PR TITLE
test: fix duvet appendix links

### DIFF
--- a/quic/s2n-quic-core/src/crypto/initial.rs
+++ b/quic/s2n-quic-core/src/crypto/initial.rs
@@ -42,13 +42,13 @@ pub const INITIAL_CLIENT_LABEL: [u8; 9] = *b"client in";
 
 pub const INITIAL_SERVER_LABEL: [u8; 9] = *b"server in";
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A
 //# These packets use an 8-byte client-chosen Destination Connection ID
 //# of 0x8394c8f03e515708.
 
 pub const EXAMPLE_DCID: [u8; 8] = hex!("8394c8f03e515708");
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A.1
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.1
 //# client_initial_secret
 //#     = HKDF-Expand-Label(initial_secret, "client in", "", 32)
 //#     = c00cf151ca5be075ed0ebfb5c80323c4
@@ -61,7 +61,7 @@ pub const EXAMPLE_CLIENT_INITIAL_SECRET: [u8; 32] = hex!(
     "
 );
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A.1
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.1
 //# server_initial_secret
 //#     = HKDF-Expand-Label(initial_secret, "server in", "", 32)
 //#     = 3c199828fd139efd216c155ad844cc81
@@ -74,7 +74,7 @@ pub const EXAMPLE_SERVER_INITIAL_SECRET: [u8; 32] = hex!(
     "
 );
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A.2
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.2
 //# The client sends an Initial packet.  The unprotected payload of this
 //# packet contains the following CRYPTO frame, plus enough PADDING
 //# frames to make an 1162-byte payload:
@@ -88,7 +88,7 @@ pub const EXAMPLE_SERVER_INITIAL_SECRET: [u8; 32] = hex!(
 //# 3900320408ffffffffffffffff050480 00ffff07048000ffff08011001048000
 //# 75300901100f088394c8f03e51570806 048000ffff
 
-/// Example payload from <https://www.rfc-editor.org/rfc/rfc9001#section-A.2>
+/// Example payload from <https://www.rfc-editor.org/rfc/rfc9001#appendix-A.2>
 pub const EXAMPLE_CLIENT_INITIAL_PAYLOAD: [u8; 245] = hex!(
     "
    060040f1010000ed0303ebf8fa56f129 39b9584a3896472ec40bb863cfd3e868
@@ -102,7 +102,7 @@ pub const EXAMPLE_CLIENT_INITIAL_PAYLOAD: [u8; 245] = hex!(
     "
 );
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A.2
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.2
 //# The unprotected header indicates a length of 1182 bytes: the 4-byte
 //# packet number, 1162 bytes of frames, and the 16-byte authentication
 //# tag.  The header includes the connection ID and a packet number of 2:
@@ -112,7 +112,7 @@ pub const EXAMPLE_CLIENT_INITIAL_PAYLOAD: [u8; 245] = hex!(
 pub const EXAMPLE_CLIENT_INITIAL_HEADER: [u8; 22] =
     hex!("c300000001088394c8f03e5157080000449e00000002");
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A.2
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.2
 //# Protecting the payload produces output that is sampled for header
 //# protection.  Because the header uses a 4-byte packet number encoding,
 //# the first 16 bytes of the protected payload is sampled and then
@@ -139,7 +139,7 @@ fn client_initial_protection_test() {
     header_protection_test_helper(mask, &unprotected_header, &protected_header, packet_tag);
 }
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A.2
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.2
 //# The resulting protected packet is:
 //#
 //# c000000001088394c8f03e5157080000 449e7b9aec34d1b1c98dd7689fb8ec11
@@ -181,7 +181,7 @@ fn client_initial_protection_test() {
 //# 7e78bfe706ca4cf5e9c5453e9f7cfd2b 8b4c8d169a44e55c88d4a9a7f9474241
 //# e221af44860018ab0856972e194cd934
 
-/// <https://www.rfc-editor.org/rfc/rfc9001#section-A.2>
+/// <https://www.rfc-editor.org/rfc/rfc9001#appendix-A.2>
 pub const EXAMPLE_CLIENT_INITIAL_PROTECTED_PACKET: [u8; 1200] = hex!(
     "
    c000000001088394c8f03e5157080000 449e7b9aec34d1b1c98dd7689fb8ec11
@@ -225,7 +225,7 @@ pub const EXAMPLE_CLIENT_INITIAL_PROTECTED_PACKET: [u8; 1200] = hex!(
     "
 );
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A.3
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.3
 //# The server sends the following payload in response, including an ACK
 //# frame, a CRYPTO frame, and no PADDING frames:
 //#
@@ -235,7 +235,7 @@ pub const EXAMPLE_CLIENT_INITIAL_PROTECTED_PACKET: [u8; 1200] = hex!(
 //# 020304
 //#
 
-/// Example payload from <https://www.rfc-editor.org/rfc/rfc9001#section-A.3>
+/// Example payload from <https://www.rfc-editor.org/rfc/rfc9001#appendix-A.3>
 pub const EXAMPLE_SERVER_INITIAL_PAYLOAD: [u8; 99] = hex!(
     "
    02000000000600405a020000560303ee fce7f7b37ba1d1632e96677825ddf739
@@ -245,7 +245,7 @@ pub const EXAMPLE_SERVER_INITIAL_PAYLOAD: [u8; 99] = hex!(
     "
 );
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A.3
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.3
 //# The header from the server includes a new connection ID and a 2-byte
 //# packet number encoding for a packet number of 1:
 //#
@@ -254,7 +254,7 @@ pub const EXAMPLE_SERVER_INITIAL_PAYLOAD: [u8; 99] = hex!(
 pub const EXAMPLE_SERVER_INITIAL_HEADER: [u8; 20] =
     hex!("c1000000010008f067a5502a4262b50040750001");
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A.3
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.3
 //# As a result, after protection, the header protection sample is taken
 //# starting from the third protected byte:
 //#
@@ -273,7 +273,7 @@ fn server_initial_protection_test() {
     header_protection_test_helper(mask, &unprotected_header, &protected_header, packet_tag);
 }
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A.3
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.3
 //# The final protected packet is then:
 //#
 //# cf000000010008f067a5502a4262b500 4075c0d95a482cd0991cd25b0aac406a
@@ -283,7 +283,7 @@ fn server_initial_protection_test() {
 //# 2158407dd074ee
 
 /// Example protected packet from
-/// <https://www.rfc-editor.org/rfc/rfc9001#section-A.3>
+/// <https://www.rfc-editor.org/rfc/rfc9001#appendix-A.3>
 pub const EXAMPLE_SERVER_INITIAL_PROTECTED_PACKET: [u8; 135] = hex!(
     "
    cf000000010008f067a5502a4262b500 4075c0d95a482cd0991cd25b0aac406a

--- a/quic/s2n-quic-core/src/crypto/label.rs
+++ b/quic/s2n-quic-core/src/crypto/label.rs
@@ -3,7 +3,7 @@
 
 use hex_literal::hex;
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A.1
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.1
 //# The labels generated during the execution of the HKDF-Expand-Label
 //# function (that is, HkdfLabel.label) and part of the value given to
 //# the HKDF-Expand function in order to produce its output are:
@@ -12,22 +12,22 @@ use hex_literal::hex;
 
 pub const CLIENT_IN: [u8; 19] = hex!("00200f746c73313320636c69656e7420696e00");
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A.1
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.1
 //# server in:  00200f746c7331332073657276657220696e00
 
 pub const SERVER_IN: [u8; 19] = hex!("00200f746c7331332073657276657220696e00");
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A.1
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.1
 //# quic key:  00100e746c7331332071756963206b657900
 
 pub const QUIC_KEY_16: [u8; 18] = hex!("00100e746c7331332071756963206b657900");
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A.1
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.1
 //# quic iv:  000c0d746c733133207175696320697600
 
 pub const QUIC_IV_12: [u8; 17] = hex!("000c0d746c733133207175696320697600");
 
-//= https://www.rfc-editor.org/rfc/rfc9001#section-A.1
+//= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.1
 //# quic hp:  00100d746c733133207175696320687000
 
 pub const QUIC_HP_16: [u8; 17] = hex!("00100d746c733133207175696320687000");

--- a/quic/s2n-quic-core/src/crypto/retry.rs
+++ b/quic/s2n-quic-core/src/crypto/retry.rs
@@ -38,7 +38,7 @@ pub mod example {
     );
     pub const PACKET_LEN: usize = 36;
 
-    //= https://www.rfc-editor.org/rfc/rfc9001#section-A.4
+    //= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.4
     //# This shows a Retry packet that might be sent in response to the
     //# Initial packet in Appendix A.2.  The integrity check includes the
     //# client-chosen connection ID value of 0x8394c8f03e515708, but that
@@ -65,7 +65,7 @@ pub mod example {
     // The Retry Packet should have this as the source connection ID
     pub const SCID: [u8; 8] = hex!("f067a5502a4262b5");
 
-    //= https://www.rfc-editor.org/rfc/rfc9001#section-A
+    //= https://www.rfc-editor.org/rfc/rfc9001#appendix-A
     //# These packets use an 8-byte client-chosen Destination Connection ID
     //# of 0x8394c8f03e515708.
 

--- a/quic/s2n-quic-core/src/packet/number/mod.rs
+++ b/quic/s2n-quic-core/src/packet/number/mod.rs
@@ -95,7 +95,7 @@ fn derive_truncation_range(
 //# bit more than the base-2 logarithm of the number of contiguous
 //# unacknowledged packet numbers, including the new packet.
 
-//= https://www.rfc-editor.org/rfc/rfc9000#section-A.2
+//= https://www.rfc-editor.org/rfc/rfc9000#appendix-A.2
 //# For example, if an endpoint has received an acknowledgment for packet
 //# 0xabe8b3 and is sending a packet with a number of 0xac5c02, there are
 //# 29,519 (0x734f) outstanding packet numbers.  In order to represent at
@@ -159,7 +159,7 @@ fn packet_decoding_example_test() {
     );
 }
 
-//= https://www.rfc-editor.org/rfc/rfc9000#section-A.3
+//= https://www.rfc-editor.org/rfc/rfc9000#appendix-A.3
 //# DecodePacketNumber(largest_pn, truncated_pn, pn_nbits):
 //#   expected_pn  = largest_pn + 1
 //#   pn_win       = 1 << pn_nbits

--- a/quic/s2n-quic-core/src/packet/number/tests.rs
+++ b/quic/s2n-quic-core/src/packet/number/tests.rs
@@ -113,7 +113,7 @@ fn rfc_decoder(largest_pn: u64, truncated_pn: u64, pn_nbits: usize) -> u64 {
         };
     }
 
-    //= https://www.rfc-editor.org/rfc/rfc9000#section-A.3
+    //= https://www.rfc-editor.org/rfc/rfc9000#appendix-A.3
     //= type=test
     //# DecodePacketNumber(largest_pn, truncated_pn, pn_nbits):
     //#   expected_pn  = largest_pn + 1

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -221,7 +221,7 @@ pub struct BbrCongestionController {
     round_counter: round::Counter,
     bw_estimator: bandwidth::Estimator,
     full_pipe_estimator: full_pipe::Estimator,
-    //= https://www.rfc-editor.org/rfc/rfc9002#section-B.2
+    //= https://www.rfc-editor.org/rfc/rfc9002#appendix-B.2
     //# The sum of the size in bytes of all sent packets
     //# that contain at least one ack-eliciting or PADDING frame and have
     //# not been acknowledged or declared lost.  The size does not include

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -152,7 +152,7 @@ pub struct CubicCongestionController {
     max_datagram_size: u16,
     congestion_window: f32,
     state: State,
-    //= https://www.rfc-editor.org/rfc/rfc9002#section-B.2
+    //= https://www.rfc-editor.org/rfc/rfc9002#appendix-B.2
     //# The sum of the size in bytes of all sent packets
     //# that contain at least one ack-eliciting or PADDING frame and have
     //# not been acknowledged or declared lost.  The size does not include

--- a/quic/s2n-quic-core/src/recovery/sent_packets.rs
+++ b/quic/s2n-quic-core/src/recovery/sent_packets.rs
@@ -7,9 +7,9 @@ use crate::{
 };
 use core::convert::TryInto;
 
-//= https://www.rfc-editor.org/rfc/rfc9002#section-A.1
+//= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.1
 
-//= https://www.rfc-editor.org/rfc/rfc9002#section-A.1.1
+//= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.1.1
 
 #[cfg(feature = "alloc")]
 pub type SentPackets<PacketInfo> = crate::packet::number::Map<SentPacketInfo<PacketInfo>>;

--- a/quic/s2n-quic-core/src/varint/tests.rs
+++ b/quic/s2n-quic-core/src/varint/tests.rs
@@ -34,7 +34,7 @@ fn table_snapshot_test() {
     }
 }
 
-//= https://www.rfc-editor.org/rfc/rfc9000#section-A.1
+//= https://www.rfc-editor.org/rfc/rfc9000#appendix-A.1
 //# For example, the eight-byte sequence 0xc2197c5eff14e88c decodes to
 //# the decimal value 151,288,809,941,952,652; the four-byte sequence
 //# 0x9d7f3e7d decodes to 494,878,333; the two-byte sequence 0x7bbd

--- a/quic/s2n-quic-crypto/src/one_rtt.rs
+++ b/quic/s2n-quic-crypto/src/one_rtt.rs
@@ -33,7 +33,7 @@ mod tests {
     use ring::hkdf;
     use s2n_quic_core::crypto::Key;
 
-    //= https://www.rfc-editor.org/rfc/rfc9001#section-A.5
+    //= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.5
     //# In this example, TLS produces an application write secret from which
     //# a server uses HKDF-Expand-Label to produce four values: a key, an IV,
     //# a header protection key, and the secret that will be used after keys

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1147,7 +1147,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                     .on_datagram_received(rtt, datagram.timestamp);
             }
         } else if unblocked {
-            //= https://www.rfc-editor.org/rfc/rfc9002#section-A.6
+            //= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.6
             //# When a server is blocked by anti-amplification limits, receiving a
             //# datagram unblocks it, even if none of the packets in the datagram are
             //# successfully processed.  In such a case, the PTO timer will need to

--- a/quic/s2n-quic-transport/src/path/ecn.rs
+++ b/quic/s2n-quic-transport/src/path/ecn.rs
@@ -132,7 +132,7 @@ impl Controller {
         }
 
         match self.state {
-            //= https://www.rfc-editor.org/rfc/rfc9000#section-A.4
+            //= https://www.rfc-editor.org/rfc/rfc9000#appendix-A.4
             //# On paths with a "testing" or "capable" state, the endpoint
             //# sends packets with an ECT marking -- ECT(0) by default;
             //# otherwise, the endpoint sends unmarked packets.
@@ -257,7 +257,7 @@ impl Controller {
             return ValidationOutcome::Failed;
         };
 
-        //= https://www.rfc-editor.org/rfc/rfc9000#section-A.4
+        //= https://www.rfc-editor.org/rfc/rfc9000#appendix-A.4
         //# From the "unknown" state, successful validation of the ECN counts in an ACK frame
         //# (see Section 13.4.2.1) causes the ECN state for the path to become "capable",
         //# unless no marked packet has been acknowledged.

--- a/quic/s2n-quic-transport/src/path/ecn/tests.rs
+++ b/quic/s2n-quic-transport/src/path/ecn/tests.rs
@@ -437,7 +437,7 @@ fn validate_ecn_decrease() {
     assert!(matches!(controller.state, State::Failed(_)));
 }
 
-//= https://www.rfc-editor.org/rfc/rfc9000#section-A.4
+//= https://www.rfc-editor.org/rfc/rfc9000#appendix-A.4
 //= type=test
 //# From the "unknown" state, successful validation of the ECN counts in an ACK frame
 //# (see Section 13.4.2.1) causes the ECN state for the path to become "capable",

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -30,11 +30,11 @@ pub struct Manager<Config: endpoint::Config> {
     // The packet space for this recovery manager
     space: PacketNumberSpace,
 
-    //= https://www.rfc-editor.org/rfc/rfc9002#section-A.3
+    //= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.3
     //# The largest packet number acknowledged in the packet number space so far.
     largest_acked_packet: Option<PacketNumber>,
 
-    //= https://www.rfc-editor.org/rfc/rfc9002#section-A.3
+    //= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.3
     //# An association of packet numbers in a packet number space to information about them.
     //  These are packets that are pending acknowledgement.
     sent_packets: SentPackets<<<Config::CongestionControllerEndpoint as congestion_controller::Endpoint>::CongestionController as congestion_controller::CongestionController>::PacketInfo>,
@@ -50,7 +50,7 @@ pub struct Manager<Config: endpoint::Config> {
     //# tail packets or acknowledgments.
     pto: Pto,
 
-    //= https://www.rfc-editor.org/rfc/rfc9002#section-A.3
+    //= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.3
     //# The time the most recent ack-eliciting packet was sent.
     time_of_last_ack_eliciting_packet: Option<Timestamp>,
 
@@ -195,7 +195,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         publisher.on_recovery_metrics(recovery_event!(path_id, path));
     }
 
-    //= https://www.rfc-editor.org/rfc/rfc9002#section-A.5
+    //= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.5
     //# After a packet is sent, information about the packet is stored.
     #[allow(clippy::too_many_arguments)]
     pub fn on_packet_sent<Ctx: Context<Config>, Pub: event::ConnectionPublisher>(
@@ -725,7 +725,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         matches!(self.pto.state, PtoState::RequiresTransmission(_))
     }
 
-    //= https://www.rfc-editor.org/rfc/rfc9002#section-B.9
+    //= https://www.rfc-editor.org/rfc/rfc9002#appendix-B.9
     //# When Initial or Handshake keys are discarded, packets sent in that
     //# space no longer count toward bytes in flight.
     /// Clears bytes in flight for sent packets.
@@ -756,7 +756,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         );
     }
 
-    //= https://www.rfc-editor.org/rfc/rfc9002#section-A.10
+    //= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.10
     //# DetectAndRemoveLostPackets is called every time an ACK is received or the time threshold
     //# loss detection timer expires. This function operates on the sent_packets for that packet
     //# number space and returns a list of packets newly detected as lost.
@@ -1150,7 +1150,7 @@ impl Pto {
                 //# has Handshake keys, otherwise it MUST send an Initial packet in a
                 //# UDP datagram with a payload of at least 1200 bytes.
 
-                //= https://www.rfc-editor.org/rfc/rfc9002#section-A.9
+                //= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.9
                 //# // Client sends an anti-deadlock packet: Initial is padded
                 //# // to earn more anti-amplification credit,
                 //# // a Handshake packet proves address ownership.

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -69,7 +69,7 @@ fn one_second_pto_when_no_previous_rtt_available() {
     );
 }
 
-//= https://www.rfc-editor.org/rfc/rfc9002#section-A.5
+//= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.5
 //= type=test
 #[test]
 fn on_packet_sent() {
@@ -328,7 +328,7 @@ fn on_packet_sent_across_multiple_paths() {
     assert_eq!(Some(expected_pto), manager.pto.timer.next_expiration());
 }
 
-//= https://www.rfc-editor.org/rfc/rfc9002#section-A.7
+//= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.7
 //= type=test
 #[test]
 fn on_ack_frame() {
@@ -1365,7 +1365,7 @@ fn rtt_update_when_receiving_ack_from_multiple_paths() {
     assert_eq!(second_path.congestion_controller.on_rtt_update, 0);
 }
 
-//= https://www.rfc-editor.org/rfc/rfc9002#section-A.10
+//= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.10
 //= type=test
 #[test]
 fn detect_and_remove_lost_packets() {

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -324,7 +324,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
             "Clients are never in an anti-amplification state"
         );
 
-        //= https://www.rfc-editor.org/rfc/rfc9002#section-A.6
+        //= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.6
         //# When a server is blocked by anti-amplification limits, receiving a
         //# datagram unblocks it, even if none of the packets in the datagram are
         //# successfully processed.  In such a case, the PTO timer will need to

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -254,7 +254,7 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
             "Clients are never in an anti-amplification state"
         );
 
-        //= https://www.rfc-editor.org/rfc/rfc9002#section-A.6
+        //= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.6
         //# When a server is blocked by anti-amplification limits, receiving a
         //# datagram unblocks it, even if none of the packets in the datagram are
         //# successfully processed.  In such a case, the PTO timer will need to

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -304,7 +304,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
             "Clients are never in an anti-amplification state"
         );
 
-        //= https://www.rfc-editor.org/rfc/rfc9002#section-A.6
+        //= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.6
         //# When a server is blocked by anti-amplification limits, receiving a
         //# datagram unblocks it, even if none of the packets in the datagram are
         //# successfully processed.  In such a case, the PTO timer will need to


### PR DESCRIPTION
### Description of changes: 

There used to be an issue in duvet when copying references in appendix sections, where the `appendix-` prefix was assumed to be `section-`. This was fixed in https://github.com/awslabs/duvet/pull/68. 

This change fixes all of the cited appendix links to the correct prefix.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

