### PR TITLE
example(client_hello_callback): add an example demonstrating use of the async cert loading

### DIFF
--- a/examples/async_client_hello_callback/.cargo/config.toml
+++ b/examples/async_client_hello_callback/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags=['--cfg', 's2n_quic_unstable']

--- a/examples/async_client_hello_callback/Cargo.toml
+++ b/examples/async_client_hello_callback/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 s2n-quic = { version = "1", path = "../../quic/s2n-quic", features = ["provider-tls-s2n", "unstable_client_hello"]}
 tokio = { version = "1", features = ["full"] }
-s2n-tls = { version = "=0.0.21", features = ["quic"] }
+s2n-tls = { version = "0", features = ["quic"] }
 moka = "0.9"
 rand = "0.8"
 

--- a/examples/async_client_hello_callback/Cargo.toml
+++ b/examples/async_client_hello_callback/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "async_client_hello_callback"
+version = "0.1.0"
+authors = ["AWS s2n"]
+edition = "2021"
+
+[dependencies]
+s2n-quic = { version = "1", path = "../../quic/s2n-quic", features = ["provider-tls-s2n", "unstable_client_hello"]}
+tokio = { version = "1", features = ["full"] }
+s2n-tls = { version = "=0.0.21", features = ["quic"] }
+moka = "0.9"
+rand = "0.8"
+
+[workspace]
+members = ["."]

--- a/examples/async_client_hello_callback/Cargo.toml
+++ b/examples/async_client_hello_callback/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [dependencies]
 s2n-quic = { version = "1", path = "../../quic/s2n-quic", features = ["provider-tls-s2n", "unstable_client_hello"]}
 tokio = { version = "1", features = ["full"] }
-s2n-tls = { version = "0", features = ["quic"] }
 moka = "0.9"
 rand = "0.8"
 

--- a/examples/async_client_hello_callback/src/bin/quic_async_client_hello_callback_client.rs
+++ b/examples/async_client_hello_callback/src/bin/quic_async_client_hello_callback_client.rs
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_quic::{client::Connect, Client};
+use std::{error::Error, net::SocketAddr};
+
+/// NOTE: this certificate is to be used for demonstration purposes only!
+pub static CERT_PEM: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../quic/s2n-quic-core/certs/cert.pem"
+));
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let client = Client::builder()
+        .with_tls(CERT_PEM)?
+        .with_io("0.0.0.0:0")?
+        .start()?;
+
+    let addr: SocketAddr = "127.0.0.1:4433".parse()?;
+    let connect = Connect::new(addr).with_server_name("localhost");
+    let mut connection = client.connect(connect).await?;
+
+    // ensure the connection doesn't time out with inactivity
+    connection.keep_alive(true)?;
+
+    // open a new stream and split the receiving and sending sides
+    let stream = connection.open_bidirectional_stream().await?;
+    let (mut receive_stream, mut send_stream) = stream.split();
+
+    // spawn a task that copies responses from the server to stdout
+    tokio::spawn(async move {
+        let mut stdout = tokio::io::stdout();
+        let _ = tokio::io::copy(&mut receive_stream, &mut stdout).await;
+    });
+
+    // copy data from stdin and send it to the server
+    let mut stdin = tokio::io::stdin();
+    tokio::io::copy(&mut stdin, &mut send_stream).await?;
+
+    Ok(())
+}

--- a/examples/async_client_hello_callback/src/bin/quic_async_client_hello_callback_server.rs
+++ b/examples/async_client_hello_callback/src/bin/quic_async_client_hello_callback_server.rs
@@ -1,0 +1,146 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use moka::sync::Cache;
+use s2n_quic::{
+    provider::tls::s2n_tls::{ClientHelloCallback, Connection},
+    Server,
+};
+use s2n_tls::{
+    callbacks::{ConfigResolver, ConnectionFuture},
+    config::Config,
+    error::Error as S2nError,
+};
+use std::{error::Error, fmt::Display, pin::Pin, sync::Arc, time::Duration};
+use tokio::{fs, sync::OnceCell};
+
+/// NOTE: this certificate is to be used for demonstration purposes only!
+pub static CERT_PEM_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../quic/s2n-quic-core/certs/cert.pem"
+);
+/// NOTE: this certificate is to be used for demonstration purposes only!
+pub static KEY_PEM_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../quic/s2n-quic-core/certs/key.pem"
+);
+
+type Sni = String;
+
+struct MyAsyncCertLoaderCHCallback {
+    cache: Cache<Sni, Arc<OnceCell<Config>>>,
+}
+
+impl MyAsyncCertLoaderCHCallback {
+    fn new() -> Self {
+        MyAsyncCertLoaderCHCallback {
+            // store Configs for up to 100 unique SNIs
+            cache: Cache::new(100),
+        }
+    }
+}
+
+impl ClientHelloCallback for MyAsyncCertLoaderCHCallback {
+    fn on_client_hello(
+        &self,
+        connection: &mut Connection,
+    ) -> Result<Option<Pin<Box<dyn ConnectionFuture>>>, S2nError> {
+        let sni = connection
+            .server_name()
+            .ok_or_else(|| S2nError::application(Box::new(CustomError)))?
+            .to_string();
+
+        let once_cell_config = self
+            .cache
+            .get_with(sni.clone(), || Arc::new(OnceCell::new()));
+        if let Some(config) = once_cell_config.get() {
+            connection.set_config(config.clone())?;
+            // return `None` if the Config is already in the cache
+            return Ok(None);
+        }
+
+        let fut = async move {
+            let fut = once_cell_config.get_or_try_init(|| async {
+                let fail = rand::random();
+                eprintln!("simulating network failure. failed: {}", fail);
+                if fail {
+                    return Err(S2nError::application(Box::new(CustomError)));
+                }
+
+                // load the cert and key file asynchronously.
+                let (cert, key) = {
+                    // the SNI can be used to load the appropriate cert file
+                    let _sni = sni;
+                    let cert = fs::read_to_string(CERT_PEM_PATH)
+                        .await
+                        .map_err(|_| S2nError::application(Box::new(CustomError)))?;
+                    let key = fs::read_to_string(KEY_PEM_PATH)
+                        .await
+                        .map_err(|_| S2nError::application(Box::new(CustomError)))?;
+                    (cert, key)
+                };
+
+                // sleep(async tokio task which doesn't block thread) to mimic delay
+                tokio::time::sleep(Duration::from_secs(5)).await;
+
+                let mut config = Config::builder();
+                config
+                    .load_pem(cert.as_bytes(), key.as_bytes())?
+                    .enable_quic()?
+                    .set_security_policy(&s2n_tls::security::DEFAULT_TLS13)?
+                    .set_application_protocol_preference([b"h3"])?;
+                config.build()
+            });
+            fut.await.map(|config| config.clone())
+        };
+
+        // return `Some(ConnectionFuture)` if the Config wasn't found in the
+        // cache and we need to load it asynchronously
+        Ok(Some(Box::pin(ConfigResolver::new(fut))))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let tls = s2n_quic::provider::tls::s2n_tls::Server::builder()
+        .with_client_hello_handler(MyAsyncCertLoaderCHCallback::new())?
+        .build()?;
+
+    let mut server = Server::builder()
+        .with_tls(tls)?
+        .with_io("127.0.0.1:4433")?
+        .start()?;
+
+    while let Some(mut connection) = server.accept().await {
+        // spawn a new task for the connection
+        tokio::spawn(async move {
+            eprintln!("Connection accepted from {:?}", connection.remote_addr());
+
+            while let Ok(Some(mut stream)) = connection.accept_bidirectional_stream().await {
+                // spawn a new task for the stream
+                tokio::spawn(async move {
+                    eprintln!("Stream opened from {:?}", stream.connection().remote_addr());
+
+                    // echo any data back to the stream
+                    while let Ok(Some(data)) = stream.receive().await {
+                        stream.send(data).await.expect("stream should be open");
+                    }
+                });
+            }
+        });
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct CustomError;
+
+impl Display for CustomError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "custom error")?;
+        Ok(())
+    }
+}
+
+impl Error for CustomError {}

--- a/examples/async_client_hello_callback/src/bin/quic_async_client_hello_callback_server.rs
+++ b/examples/async_client_hello_callback/src/bin/quic_async_client_hello_callback_server.rs
@@ -83,13 +83,9 @@ impl ClientHelloCallback for MyAsyncCertLoaderCHCallback {
                 // sleep(async tokio task which doesn't block thread) to mimic delay
                 tokio::time::sleep(Duration::from_secs(5)).await;
 
-                let mut config = Config::builder();
-                config
-                    .load_pem(cert.as_bytes(), key.as_bytes())?
-                    .enable_quic()?
-                    .set_security_policy(&s2n_tls::security::DEFAULT_TLS13)?
-                    .set_application_protocol_preference([b"h3"])?;
-                config.build()
+                s2n_quic::provider::tls::s2n_tls::Server::builder()
+                    .with_certificate(cert, key)?
+                    .into_config()
             });
             fut.await.map(|config| config.clone())
         };

--- a/examples/async_client_hello_callback/src/bin/quic_async_client_hello_callback_server.rs
+++ b/examples/async_client_hello_callback/src/bin/quic_async_client_hello_callback_server.rs
@@ -107,9 +107,9 @@ impl ClientHelloCallback for ConfigCache {
 
                 let config = s2n_quic::provider::tls::s2n_tls::Server::builder()
                     .with_certificate(cert, key)?
-                    .build()
-                    .map(|s| s.into());
-                config
+                    .build()?
+                    .into();
+                Ok(config)
             });
             fut.await.map(|config| config.clone())
         };

--- a/quic/s2n-quic-tls/src/lib.rs
+++ b/quic/s2n-quic-tls/src/lib.rs
@@ -62,7 +62,7 @@ pub use server::Server;
 // Re-export the `ClientHelloHandler` and `Connection` to make it easier for users
 // to consume. This depends on experimental behavior in s2n-tls.
 #[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_client_hello")))]
-pub use s2n_tls::{callbacks::ClientHelloCallback, connection::Connection};
+pub use s2n_tls::{self, callbacks::ClientHelloCallback, connection::Connection};
 
 #[cfg(test)]
 mod tests;

--- a/quic/s2n-quic-tls/src/server.rs
+++ b/quic/s2n-quic-tls/src/server.rs
@@ -65,6 +65,12 @@ impl<L: ConfigLoader> ConfigLoader for Server<L> {
     }
 }
 
+impl<L: ConfigLoader> From<Server<L>> for Config {
+    fn from(mut server: Server<L>) -> Self {
+        server.load(crate::ConnectionContext { server_name: None })
+    }
+}
+
 pub struct Builder {
     config: config::Builder,
     keylog: Option<KeyLogHandle>,
@@ -205,11 +211,6 @@ impl Builder {
             keylog: self.keylog,
             params: Default::default(),
         })
-    }
-
-    /// Returns the underlying [`Config`](s2n_tls::config::Config).
-    pub fn into_config(self) -> Result<Config, Error> {
-        self.config.build()
     }
 }
 

--- a/quic/s2n-quic-tls/src/server.rs
+++ b/quic/s2n-quic-tls/src/server.rs
@@ -206,6 +206,11 @@ impl Builder {
             params: Default::default(),
         })
     }
+
+    /// Returns the underlying [`Config`](s2n_tls::config::Config).
+    pub fn into_config(self) -> Result<Config, Error> {
+        self.config.build()
+    }
 }
 
 impl<L: ConfigLoader> tls::Endpoint for Server<L> {


### PR DESCRIPTION
pending PR https://github.com/aws/s2n-quic/pull/1587

### Description of changes: 
This example demonstrates the ability for an application to set a `ClientHelloCallback`, which loads the certificate/key associated with the Client. The certificate/key is set on a new Config object and set on the connection. The callback runs as an asynchronous task and caches the result so that subsequent callbacks can resolve immediately.

### Testing:

A test [commit](https://github.com/aws/s2n-quic/commit/ec88c6689d4f42041c2e79557bb6950f7687caf6) which simulates random async task failure (this is likely for network calls). It also demonstrates the Config caching and the async task not running after a successful run.
 
Server:
```
> ./target/debug/quic_async_client_hello_callback_server

running server ---
simulating network failure. failed: true
simulating network failure. failed: true
simulating network failure. failed: true
simulating network failure. failed: true
simulating network failure. failed: false
Connection accepted from Ok(127.0.0.1:56105)
Stream opened from Ok(127.0.0.1:56105)

# subsequent connections resolve immediately
Connection accepted from Ok(127.0.0.1:48291)
Stream opened from Ok(127.0.0.1:48291)
```

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

