### PR TITLE
style(s2n-quic-core): remove redundant assignment

### DIFF
--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -1448,7 +1448,6 @@ impl<
         }
 
         load!(max_idle_timeout, max_idle_timeout);
-        load!(max_ack_delay, max_ack_delay);
         load!(data_window, initial_max_data);
         load!(
             bidirectional_local_data_window,


### PR DESCRIPTION
The max_ack_delay transport parameter is loaded multiple times. This commit removes that multiple load.

### Description of changes: 
The `max_ack_delay` parameter is currently loaded multiple times. This looks to be redundant, and this commit removes it.

There are no semantic changes expected with this commit. I also wouldn't be surprised if this gets optimized out by the compiler, so I don't expect any performance changes either.

### Call-outs:

I have this commit under the style tag, since it isn't necessarily a bug fix. And if the compiler is optimizing this out, then it's not a perf thing either.

### Testing:

Passed all unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

