### PR TITLE
Give datagram receiver access to current connection path

### DIFF
--- a/quic/s2n-quic-core/src/datagram/disabled.rs
+++ b/quic/s2n-quic-core/src/datagram/disabled.rs
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::datagram::{ConnectionInfo, Endpoint, Packet, PreConnectionInfo, Receiver, Sender};
+use crate::datagram::{
+    ConnectionInfo, Endpoint, Packet, PreConnectionInfo, ReceiveContext, Receiver, Sender,
+};
 
 #[derive(Debug, Default)]
 pub struct Disabled(());
@@ -34,7 +36,7 @@ impl Sender for DisabledSender {
 }
 
 impl Receiver for DisabledReceiver {
-    fn on_datagram(&mut self, _datagram: &[u8]) {}
+    fn on_datagram(&mut self, _: &ReceiveContext<'_>, _: &[u8]) {}
 
     fn on_connection_error(&mut self, _error: crate::connection::Error) {}
 }

--- a/quic/s2n-quic-core/src/datagram/traits.rs
+++ b/quic/s2n-quic-core/src/datagram/traits.rs
@@ -60,10 +60,25 @@ impl Default for PreConnectionInfo {
     }
 }
 
+/// ReceiveContext contains information about the connection.
+#[non_exhaustive]
+#[derive(Debug)]
+pub struct ReceiveContext<'a> {
+    /// This is the current connection path this datagram was received on.
+    pub path: crate::event::api::Path<'a>,
+}
+
+impl<'a> ReceiveContext<'a> {
+    #[doc(hidden)]
+    pub fn new(path: crate::event::api::Path<'a>) -> Self {
+        ReceiveContext { path }
+    }
+}
+
 /// Allows users to configure the behavior of receiving datagrams.
 pub trait Receiver: 'static + Send {
     /// A callback that gives users direct access to datagrams as they are read off a packet
-    fn on_datagram(&mut self, datagram: &[u8]);
+    fn on_datagram(&mut self, context: &ReceiveContext<'_>, datagram: &[u8]);
 
     /// A callback used to notify the application in the case of a connection error
     fn on_connection_error(&mut self, error: connection::Error);

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -752,8 +752,12 @@ impl<Config: endpoint::Config> PacketSpace<Config> for ApplicationSpace<Config> 
         Ok(())
     }
 
-    fn handle_datagram_frame(&mut self, frame: DatagramRef) -> Result<(), transport::Error> {
-        self.datagram_manager.on_datagram_frame(frame);
+    fn handle_datagram_frame(
+        &mut self,
+        path: s2n_quic_core::event::api::Path<'_>,
+        frame: DatagramRef,
+    ) -> Result<(), transport::Error> {
+        self.datagram_manager.on_datagram_frame(path, frame);
         Ok(())
     }
 

--- a/quic/s2n-quic-transport/src/space/datagram.rs
+++ b/quic/s2n-quic-transport/src/space/datagram.rs
@@ -12,7 +12,7 @@ use crate::{
 use core::task::Poll;
 use s2n_codec::EncoderValue;
 use s2n_quic_core::{
-    datagram::{Endpoint, Receiver, Sender, WriteError},
+    datagram::{Endpoint, ReceiveContext, Receiver, Sender, WriteError},
     frame::{self, datagram::DatagramRef},
     query,
     varint::VarInt,
@@ -59,8 +59,13 @@ impl<Config: endpoint::Config> Manager<Config> {
 
     // A callback that allows users to access datagrams directly after they are
     // received.
-    pub fn on_datagram_frame(&mut self, datagram: DatagramRef) {
-        self.receiver.on_datagram(datagram.data);
+    pub fn on_datagram_frame(
+        &mut self,
+        path: s2n_quic_core::event::api::Path<'_>,
+        datagram: DatagramRef,
+    ) {
+        let context = ReceiveContext::new(path);
+        self.receiver.on_datagram(&context, datagram.data);
     }
 
     pub fn datagram_mut(&mut self, query: &mut dyn query::QueryMut) -> Poll<()> {

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -623,7 +623,11 @@ pub trait PacketSpace<Config: endpoint::Config> {
             .with_frame_type(frame.tag().into()))
     }
 
-    fn handle_datagram_frame(&mut self, frame: DatagramRef) -> Result<(), transport::Error> {
+    fn handle_datagram_frame(
+        &mut self,
+        _path: s2n_quic_core::event::api::Path<'_>,
+        frame: DatagramRef,
+    ) -> Result<(), transport::Error> {
         Err(transport::Error::PROTOCOL_VIOLATION
             .with_reason(Self::INVALID_FRAME_ERROR)
             .with_frame_type(frame.tag().into()))
@@ -772,7 +776,11 @@ pub trait PacketSpace<Config: endpoint::Config> {
                 }
                 Frame::Datagram(frame) => {
                     let on_error = on_frame_processed!(frame);
-                    self.handle_datagram_frame(frame.into()).map_err(on_error)?;
+                    self.handle_datagram_frame(
+                        path_event!(path, path_id).into_event(),
+                        frame.into(),
+                    )
+                    .map_err(on_error)?;
                 }
                 Frame::DataBlocked(frame) => {
                     let on_error = on_frame_processed!(frame);


### PR DESCRIPTION
This allows the receiver to differentiate the handling based on the connection's remote address. For example, if a datagram receiver wants to process the payload differently depending on the source address, this allows it to do so. The path a connection takes may change over time, so passing this state on each on_datagram call seems like the best bet.

One alternative design (not thoroughly explored) is to expose the datagram payloads to the Subscriber interface, and just have the datagram provider ignore payloads. Since there are no payloads anywhere in that trait today that I can see, it seems like it might be intentional to not surface them there?

This doesn't fully address #1565, but does surface most of the (by me) currently desired information. Based on poking around the code it seems like there would be more extensive changes required for the Connect struct to gain fields that are generic, I'm not sure it's worth making that investment now.

### Call-outs:

The usage of the event API Path struct here is a bit odd -- I'm not sure if there's a better type to be using. Maybe we should be defining a datagram-specific wrapper.

Note also that this will be a breaking change to the datagram trait -- if we wanted to avoid that we can define a new method on the trait with a default implementation that calls the current one, but seems like it might make sense to just make the change while the interface is still unstable.

### Testing:

No particular testing yet.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

