### PR TITLE
Remove &mut from datagram_mut

### DIFF
--- a/quic/s2n-quic/src/connection/handle.rs
+++ b/quic/s2n-quic/src/connection/handle.rs
@@ -389,7 +389,7 @@ macro_rules! impl_handle_api {
         ///     );
         /// ```
         pub fn datagram_mut<Query, ProviderType, Outcome>(
-            &mut self,
+            &self,
             query: Query,
         ) -> core::result::Result<Outcome, s2n_quic_core::query::Error>
         where


### PR DESCRIPTION
The internal API is locking anyway, so there's no need for the &mut here. This doesn't change anything from being *possible* (you can `.clone().datagram_mut(...)` already), but it does mean that callers need that extra clone().

Note that this changes a technically stable API, though I doubt there are users (since datagrams themselves are unstable). The change is also likely to be compatible with most call sites.

### Testing:

No particular testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

