### PR TITLE
test(s2n-quic-core): add a bolero harness for the varint table

### DIFF
--- a/quic/s2n-quic-core/src/varint/mod.rs
+++ b/quic/s2n-quic-core/src/varint/mod.rs
@@ -335,44 +335,6 @@ decoder_value!(
     }
 );
 
-#[cfg(test)]
-mod encoder_tests {
-    use super::*;
-    use core::mem::size_of;
-    use s2n_codec::{DecoderBuffer, EncoderBuffer};
-
-    fn test_update(initial: VarInt, expected: VarInt, encoder: &mut EncoderBuffer) {
-        encoder.set_position(0);
-        initial.encode_updated(expected, encoder);
-        let decoder = DecoderBuffer::new(encoder.as_mut_slice());
-        let (actual, _) = decoder.decode::<VarInt>().unwrap();
-        assert_eq!(expected, actual);
-    }
-
-    #[test]
-    fn encode_updated_test() {
-        let mut buffer = [0u8; size_of::<VarInt>()];
-        let mut encoder = EncoderBuffer::new(&mut buffer);
-        let initial = VarInt::from_u16(1 << 14);
-        encoder.encode(&initial);
-
-        test_update(initial, VarInt::from_u32(0), &mut encoder);
-        test_update(initial, VarInt::from_u32(1 << 14), &mut encoder);
-        test_update(initial, VarInt::from_u32(1 << 29), &mut encoder);
-    }
-
-    #[test]
-    #[should_panic]
-    fn encode_updated_invalid_test() {
-        let mut buffer = [0u8; size_of::<VarInt>()];
-        let mut encoder = EncoderBuffer::new(&mut buffer);
-        let initial = VarInt::from_u16(1 << 14);
-        encoder.encode(&initial);
-
-        test_update(initial, VarInt::from_u32(1 << 30), &mut encoder);
-    }
-}
-
 impl AsRef<u64> for VarInt {
     #[inline]
     fn as_ref(&self) -> &u64 {


### PR DESCRIPTION
### Description of changes: 

I had a branch from ~6 months ago that included a kani proof showing that the optimized version of the varint table matches the non-optimized version that more clearly matches what the RFC describes. It also included a proof that the math operations matched the underlying `u64` operations, when possible.

### Testing:

```sh
$ cargo kani --tests --harness round_trip_values_test
$ cargo kani --tests --harness table_differential_test
$ cargo kani --tests --harness checked_ops_test
```

[CI Job](https://github.com/aws/s2n-quic/actions/runs/3624251741/jobs/6111021374)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

