### PR TITLE
ci: move tshark build to separate workflow

### DIFF
--- a/.github/Dockerfile.tshark
+++ b/.github/Dockerfile.tshark
@@ -1,0 +1,19 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN \
+  set -eux; \
+  apt-get -o Acquire::Retries=3 update; \
+  apt-get -o Acquire::Retries=3 install -y cmake libglib2.0-dev libc-ares-dev libgcrypt20-dev flex bison byacc libpcap-dev ninja-build wget build-essential;
+
+ARG version="4.0.2"
+
+RUN \
+  set -eux; \
+  wget https://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.xz; \
+  tar xf wireshark-${version}.tar.xz; \
+  cd wireshark-${version}; \
+  cmake -GNinja -DBUILD_wireshark=0 -DBUILD_qtshark=0 -DBUILD_editcap=1 -DBUILD_capinfos=0 -DBUILD_text2pcap=0 -DBUILD_rawshark=0 -DBUILD_sdjournal=0 -DBUILD_sshdump=0 -DBUILD_ciscodump=0 -DENABLE_STATIC=1 -DENABLE_PLUGINS=0 -DENABLE_LIBXML2=0 -DUSE_STATIC=1 -DENABLE_GNUTLS=1 .; \
+  ninja; \
+  cp run/tshark run/editcap /usr/local/bin/;

--- a/.github/interop/runner.patch
+++ b/.github/interop/runner.patch
@@ -1,5 +1,5 @@
 diff --git a/certs.sh b/certs.sh
-index b26b2f8..b7652af 100755
+index b26b2f8..1547dae 100755
 --- a/certs.sh
 +++ b/certs.sh
 @@ -1,4 +1,4 @@
@@ -7,6 +7,17 @@ index b26b2f8..b7652af 100755
 +#!/usr/bin/env bash
  
  set -e
+ 
+@@ -52,8 +52,8 @@ cp $CERTDIR/ca_$CHAINLEN.key $CERTDIR/priv.key
+ # combine certificates
+ for i in $(seq $CHAINLEN -1 1); do
+   cat $CERTDIR/cert_$i.pem >> $CERTDIR/cert.pem
+-  rm $CERTDIR/cert_$i.pem $CERTDIR/ca_$i.key
++  rm -f $CERTDIR/cert_$i.pem $CERTDIR/ca_$i.key
+ done
+-rm $CERTDIR/*.srl $CERTDIR/ca_0.key $CERTDIR/cert.csr
++rm -f $CERTDIR/*.srl $CERTDIR/ca_0.key $CERTDIR/cert.csr
+ 
  
 diff --git a/docker-compose.yml b/docker-compose.yml
 index 7541cae..ba1b4da 100644
@@ -38,7 +49,7 @@ index 7541cae..ba1b4da 100644
        - VERSION=$VERSION
      depends_on:
 diff --git a/implementations.json b/implementations.json
-index 5a88ee2..df511e3 100644
+index 9150551..55aaa4a 100644
 --- a/implementations.json
 +++ b/implementations.json
 @@ -9,11 +9,6 @@
@@ -162,11 +173,11 @@ index c2d6d1f..844bbd5 100644
  print("\nPulling the iperf endpoint...")
  os.system("docker pull martenseemann/quic-interop-iperf-endpoint")
 diff --git a/requirements.txt b/requirements.txt
-index fff6217..07a1506 100644
+index 131cf94..ce5960d 100644
 --- a/requirements.txt
 +++ b/requirements.txt
 @@ -1,4 +1,4 @@
- pycrypto
+ pycryptodome
  termcolor
  prettytable
 -pyshark
@@ -184,7 +195,7 @@ index fbd9515..aa8d6ed 100755
 -    sys.exit(main())
 +    main()
 diff --git a/testcases.py b/testcases.py
-index 2741a0d..5c0a862 100644
+index 6d7ecfb..f2f9dea 100644
 --- a/testcases.py
 +++ b/testcases.py
 @@ -90,6 +90,10 @@ class TestCase(abc.ABC):
@@ -198,7 +209,7 @@ index 2741a0d..5c0a862 100644
      @staticmethod
      def scenario() -> str:
          """ Scenario for the ns3 simulator """
-@@ -1201,54 +1205,26 @@ class TestCasePortRebinding(TestCaseTransfer):
+@@ -1203,54 +1207,26 @@ class TestCasePortRebinding(TestCaseTransfer):
              logging.info("Server saw only a single client port in use; test broken?")
              return TestResult.FAILED
  
@@ -261,7 +272,7 @@ index 2741a0d..5c0a862 100644
                  if hasattr(p["quic"], "path_response.data")
              )
          )
-@@ -1445,6 +1421,10 @@ class MeasurementGoodput(Measurement):
+@@ -1532,6 +1508,10 @@ class MeasurementGoodput(Measurement):
      def testname(p: Perspective):
          return "transfer"
  
@@ -272,7 +283,7 @@ index 2741a0d..5c0a862 100644
      @staticmethod
      def abbreviation():
          return "G"
-@@ -1455,7 +1435,7 @@ class MeasurementGoodput(Measurement):
+@@ -1542,7 +1522,7 @@ class MeasurementGoodput(Measurement):
  
      @staticmethod
      def repetitions() -> int:
@@ -281,21 +292,7 @@ index 2741a0d..5c0a862 100644
  
      def get_paths(self):
          self._files = [self._generate_random_file(self.FILESIZE)]
-@@ -1469,12 +1449,7 @@ class MeasurementGoodput(Measurement):
-         if not self._check_version_and_files():
-             return TestResult.FAILED
- 
--        packets = self._client_trace().get_1rtt(Direction.FROM_SERVER)
--        first, last = 0, 0
--        for p in packets:
--            if first == 0:
--                first = p.sniff_time
--            last = p.sniff_time
-+        first, last = self._client_trace().get_start_end(Direction.FROM_SERVER)
- 
-         if last - first == 0:
-             return TestResult.FAILED
-@@ -1528,8 +1503,8 @@ TESTCASES = [
+@@ -1610,8 +1590,8 @@ TESTCASES = [
      TestCaseChaCha20,
      TestCaseMultiplexing,
      TestCaseRetry,
@@ -306,49 +303,21 @@ index 2741a0d..5c0a862 100644
      TestCaseHTTP3,
      TestCaseBlackhole,
      TestCaseKeyUpdate,
-@@ -1540,11 +1515,9 @@ TESTCASES = [
+@@ -1622,12 +1602,11 @@ TESTCASES = [
      TestCaseHandshakeCorruption,
      TestCaseTransferCorruption,
      TestCaseIPv6,
+-    TestCaseV2,
 -    # The next three tests are disabled due to Wireshark not being able
 -    # to decrypt packets sent on the new path.
 -    # TestCasePortRebinding,
 -    # TestCaseAddressRebinding,
 -    # TestCaseConnectionMigration,
++    # s2n-quic doesn't currently support v2
++    # TestCaseV2,
 +    TestCasePortRebinding,
 +    TestCaseAddressRebinding,
 +    TestCaseConnectionMigration,
  ]
  
  MEASUREMENTS = [
-diff --git a/trace.py b/trace.py
-index 215f25a..00759d4 100644
---- a/trace.py
-+++ b/trace.py
-@@ -125,10 +125,25 @@ class TraceAnalyzer:
-                 if layer.layer_name == "quic" and not hasattr(
-                     layer, "long_packet_type"
-                 ):
--                    layer.sniff_time = packet.sniff_time
-                     packets.append(layer)
-         return packets
- 
-+    def get_start_end(self, direction: Direction = Direction.ALL) -> (int, int):
-+        """ Get start and end time, one or both directions. """
-+        start = 0
-+        end = 0
-+        for packet in self._get_packets(
-+            self._get_direction_filter(direction) + "quic.header_form==0"
-+        ):
-+            for layer in packet.layers:
-+                if layer.layer_name == "quic" and not hasattr(
-+                    layer, "long_packet_type"
-+                ):
-+                    if start == 0:
-+                        start = packet.sniff_time
-+                    end = packet.sniff_time
-+        return (start, end)
-+
-     def get_vnp(self, direction: Direction = Direction.ALL) -> List:
-         return self._get_packets(
-             self._get_direction_filter(direction) + "quic.version==0"

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -66,7 +66,7 @@ jobs:
           echo "::set-output name=matrix::$MATRIX"
 
   s2n-quic-qns:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         mode: ["debug", "release"]
@@ -378,7 +378,7 @@ jobs:
             web/logs/latest/result.json
 
   bench:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [env, s2n-quic-qns]
     steps:
       - uses: actions/checkout@v3
@@ -475,7 +475,7 @@ jobs:
           ! grep -Rq 'The s2n-quic-qns application shut down unexpectedly' target/benchmark/results
 
   h3spec:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [s2n-quic-qns]
     strategy:
       matrix:
@@ -533,7 +533,7 @@ jobs:
             --skip "MUST send no_application_protocol TLS alert if no application protocols are supported [TLS 8.1]" \
 
   perf:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: [quinn, s2n-quic-qns]
     strategy:
       matrix:

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -19,7 +19,7 @@ env:
   # This should be updated when updating wesleyrosenblum/quic-network-simulator
   NETWORK_SIMULATOR_REF: sha256:20abe0bed8c0e39e1d8750507b24295f7c978bdd7e05fa6f3a5afed4b76dc191
   IPERF_ENDPOINT_REF: sha256:cb50cc8019d45d9cad5faecbe46a3c21dd5e871949819a5175423755a9045106
-  WIRESHARK_VERSION: 3.6.6
+  WIRESHARK_VERSION: 4.0.2
   CDN: https://dnglbrstg7yg.cloudfront.net
   LOG_URL: logs/latest/SERVER_CLIENT/TEST/index.html
   H3_SPEC_VERSION: v0.1.8
@@ -150,45 +150,9 @@ jobs:
           name: quinn
           path: quinn/
 
-  tshark:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cache
-        id: cache
-        uses: actions/cache@v3.0.3
-        continue-on-error: true
-        with:
-          path: tshark
-          key: wireshark-${{ env.WIRESHARK_VERSION }}
-
-      - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          sudo apt-get -o Acquire::Retries=3 update
-          sudo apt-get -o Acquire::Retries=3 install -y cmake libglib2.0-dev libc-ares-dev libgcrypt20-dev flex bison byacc libpcap-dev ninja-build
-
-      - name: Build tshark
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: |
-          wget https://www.wireshark.org/download/src/all-versions/wireshark-${{ env.WIRESHARK_VERSION }}.tar.xz
-          tar xf wireshark-${{ env.WIRESHARK_VERSION }}.tar.xz
-          cd wireshark-${{ env.WIRESHARK_VERSION }}
-          cmake -GNinja -DBUILD_wireshark=0 -DBUILD_qtshark=0 -DBUILD_editcap=0 -DBUILD_capinfos=0 -DBUILD_text2pcap=0 -DBUILD_rawshark=0 -DBUILD_sdjournal=0 -DBUILD_sshdump=0 -DBUILD_ciscodump=0 -DENABLE_STATIC=1 -DENABLE_PLUGINS=0 -DENABLE_LIBXML2=0 -DUSE_STATIC=1 -DENABLE_GNUTLS=1 .
-          ninja
-          cp run/tshark ..
-
-      - name: Tshark version
-        run: ./tshark -v
-
-      - name: Upload
-        uses: actions/upload-artifact@v3
-        with:
-          name: tshark
-          path: tshark
-
   interop:
     runs-on: ubuntu-latest
-    needs: [env, s2n-quic-qns, tshark]
+    needs: [env, s2n-quic-qns]
     strategy:
       matrix: ${{ fromJson(needs.env.outputs.matrix) }}
     steps:
@@ -239,14 +203,9 @@ jobs:
         with:
           python-version: 3.7
 
-      - name: Download tshark
-        uses: actions/download-artifact@v3
-        with:
-          name: tshark
-          path: .
-
       - name: Install tshark
         run: |
+          wget https://dnglbrstg7yg.cloudfront.net/tshark/v$WIRESHARK_VERSION/tshark
           chmod +x tshark
           sudo mv tshark /usr/bin
           /usr/bin/tshark -v
@@ -420,7 +379,7 @@ jobs:
 
   bench:
     runs-on: ubuntu-latest
-    needs: [env, s2n-quic-qns, tshark]
+    needs: [env, s2n-quic-qns]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -434,14 +393,9 @@ jobs:
 
       - uses: camshaft/rust-cache@v1
 
-      - name: Download tshark
-        uses: actions/download-artifact@v3
-        with:
-          name: tshark
-          path: .
-
       - name: Install tshark
         run: |
+          wget https://dnglbrstg7yg.cloudfront.net/tshark/v$WIRESHARK_VERSION/tshark
           chmod +x tshark
           sudo mv tshark /usr/bin
           /usr/bin/tshark -v

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   # This kept breaking builds so we're pinning for now. We should do our best to keep
   # up with the changes, though.
-  INTEROP_RUNNER_REF: bdb2c815b8cfd70de4c2efb1bd278b1e87018ff8
+  INTEROP_RUNNER_REF: e73ec56cdf5423fa6b1576a2b5fec5eb2171ec5d
   # This should be updated when updating wesleyrosenblum/quic-network-simulator
   NETWORK_SIMULATOR_REF: sha256:20abe0bed8c0e39e1d8750507b24295f7c978bdd7e05fa6f3a5afed4b76dc191
   IPERF_ENDPOINT_REF: sha256:cb50cc8019d45d9cad5faecbe46a3c21dd5e871949819a5175423755a9045106

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -19,7 +19,7 @@ env:
   # This should be updated when updating wesleyrosenblum/quic-network-simulator
   NETWORK_SIMULATOR_REF: sha256:20abe0bed8c0e39e1d8750507b24295f7c978bdd7e05fa6f3a5afed4b76dc191
   IPERF_ENDPOINT_REF: sha256:cb50cc8019d45d9cad5faecbe46a3c21dd5e871949819a5175423755a9045106
-  WIRESHARK_VERSION: 4.0.2
+  WIRESHARK_VERSION: 3.7.1
   CDN: https://dnglbrstg7yg.cloudfront.net
   LOG_URL: logs/latest/SERVER_CLIENT/TEST/index.html
   H3_SPEC_VERSION: v0.1.8

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -106,7 +106,7 @@ jobs:
           path: s2n-quic-qns/
 
   quinn:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     # enable debug information
     env:
       RUSTFLAGS: "-g"
@@ -205,7 +205,7 @@ jobs:
 
       - name: Install tshark
         run: |
-          wget https://dnglbrstg7yg.cloudfront.net/tshark/v$WIRESHARK_VERSION/tshark
+          wget --no-verbose https://dnglbrstg7yg.cloudfront.net/tshark/v$WIRESHARK_VERSION/tshark
           chmod +x tshark
           sudo mv tshark /usr/bin
           /usr/bin/tshark -v
@@ -395,7 +395,7 @@ jobs:
 
       - name: Install tshark
         run: |
-          wget https://dnglbrstg7yg.cloudfront.net/tshark/v$WIRESHARK_VERSION/tshark
+          wget --no-verbose https://dnglbrstg7yg.cloudfront.net/tshark/v$WIRESHARK_VERSION/tshark
           chmod +x tshark
           sudo mv tshark /usr/bin
           /usr/bin/tshark -v

--- a/.github/workflows/tshark.yml
+++ b/.github/workflows/tshark.yml
@@ -18,11 +18,19 @@ on:
     # Running this every day makes sure the static dependencies are up to date
     - cron: '0 17 * * *'
 
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'wireshark version'
+        required: true
+        default: '3.7.1'
+        type: string
+
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      WIRESHARK_VERSION: "4.0.2"
+      WIRESHARK_VERSION: ${{ inputs.version || '3.7.1' }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/tshark.yml
+++ b/.github/workflows/tshark.yml
@@ -1,0 +1,51 @@
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/Dockerfile.tshark"
+      - ".github/workflows/tshark.yml"
+
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/Dockerfile.tshark"
+      - ".github/workflows/tshark.yml"
+
+  schedule:
+    # run every morning at 10am Pacific Time
+    # Running this every day makes sure the static dependencies are up to date
+    - cron: '0 17 * * *'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      WIRESHARK_VERSION: "4.0.2"
+    steps:
+      - uses: actions/checkout@v2
+
+      - run: mkdir -p target/tshark/v$WIRESHARK_VERSION
+
+      - name: Build
+        working-directory: .github
+        run: |
+          docker build -f Dockerfile.tshark -t tshark-static --build-arg version=$WIRESHARK_VERSION .
+          docker run \
+            -v `pwd`/../target/tshark/v$WIRESHARK_VERSION:/host-dir \
+            tshark-static \
+            cp /usr/local/bin/tshark /usr/local/bin/editcap /host-dir/
+
+      - uses: aws-actions/configure-aws-credentials@v1.7.0
+        if: github.event_name == 'schedule' || github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-1
+
+      - name: Upload to S3
+        if: github.event_name == 'schedule' || github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        run: |
+          aws s3 sync target/tshark "s3://s2n-quic-ci-artifacts/tshark" --acl private --follow-symlinks
+


### PR DESCRIPTION

### Description of changes: 

The tshark and interop runner started failing after `ubuntu-latest` changed to 22.04 instead of 20.04. This change pins the broken jobs to 20.04 until the interop runner docker image is updated.

### Call-outs:

The latest version of wireshark has a problem with the longrtt test. This will need a separate fix applied upstream.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

