### PR TITLE
ci: ignore more broken clippy lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,10 @@ jobs:
           command: clippy
           # deriving Eq may break API compatibility so we disable it
           # See https://github.com/rust-lang/rust-clippy/issues/9063
-          args: --all-features --all-targets -- -A clippy::derive_partial_eq_without_eq ${{ matrix.args }}
+
+          # manual_clamp will panic when min > max
+          # See https://github.com/rust-lang/rust-clippy/pull/10101
+          args: --all-features --all-targets -- -A clippy::derive_partial_eq_without_eq -A clippy::manual_clamp ${{ matrix.args }}
 
   udeps:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
 
           # manual_clamp will panic when min > max
           # See https://github.com/rust-lang/rust-clippy/pull/10101
-          args: --all-features --all-targets -- -A clippy::derive_partial_eq_without_eq -A clippy::manual_clamp ${{ matrix.args }}
+          args: --all-features --all-targets -- -A clippy::derive_partial_eq_without_eq -A clippy::manual_clamp -A clippy::uninlined_format_args ${{ matrix.args }}
 
   udeps:
     runs-on: ubuntu-latest

--- a/netbench/netbench/src/scenario.rs
+++ b/netbench/netbench/src/scenario.rs
@@ -124,7 +124,7 @@ pub(crate) mod pkcs12_format {
     {
         if deserializer.is_human_readable() {
             let s = String::deserialize(deserializer)?;
-            let out = base64::decode(&s).map_err(serde::de::Error::custom)?;
+            let out = base64::decode(s).map_err(serde::de::Error::custom)?;
             Ok(out)
         } else {
             Vec::deserialize(deserializer)

--- a/quic/s2n-quic-core/src/packet/decoding.rs
+++ b/quic/s2n-quic-core/src/packet/decoding.rs
@@ -46,9 +46,9 @@ impl<'a> HeaderDecoder<'a> {
         }
     }
 
-    pub fn decode_destination_connection_id<'b>(
+    pub fn decode_destination_connection_id(
         &mut self,
-        buffer: &DecoderBufferMut<'b>,
+        buffer: &DecoderBufferMut<'_>,
     ) -> Result<CheckedRange, DecoderError> {
         let destination_connection_id =
             self.decode_checked_range::<DestinationConnectionIdLen>(buffer)?;
@@ -56,9 +56,9 @@ impl<'a> HeaderDecoder<'a> {
         Ok(destination_connection_id)
     }
 
-    pub fn decode_short_destination_connection_id<'b, Validator: connection::id::Validator>(
+    pub fn decode_short_destination_connection_id<Validator: connection::id::Validator>(
         &mut self,
-        buffer: &DecoderBufferMut<'b>,
+        buffer: &DecoderBufferMut<'_>,
         connection_info: &ConnectionInfo,
         connection_id_validator: &Validator,
     ) -> Result<CheckedRange, DecoderError> {
@@ -78,18 +78,18 @@ impl<'a> HeaderDecoder<'a> {
         Ok(destination_connection_id)
     }
 
-    pub fn decode_source_connection_id<'b>(
+    pub fn decode_source_connection_id(
         &mut self,
-        buffer: &DecoderBufferMut<'b>,
+        buffer: &DecoderBufferMut<'_>,
     ) -> Result<CheckedRange, DecoderError> {
         let source_connection_id = self.decode_checked_range::<SourceConnectionIdLen>(buffer)?;
         validate_source_connection_id_range(&source_connection_id)?;
         Ok(source_connection_id)
     }
 
-    pub fn decode_checked_range<'b, Len: DecoderValue<'a> + TryInto<usize>>(
+    pub fn decode_checked_range<Len: DecoderValue<'a> + TryInto<usize>>(
         &mut self,
-        buffer: &DecoderBufferMut<'b>,
+        buffer: &DecoderBufferMut<'_>,
     ) -> Result<CheckedRange, DecoderError> {
         let (value, peek) = self.peek.skip_into_range_with_len_prefix::<Len>(buffer)?;
         self.peek = peek;

--- a/quic/s2n-quic-core/src/packet/interceptor.rs
+++ b/quic/s2n-quic-core/src/packet/interceptor.rs
@@ -54,11 +54,11 @@ pub trait Interceptor: 'static + Send {
     }
 
     #[inline(always)]
-    fn intercept_tx_datagram<'a>(
+    fn intercept_tx_datagram(
         &mut self,
         subject: &Subject,
         datagram: &Datagram,
-        payload: &mut EncoderBuffer<'a>,
+        payload: &mut EncoderBuffer,
     ) {
         let _ = subject;
         let _ = datagram;
@@ -66,11 +66,11 @@ pub trait Interceptor: 'static + Send {
     }
 
     #[inline(always)]
-    fn intercept_tx_payload<'a>(
+    fn intercept_tx_payload(
         &mut self,
         subject: &Subject,
         packet: &Packet,
-        payload: &mut EncoderBuffer<'a>,
+        payload: &mut EncoderBuffer,
     ) {
         let _ = subject;
         let _ = packet;
@@ -111,22 +111,22 @@ where
     }
 
     #[inline(always)]
-    fn intercept_tx_datagram<'a>(
+    fn intercept_tx_datagram(
         &mut self,
         subject: &Subject,
         datagram: &Datagram,
-        payload: &mut EncoderBuffer<'a>,
+        payload: &mut EncoderBuffer,
     ) {
         self.0.intercept_tx_datagram(subject, datagram, payload);
         self.1.intercept_tx_datagram(subject, datagram, payload);
     }
 
     #[inline(always)]
-    fn intercept_tx_payload<'a>(
+    fn intercept_tx_payload(
         &mut self,
         subject: &Subject,
         packet: &Packet,
-        payload: &mut EncoderBuffer<'a>,
+        payload: &mut EncoderBuffer,
     ) {
         self.0.intercept_tx_payload(subject, packet, payload);
         self.1.intercept_tx_payload(subject, packet, payload);
@@ -175,11 +175,11 @@ where
     }
 
     #[inline]
-    fn intercept_tx_payload<'a>(
+    fn intercept_tx_payload(
         &mut self,
         _subject: &Subject,
         _packet: &Packet,
-        payload: &mut EncoderBuffer<'a>,
+        payload: &mut EncoderBuffer,
     ) {
         self.tx.havoc(&mut self.random, payload);
     }

--- a/quic/s2n-quic-core/src/packet/interceptor/loss.rs
+++ b/quic/s2n-quic-core/src/packet/interceptor/loss.rs
@@ -164,11 +164,11 @@ where
     }
 
     #[inline]
-    fn intercept_tx_datagram<'a>(
+    fn intercept_tx_datagram(
         &mut self,
         _subject: &crate::event::api::Subject,
         _datagram: &super::Datagram,
-        payload: &mut s2n_codec::EncoderBuffer<'a>,
+        payload: &mut s2n_codec::EncoderBuffer,
     ) {
         if !self.tx.should_pass(&mut self.random) {
             payload.set_position(0);

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -740,7 +740,7 @@ impl Cubic {
     //# where beta_cubic is the CUBIC multiplication decrease factor
     #[inline]
     fn w_cubic(&self, t: Duration) -> f32 {
-        C * (t.as_secs_f32() - self.k.as_secs_f32()).powi(3) + self.w_max as f32
+        C * (t.as_secs_f32() - self.k.as_secs_f32()).powi(3) + self.w_max
     }
 
     //= https://www.rfc-editor.org/rfc/rfc8312#section-4.2

--- a/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
@@ -730,7 +730,7 @@ mod test {
                 let weight = 8;
 
                 // perform the unoptimized version
-                let expected = ((weight - 1) as u32 * a) / weight + b / weight;
+                let expected = ((weight - 1) * a) / weight + b / weight;
                 let actual = super::weighted_average(a, b, weight as _);
 
                 // assert that the unoptimized result matches the optimized to the nearest `weight` nanos

--- a/quic/s2n-quic-platform/src/message/cmsg.rs
+++ b/quic/s2n-quic-platform/src/message/cmsg.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(clippy::unnecessary_cast)] // some platforms encode lengths as `u32` so we cast everything to be safe
+
 use core::mem::{align_of, size_of};
 use s2n_quic_core::inet::{AncillaryData, ExplicitCongestionNotification};
 

--- a/quic/s2n-quic-platform/src/message/msg.rs
+++ b/quic/s2n-quic-platform/src/message/msg.rs
@@ -308,11 +308,13 @@ impl MessageTrait for msghdr {
         }
 
         // reset the control messages if it isn't set to the default value
-        if self.msg_controllen as usize != cmsg::MAX_LEN {
-            let cmsg = core::slice::from_raw_parts_mut(
-                self.msg_control as *mut u8,
-                self.msg_controllen as _,
-            );
+
+        // some platforms encode lengths as `u32` so we cast everything to be safe
+        #[allow(clippy::unnecessary_cast)]
+        let msg_controllen = self.msg_controllen as usize;
+
+        if msg_controllen != cmsg::MAX_LEN {
+            let cmsg = core::slice::from_raw_parts_mut(self.msg_control as *mut u8, msg_controllen);
 
             for byte in cmsg.iter_mut() {
                 *byte = 0;

--- a/quic/s2n-quic-platform/src/message/queue/slice.rs
+++ b/quic/s2n-quic-platform/src/message/queue/slice.rs
@@ -341,6 +341,7 @@ impl<
     }
 
     #[inline]
+    #[allow(unknown_lints, clippy::misnamed_getters)] // this slice is made up of two halves and uses the primary for unfilled data
     fn capacity(&self) -> usize {
         self.primary.len
     }

--- a/quic/s2n-quic-platform/src/message/simple.rs
+++ b/quic/s2n-quic-platform/src/message/simple.rs
@@ -50,7 +50,7 @@ impl MessageTrait for Message {
     }
 
     fn payload_len(&self) -> usize {
-        self.payload_len as usize
+        self.payload_len
     }
 
     unsafe fn set_payload_len(&mut self, len: usize) {

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -415,12 +415,12 @@ impl<Config: endpoint::Config> ConnectionImpl<Config> {
     /// Since non-probing frames can only be sent on the active path, a separate
     /// transmission context with Mode::PathValidationOnly is used to send on
     /// other paths.
-    fn path_validation_only_transmission<'a, 'sub, Tx: tx::Queue<Handle = Config::PathHandle>>(
+    fn path_validation_only_transmission<'a, Tx: tx::Queue<Handle = Config::PathHandle>>(
         &mut self,
         queue: &mut Tx,
         timestamp: Timestamp,
         outcome: &'a mut transmission::Outcome,
-        subscriber: &'sub mut Config::EventSubscriber,
+        subscriber: &mut Config::EventSubscriber,
         packet_interceptor: &'a mut Config::PacketInterceptor,
     ) -> usize {
         let mut count = 0;

--- a/quic/s2n-quic-transport/src/stream/receive_stream/tests.rs
+++ b/quic/s2n-quic-transport/src/stream/receive_stream/tests.rs
@@ -1056,7 +1056,7 @@ fn flow_control_window_update_is_only_sent_when_minimum_data_size_is_consumed() 
         test_env.stream.get_stream_interests()
     );
 
-    let expected_window = absolute_threshold as u64 - 1;
+    let expected_window = absolute_threshold - 1;
     assert_eq!(
         expected_window,
         Into::<u64>::into(
@@ -1156,7 +1156,7 @@ fn connection_flow_control_window_update_is_only_sent_when_minimum_data_size_is_
             .get_transmission_interest()
     );
 
-    let expected_window = absolute_threshold as u64 - 1;
+    let expected_window = absolute_threshold - 1;
     assert_eq!(
         expected_window,
         Into::<u64>::into(

--- a/quic/s2n-quic-transport/src/stream/send_stream/tests.rs
+++ b/quic/s2n-quic-transport/src/stream/send_stream/tests.rs
@@ -360,7 +360,7 @@ fn can_not_enqueue_data_if_max_buffer_size_has_been_reached() {
             // as long as we are below the flow control window. We subtract 2
             // in the second instruction so that even the the third instruction
             // would not cause us a rejection based on the flow control size.
-            Instruction::EnqueueData(VarInt::from_u32(0), MAX_BUFFER_SIZE as usize - 1, true),
+            Instruction::EnqueueData(VarInt::from_u32(0), MAX_BUFFER_SIZE - 1, true),
             Instruction::EnqueueData(
                 max_buffer_size_varint - 1,
                 RECEIVE_WINDOW as usize - MAX_BUFFER_SIZE - 2,
@@ -488,7 +488,7 @@ fn multiple_stream_frames_are_sent_in_a_packet() {
             // as long as we are below the flow control window. We subtract 2
             // in the second instruction so that even the the third instruction
             // would not cause us a rejection based on the flow control size.
-            Instruction::EnqueueData(VarInt::from_u32(0), MAX_BUFFER_SIZE as usize - 1, true),
+            Instruction::EnqueueData(VarInt::from_u32(0), MAX_BUFFER_SIZE - 1, true),
             Instruction::EnqueueData(
                 max_buffer_size_varint - 1,
                 RECEIVE_WINDOW as usize - MAX_BUFFER_SIZE - 2,

--- a/scripts/local_test
+++ b/scripts/local_test
@@ -10,5 +10,5 @@
 set -e
 
 cargo +nightly fmt --all -- --check
-cargo +stable clippy --all-features --all-targets -- -D warnings -A clippy::derive_partial_eq_without_eq
+cargo +stable clippy --all-features --all-targets -- -D warnings -A clippy::derive_partial_eq_without_eq -A clippy::manual_clamp -A clippy::uninlined_format_args
 cargo test


### PR DESCRIPTION
### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.-->

Clippy released a couple of broken lints that were rolled back in beta (and eventually the next release). This PR makes an exception for them so it doesn't break our CI.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

The exceptions should probably be removed after the next stable release but it isn't a huge deal if it's not.

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

The CI checks are all passing now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

