### PR TITLE
Expose ReceiveContext too

### DIFF
--- a/quic/s2n-quic/src/provider/datagram.rs
+++ b/quic/s2n-quic/src/provider/datagram.rs
@@ -6,7 +6,10 @@
 use s2n_quic_core::datagram::Disabled;
 pub use s2n_quic_core::datagram::{
     default,
-    traits::{ConnectionInfo, Endpoint, Packet, PreConnectionInfo, Receiver, Sender, WriteError},
+    traits::{
+        ConnectionInfo, Endpoint, Packet, PreConnectionInfo, ReceiveContext, Receiver, Sender,
+        WriteError,
+    },
 };
 
 pub trait Provider {


### PR DESCRIPTION
### Description of changes: 

This was missed in the original PR review (the type was introduced in a refactor and overlooked as a new thing to expose).

### Testing:

No testing. I think in the future it might be nice to have some kind of pass (with rustdoc-json, maybe?) that validates that there's only intentional non-exposed types in the s2n-quic API, but that would require quite a bit of work I think.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

