### PR TITLE
Provide access to connection Waker to datagram Endpoint

### DIFF
--- a/quic/s2n-quic-core/src/datagram/default.rs
+++ b/quic/s2n-quic-core/src/datagram/default.rs
@@ -554,12 +554,13 @@ mod tests {
     use super::*;
     use crate::datagram::WriteError;
     use core::task::{Context, Poll};
-    use futures_test::task::new_count_waker;
+    use futures_test::task::{new_count_waker, noop_waker};
 
     #[test]
     fn send_datagram_forced() {
         let conn_info = ConnectionInfo {
             max_datagram_payload: 100,
+            waker: noop_waker(),
         };
         // Create a default sender queue that only holds two elements
         let mut default_sender = Sender::builder()
@@ -598,6 +599,7 @@ mod tests {
     fn send_datagram() {
         let conn_info = ConnectionInfo {
             max_datagram_payload: 100,
+            waker: noop_waker(),
         };
         // Create a default sender queue that only holds two elements
         let mut default_sender = Sender::builder()
@@ -636,7 +638,7 @@ mod tests {
 
     #[test]
     fn poll_send_datagram() {
-        let conn_info = ConnectionInfo::new(100);
+        let conn_info = ConnectionInfo::new(100, noop_waker());
         let mut default_sender = Sender::builder()
             .with_capacity(2)
             .with_connection_info(&conn_info)
@@ -708,6 +710,7 @@ mod tests {
     fn retain_datagrams() {
         let conn_info = ConnectionInfo {
             max_datagram_payload: 100,
+            waker: noop_waker(),
         };
         let mut default_sender = Sender::builder()
             .with_capacity(3)
@@ -752,7 +755,7 @@ mod tests {
     // Check that our default on_transmit function doesn't continue to pop datagrams
     // off the send queue if the remaining packet space is too small to send datagrams.
     fn has_written_test() {
-        let conn_info = ConnectionInfo::new(100);
+        let conn_info = ConnectionInfo::new(100, noop_waker());
         let mut default_sender = Sender::builder()
             .with_connection_info(&conn_info)
             .build()

--- a/quic/s2n-quic-core/src/datagram/traits.rs
+++ b/quic/s2n-quic-core/src/datagram/traits.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use core::task::Waker;
+
 use crate::connection;
 
 /// The datagram endpoint trait provides a way to implement custom unreliable datagram
@@ -17,21 +19,29 @@ pub trait Endpoint: 'static + Send {
     fn max_datagram_frame_size(&self, info: &PreConnectionInfo) -> u64;
 }
 
-/// ConnectionInfo contains the peer's limit on the size of datagrams
-/// they accept
-///
-/// Sending a datagram larger than this will result in an error
+/// Information about the accepted connection for which the Sender/Receiver are being created.
 #[non_exhaustive]
 #[derive(Debug)]
 pub struct ConnectionInfo {
+    /// The peer's limit on the size of datagrams they will accept. Datagrams larger than this will
+    /// result in an error.
     pub max_datagram_payload: u64,
+
+    /// The `waker` associated with this connection. When woken, the connection will check the
+    /// interest in sending ([`Sender::has_transmission_interest`]), and send packets if necessary.
+    ///
+    /// This is useful for applications that wish to enqueue packets with `Sender` without calling
+    /// `datagram_mut`, perhaps because they don't have an available handle to the connection when
+    /// enqueuing packets, or wish to avoid incurring the lock/unlock required by `datagram_mut`.
+    pub waker: Waker,
 }
 
 impl ConnectionInfo {
     #[doc(hidden)]
-    pub fn new(max_datagram_payload: u64) -> Self {
+    pub fn new(max_datagram_payload: u64, waker: Waker) -> Self {
         ConnectionInfo {
             max_datagram_payload,
+            waker,
         }
     }
 }

--- a/quic/s2n-quic-core/src/datagram/traits.rs
+++ b/quic/s2n-quic-core/src/datagram/traits.rs
@@ -36,12 +36,6 @@ impl ConnectionInfo {
     }
 }
 
-impl Default for ConnectionInfo {
-    fn default() -> Self {
-        ConnectionInfo::new(0)
-    }
-}
-
 /// PreConnectionInfo will contain information needed to determine whether
 /// or not a provider will accept datagrams.
 #[non_exhaustive]
@@ -49,14 +43,9 @@ pub struct PreConnectionInfo(());
 
 impl PreConnectionInfo {
     #[doc(hidden)]
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         PreConnectionInfo(())
-    }
-}
-
-impl Default for PreConnectionInfo {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -399,7 +399,8 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
             self.limits.max_keep_alive_period(),
         );
 
-        let conn_info = ConnectionInfo::new(datagram_limits.max_datagram_payload);
+        let conn_info =
+            ConnectionInfo::new(datagram_limits.max_datagram_payload, self.waker.clone());
         let (datagram_sender, datagram_receiver) = self.datagram.create_connection(&conn_info);
         let datagram_manager = datagram::Manager::new(
             datagram_sender,


### PR DESCRIPTION
### Description of changes: 

This waker allows datagram receiver/senders to wake up the connection,
which will re-poll the connection for interest in sending. When
implementing a custom datagram Receiver which wants to schedule a reply
datagram, this Waker or something like it is necessary to indirect the
wakeup of the connection and subsequent call to the Sender's
on_transmit.

This is a waker and not a connection handle for two reasons:

* The Waker does not directly extend the lifetime of the connection,
  which avoids keeping the connection data indefinitely alive for cases
  where the Waker is stored within the Sender or Receiver.
* s2n-quic calling datagram Endpoint::new_connection doesn't have easy
  access to an application handle to the connection.

Note that applications still must retain the Connection or a Handle to
it: when the last application handle closes, the connection is also
closed, even if there are Wakers for that connection still around.

In practice this seems useful as it allows bounding the number of active
connections with an Endpoint and the extra waste of connection handles
is unlikely to be significant.

### Call-outs:

* The choice to expose a Waker might not have any precedent in s2n-quic -- not sure if there's other APIs that do that.
* The first commit removes `Default` impls for `ConnectionInfo` and `PreConnectionInfo`. This is intended to avoid needing to provide a default for the Waker field, which doesn't seem like it *has* an obvious default (a no-op waker, perhaps?). I believe these impls exist for construction outside of s2n-quic-owned crates as a way to construct despite the non_exhaustive annotations, but I'm not sure they are actually a good idea. Open to alternatives here.

This is sort of further iterating on options around https://github.com/aws/s2n-quic/issues/1565 -- it's not really directly related but provides another way of bypassing the normal structure.

### Testing:

No dedicated tests are added. I'm not sure if there are tests related to connection wakeup & polling today -- it seems like the functionality added here would need to build essentially a full Endpoint to test it well. Happy to add that if pointed to some existing framework for it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

