### PR TITLE
add packet_len field to Packet Sent event

### DIFF
--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -563,6 +563,7 @@ pub mod api {
     #[doc = " Packet was sent by a connection"]
     pub struct PacketSent {
         pub packet_header: PacketHeader,
+        pub packet_len: usize,
     }
     impl Event for PacketSent {
         const NAME: &'static str = "transport:packet_sent";
@@ -1160,7 +1161,7 @@ pub mod api {
         }
     }
     macro_rules! impl_conn_id {
-        ($name:ident) => {
+        ($ name : ident) => {
             impl<'a> IntoEvent<builder::ConnectionId<'a>> for &'a crate::connection::id::$name {
                 #[inline]
                 fn into_event(self) -> builder::ConnectionId<'a> {
@@ -1596,8 +1597,11 @@ pub mod tracing {
             event: &api::PacketSent,
         ) {
             let id = context.id();
-            let api::PacketSent { packet_header } = event;
-            tracing :: event ! (target : "packet_sent" , parent : id , tracing :: Level :: DEBUG , packet_header = tracing :: field :: debug (packet_header));
+            let api::PacketSent {
+                packet_header,
+                packet_len,
+            } = event;
+            tracing :: event ! (target : "packet_sent" , parent : id , tracing :: Level :: DEBUG , packet_header = tracing :: field :: debug (packet_header) , packet_len = tracing :: field :: debug (packet_len));
         }
         #[inline]
         fn on_packet_received(
@@ -3262,13 +3266,18 @@ pub mod builder {
     #[doc = " Packet was sent by a connection"]
     pub struct PacketSent {
         pub packet_header: PacketHeader,
+        pub packet_len: usize,
     }
     impl IntoEvent<api::PacketSent> for PacketSent {
         #[inline]
         fn into_event(self) -> api::PacketSent {
-            let PacketSent { packet_header } = self;
+            let PacketSent {
+                packet_header,
+                packet_len,
+            } = self;
             api::PacketSent {
                 packet_header: packet_header.into_event(),
+                packet_len: packet_len.into_event(),
             }
         }
     }

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -1161,7 +1161,7 @@ pub mod api {
         }
     }
     macro_rules! impl_conn_id {
-        ($ name : ident) => {
+        ($name:ident) => {
             impl<'a> IntoEvent<builder::ConnectionId<'a>> for &'a crate::connection::id::$name {
                 #[inline]
                 fn into_event(self) -> builder::ConnectionId<'a> {

--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -21,6 +21,7 @@ struct ServerNameInformation<'a> {
 /// Packet was sent by a connection
 struct PacketSent {
     packet_header: PacketHeader,
+    packet_len: usize,
 }
 
 #[event("transport:packet_received")]

--- a/quic/s2n-quic-platform/src/io/testing.rs
+++ b/quic/s2n-quic-platform/src/io/testing.rs
@@ -17,7 +17,7 @@ mod model;
 pub mod network;
 pub mod time;
 
-pub use model::Model;
+pub use model::{Model, TxRecorder};
 pub use network::{Network, PathHandle};
 pub use time::now;
 

--- a/quic/s2n-quic-platform/src/io/testing/model.rs
+++ b/quic/s2n-quic-platform/src/io/testing/model.rs
@@ -19,7 +19,7 @@ pub struct TxRecorder {
 
 impl TxRecorder {
     pub fn get_packets(&self) -> Arc<Mutex<Vec<Packet>>> {
-        &self.packets.clone()
+        self.packets.clone()
     }
 }
 

--- a/quic/s2n-quic-platform/src/io/testing/model.rs
+++ b/quic/s2n-quic-platform/src/io/testing/model.rs
@@ -14,12 +14,12 @@ use std::{
 
 #[derive(Clone, Default)]
 pub struct TxRecorder {
-    packets: Arc<Mutex<Vec<Packet>>>
+    packets: Arc<Mutex<Vec<Packet>>>,
 }
 
 impl TxRecorder {
     pub fn get_packets(&self) -> Arc<Mutex<Vec<Packet>>> {
-        Arc::clone(&self.packets)
+        &self.packets.clone()
     }
 }
 

--- a/quic/s2n-quic-platform/src/io/testing/model.rs
+++ b/quic/s2n-quic-platform/src/io/testing/model.rs
@@ -8,9 +8,30 @@ use std::{
     borrow::Cow,
     sync::{
         atomic::{AtomicU16, AtomicU64, Ordering},
-        Arc,
+        Arc, Mutex,
     },
 };
+
+#[derive(Clone, Default)]
+pub struct TxRecorder {
+    packets: Arc<Mutex<Vec<Packet>>>
+}
+
+impl TxRecorder {
+    pub fn get_packets(&self) -> Arc<Mutex<Vec<Packet>>> {
+        Arc::clone(&self.packets)
+    }
+}
+
+impl Network for TxRecorder {
+    fn execute(&mut self, buffers: &Buffers) -> usize {
+        let mut packets = self.packets.lock().unwrap();
+        buffers.pending_transmission(|packet| {
+            packets.push(packet.clone());
+        });
+        0
+    }
+}
 
 #[derive(Clone, Default)]
 pub struct Model(Arc<State>);
@@ -298,7 +319,7 @@ impl Network for Model {
         };
 
         let mut transmission_count = 0;
-        buffers.pending_transmissions(|packet| {
+        buffers.drain_pending_transmissions(|packet| {
             // retransmit the packet until the rate fails or we retransmit 5
             //
             // We limit retransmissions to 5 just so we don't endlessly iterate when the

--- a/quic/s2n-quic-platform/src/io/testing/network.rs
+++ b/quic/s2n-quic-platform/src/io/testing/network.rs
@@ -87,7 +87,7 @@ impl Buffers {
 
     pub fn pending_transmission<F: FnMut(&Packet)>(&self, mut f: F) {
         let lock = self.inner.lock().unwrap();
-        for (_addr, queue) in &lock.tx {
+        for queue in lock.tx.values() {
             for packet in &queue.packets {
                 f(packet);
             }

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -242,6 +242,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
                     packet_number,
                     context.publisher.quic_version(),
                 ),
+                packet_len: outcome.bytes_sent,
             });
 
         Ok((outcome, buffer))
@@ -306,6 +307,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
                     packet_number,
                     context.publisher.quic_version(),
                 ),
+                packet_len: outcome.bytes_sent,
             });
 
         Ok((outcome, buffer))

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -179,6 +179,7 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
                     packet_number,
                     context.publisher.quic_version(),
                 ),
+                packet_len: outcome.bytes_sent,
             });
 
         Ok((outcome, buffer))
@@ -236,6 +237,7 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
                     packet_number,
                     context.publisher.quic_version(),
                 ),
+                packet_len: outcome.bytes_sent,
             });
 
         Ok((outcome, buffer))

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -228,6 +228,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
                     packet_number,
                     context.publisher.quic_version(),
                 ),
+                packet_len: outcome.bytes_sent,
             });
 
         Ok((outcome, buffer))
@@ -286,6 +287,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
                     packet_number,
                     context.publisher.quic_version(),
                 ),
+                packet_len: outcome.bytes_sent,
             });
 
         Ok((outcome, buffer))

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -359,7 +359,7 @@ fn packet_sent_event_test() {
         })
         .collect();
 
-    // tranmitted quic packets may be coalesced into a single datagram (network packet)
+    // transmitted quic packets may be coalesced into a single datagram (network packet)
     // so it might be the case that network_packet[0] = quic_packet[0] + quic_packet[1]
     while let Some(server_packet) = server_tx_network_packets.pop() {
         let expected_len = server_packet.payload.len();

--- a/quic/s2n-quic/src/tests/setup.rs
+++ b/quic/s2n-quic/src/tests/setup.rs
@@ -10,7 +10,9 @@ use crate::{
     Client, Server,
 };
 use rand::{Rng, RngCore};
-use s2n_quic_core::{crypto::tls::testing::certificates, havoc, stream::testing::Data, event::Subscriber};
+use s2n_quic_core::{
+    crypto::tls::testing::certificates, event::Subscriber, havoc, stream::testing::Data,
+};
 use std::net::SocketAddr;
 
 pub static SERVER_CERTS: (&str, &str) = (certificates::CERT_PEM, certificates::KEY_PEM);

--- a/quic/s2n-quic/src/tests/setup.rs
+++ b/quic/s2n-quic/src/tests/setup.rs
@@ -10,7 +10,7 @@ use crate::{
     Client, Server,
 };
 use rand::{Rng, RngCore};
-use s2n_quic_core::{crypto::tls::testing::certificates, havoc, stream::testing::Data};
+use s2n_quic_core::{crypto::tls::testing::certificates, havoc, stream::testing::Data, event::Subscriber};
 use std::net::SocketAddr;
 
 pub static SERVER_CERTS: (&str, &str) = (certificates::CERT_PEM, certificates::KEY_PEM);
@@ -69,6 +69,16 @@ pub fn server(handle: &Handle) -> Result<SocketAddr> {
             .with_io(io)?
             .with_tls(SERVER_CERTS)?
             .with_event(events())?
+            .start()?)
+    })
+}
+
+pub fn server_with_subscriber<S: Subscriber>(handle: &Handle, subscriber: S) -> Result<SocketAddr> {
+    server_with(handle, |io| {
+        Ok(Server::builder()
+            .with_io(io)?
+            .with_tls(SERVER_CERTS)?
+            .with_event(subscriber)?
             .start()?)
     })
 }


### PR DESCRIPTION
### Resolved issues:

#1444 

### Description of changes: 

This PR adds a `packet_len` field to the `PacketSent` event. It also adds a unit test to check that the `packet_len` is correct.

### Call-outs:

I don't particularly love the location of the unit test right now, but because it relies on the network simulator and the setup methods, it feels easiest to fit it in the `s2n-quic` crate. 

### Testing:

1. run the client_server interaction on the network simulator
2. capture all network packets transmitted
3. record all PacketSent events from the server
4. ensure that packet sent events have the correct lengths, given that we know the size of the network packets

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

