### PR TITLE
fix(s2n-quic-transport): only allow GSO of MTU-sized packets

### DIFF
--- a/quic/s2n-quic-platform/src/buffer/vec.rs
+++ b/quic/s2n-quic-platform/src/buffer/vec.rs
@@ -6,10 +6,18 @@ use core::{
     fmt,
     ops::{Deref, DerefMut},
 };
+use lazy_static::lazy_static;
 use s2n_quic_core::path::DEFAULT_MAX_MTU;
 
 // TODO decide on better defaults
-const DEFAULT_MESSAGE_COUNT: usize = 1024;
+lazy_static! {
+    static ref DEFAULT_MESSAGE_COUNT: usize = {
+        std::env::var("S2N_UNSTABLE_DEFAULT_MESSAGE_COUNT")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(1024 * 2)
+    };
+}
 
 pub struct VecBuffer {
     region: alloc::vec::Vec<u8>,
@@ -33,7 +41,7 @@ impl Default for VecBuffer {
         if cfg!(test) {
             Self::new(64, 1200)
         } else {
-            Self::new(DEFAULT_MESSAGE_COUNT, DEFAULT_MAX_MTU.into())
+            Self::new(*DEFAULT_MESSAGE_COUNT, DEFAULT_MAX_MTU.into())
         }
     }
 }

--- a/quic/s2n-quic-transport/src/connection/connection_container.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container.rs
@@ -645,7 +645,7 @@ macro_rules! iterate_interruptible {
             }
 
             match result {
-                ConnectionContainerIterationResult::BreakAndInsertAtBack => {
+                ConnectionContainerIterationResult::BreakAndInsertAtFront => {
                     $sel.interest_lists
                         .$list_name
                         .front_mut()
@@ -1072,11 +1072,12 @@ impl<C: connection::Trait, L: connection::Lock<C>> ConnectionContainer<C, L> {
 /// The value instructs the iterator whether iteration will be continued.
 #[derive(Clone, Copy, Debug)]
 pub enum ConnectionContainerIterationResult {
-    /// Continue iteration over the list
+    /// Continue iteration over the list and insert the current connection
+    /// to the back
     Continue,
     /// Aborts the iteration over a list and add the remaining items at the
-    /// back of the list
-    BreakAndInsertAtBack,
+    /// front of the list
+    BreakAndInsertAtFront,
 }
 
 #[cfg(test)]

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -517,7 +517,7 @@ fn container_test() {
                         assert!(conn.interests.transmission);
 
                         if count == 0 {
-                            ConnectionContainerIterationResult::BreakAndInsertAtBack
+                            ConnectionContainerIterationResult::BreakAndInsertAtFront
                         } else {
                             count -= 1;
                             ConnectionContainerIterationResult::Continue
@@ -530,7 +530,7 @@ fn container_test() {
                         assert!(conn.interests.new_connection_id);
 
                         if count == 0 {
-                            ConnectionContainerIterationResult::BreakAndInsertAtBack
+                            ConnectionContainerIterationResult::BreakAndInsertAtFront
                         } else {
                             count -= 1;
                             ConnectionContainerIterationResult::Continue

--- a/quic/s2n-quic-transport/src/connection/transmission.rs
+++ b/quic/s2n-quic-transport/src/connection/transmission.rs
@@ -87,10 +87,9 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
         }
 
         // If a packet can be GSO'd it means it's limited to the previously written packet
-        // size. This becomes a problem for MTU probes where they will likely exceed that amount.
-        // As such, if we're probing we want to let the IO layer know to not GSO the current
-        // packet.
-        !self.context.transmission_mode.is_mtu_probing()
+        // size. We want to avoid sending several small packets and artificially clamping packets to
+        // less that a MTU.
+        segment_len >= self.context.path().mtu(self.context.transmission_mode)
     }
 
     fn write_payload(

--- a/quic/s2n-quic-transport/src/connection/transmission.rs
+++ b/quic/s2n-quic-transport/src/connection/transmission.rs
@@ -88,7 +88,7 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
 
         // If a packet can be GSO'd it means it's limited to the previously written packet
         // size. We want to avoid sending several small packets and artificially clamping packets to
-        // less that a MTU.
+        // less than an MTU.
         segment_len >= self.context.path().mtu(self.context.transmission_mode)
     }
 

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -406,7 +406,7 @@ impl<Config: endpoint::Config> Path<Config> {
     }
 
     #[inline]
-    fn mtu(&self, transmission_mode: transmission::Mode) -> usize {
+    pub fn mtu(&self, transmission_mode: transmission::Mode) -> usize {
         match transmission_mode {
             // Use the minimum MTU for loss recovery probes to allow detection of packets
             // lost when the previously confirmed path MTU is no longer supported.

--- a/tools/memory-report/src/main.rs
+++ b/tools/memory-report/src/main.rs
@@ -34,7 +34,7 @@ impl Snapshot {
                     assert!(rss < 30_000, "{rss}");
                 }
                 "post-close" => {
-                    assert_eq!(rss, 0, "{rss}");
+                    assert!(rss < 128, "{rss}");
                 }
                 e => unimplemented!("{}", e),
             }


### PR DESCRIPTION
### Description of changes: 

I noticed an issue when determining if a transmission can be included as a GSO segment or not. The current logic is to allow any packet sizes to be considered for GSO, as long we aren't MTU probing. This isn't really ideal, since a previous transmission to the same tuple could have been a small ACK packet. This means we're artificially clamping MTU to the small ACK size, rather than allowing the connection to transmit a full MTU.

This change, instead, only allows GSO on transmissions if the segment size is `>=` than the path's MTU for the current transmission mode. This results in more connections transmitting correctly, rather than bailing since we may end up deciding to not write a packet if the segment size is too small (initial packets, etc).

### Call-outs:

In experimentation, I also noticed the socket buffer queue sizes were somewhat small and will many concurrent connections I was filling it up a lot. This PR includes a default that is double the previous, as well as an unstable configuration of the value via environment variables.

I'm going to be revamping the IO implementation in the next coming weeks, and this environment variable will likely be gone after I'm done.

### Testing:

I wrote a [handshake fuzzer](https://gist.github.com/camshaft/35ea32c01732d3935f45ffab73d1434c) for this test. I'm planning on submitting a PR and put it under `/tools` later.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

