### PR TITLE
feat(s2n-quic-core): add spsc channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -682,3 +682,29 @@ jobs:
           name: "dhat / report"
           status: "success"
           url: "${{ steps.s3.outputs.URL }}"
+
+  loom:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        crate: [quic/s2n-quic-core]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: stable
+          profile: minimal
+
+      - uses: camshaft/rust-cache@v1
+        with:
+          key: ${{ matrix.crate }}
+
+      - name: ${{ matrix.crate }}
+        # run the tests with release mode since some of the loom models can be expensive
+        run: cd ${{ matrix.crate }} && cargo test --release loom
+        env:
+          RUSTFLAGS: --cfg loom

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -698,6 +698,7 @@ jobs:
         with:
           toolchain: stable
           profile: minimal
+          override: true
 
       - uses: camshaft/rust-cache@v1
         with:
@@ -707,4 +708,4 @@ jobs:
         # run the tests with release mode since some of the loom models can be expensive
         run: cd ${{ matrix.crate }} && cargo test --release loom
         env:
-          RUSTFLAGS: --cfg loom
+          RUSTFLAGS: --cfg loom -Cdebug-assertions

--- a/quic/s2n-quic-bench/Cargo.toml
+++ b/quic/s2n-quic-bench/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 
 [dependencies]
 criterion = { version = "0.4", features = ["html_reports"] }
+crossbeam-channel = { version = "0.5" }
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-crypto = { path = "../s2n-quic-crypto", features = ["testing"] }

--- a/quic/s2n-quic-bench/src/lib.rs
+++ b/quic/s2n-quic-bench/src/lib.rs
@@ -7,6 +7,7 @@ mod buffer;
 mod crypto;
 mod frame;
 mod packet;
+mod sync;
 mod varint;
 
 pub fn benchmarks(c: &mut Criterion) {
@@ -14,5 +15,6 @@ pub fn benchmarks(c: &mut Criterion) {
     crypto::benchmarks(c);
     frame::benchmarks(c);
     packet::benchmarks(c);
+    sync::benchmarks(c);
     varint::benchmarks(c);
 }

--- a/quic/s2n-quic-bench/src/sync.rs
+++ b/quic/s2n-quic-bench/src/sync.rs
@@ -1,0 +1,80 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{BenchmarkId, Criterion, Throughput};
+use crossbeam_channel::bounded;
+use s2n_quic_core::sync::spsc;
+
+pub fn benchmarks(c: &mut Criterion) {
+    spsc_benches(c);
+}
+
+fn spsc_benches(c: &mut Criterion) {
+    let mut group = c.benchmark_group("spsc");
+
+    for i in [1, 64, 1024, 4096] {
+        group.throughput(Throughput::Elements(i as _));
+        group.bench_with_input(BenchmarkId::new("s2n/send_recv", i), &i, |b, input| {
+            let (mut sender, mut receiver) = spsc::channel(*input);
+            b.iter(|| {
+                {
+                    let mut slice = sender.try_slice().unwrap().unwrap();
+                    while slice.push(123usize).is_ok() {}
+                }
+
+                {
+                    let mut slice = receiver.try_slice().unwrap().unwrap();
+                    while slice.pop().is_some() {}
+                }
+            });
+        });
+        group.bench_with_input(
+            BenchmarkId::new("crossbeam/send_recv", i),
+            &i,
+            |b, input| {
+                let (sender, receiver) = bounded(*input);
+                b.iter(|| {
+                    {
+                        while sender.try_send(123usize).is_ok() {}
+                    }
+
+                    {
+                        while receiver.try_recv().is_ok() {}
+                    }
+                });
+            },
+        );
+
+        group.bench_with_input(BenchmarkId::new("s2n/send_recv_iter", i), &i, |b, input| {
+            let (mut sender, mut receiver) = spsc::channel(*input);
+            b.iter(|| {
+                {
+                    let mut slice = sender.try_slice().unwrap().unwrap();
+                    let _ = slice.extend(&mut core::iter::repeat(123usize));
+                }
+
+                {
+                    let mut slice = receiver.try_slice().unwrap().unwrap();
+                    slice.clear();
+                }
+            });
+        });
+        group.bench_with_input(
+            BenchmarkId::new("crossbeam/send_recv_iter", i),
+            &i,
+            |b, input| {
+                let (sender, receiver) = bounded(*input);
+                b.iter(|| {
+                    {
+                        while sender.try_send(123usize).is_ok() {}
+                    }
+
+                    {
+                        for _ in receiver.try_iter() {}
+                    }
+                });
+            },
+        );
+    }
+    group.finish();
+}

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["corpus.tar.gz"]
 
 [features]
 default = ["alloc", "std"]
-alloc = []
+alloc = ["atomic-waker"]
 std = ["alloc", "once_cell"]
 testing = ["std", "generator", "s2n-codec/testing", "checked-counters", "insta", "futures-test"]
 generator = ["bolero-generator"]
@@ -20,6 +20,7 @@ checked-counters = []
 event-tracing = ["tracing"]
 
 [dependencies]
+atomic-waker = { version = "1", optional = true }
 bolero-generator = { version = "0.8", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false }
 bytes = { version = "1", default-features = false }

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -42,7 +42,11 @@ once_cell = { version = "1", optional = true }
 bolero = "0.8"
 bolero-generator = { version = "0.8", default-features = false }
 insta = { version = "1", features = ["json"] }
+futures = "0.3"
 futures-test = "0.3"
 ip_network = "0.4"
 plotters = { version = "0.3", default-features = false, features = ["svg_backend", "line_series"] }
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
+
+[target.'cfg(loom)'.dev-dependencies]
+loom = { version = "0.5", features = ["checkpoint", "futures"] }

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["corpus.tar.gz"]
 
 [features]
 default = ["alloc", "std"]
-alloc = ["atomic-waker"]
+alloc = ["atomic-waker", "cache-padded"]
 std = ["alloc", "once_cell"]
 testing = ["std", "generator", "s2n-codec/testing", "checked-counters", "insta", "futures-test"]
 generator = ["bolero-generator"]
@@ -24,6 +24,7 @@ atomic-waker = { version = "1", optional = true }
 bolero-generator = { version = "0.8", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false }
 bytes = { version = "1", default-features = false }
+cache-padded = { version = "1", optional = true }
 hex-literal = "0.3"
 # used for event snapshot testing - needs an internal API so we require a minimum version
 insta = { version = ">=1.12", features = ["json"], optional = true }

--- a/quic/s2n-quic-core/src/lib.rs
+++ b/quic/s2n-quic-core/src/lib.rs
@@ -6,6 +6,30 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+/// Asserts that a boolean expression is true at runtime, only if debug_assertions are enabled.
+///
+/// Otherwise, the compiler is told to assume that the expression is always true and can perform
+/// additional optimizations.
+///
+/// # Safety
+///
+/// The caller _must_ ensure this condition is never possible, otherwise the compiler
+/// may optimize based on false assumptions and behave incorrectly.
+#[macro_export]
+macro_rules! assume {
+    ($cond:expr) => {
+        $crate::assume!($cond, "assumption failed: {}", stringify!($cond));
+    };
+    ($cond:expr $(, $fmtarg:expr)* $(,)?) => {
+        let v = $cond;
+
+        debug_assert!(v $(, $fmtarg)*);
+        if cfg!(not(debug_assertions)) && !v {
+            core::hint::unreachable_unchecked();
+        }
+    };
+}
+
 pub mod ack;
 pub mod application;
 #[cfg(feature = "alloc")]

--- a/quic/s2n-quic-core/src/lib.rs
+++ b/quic/s2n-quic-core/src/lib.rs
@@ -33,8 +33,12 @@ pub mod recovery;
 pub mod slice;
 pub mod stateless_reset;
 pub mod stream;
+pub mod sync;
 pub mod time;
 pub mod token;
 pub mod transmission;
 pub mod transport;
 pub mod varint;
+
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;

--- a/quic/s2n-quic-core/src/slice.rs
+++ b/quic/s2n-quic-core/src/slice.rs
@@ -91,7 +91,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bolero::{check, generator::*};
+    use crate::testing::InlineVec;
+    use bolero::check;
 
     fn assert_eq_slices<A, B, T>(a: &[A], b: &[B])
     where
@@ -125,28 +126,6 @@ mod tests {
             let copied_len = vectored_copy(&from, &mut to);
             assert_eq!(copied_len, len * 2);
             assert_eq_slices(&from, &to);
-        }
-    }
-
-    #[derive(Clone, Copy, Debug, TypeGenerator)]
-    struct InlineVec<T, const LEN: usize> {
-        values: [T; LEN],
-
-        #[generator(_code = "0..LEN")]
-        len: usize,
-    }
-
-    impl<T, const LEN: usize> core::ops::Deref for InlineVec<T, LEN> {
-        type Target = [T];
-
-        fn deref(&self) -> &Self::Target {
-            &self.values[..self.len]
-        }
-    }
-
-    impl<T, const LEN: usize> core::ops::DerefMut for InlineVec<T, LEN> {
-        fn deref_mut(&mut self) -> &mut Self::Target {
-            &mut self.values[..self.len]
         }
     }
 

--- a/quic/s2n-quic-core/src/sync.rs
+++ b/quic/s2n-quic-core/src/sync.rs
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod spsc;

--- a/quic/s2n-quic-core/src/sync.rs
+++ b/quic/s2n-quic-core/src/sync.rs
@@ -1,4 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "alloc")]
 pub mod spsc;

--- a/quic/s2n-quic-core/src/sync/__fuzz___/sync__spsc__tests__model/corpus.tar.gz
+++ b/quic/s2n-quic-core/src/sync/__fuzz___/sync__spsc__tests__model/corpus.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:16959cd0f6caa76f919caf98d976bd25db44c813ca60c684892f4db108694b90
+size 993280

--- a/quic/s2n-quic-core/src/sync/spsc.rs
+++ b/quic/s2n-quic-core/src/sync/spsc.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod primitive;
 mod recv;
 mod send;
 mod slice;

--- a/quic/s2n-quic-core/src/sync/spsc.rs
+++ b/quic/s2n-quic-core/src/sync/spsc.rs
@@ -33,8 +33,8 @@ pub use send::{SendSlice, Sender};
 #[inline]
 pub fn channel<T>(capacity: usize) -> (Sender<T>, Receiver<T>) {
     let state = State::new(capacity);
-    let sender = send::Sender(state.clone());
-    let receiver = recv::Receiver(state);
+    let sender = Sender(state.clone());
+    let receiver = Receiver(state);
     (sender, receiver)
 }
 

--- a/quic/s2n-quic-core/src/sync/spsc.rs
+++ b/quic/s2n-quic-core/src/sync/spsc.rs
@@ -27,42 +27,16 @@ mod state;
 use slice::*;
 use state::*;
 
-macro_rules! impl_channel {
-    ($name:ident) => {
-        pub use recv::$name::*;
-        pub use send::$name::*;
+pub use recv::{Receiver, RecvSlice};
+pub use send::{SendSlice, Sender};
 
-        #[inline]
-        pub fn channel<T>(capacity: usize) -> (send::$name::Sender<T>, recv::$name::Receiver<T>) {
-            let state = State::new(capacity);
-            let sender = send::$name(state.clone());
-            let receiver = recv::$name(state);
-            (sender, receiver)
-        }
-    };
+#[inline]
+pub fn channel<T>(capacity: usize) -> (Sender<T>, Receiver<T>) {
+    let state = State::new(capacity);
+    let sender = send::Sender(state.clone());
+    let receiver = recv::Receiver(state);
+    (sender, receiver)
 }
-
-pub mod contiguous {
-    use super::*;
-    impl_channel!(double_ring);
-}
-
-pub mod generic {
-    use super::*;
-    pub use recv::{Receiver, RecvSlice};
-    pub use send::{SendSlice, Sender};
-    pub use state::{Behavior, DoubleRing, Ring};
-
-    #[inline]
-    pub fn channel<T, B: Behavior>(capacity: usize) -> (Sender<T, B>, Receiver<T, B>) {
-        let state = State::new(capacity);
-        let sender = Sender(state.clone());
-        let receiver = Receiver(state);
-        (sender, receiver)
-    }
-}
-
-impl_channel!(ring);
 
 #[cfg(test)]
 mod tests;

--- a/quic/s2n-quic-core/src/sync/spsc.rs
+++ b/quic/s2n-quic-core/src/sync/spsc.rs
@@ -1,24 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Asserts that a boolean expression is true at runtime, only if debug_assertions are enabled.
-///
-/// Otherwise, the compiler is told to assume that the expression is always true and can perform
-/// additional optimizations.
-macro_rules! unsafe_assert {
-    ($cond:expr) => {
-        unsafe_assert!($cond, "assumption failed: {}", stringify!($cond));
-    };
-    ($cond:expr $(, $fmtarg:expr)* $(,)?) => {
-        let v = $cond;
-
-        debug_assert!(v $(, $fmtarg)*);
-        if cfg!(not(debug_assertions)) && !v {
-            core::hint::unreachable_unchecked();
-        }
-    };
-}
-
 mod recv;
 mod send;
 mod slice;

--- a/quic/s2n-quic-core/src/sync/spsc.rs
+++ b/quic/s2n-quic-core/src/sync/spsc.rs
@@ -1,0 +1,85 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Asserts that a boolean expression is true at runtime, only if debug_assertions are enabled.
+///
+/// Otherwise, the compiler is told to assume that the expression is always true and can perform
+/// additional optimizations.
+macro_rules! unsafe_assert {
+    ($cond:expr) => {
+        unsafe_assert!($cond, "assumption failed: {}", stringify!($cond));
+    };
+    ($cond:expr $(, $fmtarg:expr)* $(,)?) => {
+        let v = $cond;
+
+        debug_assert!(v $(, $fmtarg)*);
+        if cfg!(not(debug_assertions)) && !v {
+            core::hint::unreachable_unchecked();
+        }
+    };
+}
+
+mod recv;
+mod send;
+mod slice;
+mod state;
+
+use slice::*;
+use state::*;
+
+macro_rules! impl_channel {
+    ($name:ident) => {
+        pub use recv::$name::*;
+        pub use send::$name::*;
+
+        #[inline]
+        pub fn channel<T>(capacity: usize) -> (send::$name::Sender<T>, recv::$name::Receiver<T>) {
+            let state = State::new(capacity);
+            let sender = send::$name(state.clone());
+            let receiver = recv::$name(state);
+            (sender, receiver)
+        }
+    };
+}
+
+pub mod contiguous {
+    use super::*;
+    impl_channel!(double_ring);
+}
+
+pub mod generic {
+    use super::*;
+    pub use recv::{Receiver, RecvSlice};
+    pub use send::{SendSlice, Sender};
+    pub use state::{Behavior, DoubleRing, Ring};
+
+    #[inline]
+    pub fn channel<T, B: Behavior>(capacity: usize) -> (Sender<T, B>, Receiver<T, B>) {
+        let state = State::new(capacity);
+        let sender = Sender(state.clone());
+        let receiver = Receiver(state);
+        (sender, receiver)
+    }
+}
+
+impl_channel!(ring);
+
+#[cfg(test)]
+mod tests;
+
+type Result<T, E = ClosedError> = core::result::Result<T, E>;
+
+#[derive(Clone, Copy, Debug)]
+pub struct ClosedError;
+
+#[derive(Clone, Copy, Debug)]
+pub enum PushError<T> {
+    Full(T),
+    Closed,
+}
+
+impl<T> From<ClosedError> for PushError<T> {
+    fn from(_error: ClosedError) -> Self {
+        Self::Closed
+    }
+}

--- a/quic/s2n-quic-core/src/sync/spsc/primitive.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/primitive.rs
@@ -40,3 +40,14 @@ mod core {
 
 #[cfg(not(all(loom, test)))]
 pub use self::core::*;
+
+/// Indicates if the type is a zero-sized type
+///
+/// This can be used to optimize the code to avoid needless calculations.
+pub trait IsZst {
+    const IS_ZST: bool;
+}
+
+impl<T> IsZst for T {
+    const IS_ZST: bool = ::core::mem::size_of::<T>() == 0;
+}

--- a/quic/s2n-quic-core/src/sync/spsc/primitive.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/primitive.rs
@@ -1,0 +1,116 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(any(test, kani))]
+mod kani {
+    #![allow(dead_code)]
+
+    use core::{
+        cell::{Cell, UnsafeCell},
+        task::Waker,
+    };
+
+    #[derive(Debug, Default)]
+    pub struct AtomicBool(Cell<bool>);
+
+    impl AtomicBool {
+        pub const fn new(value: bool) -> Self {
+            Self(Cell::new(value))
+        }
+
+        pub fn load(&self, _order: Ordering) -> bool {
+            self.0.get()
+        }
+
+        pub fn swap(&self, value: bool, _order: Ordering) -> bool {
+            self.0.replace(value)
+        }
+    }
+
+    #[derive(Debug, Default)]
+    pub struct AtomicUsize(Cell<usize>);
+
+    impl AtomicUsize {
+        pub const fn new(value: usize) -> Self {
+            Self(Cell::new(value))
+        }
+
+        pub fn store(&self, value: usize, _order: Ordering) {
+            self.0.set(value)
+        }
+
+        pub fn load(&self, _order: Ordering) -> usize {
+            self.0.get()
+        }
+    }
+
+    pub use ::core::sync::atomic::Ordering;
+
+    #[derive(Debug, Default)]
+    pub struct AtomicWaker(UnsafeCell<Option<Waker>>);
+
+    impl AtomicWaker {
+        pub const fn new() -> Self {
+            Self(UnsafeCell::new(None))
+        }
+
+        pub fn wake(&self) {
+            if let Some(waker) = self.take() {
+                waker.wake();
+            }
+        }
+
+        pub fn take(&self) -> Option<Waker> {
+            unsafe { core::mem::take(&mut *self.0.get()) }
+        }
+
+        pub fn register(&self, waker: &Waker) {
+            let cell = unsafe { &mut *self.0.get() };
+            *cell = Some(waker.clone());
+        }
+    }
+}
+
+#[cfg(kani)]
+pub use self::kani::*;
+
+#[cfg(loom)]
+mod loom {
+    use ::core::task::Waker;
+    use ::loom::future::AtomicWaker as Inner;
+
+    pub use ::loom::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    #[derive(Debug, Default)]
+    pub struct AtomicWaker(Inner);
+
+    impl AtomicWaker {
+        pub fn new() -> Self {
+            Self(Inner::new())
+        }
+
+        pub fn wake(&self) {
+            self.0.wake();
+        }
+
+        pub fn take(&self) -> Option<Waker> {
+            self.0.take_waker()
+        }
+
+        pub fn register(&self, waker: &Waker) {
+            self.0.register_by_ref(waker);
+        }
+    }
+}
+
+#[cfg(loom)]
+pub use self::loom::*;
+
+#[cfg(not(kani))]
+mod core {
+    pub use ::core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    pub use atomic_waker::AtomicWaker;
+}
+
+#[cfg(not(any(kani, loom)))]
+pub use self::core::*;

--- a/quic/s2n-quic-core/src/sync/spsc/primitive.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/primitive.rs
@@ -1,80 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(any(test, kani))]
-mod kani {
-    #![allow(dead_code)]
-
-    use core::{
-        cell::{Cell, UnsafeCell},
-        task::Waker,
-    };
-
-    #[derive(Debug, Default)]
-    pub struct AtomicBool(Cell<bool>);
-
-    impl AtomicBool {
-        pub const fn new(value: bool) -> Self {
-            Self(Cell::new(value))
-        }
-
-        pub fn load(&self, _order: Ordering) -> bool {
-            self.0.get()
-        }
-
-        pub fn swap(&self, value: bool, _order: Ordering) -> bool {
-            self.0.replace(value)
-        }
-    }
-
-    #[derive(Debug, Default)]
-    pub struct AtomicUsize(Cell<usize>);
-
-    impl AtomicUsize {
-        pub const fn new(value: usize) -> Self {
-            Self(Cell::new(value))
-        }
-
-        pub fn store(&self, value: usize, _order: Ordering) {
-            self.0.set(value)
-        }
-
-        pub fn load(&self, _order: Ordering) -> usize {
-            self.0.get()
-        }
-    }
-
-    pub use ::core::sync::atomic::Ordering;
-
-    #[derive(Debug, Default)]
-    pub struct AtomicWaker(UnsafeCell<Option<Waker>>);
-
-    impl AtomicWaker {
-        pub const fn new() -> Self {
-            Self(UnsafeCell::new(None))
-        }
-
-        pub fn wake(&self) {
-            if let Some(waker) = self.take() {
-                waker.wake();
-            }
-        }
-
-        pub fn take(&self) -> Option<Waker> {
-            unsafe { core::mem::take(&mut *self.0.get()) }
-        }
-
-        pub fn register(&self, waker: &Waker) {
-            let cell = unsafe { &mut *self.0.get() };
-            *cell = Some(waker.clone());
-        }
-    }
-}
-
-#[cfg(kani)]
-pub use self::kani::*;
-
-#[cfg(loom)]
+#[cfg(all(loom, test))]
 mod loom {
     use ::core::task::Waker;
     use ::loom::future::AtomicWaker as Inner;
@@ -103,14 +30,13 @@ mod loom {
     }
 }
 
-#[cfg(loom)]
+#[cfg(all(loom, test))]
 pub use self::loom::*;
 
-#[cfg(not(kani))]
 mod core {
     pub use ::core::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     pub use atomic_waker::AtomicWaker;
 }
 
-#[cfg(not(any(kani, loom)))]
+#[cfg(not(all(loom, test)))]
 pub use self::core::*;

--- a/quic/s2n-quic-core/src/sync/spsc/recv.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/recv.rs
@@ -7,8 +7,24 @@ use core::task::{Context, Poll};
 pub struct Receiver<T>(pub(super) State<T>);
 
 impl<T> Receiver<T> {
+    #[inline]
     pub fn capacity(&self) -> usize {
         self.0.cursor.capacity()
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.cursor.recv_len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.cursor.is_empty()
+    }
+
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        self.0.cursor.is_full()
     }
 
     #[inline]

--- a/quic/s2n-quic-core/src/sync/spsc/recv.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/recv.rs
@@ -73,9 +73,8 @@ impl<T> Receiver<T> {
 impl<T> Drop for Receiver<T> {
     #[inline]
     fn drop(&mut self) {
-        if self.0.try_close() {
-            self.0.sender.wake();
-        }
+        self.0.try_close();
+        self.0.sender.wake();
     }
 }
 

--- a/quic/s2n-quic-core/src/sync/spsc/recv.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/recv.rs
@@ -1,0 +1,177 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Behavior, Cursor, DoubleRing, Result, Ring, State};
+use core::task::{Context, Poll};
+
+macro_rules! impl_recv {
+    ($name:ident, $B:ty, $peek:ident, $peek_ty:ty) => {
+        pub mod $name {
+            use super::*;
+
+            pub struct Receiver<T>(pub(super) super::Receiver<T, $B>);
+
+            impl<T> Receiver<T> {
+                #[inline]
+                pub fn poll_slice(&mut self, cx: &mut Context) -> Poll<Result<RecvSlice<T>>> {
+                    match self.0.poll_slice(cx) {
+                        Poll::Ready(Ok(s)) => Poll::Ready(Ok(RecvSlice(s))),
+                        Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+                        Poll::Pending => Poll::Pending,
+                    }
+                }
+
+                #[inline]
+                pub fn try_slice(&mut self) -> Result<Option<RecvSlice<T>>> {
+                    match self.0.try_slice() {
+                        Ok(Some(s)) => Ok(Some(RecvSlice(s))),
+                        Ok(None) => Ok(None),
+                        Err(e) => Err(e),
+                    }
+                }
+            }
+
+            pub struct RecvSlice<'a, T>(super::RecvSlice<'a, T, $B>);
+
+            impl<'a, T> RecvSlice<'a, T> {
+                #[inline]
+                pub fn peek(&mut self) -> $peek_ty {
+                    self.0.$peek()
+                }
+
+                #[inline]
+                pub fn pop(&mut self) -> Option<T> {
+                    self.0.pop()
+                }
+
+                #[inline]
+                pub fn len(&self) -> usize {
+                    self.0.len()
+                }
+
+                #[inline]
+                pub fn is_empty(&self) -> bool {
+                    self.0.is_empty()
+                }
+            }
+
+            impl<'a, T> Iterator for RecvSlice<'a, T> {
+                type Item = T;
+
+                #[inline]
+                fn next(&mut self) -> Option<T> {
+                    self.pop()
+                }
+            }
+        }
+
+        pub(super) fn $name<T>(state: State<T, $B>) -> $name::Receiver<T> {
+            $name::Receiver(Receiver(state))
+        }
+    };
+}
+
+impl_recv!(ring, Ring, peek, (&mut [T], &mut [T]));
+impl_recv!(double_ring, DoubleRing, peek_slice, &mut [T]);
+
+pub struct Receiver<T, B: Behavior>(pub(super) State<T, B>);
+
+impl<T, B: Behavior> Receiver<T, B> {
+    #[inline]
+    pub fn poll_slice(&mut self, cx: &mut Context) -> Poll<Result<RecvSlice<T, B>>> {
+        macro_rules! acquire_filled {
+            () => {
+                match self.0.acquire_filled() {
+                    Ok(true) => {
+                        let cursor = self.0.cursor;
+                        return Ok(RecvSlice(&mut self.0, cursor)).into();
+                    }
+                    Ok(false) => {
+                        // the queue is full
+                    }
+                    Err(err) => {
+                        // the channel was closed
+                        return Err(err).into();
+                    }
+                }
+            };
+        }
+
+        // check capacity before registering a waker
+        acquire_filled!();
+
+        // register the waker
+        self.0.receiver.register(cx.waker());
+
+        // check once more to avoid a loss of notification
+        acquire_filled!();
+
+        Poll::Pending
+    }
+
+    #[inline]
+    pub fn try_slice(&mut self) -> Result<Option<RecvSlice<T, B>>> {
+        Ok(if self.0.acquire_filled()? {
+            let cursor = self.0.cursor;
+            Some(RecvSlice(&mut self.0, cursor))
+        } else {
+            None
+        })
+    }
+}
+
+impl<T, B: Behavior> Drop for Receiver<T, B> {
+    #[inline]
+    fn drop(&mut self) {
+        if self.0.try_close() {
+            self.0.sender.wake();
+        }
+    }
+}
+
+pub struct RecvSlice<'a, T, B: Behavior>(&'a mut State<T, B>, Cursor);
+
+impl<'a, T, B: Behavior> RecvSlice<'a, T, B> {
+    #[inline]
+    pub fn peek(&mut self) -> (&mut [T], &mut [T]) {
+        let (slice, _) = self.0.as_pairs();
+        unsafe { slice.assume_init().into_mut() }
+    }
+
+    #[inline]
+    pub fn pop(&mut self) -> Option<T> {
+        if self.0.cursor.is_empty() && !self.0.acquire_filled().unwrap_or(false) {
+            return None;
+        }
+
+        let (pair, _) = self.0.as_pairs();
+        let value = unsafe { pair.take(0) };
+        self.0.cursor.increment_head(1);
+        Some(value)
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0.cursor.recv_len()
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.0.cursor.is_empty()
+    }
+}
+
+impl<'a, T> RecvSlice<'a, T, DoubleRing> {
+    #[inline]
+    pub fn peek_slice(&mut self) -> &mut [T] {
+        let (slice, _) = self.0.as_slices();
+        unsafe { slice.assume_init().into_mut() }
+    }
+}
+
+impl<'a, T, B: Behavior> Drop for RecvSlice<'a, T, B> {
+    #[inline]
+    fn drop(&mut self) {
+        self.0.persist_head(self.1);
+    }
+}

--- a/quic/s2n-quic-core/src/sync/spsc/recv.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/recv.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{Cursor, Result, State};
+use super::{state::Side, Cursor, Result, State};
 use core::task::{Context, Poll};
 
 pub struct Receiver<T>(pub(super) State<T>);
@@ -73,8 +73,7 @@ impl<T> Receiver<T> {
 impl<T> Drop for Receiver<T> {
     #[inline]
     fn drop(&mut self) {
-        self.0.try_close();
-        self.0.sender.wake();
+        self.0.try_close(Side::Receiver);
     }
 }
 
@@ -132,8 +131,6 @@ impl<'a, T> RecvSlice<'a, T> {
 impl<'a, T> Drop for RecvSlice<'a, T> {
     #[inline]
     fn drop(&mut self) {
-        if self.0.persist_head(self.1) {
-            self.0.sender.wake();
-        }
+        self.0.persist_head(self.1);
     }
 }

--- a/quic/s2n-quic-core/src/sync/spsc/send.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/send.rs
@@ -1,0 +1,154 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Behavior, Cursor, DoubleRing, PushError, Result, Ring, State};
+use core::task::{Context, Poll};
+
+macro_rules! impl_send {
+    ($name:ident, $B:ty) => {
+        pub mod $name {
+            use super::*;
+
+            pub struct Sender<T>(pub(super) super::Sender<T, $B>);
+
+            impl<T> Sender<T> {
+                #[inline]
+                pub fn poll_slice(&mut self, cx: &mut Context) -> Poll<Result<SendSlice<T>>> {
+                    match self.0.poll_slice(cx) {
+                        Poll::Ready(Ok(s)) => Poll::Ready(Ok(SendSlice(s))),
+                        Poll::Ready(Err(e)) => Poll::Ready(Err(e)),
+                        Poll::Pending => Poll::Pending,
+                    }
+                }
+
+                #[inline]
+                pub fn try_slice(&mut self) -> Result<Option<SendSlice<T>>> {
+                    match self.0.try_slice() {
+                        Ok(Some(s)) => Ok(Some(SendSlice(s))),
+                        Ok(None) => Ok(None),
+                        Err(e) => Err(e),
+                    }
+                }
+            }
+
+            pub struct SendSlice<'a, T>(super::SendSlice<'a, T, $B>);
+
+            impl<'a, T> SendSlice<'a, T> {
+                #[inline]
+                pub fn push(&mut self, value: T) -> Result<(), PushError<T>> {
+                    self.0.push(value)
+                }
+
+                #[inline]
+                pub fn capacity(&self) -> usize {
+                    self.0.capacity()
+                }
+            }
+        }
+
+        pub(super) fn $name<T>(state: State<T, $B>) -> $name::Sender<T> {
+            $name::Sender(Sender(state))
+        }
+    };
+}
+
+impl_send!(ring, Ring);
+impl_send!(double_ring, DoubleRing);
+
+pub struct Sender<T, B: Behavior>(pub(super) State<T, B>);
+
+impl<T, B: Behavior> Sender<T, B> {
+    /*
+    pub async fn slice(&mut self) -> Result<SendSlice<T>> {
+        poll_fn(|cx| self.poll_slice(cx))
+    }
+
+    pub async fn push(&mut self, value: Value) -> Result<()> {
+        // TODO
+    }
+    */
+
+    #[inline]
+    pub fn poll_slice(&mut self, cx: &mut Context) -> Poll<Result<SendSlice<T, B>>> {
+        macro_rules! acquire_capacity {
+            () => {
+                match self.0.acquire_capacity() {
+                    Ok(true) => {
+                        let cursor = self.0.cursor;
+                        return Ok(SendSlice(&mut self.0, cursor)).into();
+                    }
+                    Ok(false) => {
+                        // the queue is full
+                    }
+                    Err(err) => {
+                        // the channel was closed
+                        return Err(err).into();
+                    }
+                }
+            };
+        }
+
+        // check capacity before registering a waker
+        acquire_capacity!();
+
+        // register the waker
+        self.0.sender.register(cx.waker());
+
+        // check once more to avoid a loss of notification
+        acquire_capacity!();
+
+        Poll::Pending
+    }
+
+    #[inline]
+    pub fn try_slice(&mut self) -> Result<Option<SendSlice<T, B>>> {
+        Ok(if self.0.acquire_capacity()? {
+            let cursor = self.0.cursor;
+            Some(SendSlice(&mut self.0, cursor))
+        } else {
+            None
+        })
+    }
+}
+
+impl<T, B: Behavior> Drop for Sender<T, B> {
+    #[inline]
+    fn drop(&mut self) {
+        if self.0.try_close() {
+            self.0.receiver.wake();
+        }
+    }
+}
+
+pub struct SendSlice<'a, T, B: Behavior>(&'a mut State<T, B>, Cursor);
+
+impl<'a, T, B: Behavior> SendSlice<'a, T, B> {
+    #[inline]
+    pub fn push(&mut self, value: T) -> Result<(), PushError<T>> {
+        if self.0.cursor.is_full() && !self.0.acquire_capacity()? {
+            return Err(PushError::Full(value));
+        }
+
+        let (_, pair) = self.0.as_pairs();
+
+        unsafe {
+            pair.write(0, value);
+        }
+
+        self.0.cursor.increment_tail(1);
+
+        Ok(())
+    }
+
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.0.cursor.send_capacity()
+    }
+}
+
+impl<'a, T, B: Behavior> Drop for SendSlice<'a, T, B> {
+    #[inline]
+    fn drop(&mut self) {
+        self.0.persist_tail(self.1);
+    }
+}

--- a/quic/s2n-quic-core/src/sync/spsc/send.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/send.rs
@@ -7,16 +7,7 @@ use core::task::{Context, Poll};
 pub struct Sender<T>(pub(super) State<T>);
 
 impl<T> Sender<T> {
-    /*
-    pub async fn slice(&mut self) -> Result<SendSlice<T>> {
-        poll_fn(|cx| self.poll_slice(cx))
-    }
-
-    pub async fn push(&mut self, value: Value) -> Result<()> {
-        // TODO
-    }
-    */
-
+    #[inline]
     pub fn capacity(&self) -> usize {
         self.0.cursor.capacity()
     }

--- a/quic/s2n-quic-core/src/sync/spsc/send.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/send.rs
@@ -58,9 +58,8 @@ impl<T> Sender<T> {
 impl<T> Drop for Sender<T> {
     #[inline]
     fn drop(&mut self) {
-        if self.0.try_close() {
-            self.0.receiver.wake();
-        }
+        self.0.try_close();
+        self.0.receiver.wake();
     }
 }
 

--- a/quic/s2n-quic-core/src/sync/spsc/send.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/send.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{Cursor, PushError, Result, State};
+use super::{state::Side, Cursor, PushError, Result, State};
 use core::task::{Context, Poll};
 
 pub struct Sender<T>(pub(super) State<T>);
@@ -58,8 +58,7 @@ impl<T> Sender<T> {
 impl<T> Drop for Sender<T> {
     #[inline]
     fn drop(&mut self) {
-        self.0.try_close();
-        self.0.receiver.wake();
+        self.0.try_close(Side::Sender);
     }
 }
 
@@ -116,8 +115,6 @@ impl<'a, T> SendSlice<'a, T> {
 impl<'a, T> Drop for SendSlice<'a, T> {
     #[inline]
     fn drop(&mut self) {
-        if self.0.persist_tail(self.1) {
-            self.0.receiver.wake();
-        }
+        self.0.persist_tail(self.1);
     }
 }

--- a/quic/s2n-quic-core/src/sync/spsc/slice.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/slice.rs
@@ -1,0 +1,174 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::{cell::UnsafeCell, mem::MaybeUninit, ops::Deref};
+
+#[repr(transparent)]
+pub struct Cell<T>(MaybeUninit<UnsafeCell<T>>);
+
+impl<T> Cell<T> {
+    #[inline]
+    pub unsafe fn write(&self, value: T) {
+        UnsafeCell::raw_get(self.0.as_ptr()).write(value);
+    }
+
+    #[inline]
+    pub unsafe fn take(&self) -> T {
+        self.0.assume_init_read().into_inner()
+    }
+
+    #[inline]
+    pub unsafe fn replicate_to(&self, dst: &Self) {
+        UnsafeCell::raw_get(self.0.as_ptr())
+            .copy_to_nonoverlapping(UnsafeCell::raw_get(dst.0.as_ptr()), 1)
+    }
+}
+
+#[derive(Debug)]
+pub struct Slice<'a, T>(pub(super) &'a [T]);
+
+impl<'a, T> Slice<'a, Cell<T>> {
+    #[inline]
+    pub unsafe fn assume_init(self) -> Slice<'a, UnsafeCell<T>> {
+        Slice(&*(self.0 as *const [Cell<T>] as *const [UnsafeCell<T>]))
+    }
+
+    #[inline]
+    pub unsafe fn write(&self, index: usize, value: T) {
+        self.0.get_unchecked(index).write(value)
+    }
+
+    #[inline]
+    pub unsafe fn take(&self, index: usize) -> T {
+        self.0.get_unchecked(index).take()
+    }
+}
+
+impl<'a, T> Slice<'a, UnsafeCell<T>> {
+    #[inline]
+    pub unsafe fn into_mut(self) -> &'a mut [T] {
+        let ptr = self.0.as_ptr() as *mut T;
+        let len = self.0.len();
+        core::slice::from_raw_parts_mut(ptr, len)
+    }
+}
+
+impl<'a, T> Deref for Slice<'a, T> {
+    type Target = [T];
+
+    #[inline]
+    fn deref(&self) -> &[T] {
+        self.0
+    }
+}
+
+impl<'a, T: PartialEq> PartialEq<[T]> for Slice<'a, UnsafeCell<T>> {
+    #[inline]
+    fn eq(&self, other: &[T]) -> bool {
+        if self.len() != other.len() {
+            return false;
+        }
+
+        for (a, b) in self.iter().zip(other) {
+            if unsafe { &*a.get() } != b {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+impl<'a, T: PartialEq> PartialEq<Slice<'a, UnsafeCell<T>>> for [T] {
+    #[inline]
+    fn eq(&self, other: &Slice<'a, UnsafeCell<T>>) -> bool {
+        other.eq(self)
+    }
+}
+
+impl<'a, T: PartialEq> PartialEq<Slice<'a, UnsafeCell<T>>> for &[T] {
+    #[inline]
+    fn eq(&self, other: &Slice<'a, UnsafeCell<T>>) -> bool {
+        other.eq(self)
+    }
+}
+
+#[derive(Debug)]
+pub struct Pair<S> {
+    pub head: S,
+    pub tail: S,
+}
+
+impl<'a, T> Pair<Slice<'a, Cell<T>>> {
+    #[inline]
+    pub unsafe fn assume_init(self) -> Pair<Slice<'a, UnsafeCell<T>>> {
+        Pair {
+            head: self.head.assume_init(),
+            tail: self.tail.assume_init(),
+        }
+    }
+
+    #[inline]
+    pub unsafe fn write(&self, index: usize, value: T) {
+        self.cell(index).write(value)
+    }
+
+    #[inline]
+    pub unsafe fn take(&self, index: usize) -> T {
+        self.cell(index).take()
+    }
+
+    unsafe fn cell(&self, index: usize) -> &Cell<T> {
+        if let Some(cell) = self.head.0.get(index) {
+            cell
+        } else {
+            unsafe_assert!(index >= self.head.0.len());
+            let index = index - self.head.0.len();
+            unsafe_assert!(
+                self.tail.get(index).is_some(),
+                "head={}, tail={}, index={}",
+                self.head.0.len(),
+                self.tail.0.len(),
+                index
+            );
+            self.tail.get_unchecked(index)
+        }
+    }
+
+    #[inline]
+    pub fn iter(&self) -> impl Iterator<Item = &Cell<T>> {
+        self.head.0.iter().chain(self.tail.0)
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.head.0.len() + self.tail.0.len()
+    }
+
+    #[inline]
+    pub unsafe fn replicate_to(&self, other: Self, skip: usize, len: usize) {
+        unsafe_assert!(self.head.len() == other.head.len());
+        unsafe_assert!(self.tail.len() == other.tail.len());
+        unsafe_assert!(len > 0);
+        unsafe_assert!(
+            self.len() >= len + skip,
+            "self.len={}, len={}, skip={}",
+            self.len(),
+            len,
+            skip
+        );
+
+        for index in skip..skip + len {
+            self.cell(index).replicate_to(other.cell(index));
+        }
+    }
+}
+
+impl<'a, T> Pair<Slice<'a, UnsafeCell<T>>> {
+    #[inline]
+    pub unsafe fn into_mut(self) -> (&'a mut [T], &'a mut [T]) {
+        let head = self.head.into_mut();
+        let tail = self.tail.into_mut();
+        (head, tail)
+    }
+}

--- a/quic/s2n-quic-core/src/sync/spsc/slice.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/slice.rs
@@ -14,13 +14,7 @@ impl<T> Cell<T> {
 
     #[inline]
     pub unsafe fn take(&self) -> T {
-        self.0.assume_init_read().into_inner()
-    }
-
-    #[inline]
-    pub unsafe fn replicate_to(&self, dst: &Self) {
-        UnsafeCell::raw_get(self.0.as_ptr())
-            .copy_to_nonoverlapping(UnsafeCell::raw_get(dst.0.as_ptr()), 1)
+        self.0.assume_init_ref().get().read()
     }
 }
 
@@ -122,9 +116,9 @@ impl<'a, T> Pair<Slice<'a, Cell<T>>> {
         if let Some(cell) = self.head.0.get(index) {
             cell
         } else {
-            unsafe_assert!(index >= self.head.0.len());
+            assume!(index >= self.head.0.len());
             let index = index - self.head.0.len();
-            unsafe_assert!(
+            assume!(
                 self.tail.get(index).is_some(),
                 "head={}, tail={}, index={}",
                 self.head.0.len(),

--- a/quic/s2n-quic-core/src/sync/spsc/slice.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/slice.rs
@@ -139,6 +139,11 @@ impl<'a, T> Pair<Slice<'a, Cell<T>>> {
     pub fn iter(&self) -> impl Iterator<Item = &Cell<T>> {
         self.head.0.iter().chain(self.tail.0)
     }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.head.len() + self.tail.len()
+    }
 }
 
 impl<'a, T> Pair<Slice<'a, UnsafeCell<T>>> {

--- a/quic/s2n-quic-core/src/sync/spsc/slice.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/slice.rs
@@ -139,29 +139,6 @@ impl<'a, T> Pair<Slice<'a, Cell<T>>> {
     pub fn iter(&self) -> impl Iterator<Item = &Cell<T>> {
         self.head.0.iter().chain(self.tail.0)
     }
-
-    #[inline]
-    pub fn len(&self) -> usize {
-        self.head.0.len() + self.tail.0.len()
-    }
-
-    #[inline]
-    pub unsafe fn replicate_to(&self, other: Self, skip: usize, len: usize) {
-        unsafe_assert!(self.head.len() == other.head.len());
-        unsafe_assert!(self.tail.len() == other.tail.len());
-        unsafe_assert!(len > 0);
-        unsafe_assert!(
-            self.len() >= len + skip,
-            "self.len={}, len={}, skip={}",
-            self.len(),
-            len,
-            skip
-        );
-
-        for index in skip..skip + len {
-            self.cell(index).replicate_to(other.cell(index));
-        }
-    }
 }
 
 impl<'a, T> Pair<Slice<'a, UnsafeCell<T>>> {

--- a/quic/s2n-quic-core/src/sync/spsc/state.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/state.rs
@@ -1,0 +1,449 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{Cell, ClosedError, Result, Slice};
+use alloc::alloc::Layout;
+use atomic_waker::AtomicWaker;
+use core::{
+    marker::PhantomData,
+    ops::Deref,
+    panic::{RefUnwindSafe, UnwindSafe},
+    ptr::NonNull,
+    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+};
+
+type Pair<'a, T> = super::Pair<Slice<'a, Cell<T>>>;
+
+#[derive(Clone, Copy, Debug)]
+pub struct Cursor {
+    head: usize,
+    tail: usize,
+    capacity: usize,
+}
+
+impl Cursor {
+    #[inline]
+    fn new(capacity: usize) -> Self {
+        Self {
+            head: 0,
+            tail: 0,
+            capacity,
+        }
+    }
+
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.head == self.tail
+    }
+
+    #[inline]
+    pub fn is_full(&self) -> bool {
+        self.recv_len() == self.capacity
+    }
+
+    #[inline]
+    pub fn recv_len(&self) -> usize {
+        self.distance(self.head, self.tail)
+    }
+
+    #[inline]
+    pub fn send_capacity(&self) -> usize {
+        self.capacity - self.recv_len()
+    }
+
+    #[inline]
+    pub fn increment_head(&mut self, len: usize) {
+        self.head = self.increment(self.head, len);
+    }
+
+    #[inline]
+    pub fn increment_tail(&mut self, len: usize) {
+        self.tail = self.increment(self.tail, len);
+    }
+
+    #[inline]
+    fn wrapped_head(&self) -> usize {
+        self.collapse_position(self.head)
+    }
+
+    #[inline]
+    fn wrapped_tail(&self) -> usize {
+        self.collapse_position(self.tail)
+    }
+
+    /// Returns the distance between two positions.
+    #[inline]
+    fn distance(&self, a: usize, b: usize) -> usize {
+        unsafe {
+            unsafe_assert!(a == 0 || a < 2 * self.capacity);
+            unsafe_assert!(b == 0 || b < 2 * self.capacity);
+        }
+        if a <= b {
+            b - a
+        } else {
+            2 * self.capacity - a + b
+        }
+    }
+
+    #[inline]
+    fn increment(&self, pos: usize, n: usize) -> usize {
+        unsafe {
+            unsafe_assert!(pos == 0 || pos < 2 * self.capacity);
+            unsafe_assert!(n <= self.capacity);
+        }
+        let threshold = 2 * self.capacity - n;
+        if pos < threshold {
+            pos + n
+        } else {
+            pos - threshold
+        }
+    }
+
+    #[inline]
+    fn collapse_position(&self, pos: usize) -> usize {
+        unsafe {
+            unsafe_assert!(pos == 0 || pos < 2 * self.capacity);
+        }
+        if pos < self.capacity {
+            pos
+        } else {
+            pos - self.capacity
+        }
+    }
+}
+
+pub struct Ring;
+
+impl Behavior for Ring {}
+
+pub struct DoubleRing;
+
+impl Behavior for DoubleRing {
+    #[inline]
+    fn header_capacity(capacity: usize) -> usize {
+        capacity * 2
+    }
+
+    #[inline]
+    fn replicate_tail<T>(prev: &Cursor, state: &State<T, Self>) {
+        let (front_filled, _) = state.as_pairs();
+        let back = unsafe {
+            let capacity = state.cursor.capacity;
+            let ptr = state.data_ptr().add(capacity);
+            core::slice::from_raw_parts(ptr, capacity)
+        };
+        let (back_filled, _) = state.data_to_pairs(back);
+
+        let mut skip = prev.recv_len();
+        let len = prev.distance(prev.tail, state.cursor.tail);
+
+        if len == state.cursor.capacity {
+            skip = 0;
+        }
+
+        unsafe {
+            front_filled.replicate_to(back_filled, skip, len);
+        }
+    }
+}
+
+pub trait Behavior: Sized {
+    #[inline]
+    fn header_capacity(capacity: usize) -> usize {
+        capacity
+    }
+
+    #[inline]
+    fn replicate_tail<T>(prev: &Cursor, state: &State<T, Self>) {
+        let _ = prev;
+        let _ = state;
+    }
+}
+
+#[derive(Debug)]
+pub struct State<T, B> {
+    header: NonNull<Header<T>>,
+    pub cursor: Cursor,
+    behavior: PhantomData<B>,
+}
+
+unsafe impl<T: Send, B> Send for State<T, B> {}
+unsafe impl<T: Sync, B> Sync for State<T, B> {}
+impl<T: RefUnwindSafe, B> UnwindSafe for State<T, B> {}
+
+impl<T, B> Clone for State<T, B> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            header: self.header,
+            cursor: self.cursor,
+            behavior: PhantomData,
+        }
+    }
+}
+
+impl<T, B> Deref for State<T, B> {
+    type Target = Header<T>;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.header.as_ref() }
+    }
+}
+
+impl<T, B: Behavior> State<T, B> {
+    #[inline]
+    pub fn new(capacity: usize) -> Self {
+        // double the capacity of the header so we can return contiguous regions
+        let header_capacity = B::header_capacity(capacity);
+        let header = Header::alloc(header_capacity).expect("could not allocate channel");
+        let cursor = Cursor::new(capacity);
+        Self {
+            header,
+            cursor,
+            behavior: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub fn acquire_capacity(&mut self) -> Result<bool> {
+        if !self.open.load(Ordering::Acquire) {
+            return Err(ClosedError);
+        }
+
+        if !self.cursor.is_full() {
+            return Ok(true);
+        }
+
+        // update the cached version
+        self.cursor.head = self.head.load(Ordering::Acquire);
+
+        let is_full = self.cursor.is_full();
+
+        Ok(!is_full)
+    }
+
+    #[inline]
+    pub fn acquire_filled(&mut self) -> Result<bool> {
+        if !self.cursor.is_empty() {
+            return Ok(true);
+        }
+
+        self.cursor.tail = self.tail.load(Ordering::Acquire);
+
+        if !self.cursor.is_empty() {
+            return Ok(true);
+        }
+
+        if !self.open.load(Ordering::Acquire) {
+            return Err(ClosedError);
+        }
+
+        Ok(false)
+    }
+
+    #[inline]
+    pub fn persist_head(&self, prev: Cursor) {
+        // nothing changed
+        if prev.head == self.cursor.head {
+            return;
+        }
+
+        self.head.store(self.cursor.head, Ordering::Release);
+    }
+
+    #[inline]
+    pub fn persist_tail(&self, prev: Cursor) {
+        // nothing changed
+        if prev.tail == self.cursor.tail {
+            return;
+        }
+
+        B::replicate_tail(&prev, self);
+
+        self.tail.store(self.cursor.tail, Ordering::Release);
+    }
+
+    #[inline]
+    fn data(&self) -> &[Cell<T>] {
+        unsafe {
+            let ptr = self.data_ptr();
+            // we don't multiply the capacity here for simplicity
+            let capacity = self.cursor.capacity;
+            core::slice::from_raw_parts(ptr, capacity)
+        }
+    }
+
+    #[inline]
+    fn data_ptr(&self) -> *const Cell<T> {
+        unsafe {
+            let capacity = B::header_capacity(self.cursor.capacity);
+            let (_, offset) = Header::<T>::layout_unchecked(capacity);
+
+            let ptr = self.header.as_ptr() as *const u8;
+            let ptr = ptr.add(offset);
+            ptr as *const Cell<T>
+        }
+    }
+
+    #[inline]
+    pub fn try_close(&mut self) -> bool {
+        let prev = self.open.swap(false, Ordering::Acquire);
+        if !prev {
+            unsafe {
+                self.drop_contents();
+            }
+        }
+        prev
+    }
+
+    #[inline]
+    pub fn as_pairs(&self) -> (Pair<T>, Pair<T>) {
+        let data = self.data();
+        self.data_to_pairs(data)
+    }
+
+    #[inline]
+    fn data_to_pairs<'a>(&self, data: &'a [Cell<T>]) -> (Pair<'a, T>, Pair<'a, T>) {
+        if self.cursor.is_full() {
+            let head = self.cursor.wrapped_head();
+            let (filled_tail, filled_head) = data.split_at(head);
+            let filled = Pair {
+                head: Slice(filled_head),
+                tail: Slice(filled_tail),
+            };
+            let unfilled = Pair {
+                head: Slice(&[]),
+                tail: Slice(&[]),
+            };
+            return (filled, unfilled);
+        }
+
+        let head = self.cursor.wrapped_head();
+        let tail = self.cursor.wrapped_tail();
+
+        let is_contiguous = tail >= head;
+
+        if is_contiguous {
+            let (data, unfilled_head) = data.split_at(tail);
+            let (unfilled_tail, filled_head) = data.split_at(head);
+
+            let filled = Pair {
+                head: Slice(filled_head),
+                tail: Slice(&[]),
+            };
+            let unfilled = Pair {
+                head: Slice(unfilled_head),
+                tail: Slice(unfilled_tail),
+            };
+            (filled, unfilled)
+        } else {
+            let (data, filled_head) = data.split_at(head);
+            let (filled_tail, unfilled_head) = data.split_at(tail);
+
+            let filled = Pair {
+                head: Slice(filled_head),
+                tail: Slice(filled_tail),
+            };
+            let unfilled = Pair {
+                head: Slice(unfilled_head),
+                tail: Slice(&[]),
+            };
+            (filled, unfilled)
+        }
+    }
+
+    #[inline]
+    unsafe fn drop_contents(&mut self) {
+        // refresh the cursor from the shared state
+        self.cursor.head = self.head.load(Ordering::Acquire);
+        self.cursor.tail = self.tail.load(Ordering::Acquire);
+
+        // release all of the filled data
+        let (filled, _unfilled) = self.as_pairs();
+        for cell in filled.iter() {
+            drop(cell.take());
+        }
+
+        // free the header
+        let ptr = self.header.as_ptr() as *mut u8;
+        let capacity = B::header_capacity(self.cursor.capacity);
+        let (layout, _offset) = Header::<T>::layout_unchecked(capacity);
+        alloc::alloc::dealloc(ptr, layout)
+    }
+}
+
+impl<T> State<T, DoubleRing> {
+    #[inline]
+    pub fn as_slices(&self) -> (Slice<Cell<T>>, Slice<Cell<T>>) {
+        let data = self.data();
+
+        if self.cursor.is_full() {
+            let head = self.cursor.wrapped_head();
+            let filled = Slice(unsafe { data.get_unchecked(head..) });
+            let unfilled = Slice(&[]);
+            return (filled, unfilled);
+        }
+
+        let head = self.cursor.wrapped_head();
+        let tail = self.cursor.wrapped_tail();
+
+        let filled = Slice(unsafe { data.get_unchecked(head..tail) });
+        let unfilled = Slice(unsafe { data.get_unchecked(tail..) });
+        (filled, unfilled)
+    }
+}
+
+#[derive(Debug)]
+pub struct Header<T> {
+    head: AtomicUsize,
+    pub receiver: AtomicWaker,
+    tail: AtomicUsize,
+    pub sender: AtomicWaker,
+    open: AtomicBool,
+    data: PhantomData<T>,
+}
+
+impl<T> Header<T> {
+    fn alloc(capacity: usize) -> Option<NonNull<Self>> {
+        unsafe {
+            let (layout, _offset) = Self::layout(capacity).ok()?;
+            let state = alloc::alloc::alloc(layout);
+            let state = state as *mut Self;
+            let state = NonNull::new(state)?;
+
+            state.as_ptr().write(Self::new());
+
+            Some(state)
+        }
+    }
+
+    #[inline]
+    const fn new() -> Self {
+        Self {
+            head: AtomicUsize::new(0),
+            tail: AtomicUsize::new(0),
+            sender: AtomicWaker::new(),
+            receiver: AtomicWaker::new(),
+            open: AtomicBool::new(true),
+            data: PhantomData,
+        }
+    }
+
+    #[inline]
+    fn layout(capacity: usize) -> Result<(Layout, usize), alloc::alloc::LayoutError> {
+        let header_layout = Layout::new::<Self>();
+        let data_layout = Layout::array::<Cell<T>>(capacity)?;
+        let (layout, offset) = header_layout.extend(data_layout)?;
+        Ok((layout, offset))
+    }
+
+    #[inline]
+    unsafe fn layout_unchecked(capacity: usize) -> (Layout, usize) {
+        if let Ok(v) = Self::layout(capacity) {
+            v
+        } else {
+            core::hint::unreachable_unchecked()
+        }
+    }
+}

--- a/quic/s2n-quic-core/src/sync/spsc/state.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/state.rs
@@ -52,11 +52,11 @@ impl Cursor {
     #[inline]
     fn invariants(&self) {
         unsafe {
-            unsafe_assert!(self.capacity >= MINIMUM_CAPACITY);
-            unsafe_assert!(self.head < self.capacity);
-            unsafe_assert!(self.tail < self.capacity);
+            assume!(self.capacity >= MINIMUM_CAPACITY);
+            assume!(self.head < self.capacity);
+            assume!(self.tail < self.capacity);
             let len = count(self.head, self.tail, self.capacity);
-            unsafe_assert!(len < self.capacity);
+            assume!(len < self.capacity);
         }
     }
 
@@ -106,7 +106,7 @@ impl Cursor {
     pub fn increment_head(&mut self, n: usize) {
         self.invariants();
         unsafe {
-            unsafe_assert!(n <= self.capacity());
+            assume!(n <= self.capacity());
         }
         self.head = self.wrap_add(self.head, n);
         self.invariants();
@@ -116,7 +116,7 @@ impl Cursor {
     pub fn increment_tail(&mut self, n: usize) {
         self.invariants();
         unsafe {
-            unsafe_assert!(n <= self.capacity());
+            assume!(n <= self.capacity());
         }
         self.tail = self.wrap_add(self.tail, n);
         self.invariants();
@@ -138,8 +138,8 @@ impl Cursor {
 fn wrap_index(index: usize, size: usize) -> usize {
     // size is always a power of 2
     unsafe {
-        unsafe_assert!(size.is_power_of_two());
-        unsafe_assert!(size >= MINIMUM_CAPACITY);
+        assume!(size.is_power_of_two());
+        assume!(size >= MINIMUM_CAPACITY);
     }
     index & (size - 1)
 }
@@ -149,8 +149,8 @@ fn wrap_index(index: usize, size: usize) -> usize {
 fn count(head: usize, tail: usize, size: usize) -> usize {
     // size is always a power of 2
     unsafe {
-        unsafe_assert!(size.is_power_of_two());
-        unsafe_assert!(size >= MINIMUM_CAPACITY);
+        assume!(size.is_power_of_two());
+        assume!(size >= MINIMUM_CAPACITY);
     }
     (tail.wrapping_sub(head)) & (size - 1)
 }
@@ -301,12 +301,12 @@ impl<T> State<T> {
 
         let (filled, unfilled) = if self.cursor.is_contiguous() {
             unsafe {
-                unsafe_assert!(data.len() >= tail);
+                assume!(data.len() >= tail);
             }
             let (data, unfilled_head) = data.split_at(tail);
 
             unsafe {
-                unsafe_assert!(data.len() >= head);
+                assume!(data.len() >= head);
             }
             let (unfilled_tail, filled_head) = data.split_at(head);
 
@@ -321,12 +321,12 @@ impl<T> State<T> {
             (filled, unfilled)
         } else {
             unsafe {
-                unsafe_assert!(data.len() >= head);
+                assume!(data.len() >= head);
             }
             let (data, filled_head) = data.split_at(head);
 
             unsafe {
-                unsafe_assert!(data.len() >= tail);
+                assume!(data.len() >= tail);
             }
             let (filled_tail, unfilled_head) = data.split_at(tail);
 
@@ -342,7 +342,7 @@ impl<T> State<T> {
         };
 
         unsafe {
-            unsafe_assert!(
+            assume!(
                 filled.len() == self.cursor.recv_len(),
                 "filled mismatch {} == {}\n{:?}",
                 filled.len(),

--- a/quic/s2n-quic-core/src/sync/spsc/tests.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/tests.rs
@@ -1,0 +1,123 @@
+use super::generic::*;
+use bolero::{check, generator::*};
+use std::collections::VecDeque;
+
+#[derive(Clone, Copy, Debug, TypeGenerator)]
+enum Operation {
+    Push(u16),
+    Pop(u16),
+    DropSend,
+    DropRecv,
+}
+
+struct Model<T, B: Behavior> {
+    oracle: VecDeque<T>,
+    send: Option<Sender<T, B>>,
+    recv: Option<Receiver<T, B>>,
+    capacity: usize,
+}
+
+impl<T: Clone + PartialEq + core::fmt::Debug, B: Behavior> Model<T, B> {
+    fn new(capacity: usize) -> Self {
+        let (send, recv) = channel(capacity);
+        Self {
+            oracle: Default::default(),
+            send: Some(send),
+            recv: Some(recv),
+            capacity,
+        }
+    }
+
+    fn apply_all(&mut self, operations: &[Operation], mut generator: impl FnMut() -> T) {
+        for op in operations {
+            self.apply(*op, &mut generator);
+        }
+    }
+
+    fn apply(&mut self, operation: Operation, mut generator: impl FnMut() -> T) {
+        match operation {
+            Operation::Push(count) => {
+                if let Some(send) = self.send.as_mut() {
+                    match send.try_slice() {
+                        Ok(Some(mut slice)) => {
+                            for _ in 0..count {
+                                let value = generator();
+                                if slice.push(value.clone()).is_ok() {
+                                    self.oracle.push_back(value);
+                                }
+                            }
+                        }
+                        Ok(None) => {
+                            assert_eq!(self.oracle.len(), self.capacity);
+                        }
+                        Err(_) => {
+                            assert!(self.recv.is_none());
+                        }
+                    }
+                }
+            }
+            Operation::Pop(count) => {
+                if let Some(recv) = self.recv.as_mut() {
+                    match recv.try_slice() {
+                        Ok(Some(mut slice)) => {
+                            for _ in 0..count {
+                                assert_eq!(slice.pop(), self.oracle.pop_front());
+                            }
+                        }
+                        Ok(None) => {
+                            assert!(self.oracle.is_empty());
+                        }
+                        Err(_) => {
+                            assert!(self.send.is_none());
+                            assert!(self.oracle.is_empty());
+                        }
+                    }
+                }
+            }
+            Operation::DropSend => {
+                self.send = None;
+            }
+            Operation::DropRecv => {
+                self.recv = None;
+            }
+        }
+    }
+
+    fn finish(mut self) {
+        loop {
+            self.apply(Operation::Pop(u16::MAX), || unimplemented!());
+            if self.oracle.is_empty() || self.recv.is_none() {
+                return;
+            }
+        }
+    }
+}
+
+type Operations = Vec<Operation>;
+
+fn generic_model<B: Behavior>(capacity: usize, ops: &[Operation]) {
+    let mut model = Model::<_, B>::new(capacity);
+    let mut cursor = 0;
+    let generator = || {
+        let v = cursor;
+        cursor += 1;
+        Box::new(v)
+    };
+
+    model.apply_all(ops, generator);
+    model.finish();
+}
+
+#[test]
+fn ring() {
+    check!()
+        .with_generator((1usize..64, gen::<Operations>()))
+        .for_each(|(capacity, ops)| generic_model::<Ring>(*capacity, ops))
+}
+
+#[test]
+fn double_ring() {
+    check!()
+        .with_generator((1usize..64, gen::<Operations>()))
+        .for_each(|(capacity, ops)| generic_model::<DoubleRing>(*capacity, ops))
+}

--- a/quic/s2n-quic-core/src/sync/spsc/tests.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/tests.rs
@@ -268,6 +268,23 @@ fn model() {
 }
 
 #[test]
+fn model_zst() {
+    let max_capacity = if cfg!(any(kani, miri)) { 2 } else { 64 };
+
+    let generator = (1usize..max_capacity, gen::<Operations>());
+
+    check!()
+        .with_generator(generator)
+        .for_each(|(capacity, ops)| {
+            let mut model = Model::new(*capacity);
+            let generator = || ();
+
+            model.apply_all(ops, generator);
+            model.finish();
+        })
+}
+
+#[test]
 // TODO enable this once https://github.com/model-checking/kani/pull/2172 is merged and released
 // #[cfg_attr(kani, kani::proof, kani::unwind(3))]
 fn alloc_test() {

--- a/quic/s2n-quic-core/src/sync/spsc/tests.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/tests.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use super::*;
 use bolero::{check, generator::*};
 use core::task::{Context, Poll, Waker};

--- a/quic/s2n-quic-core/src/sync/spsc/tests.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/tests.rs
@@ -1,29 +1,72 @@
 use super::*;
 use bolero::{check, generator::*};
+use core::task::{Context, Poll, Waker};
+use futures_test::task::{new_count_waker, AwokenCount};
 use std::collections::VecDeque;
 
 #[derive(Clone, Copy, Debug, TypeGenerator)]
 enum Operation {
     Push(u16),
+    AsyncPush(u16),
     Pop(u16),
+    AsyncPop(u16),
+    Clear,
     DropSend,
     DropRecv,
+}
+
+struct WakeState {
+    waker: Waker,
+    wake_count: AwokenCount,
+    snapshot: Option<usize>,
+}
+
+impl Default for WakeState {
+    fn default() -> Self {
+        let (waker, wake_count) = new_count_waker();
+        Self {
+            waker,
+            wake_count,
+            snapshot: None,
+        }
+    }
+}
+
+impl WakeState {
+    fn context(&self) -> Context {
+        Context::from_waker(&self.waker)
+    }
+
+    fn snapshot(&mut self) {
+        self.snapshot = Some(self.wake_count.get());
+    }
+
+    fn assert_wake(&mut self) {
+        if let Some(prev) = self.snapshot.take() {
+            assert_eq!(self.wake_count.get(), prev + 1);
+        }
+    }
 }
 
 struct Model<T> {
     oracle: VecDeque<T>,
     send: Option<Sender<T>>,
+    send_waker: WakeState,
     recv: Option<Receiver<T>>,
+    recv_waker: WakeState,
     capacity: usize,
 }
 
 impl<T: Clone + PartialEq + core::fmt::Debug> Model<T> {
     fn new(capacity: usize) -> Self {
         let (send, recv) = channel(capacity);
+        let capacity = send.capacity();
         Self {
             oracle: Default::default(),
             send: Some(send),
+            send_waker: Default::default(),
             recv: Some(recv),
+            recv_waker: Default::default(),
             capacity,
         }
     }
@@ -37,6 +80,7 @@ impl<T: Clone + PartialEq + core::fmt::Debug> Model<T> {
     fn apply(&mut self, operation: Operation, mut generator: impl FnMut() -> T) {
         match operation {
             Operation::Push(count) => {
+                let mut did_push = false;
                 if let Some(send) = self.send.as_mut() {
                     match send.try_slice() {
                         Ok(Some(mut slice)) => {
@@ -44,24 +88,68 @@ impl<T: Clone + PartialEq + core::fmt::Debug> Model<T> {
                                 let value = generator();
                                 if slice.push(value.clone()).is_ok() {
                                     self.oracle.push_back(value);
+                                    did_push = true;
                                 }
                             }
                         }
                         Ok(None) => {
-                            assert_eq!(self.oracle.len(), self.capacity);
+                            assert_eq!(
+                                self.oracle.len(),
+                                self.capacity,
+                                "slice should return None when at capacity"
+                            );
                         }
                         Err(_) => {
                             assert!(self.recv.is_none());
                         }
                     }
                 }
+
+                if did_push {
+                    self.recv_waker.assert_wake();
+                }
+            }
+            Operation::AsyncPush(count) => {
+                let mut did_push = false;
+                if let Some(send) = self.send.as_mut() {
+                    match send.poll_slice(&mut self.send_waker.context()) {
+                        Poll::Ready(Ok(mut slice)) => {
+                            for _ in 0..count {
+                                let value = generator();
+                                if slice.push(value.clone()).is_ok() {
+                                    self.oracle.push_back(value);
+
+                                    did_push = true;
+                                }
+                            }
+                        }
+                        Poll::Ready(Err(_)) => {
+                            assert!(self.recv.is_none());
+                        }
+                        Poll::Pending => {
+                            assert_eq!(
+                                self.oracle.len(),
+                                self.capacity,
+                                "slice should return Pending when at capacity"
+                            );
+                            self.send_waker.snapshot();
+                        }
+                    }
+                }
+
+                if did_push {
+                    self.recv_waker.assert_wake();
+                }
             }
             Operation::Pop(count) => {
+                let mut did_pop = false;
                 if let Some(recv) = self.recv.as_mut() {
                     match recv.try_slice() {
                         Ok(Some(mut slice)) => {
                             for _ in 0..count {
-                                assert_eq!(slice.pop(), self.oracle.pop_front());
+                                let value = slice.pop();
+                                assert_eq!(value, self.oracle.pop_front());
+                                did_pop |= value.is_some();
                             }
                         }
                         Ok(None) => {
@@ -72,6 +160,58 @@ impl<T: Clone + PartialEq + core::fmt::Debug> Model<T> {
                             assert!(self.oracle.is_empty());
                         }
                     }
+                }
+
+                if did_pop {
+                    self.send_waker.assert_wake();
+                }
+            }
+            Operation::AsyncPop(count) => {
+                let mut did_pop = false;
+                if let Some(recv) = self.recv.as_mut() {
+                    match recv.poll_slice(&mut self.recv_waker.context()) {
+                        Poll::Ready(Ok(mut slice)) => {
+                            for _ in 0..count {
+                                let value = slice.pop();
+                                assert_eq!(value, self.oracle.pop_front());
+                                did_pop |= value.is_some();
+                            }
+                        }
+                        Poll::Ready(Err(_)) => {
+                            assert!(self.send.is_none());
+                            assert!(self.oracle.is_empty());
+                        }
+                        Poll::Pending => {
+                            assert!(self.oracle.is_empty());
+                            self.recv_waker.snapshot();
+                        }
+                    }
+                }
+
+                if did_pop {
+                    self.send_waker.assert_wake();
+                }
+            }
+            Operation::Clear => {
+                let mut did_pop = false;
+                if let Some(recv) = self.recv.as_mut() {
+                    match recv.try_slice() {
+                        Ok(Some(mut slice)) => {
+                            self.oracle.clear();
+                            did_pop = slice.clear() > 0;
+                        }
+                        Ok(None) => {
+                            assert!(self.oracle.is_empty());
+                        }
+                        Err(_) => {
+                            assert!(self.send.is_none());
+                            assert!(self.oracle.is_empty());
+                        }
+                    }
+                }
+
+                if did_pop {
+                    self.send_waker.assert_wake();
                 }
             }
             Operation::DropSend => {

--- a/quic/s2n-quic-core/src/testing.rs
+++ b/quic/s2n-quic-core/src/testing.rs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use bolero_generator::TypeGenerator;
+
+#[derive(Clone, Copy, Debug, TypeGenerator)]
+pub struct InlineVec<T, const LEN: usize> {
+    values: [T; LEN],
+
+    #[generator(_code = "0..LEN")]
+    len: usize,
+}
+
+impl<T, const LEN: usize> core::ops::Deref for InlineVec<T, LEN> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        &self.values[..self.len]
+    }
+}
+
+impl<T, const LEN: usize> core::ops::DerefMut for InlineVec<T, LEN> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.values[..self.len]
+    }
+}

--- a/quic/s2n-quic-crypto/src/aes/x86.rs
+++ b/quic/s2n-quic-crypto/src/aes/x86.rs
@@ -6,6 +6,7 @@ use crate::{
     arch::*,
     block::{BatchMut, Block, Zeroed},
 };
+use s2n_quic_core::assume;
 use zeroize::Zeroize;
 
 #[cfg(any(test, feature = "testing"))]
@@ -67,7 +68,7 @@ impl<const N: usize> super::aes128::EncryptionKey for EncryptionKey<N> {
     #[inline(always)]
     fn keyround(&self, index: usize) -> &Self::KeyRound {
         unsafe {
-            unsafe_assert!(index < N);
+            assume!(index < N);
             self.0.get_unchecked(index)
         }
     }
@@ -80,7 +81,7 @@ impl<const N: usize> super::aes256::EncryptionKey for EncryptionKey<N> {
     #[inline(always)]
     fn keyround(&self, index: usize) -> &Self::KeyRound {
         unsafe {
-            unsafe_assert!(index < N);
+            assume!(index < N);
             self.0.get_unchecked(index)
         }
     }
@@ -96,7 +97,7 @@ impl<const N: usize> super::aes128::DecryptionKey for DecryptionKey<N> {
     #[inline(always)]
     fn keyround(&self, index: usize) -> &Self::KeyRound {
         unsafe {
-            unsafe_assert!(index < N);
+            assume!(index < N);
             self.0.get_unchecked(index)
         }
     }
@@ -109,7 +110,7 @@ impl<const N: usize> super::aes256::DecryptionKey for DecryptionKey<N> {
     #[inline(always)]
     fn keyround(&self, index: usize) -> &Self::KeyRound {
         unsafe {
-            unsafe_assert!(index < N);
+            assume!(index < N);
             self.0.get_unchecked(index)
         }
     }

--- a/quic/s2n-quic-crypto/src/aesgcm/x86.rs
+++ b/quic/s2n-quic-crypto/src/aesgcm/x86.rs
@@ -9,6 +9,7 @@ use crate::{
         Block,
     },
 };
+use s2n_quic_core::assume;
 
 #[cfg(any(test, feature = "testing"))]
 pub mod testing;
@@ -21,13 +22,13 @@ impl Payload<__m128i> for &mut [u8] {
 
     #[inline(always)]
     unsafe fn read_block(&self) -> __m128i {
-        unsafe_assert!(self.len() >= BLOCK_LEN);
+        assume!(self.len() >= BLOCK_LEN);
         _mm_loadu_si128(*self as *const _ as *const _)
     }
 
     #[inline(always)]
     unsafe fn xor_block(&mut self, cleartext_block: __m128i, aes_block: __m128i) -> __m128i {
-        unsafe_assert!(self.len() >= BLOCK_LEN);
+        assume!(self.len() >= BLOCK_LEN);
         let addr = *self as *mut [u8] as *mut u8;
 
         // read the cleartext block and XOR it with the provided AES block
@@ -46,8 +47,8 @@ impl Payload<__m128i> for &mut [u8] {
 
     #[inline(always)]
     unsafe fn read_last_block(&self, len: usize) -> __m128i {
-        unsafe_assert!(0 < len && len < BLOCK_LEN);
-        unsafe_assert!(self.len() == len);
+        assume!(0 < len && len < BLOCK_LEN);
+        assume!(self.len() == len);
         __m128i::from_slice(self)
     }
 
@@ -58,8 +59,8 @@ impl Payload<__m128i> for &mut [u8] {
         aes_block: __m128i,
         len: usize,
     ) -> __m128i {
-        unsafe_assert!(0 < len && len < BLOCK_LEN);
-        unsafe_assert!(self.len() == len);
+        assume!(0 < len && len < BLOCK_LEN);
+        assume!(self.len() == len);
         let addr = *self as *mut [u8] as *mut u8;
 
         let xored = cleartext_block.xor(aes_block.mask(len));

--- a/quic/s2n-quic-crypto/src/block/x86.rs
+++ b/quic/s2n-quic-crypto/src/block/x86.rs
@@ -6,6 +6,7 @@ use crate::{
     block::{Batch, BatchMut, Block, Zeroed},
 };
 use core::mem::size_of;
+use s2n_quic_core::assume;
 
 pub const LEN: usize = size_of::<__m128i>();
 
@@ -126,7 +127,7 @@ impl M128iExt for __m128i {
     fn into_slice(self, bytes: &mut [u8]) {
         unsafe {
             debug_assert!(Avx2::is_supported());
-            unsafe_assert!(bytes.len() <= LEN);
+            assume!(bytes.len() <= LEN);
             copy_128(
                 &self as *const _ as *const u8,
                 bytes.as_mut_ptr(),
@@ -139,7 +140,7 @@ impl M128iExt for __m128i {
     fn mask(self, len: usize) -> Self {
         unsafe {
             debug_assert!(Avx2::is_supported());
-            unsafe_assert!(0 < len && len < LEN);
+            assume!(0 < len && len < LEN);
 
             // compute a mask that can be shifted to only include a `len` of bytes
             const MASK: [u8; 31] = {

--- a/quic/s2n-quic-crypto/src/cipher_suite.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite.rs
@@ -4,7 +4,10 @@
 use crate::{aead::Aead, header_key::HeaderKey, iv};
 use ::ring::{aead, hkdf};
 use core::fmt;
-use s2n_quic_core::crypto::{label, CryptoError};
+use s2n_quic_core::{
+    assume,
+    crypto::{label, CryptoError},
+};
 use zeroize::{Zeroize, Zeroizing};
 
 mod negotiated;
@@ -141,7 +144,7 @@ macro_rules! impl_cipher_suite {
                         use core::convert::TryInto;
                         let res = (&tag[..]).try_into();
                         unsafe {
-                            unsafe_assert!(res.is_ok());
+                            assume!(res.is_ok());
                         }
                         res.unwrap()
                     };
@@ -170,7 +173,7 @@ macro_rules! impl_cipher_suite {
                         use core::convert::TryInto;
                         let res = tag.try_into();
                         unsafe {
-                            unsafe_assert!(res.is_ok());
+                            assume!(res.is_ok());
                         }
                         res.unwrap()
                     };

--- a/quic/s2n-quic-crypto/src/ghash/x86/precomputed.rs
+++ b/quic/s2n-quic-crypto/src/ghash/x86/precomputed.rs
@@ -10,6 +10,7 @@ use crate::{
         KEY_LEN,
     },
 };
+use s2n_quic_core::assume;
 use zeroize::{DefaultIsZeroes, Zeroize};
 
 impl<P: Powers> ghash::GHash for P {
@@ -76,7 +77,7 @@ impl<H: HKey> Powers for Allocated<H> {
     #[inline(always)]
     fn power(&self, index: usize) -> &H {
         unsafe {
-            unsafe_assert!(index < self.state.len());
+            assume!(index < self.state.len());
             self.state.get_unchecked(index)
         }
     }
@@ -125,7 +126,7 @@ impl<H: HKey, const N: usize> Powers for Array<H, N> {
     #[inline(always)]
     fn power(&self, index: usize) -> &H {
         unsafe {
-            unsafe_assert!(index < self.state.len());
+            assume!(index < self.state.len());
             self.state.get_unchecked(index)
         }
     }
@@ -169,7 +170,7 @@ impl State {
     fn update<P: Powers>(&self, powers: &P, b: &__m128i) -> Self {
         unsafe {
             debug_assert!(Avx2::is_supported());
-            unsafe_assert!(
+            assume!(
                 self.power != 0,
                 "update called more than requested capacity"
             );
@@ -208,7 +209,7 @@ impl State {
 
         unsafe {
             debug_assert!(Avx2::is_supported());
-            unsafe_assert!(
+            assume!(
                 power == 0,
                 "ghash update count incorrect: remaining {}",
                 power

--- a/quic/s2n-quic-crypto/src/lib.rs
+++ b/quic/s2n-quic-crypto/src/lib.rs
@@ -1,24 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-/// Asserts that a boolean expression is true at runtime, only if debug_assertions are enabled.
-///
-/// Otherwise, the compiler is told to assume that the expression is always true and can perform
-/// additional optimizations.
-macro_rules! unsafe_assert {
-    ($cond:expr) => {
-        unsafe_assert!($cond, "assumption failed: {}", stringify!($cond));
-    };
-    ($cond:expr $(, $fmtarg:expr)* $(,)?) => {
-        let v = $cond;
-
-        debug_assert!(v $(, $fmtarg)*);
-        if cfg!(not(debug_assertions)) && !v {
-            core::hint::unreachable_unchecked();
-        }
-    };
-}
-
 #[macro_use]
 mod negotiated;
 #[macro_use]


### PR DESCRIPTION
### Description of changes: 

This change adds a `spsc` (single-producer/single-consumer) channel to s2n-quic-core. This will be used to split the endpoint up into multiple tasks, which _should_ improve packet processing latencies.

### Call-outs:

I needed the `unsafe_assert` macro from `s2n-quic-crypto` moved into `s2n-quic-core` for this. I also renamed it to `assume!`, since you already have to call it in an `unsafe` block, the name seemed redundant.

### Testing:

The feature includes a `bolero` test that generates random sequences of events to push/pop items from the queue. I ran the test under `kani` but am waiting on https://github.com/model-checking/kani/issues/2169 to be released. I also used `loom` to exhaustively explore atomic interleavings and assert that invariants hold in each case (I caught a few _very_ subtle bugs with this - pretty cool!).

I've also included a benchmark that compares `crossbeam-channel`:

```
spsc/s2n/send_recv/4096 time:   [7.2070 µs 7.2119 µs 7.2182 µs]
                        thrpt:  [567.46 Melem/s 567.95 Melem/s 568.34 Melem/s]
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

spsc/crossbeam/send_recv/4096
                        time:   [36.976 µs 36.999 µs 37.027 µs]
                        thrpt:  [110.62 Melem/s 110.71 Melem/s 110.77 Melem/s]
Found 13 outliers among 100 measurements (13.00%)
  7 (7.00%) low severe
  2 (2.00%) high mild
  4 (4.00%) high severe

spsc/s2n/send_recv_iter/4096
                        time:   [4.5944 µs 4.5991 µs 4.6044 µs]
                        thrpt:  [889.57 Melem/s 890.61 Melem/s 891.52 Melem/s]
Found 25 outliers among 100 measurements (25.00%)
  10 (10.00%) low severe
  8 (8.00%) low mild
  4 (4.00%) high mild
  3 (3.00%) high severe

spsc/crossbeam/send_recv_iter/4096
                        time:   [34.846 µs 34.864 µs 34.886 µs]
                        thrpt:  [117.41 Melem/s 117.49 Melem/s 117.55 Melem/s]
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

