### PR TITLE
fix(s2n-quic-events): correct tx error emission

### DIFF
--- a/quic/s2n-quic-platform/src/socket/std.rs
+++ b/quic/s2n-quic-platform/src/socket/std.rs
@@ -109,7 +109,7 @@ impl<B: Buffer> Queue<B> {
                     Err(err) => {
                         entries.finish(count);
 
-                        publisher.on_platform_rx_error(event::builder::PlatformRxError {
+                        publisher.on_platform_tx_error(event::builder::PlatformTxError {
                             errno: errno().0,
                         });
 


### PR DESCRIPTION
When a tx error occurs in the standard queue (used for recvfrom and sendto system call) we previously emitted an rx error. This commit corrects this, so now tx failures result in tx error events.

### Call-outs:

We don't currently have tests for these events, but if there is interest I can add some.

### Testing:

Manually looked through the rest of the queue implementations and confirmed that errors corresponded to the proper methods. See call-out about unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

