### PR TITLE
tests(s2n-quic-core): update kani to 0.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -621,7 +621,7 @@ jobs:
           submodules: true
 
       - name: Kani run
-        uses: model-checking/kani-github-action@v0.20
+        uses: model-checking/kani-github-action@v0.21
         with:
           working-directory: quic/s2n-quic-core
           args: --tests

--- a/quic/s2n-quic-core/src/interval_set/tests.rs
+++ b/quic/s2n-quic-core/src/interval_set/tests.rs
@@ -100,7 +100,7 @@ fn interval_set_test() {
 }
 
 #[test]
-#[cfg_attr(kani, kani::proof, kani::unwind(2))]
+#[cfg_attr(kani, kani::proof, kani::unwind(2), kani::solver(kissat))]
 #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
 fn interval_set_inset_range_test() {
     // Generate valid ranges (lb <= ub)

--- a/quic/s2n-quic-core/src/packet/number/sliding_window.rs
+++ b/quic/s2n-quic-core/src/packet/number/sliding_window.rs
@@ -277,7 +277,7 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(kani, kani::proof, kani::unwind(2))]
+    #[cfg_attr(kani, kani::proof, kani::unwind(2), kani::solver(kissat))]
     #[cfg_attr(miri, ignore)] // this test is too expensive for miri
     fn insert_test() {
         // Make sure the two packet numbers are not the same

--- a/quic/s2n-quic-core/src/packet/number/tests.rs
+++ b/quic/s2n-quic-core/src/packet/number/tests.rs
@@ -10,7 +10,7 @@ use bolero::{check, generator::*};
 use s2n_codec::{testing::encode, DecoderBuffer};
 
 #[test]
-#[cfg_attr(kani, kani::proof, kani::unwind(5))]
+#[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(kissat))]
 fn round_trip() {
     check!()
         .with_generator(
@@ -160,7 +160,7 @@ fn rfc_decoder(largest_pn: u64, truncated_pn: u64, pn_nbits: usize) -> u64 {
 }
 
 #[test]
-#[cfg_attr(kani, kani::proof, kani::unwind(5))]
+#[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(kissat))]
 fn truncate_expand_test() {
     check!()
         .with_type()
@@ -175,7 +175,7 @@ fn truncate_expand_test() {
 }
 
 #[test]
-#[cfg_attr(kani, kani::proof, kani::unwind(5))]
+#[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(kissat))]
 fn rfc_differential_test() {
     check!()
         .with_type()
@@ -207,7 +207,7 @@ fn rfc_differential_test() {
 }
 
 #[test]
-#[cfg_attr(kani, kani::proof, kani::unwind(5))]
+#[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(kissat))]
 fn example_test() {
     macro_rules! example {
         ($largest:expr, $truncated:expr, $expected:expr) => {{

--- a/quic/s2n-quic-core/src/random.rs
+++ b/quic/s2n-quic-core/src/random.rs
@@ -75,7 +75,7 @@ mod tests {
 
     #[test]
     #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
-    #[cfg_attr(kani, kani::proof, kani::unwind(10))]
+    #[cfg_attr(kani, kani::proof, kani::unwind(10), kani::solver(kissat))]
     fn gen_range_biased_test() {
         bolero::check!()
             .with_type()

--- a/quic/s2n-quic-core/src/slice.rs
+++ b/quic/s2n-quic-core/src/slice.rs
@@ -132,8 +132,7 @@ mod tests {
     const LEN: usize = if cfg!(kani) { 2 } else { 32 };
 
     #[test]
-    #[cfg(any(not(kani), kani_slow))]
-    #[cfg_attr(kani, kani::proof, kani::unwind(5))]
+    #[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(kissat))]
     #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
     fn vectored_copy_fuzz_test() {
         check!()

--- a/quic/s2n-quic-core/src/sync/spsc/tests.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/tests.rs
@@ -285,8 +285,7 @@ fn model_zst() {
 }
 
 #[test]
-// TODO enable this once https://github.com/model-checking/kani/pull/2172 is merged and released
-// #[cfg_attr(kani, kani::proof, kani::unwind(3))]
+#[cfg_attr(kani, kani::proof, kani::unwind(3), kani::solver(kissat))]
 fn alloc_test() {
     let capacity = if cfg!(any(kani, miri)) {
         1usize..3
@@ -299,11 +298,6 @@ fn alloc_test() {
         .cloned()
         .for_each(|(capacity, push_value)| {
             let (mut send, mut recv) = channel(capacity);
-
-            // kani takes a very long time to check the push/pop functionality so bail for now
-            if cfg!(not(kani_slow)) {
-                return;
-            }
 
             send.try_slice().unwrap().unwrap().push(push_value).unwrap();
 

--- a/quic/s2n-quic-core/src/varint/tests.rs
+++ b/quic/s2n-quic-core/src/varint/tests.rs
@@ -18,7 +18,7 @@ fn round_trip_bytes_test() {
 }
 
 #[test]
-#[cfg_attr(kani, kani::proof, kani::unwind(10))]
+#[cfg_attr(kani, kani::proof, kani::unwind(10), kani::solver(kissat))]
 fn round_trip_values_test() {
     check!().with_type().cloned().for_each(|v| {
         if let Ok(v) = VarInt::new(v) {
@@ -91,7 +91,7 @@ sequence_test!(one_byte_sequence_example([0x25], 37));
 // # +------+--------+-------------+-----------------------+
 #[test]
 #[cfg_attr(miri, ignore)]
-#[cfg_attr(kani, kani::proof, kani::unwind(3))]
+#[cfg_attr(kani, kani::proof, kani::unwind(3), kani::solver(kissat))]
 fn one_byte_sequence_test() {
     bolero::check!()
         .with_type()
@@ -107,7 +107,7 @@ fn one_byte_sequence_test() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-#[cfg_attr(kani, kani::proof, kani::unwind(4))]
+#[cfg_attr(kani, kani::proof, kani::unwind(4), kani::solver(kissat))]
 fn two_byte_sequence_test() {
     // the s2n-quic implementation always chooses the smallest encoding possible.
     // this means if we wish to test two-byte sequences, we need to encode a number
@@ -130,7 +130,7 @@ fn two_byte_sequence_test() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-#[cfg_attr(kani, kani::proof, kani::unwind(10))]
+#[cfg_attr(kani, kani::proof, kani::unwind(10), kani::solver(kissat))]
 fn four_byte_sequence_test() {
     // The s2n-quic implementation always chooses the smallest encoding possible.
     // This means if we wish to test the four-byte sequences, we need to encode a number
@@ -153,7 +153,7 @@ fn four_byte_sequence_test() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-#[cfg_attr(kani, kani::proof, kani::unwind(10))]
+#[cfg_attr(kani, kani::proof, kani::unwind(10), kani::solver(kissat))]
 fn eight_byte_sequence_test() {
     // The s2n-quic implementation always chooses the smallest encoding possible.
     // This means if we wish to test eight-byte sequences, we need to encode a number
@@ -223,7 +223,7 @@ fn encode_updated_invalid_test() {
 }
 
 #[test]
-#[cfg_attr(kani, kani::proof, kani::unwind(5))]
+#[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(kissat))]
 fn table_differential_test() {
     //= https://www.rfc-editor.org/rfc/rfc9000#section-16
     //= type=test
@@ -268,7 +268,7 @@ fn table_differential_test() {
 }
 
 #[test]
-#[cfg_attr(kani, kani::proof, kani::unwind(5))]
+#[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(kissat))]
 fn checked_ops_test() {
     check!().with_type().cloned().for_each(|(a, b)| {
         if let (Ok(a_v), Ok(b_v)) = (VarInt::new(a), VarInt::new(b)) {


### PR DESCRIPTION
### Description of changes: 

Kani 0.21 was released recently and this is upgrading our version to that. With it, includes the ability to override the solver. After running some performance tests locally, we saw a reduction in proof time for every single one of our proofs by using the `kissat` solver instead of the default (`minisat`). I was even able to enable the `vectored_copy` proof, which was previously marked with `cfg(kani_slow)` as well as expand the `spsc` proof to include more checks, which as also gated behind `cfg(kani_slow)`.

### Testing:

I tested this all locally. Kani is also [part of our CI](https://github.com/aws/s2n-quic/actions/runs/4147909238/jobs/7175336688).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

