### PR TITLE
Add support for unreliable streams

### DIFF
--- a/quic/s2n-quic-transport/src/stream/api.rs
+++ b/quic/s2n-quic-transport/src/stream/api.rs
@@ -490,6 +490,11 @@ macro_rules! tx_request_apis {
             self
         }
 
+        pub fn reset_on_loss(&mut self) -> &mut Self {
+            self.request.reset_on_loss();
+            self
+        }
+
         pub fn flush(&mut self) -> &mut Self {
             self.request.flush();
             self

--- a/quic/s2n-quic/src/stream/send.rs
+++ b/quic/s2n-quic/src/stream/send.rs
@@ -577,6 +577,22 @@ impl SendStream {
         self.0.id().into()
     }
 
+    /// Set this stream to immediately terminate on any detected loss.
+    ///
+    /// This creates a stream that acts similar to an unreliable datagram, but is allowed to be
+    /// of arbitrary size. That means that s2n-quic will transparently handle the current MTU
+    /// to "fragment" the payload of this stream (like with any other stream), but if loss is
+    /// detected the stream is abandoned and will be immediately closed.
+    #[inline]
+    pub fn reset_on_loss(&mut self) {
+        self.0
+            .tx_request()
+            .unwrap()
+            .reset_on_loss()
+            .poll(None)
+            .unwrap();
+    }
+
     impl_connection_api!(|stream| crate::connection::Handle(stream.0.connection().clone()));
 
     impl_send_stream_api!(|stream, dispatch| dispatch!(stream.0));


### PR DESCRIPTION
### Resolved issues:

cc https://github.com/aws/s2n-quic/issues/1253 (unreliable datagram support)

### Description of changes: 

This provides support for the sender of a stream to abort transmission if s2n-quic detects packet loss, rather than attempting to retransmit. This is primarily intended as a potentially better alternative to unreliable datagrams for UDP-like workloads atop QUIC, because this method isn't constrained to the network MTU. Obviously, very large stream lengths would likely lead to high rates of failure, but for typically small payloads this can work well.

The current design is intended to be compatible with any QUIC endpoint, no custom protocol extensions are required for this support.

In the future we may consider alternative points on the spectrum (e.g., limiting retranmissions to only if loss was detected quickly enough), but for now this is already quite workable.

### Call-outs:

This still needs tests, documentation, and gating behind an unstable feature flag -- putting it up for any early commentary on the concrete implementation, and to solicit input on where to add the tests.

### Testing:

No tests yet, see above. Should be added prior to merging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

