### PR TITLE
fix(s2n-quic-core): enable building for bpf applications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2022-09-15
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2023-02-20
   CDN: https://dnglbrstg7yg.cloudfront.net
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100
@@ -269,7 +269,6 @@ jobs:
         with:
           toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
           override: true
-          target: bpfel-unknown-none
 
       - uses: camshaft/rust-cache@v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,7 +269,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
           override: true
-          target: thumbv7m-none-eabi
+          target: bpfel-unknown-none
 
       - uses: camshaft/rust-cache@v1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,7 @@ jobs:
         with:
           toolchain: ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
           override: true
+          components: rust-src
 
       - uses: camshaft/rust-cache@v1
 

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["corpus.tar.gz"]
 
 [features]
 default = ["alloc", "std"]
-alloc = ["atomic-waker", "cache-padded"]
+alloc = ["atomic-waker", "bytes", "cache-padded"]
 std = ["alloc", "once_cell"]
 testing = ["std", "generator", "s2n-codec/testing", "checked-counters", "insta", "futures-test"]
 generator = ["bolero-generator"]
@@ -23,7 +23,7 @@ event-tracing = ["tracing"]
 atomic-waker = { version = "1", optional = true }
 bolero-generator = { version = "0.8", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false }
-bytes = { version = "1", default-features = false }
+bytes = { version = "1", optional = true, default-features = false }
 cache-padded = { version = "1", optional = true }
 hex-literal = "0.3"
 # used for event snapshot testing - needs an internal API so we require a minimum version

--- a/quic/s2n-quic-core/src/application/mod.rs
+++ b/quic/s2n-quic-core/src/application/mod.rs
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod error;
+#[cfg(feature = "alloc")]
 mod server_name;
 
 pub use error::Error;
+#[cfg(feature = "alloc")]
 pub use server_name::ServerName;

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -7439,6 +7439,9 @@ pub mod testing {
             }
         }
         fn snapshot(&self, output: &[String]) {
+            if cfg!(miri) {
+                return;
+            }
             use std::path::{Component, Path};
             let value = output.join("\n");
             let thread = std::thread::current();

--- a/quic/s2n-quic-core/src/stream/mod.rs
+++ b/quic/s2n-quic-core/src/stream/mod.rs
@@ -5,6 +5,7 @@ mod error;
 mod id;
 pub mod iter;
 pub mod limits;
+#[cfg(feature = "alloc")]
 pub mod ops;
 mod type_;
 

--- a/quic/s2n-quic-core/src/sync/spsc/tests.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/tests.rs
@@ -332,6 +332,7 @@ const ASYNC_RX_BATCH_SIZE: usize = if cfg!(loom) { 1 } else { BATCH_SIZE };
 const ASYNC_RX_EXPECTED_COUNT: usize = ASYNC_RX_BATCH_COUNT * ASYNC_RX_BATCH_SIZE;
 
 #[test]
+#[cfg_attr(miri, ignore)] // TODO https://github.com/aws/s2n-quic/issues/1635
 fn loom_spin_tx_spin_rx_test() {
     loom_scenario(
         CAPACITY,
@@ -341,6 +342,7 @@ fn loom_spin_tx_spin_rx_test() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // TODO https://github.com/aws/s2n-quic/issues/1635
 fn loom_spin_tx_async_rx_test() {
     loom_scenario(
         CAPACITY,
@@ -350,6 +352,7 @@ fn loom_spin_tx_async_rx_test() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // TODO https://github.com/aws/s2n-quic/issues/1635
 fn loom_async_tx_spin_rx_test() {
     loom_scenario(
         CAPACITY,
@@ -359,6 +362,7 @@ fn loom_async_tx_spin_rx_test() {
 }
 
 #[test]
+#[cfg_attr(miri, ignore)] // TODO https://github.com/aws/s2n-quic/issues/1635
 fn loom_async_tx_async_rx_test() {
     loom_scenario(
         CAPACITY,

--- a/quic/s2n-quic-events/src/main.rs
+++ b/quic/s2n-quic-events/src/main.rs
@@ -627,6 +627,11 @@ impl ToTokens for Output {
                     }
 
                     fn snapshot(&self, output: &[String]) {
+                        // miri doesn't support the syscalls that insta uses
+                        if cfg!(miri) {
+                            return;
+                        }
+
                         use std::path::{Path, Component};
                         let value = output.join("\n");
 

--- a/scripts/test_no_std
+++ b/scripts/test_no_std
@@ -10,7 +10,4 @@ set -e
 # can be run for specific toolchain: `./scripts/test_no_std nightly-2021-06-21`
 TOOLCHAIN=${1:-nightly}
 
-rustup target add thumbv7m-none-eabi --toolchain $TOOLCHAIN
-
-# see https://github.com/rust-lang/cargo/issues/7916
-cargo +$TOOLCHAIN build --package=s2n-quic-core --no-default-features -Z features=dev_dep --target thumbv7m-none-eabi
+cargo +$TOOLCHAIN build --package=s2n-quic-core -Zbuild-std=core --no-default-features --target=bpfel-unknown-none


### PR DESCRIPTION
### Description of changes: 

I tried pulling s2n-quic-core into a BPF program and got a couple of compilation errors related to no_std. Our current no_std checks are clearly not checking what we thought.

This PR fixes the no_std errors as well as updates the no_std script to compile to BPF instead of the `thumbv7m-none-eabi` target, since this is something that we're wanting to test for anyway.

### Call-outs:

The netbench MSRV needs to be updated to fix that failing task. However this has already been incorporated into #1630 so I'll just let that take care of it so we don't get merge conflicts.

### Testing:

The [no_std](https://github.com/aws/s2n-quic/actions/runs/4236631844/jobs/7361674444) job is now targeting BPF and passes locally and in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

