### PR TITLE
Allow rustls provider to be cloned and take in Arcs

### DIFF
--- a/quic/s2n-quic-rustls/src/client.rs
+++ b/quic/s2n-quic-rustls/src/client.rs
@@ -8,6 +8,7 @@ use s2n_codec::EncoderValue;
 use s2n_quic_core::{application::ServerName, crypto::tls};
 use std::sync::Arc;
 
+#[derive(Clone)]
 pub struct Client {
     config: Arc<ClientConfig>,
 }
@@ -36,6 +37,12 @@ impl Default for Client {
 impl From<ClientConfig> for Client {
     fn from(config: ClientConfig) -> Self {
         Self::new(config)
+    }
+}
+
+impl From<Arc<ClientConfig>> for Client {
+    fn from(config: Arc<ClientConfig>) -> Self {
+        Self { config }
     }
 }
 

--- a/quic/s2n-quic-rustls/src/server.rs
+++ b/quic/s2n-quic-rustls/src/server.rs
@@ -7,6 +7,7 @@ use s2n_codec::EncoderValue;
 use s2n_quic_core::{application::ServerName, crypto::tls};
 use std::sync::Arc;
 
+#[derive(Clone)]
 pub struct Server {
     config: Arc<ServerConfig>,
 }
@@ -34,6 +35,12 @@ impl Default for Server {
 impl From<ServerConfig> for Server {
     fn from(config: ServerConfig) -> Self {
         Self::new(config)
+    }
+}
+
+impl From<Arc<ServerConfig>> for Server {
+    fn from(config: Arc<ServerConfig>) -> Self {
+        Self { config }
     }
 }
 


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

Currently, if you have existing `ClientConfig` and `ServerConfig` objects from rustls, in order to feed them into `s2n-quic`, you need to clone the entire backing rustls config objects. This can be an extremely expensive operation memory-wise, especially if you have a large number of certificates installed.

I've changed the code to allow both implementations of tls::Endpoint to be cloned. I've also implemented their respective `From<Arc<*>>` traits to allow you to construct them from existing Arcs. 

### Call-outs:

N/A

### Testing:

It doesn't alter any major functionality, so if it builds, it should work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

