### PR TITLE
test(s2n-quic-core): enable kani on a few harnesses

### DIFF
--- a/quic/s2n-quic-core/src/ct.rs
+++ b/quic/s2n-quic-core/src/ct.rs
@@ -346,6 +346,7 @@ mod tests {
     macro_rules! binop_test {
         ($op:ident, $checked_op:ident) => {
             #[test]
+            #[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(kissat))]
             fn $op() {
                 check!()
                     .with_type::<(u8, u8)>()
@@ -371,6 +372,7 @@ mod tests {
     macro_rules! cmp_test {
         ($op:ident, $core_op:ident) => {
             #[test]
+            #[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(kissat))]
             fn $op() {
                 check!()
                     .with_type::<(u8, u8)>()

--- a/quic/s2n-quic-core/src/inet/ipv4.rs
+++ b/quic/s2n-quic-core/src/inet/ipv4.rs
@@ -740,6 +740,7 @@ mod tests {
 
     /// Asserts the Scope returned matches a known implementation
     #[test]
+    #[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(kissat))]
     fn scope_test() {
         let g = gen::<[u8; 4]>().map_gen(IpV4Address::from);
         check!().with_generator(g).cloned().for_each(|subject| {
@@ -808,6 +809,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(kissat))]
     fn header_getter_setter_test() {
         check!().with_type::<Header>().for_each(|expected| {
             let mut buffer = [255u8; core::mem::size_of::<Header>()];

--- a/quic/s2n-quic-core/src/inet/ipv6.rs
+++ b/quic/s2n-quic-core/src/inet/ipv6.rs
@@ -667,6 +667,7 @@ mod tests {
 
     /// Asserts the UnicastScope returned matches a known implementation
     #[test]
+    #[cfg_attr(kani, kani::proof, kani::unwind(2), kani::solver(kissat))]
     fn scope_test() {
         let g = gen::<[u8; 16]>().map_gen(IpV6Address::from);
         check!().with_generator(g).cloned().for_each(|subject| {
@@ -732,6 +733,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(kani, kani::proof, kani::unwind(17), kani::solver(kissat))]
     fn header_getter_setter_test() {
         check!().with_type::<Header>().for_each(|expected| {
             let mut buffer = [255u8; core::mem::size_of::<Header>()];

--- a/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
@@ -719,6 +719,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(kani, kani::proof, kani::unwind(3), kani::solver(kissat))]
     #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
     fn weighted_average_test() {
         bolero::check!()


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.-->

Enable Kani on a few Bolero harnesses (`ct`, `ipv4`, `ipv6`, and `rtt_estimator`). This brings up the number of harnesses run by Kani from 16 to 30.

The runtime goes up by about 4 minutes. Current:
```
Complete - 16 successfully verified harnesses, 0 failures, 16 total.
        Command being timed: "cargo kani --tests"
        User time (seconds): 412.77
        System time (seconds): 22.20
        Percent of CPU this job got: 107%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 6:43.56
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 3067656
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 527
        Minor (reclaiming a frame) page faults: 9324258
        Voluntary context switches: 132921
        Involuntary context switches: 3566
        Swaps: 0
        File system inputs: 280
        File system outputs: 10068744
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```
After:
```
Complete - 30 successfully verified harnesses, 0 failures, 30 total.
        Command being timed: "cargo kani --tests"
        User time (seconds): 634.79
        System time (seconds): 30.46
        Percent of CPU this job got: 106%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 10:26.72
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 3096388
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 569
        Minor (reclaiming a frame) page faults: 13935868
        Voluntary context switches: 179314
        Involuntary context switches: 4479
        Swaps: 0
        File system inputs: 296
        File system outputs: 11680040
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 0
```

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? --> No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

