### PR TITLE
feat(event): `WriteContext::write_ack_frame` records events `AckRangeSent`

### DIFF
--- a/quic/s2n-quic-core/src/varint/mod.rs
+++ b/quic/s2n-quic-core/src/varint/mod.rs
@@ -11,6 +11,8 @@ use s2n_codec::{decoder_value, Encoder, EncoderValue};
 #[cfg(any(test, feature = "generator"))]
 use bolero_generator::*;
 
+use crate::event::IntoEvent;
+
 #[cfg(test)]
 mod tests;
 
@@ -300,6 +302,13 @@ impl EncoderValue for VarInt {
     #[inline]
     fn encoding_size_for_encoder<E: Encoder>(&self, _encoder: &E) -> usize {
         encoding_size(self.0)
+    }
+}
+
+impl IntoEvent<u64> for VarInt {
+    #[inline]
+    fn into_event(self) -> u64 {
+        self.as_u64()
     }
 }
 

--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -139,6 +139,14 @@ struct AckRangeReceived<'a> {
     ack_range: RangeInclusive<u64>,
 }
 
+#[event("recovery:ack_range_sent")]
+/// ACK range was sent
+struct AckRangeSent {
+    packet_header: PacketHeader,
+    path_id: u64,
+    ack_range: RangeInclusive<u64>,
+}
+
 #[event("transport:packet_dropped")]
 /// Packet was dropped with the given reason
 struct PacketDropped<'a> {

--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -111,14 +111,11 @@ impl AckManager {
         //# the endpoint MUST provide feedback about ECN markings it receives, if
         //# these are accessible.
         context
-            .write_ack_frame(
-                &Ack {
-                    ack_delay,
-                    ack_ranges: &self.ack_ranges,
-                    ecn_counts: self.ecn_counts.as_option(),
-                },
-                &self.ack_ranges,
-            )
+            .write_ack_frame(&Ack {
+                ack_delay,
+                ack_ranges: &self.ack_ranges,
+                ecn_counts: self.ecn_counts.as_option(),
+            })
             .is_some()
     }
 

--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -110,14 +110,14 @@ impl AckManager {
         //# Even if an endpoint does not set an ECT field on packets it sends,
         //# the endpoint MUST provide feedback about ECN markings it receives, if
         //# these are accessible.
-       context
+        context
             .write_ack_frame(
                 &Ack {
                     ack_delay,
                     ack_ranges: &self.ack_ranges,
                     ecn_counts: self.ecn_counts.as_option(),
                 },
-                &self.ack_ranges
+                &self.ack_ranges,
             )
             .is_some()
     }

--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -110,12 +110,15 @@ impl AckManager {
         //# Even if an endpoint does not set an ECT field on packets it sends,
         //# the endpoint MUST provide feedback about ECN markings it receives, if
         //# these are accessible.
-        context
-            .write_frame(&Ack {
-                ack_delay,
-                ack_ranges: &self.ack_ranges,
-                ecn_counts: self.ecn_counts.as_option(),
-            })
+       context
+            .write_ack_frame(
+                &Ack {
+                    ack_delay,
+                    ack_ranges: &self.ack_ranges,
+                    ecn_counts: self.ecn_counts.as_option(),
+                },
+                &self.ack_ranges
+            )
             .is_some()
     }
 

--- a/quic/s2n-quic-transport/src/contexts/mod.rs
+++ b/quic/s2n-quic-transport/src/contexts/mod.rs
@@ -9,7 +9,7 @@ use s2n_codec::encoder::EncoderValue;
 use s2n_quic_core::{
     endpoint,
     event::{self, IntoEvent},
-    frame::{ack::AckRanges as AckRangesTrait, ack_elicitation::AckElicitation, FrameTrait},
+    frame::{ack::AckRanges as AckRangesTrait, ack_elicitation::AckElicitation, Ack, FrameTrait},
     packet::number::PacketNumber,
     time::Timestamp,
 };
@@ -32,17 +32,11 @@ pub trait WriteContext {
     ///
     /// If this was successful the number of the packet
     /// that will be used to send the frame will be returned.
-    fn write_ack_frame<Frame, AckRanges: AckRangesTrait>(
+    fn write_ack_frame<AckRanges: AckRangesTrait>(
         &mut self,
-        frame: &Frame,
-        ack_ranges: AckRanges,
-    ) -> Option<PacketNumber>
-    where
-        Frame: EncoderValue + FrameTrait,
-        for<'frame> &'frame Frame: IntoEvent<event::builder::Frame>,
-    {
-        let _ = ack_ranges;
-        self.write_frame(frame)
+        ack_frame: &Ack<AckRanges>,
+    ) -> Option<PacketNumber> {
+        self.write_frame(ack_frame)
     }
 
     /// Attempt to write a frame.

--- a/quic/s2n-quic-transport/src/contexts/mod.rs
+++ b/quic/s2n-quic-transport/src/contexts/mod.rs
@@ -9,7 +9,7 @@ use s2n_codec::encoder::EncoderValue;
 use s2n_quic_core::{
     endpoint,
     event::{self, IntoEvent},
-    frame::{ack_elicitation::AckElicitation, FrameTrait},
+    frame::{ack_elicitation::AckElicitation, ack::AckRanges as AckRangesTrait, FrameTrait},
     packet::number::PacketNumber,
     time::Timestamp,
 };
@@ -27,6 +27,19 @@ pub trait WriteContext {
 
     /// Returns the number of available bytes remaining in the current payload
     fn remaining_capacity(&self) -> usize;
+
+    /// Attempt to write an ack frame.
+    ///
+    /// If this was successful the number of the packet
+    /// that will be used to send the frame will be returned.
+    fn write_ack_frame<Frame, AckRanges: AckRangesTrait>(&mut self, frame: &Frame, ack_ranges: AckRanges) -> Option<PacketNumber>
+    where
+        Frame: EncoderValue + FrameTrait,
+        for<'frame> &'frame Frame: IntoEvent<event::builder::Frame> 
+    {
+        let _ = ack_ranges;
+        self.write_frame(frame)
+    }
 
     /// Attempt to write a frame.
     ///

--- a/quic/s2n-quic-transport/src/contexts/mod.rs
+++ b/quic/s2n-quic-transport/src/contexts/mod.rs
@@ -9,7 +9,7 @@ use s2n_codec::encoder::EncoderValue;
 use s2n_quic_core::{
     endpoint,
     event::{self, IntoEvent},
-    frame::{ack_elicitation::AckElicitation, ack::AckRanges as AckRangesTrait, FrameTrait},
+    frame::{ack::AckRanges as AckRangesTrait, ack_elicitation::AckElicitation, FrameTrait},
     packet::number::PacketNumber,
     time::Timestamp,
 };
@@ -32,10 +32,14 @@ pub trait WriteContext {
     ///
     /// If this was successful the number of the packet
     /// that will be used to send the frame will be returned.
-    fn write_ack_frame<Frame, AckRanges: AckRangesTrait>(&mut self, frame: &Frame, ack_ranges: AckRanges) -> Option<PacketNumber>
+    fn write_ack_frame<Frame, AckRanges: AckRangesTrait>(
+        &mut self,
+        frame: &Frame,
+        ack_ranges: AckRanges,
+    ) -> Option<PacketNumber>
     where
         Frame: EncoderValue + FrameTrait,
-        for<'frame> &'frame Frame: IntoEvent<event::builder::Frame> 
+        for<'frame> &'frame Frame: IntoEvent<event::builder::Frame>,
     {
         let _ = ack_ranges;
         self.write_frame(frame)

--- a/quic/s2n-quic-transport/src/transmission/context.rs
+++ b/quic/s2n-quic-transport/src/transmission/context.rs
@@ -6,7 +6,7 @@ use core::marker::PhantomData;
 use s2n_codec::{Encoder, EncoderBuffer, EncoderValue};
 use s2n_quic_core::{
     event::{self, ConnectionPublisher as _, IntoEvent},
-    frame::{ack_elicitation::AckElicitation, FrameTrait},
+    frame::{ack_elicitation::AckElicitation, FrameTrait, ack::AckRanges as AckRangesTrait},
     packet::number::PacketNumber,
     time::Timestamp,
 };
@@ -79,6 +79,29 @@ impl<'a, 'b, 'sub, Config: endpoint::Config> WriteContext for Context<'a, 'b, 's
     #[inline]
     fn remaining_capacity(&self) -> usize {
         self.buffer.remaining_capacity()
+    }
+
+    #[inline]
+    fn write_ack_frame<Frame, AckRanges: AckRangesTrait>(&mut self, frame: &Frame, ack_ranges: AckRanges) -> Option<PacketNumber>
+    where
+        Frame: EncoderValue + FrameTrait,
+        for<'frame> &'frame Frame: IntoEvent<event::builder::Frame>,
+    {
+        self.check_frame_constraint(frame);
+        let res = self.write_frame_forced(frame);
+        if res.is_some() {
+            for range in ack_ranges.ack_ranges() {
+                self.publisher.on_ack_range_sent(event::builder::AckRangeSent {
+                    packet_header: event::builder::PacketHeader::new(
+                        self.packet_number,
+                        self.publisher.quic_version(),
+                    ),
+                    path_id: self.path_id.into_event(),
+                    ack_range: range.start().into_event()..=range.end().into_event(),
+                });
+            }
+        }
+        res
     }
 
     #[inline]
@@ -201,6 +224,15 @@ impl<'a, C: WriteContext> WriteContext for RetransmissionContext<'a, C> {
     #[inline]
     fn remaining_capacity(&self) -> usize {
         self.context.remaining_capacity()
+    }
+
+    #[inline]
+    fn write_ack_frame<Frame, AckRanges: AckRangesTrait>(&mut self, frame: &Frame, ack_ranges: AckRanges) -> Option<PacketNumber>
+    where
+        Frame: EncoderValue + FrameTrait,
+        for<'frame> &'frame Frame: IntoEvent<event::builder::Frame>,
+    {
+        self.context.write_ack_frame(frame, ack_ranges)
     }
 
     #[inline]

--- a/quic/s2n-quic-transport/src/transmission/context.rs
+++ b/quic/s2n-quic-transport/src/transmission/context.rs
@@ -87,8 +87,7 @@ impl<'a, 'b, 'sub, Config: endpoint::Config> WriteContext for Context<'a, 'b, 's
         Frame: EncoderValue + FrameTrait,
         for<'frame> &'frame Frame: IntoEvent<event::builder::Frame>,
     {
-        self.check_frame_constraint(frame);
-        let res = self.write_frame_forced(frame);
+        let res = self.write_frame(frame);
         if res.is_some() {
             for range in ack_ranges.ack_ranges() {
                 self.publisher.on_ack_range_sent(event::builder::AckRangeSent {


### PR DESCRIPTION
### Resolved issues:

resolves: https://github.com/aws/s2n-quic/issues/1416

### Description of changes: 
Specialize `write_frame` for ack frame: `write_ack_frame`.

### Call-outs:

Advantage: essentially zero-cost: `write_ack_frame` only specializes for `Frame::Ack` anyway.

Alternatives considered:
1. expose `get_publisher(&self) -> &mut Publisher` (requires exposing generic Publisher through `WriteContext`)
2. Add a method `on_ack_range_sent` to `WriteContext` accepting `event::builder::AckRangeSent`/`AckRanges` (It looks slightly ad-hoc, and a lot of data-passing, may as well combine into `write_ack_frame`). 

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->
Not sure how to generate appropriate tests - `MockContext` for `WriteContext` currently doesn't accept a publisher.

### Results
Here is some sample output running the `event-framework` example with the `async-client` example. 

As you can see, `AckRangeSent` is recorded after `FrameSent {.. frame: Ack {..}, ..}` is recorded.
```
event: ConnectionMeta { endpoint_type: Server, id: 0, timestamp: Timestamp(Timestamp(0:01:21.403762)) } FrameSent { packet_header: OneRtt { number: 7 }, path_id: 0, frame: Ack { ecn_counts: Some(EcnCounts { ect_0_count: 7, ect_1_count: 0, ce_count: 1 }), largest_acknowledged: 7, ack_range_count: 1 } }
event: ConnectionMeta { endpoint_type: Server, id: 0, timestamp: Timestamp(Timestamp(0:01:21.403762)) } AckRangeSent { packet_header: OneRtt { number: 7 }, path_id: 0, ack_range: 3..=7 }
event: ConnectionMeta { endpoint_type: Server, id: 0, timestamp: Timestamp(Timestamp(0:01:21.403762)) } FrameSent { packet_header: OneRtt { number: 7 }, path_id: 0, frame: Padding }
event: ConnectionMeta { endpoint_type: Server, id: 0, timestamp: Timestamp(Timestamp(0:01:21.403762)) } PacketSent { packet_header: OneRtt { number: 7 }, packet_len: 53 }
event: ConnectionMeta { endpoint_type: Server, id: 0, timestamp: Timestamp(Timestamp(0:01:21.403762)) } DatagramSent { len: 53, gso_offset: 0 }

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

