### PR TITLE
fix(s2n-quic-core): decrease minimum allowed RTT sample to 1 microsecond

### DIFF
--- a/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
@@ -174,7 +174,7 @@ impl RttEstimator {
         is_handshake_confirmed: bool,
         space: PacketNumberSpace,
     ) {
-        self.latest_rtt = rtt_sample.max(Duration::from_millis(1));
+        self.latest_rtt = rtt_sample.max(Duration::from_micros(1));
 
         if self.first_rtt_sample.is_none() {
             self.first_rtt_sample = Some(timestamp);
@@ -362,7 +362,7 @@ mod test {
         );
     }
 
-    /// Test a zero RTT value is treated as 1 ms
+    /// Test a zero RTT value is treated as 1 µs
     #[test]
     fn zero_rtt_sample() {
         let mut rtt_estimator = RttEstimator::new(Duration::from_millis(10));
@@ -374,12 +374,12 @@ mod test {
             false,
             PacketNumberSpace::ApplicationData,
         );
-        assert_eq!(rtt_estimator.min_rtt, Duration::from_millis(1));
-        assert_eq!(rtt_estimator.latest_rtt(), Duration::from_millis(1));
+        assert_eq!(rtt_estimator.min_rtt, Duration::from_micros(1));
+        assert_eq!(rtt_estimator.latest_rtt(), Duration::from_micros(1));
         assert_eq!(rtt_estimator.first_rtt_sample(), Some(now));
         assert_eq!(
             rtt_estimator.pto_period(INITIAL_PTO_BACKOFF, PacketNumberSpace::Initial),
-            Duration::from_millis(3)
+            Duration::from_millis(1)
         );
     }
 


### PR DESCRIPTION
### Description of changes: 

Currently s2n-quic enforces a minimum RTT estimate of 1 millisecond, which may be too high a value for intra datacenter connections. I thought this might be an RFC requirement, but it [looks like](https://github.com/aws/s2n-quic/pull/38/commits/601df33f700fade618b289b9846071ab128d04bb#r458321409) we just did it to save on having an `is_first_rtt_sample` in the `RTTEstimator` (which we ended up adding back in anyway). This change reduces the minimum RTT estimate to 1 microsecond.

### Testing:

Updated existing unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

