### PR TITLE
test(s2n-quic-core): Enable Kani on more Bolero harnesses

### DIFF
--- a/quic/s2n-quic-core/src/frame/crypto.rs
+++ b/quic/s2n-quic-core/src/frame/crypto.rs
@@ -190,6 +190,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(kani, kani::proof, kani::unwind(1), kani::solver(kissat))]
     fn try_fit_test() {
         check!()
             .with_type()

--- a/quic/s2n-quic-core/src/stream/iter.rs
+++ b/quic/s2n-quic-core/src/stream/iter.rs
@@ -77,6 +77,7 @@ mod fuzz_target {
 
     #[test]
     #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
+    #[cfg_attr(kani, kani::proof, kani::unwind(1), kani::solver(kissat))]
     fn fuzz_builder() {
         bolero::check!()
             .with_type::<(StreamId, StreamId)>()


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 



Enable Kani on a few Bolero harnesses (try_fit_test and fuzz_builder). This brings up the number of harnesses run by Kani from 32 to 34.

The runtime doesn't change much on my local machine. Current:
```
Complete - 32 successfully verified harnesses, 0 failures, 32 total.
	Command being timed: "cargo kani --tests"
	User time (seconds): 2075.21
	System time (seconds): 43.13
	Percent of CPU this job got: 100%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 34:59.25
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 2261392
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 14352
	Minor (reclaiming a frame) page faults: 14704137
	Voluntary context switches: 69401
	Involuntary context switches: 340621
	Swaps: 0
	File system inputs: 0
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 1
	Page size (bytes): 4096
	Exit status: 0
```
After:
```
Complete - 34 successfully verified harnesses, 0 failures, 34 total.
	Command being timed: “cargo kani --tests”
	User time (seconds): 2108.20
	System time (seconds): 47.74
	Percent of CPU this job got: 100%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 35:36.26
	Average shared text size (kbytes): 0
	Average unshared data size (kbytes): 0
	Average stack size (kbytes): 0
	Average total size (kbytes): 0
	Maximum resident set size (kbytes): 2285648
	Average resident set size (kbytes): 0
	Major (requiring I/O) page faults: 57776
	Minor (reclaiming a frame) page faults: 15529304
	Voluntary context switches: 71173
	Involuntary context switches: 106178
	Swaps: 0
	File system inputs: 0
	File system outputs: 0
	Socket messages sent: 0
	Socket messages received: 0
	Signals delivered: 1
	Page size (bytes): 4096
	Exit status: 0
```

### Call-outs:

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

