### PR TITLE
fix(s2n-quic-rustls, s2n-quic-tls): enable building with default features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ env:
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
   RUST_NIGHTLY_TOOLCHAIN: nightly-2023-02-20
-  MSRV: 1.63
   CDN: https://dnglbrstg7yg.cloudfront.net
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100
@@ -381,7 +380,7 @@ jobs:
       - uses: actions-rs/toolchain@v1.0.7
         id: toolchain
         with:
-          toolchain: ${{ env.MSRV }}
+          toolchain: ${{ needs.env.outputs.msrv }}
           profile: minimal
           override: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ env:
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
   RUST_NIGHTLY_TOOLCHAIN: nightly-2023-02-20
+  MSRV: 1.63
   CDN: https://dnglbrstg7yg.cloudfront.net
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100
@@ -28,6 +29,7 @@ jobs:
       rust-versions: ${{ steps.definitions.outputs.versions }}
       msrv: ${{ steps.definitions.outputs.msrv }}
       examples: ${{ steps.definitions.outputs.examples }}
+      crates: ${{ steps.definitions.outputs.crates }}
     steps:
       - uses: actions/checkout@v3
       # examples is populated by
@@ -50,6 +52,9 @@ jobs:
           export EXAMPLES=$(find examples/ -maxdepth 1 -mindepth 1 -type d | jq -R | jq -sc)
           echo "examples=$EXAMPLES"
           echo "examples=$EXAMPLES" >> $GITHUB_OUTPUT
+          export CRATES=$(find find quic common -name *Cargo.toml | jq -R | jq -sc)
+          echo "crates=$CRATES"
+          echo "crates=$CRATES" >> $GITHUB_OUTPUT
 
   rustfmt:
     runs-on: ubuntu-latest
@@ -356,6 +361,35 @@ jobs:
           name: "coverage / report"
           status: "success"
           url: "${{ steps.s3.outputs.URL }}"
+
+  # This CI step will directly build each crate in common/ and quic/ which is
+  # useful because it sidesteps the feature resolution that normally occurs in a
+  # workspace build. We make sure that the crates build with default features,
+  # otherwise release to crates.io will be blocked
+  crates:
+    needs: env
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: ${{ fromJson(needs.env.outputs.crates) }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: ${{ env.MSRV }}
+          profile: minimal
+          override: true
+
+      - name: build
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+          args: --manifest-path ${{ matrix.crate }}
 
   examples:
     needs: env

--- a/quic/s2n-quic-h3/Cargo.toml
+++ b/quic/s2n-quic-h3/Cargo.toml
@@ -12,6 +12,6 @@ publish = false
 [dependencies]
 bytes = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false }
-h3 = { git = "https://github.com/hyperium/h3" } # TODO: Update once hyperium h3 is in crates.io
-s2n-quic = { path = "../s2n-quic", default-features = false }
-s2n-quic-core = { path = "../s2n-quic-core", default-features = false }
+h3 = "0.0.1"
+s2n-quic = { path = "../s2n-quic" }
+s2n-quic-core = { path = "../s2n-quic-core" }

--- a/quic/s2n-quic-h3/README.md
+++ b/quic/s2n-quic-h3/README.md
@@ -1,6 +1,6 @@
 # s2n-quic-h3
 
-This is an internal crate used by [s2n-quic](https://github.com/aws/s2n-quic). The API is not currently stable and should not be used directly.
+This is an internal crate used by [s2n-quic](https://github.com/aws/s2n-quic) written as a proof of concept for implementing HTTP3 on top of s2n-quic. The API is not currently stable and should not be used directly.
 
 ## License
 

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -15,7 +15,7 @@ bytes = { version = "1", default-features = false }
 rustls = { version = "0.20", features = ["quic"] }
 rustls-pemfile = "1"
 s2n-codec = { version = "=0.4.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.18.0", path = "../s2n-quic-core", default-features = false }
+s2n-quic-core = { version = "=0.18.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
 s2n-quic-crypto = { version = "=0.18.0", path = "../s2n-quic-crypto", default-features = false }
 
 [dev-dependencies]

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -19,7 +19,7 @@ bytes = { version = "1", default-features = false }
 errno = "0.2"
 libc = "0.2"
 s2n-codec = { version = "=0.4.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.18.0", path = "../s2n-quic-core", default-features = false }
+s2n-quic-core = { version = "=0.18.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
 s2n-quic-crypto = { version = "=0.18.0", path = "../s2n-quic-crypto", default-features = false }
 s2n-tls = { version = "=0.0.26", features = ["quic"] }
 


### PR DESCRIPTION
### Description of changes: 
* add alloc dependency to rustls and tls crates
* add default dependency to h3 crate
* add CI step to check that each crate builds.

Note that the name of this PR is confusing. "default" features is literally referring to "the set of features included when build is invoked directly on the package", and not necessarily cargo's concept of "default-features".

Currently we are unable to release to crates.io because `s2n-quic-rustls` and `s2n-quic-tls` do not build with default features. This happened because in a #1633 , components that `s2n-quic-rustls` depends on were moved behind the `alloc` feature flag.

We failed to detect this in our CI because the workspace build builds from `s2n-quic` with `default` features enabled. This build happens successfully because the `alloc` feature is included in `default`. 

An issue that seems to describe in a bit more detail is linked here: https://github.com/rust-lang/cargo/issues/8366

### Call-outs:
I'm still a bit uncertain on our overall story for no-std usage. It might be good to add an example showing an intended use case. 

#### Why not just dry run publishing/packaging?
Because that relies on artifacts being *published* to crates.io

For example consider that we just version bumped things so that for crate A which consumes B, we now have
A = 1.0.0 depends on B = 1.0.0. 
- dry run publish B = 1.0.0 succeeds
- dry run publish A = 1.0.0 fails because B 1.0.0 can't be found on crates (because it wasn't actually published)
The same problem applies to the `cargo package` workflow.

### Testing:

Tested by invoking the individual package builds. Also adding a step for that to the CI. The list of packages that are will be dynamically updated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

