### PR TITLE
do-not-merge - add crate build to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ jobs:
       rust-versions: ${{ steps.definitions.outputs.versions }}
       msrv: ${{ steps.definitions.outputs.msrv }}
       examples: ${{ steps.definitions.outputs.examples }}
+      crates: ${{ steps.definitions.outputs.crates }}
     steps:
       - uses: actions/checkout@v3
       # examples is populated by
@@ -50,6 +51,9 @@ jobs:
           export EXAMPLES=$(find examples/ -maxdepth 1 -mindepth 1 -type d | jq -R | jq -sc)
           echo "examples=$EXAMPLES"
           echo "examples=$EXAMPLES" >> $GITHUB_OUTPUT
+          export CRATES=$(find find quic common -name *Cargo.toml | jq -R | jq -sc)
+          echo "crates=$CRATES"
+          echo "crates=$CRATES" >> $GITHUB_OUTPUT
 
   rustfmt:
     runs-on: ubuntu-latest
@@ -356,6 +360,35 @@ jobs:
           name: "coverage / report"
           status: "success"
           url: "${{ steps.s3.outputs.URL }}"
+
+  # This CI step will directly build each crate in common/ and quic/ which is
+  # useful because it sidesteps the feature resolution that normally occurs in a
+  # workspace build. We make sure that the crates build with default features,
+  # otherwise release to crates.io will be blocked
+  crates:
+    needs: env
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        crate: ${{ fromJson(needs.env.outputs.crates) }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: ${{ needs.env.outputs.msrv }}
+          profile: minimal
+          override: true
+
+      - name: build
+        uses: actions-rs/cargo@v1.0.3
+        with:
+          command: build
+          args: --manifest-path ${{ matrix.crate }}
 
   examples:
     needs: env


### PR DESCRIPTION
This is a dry-run PR intended to make sure that a new CI workflow will prevent us from entering a broken state again.

The `crates` workflow is expected to fail in multiple instances.
- s2n-quic-rustls
- s2n-quic-tls
- s2n-quic-h3

The actual workflow will be added in PR #1673 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

