### PR TITLE
fix(s2n-quic-crypto): pin zeroize_derive until fixed

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -120,9 +120,7 @@
     "picoquic": [
       "client"
     ],
-    "quic-go": [
-      "client"
-    ],
+    "quic-go": [],
     "quiche": [],
     "xquic": []
   },

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,6 +768,13 @@ jobs:
         with:
           lfs: true
 
+      - uses: actions-rs/toolchain@v1.0.7
+        id: toolchain
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
       - uses: camshaft/install@v1
         with:
           crate: bpf-linker

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -21,6 +21,9 @@ ring = { version = "0.16", default-features = false }
 s2n-codec = { version = "=0.4.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.18.1", path = "../s2n-quic-core", default-features = false }
 zeroize = { version = "1.5", default-features = false, features = ["zeroize_derive"] }
+# 1.4 broke derive bounds; see https://github.com/RustCrypto/utils/issues/878#issuecomment-1488918669
+# TODO remove this dependency once the issue is resolved
+zeroize_derive = { version = "<1.4" }
 
 [dev-dependencies]
 aes = "0.8"


### PR DESCRIPTION
### Description of changes: 

Zeroize [recently broke generic bounds](https://github.com/RustCrypto/utils/issues/878) in the derive macro. The fix in https://github.com/RustCrypto/utils/pull/879 does not resolve our current usage of the macro.

This change pins the dependency until a fix is available.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

