### PR TITLE
fix(s2n-quic-transport): decrease sensitivity of MTU black hole detection

### DIFF
--- a/quic/s2n-quic-transport/src/path/mtu.rs
+++ b/quic/s2n-quic-transport/src/path/mtu.rs
@@ -241,6 +241,7 @@ impl Controller {
     //# robust in the case where probe packets are lost due to other
     //# reasons (including link transmission error, congestion).
     /// This method gets called when a packet loss is reported
+    #[allow(clippy::too_many_arguments)]
     pub fn on_packet_loss<CC: CongestionController, Pub: event::ConnectionPublisher>(
         &mut self,
         packet_number: PacketNumber,

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -951,6 +951,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             path.mtu_controller.on_packet_loss(
                 packet_number,
                 sent_info.sent_bytes,
+                new_loss_burst,
                 now,
                 &mut path.congestion_controller,
                 sent_info.path_id,

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -110,7 +110,7 @@ fn interceptor_failure_test() {
     intercept_loss(
         Loss::builder(Random::with_seed(123))
             .with_rx_loss(0..20)
-            .with_rx_pass(1..4)
+            .with_rx_pass(1..2)
             .build(),
     )
 }

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -479,3 +479,95 @@ fn mtu_probe_jumbo_frame_unsupported_test() {
     // ETHERNET_MTU - UDP_HEADER_LEN - IPV4_HEADER_LEN
     assert_eq!(last_mtu.mtu, 1472);
 }
+
+// if we lose every packet during a round trip and then allow packets through,
+// this is not determined to be an MTU black hole
+#[test]
+fn mtu_loss_no_blackhole() {
+    let model = Model::default();
+    let rtt = Duration::from_millis(100);
+    let max_mtu = 9001;
+    let subscriber = MtuUpdatedRecorder::new();
+    let events = subscriber.events();
+
+    model.set_delay(rtt / 2);
+    model.set_max_udp_payload(max_mtu);
+
+    test(model.clone(), |handle| {
+        let server = Server::builder()
+            .with_io(handle.builder().with_max_mtu(max_mtu).build()?)?
+            .with_tls(SERVER_CERTS)?
+            .with_event(subscriber)?
+            .start()?;
+        let client = Client::builder()
+            .with_io(handle.builder().with_max_mtu(max_mtu).build()?)?
+            .with_tls(certificates::CERT_PEM)?
+            .start()?;
+        let addr = start_server(server)?;
+        // we need a large payload to allow for multiple rounds of MTU probing
+        start_client(client, addr, Data::new(10_000_000))?;
+
+        spawn(async move {
+            // let all packets go through for 10 RTTs - this will reach the end of MTU probing
+            model.set_drop_rate(0.0);
+            delay(rtt * 10).await;
+
+            // drop all packets for a single round trip
+            model.set_drop_rate(1.0);
+            delay(rtt * 1).await;
+
+            // now let the rest of the packets through
+            model.set_drop_rate(0.0);
+        });
+
+        Ok(addr)
+    })
+    .unwrap();
+
+    // MTU remained jumbo despite the packet loss
+    assert_eq!(8943, events.lock().unwrap().last().unwrap().mtu);
+}
+
+// if the MTU is decreased after an MTU probe previously raised the MTU for the path,
+// we detect an MTU black hole and decrease the MTU to the minimum
+#[test]
+fn mtu_blackhole() {
+    let model = Model::default();
+    let rtt = Duration::from_millis(100);
+    let max_mtu = 9001;
+    let subscriber = MtuUpdatedRecorder::new();
+    let events = subscriber.events();
+
+    model.set_delay(rtt / 2);
+    model.set_max_udp_payload(max_mtu);
+
+    test(model.clone(), |handle| {
+        let server = Server::builder()
+            .with_io(handle.builder().with_max_mtu(max_mtu).build()?)?
+            .with_tls(SERVER_CERTS)?
+            .with_event(subscriber)?
+            .start()?;
+        let client = Client::builder()
+            .with_io(handle.builder().with_max_mtu(max_mtu).build()?)?
+            .with_tls(certificates::CERT_PEM)?
+            .start()?;
+        let addr = start_server(server)?;
+        // we need a large payload to allow for multiple rounds of MTU probing
+        start_client(client, addr, Data::new(10_000_000))?;
+
+        spawn(async move {
+            // let all packets go through for 10 RTTs - this will reach the end of MTU probing
+            model.set_drop_rate(0.0);
+            delay(rtt * 10).await;
+
+            // decrease the MTU to trigger a blackhole
+            model.set_max_udp_payload(1200);
+        });
+
+        Ok(addr)
+    })
+    .unwrap();
+
+    // MTU dropped to the minimum
+    assert_eq!(1200, events.lock().unwrap().last().unwrap().mtu);
+}


### PR DESCRIPTION
### Resolved issues:

resolves #1680

### Description of changes: 

This change decreases the sensitivity of MTU black hole detection by requiring >3 distinct bursts of packet loss to trigger a blackhole, rather then >3 individual packets. 

### Call-outs:

I had to update the `interceptor_failure_test`, as it was not panicking anymore after this change. I guess the decreased likely hood of a blackhole meant a higher MTU was maintained and all the data was being transmitted before the test would time out as expected.

### Testing:

Added integration tests and updated existing unit tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

