### PR TITLE
fix(s2n-quic-core): enforce max data limit size for stream and connection

### DIFF
--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -74,7 +74,7 @@ impl Default for Limits {
 }
 
 macro_rules! setter {
-    ($name:ident, $field:ident, $inner:ty $(, $validate_value:ident, $validaiton:tt)?) => {
+    ($name:ident, $field:ident, $inner:ty $(, |$validate_value:ident| $validaiton:block)?) => {
         pub fn $name(mut self, value: $inner) -> Result<Self, ValidationError> {
             $(
                 let $validate_value = value;
@@ -116,21 +116,20 @@ impl Limits {
     //
     // By representing the flow control value as a u32, we save space
     // on the connection state.
-    setter!(with_data_window, data_window, u64, validate_value, {
+    setter!(with_data_window, data_window, u64, |validate_value| {
         decoder_invariant!(
             validate_value <= u32::MAX.into(),
-            "data_window must be less than u32::MAX"
+            "data_window must be <= u32::MAX"
         );
     });
     setter!(
         with_bidirectional_local_data_window,
         bidirectional_local_data_window,
         u64,
-        validate_value,
-        {
+        |validate_value| {
             decoder_invariant!(
                 validate_value <= u32::MAX.into(),
-                "bidirectional_local_data_window must be less than u32::MAX"
+                "bidirectional_local_data_window must be <= u32::MAX"
             );
         }
     );
@@ -138,11 +137,10 @@ impl Limits {
         with_bidirectional_remote_data_window,
         bidirectional_remote_data_window,
         u64,
-        validate_value,
-        {
+        |validate_value| {
             decoder_invariant!(
                 validate_value <= u32::MAX.into(),
-                "bidirectional_remote_data_window must be less than u32::MAX"
+                "bidirectional_remote_data_window must be <= u32::MAX"
             );
         }
     );
@@ -150,11 +148,10 @@ impl Limits {
         with_unidirectional_data_window,
         unidirectional_data_window,
         u64,
-        validate_value,
-        {
+        |validate_value| {
             decoder_invariant!(
                 validate_value <= u32::MAX.into(),
-                "unidirectional_data_window must be less than u32::MAX"
+                "unidirectional_data_window must be <= u32::MAX"
             );
         }
     );

--- a/quic/s2n-quic-qns/src/perf.rs
+++ b/quic/s2n-quic-qns/src/perf.rs
@@ -110,23 +110,22 @@ pub struct Limits {
 
 impl Limits {
     pub fn limits(&self) -> s2n_quic::provider::limits::Limits {
-        let buffer_size = self.buffer_size();
-        let max_limit = u32::MAX as u64;
+        let data_window = self.data_window();
 
         s2n_quic::provider::limits::Limits::default()
-            .with_data_window(max_limit)
+            .with_data_window(data_window)
             .unwrap()
-            .with_max_send_buffer_size(buffer_size.min(u32::MAX as _) as _)
+            .with_max_send_buffer_size(data_window.min(u32::MAX as _) as _)
             .unwrap()
-            .with_bidirectional_local_data_window(max_limit)
+            .with_bidirectional_local_data_window(data_window)
             .unwrap()
-            .with_bidirectional_remote_data_window(max_limit)
+            .with_bidirectional_remote_data_window(data_window)
             .unwrap()
-            .with_unidirectional_data_window(max_limit)
+            .with_unidirectional_data_window(data_window)
             .unwrap()
     }
 
-    fn buffer_size(&self) -> u64 {
+    fn data_window(&self) -> u64 {
         s2n_quic_core::transport::parameters::compute_data_window(
             self.max_throughput,
             core::time::Duration::from_millis(self.expected_rtt),

--- a/quic/s2n-quic-qns/src/perf.rs
+++ b/quic/s2n-quic-qns/src/perf.rs
@@ -110,22 +110,23 @@ pub struct Limits {
 
 impl Limits {
     pub fn limits(&self) -> s2n_quic::provider::limits::Limits {
-        let data_window = self.data_window();
+        let buffer_size = self.buffer_size();
+        let max_limit = u32::MAX as u64;
 
         s2n_quic::provider::limits::Limits::default()
-            .with_data_window(data_window)
+            .with_data_window(max_limit)
             .unwrap()
-            .with_max_send_buffer_size(data_window.min(u32::MAX as _) as _)
+            .with_max_send_buffer_size(buffer_size.min(u32::MAX as _) as _)
             .unwrap()
-            .with_bidirectional_local_data_window(data_window)
+            .with_bidirectional_local_data_window(max_limit)
             .unwrap()
-            .with_bidirectional_remote_data_window(data_window)
+            .with_bidirectional_remote_data_window(max_limit)
             .unwrap()
-            .with_unidirectional_data_window(data_window)
+            .with_unidirectional_data_window(max_limit)
             .unwrap()
     }
 
-    fn data_window(&self) -> u64 {
+    fn buffer_size(&self) -> u64 {
         s2n_quic_core::transport::parameters::compute_data_window(
             self.max_throughput,
             core::time::Duration::from_millis(self.expected_rtt),

--- a/quic/s2n-quic-transport/src/stream/manager.rs
+++ b/quic/s2n-quic-transport/src/stream/manager.rs
@@ -225,7 +225,14 @@ impl<S: StreamTrait> StreamManagerState<S> {
         // limits for the various combinations of unidirectional/bidirectional
         // Streams. Those would bloat up the config, and essentially just
         // duplicate the transport parameters.
-        debug_assert!(
+
+        // We limit the initial data limit to u32::MAX (4GB), which far
+        // exceeds the reasonable amount of data a connection is
+        // initially allowed to send.
+        //
+        // By representing the flow control value as a u32, we save space
+        // on the connection state.
+        assert!(
             initial_receive_window <= VarInt::from_u32(core::u32::MAX),
             "Receive window must not exceed 32bit range"
         );
@@ -426,7 +433,13 @@ impl<S: StreamTrait> AbstractStreamManager<S> {
         initial_local_limits: InitialFlowControlLimits,
         initial_peer_limits: InitialFlowControlLimits,
     ) -> Self {
-        debug_assert!(
+        // We limit the initial data limit to u32::MAX (4GB), which far
+        // exceeds the reasonable amount of data a connection is
+        // initially allowed to send.
+        //
+        // By representing the flow control value as a u32, we save space
+        // on the connection state.
+        assert!(
             initial_local_limits.max_data <= VarInt::from_u32(core::u32::MAX),
             "Receive window must not exceed 32bit range"
         );

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -7,6 +7,7 @@ use crate::{
         self,
         event::{events::PacketSent, ConnectionInfo, ConnectionMeta, Subscriber},
         io::testing::{rand, spawn, test, time::delay, Model},
+        limits::Limits,
         packet_interceptor::Loss,
     },
     Client, Server,
@@ -570,4 +571,22 @@ fn mtu_blackhole() {
 
     // MTU dropped to the minimum
     assert_eq!(1200, events.lock().unwrap().last().unwrap().mtu);
+}
+
+// Local max data limits should be <= u32::MAX
+#[test]
+fn limit_validation() {
+    let mut limit = u32::MAX as u64 + 1;
+    let limits = Limits::default();
+    assert!(limits.with_data_window(limit).is_err());
+    assert!(limits.with_bidirectional_local_data_window(limit).is_err());
+    assert!(limits.with_bidirectional_remote_data_window(limit).is_err());
+    assert!(limits.with_unidirectional_data_window(limit).is_err());
+
+    limit = u32::MAX as u64;
+    let limits = Limits::default();
+    assert!(limits.with_data_window(limit).is_ok());
+    assert!(limits.with_bidirectional_local_data_window(limit).is_ok());
+    assert!(limits.with_bidirectional_remote_data_window(limit).is_ok());
+    assert!(limits.with_unidirectional_data_window(limit).is_ok());
 }

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -576,17 +576,16 @@ fn mtu_blackhole() {
 // Local max data limits should be <= u32::MAX
 #[test]
 fn limit_validation() {
-    let mut limit = u32::MAX as u64 + 1;
+    let mut data = u32::MAX as u64 + 1;
     let limits = Limits::default();
-    assert!(limits.with_data_window(limit).is_err());
-    assert!(limits.with_bidirectional_local_data_window(limit).is_err());
-    assert!(limits.with_bidirectional_remote_data_window(limit).is_err());
-    assert!(limits.with_unidirectional_data_window(limit).is_err());
+    assert!(limits.with_data_window(data).is_err());
+    assert!(limits.with_bidirectional_local_data_window(data).is_err());
+    assert!(limits.with_bidirectional_remote_data_window(data).is_err());
+    assert!(limits.with_unidirectional_data_window(data).is_err());
 
-    limit = u32::MAX as u64;
-    let limits = Limits::default();
-    assert!(limits.with_data_window(limit).is_ok());
-    assert!(limits.with_bidirectional_local_data_window(limit).is_ok());
-    assert!(limits.with_bidirectional_remote_data_window(limit).is_ok());
-    assert!(limits.with_unidirectional_data_window(limit).is_ok());
+    data = u32::MAX as u64;
+    assert!(limits.with_data_window(data).is_ok());
+    assert!(limits.with_bidirectional_local_data_window(data).is_ok());
+    assert!(limits.with_bidirectional_remote_data_window(data).is_ok());
+    assert!(limits.with_unidirectional_data_window(data).is_ok());
 }


### PR DESCRIPTION
### Resolved issues:
https://github.com/aws/s2n-quic/issues/1675

### Description of changes: 
[Limits::with_data_window](https://docs.rs/s2n-quic/latest/s2n_quic/provider/limits/struct.Limits.html#method.with_data_window) accepts a u64 and is a limit specified by our users. In the `debug` build, we currently enforce that max_data limit is [<= u32::MAX](https://github.com/aws/s2n-quic/blob/5ba26ae6d243d1ad53d518245064e2d592a246f9/quic/s2n-quic-transport/src/stream/manager.rs#L429-L432) with a debug_assert. In the `release` build, the debug_assert is compiled out and applications can erroneously provide a value larger than u32::MAX.

This PR adds validation to the Limits builder which checks the value is less than u32 and provides a better user error. I also added comments on why its reasonable to restrict the value to u32 in this case. Finally, I convert the debug_asset into an assert to ensure we do no accidentally revert this change and re-introduce the bug only for the release build.

### Call-outs:
**Note** that is issue actually applies to 4 data limits:
- [with_data_window](https://github.com/aws/s2n-quic/blob/5ba26ae6d243d1ad53d518245064e2d592a246f9/quic/s2n-quic-transport/src/stream/manager.rs#L429-L432)
- [with_bidirectional_local_data_window, with_bidirectional_remote_data_window, with_unidirectional_data_window](https://github.com/aws/s2n-quic/blob/5ba26ae6d243d1ad53d518245064e2d592a246f9/quic/s2n-quic-transport/src/stream/manager.rs#L228-L231)

**Note** that the limits are backed by a [IncrementalValueSync](https://github.com/aws/s2n-quic/blob/69678368872f65c7286225d4e3b3b3d6624bed3e/quic/s2n-quic-transport/src/sync/incremental_value_sync.rs#L13-L26) which will periodically update a bigger value to the remote endpoint so restricting the initial value to u32 is not a loss of functionality.

### Testing:
- Repro the bug: I ran tests against the original code and confirmed that we were getting overflow and UB based on the overflow value.
- I have set the perf runner to use the max value (u32::MAX) as its limit. 
- Validated the fix locally
  - by providing values >u32::MAX and getting a ValidationError
  - running perf with a large transfer and confirming a successful run ` 482s s2n_quic:server:conn: packet_header=OneRtt { number: 28672209 } frame=Stream { id: 0, offset: 40294967189 } ...`

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

