### PR TITLE
fix(s2n-quic-core): Advance max bw filter only once per probe bw cycle

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bbr/data_rate.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/data_rate.rs
@@ -147,6 +147,11 @@ impl Model {
         //#   BBR.bw = min(BBR.max_bw, BBR.bw_lo, BBR.bw_hi)
         self.bw = self.max_bw().min(self.bw_lo()).min(self.bw_hi())
     }
+
+    #[cfg(test)]
+    pub fn cycle_count(&self) -> u8 {
+        self.cycle_count.0
+    }
 }
 
 #[cfg(test)]

--- a/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__probe_bw__events__update_ack_phase.snap
+++ b/quic/s2n-quic-core/src/recovery/bbr/snapshots/quic__s2n-quic-core__src__recovery__bbr__probe_bw__events__update_ack_phase.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+expression: ""
+---
+BbrStateChanged { path_id: 0, state: ProbeBwDown }


### PR DESCRIPTION
### Description of changes: 

BBRv2 uses a `WindowedMaxFilter` of size 2 to track the maximum bandwidth sample that had been obtained over the current bandwidth probing cycle and the previous bandwidth probing cycle. The way this is supposed to work is each time BBR completes a cycle from ProbeBW_Down -> ProbeBW_Cruise -> ProbeBW_Refill -> ProbeBW_Up, a counter is incremented. 

This can be seen in the [BBR draft RFC](https://www.ietf.org/archive/id/draft-cardwell-iccrg-bbr-congestion-control-02.html#section-4.3.3.6-8) pseudo-code. `BBRAdvanceMaxBwFilter()` increments the counter:

```
if (BBR.ack_phase == ACKS_PROBE_STOPPING and BBR.round_start)
      /* end of samples from bw probing phase */
      if (IsInAProbeBWState() and !rs.is_app_limited)
        BBRAdvanceMaxBwFilter()
```

Unfortunetly this pseudocode does not change the `BBR.ack_phase`, which allows the `BBRAdvanceMaxBwFilter()` function to be called multiple times within the same bandwidth probing cycle.

This is addressed in the [Linux TCP BBRv2](https://github.com/google/bbr/blob/cf9b1dacabb1ef62481a452f7f169e1679e2da49/net/ipv4/tcp_bbr2.c#L1906-L1909) implementation by setting the ACK phase to the `Init` phase, ensuring that the max bandwidth counter is only incremented once: 
```c
if (bbr->ack_phase == BBR_ACKS_PROBE_STOPPING && bbr->round_start) {
	/* End of samples from bw probing phase. */
	bbr->bw_probe_samples = 0;
	bbr->ack_phase = BBR_ACKS_INIT;
```

This change follows the Linux TCP BBRv2 implementation and transitions the ack phase to `AckPhase::Init` from `AckPhase::ProbeStopping`

### Testing:

Added a unit test and updated others

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

