### PR TITLE
feat(s2n-quic-qns): Add max pacing rate and delivery rate to perf stats

### DIFF
--- a/quic/s2n-quic-qns/src/perf.rs
+++ b/quic/s2n-quic-qns/src/perf.rs
@@ -310,7 +310,31 @@ impl Counters {
         let max_delivery_rate = self.max_delivery_rate.swap(0, Ordering::Relaxed);
         let max_delivery_rate = rate(max_delivery_rate, Duration::from_secs(1));
         eprintln!(
-            "{send_rate}\t{receive_rate}\t{max_cwnd}\t{max_bytes_in_flight}\t{lost_packets}\t{wakeups}\t{duration:?}\t{max_rtt:?}\t{max_smoothed_rtt:?}\t{pto_count}\t{max_pacing_rate}\t{max_delivery_rate}",
+            "\
+            // The goodput of data transmitted to the peer
+            {send_rate}\t\
+            // The goodput of data received from the peer
+            {receive_rate}\t\
+            // The maximum congestion window observed during the interval
+            {max_cwnd}\t\
+            // The maximum amount of unacknowledged data in flight during the interval
+            {max_bytes_in_flight}\t\
+            // The number of packets recorded lost during the interval
+            {lost_packets}\t\
+            // The number of event loop wakeups recorded during the interval
+            {wakeups}\t\
+            // The duration of the latest event loop wakeup
+            {duration:?}\t\
+            // The maximum round trip time observed during the interval
+            {max_rtt:?}\t\
+            // The maximum smoothed (weighted average) round trip time observed during the interval
+            {max_smoothed_rtt:?}\t\
+            // The number of packet time out events observed during the interval
+            {pto_count}\t\
+            // The maximum rate at which packets are paced out observed during the interval
+            {max_pacing_rate}\t\
+            // The maximum estimate of bandwidth observed during the interval. Only output for BBRv2
+            {max_delivery_rate}",
         );
     }
 }

--- a/quic/s2n-quic-qns/src/perf.rs
+++ b/quic/s2n-quic-qns/src/perf.rs
@@ -301,7 +301,8 @@ impl Counters {
             Max SRTT\t\
             PTO Count\t\
             Max Pacing Rate\t\
-            Max Delivery Rate");
+            Max Delivery Rate"
+        );
     }
 
     pub fn print(&self, duration: Duration) {


### PR DESCRIPTION
### Description of changes: 

This change adds the maximum pacing rate and maximum delivery rate that has been observed over the reporting interval to the stats output from the Perf client and server. I've also added a header to the output.

### Call-outs:

Delivery rate is only recorded for BBRv2, so if CUBIC is being used this will always report 0bps.

### Testing:

Ran the perf client:

```
Tx Rate Rx Rate Max Cwnd        Max Inflight    Lost Packets    Wakeups Duration        Max RTT Max SRTT        PTO Count       Max Pacing Rate Max Delivery Rate
435.67Mbps      0bps    1.93MB  1.84MB  0       769     26.492ms        30.159ms        18.832736ms     0       872.70Mbps      642.06Mbps
443.62Mbps      0bps    6.30MB  3.86MB  0       791     83.642ms        62.176ms        45.982567ms     0       635.68Mbps      535.11Mbps
479.89Mbps      0bps    12.58MB 3.87MB  0       666     76.469ms        61.861ms        46.870825ms     0       794.57Mbps      509.45Mbps
479.91Mbps      0bps    18.32MB 3.87MB  0       672     77.935ms        62.372ms        46.312216ms     0       635.68Mbps      508.35Mbps
479.91Mbps      0bps    24.47MB 3.87MB  0       675     99.391ms        62.204ms        46.674211ms     0       794.57Mbps      509.96Mbps
434.74Mbps      0bps    29.46MB 3.87MB  0       711     26.479ms        64.434ms        49.190922ms     0       635.68Mbps      512.93Mbps
```

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

