### PR TITLE
feat(s2n-quic-xdp): add ring module

### DIFF
--- a/tools/xdp/s2n-quic-xdp/src/lib.rs
+++ b/tools/xdp/s2n-quic-xdp/src/lib.rs
@@ -9,6 +9,10 @@ type Result<T = (), E = std::io::Error> = core::result::Result<T, E>;
 mod if_xdp;
 /// Helpers for creating mmap'd regions
 mod mmap;
+/// Structures for tracking ring cursors and synchronizing with the kernel
+mod ring;
+/// Structure for opening and reference counting an AF-XDP socket
+mod socket;
 /// Helpers for making API calls to AF-XDP sockets
 mod syscall;
 /// A shared region of memory for holding frame (packet) data

--- a/tools/xdp/s2n-quic-xdp/src/ring.rs
+++ b/tools/xdp/s2n-quic-xdp/src/ring.rs
@@ -1,0 +1,175 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    if_xdp::{MmapOffsets, RxTxDescriptor, UmemDescriptor},
+    mmap::Mmap,
+    socket, syscall,
+};
+use core::{fmt, mem::size_of};
+use std::{io, os::fd::AsRawFd};
+
+mod cursor;
+
+use cursor::Cursor;
+
+#[derive(Debug)]
+struct Ring<T: Copy + fmt::Debug> {
+    cursor: Cursor<T>,
+    area: Mmap,
+    socket: socket::Fd,
+}
+
+/// Safety: the Mmap area is held for as long as the Cursor
+unsafe impl<T: Copy + fmt::Debug> Send for Ring<T> {}
+
+/// Safety: the Mmap area is held for as long as the Cursor
+unsafe impl<T: Copy + fmt::Debug> Sync for Ring<T> {}
+
+macro_rules! impl_producer {
+    ($T:ty, $syscall:ident, $field:ident, $offset:ident) => {
+        /// Creates a new ring with the given configuration
+        pub fn new(socket: socket::Fd, offsets: &MmapOffsets, size: u32) -> io::Result<Self> {
+            syscall::$syscall(&socket, size)?;
+            let offsets = &offsets.$field;
+
+            let len = offsets.desc as usize + size as usize * size_of::<$T>();
+            let offset = MmapOffsets::$offset;
+
+            let area = Mmap::new(len, offset, Some(socket.as_raw_fd()))?;
+
+            let mut cursor = unsafe { Cursor::new(&area, offsets, size) };
+
+            // initialize the cached producer cursor
+            cursor.acquire_producer(u32::MAX);
+
+            Ok(Self(Ring {
+                cursor,
+                area,
+                socket,
+            }))
+        }
+
+        /// Acquire a number of entries for the ring
+        ///
+        /// If the cached length is lower than the provided `watermark` no synchronization will be
+        /// performed.
+        #[inline]
+        pub fn acquire(&mut self, watermark: u32) -> u32 {
+            self.0.cursor.acquire_producer(watermark)
+        }
+
+        /// Releases `len` number of entries to the consumer side of the ring.
+        ///
+        /// # Panics
+        ///
+        /// If the `len` exceeds the number of acquired entries, this function will panic.
+        #[inline]
+        pub fn release(&mut self, len: u32) {
+            self.0.cursor.release_producer(len)
+        }
+
+        /// Returns `true` if the ring needs to be woken up in order to notify the kernel
+        #[inline]
+        pub fn needs_wakeup(&self) -> bool {
+            self.0.cursor.needs_wakeup()
+        }
+
+        /// Returns the unfilled entries for the producer
+        ///
+        /// After filling `n` entries, the `release` function should be called with `n`.
+        #[inline]
+        pub fn data(&mut self) -> (&mut [$T], &mut [$T]) {
+            unsafe {
+                // Safety: this is the producer for the ring
+                self.0.cursor.producer_data()
+            }
+        }
+    };
+}
+
+macro_rules! impl_consumer {
+    ($T:ty, $syscall:ident, $field:ident, $offset:ident) => {
+        /// Creates a new ring with the given configuration
+        pub fn new(socket: socket::Fd, offsets: &MmapOffsets, size: u32) -> io::Result<Self> {
+            syscall::$syscall(&socket, size)?;
+            let offsets = &offsets.$field;
+
+            let len = offsets.desc as usize + size as usize * size_of::<$T>();
+            let offset = MmapOffsets::$offset;
+
+            let area = Mmap::new(len, offset, Some(socket.as_raw_fd()))?;
+
+            let cursor = unsafe { Cursor::new(&area, offsets, size) };
+
+            Ok(Self(Ring {
+                cursor,
+                area,
+                socket,
+            }))
+        }
+
+        /// Acquire a number of entries for the ring
+        ///
+        /// If the cached length is lower than the provided `watermark` no synchronization will be
+        /// performed.
+        #[inline]
+        pub fn acquire(&mut self, watermark: u32) -> u32 {
+            self.0.cursor.acquire_consumer(watermark)
+        }
+
+        /// Releases `len` number of entries to the producer side of the ring.
+        ///
+        /// # Panics
+        ///
+        /// If the `len` exceeds the number of acquired entries, this function will panic.
+        #[inline]
+        pub fn release(&mut self, len: u32) {
+            self.0.cursor.release_consumer(len)
+        }
+
+        /// Returns the filled entries for the consumer
+        ///
+        /// After filling `n` entries, the `release` function should be called with `n`.
+        #[inline]
+        pub fn data(&mut self) -> (&mut [$T], &mut [$T]) {
+            unsafe {
+                // Safety: this is the consumer for the ring
+                self.0.cursor.consumer_data()
+            }
+        }
+    };
+}
+
+/// A transmission ring for entries to be transmitted
+pub struct Tx(Ring<RxTxDescriptor>);
+
+impl Tx {
+    impl_producer!(RxTxDescriptor, set_tx_ring_size, tx, TX_RING);
+}
+
+/// A receive ring for entries to be processed
+pub struct Rx(Ring<RxTxDescriptor>);
+
+impl Rx {
+    impl_consumer!(RxTxDescriptor, set_rx_ring_size, rx, RX_RING);
+}
+
+/// The fill ring for entries to be populated
+pub struct Fill(Ring<UmemDescriptor>);
+
+impl Fill {
+    impl_producer!(UmemDescriptor, set_fill_ring_size, fill, FILL_RING);
+}
+
+/// The completion ring for entries to be reused for transmission
+pub struct Completion(Ring<UmemDescriptor>);
+
+impl Completion {
+    impl_consumer!(
+        UmemDescriptor,
+        set_completion_ring_size,
+        completion,
+        COMPLETION_RING
+    );
+}

--- a/tools/xdp/s2n-quic-xdp/src/ring/__fuzz__/ring__cursor__tests__oracle/corpus.tar.gz
+++ b/tools/xdp/s2n-quic-xdp/src/ring/__fuzz__/ring__cursor__tests__oracle/corpus.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:344f72daf5c8935b99a7dbef2d9a0cf41c70d3f84c678e1d736793f4d9c3b4db
+size 3768320

--- a/tools/xdp/s2n-quic-xdp/src/ring/cursor.rs
+++ b/tools/xdp/s2n-quic-xdp/src/ring/cursor.rs
@@ -1,0 +1,446 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    if_xdp::{RingFlags, RingOffsetV2},
+    mmap::Mmap,
+};
+use core::{
+    ffi::c_void,
+    fmt,
+    marker::PhantomData,
+    num::Wrapping,
+    ptr::NonNull,
+    sync::atomic::{AtomicU32, Ordering},
+};
+
+/// A structure for tracking a ring shared between a producer and consumer
+///
+/// See [xsk.h](https://github.com/xdp-project/xdp-tools/blob/a76e7a2b156b8cfe38992206abe9df1df0a29e38/headers/xdp/xsk.h#L34-L42).
+#[derive(Debug)]
+pub struct Cursor<T: Copy + fmt::Debug> {
+    /// A cached value for the producer cursor index
+    ///
+    /// This is stored locally to avoid atomic synchronization, if possible
+    cached_producer: Wrapping<u32>,
+    /// A cached value for the consumer cursor index
+    ///
+    /// This is stored locally to avoid atomic synchronization, if possible
+    cached_consumer: Wrapping<u32>,
+    /// The number of entries in the ring
+    ///
+    /// This value MUST be a power of two
+    size: u32,
+    /// A mask value to ensure validity of cursor indexes
+    ///
+    /// This value assumes that the size of the ring is a power of two
+    mask: u32,
+    /// Points to the producer cursor index
+    producer: NonNull<AtomicU32>,
+    /// Points to the consumer cursor index
+    consumer: NonNull<AtomicU32>,
+    /// Points to the shared flags for the ring
+    flags: NonNull<RingFlags>,
+    /// Points to the descriptor values in the ring
+    desc: NonNull<c_void>,
+    /// Holds the type of the entries in the ring
+    entry: PhantomData<T>,
+}
+
+impl<T: Copy + fmt::Debug> Cursor<T> {
+    /// Creates a cursor structure from a shared memory region and configured offsets
+    ///
+    /// # Safety
+    ///
+    /// The `Cursor` structure holds references to the provided `area` argument. As such, the
+    /// `area` MUST outlive the `Cursors` structure.
+    ///
+    /// The provided `T` MUST be the type of data pointed to by the `desc` offset.
+    ///
+    /// The `size` MUST be a power of two.
+    #[inline]
+    pub unsafe fn new(area: &Mmap, offsets: &RingOffsetV2, size: u32) -> Self {
+        debug_assert!(size.is_power_of_two());
+
+        let mask = size - 1;
+
+        let producer = area.addr().as_ptr().add(offsets.producer as _);
+        let producer = NonNull::new_unchecked(producer as _);
+        let consumer = area.addr().as_ptr().add(offsets.consumer as _);
+        let consumer = NonNull::new_unchecked(consumer as _);
+
+        let flags = area.addr().as_ptr().add(offsets.flags as _);
+        let flags = NonNull::new_unchecked(flags as *mut RingFlags);
+
+        let desc = area.addr().as_ptr().add(offsets.desc as _);
+        let desc = NonNull::new_unchecked(desc);
+
+        Self {
+            cached_consumer: Wrapping(0),
+            cached_producer: Wrapping(0),
+            size,
+            mask,
+            producer,
+            consumer,
+            flags,
+            desc,
+            entry: PhantomData,
+        }
+    }
+
+    /// Returns a reference to the producer atomic cursor
+    #[inline]
+    pub fn producer(&self) -> &AtomicU32 {
+        unsafe { &*self.producer.as_ptr() }
+    }
+
+    /// Returns a reference to the producer atomic cursor
+    #[inline]
+    pub fn consumer(&self) -> &AtomicU32 {
+        unsafe { &*self.consumer.as_ptr() }
+    }
+
+    /// Acquires a cursor index for a producer half
+    ///
+    /// The `watermark` can be provided to avoid synchronization by reusing the cached cursor
+    /// value.
+    ///
+    /// See [xsk.h](https://github.com/xdp-project/xdp-tools/blob/a76e7a2b156b8cfe38992206abe9df1df0a29e38/headers/xdp/xsk.h#L92).
+    #[inline]
+    pub fn acquire_producer(&mut self, watermark: u32) -> u32 {
+        let free = self.cached_producer_len();
+
+        // if we have enough space, then return the cached value
+        if free >= watermark {
+            return free;
+        }
+
+        self.cached_consumer.0 = self.consumer().load(Ordering::Acquire);
+
+        // increment the consumer cursor by the total size to avoid doing an addition inside
+        // `cached_producer`
+        //
+        // See
+        // https://github.com/xdp-project/xdp-tools/blob/a76e7a2b156b8cfe38992206abe9df1df0a29e38/headers/xdp/xsk.h#L99-L104
+        self.cached_consumer += self.size;
+
+        self.cached_producer_len()
+    }
+
+    /// Returns the cached producer cursor which is also maxed by the cursor mask
+    ///
+    /// See [xsk.h](https://github.com/xdp-project/xdp-tools/blob/a76e7a2b156b8cfe38992206abe9df1df0a29e38/headers/xdp/xsk.h#L60).
+    #[inline]
+    pub fn cached_producer(&self) -> u32 {
+        self.cached_producer.0 & self.mask
+    }
+
+    /// Returns the cached number of available entries for the consumer
+    ///
+    /// See [xsk.h](https://github.com/xdp-project/xdp-tools/blob/a76e7a2b156b8cfe38992206abe9df1df0a29e38/headers/xdp/xsk.h#L94).
+    #[inline]
+    pub fn cached_producer_len(&self) -> u32 {
+        (self.cached_consumer - self.cached_producer).0
+    }
+
+    /// Releases a `len` number of entries from the producer to the consumer.
+    ///
+    /// See [xsk.h](https://github.com/xdp-project/xdp-tools/blob/a76e7a2b156b8cfe38992206abe9df1df0a29e38/headers/xdp/xsk.h#L135).
+    ///
+    /// The provided `len` should not exceed the number from `acquire_producer`. With
+    /// debug_assertions enabled, this will panic if it occurs.
+    #[inline]
+    pub fn release_producer(&mut self, len: u32) {
+        if cfg!(debug_assertions) {
+            let max_len = self.cached_producer_len();
+            assert!(
+                max_len >= len,
+                "available: {}, requested: {}, {self:?}",
+                max_len,
+                len
+            );
+        }
+        self.cached_producer += len;
+        self.producer().fetch_add(len, Ordering::Release);
+    }
+
+    /// Acquires a cursor index for a consumer half
+    ///
+    /// The `watermark` can be provided to avoid synchronization by reusing the cached cursor
+    /// value.
+    ///
+    /// See [xsk.h](https://github.com/xdp-project/xdp-tools/blob/a76e7a2b156b8cfe38992206abe9df1df0a29e38/headers/xdp/xsk.h#L112).
+    #[inline]
+    pub fn acquire_consumer(&mut self, watermark: u32) -> u32 {
+        let filled = self.cached_consumer_len();
+
+        if filled >= watermark {
+            return filled;
+        }
+
+        self.cached_producer.0 = self.producer().load(Ordering::Acquire);
+
+        self.cached_consumer_len()
+    }
+
+    /// Returns the cached consumer cursor which is also maxed by the cursor mask
+    ///
+    /// See [xsk.h](https://github.com/xdp-project/xdp-tools/blob/a76e7a2b156b8cfe38992206abe9df1df0a29e38/headers/xdp/xsk.h#L68).
+    #[inline]
+    pub fn cached_consumer(&self) -> u32 {
+        self.cached_consumer.0 & self.mask
+    }
+
+    /// Returns the cached number of available entries for the consumer
+    ///
+    /// See [xsk.h](https://github.com/xdp-project/xdp-tools/blob/a76e7a2b156b8cfe38992206abe9df1df0a29e38/headers/xdp/xsk.h#L114).
+    #[inline]
+    pub fn cached_consumer_len(&mut self) -> u32 {
+        (self.cached_producer - self.cached_consumer).0
+    }
+
+    /// Releases a `len` number of entries from the consumer to the producer.
+    ///
+    /// See [xsk.h](https://github.com/xdp-project/xdp-tools/blob/a76e7a2b156b8cfe38992206abe9df1df0a29e38/headers/xdp/xsk.h#L160).
+    ///
+    /// The provided `len` should not exceed the number from `acquire_consumer`. With
+    /// debug_assertions enabled, this will panic if it occurs.
+    #[inline]
+    pub fn release_consumer(&mut self, len: u32) {
+        if cfg!(debug_assertions) {
+            let max_len = self.cached_consumer_len();
+            assert!(
+                max_len >= len,
+                "available: {}, requested: {}, {self:?}",
+                max_len,
+                len
+            );
+        }
+        self.cached_consumer += len;
+        self.consumer().fetch_add(len, Ordering::Release);
+    }
+
+    /// Returns `true` if the ring needs to be notified when entries are updated
+    ///
+    /// See [xsk.h](https://github.com/xdp-project/xdp-tools/blob/a76e7a2b156b8cfe38992206abe9df1df0a29e38/headers/xdp/xsk.h#L87).
+    #[inline]
+    pub fn needs_wakeup(&self) -> bool {
+        self.flags().contains(RingFlags::NEED_WAKEUP)
+    }
+
+    /// Returns a reference to the flags on the ring
+    #[inline]
+    pub fn flags(&self) -> &RingFlags {
+        unsafe { &*self.flags.as_ptr() }
+    }
+
+    /// Returns the current consumer entries
+    ///
+    /// # Safety
+    ///
+    /// This function MUST only be used by the consumer side.
+    #[inline]
+    pub unsafe fn consumer_data(&mut self) -> (&mut [T], &mut [T]) {
+        let idx = self.cached_consumer();
+        let len = self.cached_consumer_len();
+
+        self.mut_slices(idx as _, len as _)
+    }
+
+    /// Returns the current producer entries
+    ///
+    /// # Safety
+    ///
+    /// This function MUST only be used by the producer side.
+    #[inline]
+    pub unsafe fn producer_data(&mut self) -> (&mut [T], &mut [T]) {
+        let idx = self.cached_producer();
+        let len = self.cached_producer_len();
+
+        self.mut_slices(idx as _, len as _)
+    }
+
+    /// Creates a pair of slices for a given cursor index and len
+    #[inline]
+    fn mut_slices(&mut self, idx: u64, len: u64) -> (&mut [T], &mut [T]) {
+        if len == 0 {
+            return (&mut [][..], &mut [][..]);
+        }
+
+        let ptr = self.desc.as_ptr() as *mut T;
+
+        if let Some(tail_len) = (idx + len).checked_sub(self.size as _) {
+            let head_len = self.size as u64 - idx;
+            debug_assert_eq!(head_len + tail_len, len);
+            let head = unsafe { core::slice::from_raw_parts_mut(ptr.add(idx as _), head_len as _) };
+            let tail = unsafe { core::slice::from_raw_parts_mut(ptr, tail_len as _) };
+            (head, tail)
+        } else {
+            let slice = unsafe { core::slice::from_raw_parts_mut(ptr.add(idx as _), len as _) };
+            (slice, &mut [][..])
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bolero::{check, generator::*};
+    use core::cell::UnsafeCell;
+
+    #[derive(Clone, Copy, Debug, TypeGenerator)]
+    enum Op {
+        ConsumerAcquire(u16),
+        ConsumerRelease(u16),
+        ProducerAcquire(u16),
+        ProducerRelease(u16),
+    }
+
+    /// Implements a FIFO queue with a monotonic value
+    #[derive(Clone, Debug, Default)]
+    struct Oracle {
+        size: u32,
+        producer: u32,
+        producer_value: u32,
+        consumer: u32,
+        consumer_value: u32,
+    }
+
+    impl Oracle {
+        fn acquire_consumer(&mut self, actual: u32) {
+            self.consumer = actual;
+            self.invariants();
+        }
+
+        fn release_consumer(&mut self, count: u16) -> u32 {
+            let count = self.consumer.min(count as u32);
+
+            self.consumer -= count;
+            self.consumer_value += count;
+
+            self.invariants();
+            count
+        }
+
+        fn validate_consumer(&self, (a, b): (&mut [u32], &mut [u32])) {
+            for (actual, expected) in a.iter().chain(b.iter()).zip(self.consumer_value..) {
+                assert_eq!(
+                    expected, *actual,
+                    "entry values should match {a:?} {b:?} {self:?}"
+                );
+            }
+        }
+
+        fn acquire_producer(&mut self, actual: u32) {
+            self.producer = actual;
+            self.invariants();
+        }
+
+        fn release_producer(&mut self, count: u16) -> u32 {
+            let count = self.producer.min(count as u32);
+
+            self.producer -= count;
+            self.producer_value += count;
+
+            self.invariants();
+            count
+        }
+
+        fn fill_producer(&self, (a, b): (&mut [u32], &mut [u32])) {
+            for (entry, value) in a.iter_mut().chain(b).zip(self.producer_value..) {
+                *entry = value;
+            }
+        }
+
+        fn invariants(&self) {
+            assert!(
+                self.size >= self.producer + self.consumer,
+                "The producer and consumer indexes should always be less than the size"
+            );
+        }
+    }
+
+    fn model(power_of_two: u8, ops: &[Op]) {
+        let size = 1 << power_of_two;
+        let mask = size - 1;
+        let producer_v = UnsafeCell::new(AtomicU32::new(0));
+        let consumer_v = UnsafeCell::new(AtomicU32::new(0));
+        let desc = UnsafeCell::new(vec![u32::MAX; size as usize]);
+
+        let producer_v = producer_v.get();
+        let consumer_v = consumer_v.get();
+        let desc = unsafe { (&mut *desc.get()).as_mut_ptr() as *mut _ };
+
+        let mut oracle = Oracle {
+            size,
+            producer: size,
+            ..Default::default()
+        };
+
+        let mut producer: Cursor<u32> = Cursor {
+            cached_consumer: Wrapping(0),
+            cached_producer: Wrapping(0),
+            size,
+            producer: NonNull::new(producer_v).unwrap(),
+            consumer: NonNull::new(consumer_v).unwrap(),
+            desc: NonNull::new(desc).unwrap(),
+            flags: NonNull::dangling(),
+            mask,
+            entry: PhantomData,
+        };
+
+        assert_eq!(producer.acquire_producer(u32::MAX), size);
+
+        let mut consumer: Cursor<u32> = Cursor {
+            cached_consumer: Wrapping(0),
+            cached_producer: Wrapping(0),
+            size,
+            producer: NonNull::new(producer_v).unwrap(),
+            consumer: NonNull::new(consumer_v).unwrap(),
+            desc: NonNull::new(desc).unwrap(),
+            flags: NonNull::dangling(),
+            mask,
+            entry: PhantomData,
+        };
+
+        assert_eq!(consumer.acquire_consumer(u32::MAX), 0);
+
+        for op in ops.iter().copied() {
+            oracle.fill_producer(unsafe { producer.producer_data() });
+
+            match op {
+                Op::ConsumerAcquire(count) => {
+                    let actual = consumer.acquire_consumer(count as _);
+                    oracle.acquire_consumer(actual);
+                }
+                Op::ConsumerRelease(count) => {
+                    let oracle_count = oracle.release_consumer(count);
+                    consumer.release_consumer(oracle_count);
+                }
+                Op::ProducerAcquire(count) => {
+                    let actual = producer.acquire_producer(count as _);
+                    oracle.acquire_producer(actual);
+                }
+                Op::ProducerRelease(count) => {
+                    let oracle_count = oracle.release_producer(count);
+                    producer.release_producer(oracle_count);
+                }
+            }
+
+            oracle.validate_consumer(unsafe { consumer.consumer_data() });
+        }
+
+        // final assertions
+        let actual = consumer.acquire_consumer(u32::MAX);
+        oracle.acquire_consumer(actual);
+        let data = unsafe { consumer.consumer_data() };
+        oracle.validate_consumer(data);
+    }
+
+    #[test]
+    fn oracle_test() {
+        check!()
+            .with_generator((1..=10, gen::<Vec<Op>>()))
+            .for_each(|(power_of_two, ops)| model(*power_of_two, ops));
+    }
+}

--- a/tools/xdp/s2n-quic-xdp/src/socket.rs
+++ b/tools/xdp/s2n-quic-xdp/src/socket.rs
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{syscall, Result};
+use core::fmt;
+use std::{
+    os::fd::{AsRawFd, RawFd},
+    sync::Arc,
+};
+
+/// A structure for reference counting an AF-XDP socket
+#[derive(Clone)]
+pub struct Fd(Arc<Inner>);
+
+impl fmt::Debug for Fd {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_tuple("Fd").field(&(self.0).0).finish()
+    }
+}
+
+impl Fd {
+    /// Opens an AF_XDP socket
+    ///
+    /// This call requires `CAP_NET_RAW` capabilities to succeed.
+    #[inline]
+    pub fn open() -> Result<Self> {
+        let fd = syscall::open()?;
+        let fd = Arc::new(Inner(fd));
+        Ok(Self(fd))
+    }
+}
+
+impl AsRawFd for Fd {
+    #[inline]
+    fn as_raw_fd(&self) -> RawFd {
+        (self.0).0
+    }
+}
+
+/// Wrap the RawFd in a structure that automatically closes the socket on drop
+struct Inner(RawFd);
+
+impl Drop for Inner {
+    fn drop(&mut self) {
+        unsafe {
+            let _ = libc::close(self.0);
+        }
+    }
+}


### PR DESCRIPTION

### Description of changes: 
This change adds the XDP ring data structure for coordinating with the kernel. Most of this code is based on the [xsk.h](https://github.com/xdp-project/xdp-tools/blob/master/headers/xdp/xsk.h) file from the xdp-project.

Each ring type (TX, RX, Fill, Comp) wraps the generic Ring structure and exports a well-typed API.

### Call-outs:

I considered generating bindings from the libxdp project for this. However, the implementation is all contained in the header, which bindgen has a hard time with - none of the meaningful functions are actually exposed. This means this logic has to be either wrapped in a C module or it needs to be ported to Rust. In this case I opted for porting it, since we'd potentially incurring runtime costs without cross-language LTO enabled. It also keeps the build simpler.

### Testing:

I added a bolero test for the ring cursor implementation. It defines a FIFO queue as an oracle and ensures the behavior of the ring matches.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

