### PR TITLE
feat(s2n-quic-xdp): add umem module

### DIFF
--- a/tools/xdp/s2n-quic-xdp/src/lib.rs
+++ b/tools/xdp/s2n-quic-xdp/src/lib.rs
@@ -11,3 +11,5 @@ mod if_xdp;
 mod mmap;
 /// Helpers for making API calls to AF-XDP sockets
 mod syscall;
+/// A shared region of memory for holding frame (packet) data
+mod umem;

--- a/tools/xdp/s2n-quic-xdp/src/umem.rs
+++ b/tools/xdp/s2n-quic-xdp/src/umem.rs
@@ -1,0 +1,242 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    if_xdp::{RxTxDescriptor, UmemDescriptor, UmemFlags, UmemReg},
+    mmap::Mmap,
+    syscall, Result,
+};
+use core::ptr::NonNull;
+use std::{os::fd::AsRawFd, sync::Arc};
+
+#[derive(Clone, Copy, Debug)]
+pub struct Builder {
+    /// The maximum number of bytes a frame can hold (MTU)
+    pub frame_size: u32,
+    /// The number of frames that should be allocated
+    pub frame_count: u32,
+    /// The headroom size for each frame
+    pub frame_headroom: u32,
+    /// The flags for the Umem
+    pub flags: UmemFlags,
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        Self {
+            frame_size: 4096,
+            frame_count: 1024,
+            frame_headroom: 0,
+            flags: Default::default(),
+        }
+    }
+}
+
+impl Builder {
+    pub fn build(self) -> Result<Umem> {
+        let len = self.frame_size as usize * self.frame_count as usize;
+        let area = Mmap::new(len, 0, None)?;
+        let area = Arc::new(area);
+        let mem = area.addr().cast();
+
+        Ok(Umem {
+            area,
+            mem,
+            frame_size: self.frame_size,
+            frame_count: self.frame_count,
+            flags: self.flags,
+            frame_headroom: self.frame_headroom,
+        })
+    }
+}
+
+/// A shared region of memory for holding frame (packet) data
+///
+/// Callers are responsible for correct descriptor allocation. This means only one descriptor
+/// should be alive for each frame. If this invariant is not held, the borrowing rules will be
+/// violated and potentially result in UB.
+#[derive(Clone)]
+pub struct Umem {
+    area: Arc<Mmap>,
+    mem: NonNull<u8>,
+    frame_size: u32,
+    frame_count: u32,
+    frame_headroom: u32,
+    flags: UmemFlags,
+}
+
+impl Umem {
+    /// Creates a Umem builder with defaults
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
+
+    /// Returns the configured size for each frame
+    #[inline]
+    pub fn frame_size(&self) -> u32 {
+        self.frame_size
+    }
+
+    /// Returns the total number of frames in the Umem
+    #[inline]
+    pub fn frame_count(&self) -> u32 {
+        self.frame_count
+    }
+
+    /// Returns the configured headroom for each frame
+    #[inline]
+    pub fn frame_headroom(&self) -> u32 {
+        self.frame_headroom
+    }
+
+    /// Returns the flags for the Umem
+    #[inline]
+    pub fn flags(&self) -> UmemFlags {
+        self.flags
+    }
+
+    /// Returns an iterator over all of the frame descriptors
+    ///
+    /// This can be used to initialize a frame allocator
+    pub fn frames(&self) -> impl Iterator<Item = UmemDescriptor> {
+        let size = self.frame_size as u64;
+        (0..self.frame_count as u64).map(move |idx| UmemDescriptor {
+            address: idx * size,
+        })
+    }
+
+    /// Returns the number of bytes in the Umem
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.area.len()
+    }
+
+    /// Returns `true` if the Umem is empty
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.area.is_empty()
+    }
+
+    /// Returns the region of memory as specified by the index type
+    ///
+    /// # Safety
+    ///
+    /// The caller MUST ensure that this index is not already mutably borrowed and that the index
+    /// is in bounds for this Umem.
+    #[inline]
+    pub unsafe fn get<T>(&self, idx: T) -> &[u8]
+    where
+        Self: UnsafeIndex<T>,
+    {
+        self.index(idx)
+    }
+
+    /// Returns the mutable region of memory as specified by the index type
+    ///
+    /// # Safety
+    ///
+    /// The caller MUST ensure that this index is not already mutably borrowed and that the index
+    /// is in bounds for this Umem.
+    #[inline]
+    #[allow(clippy::mut_from_ref)] // interior mutability safety is enforced by the caller
+    pub unsafe fn get_mut<T>(&self, idx: T) -> &mut [u8]
+    where
+        Self: UnsafeIndex<T>,
+    {
+        self.index_mut(idx)
+    }
+
+    /// Attaches the Umem to the specified socket
+    pub(crate) fn attach<Fd: AsRawFd>(&self, socket: &Fd) -> Result<()> {
+        let umem_conf = UmemReg {
+            addr: self.area.addr().as_ptr() as _,
+            chunk_size: self.frame_size,
+            flags: self.flags,
+            headroom: self.frame_headroom,
+            len: self.area.len() as _,
+        };
+
+        syscall::set_umem(socket, &umem_conf)?;
+
+        Ok(())
+    }
+
+    #[inline]
+    fn validate_rx_tx_descriptor(&self, desc: RxTxDescriptor) -> *mut u8 {
+        debug_assert!(desc.len <= self.frame_size, "frame too large");
+        debug_assert!(
+            desc.address + desc.len as u64 <= self.area.len() as u64,
+            "pointer out of bounds"
+        );
+        unsafe { self.mem.as_ptr().add(desc.address as _) }
+    }
+
+    #[inline]
+    fn validate_umem_descriptor(&self, desc: UmemDescriptor) -> *mut u8 {
+        debug_assert!(
+            desc.address + self.frame_size as u64 <= self.area.len() as u64,
+            "pointer out of bounds"
+        );
+        unsafe { self.mem.as_ptr().add(desc.address as _) }
+    }
+}
+
+/// Specifies an indexable value, which relies on the caller to guarantee borrowing rules are not
+/// violated.
+pub trait UnsafeIndex<T> {
+    unsafe fn index(&self, idx: T) -> &[u8];
+    #[allow(clippy::mut_from_ref)] // interior mutability safety is enforced by the caller
+    unsafe fn index_mut(&self, idx: T) -> &mut [u8];
+}
+
+impl UnsafeIndex<RxTxDescriptor> for Umem {
+    unsafe fn index(&self, idx: RxTxDescriptor) -> &[u8] {
+        let ptr = self.validate_rx_tx_descriptor(idx);
+        core::slice::from_raw_parts(ptr, idx.len as _)
+    }
+
+    unsafe fn index_mut(&self, idx: RxTxDescriptor) -> &mut [u8] {
+        let ptr = self.validate_rx_tx_descriptor(idx);
+        core::slice::from_raw_parts_mut(ptr, idx.len as _)
+    }
+}
+
+impl UnsafeIndex<UmemDescriptor> for Umem {
+    unsafe fn index(&self, idx: UmemDescriptor) -> &[u8] {
+        let ptr = self.validate_umem_descriptor(idx);
+        core::slice::from_raw_parts(ptr, self.frame_size as _)
+    }
+
+    unsafe fn index_mut(&self, idx: UmemDescriptor) -> &mut [u8] {
+        let ptr = self.validate_umem_descriptor(idx);
+        core::slice::from_raw_parts_mut(ptr, self.frame_size as _)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn index_test() {
+        let umem = Umem::builder().build().unwrap();
+
+        for descriptor in umem.frames() {
+            unsafe {
+                let _ = umem.get(descriptor);
+                let _ = umem.get_mut(descriptor);
+            }
+
+            let rx = RxTxDescriptor {
+                address: descriptor.address,
+                len: 1,
+                options: Default::default(),
+            };
+
+            unsafe {
+                let _ = umem.get(rx);
+                let _ = umem.get_mut(rx);
+            }
+        }
+    }
+}


### PR DESCRIPTION

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.-->

This PR adds the last component of the libxdp port. This is the UMEM component which holds the region of memory with actual packet data. It can be indexed with either a UmemDescriptor and RxTxDescriptor. However, this is not a safe operation since descriptors can be forged and/or copied, meaning holding one doesn't guarantee uniqueness. Luckily, this API will just be internal implementation details of the XDP IO provider so I don't think we need a completely safe abstraction (which could affect performance).

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

I added a simple test making sure the indexing works. I've also got an overall integration test in another branch that shows this working.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

