### PR TITLE
fix(s2n-quic-xdp): use unix-specific traits for better compat

### DIFF
--- a/tools/xdp/s2n-quic-xdp/src/if_xdp.rs
+++ b/tools/xdp/s2n-quic-xdp/src/if_xdp.rs
@@ -5,7 +5,8 @@
 
 use crate::Result;
 use bitflags::bitflags;
-use core::{ffi::CStr, mem::size_of};
+use core::mem::size_of;
+use std::ffi::CStr;
 
 bitflags!(
     /// Options for the `flags` field in [`Address`]

--- a/tools/xdp/s2n-quic-xdp/src/mmap.rs
+++ b/tools/xdp/s2n-quic-xdp/src/mmap.rs
@@ -10,7 +10,7 @@ use core::{
     ops::{Deref, DerefMut},
     ptr::NonNull,
 };
-use std::os::fd::RawFd;
+use std::os::unix::io::RawFd;
 
 /// A mmap'd region in memory
 #[derive(Debug)]
@@ -18,6 +18,12 @@ pub struct Mmap {
     addr: NonNull<c_void>,
     len: usize,
 }
+
+/// Safety: Mmap pointer can be sent between threads
+unsafe impl Send for Mmap {}
+
+/// Safety: Mmap pointer can be shared between threads
+unsafe impl Sync for Mmap {}
 
 impl Mmap {
     /// Creates a new mmap'd region, with an optional file descriptor.

--- a/tools/xdp/s2n-quic-xdp/src/ring.rs
+++ b/tools/xdp/s2n-quic-xdp/src/ring.rs
@@ -7,7 +7,7 @@ use crate::{
     socket, syscall,
 };
 use core::{fmt, mem::size_of};
-use std::{io, os::fd::AsRawFd};
+use std::{io, os::unix::io::AsRawFd};
 
 mod cursor;
 

--- a/tools/xdp/s2n-quic-xdp/src/socket.rs
+++ b/tools/xdp/s2n-quic-xdp/src/socket.rs
@@ -4,7 +4,7 @@
 use crate::{syscall, Result};
 use core::fmt;
 use std::{
-    os::fd::{AsRawFd, RawFd},
+    os::unix::io::{AsRawFd, RawFd},
     sync::Arc,
 };
 

--- a/tools/xdp/s2n-quic-xdp/src/umem.rs
+++ b/tools/xdp/s2n-quic-xdp/src/umem.rs
@@ -7,7 +7,7 @@ use crate::{
     syscall, Result,
 };
 use core::ptr::NonNull;
-use std::{os::fd::AsRawFd, sync::Arc};
+use std::{os::unix::io::AsRawFd, sync::Arc};
 
 #[derive(Clone, Copy, Debug)]
 pub struct Builder {
@@ -64,6 +64,13 @@ pub struct Umem {
     frame_headroom: u32,
     flags: UmemFlags,
 }
+
+/// Safety: The umem mmap region can be sent to other threads
+unsafe impl Send for Umem {}
+
+/// Safety: The umem mmap region is synchronized by Rings and the data getters are marked as
+/// `unsafe`.
+unsafe impl Sync for Umem {}
 
 impl Umem {
     /// Creates a Umem builder with defaults


### PR DESCRIPTION
### Description of changes: 

I ran into a couple of incompatibilities with our current MSRV (1.63) and the XDP code. Namely:

* the AsRawFd trait was exposed in a generic location (`std::os`) in a later version. However, the same trait is still available in `std::os::unix` so we can just use that since XDP is always going to be Linux-specific.
* The 1.63 rustc complains about nested `unsafe` blocks in the `libc` macro so I just opted to make the caller responsible for the unsafe block.
* The structs with raw pointers needed `Sync` and `Send` impls, which are safe according to the inline comments.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

