### PR TITLE
build: add excluded directories for main workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,12 @@ members = [
     "quic/s2n-*",
 ]
 resolver = "2"
+# don't include any workspaces outside of the main project
+exclude = [
+    "examples",
+    "netbench",
+    "tools",
+]
 
 [profile.release]
 lto = true


### PR DESCRIPTION
### Description of changes: 

Cargo complains about a crate depending on another crate in a subdirectory that isn't part of a workspace:

```
$ cargo build
error: package `/home/cameron/Projects/aws/s2n-quic/tools/xdp/s2n-quic-xdp/Cargo.toml` is a member of the wrong workspace
expected: /home/cameron/Projects/aws/s2n-quic/Cargo.toml
actual:   /home/cameron/Projects/aws/s2n-quic/tools/xdp/Cargo.toml
```

Adding an explicit `exclude` field to the root workspace fixes this issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

