### PR TITLE
feat(s2n-quic-crypto): use aws-lc-rs on linux/aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ See the [API documentation](https://docs.rs/s2n-quic) and [examples](https://git
 s2n-quic = "1"
 ```
 
-**NOTE**: On unix-like systems, [`s2n-tls`](https://github.com/aws/s2n-tls) will be used as the default TLS provider and requires a C compiler to be installed.
+**NOTE**: On unix-like systems, [`s2n-tls`](https://github.com/aws/s2n-tls) will be used as the default TLS provider,
+and [`aws-lc-rs`](https://github.com/awslabs/aws-lc-rs) will be used for cryptographic operations. A C compiler and
+CMake are required on these systems for installation.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ s2n-quic = "1"
 
 **NOTE**: On unix-like systems, [`s2n-tls`](https://github.com/aws/s2n-tls) will be used as the default TLS provider,
 and [`aws-lc-rs`](https://github.com/awslabs/aws-lc-rs) will be used for cryptographic operations. A C compiler and
-CMake are required on these systems for installation.
+CMake are required on these systems for installation. For platforms that lack [pregenerated bindings](https://github.com/awslabs/aws-lc-rs/blob/main/aws-lc-sys/README.md#pregenerated-bindings-availability)
+for `aws-lc-rs`, `libclang` is also needed for [`bindgen`](https://github.com/rust-lang/rust-bindgen#environment-variables)
+to generate bindings.
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,9 @@ See the [API documentation](https://docs.rs/s2n-quic) and [examples](https://git
 s2n-quic = "1"
 ```
 
-**NOTE**: On unix-like systems, [`s2n-tls`](https://github.com/aws/s2n-tls) will be used as the default TLS provider,
-and [`aws-lc-rs`](https://github.com/awslabs/aws-lc-rs) will be used for cryptographic operations. A C compiler and
-CMake are required on these systems for installation. For platforms that lack [pregenerated bindings](https://github.com/awslabs/aws-lc-rs/blob/main/aws-lc-sys/README.md#pregenerated-bindings-availability)
-for `aws-lc-rs`, `libclang` is also needed for [`bindgen`](https://github.com/rust-lang/rust-bindgen#environment-variables)
-to generate bindings.
+**NOTE**: On unix-like systems, [`s2n-tls`](https://github.com/aws/s2n-tls) will be used as the default TLS provider.
+On `aarch64` linux systems,  [`aws-lc-rs`](https://github.com/awslabs/aws-lc-rs) will be used for cryptographic 
+operations. A C compiler and CMake may be required on these systems for installation.
 
 ## Example
 

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -17,10 +17,25 @@ testing = []
 [dependencies]
 cfg-if = "1"
 lazy_static = "1"
-ring = { version = "0.16", default-features = false }
 s2n-codec = { version = "=0.4.1", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.18.2", path = "../s2n-quic-core", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["derive"] }
+
+# aws-lc-sys has pre-generated bindings for the following platforms:
+# * macos/x86_64
+# * linux/x86
+# * linux/x86_64
+# * linux/aarch64
+[target.'cfg(any(all(target_os = "macos", target_arch = "x86_64"), all(target_os = "linux", target_arch = "x86"), all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64")))'.dependencies]
+aws-lc-rs = { version = "1.0.0", default-features = false, features = ["aws-lc-sys"] }
+
+# aws-lc-sys can generate bindings for other unix-y platforms when the "bindgen" feature is used.
+[target.'cfg(all(unix, not(any(all(target_os = "macos", target_arch = "x86_64"), all(target_os = "linux", target_arch = "x86"), all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64")))))'.dependencies]
+aws-lc-rs = { version = "1.0.0", default-features = false, features = ["bindgen", "aws-lc-sys"] }
+
+[target.'cfg(not(unix))'.dependencies]
+ring = { version = "0.16.20", default-features = false }
+
 
 [dev-dependencies]
 aes = "0.8"

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -21,19 +21,10 @@ s2n-codec = { version = "=0.5.0", path = "../../common/s2n-codec", default-featu
 s2n-quic-core = { version = "=0.19.0", path = "../s2n-quic-core", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["derive"] }
 
-# aws-lc-sys has pre-generated bindings for the following platforms:
-# * macos/x86_64
-# * linux/x86
-# * linux/x86_64
-# * linux/aarch64
-[target.'cfg(any(all(target_os = "macos", target_arch = "x86_64"), all(target_os = "linux", target_arch = "x86"), all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64")))'.dependencies]
+[target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
 aws-lc-rs = { version = "1.0.0", default-features = false, features = ["aws-lc-sys"] }
 
-# aws-lc-sys can generate bindings for other unix-y platforms when the "bindgen" feature is used.
-[target.'cfg(all(unix, not(any(all(target_os = "macos", target_arch = "x86_64"), all(target_os = "linux", target_arch = "x86"), all(target_os = "linux", target_arch = "x86_64"), all(target_os = "linux", target_arch = "aarch64")))))'.dependencies]
-aws-lc-rs = { version = "1.0.0", default-features = false, features = ["bindgen", "aws-lc-sys"] }
-
-[target.'cfg(not(unix))'.dependencies]
+[target.'cfg(not(all(target_os = "linux", target_arch = "aarch64")))'.dependencies]
 ring = { version = "0.16.20", default-features = false }
 
 

--- a/quic/s2n-quic-crypto/src/aesgcm/ring.rs
+++ b/quic/s2n-quic-crypto/src/aesgcm/ring.rs
@@ -4,8 +4,8 @@
 use crate::{
     aead,
     aesgcm::{NONCE_LEN, TAG_LEN},
+    ring_aead::{Aad, LessSafeKey, Nonce},
 };
-use ::ring::aead::{Aad, LessSafeKey, Nonce};
 
 impl aead::Aead for LessSafeKey {
     type Nonce = [u8; NONCE_LEN];
@@ -62,8 +62,10 @@ macro_rules! impl_aesgcm {
     ($name:ident, $lower:ident) => {
         #[cfg(any(test, feature = "testing"))]
         pub mod $lower {
-            use crate::aesgcm::testing::$lower::Implementation;
-            use ::ring::aead::{$name, LessSafeKey, UnboundKey};
+            use crate::{
+                aesgcm::testing::$lower::Implementation,
+                ring_aead::{$name, LessSafeKey, UnboundKey},
+            };
 
             pub fn implementations(impls: &mut Vec<Implementation>) {
                 impls.push(Implementation {

--- a/quic/s2n-quic-crypto/src/cipher_suite.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite.rs
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{aead::Aead, header_key::HeaderKey, iv};
-use ::ring::{aead, hkdf};
+use crate::{aead::Aead, header_key::HeaderKey, hkdf, iv, ring_aead as aead};
 use core::fmt;
 use s2n_quic_core::{
     assume,

--- a/quic/s2n-quic-crypto/src/cipher_suite/negotiated.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite/negotiated.rs
@@ -4,9 +4,9 @@
 use crate::{
     cipher_suite::{TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256},
     header_key::HeaderKey,
+    hkdf, ring_aead as aead,
 };
 use core::fmt;
-use ring::{aead, hkdf};
 use s2n_quic_core::crypto::{self, CryptoError};
 
 // ignore casing warnings in order to preserve the IANA name

--- a/quic/s2n-quic-crypto/src/cipher_suite/ring.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite/ring.rs
@@ -5,7 +5,7 @@ macro_rules! key {
     ($name:ident, $ring_cipher:path, $key_size:expr, $tag_len:expr) => {
         pub mod $name {
             use super::super::$name::{KEY_LEN, NONCE_LEN, TAG_LEN};
-            use ::ring::aead::{self, LessSafeKey, UnboundKey};
+            use crate::ring_aead::{self as aead, LessSafeKey, UnboundKey};
             use zeroize::Zeroize;
 
             pub struct Key {

--- a/quic/s2n-quic-crypto/src/header_key.rs
+++ b/quic/s2n-quic-crypto/src/header_key.rs
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::{hkdf, ring_aead as aead};
 use core::fmt;
-use ring::{aead, hkdf};
 use s2n_quic_core::crypto::{self, HeaderProtectionMask};
 
 pub struct HeaderKey(pub(crate) aead::quic::HeaderProtectionKey);

--- a/quic/s2n-quic-crypto/src/initial.rs
+++ b/quic/s2n-quic-crypto/src/initial.rs
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{cipher_suite::TLS_AES_128_GCM_SHA256 as CipherSuite, header_key::HeaderKeyPair};
-use ring::hkdf;
+use crate::{cipher_suite::TLS_AES_128_GCM_SHA256 as CipherSuite, header_key::HeaderKeyPair, hkdf};
 use s2n_quic_core::{
     crypto::{
         self,

--- a/quic/s2n-quic-crypto/src/iv.rs
+++ b/quic/s2n-quic-crypto/src/iv.rs
@@ -1,11 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use ::ring::hkdf;
+use crate::hkdf;
 use s2n_codec::{Encoder, EncoderBuffer};
 use zeroize::Zeroize;
 
-pub use ring::aead::NONCE_LEN;
+pub use crate::ring_aead::NONCE_LEN;
 
 pub struct Iv([u8; NONCE_LEN]);
 

--- a/quic/s2n-quic-crypto/src/lib.rs
+++ b/quic/s2n-quic-crypto/src/lib.rs
@@ -16,11 +16,16 @@ mod ctr;
 mod ghash;
 mod iv;
 
+#[cfg(unix)]
+use aws_lc_rs as ring;
+
 #[doc(hidden)]
 pub use ring::{
-    self,
+    aead as ring_aead,
     aead::{Algorithm, MAX_TAG_LEN},
+    constant_time, digest, hkdf,
     hkdf::Prk,
+    hmac,
 };
 
 #[derive(Clone)]

--- a/quic/s2n-quic-crypto/src/lib.rs
+++ b/quic/s2n-quic-crypto/src/lib.rs
@@ -16,7 +16,7 @@ mod ctr;
 mod ghash;
 mod iv;
 
-#[cfg(unix)]
+#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
 use aws_lc_rs as ring;
 
 #[doc(hidden)]

--- a/quic/s2n-quic-crypto/src/one_rtt.rs
+++ b/quic/s2n-quic-crypto/src/one_rtt.rs
@@ -28,9 +28,8 @@ impl crypto::OneRttHeaderKey for OneRttHeaderKey {}
 
 #[cfg(test)]
 mod tests {
-    use crate::cipher_suite::TLS_CHACHA20_POLY1305_SHA256;
+    use crate::{cipher_suite::TLS_CHACHA20_POLY1305_SHA256, hkdf};
     use hex_literal::hex;
-    use ring::hkdf;
     use s2n_quic_core::crypto::Key;
 
     //= https://www.rfc-editor.org/rfc/rfc9001#appendix-A.5

--- a/quic/s2n-quic-crypto/src/retry.rs
+++ b/quic/s2n-quic-crypto/src/retry.rs
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::{constant_time, ring_aead as aead};
 use core::convert::TryInto;
-use ring::aead;
 use s2n_quic_core::crypto::{
     self,
     retry::{IntegrityTag, NONCE_BYTES, SECRET_KEY_BYTES},
@@ -34,7 +34,7 @@ impl crypto::RetryKey for RetryKey {
     fn validate(pseudo_packet: &[u8], tag: IntegrityTag) -> Result<(), CryptoError> {
         let expected = Self::generate_tag(pseudo_packet);
 
-        ring::constant_time::verify_slices_are_equal(&expected, &tag)
+        constant_time::verify_slices_are_equal(&expected, &tag)
             .map_err(|_| CryptoError::DECRYPT_ERROR)
     }
 }

--- a/quic/s2n-quic-tls/src/callback.rs
+++ b/quic/s2n-quic-tls/src/callback.rs
@@ -9,10 +9,7 @@ use s2n_quic_core::{
     endpoint, transport,
 };
 use s2n_quic_crypto::{
-    handshake::HandshakeKey,
-    one_rtt::OneRttKey,
-    ring::{aead, hkdf},
-    Prk, SecretPair, Suite,
+    handshake::HandshakeKey, hkdf, one_rtt::OneRttKey, ring_aead as aead, Prk, SecretPair, Suite,
 };
 use s2n_tls::{connection::Connection, error::Fallible, ffi::*};
 

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -55,7 +55,7 @@ futures = { version = "0.3", default-features = false, features = ["std"] }
 hash_hasher = { version = "2", optional = true }
 rand = "0.8"
 rand_chacha = "0.3"
-s2n-quic-crypto = { version = ""0.19.0", path = "../s2n-quic-crypto", optional = true }
+s2n-quic-crypto = { version = "0.19.0", path = "../s2n-quic-crypto", optional = true }
 s2n-codec = { version = "=0.5.0", path = "../../common/s2n-codec" }
 s2n-quic-core = { version = "=0.19.0", path = "../s2n-quic-core" }
 s2n-quic-platform = { version = "=0.20.0", path = "../s2n-quic-platform", features = ["tokio-runtime"] }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -19,7 +19,7 @@ default = [
 provider-address-token-default = [
     "cuckoofilter",
     "hash_hasher",
-    "ring",
+    "s2n-quic-crypto",
     "zerocopy",
     "zerocopy-derive",
     "zeroize",
@@ -55,11 +55,11 @@ futures = { version = "0.3", default-features = false, features = ["std"] }
 hash_hasher = { version = "2", optional = true }
 rand = "0.8"
 rand_chacha = "0.3"
-ring = { version = "0.16", optional = true, default-features = false }
 s2n-codec = { version = "=0.4.1", path = "../../common/s2n-codec" }
 s2n-quic-core = { version = "=0.18.2", path = "../s2n-quic-core" }
 s2n-quic-platform = { version = "=0.19.0", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
 s2n-quic-rustls = { version = "=0.18.2", path = "../s2n-quic-rustls", optional = true }
+s2n-quic-crypto = { version = "0.18.2", path = "../s2n-quic-crypto", optional = true }
 s2n-quic-tls = { version = "=0.18.2", path = "../s2n-quic-tls", optional = true }
 s2n-quic-tls-default = { version = "=0.18.2", path = "../s2n-quic-tls-default", optional = true }
 s2n-quic-transport = { version = "=0.18.2", path = "../s2n-quic-transport" }

--- a/quic/s2n-quic/src/provider/address_token/default.rs
+++ b/quic/s2n-quic/src/provider/address_token/default.rs
@@ -10,11 +10,11 @@
 
 use core::{mem::size_of, time::Duration};
 use hash_hasher::HashHasher;
-use ring::{digest, hmac};
 use s2n_codec::{DecoderBuffer, DecoderBufferMut};
 use s2n_quic_core::{
     connection, event::api::SocketAddress, random, time::Timestamp, token::Source,
 };
+use s2n_quic_crypto::{constant_time, digest, hmac};
 use std::hash::{Hash, Hasher};
 use zerocopy::{AsBytes, FromBytes, Unaligned};
 use zeroize::Zeroizing;
@@ -208,7 +208,7 @@ impl Format {
 
         let tag = self.tag_retry_token(token, context)?;
 
-        if ring::constant_time::verify_slices_are_equal(&token.hmac, tag.as_ref()).is_ok() {
+        if constant_time::verify_slices_are_equal(&token.hmac, tag.as_ref()).is_ok() {
             // Only add the token once it has been validated. This will prevent the filter from
             // being filled with garbage tokens.
 


### PR DESCRIPTION
### Resolved issues:

Relates to #1683

### Description of changes: 

This change migrates the cryptographic library used on unix platforms from [ring](https://crates.io/crates/ring) to [aws-lc-rs](https://crates.io/crates/aws-lc-rs).

### Call-outs:

aws-lc-rs does not yet support Windows platforms, but support for Windows is planned. For non-unix platforms, ring will continue to be used.

### Testing:

Performed the release build and tests. Ran rustfmt and clippy.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

