### PR TITLE
fix(s2n-quic-core): calculate PTO period with microsecond precision

### DIFF
--- a/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
@@ -119,7 +119,7 @@ impl RttEstimator {
     #[inline]
     pub fn pto_period(&self, pto_backoff: u32, space: PacketNumberSpace) -> Duration {
         // We operate on microseconds rather than `Duration` to improve efficiency.
-        // See https://godbolt.org/z/4o71WPods
+        // See https://godbolt.org/z/osEd9rj9a
 
         //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.1
         //# When an ack-eliciting packet is transmitted, the sender schedules a

--- a/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
@@ -118,7 +118,7 @@ impl RttEstimator {
     //# an acknowledgement of a sent packet.
     #[inline]
     pub fn pto_period(&self, pto_backoff: u32, space: PacketNumberSpace) -> Duration {
-        // Since K_GRANULARITY is 1ms, we operate on microseconds rather than `Duration` to improve efficiency.
+        // We operate on microseconds rather than `Duration` to improve efficiency.
         // See https://godbolt.org/z/4o71WPods
 
         //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.1


### PR DESCRIPTION
### Description of changes: 

Currently the PTO period is calculated by converting RTT `Duration`s to milliseconds as an optimization (see #1493). This change updates this calculation to use microseconds as the minimum allowed RTT is now 1 microsecond (#1651). 


### Call-outs:

I updated the Godbolt link with one using microseconds and the results look similar

### Testing:

Updated unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

