### PR TITLE
refactor(s2n-quic-core): use an event handler for XDP decoding

### DIFF
--- a/common/s2n-codec/src/lib.rs
+++ b/common/s2n-codec/src/lib.rs
@@ -14,6 +14,10 @@ pub mod decoder;
 pub mod encoder;
 pub mod unaligned;
 
-pub use decoder::*;
-pub use encoder::*;
+pub use decoder::{
+    CheckedRange, DecoderBuffer, DecoderBufferMut, DecoderBufferMutResult, DecoderBufferResult,
+    DecoderError, DecoderParameterizedValue, DecoderParameterizedValueMut, DecoderValue,
+    DecoderValueMut,
+};
+pub use encoder::{Encoder, EncoderBuffer, EncoderLenEstimator, EncoderValue};
 pub use unaligned::*;

--- a/quic/s2n-quic-core/src/inet/ip.rs
+++ b/quic/s2n-quic-core/src/inet/ip.rs
@@ -328,6 +328,7 @@ impl fmt::Display for Protocol {
             Self::IPV6_ICMP => "ICMP for IPv6",
             Self::IPV6_NO_NXT => "No Next Header for IPv6",
             Self::IPV6_OPTS => "Destination Options for IPv6",
+            Self::UDPLITE => "Lightweight User Datagram",
             Self { id } => return write!(f, "[unknown 0x{id:02x}]"),
         }
         .fmt(f)
@@ -360,6 +361,7 @@ impl Protocol {
     impl_p!(is_ipv6_icmp, IPV6_ICMP, 58);
     impl_p!(is_ipv6_no_next, IPV6_NO_NXT, 59);
     impl_p!(is_ipv6_options, IPV6_OPTS, 60);
+    impl_p!(is_udplite, UDPLITE, 136);
 }
 
 #[cfg(test)]

--- a/quic/s2n-quic-core/src/inet/mod.rs
+++ b/quic/s2n-quic-core/src/inet/mod.rs
@@ -14,9 +14,9 @@ pub mod ipv6;
 pub mod udp;
 pub mod unspecified;
 
-pub use datagram::*;
+pub use datagram::{AncillaryData, DatagramInfo};
 pub use ecn::*;
 pub use ip::*;
-pub use ipv4::*;
-pub use ipv6::*;
+pub use ipv4::{IpV4Address, SocketAddressV4};
+pub use ipv6::{IpV6Address, SocketAddressV6};
 pub use unspecified::*;

--- a/quic/s2n-quic-core/src/xdp/encoder.rs
+++ b/quic/s2n-quic-core/src/xdp/encoder.rs
@@ -406,14 +406,15 @@ mod tests {
                 return;
             }
 
-            let (mut path, payload) =
+            let (mut header, payload) =
                 crate::xdp::decoder::decode_packet(DecoderBufferMut::new(&mut buffer))
                     .unwrap()
                     .unwrap();
 
-            path.swap();
+            header.path.swap();
 
-            assert!(Handle::eq(&path, &message.path));
+            assert!(Handle::eq(&header.path, &message.path));
+            assert_eq!(header.ecn, message.ecn);
             assert_eq!(payload.into_less_safe_slice(), &message.payload);
         });
     }

--- a/quic/s2n-quic-core/src/xdp/path.rs
+++ b/quic/s2n-quic-core/src/xdp/path.rs
@@ -67,6 +67,11 @@ pub struct Tuple {
 }
 
 impl Tuple {
+    pub const UNSPECIFIED: Self = Self {
+        remote_address: RemoteAddress::UNSPECIFIED,
+        local_address: LocalAddress::UNSPECIFIED,
+    };
+
     #[inline]
     pub fn swap(&mut self) {
         core::mem::swap(&mut self.remote_address.mac, &mut self.local_address.mac);

--- a/tools/xdp/ebpf/rust-toolchain.toml
+++ b/tools/xdp/ebpf/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # pin the version to prevent random breakage
-channel = "nightly-2023-03-12"
+channel = "nightly-2023-04-28"
 # The source code of rustc, provided by the rust-src component, is needed for
 # building eBPF programs.
 components = [ "rustc", "cargo", "rust-src" ]

--- a/tools/xdp/lib/s2n-quic-xdp-bpfeb-trace.ebpf
+++ b/tools/xdp/lib/s2n-quic-xdp-bpfeb-trace.ebpf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:79d7fe88eb5ab1117b623c5a4b0b614d3027116e091a4fd56b6d80242f58a004
-size 12112
+oid sha256:24af46a5435bf473183bea2b750760c1d85e6707b3405d046b7c4eeac928c128
+size 12184

--- a/tools/xdp/lib/s2n-quic-xdp-bpfeb.ebpf
+++ b/tools/xdp/lib/s2n-quic-xdp-bpfeb.ebpf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:22043f019bb4a775a728fcad1b16039913820beb2e974bc9448784c405c39501
-size 2448
+oid sha256:7ff12a1388d365ae65ec1314bf49b6d54889d567f04cc99bc96a8d410e0fc39c
+size 2456

--- a/tools/xdp/lib/s2n-quic-xdp-bpfel-trace.ebpf
+++ b/tools/xdp/lib/s2n-quic-xdp-bpfel-trace.ebpf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:641dc1be3f5c765aa0a79272f34d11b8a1edc51a63c741058dacc9ad14a68f86
-size 12128
+oid sha256:93ac243f50520ca4aa291a1532359315b4585bc10fb74a22b29d1bf6ea585482
+size 12216

--- a/tools/xdp/lib/s2n-quic-xdp-bpfel.ebpf
+++ b/tools/xdp/lib/s2n-quic-xdp-bpfel.ebpf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0373bdcc88e9900b3bbb38967ef07fec53ce772c35b40bce30f44a457b47f78e
-size 2480
+oid sha256:1aac236a9fc8b5f36c9bd28bdf437e0c52932ffaeba0ccbf37196d436d2e6f0d
+size 2488


### PR DESCRIPTION
### Description of changes: 

While implementing the AF_XDP IO provider, I realized I didn't expose a way to get the ECN value out of the XDP decoding function. I've repurposed the `Validator` trait to be a more generic `EventHandler` trait which has callbacks for each of the different types of headers we handle. I've also implemented this trait for the `xdp::path::Tuple` and `datagram::Header` to make it easy to extract all of the required information for the IO traits.

### Call-outs:

The latest nightly started complaining about conflicting exports in `inet` - each module has a `Header` and does a `pub use module::*;`. I made it so they all explicitly export types that are used in the code base.

### Testing:

All of the XDP decoder tests should handle this change. I've also updated the BPF programs and checked that they continue to load and pass the kernel verifier.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

