### PR TITLE
refactor(s2n-quic-core): simplify clock and timer traits

### DIFF
--- a/quic/s2n-quic-core/src/time/clock.rs
+++ b/quic/s2n-quic-core/src/time/clock.rs
@@ -2,13 +2,42 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::time::timestamp::Timestamp;
-use core::time::Duration;
+use core::{
+    task::{Context, Poll},
+    time::Duration,
+};
+
+#[cfg(any(test, feature = "std"))]
+mod std;
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;
+
+#[cfg(any(test, feature = "std"))]
+pub use self::std::*;
 
 /// A `Clock` is a source of [`Timestamp`]s.
 pub trait Clock {
     /// Returns the current [`Timestamp`]
     fn get_time(&self) -> Timestamp;
 }
+
+pub trait ClockWithTimer: Clock {
+    type Timer: Timer;
+
+    fn timer(&self) -> Self::Timer;
+}
+
+pub trait Timer: Sized {
+    #[inline]
+    fn ready(&mut self) -> TimerReady<Self> {
+        TimerReady(self)
+    }
+
+    fn poll_ready(&mut self, cx: &mut Context) -> Poll<()>;
+    fn update(&mut self, timestamp: Timestamp);
+}
+
+impl_ready_future!(Timer, TimerReady, ());
 
 /// A clock which always returns a Timestamp of value 1us
 #[derive(Clone, Copy, Debug)]
@@ -17,86 +46,5 @@ pub struct NoopClock;
 impl Clock for NoopClock {
     fn get_time(&self) -> Timestamp {
         unsafe { Timestamp::from_duration(Duration::from_micros(1)) }
-    }
-}
-
-#[cfg(any(test, feature = "std"))]
-mod std_clock {
-    use super::*;
-    use std::time::Instant;
-
-    impl<C: 'static + Clock> Clock for &'static std::thread::LocalKey<C> {
-        fn get_time(&self) -> Timestamp {
-            self.with(|clock| clock.get_time())
-        }
-    }
-
-    #[derive(Clone, Copy, Debug)]
-    pub struct StdClock {
-        epoch: Instant,
-    }
-
-    impl Default for StdClock {
-        fn default() -> Self {
-            Self {
-                epoch: Instant::now(),
-            }
-        }
-    }
-
-    impl StdClock {
-        /// Creates a new `StdClock` with the given epoch
-        pub const fn new(epoch: Instant) -> Self {
-            Self { epoch }
-        }
-    }
-
-    impl Clock for StdClock {
-        fn get_time(&self) -> Timestamp {
-            unsafe { Timestamp::from_duration(self.epoch.elapsed()) }
-        }
-    }
-
-    #[test]
-    #[cfg_attr(miri, ignore)] // time isn't queryable in miri
-    fn monotonicity_test() {
-        let clock = StdClock::default();
-        let ts1 = clock.get_time();
-        ::std::thread::sleep(Duration::from_millis(50));
-        let ts2 = clock.get_time();
-        assert!(ts2 - ts1 >= Duration::from_millis(50));
-    }
-}
-
-#[cfg(any(test, feature = "std"))]
-pub use std_clock::*;
-
-#[cfg(any(test, feature = "testing"))]
-pub mod testing {
-    use super::{Duration, Timestamp};
-
-    #[derive(Clone, Copy, Debug)]
-    pub struct Clock {
-        current_timestamp: Timestamp,
-    }
-
-    impl Default for Clock {
-        fn default() -> Self {
-            Self {
-                current_timestamp: unsafe { Timestamp::from_duration(Duration::from_micros(1)) },
-            }
-        }
-    }
-
-    impl super::Clock for Clock {
-        fn get_time(&self) -> Timestamp {
-            self.current_timestamp
-        }
-    }
-
-    impl Clock {
-        pub fn inc_by(&mut self, duration: Duration) {
-            self.current_timestamp += duration
-        }
     }
 }

--- a/quic/s2n-quic-core/src/time/clock/std.rs
+++ b/quic/s2n-quic-core/src/time/clock/std.rs
@@ -1,0 +1,47 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use ::std::time::Instant;
+
+impl<C: 'static + Clock> Clock for &'static ::std::thread::LocalKey<C> {
+    fn get_time(&self) -> Timestamp {
+        self.with(|clock| clock.get_time())
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct StdClock {
+    epoch: Instant,
+}
+
+impl Default for StdClock {
+    fn default() -> Self {
+        Self {
+            epoch: Instant::now(),
+        }
+    }
+}
+
+impl StdClock {
+    /// Creates a new `StdClock` with the given epoch
+    pub const fn new(epoch: Instant) -> Self {
+        Self { epoch }
+    }
+}
+
+impl Clock for StdClock {
+    fn get_time(&self) -> Timestamp {
+        unsafe { Timestamp::from_duration(self.epoch.elapsed()) }
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore)] // time isn't queryable in miri
+fn monotonicity_test() {
+    let clock = StdClock::default();
+    let ts1 = clock.get_time();
+    ::std::thread::sleep(Duration::from_millis(50));
+    let ts2 = clock.get_time();
+    assert!(ts2 - ts1 >= Duration::from_millis(50));
+}

--- a/quic/s2n-quic-core/src/time/clock/testing.rs
+++ b/quic/s2n-quic-core/src/time/clock/testing.rs
@@ -1,0 +1,46 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::time::{Duration, Timestamp};
+use core::cell::Cell;
+
+fn initial() -> Timestamp {
+    unsafe {
+        // Safety: the timestamp is non-zero
+        Timestamp::from_duration(Duration::from_micros(1))
+    }
+}
+
+thread_local! {
+    static CLOCK: Cell<Timestamp> = Cell::new(initial());
+}
+
+pub fn now() -> Timestamp {
+    CLOCK.with(|c| c.get())
+}
+
+pub fn reset() {
+    CLOCK.with(|c| c.set(initial()));
+}
+
+pub fn advance(duration: Duration) {
+    CLOCK.with(|c| {
+        let next = c.get() + duration;
+        c.set(next);
+    });
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Clock(());
+
+impl super::Clock for Clock {
+    fn get_time(&self) -> Timestamp {
+        now()
+    }
+}
+
+impl Clock {
+    pub fn inc_by(&mut self, duration: Duration) {
+        advance(duration);
+    }
+}

--- a/quic/s2n-quic-core/src/time/mod.rs
+++ b/quic/s2n-quic-core/src/time/mod.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-mod clock;
+pub mod clock;
 pub mod timer;
 mod timestamp;
 

--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -9,7 +9,10 @@ use s2n_quic_core::{
     event::{self, EndpointPublisher as _},
     inet::{self, SocketAddress},
     path::MaxMtu,
-    time::Clock as ClockTrait,
+    time::{
+        clock::{ClockWithTimer as _, Timer as _},
+        Clock as ClockTrait,
+    },
 };
 use std::{convert::TryInto, io, io::ErrorKind};
 use tokio::{net::UdpSocket, runtime::Handle};
@@ -383,12 +386,14 @@ impl<E: Endpoint<PathHandle = PathHandle>> Instance<E> {
             // pin the wakeups future so we don't have to move it into the Select future.
             tokio::pin!(wakeups);
 
+            let timer_ready = timer.ready();
+
             let select::Outcome {
                 rx_result,
                 tx_result,
                 timeout_expired,
                 application_wakeup,
-            } = if let Ok(res) = Select::new(rx_task, tx_task, &mut wakeups, &mut timer).await {
+            } = if let Ok(res) = Select::new(rx_task, tx_task, &mut wakeups, timer_ready).await {
                 res
             } else {
                 // The endpoint has shut down

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -32,4 +32,3 @@ futures-test = "0.3" # For testing Waker interactions
 insta = { version = "1", features = ["json"] }
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
-s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }

--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -415,7 +415,7 @@ mod tests {
         frame::{ack_elicitation::AckElicitation, ping, Frame},
         inet::{DatagramInfo, ExplicitCongestionNotification},
         path,
-        time::{Clock, NoopClock},
+        time::{clock::testing as time, Clock, NoopClock},
     };
 
     #[test]
@@ -541,7 +541,7 @@ mod tests {
             AckManager::new(PacketNumberSpace::ApplicationData, ack::Settings::default());
         let mut frame_buffer = OutgoingFrameBuffer::new();
         let mut write_context = MockWriteContext::new(
-            s2n_quic_platform::time::now(),
+            time::now(),
             &mut frame_buffer,
             transmission::Constraint::None,
             transmission::Mode::Normal,
@@ -607,7 +607,7 @@ mod tests {
             AckManager::new(PacketNumberSpace::ApplicationData, ack::Settings::default());
         let mut frame_buffer = OutgoingFrameBuffer::new();
         let mut write_context = MockWriteContext::new(
-            s2n_quic_platform::time::now(),
+            time::now(),
             &mut frame_buffer,
             transmission::Constraint::None,
             transmission::Mode::Normal,

--- a/quic/s2n-quic-transport/src/ack/tests/environment.rs
+++ b/quic/s2n-quic-transport/src/ack/tests/environment.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::contexts::testing::{MockWriteContext, OutgoingFrameBuffer};
-use s2n_quic_core::{endpoint, time::Timestamp, transmission};
+use s2n_quic_core::{
+    endpoint,
+    time::{clock::testing as time, Timestamp},
+    transmission,
+};
 
 #[derive(Clone, Debug)]
 pub struct TestEnvironment {
@@ -27,7 +31,7 @@ impl TestEnvironment {
 
         Self {
             sent_frames,
-            current_time: s2n_quic_platform::time::now(),
+            current_time: time::now(),
             transmission_constraint: transmission::Constraint::None,
             transmission_mode: transmission::Mode::Normal,
             local_endpoint_type: endpoint::Type::Server,

--- a/quic/s2n-quic-transport/src/ack/tests/simulation.rs
+++ b/quic/s2n-quic-transport/src/ack/tests/simulation.rs
@@ -4,7 +4,7 @@
 use super::{generator::gen_duration, Network, NetworkEvent, Report};
 use alloc::collections::VecDeque;
 use bolero::generator::*;
-use s2n_quic_core::time::Duration;
+use s2n_quic_core::time::{clock::testing as time, Duration};
 
 #[derive(Clone, Debug, TypeGenerator)]
 pub struct Simulation {
@@ -20,7 +20,7 @@ impl Simulation {
         let delay = self.delay;
         let mut report = Report::default();
 
-        self.network.init(s2n_quic_platform::time::now());
+        self.network.init(time::now());
 
         while let Some(now) = self.network.next_tick() {
             self.network.tick(now, &mut events, delay, &mut report);

--- a/quic/s2n-quic-transport/src/connection/close_sender.rs
+++ b/quic/s2n-quic-transport/src/connection/close_sender.rs
@@ -322,7 +322,7 @@ mod tests {
         event::testing::Publisher,
         io::tx::Message as _,
         path::MINIMUM_MTU,
-        time::{testing::Clock, timer::Provider as _, Clock as _},
+        time::{clock::testing as time, testing::Clock, timer::Provider as _, Clock as _},
     };
 
     static PACKET: Bytes = Bytes::from_static(b"CLOSE");
@@ -362,7 +362,7 @@ mod tests {
 
                 // transmit an initial packet
                 assert!(sender.can_transmit(path.transmission_constraint()));
-                let now = s2n_quic_platform::time::now();
+                let now = time::now();
                 let _ = sender
                     .transmission(&mut path, now, &mut publisher)
                     .write_payload(tx::PayloadBuffer::new(&mut buffer), 0);

--- a/quic/s2n-quic-transport/src/connection/local_id_registry/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/local_id_registry/tests.rs
@@ -8,7 +8,7 @@ use s2n_quic_core::{
     packet::number::PacketNumberRange,
     random,
     stateless_reset::token::testing::*,
-    time::timer::Provider as _,
+    time::{clock::testing as time, timer::Provider as _},
     varint::VarInt,
 };
 
@@ -68,7 +68,7 @@ fn minimum_lifetime() {
     let ext_id_1 = id(b"id01");
     let ext_id_2 = id(b"id02");
 
-    let expiration = s2n_quic_platform::time::now() + MIN_LIFETIME;
+    let expiration = time::now() + MIN_LIFETIME;
 
     let (_mapper, mut reg1) = mapper(ext_id_1, Some(expiration), TEST_TOKEN_1);
     reg1.set_active_connection_id_limit(3);
@@ -144,7 +144,7 @@ fn connection_mapper_test() {
     let ext_id_3 = id(b"id03");
     let ext_id_4 = id(b"id04");
 
-    let now = s2n_quic_platform::time::now();
+    let now = time::now();
     let handshake_id_expiration_time = now + Duration::from_secs(60);
 
     let mut reg1 = mapper.create_local_id_registry(
@@ -240,7 +240,7 @@ fn on_retire_connection_id() {
     let ext_id_1 = id(b"id01");
     let ext_id_2 = id(b"id02");
 
-    let now = s2n_quic_platform::time::now();
+    let now = time::now();
     let (mapper, mut reg1) = mapper(ext_id_1, None, TEST_TOKEN_1);
 
     reg1.set_active_connection_id_limit(2);
@@ -321,7 +321,7 @@ fn on_retire_connection_id_pending_removal() {
     let ext_id_1 = id(b"id01");
     let ext_id_2 = id(b"id02");
 
-    let now = s2n_quic_platform::time::now() + Duration::from_secs(60);
+    let now = time::now() + Duration::from_secs(60);
 
     let (_, mut reg1) = mapper(ext_id_1, None, TEST_TOKEN_1);
     reg1.set_active_connection_id_limit(2);
@@ -460,7 +460,7 @@ fn endpoint_may_exceed_limit_temporarily() {
     let ext_id_2 = id(b"id02");
     let ext_id_3 = id(b"id03");
 
-    let now = s2n_quic_platform::time::now();
+    let now = time::now();
 
     let (_, mut reg1) = mapper(ext_id_1, None, TEST_TOKEN_1);
     reg1.set_active_connection_id_limit(2);
@@ -510,7 +510,7 @@ fn on_transmit() {
     let ext_id_2 = id(b"id02");
     let ext_id_3 = id(b"id03");
 
-    let now = s2n_quic_platform::time::now() + Duration::from_secs(60);
+    let now = time::now() + Duration::from_secs(60);
 
     let (_, mut reg1) = mapper(ext_id_1, None, TEST_TOKEN_1);
 
@@ -532,7 +532,7 @@ fn on_transmit() {
 
     let mut frame_buffer = OutgoingFrameBuffer::new();
     let mut write_context = MockWriteContext::new(
-        s2n_quic_platform::time::now(),
+        time::now(),
         &mut frame_buffer,
         transmission::Constraint::None,
         transmission::Mode::Normal,
@@ -627,7 +627,7 @@ fn on_transmit_constrained() {
 
     let mut frame_buffer = OutgoingFrameBuffer::new();
     let mut write_context = MockWriteContext::new(
-        s2n_quic_platform::time::now(),
+        time::now(),
         &mut frame_buffer,
         transmission::Constraint::RetransmissionOnly,
         transmission::Mode::Normal,
@@ -684,7 +684,7 @@ fn on_packet_ack_and_loss() {
 
     let mut frame_buffer = OutgoingFrameBuffer::new();
     let mut write_context = MockWriteContext::new(
-        s2n_quic_platform::time::now(),
+        time::now(),
         &mut frame_buffer,
         transmission::Constraint::None,
         transmission::Mode::Normal,
@@ -732,7 +732,7 @@ fn timers() {
     // No timer set for the handshake connection ID
     assert_eq!(0, reg1.armed_timer_count());
 
-    let now = s2n_quic_platform::time::now();
+    let now = time::now();
     let expiration = now + Duration::from_secs(60);
 
     assert!(reg1
@@ -774,7 +774,7 @@ fn on_timeout() {
     let ext_id_2 = id(b"id02");
     let ext_id_3 = id(b"id03");
 
-    let now = s2n_quic_platform::time::now();
+    let now = time::now();
     let handshake_expiration = now + Duration::from_secs(60);
 
     let (_, mut reg1) = mapper(ext_id_1, Some(handshake_expiration), TEST_TOKEN_1);
@@ -840,7 +840,7 @@ fn retire_handshake_connection_id() {
     let ext_id_2 = id(b"id02");
     let ext_id_3 = id(b"id03");
 
-    let now = s2n_quic_platform::time::now();
+    let now = time::now();
     let handshake_expiration = now + Duration::from_secs(60);
     let (_, mut reg1) = mapper(ext_id_1, Some(handshake_expiration), TEST_TOKEN_1);
 

--- a/quic/s2n-quic-transport/src/connection/peer_id_registry/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/peer_id_registry/tests.rs
@@ -30,6 +30,7 @@ use s2n_quic_core::{
     packet::number::PacketNumberRange,
     random,
     stateless_reset::token::testing::*,
+    time::clock::testing as time,
     transport,
     varint::VarInt,
 };
@@ -253,7 +254,7 @@ fn retire_connection_id_when_retire_prior_to_increases() {
 
     let mut frame_buffer = OutgoingFrameBuffer::new();
     let mut write_context = MockWriteContext::new(
-        s2n_quic_platform::time::now(),
+        time::now(),
         &mut frame_buffer,
         transmission::Constraint::None,
         transmission::Mode::Normal,

--- a/quic/s2n-quic-transport/src/endpoint/version.rs
+++ b/quic/s2n-quic-transport/src/endpoint/version.rs
@@ -320,6 +320,7 @@ mod tests {
             zero_rtt::ZeroRtt,
         },
         path::RemoteAddress,
+        time::clock::testing as time,
         varint::VarInt,
     };
 
@@ -334,7 +335,7 @@ mod tests {
         (
             RemoteAddress::from(SocketAddress::default()),
             DatagramInfo {
-                timestamp: s2n_quic_platform::time::now(),
+                timestamp: time::now(),
                 payload_len,
                 ecn: Default::default(),
                 destination_connection_id: connection::LocalId::TEST_ID,

--- a/quic/s2n-quic-transport/src/path/mtu.rs
+++ b/quic/s2n-quic-transport/src/path/mtu.rs
@@ -467,11 +467,14 @@ mod test {
     use super::*;
     use crate::contexts::testing::{MockWriteContext, OutgoingFrameBuffer};
     use s2n_quic_core::{
-        endpoint, event::testing::Publisher, frame::Frame, packet::number::PacketNumberSpace,
+        endpoint,
+        event::testing::Publisher,
+        frame::Frame,
+        packet::number::PacketNumberSpace,
         recovery::congestion_controller::testing::mock::CongestionController,
-        time::timer::Provider as _, varint::VarInt,
+        time::{clock::testing::now, timer::Provider as _},
+        varint::VarInt,
     };
-    use s2n_quic_platform::time::now;
     use std::{convert::TryInto, net::SocketAddr};
 
     /// Creates a new mtu::Controller with an IPv4 address and the given `max_mtu`

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -26,7 +26,7 @@ use s2n_quic_core::{
         },
         DEFAULT_INITIAL_RTT,
     },
-    time::{timer::Provider as _, Clock, NoopClock},
+    time::{clock::testing as time, timer::Provider as _, Clock, NoopClock},
     varint::VarInt,
 };
 use std::{collections::HashSet, net::SocketAddr};
@@ -46,7 +46,7 @@ fn one_second_pto_when_no_previous_rtt_available() {
     let space = PacketNumberSpace::Handshake;
     let max_ack_delay = Duration::from_millis(0);
     let mut manager = Manager::new(space);
-    let now = s2n_quic_platform::time::now();
+    let now = time::now();
 
     let path = Path::new(
         Default::default(),
@@ -74,7 +74,7 @@ fn one_second_pto_when_no_previous_rtt_available() {
 #[test]
 fn on_packet_sent() {
     let max_ack_delay = Duration::from_millis(100);
-    let now = s2n_quic_platform::time::now();
+    let now = time::now();
     let mut time_sent = now;
     let ecn = ExplicitCongestionNotification::Ect0;
     let space = PacketNumberSpace::ApplicationData;
@@ -215,7 +215,7 @@ fn on_packet_sent_across_multiple_paths() {
     // let space = PacketNumberSpace::ApplicationData;
     let max_ack_delay = Duration::from_millis(100);
     // let mut manager = Manager::new(space, max_ack_delay);
-    let now = s2n_quic_platform::time::now();
+    let now = time::now();
     let ecn = ExplicitCongestionNotification::default();
     let mut time_sent = now;
     let mut publisher = Publisher::snapshot();
@@ -343,7 +343,7 @@ fn on_ack_frame() {
     // Start the pto backoff at 2 so we can tell if it was reset
     context.path_mut().pto_backoff = 2;
 
-    let time_sent = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let time_sent = time::now() + Duration::from_secs(10);
 
     // Send packets 1 to 10
     for i in 1..=10 {
@@ -555,7 +555,7 @@ fn process_new_acked_packets_update_pto_timer() {
         helper_generate_multi_path_manager(space, &mut publisher);
     let mut context = MockContext::new(&mut path_manager);
     let ecn = ExplicitCongestionNotification::default();
-    let time_sent = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let time_sent = time::now() + Duration::from_secs(10);
 
     // Send packets 1 on first_path
     manager.on_packet_sent(
@@ -672,7 +672,7 @@ fn process_new_acked_packets_congestion_controller() {
     let ecn = ExplicitCongestionNotification::default();
     let mut context = MockContext::new(&mut path_manager);
 
-    let time_sent = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let time_sent = time::now() + Duration::from_secs(10);
 
     // Send packets 1 on first_path
     manager.on_packet_sent(
@@ -800,7 +800,7 @@ fn process_new_acked_packets_pto_timer() {
         helper_generate_multi_path_manager(space, &mut publisher);
     let mut context = MockContext::new(&mut path_manager);
     let ecn = ExplicitCongestionNotification::default();
-    let time_sent = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let time_sent = time::now() + Duration::from_secs(10);
 
     // Send packets 1 on first_path
     manager.on_packet_sent(
@@ -916,7 +916,7 @@ fn process_new_acked_packets_process_ecn() {
     let packet_bytes = 128;
     let mut path_manager = helper_generate_path_manager(Duration::from_millis(10));
     let mut context = MockContext::new(&mut path_manager);
-    let time_sent = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let time_sent = time::now() + Duration::from_secs(10);
     let mut publisher = Publisher::snapshot();
 
     // Send 10 ECT0 marked packets
@@ -1018,7 +1018,7 @@ fn process_new_acked_packets_failed_ecn_validation_does_not_cause_congestion_eve
     let packet_bytes = 128;
     let mut path_manager = helper_generate_path_manager(Duration::from_millis(10));
     let mut context = MockContext::new(&mut path_manager);
-    let time_sent = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let time_sent = time::now() + Duration::from_secs(10);
     let mut publisher = Publisher::snapshot();
 
     // Send 10 ECT0 marked packets
@@ -1078,7 +1078,7 @@ fn no_rtt_update_when_not_acknowledging_the_largest_acknowledged_packet() {
     let mut context = MockContext::new(&mut path_manager);
     let mut publisher = Publisher::snapshot();
 
-    let time_sent = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let time_sent = time::now() + Duration::from_secs(10);
 
     // Send 2 packets
     manager.on_packet_sent(
@@ -1171,7 +1171,7 @@ fn no_rtt_update_when_receiving_packet_on_different_path() {
     let ecn = ExplicitCongestionNotification::default();
     let mut context = MockContext::new(&mut path_manager);
 
-    let time_sent = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let time_sent = time::now() + Duration::from_secs(10);
 
     // Send packet
     manager.on_packet_sent(
@@ -1286,7 +1286,7 @@ fn rtt_update_when_receiving_ack_from_multiple_paths() {
     let mut context = MockContext::new(&mut path_manager);
 
     // Trigger:
-    let time_sent = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let time_sent = time::now() + Duration::from_secs(10);
     let sent_time = time_sent + Duration::from_millis(300);
     let ack_receive_time = time_sent + Duration::from_millis(1000);
 
@@ -1371,7 +1371,7 @@ fn rtt_update_when_receiving_ack_from_multiple_paths() {
 fn detect_and_remove_lost_packets() {
     let space = PacketNumberSpace::ApplicationData;
     let mut manager = Manager::new(space);
-    let now = s2n_quic_platform::time::now();
+    let now = time::now();
     let mut path_manager = helper_generate_path_manager(Duration::from_millis(10));
     let ecn = ExplicitCongestionNotification::default();
     let mut context = MockContext::new(&mut path_manager);
@@ -1380,7 +1380,7 @@ fn detect_and_remove_lost_packets() {
 
     manager.largest_acked_packet = Some(space.new_packet_number(VarInt::from_u8(10)));
 
-    let mut time_sent = s2n_quic_platform::time::now();
+    let mut time_sent = time::now();
     let outcome = transmission::Outcome {
         ack_elicitation: AckElicitation::Eliciting,
         is_congestion_controlled: true,
@@ -1537,7 +1537,7 @@ fn detect_lost_packets_persistent_congestion_path_aware() {
     let ecn = ExplicitCongestionNotification::default();
     let mut context = MockContext::new(&mut path_manager);
 
-    let mut now = s2n_quic_platform::time::now();
+    let mut now = time::now();
     manager.largest_acked_packet = Some(space.new_packet_number(VarInt::from_u8(20)));
 
     // create first rtt samples so they can enter enter persistent_congestion
@@ -1664,7 +1664,7 @@ fn remove_lost_packets_persistent_congestion_path_aware() {
         helper_generate_multi_path_manager(space, &mut publisher);
     let ecn = ExplicitCongestionNotification::default();
     let mut context = MockContext::new(&mut path_manager);
-    let mut now = s2n_quic_platform::time::now();
+    let mut now = time::now();
     let random = &mut random::testing::Generator::default();
 
     assert_eq!(
@@ -1793,7 +1793,7 @@ fn detect_and_remove_lost_packets_nothing_lost() {
     let mut publisher = Publisher::snapshot();
     let random = &mut random::testing::Generator::default();
 
-    let time_sent = s2n_quic_platform::time::now();
+    let time_sent = time::now();
     let outcome = transmission::Outcome {
         ack_elicitation: AckElicitation::Eliciting,
         is_congestion_controlled: true,
@@ -1846,7 +1846,7 @@ fn detect_and_remove_lost_packets_mtu_probe() {
     let mut publisher = Publisher::snapshot();
     let random = &mut random::testing::Generator::default();
 
-    let time_sent = s2n_quic_platform::time::now();
+    let time_sent = time::now();
     let outcome = transmission::Outcome {
         ack_elicitation: AckElicitation::Eliciting,
         is_congestion_controlled: true,
@@ -1896,14 +1896,14 @@ fn persistent_congestion() {
     let mut context = MockContext::new(&mut path_manager);
     let mut publisher = Publisher::snapshot();
 
-    let time_zero = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let time_zero = time::now() + Duration::from_secs(10);
     // The RFC doesn't mention it, but it is implied that the first RTT sample has already
     // been received when this example begins, otherwise packet #2 would not be considered
     // part of the persistent congestion period.
     context.path_mut().rtt_estimator.update_rtt(
         Duration::from_millis(10),
         Duration::from_millis(700),
-        s2n_quic_platform::time::now(),
+        time::now(),
         true,
         space,
     );
@@ -2068,7 +2068,7 @@ fn persistent_congestion_multiple_periods() {
     let mut path_manager = helper_generate_path_manager(Duration::from_millis(10));
     let ecn = ExplicitCongestionNotification::default();
     let mut context = MockContext::new(&mut path_manager);
-    let time_zero = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let time_zero = time::now() + Duration::from_secs(10);
     let mut publisher = Publisher::snapshot();
 
     let outcome = transmission::Outcome {
@@ -2203,7 +2203,7 @@ fn persistent_congestion_period_does_not_start_until_rtt_sample() {
     let mut path_manager = helper_generate_path_manager(Duration::from_millis(10));
     let ecn = ExplicitCongestionNotification::default();
     let mut context = MockContext::new(&mut path_manager);
-    let time_zero = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let time_zero = time::now() + Duration::from_secs(10);
     let mut publisher = Publisher::snapshot();
 
     let outcome = transmission::Outcome {
@@ -2283,11 +2283,11 @@ fn persistent_congestion_not_ack_eliciting() {
     let mut context = MockContext::new(&mut path_manager);
     let mut publisher = Publisher::snapshot();
 
-    let time_zero = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let time_zero = time::now() + Duration::from_secs(10);
     context.path_mut().rtt_estimator.update_rtt(
         Duration::from_millis(10),
         Duration::from_millis(700),
-        s2n_quic_platform::time::now(),
+        time::now(),
         true,
         space,
     );
@@ -2371,11 +2371,11 @@ fn persistent_congestion_mtu_probe() {
     let mut context = MockContext::new(&mut path_manager);
     let mut publisher = Publisher::snapshot();
 
-    let time_zero = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let time_zero = time::now() + Duration::from_secs(10);
     context.path_mut().rtt_estimator.update_rtt(
         Duration::from_millis(10),
         Duration::from_millis(700),
-        s2n_quic_platform::time::now(),
+        time::now(),
         true,
         space,
     );
@@ -2449,7 +2449,7 @@ fn persistent_congestion_mtu_probe() {
 fn update_pto_timer() {
     let space = PacketNumberSpace::ApplicationData;
     let mut manager = Manager::new(space);
-    let now = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let now = time::now() + Duration::from_secs(10);
     let is_handshake_confirmed = true;
     let mut path_manager = helper_generate_path_manager(Duration::from_millis(10));
     let ecn = ExplicitCongestionNotification::default();
@@ -2579,7 +2579,7 @@ fn update_pto_timer() {
 fn pto_armed_if_handshake_not_confirmed() {
     let space = PacketNumberSpace::Handshake;
     let mut manager = Manager::new(space);
-    let now = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let now = time::now() + Duration::from_secs(10);
     let is_handshake_confirmed = false;
 
     let mut path = Path::new(
@@ -2608,7 +2608,7 @@ fn pto_must_be_at_least_k_granularity() {
     let space = PacketNumberSpace::Handshake;
     let max_ack_delay = Duration::from_millis(0);
     let mut manager = Manager::new(space);
-    let now = s2n_quic_platform::time::now();
+    let now = time::now();
 
     let mut path = Path::new(
         Default::default(),
@@ -2643,7 +2643,7 @@ fn pto_must_be_at_least_k_granularity() {
 fn on_timeout() {
     let space = PacketNumberSpace::ApplicationData;
     let mut manager = Manager::new(space);
-    let now = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let now = time::now() + Duration::from_secs(10);
     manager.largest_acked_packet = Some(space.new_packet_number(VarInt::from_u8(10)));
     let mut path_manager = helper_generate_path_manager(Duration::from_millis(10));
     let ecn = ExplicitCongestionNotification::default();
@@ -2762,8 +2762,8 @@ fn on_timeout() {
 fn timers() {
     let space = PacketNumberSpace::ApplicationData;
     let mut manager = Manager::new(space);
-    let loss_time = s2n_quic_platform::time::now() + Duration::from_secs(5);
-    let pto_time = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let loss_time = time::now() + Duration::from_secs(5);
+    let pto_time = time::now() + Duration::from_secs(10);
 
     // No timer is set
     assert_eq!(manager.armed_timer_count(), 0);
@@ -2792,7 +2792,7 @@ fn on_transmit() {
     let mut manager = Manager::new(space);
     let mut frame_buffer = OutgoingFrameBuffer::new();
     let mut context = MockWriteContext::new(
-        s2n_quic_platform::time::now(),
+        time::now(),
         &mut frame_buffer,
         transmission::Constraint::CongestionLimited, // Recovery manager ignores constraints
         transmission::Mode::LossRecoveryProbing,
@@ -2858,7 +2858,7 @@ fn on_transmit_normal_transmission_mode() {
     let mut manager = Manager::new(space);
     let mut frame_buffer = OutgoingFrameBuffer::new();
     let mut context = MockWriteContext::new(
-        s2n_quic_platform::time::now(),
+        time::now(),
         &mut frame_buffer,
         transmission::Constraint::CongestionLimited, // Recovery manager ignores constraints
         transmission::Mode::Normal,
@@ -2989,7 +2989,7 @@ fn probe_packets_count_towards_bytes_in_flight() {
     manager.on_packet_sent(
         space.new_packet_number(VarInt::from_u8(1)),
         outcome,
-        s2n_quic_platform::time::now(),
+        time::now(),
         ecn,
         transmission::Mode::Normal,
         None,
@@ -3027,7 +3027,7 @@ fn time_threshold_multiplier_equals_nine_eighths() {
     rtt_estimator.update_rtt(
         Duration::from_millis(10),
         Duration::from_secs(1),
-        s2n_quic_platform::time::now(),
+        time::now(),
         true,
         PacketNumberSpace::Initial,
     );
@@ -3049,7 +3049,7 @@ fn timer_granularity() {
     rtt_estimator.update_rtt(
         Duration::from_millis(0),
         Duration::from_nanos(1),
-        s2n_quic_platform::time::now(),
+        time::now(),
         true,
         PacketNumberSpace::Initial,
     );
@@ -3071,7 +3071,7 @@ fn packet_declared_lost_less_than_1_ms_from_loss_threshold() {
     let ecn = ExplicitCongestionNotification::default();
     let mut context = MockContext::new(&mut path_manager);
     let mut publisher = Publisher::snapshot();
-    let sent_time = s2n_quic_platform::time::now() + Duration::from_secs(10);
+    let sent_time = time::now() + Duration::from_secs(10);
     let outcome = transmission::Outcome {
         ack_elicitation: AckElicitation::Eliciting,
         is_congestion_controlled: true,

--- a/quic/s2n-quic-transport/src/space/handshake_status.rs
+++ b/quic/s2n-quic-transport/src/space/handshake_status.rs
@@ -209,8 +209,7 @@ mod fuzz_target;
 mod tests {
     use super::*;
     use crate::{contexts::testing::*, transmission::interest::Provider};
-    use s2n_quic_core::{endpoint, event::testing::Publisher};
-    use s2n_quic_platform::time;
+    use s2n_quic_core::{endpoint, event::testing::Publisher, time::clock::testing as time};
 
     #[test]
     fn server_test() {

--- a/quic/s2n-quic-transport/src/space/handshake_status/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/space/handshake_status/fuzz_target.rs
@@ -8,8 +8,7 @@ use crate::{
     transmission::{self, interest::Provider},
 };
 use bolero::{check, generator::*};
-use s2n_quic_core::{ack, event::testing::Publisher, packet};
-use s2n_quic_platform::time;
+use s2n_quic_core::{ack, event::testing::Publisher, packet, time::clock::testing as time};
 
 #[derive(Debug)]
 struct Oracle {

--- a/quic/s2n-quic-transport/src/stream/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/stream/manager/tests.rs
@@ -41,6 +41,7 @@ use s2n_quic_core::{
     packet::number::{PacketNumberRange, PacketNumberSpace},
     stream::{ops, StreamId, StreamType},
     time::{
+        clock::testing as time,
         timer::{self, Provider as _},
         Timestamp,
     },
@@ -761,7 +762,7 @@ fn peer_closing_streams_transmits_max_streams() {
 
         let mut frame_buffer = OutgoingFrameBuffer::new();
         let mut write_context = MockWriteContext::new(
-            s2n_quic_platform::time::now(),
+            time::now(),
             &mut frame_buffer,
             transmission::Constraint::None,
             transmission::Mode::Normal,
@@ -842,7 +843,7 @@ fn send_streams_blocked_frame_when_blocked_by_peer() {
 
         let mut frame_buffer = OutgoingFrameBuffer::new();
         let mut write_context = MockWriteContext::new(
-            s2n_quic_platform::time::now(),
+            time::now(),
             &mut frame_buffer,
             transmission::Constraint::None,
             transmission::Mode::Normal,
@@ -1001,7 +1002,7 @@ where
 
     let mut frame_buffer = OutgoingFrameBuffer::new();
     let mut write_context = MockWriteContext::new(
-        s2n_quic_platform::time::now(),
+        time::now(),
         &mut frame_buffer,
         transmission::Constraint::None,
         transmission::Mode::Normal,
@@ -1069,7 +1070,7 @@ fn send_data_blocked_frame_when_blocked_by_connection_flow_limits() {
 
     let mut frame_buffer = OutgoingFrameBuffer::new();
     let mut write_context = MockWriteContext::new(
-        s2n_quic_platform::time::now(),
+        time::now(),
         &mut frame_buffer,
         transmission::Constraint::None,
         transmission::Mode::Normal,
@@ -1247,7 +1248,7 @@ fn blocked_on_local_concurrent_stream_limit() {
 
             let mut frame_buffer = OutgoingFrameBuffer::new();
             let mut write_context = MockWriteContext::new(
-                s2n_quic_platform::time::now(),
+                time::now(),
                 &mut frame_buffer,
                 transmission::Constraint::None,
                 transmission::Mode::Normal,
@@ -2329,7 +2330,7 @@ fn on_transmit_queries_streams_for_data() {
     assert_eq!([stream_5], *manager.streams_waiting_for_retransmission());
 
     let mut write_context = MockWriteContext::new(
-        s2n_quic_platform::time::now(),
+        time::now(),
         &mut frame_buffer,
         transmission::Constraint::None,
         transmission::Mode::Normal,
@@ -2381,7 +2382,7 @@ fn on_transmit_queries_streams_for_data() {
 
     frame_buffer.set_error_write_after_n_frames(15);
     let mut write_context = MockWriteContext::new(
-        s2n_quic_platform::time::now(),
+        time::now(),
         &mut frame_buffer,
         transmission::Constraint::None,
         transmission::Mode::Normal,
@@ -2415,7 +2416,7 @@ fn on_transmit_queries_streams_for_data() {
 
     frame_buffer.set_error_write_after_n_frames(15);
     let mut write_context = MockWriteContext::new(
-        s2n_quic_platform::time::now(),
+        time::now(),
         &mut frame_buffer,
         transmission::Constraint::None,
         transmission::Mode::Normal,
@@ -2440,7 +2441,7 @@ fn on_transmit_queries_streams_for_data() {
 
     frame_buffer.set_error_write_after_n_frames(5);
     let mut write_context = MockWriteContext::new(
-        s2n_quic_platform::time::now(),
+        time::now(),
         &mut frame_buffer,
         transmission::Constraint::None,
         transmission::Mode::Normal,
@@ -2465,7 +2466,7 @@ fn on_transmit_queries_streams_for_data() {
 
     frame_buffer.set_error_write_after_n_frames(5);
     let mut write_context = MockWriteContext::new(
-        s2n_quic_platform::time::now(),
+        time::now(),
         &mut frame_buffer,
         transmission::Constraint::None,
         transmission::Mode::Normal,
@@ -2487,7 +2488,7 @@ fn on_transmit_queries_streams_for_data() {
 
     frame_buffer.set_error_write_after_n_frames(11);
     let mut write_context = MockWriteContext::new(
-        s2n_quic_platform::time::now(),
+        time::now(),
         &mut frame_buffer,
         transmission::Constraint::None,
         transmission::Mode::Normal,
@@ -3085,7 +3086,7 @@ fn stream_transmission_fairness_test() {
 
         let mut frame_buffer = OutgoingFrameBuffer::new();
         let mut write_context = MockWriteContext::new(
-            s2n_quic_platform::time::now(),
+            time::now(),
             &mut frame_buffer,
             transmission::Constraint::None,
             transmission::Mode::Normal,

--- a/quic/s2n-quic-transport/src/stream/testing.rs
+++ b/quic/s2n-quic-transport/src/stream/testing.rs
@@ -20,7 +20,7 @@ use s2n_quic_core::{
     frame::{stream::Stream as StreamFrame, Frame, ResetStream, StreamDataBlocked},
     packet::number::{PacketNumber, PacketNumberSpace},
     stream::{ops, StreamError, StreamId, StreamType},
-    time::Timestamp,
+    time::{clock::testing as time, Timestamp},
     transport,
     varint::VarInt,
 };
@@ -560,7 +560,7 @@ pub fn setup_stream_test_env_with_config(config: TestEnvironmentConfig) -> TestE
         tx_connection_flow_controller,
         wake_counter,
         waker,
-        current_time: s2n_quic_platform::time::now(),
+        current_time: time::now(),
         transmission_constraint: config.transmission_constraint,
         endpoint: config.local_endpoint_type,
     }

--- a/quic/s2n-quic-transport/src/sync/data_sender.rs
+++ b/quic/s2n-quic-transport/src/sync/data_sender.rs
@@ -541,7 +541,7 @@ mod tests {
         transmission::{self, interest::Provider as _},
     };
     use bolero::{check, generator::*};
-    use s2n_quic_core::{endpoint, frame, stream::testing as stream};
+    use s2n_quic_core::{endpoint, frame, stream::testing as stream, time::clock::testing as time};
     use std::collections::HashSet;
 
     #[derive(Clone, Copy, Debug, TypeGenerator)]
@@ -588,7 +588,7 @@ mod tests {
         let mut total_len = 0;
         let mut frame_buffer = OutgoingFrameBuffer::new();
         let mut context = MockWriteContext {
-            current_time: s2n_quic_platform::time::now(),
+            current_time: time::now(),
             frame_buffer: &mut frame_buffer,
             transmission_constraint: transmission::Constraint::None,
             transmission_mode: transmission::Mode::Normal,

--- a/quic/s2n-quic-transport/src/sync/flag.rs
+++ b/quic/s2n-quic-transport/src/sync/flag.rs
@@ -185,8 +185,7 @@ impl Writer for PingWriter {
 mod tests {
     use super::*;
     use crate::{contexts::testing::*, transmission::interest::Provider};
-    use s2n_quic_core::endpoint;
-    use s2n_quic_platform::time;
+    use s2n_quic_core::{endpoint, time::clock::testing as time};
 
     #[test]
     fn ping_test() {


### PR DESCRIPTION
### Description of changes: 

While implementing the AF_XDP IO provider, I wanted to make a generic event loop implementation so I didn't have to copy/paste the one from the tokio provider. Today, the clock to get the current time is generic. However, there's no trait for getting a timer from the clock and `await`ing on its expiration.

In this change, the clock and timer traits are refactored to make it possible to use in the IO provider event loop. This is done by adding a `ClockWithTimer` trait that is used in the IO event loop.

### Call-outs:

While I was changing the interface, I went through and removed all references to `s2n-quic-platform` in  `s2n-quic-transport` with the `testing` module in `s2n-quic-core`. This simplifies the testing dependencies a bit and makes it so every crate can use the clock in a consistent way. The only last place that uses the time module is the default address token provider, and I've opened an issue to track that separately: #1738.

### Testing:

Since this is just shuffling things around, the existing tests should cover the changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

