### PR TITLE
refactor(s2n-quic-core): simplify IO traits

### DIFF
--- a/quic/s2n-quic-core/src/lib.rs
+++ b/quic/s2n-quic-core/src/lib.rs
@@ -30,6 +30,25 @@ macro_rules! assume {
     };
 }
 
+/// Implements a future that wraps `T::poll_ready` and yields after ready
+macro_rules! impl_ready_future {
+    ($name:ident, $fut:ident, $output:ty) => {
+        pub struct $fut<'a, T>(&'a mut T);
+
+        impl<'a, T: $name> core::future::Future for $fut<'a, T> {
+            type Output = $output;
+
+            #[inline]
+            fn poll(
+                mut self: core::pin::Pin<&mut Self>,
+                cx: &mut core::task::Context,
+            ) -> core::task::Poll<Self::Output> {
+                self.0.poll_ready(cx)
+            }
+        }
+    };
+}
+
 pub mod ack;
 pub mod application;
 #[cfg(feature = "alloc")]

--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -646,10 +646,7 @@ mod tests {
         endpoint::{self, CloseError},
         event,
         inet::SocketAddress,
-        io::{
-            rx::{self, Entry as _},
-            tx,
-        },
+        io::{rx, tx},
         path::Handle as _,
         time::{Clock, Duration, Timestamp},
     };
@@ -731,19 +728,14 @@ mod tests {
         ) {
             let now = clock.get_time();
             self.now = Some(now);
-            let local_address = queue.local_address();
-            let entries = queue.as_slice_mut();
-            let len = entries.len();
-            for entry in entries {
-                if let Some((_header, payload)) = entry.read(&local_address) {
-                    assert_eq!(payload.len(), 4, "invalid payload {:?}", payload);
 
-                    let id = (&*payload).try_into().unwrap();
-                    let id = u32::from_be_bytes(id);
-                    self.messages.remove(&id);
-                }
-            }
-            queue.finish(len);
+            queue.for_each(|_header, payload| {
+                assert_eq!(payload.len(), 4, "invalid payload {:?}", payload);
+
+                let id = (&*payload).try_into().unwrap();
+                let id = u32::from_be_bytes(id);
+                self.messages.remove(&id);
+            });
         }
 
         fn poll_wakeups<C: Clock>(

--- a/quic/s2n-quic-platform/src/io/turmoil.rs
+++ b/quic/s2n-quic-platform/src/io/turmoil.rs
@@ -300,10 +300,7 @@ mod tests {
         endpoint::{self, CloseError},
         event,
         inet::SocketAddress,
-        io::{
-            rx::{self, Entry as _},
-            tx,
-        },
+        io::{rx, tx},
         path::Handle as _,
         time::{timer::Provider as _, Clock, Duration, Timer, Timestamp},
     };
@@ -375,19 +372,13 @@ mod tests {
             clock: &C,
         ) {
             let now = clock.get_time();
-            let local_address = queue.local_address();
-            let entries = queue.as_slice_mut();
-            let len = entries.len();
-            for entry in entries {
-                if let Some((_header, payload)) = entry.read(&local_address) {
-                    assert_eq!(payload.len(), 4, "invalid payload {:?}", payload);
+            queue.for_each(|_header, payload| {
+                assert_eq!(payload.len(), 4, "invalid payload {:?}", payload);
 
-                    let id = (&*payload).try_into().unwrap();
-                    let id = u32::from_be_bytes(id);
-                    self.rx_messages.insert(id, now);
-                }
-            }
-            queue.finish(len);
+                let id = (&*payload).try_into().unwrap();
+                let id = u32::from_be_bytes(id);
+                self.rx_messages.insert(id, now);
+            });
         }
 
         fn poll_wakeups<C: Clock>(

--- a/quic/s2n-quic-platform/src/message.rs
+++ b/quic/s2n-quic-platform/src/message.rs
@@ -18,7 +18,7 @@ pub mod simple;
 
 use core::ffi::c_void;
 use s2n_quic_core::{
-    inet::{ExplicitCongestionNotification, SocketAddress},
+    inet::{datagram, ExplicitCongestionNotification, SocketAddress},
     io::tx,
     path,
 };
@@ -99,6 +99,18 @@ pub trait Message {
     fn as_mut_ptr(&mut self) -> *mut c_void {
         self as *mut _ as *mut _
     }
+
+    /// Reads the message as an RX packet
+    fn rx_read(
+        &mut self,
+        local_address: &path::LocalAddress,
+    ) -> Option<(datagram::Header<Self::Handle>, &mut [u8])>;
+
+    /// Writes the message into the TX packet
+    fn tx_write<M: tx::Message<Handle = Self::Handle>>(
+        &mut self,
+        message: M,
+    ) -> Result<usize, tx::Error>;
 }
 
 /// A message ring used to back a queue

--- a/quic/s2n-quic-platform/src/message/macros.rs
+++ b/quic/s2n-quic-platform/src/message/macros.rs
@@ -65,6 +65,25 @@ macro_rules! impl_message_delegate {
             fn payload_ptr_mut(&mut self) -> *mut u8 {
                 $crate::message::Message::payload_ptr_mut(&mut self.$field)
             }
+
+            #[inline]
+            fn rx_read(
+                &mut self,
+                local_address: &s2n_quic_core::path::LocalAddress,
+            ) -> Option<(
+                s2n_quic_core::inet::datagram::Header<Self::Handle>,
+                &mut [u8],
+            )> {
+                $crate::message::Message::rx_read(&mut self.$field, local_address)
+            }
+
+            #[inline]
+            fn tx_write<M: tx::Message<Handle = Self::Handle>>(
+                &mut self,
+                message: M,
+            ) -> Result<usize, tx::Error> {
+                $crate::message::Message::tx_write(&mut self.$field, message)
+            }
         }
     };
 }

--- a/quic/s2n-quic-platform/src/message/msg.rs
+++ b/quic/s2n-quic-platform/src/message/msg.rs
@@ -14,7 +14,7 @@ use s2n_quic_core::{
         datagram, AncillaryData, ExplicitCongestionNotification, IpV4Address, IpV6Address,
         SocketAddress, SocketAddressV4, SocketAddressV6,
     },
-    io::{rx, tx},
+    io::tx,
     path::{self, Handle as _, LocalAddress, RemoteAddress},
 };
 
@@ -363,6 +363,46 @@ impl MessageTrait for msghdr {
             iovec.iov_base as *mut _
         }
     }
+
+    #[inline]
+    fn rx_read(
+        &mut self,
+        local_address: &path::LocalAddress,
+    ) -> Option<(datagram::Header<Self::Handle>, &mut [u8])> {
+        let mut header = Message::header(self)?;
+
+        // only copy the port if we are told the IP address
+        if cfg!(s2n_quic_platform_pktinfo) {
+            header.path.local_address.set_port(local_address.port());
+        } else {
+            header.path.local_address = *local_address;
+        }
+
+        let payload = self.payload_mut();
+        Some((header, payload))
+    }
+
+    #[inline]
+    fn tx_write<M: tx::Message<Handle = Self::Handle>>(
+        &mut self,
+        mut message: M,
+    ) -> Result<usize, tx::Error> {
+        let payload = self.payload_mut();
+
+        let len = message.write_payload(tx::PayloadBuffer::new(payload), 0)?;
+
+        unsafe {
+            debug_assert!(len <= payload.len());
+            let len = len.min(payload.len());
+            self.set_payload_len(len);
+        }
+
+        let handle = *message.path_handle();
+        handle.update_msg_hdr(self);
+        self.set_ecn(message.ecn(), &handle.remote_address.0);
+
+        Ok(len)
+    }
 }
 
 pub struct Ring<Payloads> {
@@ -516,64 +556,6 @@ impl<Payloads: crate::buffer::Buffer> super::Ring for Ring<Payloads> {
     #[inline]
     fn as_mut_slice(&mut self) -> &mut [Self::Message] {
         &mut self.messages[..]
-    }
-}
-
-impl tx::Entry for Message {
-    type Handle = Handle;
-
-    #[inline]
-    fn set<M: tx::Message<Handle = Self::Handle>>(
-        &mut self,
-        mut message: M,
-    ) -> Result<usize, tx::Error> {
-        let payload = MessageTrait::payload_mut(self);
-
-        let len = message.write_payload(tx::PayloadBuffer::new(payload), 0)?;
-
-        unsafe {
-            debug_assert!(len <= payload.len());
-            let len = len.min(payload.len());
-            self.set_payload_len(len);
-        }
-
-        let handle = *message.path_handle();
-        handle.update_msg_hdr(&mut self.0);
-        self.set_ecn(message.ecn(), &handle.remote_address.0);
-
-        Ok(len)
-    }
-
-    #[inline]
-    fn payload(&self) -> &[u8] {
-        MessageTrait::payload(self)
-    }
-
-    #[inline]
-    fn payload_mut(&mut self) -> &mut [u8] {
-        MessageTrait::payload_mut(self)
-    }
-}
-
-impl rx::Entry for Message {
-    type Handle = Handle;
-
-    #[inline]
-    fn read(
-        &mut self,
-        local_address: &path::LocalAddress,
-    ) -> Option<(datagram::Header<Self::Handle>, &mut [u8])> {
-        let mut header = Self::header(&self.0)?;
-
-        // only copy the port if we are told the IP address
-        if cfg!(s2n_quic_platform_pktinfo) {
-            header.path.local_address.set_port(local_address.port());
-        } else {
-            header.path.local_address = *local_address;
-        }
-
-        let payload = self.payload_mut();
-        Some((header, payload))
     }
 }
 


### PR DESCRIPTION
### Description of changes: 

While implementing the AF_XDP IO provider, I wanted to make a generic event loop implementation so I didn't have to copy/paste the one from the tokio provider.

In this change, the core IO traits are refactored to make it possible to use in the generic IO provider event loop.

### Call-outs:

The previous versions of the IO traits assumed that all of the incoming and outgoing packets were addressable through a slice. This was done to integrate with something like [`rayon`](https://docs.rs/rayon/latest/rayon/) to perform packet crypto in parallel. The problem is that assumption isn't really the case with AF_XDP, where we're putting descriptors in a ring buffer and they're not dereferenceable without the `UMEM`. I also think there's other ways to perform packet encryption in parallel that don't force the IO provider to adhere to this strict interface, so it's best to keep it simple and put the complexity elsewhere (especially since it's not even being used right now.)

I've also opened https://github.com/aws/s2n-quic/issues/1742 to highlight a better interface using GATs, which are only available in rust >=1.65. We can change the API once the MSRV bumps.

### Testing:

Since this is just shuffling things around and simplifying traits, the existing tests should cover the changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

