### PR TITLE
feat(s2n-quic-core): add generic IO event loop

### DIFF
--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -30,6 +30,7 @@ hex-literal = "0.4"
 insta = { version = ">=1.12", features = ["json"], optional = true }
 num-rational = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
+pin-project-lite = { version = "0.2" }
 s2n-codec = { version = "=0.5.0", path = "../../common/s2n-codec", default-features = false }
 subtle = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }

--- a/quic/s2n-quic-core/src/io/event_loop.rs
+++ b/quic/s2n-quic-core/src/io/event_loop.rs
@@ -1,0 +1,164 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    endpoint::Endpoint,
+    event::{self, EndpointPublisher},
+    io::{rx::Rx, tx::Tx},
+    time::clock::{ClockWithTimer, Timer},
+};
+use core::pin::Pin;
+
+pub mod select;
+use select::Select;
+
+pub struct EventLoop<E, C, R, T> {
+    pub endpoint: E,
+    pub clock: C,
+    pub rx: R,
+    pub tx: T,
+}
+
+impl<E, C, R, T> EventLoop<E, C, R, T>
+where
+    E: Endpoint,
+    C: ClockWithTimer,
+    R: Rx<PathHandle = E::PathHandle>,
+    T: Tx<PathHandle = E::PathHandle>,
+{
+    /// Starts running the endpoint event loop in an async task
+    pub async fn start(self) {
+        let Self {
+            mut endpoint,
+            clock,
+            mut rx,
+            mut tx,
+        } = self;
+
+        /// Creates a event publisher with the endpoint's subscriber
+        macro_rules! publisher {
+            ($timestamp:expr) => {{
+                let timestamp = $timestamp;
+                let subscriber = endpoint.subscriber();
+                event::EndpointPublisherSubscriber::new(
+                    event::builder::EndpointMeta {
+                        endpoint_type: E::ENDPOINT_TYPE,
+                        timestamp,
+                    },
+                    None,
+                    subscriber,
+                )
+            }};
+        }
+
+        let mut timer = clock.timer();
+
+        loop {
+            // Poll for RX readiness
+            let rx_ready = rx.ready();
+
+            // Poll for TX readiness
+            let tx_ready = tx.ready();
+
+            // Poll for any application-driven updates
+            let mut wakeups = endpoint.wakeups(&clock);
+
+            // TODO use the [pin macro](https://doc.rust-lang.org/std/pin/macro.pin.html) once
+            // available in MSRV
+            let wakeups = unsafe {
+                // Safety: the wakeups future is on the stack and won't move
+                Pin::new_unchecked(&mut wakeups)
+            };
+
+            // Poll for timer expiration
+            let timer_ready = timer.ready();
+
+            // Concurrently poll all of the futures and wake up on the first one that's ready
+            let select = Select::new(rx_ready, tx_ready, wakeups, timer_ready);
+
+            let select::Outcome {
+                rx_result,
+                tx_result,
+                timeout_expired,
+                application_wakeup,
+            } = if let Ok(outcome) = select.await {
+                outcome
+            } else {
+                // The endpoint has shut down; stop the event loop
+                return;
+            };
+
+            // notify the application that we woke up and why
+            let wakeup_timestamp = clock.get_time();
+            publisher!(wakeup_timestamp).on_platform_event_loop_wakeup(
+                event::builder::PlatformEventLoopWakeup {
+                    timeout_expired,
+                    rx_ready: rx_result.is_some(),
+                    tx_ready: tx_result.is_some(),
+                    application_wakeup,
+                },
+            );
+
+            match rx_result {
+                Some(Ok(())) => {
+                    // we received some packets. give them to the endpoint.
+                    rx.queue(|queue| {
+                        endpoint.receive(queue, &clock);
+                    });
+                }
+                Some(Err(error)) => {
+                    // The RX provider has encountered an error. shut down the event loop
+                    let mut publisher = publisher!(clock.get_time());
+                    rx.handle_error(error, &mut publisher);
+                    return;
+                }
+                None => {
+                    // We didn't receive any packets; nothing to do
+                }
+            }
+
+            match tx_result {
+                Some(Ok(())) => {
+                    // The TX queue was full and now has capacity. The endpoint can now continue to
+                    // transmit
+                }
+                Some(Err(error)) => {
+                    // The RX provider has encountered an error. shut down the event loop
+                    let mut publisher = publisher!(clock.get_time());
+                    tx.handle_error(error, &mut publisher);
+                    return;
+                }
+                None => {
+                    // The TX queue is either waiting to be flushed or has capacity. Either way, we
+                    // call `endpoint.transmit` to at least update the clock and poll any timer
+                    // expirations.
+                }
+            }
+
+            // Let the endpoint transmit, if possible
+            tx.queue(|queue| {
+                endpoint.transmit(queue, &clock);
+            });
+
+            // Get the next expiration from the endpoint and update the timer
+            let timeout = endpoint.timeout();
+            if let Some(timeout) = timeout {
+                timer.update(timeout);
+            }
+
+            let sleep_timestamp = clock.get_time();
+            // compute the relative timeout to the current time
+            let timeout = timeout.map(|t| t.saturating_duration_since(sleep_timestamp));
+            // compute how long it took to process the current iteration
+            let processing_duration = sleep_timestamp.saturating_duration_since(wakeup_timestamp);
+
+            // publish the event to the application
+            publisher!(sleep_timestamp).on_platform_event_loop_sleep(
+                event::builder::PlatformEventLoopSleep {
+                    timeout,
+                    processing_duration,
+                },
+            );
+        }
+    }
+}

--- a/quic/s2n-quic-core/src/io/event_loop.rs
+++ b/quic/s2n-quic-core/src/io/event_loop.rs
@@ -65,6 +65,8 @@ where
 
             // TODO use the [pin macro](https://doc.rust-lang.org/std/pin/macro.pin.html) once
             // available in MSRV
+            //
+            // See https://github.com/aws/s2n-quic/issues/1751
             let wakeups = unsafe {
                 // Safety: the wakeups future is on the stack and won't move
                 Pin::new_unchecked(&mut wakeups)

--- a/quic/s2n-quic-core/src/io/mod.rs
+++ b/quic/s2n-quic-core/src/io/mod.rs
@@ -1,5 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod event_loop;
 pub mod rx;
 pub mod tx;

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -16,7 +16,7 @@ std = ["s2n-quic-core/std", "socket2", "lazy_static"]
 testing = ["std", "generator", "futures/std", "io-testing"] # Testing allows to overwrite the system time
 io-testing = ["bach"]
 generator = ["bolero-generator", "s2n-quic-core/generator"]
-tokio-runtime = ["futures", "pin-project", "tokio"]
+tokio-runtime = ["futures", "tokio"]
 
 [dependencies]
 bach = { version = "0.0.6", optional = true }
@@ -25,7 +25,6 @@ cfg-if = "1"
 errno = "0.3"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 lazy_static = { version = "1", optional = true }
-pin-project = { version = "1", optional = true }
 s2n-quic-core = { version = "=0.20.0", path = "../s2n-quic-core", default-features = false }
 socket2 = { version = "0.5", features = ["all"], optional = true }
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt", "time"], optional = true }

--- a/quic/s2n-quic-platform/src/io.rs
+++ b/quic/s2n-quic-platform/src/io.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-mod select;
-
 #[cfg(feature = "tokio")]
 pub mod tokio;
 

--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -1,13 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::select::{self, Select};
 use crate::{buffer::default as buffer, features::gso, socket::default as socket, syscall};
 use cfg_if::cfg_if;
 use s2n_quic_core::{
     endpoint::Endpoint,
     event::{self, EndpointPublisher as _},
     inet::{self, SocketAddress},
+    io::event_loop::select::{self, Select},
     path::MaxMtu,
     time::{
         clock::{ClockWithTimer as _, Timer as _},

--- a/quic/s2n-quic-platform/src/io/turmoil.rs
+++ b/quic/s2n-quic-platform/src/io/turmoil.rs
@@ -1,12 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::select::{self, Select};
 use crate::{buffer::default as buffer, io::tokio::Clock, socket::std as socket};
 use s2n_quic_core::{
     endpoint::Endpoint,
     event::{self, EndpointPublisher as _},
     inet::SocketAddress,
+    io::event_loop::select::{self, Select},
     path::MaxMtu,
     time::{
         clock::{ClockWithTimer as _, Timer as _},


### PR DESCRIPTION
### Description

Using the refactors from #1734 and #1733, this PR adds a generic event loop implementation to make it easier to maintain the existing IO providers and develop new ones. I've updated the `io/testing` IO provider to use the new event loop and was able to remove quite a bit of code. This event loop will also be used in the new AF_XDP IO provider.

### Call-outs:

Note that I haven't changed either the tokio or turmoil event loops in this PR, since that will require some additional work to implement the new `Rx` and `Tx` traits for `platform/message/Queue`. This is tracked in #1746.

### Testing:

The event loop is being tested through the `io/testing` provider and all of the associated integration tests that use it. I've opened #1745 to track this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

