### PR TITLE
feat(s2n-quic): add experimental XDP IO provider

### DIFF
--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -17,6 +17,7 @@ testing = ["std", "generator", "futures/std", "io-testing"] # Testing allows to 
 io-testing = ["bach"]
 generator = ["bolero-generator", "s2n-quic-core/generator"]
 tokio-runtime = ["futures", "tokio"]
+xdp = ["s2n-quic-xdp"]
 
 [dependencies]
 bach = { version = "0.0.6", optional = true }
@@ -26,6 +27,7 @@ errno = "0.3"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 lazy_static = { version = "1", optional = true }
 s2n-quic-core = { version = "=0.20.0", path = "../s2n-quic-core", default-features = false }
+s2n-quic-xdp = { version = "=0.1.0", path = "../../tools/xdp/s2n-quic-xdp", optional = true }
 socket2 = { version = "0.5", features = ["all"], optional = true }
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt", "time"], optional = true }
 turmoil = { version = "0.5.2", optional = true }

--- a/quic/s2n-quic-platform/src/io.rs
+++ b/quic/s2n-quic-platform/src/io.rs
@@ -9,3 +9,6 @@ pub mod testing;
 
 #[cfg(feature = "turmoil")]
 pub mod turmoil;
+
+#[cfg(feature = "xdp")]
+pub mod xdp;

--- a/quic/s2n-quic-platform/src/io/xdp.rs
+++ b/quic/s2n-quic-platform/src/io/xdp.rs
@@ -1,0 +1,121 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::io::tokio::Clock;
+use s2n_quic_core::{
+    endpoint::Endpoint, inet::SocketAddress, io::event_loop::EventLoop, path::MaxMtu,
+};
+
+pub use s2n_quic_core::{
+    io::{rx, tx},
+    sync::{spsc, worker},
+    xdp::path::Tuple as PathHandle,
+};
+pub use s2n_quic_xdp::*;
+
+// export the encoder configuration for writing packets
+pub mod encoder {
+    pub use s2n_quic_core::xdp::encoder::State as Config;
+}
+
+// export socket types and helpers
+pub mod socket {
+    pub use s2n_quic_xdp::socket::*;
+
+    /// Binds a UDP socket to a particular interface and socket address
+    pub fn bind_udp(
+        interface: &::std::ffi::CStr,
+        addr: ::std::net::SocketAddr,
+    ) -> ::std::io::Result<::std::net::UdpSocket> {
+        let socket = crate::syscall::udp_socket(addr)?;
+
+        // associate the socket with a single interface
+        crate::syscall::bind_to_interface(&socket, interface)?;
+
+        socket.bind(&addr.into())?;
+
+        Ok(socket.into())
+    }
+}
+
+impl From<PathHandle> for crate::message::msg::Handle {
+    #[inline]
+    fn from(handle: PathHandle) -> Self {
+        let remote_address = handle.remote_address.into();
+        let local_address = handle.local_address.into();
+        crate::message::msg::Handle {
+            remote_address,
+            local_address,
+        }
+    }
+}
+
+impl From<&PathHandle> for crate::message::msg::Handle {
+    #[inline]
+    fn from(handle: &PathHandle) -> Self {
+        let remote_address = handle.remote_address.into();
+        let local_address = handle.local_address.into();
+        crate::message::msg::Handle {
+            remote_address,
+            local_address,
+        }
+    }
+}
+
+mod builder;
+pub use builder::Builder;
+
+pub struct Provider<Rx, Tx> {
+    rx: Rx,
+    tx: Tx,
+    max_mtu: MaxMtu,
+    handle: Option<tokio::runtime::Handle>,
+}
+
+impl Provider<(), ()> {
+    /// Creates a builder to construct an XDP provider
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
+}
+
+impl<Rx, Tx> Provider<Rx, Tx>
+where
+    Rx: 'static + rx::Rx + Send,
+    Tx: 'static + tx::Tx<PathHandle = Rx::PathHandle> + Send,
+{
+    pub fn start<E: Endpoint<PathHandle = Rx::PathHandle>>(
+        self,
+        mut endpoint: E,
+    ) -> std::io::Result<(tokio::task::JoinHandle<()>, SocketAddress)> {
+        let Self {
+            tx,
+            rx,
+            max_mtu,
+            handle,
+        } = self;
+
+        // tell the endpoint what our MTU is
+        endpoint.set_max_mtu(max_mtu);
+
+        // create a tokio clock
+        let clock = Clock::new();
+
+        // create an event loop
+        let event_loop = EventLoop {
+            endpoint,
+            clock,
+            rx,
+            tx,
+        };
+
+        // spawn the event loop on to the tokio handle
+        let task = if let Some(handle) = handle {
+            handle.spawn(event_loop.start())
+        } else {
+            tokio::spawn(event_loop.start())
+        };
+
+        Ok((task, SocketAddress::default()))
+    }
+}

--- a/quic/s2n-quic-platform/src/io/xdp/builder.rs
+++ b/quic/s2n-quic-platform/src/io/xdp/builder.rs
@@ -6,6 +6,7 @@ use s2n_quic_core::{
     inet::{ethernet, ipv4, udp},
     path::{MaxMtu, MaxMtuError},
 };
+use s2n_quic_xdp::umem::DEFAULT_FRAME_SIZE;
 use tokio::runtime::Handle;
 
 /// Calculate how much a packet will need for fixed-size headers
@@ -26,7 +27,7 @@ impl Default for Builder<(), ()> {
         Self {
             rx: (),
             tx: (),
-            max_mtu: MaxMtu::try_from(4096 - MIN_FRAME_OVERHEAD).unwrap(),
+            max_mtu: MaxMtu::try_from(DEFAULT_FRAME_SIZE as u16 - MIN_FRAME_OVERHEAD).unwrap(),
             handle: None,
         }
     }

--- a/quic/s2n-quic-platform/src/io/xdp/builder.rs
+++ b/quic/s2n-quic-platform/src/io/xdp/builder.rs
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::mem::size_of;
+use s2n_quic_core::{
+    inet::{ethernet, ipv4, udp},
+    path::{MaxMtu, MaxMtuError},
+};
+use tokio::runtime::Handle;
+
+/// Calculate how much a packet will need for fixed-size headers
+const MIN_FRAME_OVERHEAD: u16 =
+    (size_of::<ethernet::Header>() + size_of::<ipv4::Header>() + size_of::<udp::Header>()) as _;
+
+#[derive(Debug)]
+#[must_use = "Builders do nothing without calling `build`"]
+pub struct Builder<Rx = (), Tx = ()> {
+    rx: Rx,
+    tx: Tx,
+    max_mtu: MaxMtu,
+    handle: Option<Handle>,
+}
+
+impl Default for Builder<(), ()> {
+    fn default() -> Self {
+        Self {
+            rx: (),
+            tx: (),
+            max_mtu: MaxMtu::try_from(4096 - MIN_FRAME_OVERHEAD).unwrap(),
+            handle: None,
+        }
+    }
+}
+
+impl<Rx, Tx> Builder<Rx, Tx> {
+    /// Sets the tokio runtime handle for the provider
+    pub fn with_handle(mut self, handle: Handle) -> Self {
+        self.handle = Some(handle);
+        self
+    }
+
+    /// Sets the UMEM frame size for the provider
+    pub fn with_frame_size(mut self, frame_size: u16) -> Result<Self, MaxMtuError> {
+        self.max_mtu = frame_size.saturating_sub(MIN_FRAME_OVERHEAD).try_into()?;
+        Ok(self)
+    }
+
+    /// Sets the RX implementation for the provider
+    pub fn with_rx<NewRx>(self, rx: NewRx) -> Builder<NewRx, Tx>
+    where
+        NewRx: super::rx::Rx,
+    {
+        let Self {
+            tx,
+            handle,
+            max_mtu,
+            ..
+        } = self;
+        Builder {
+            rx,
+            tx,
+            handle,
+            max_mtu,
+        }
+    }
+
+    /// Sets the TX implementation for the provider
+    pub fn with_tx<NewTx>(self, tx: NewTx) -> Builder<Rx, NewTx>
+    where
+        NewTx: super::tx::Tx,
+    {
+        let Self {
+            rx,
+            handle,
+            max_mtu,
+            ..
+        } = self;
+        Builder {
+            rx,
+            tx,
+            handle,
+            max_mtu,
+        }
+    }
+}
+
+impl<Rx, Tx> Builder<Rx, Tx>
+where
+    Rx: 'static + super::rx::Rx + Send,
+    Tx: 'static + super::tx::Tx<PathHandle = Rx::PathHandle> + Send,
+{
+    pub fn build(self) -> super::Provider<Rx, Tx> {
+        let Self {
+            rx,
+            tx,
+            handle,
+            max_mtu,
+        } = self;
+        super::Provider {
+            rx,
+            tx,
+            handle,
+            max_mtu,
+        }
+    }
+}

--- a/quic/s2n-quic-platform/src/syscall.rs
+++ b/quic/s2n-quic-platform/src/syscall.rs
@@ -64,8 +64,7 @@ pub fn bind_udp<A: std::net::ToSocketAddrs>(addr: A, reuse_port: bool) -> io::Re
 }
 
 /// Binds a socket to a specified interface by name
-#[cfg(target_os = "linux")]
-#[allow(dead_code)] // This is currently only used in the XDP io provider, which is optional
+#[cfg(feature = "xdp")]
 pub fn bind_to_interface<F: std::os::unix::io::AsRawFd>(
     socket: &F,
     ifname: &std::ffi::CStr,

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -40,6 +40,8 @@ unstable-provider-datagram = []
 unstable-provider-io-testing = ["s2n-quic-platform/io-testing"]
 # This feature enables the turmoil IO provider
 unstable-provider-io-turmoil = ["s2n-quic-platform/turmoil"]
+# This feature enables the XDP IO provider
+unstable-provider-io-xdp = ["s2n-quic-platform/xdp"]
 # This feature enables the packet interceptor provider, which is invoked on each cleartext packet
 unstable-provider-packet-interceptor = []
 # This feature enables the random provider

--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -81,6 +81,7 @@ mod tests;
             feature = "unstable-provider-datagram",
             feature = "unstable-provider-io-testing",
             feature = "unstable-provider-io-turmoil",
+            feature = "unstable-provider-io-xdp",
             feature = "unstable-provider-packet-interceptor",
             feature = "unstable-provider-random",
             feature = "unstable-congestion-controller",

--- a/quic/s2n-quic/src/provider/io.rs
+++ b/quic/s2n-quic/src/provider/io.rs
@@ -22,6 +22,9 @@ pub mod testing;
 #[cfg(feature = "unstable-provider-io-turmoil")]
 pub mod turmoil;
 
+#[cfg(feature = "unstable-provider-io-xdp")]
+pub mod xdp;
+
 pub mod tokio;
 
 pub use self::tokio as default;

--- a/quic/s2n-quic/src/provider/io/xdp.rs
+++ b/quic/s2n-quic/src/provider/io/xdp.rs
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provides an implementation of the [`io::Provider`](crate::provider::io::Provider)
+//! using [AF_XDP](https://www.kernel.org/doc/html/latest/networking/af_xdp.html) sockets.
+
+use s2n_quic_core::{
+    endpoint::Endpoint,
+    inet::SocketAddress,
+    io::{rx, tx},
+};
+
+pub use s2n_quic_platform::io::xdp::*;
+
+impl<Rx, Tx> super::Provider for Provider<Rx, Tx>
+where
+    Rx: 'static + rx::Rx<PathHandle = PathHandle> + Send,
+    Tx: 'static + tx::Tx<PathHandle = PathHandle> + Send,
+{
+    type PathHandle = PathHandle;
+    type Error = std::io::Error;
+
+    fn start<E: Endpoint<PathHandle = Self::PathHandle>>(
+        self,
+        endpoint: E,
+    ) -> Result<SocketAddress, Self::Error> {
+        let (_join_handle, local_addr) = Provider::start(self, endpoint)?;
+        Ok(local_addr)
+    }
+}

--- a/tools/xdp/s2n-quic-xdp/src/lib.rs
+++ b/tools/xdp/s2n-quic-xdp/src/lib.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(dead_code)] // TODO remove once the crate is finished
-
 type Result<T = (), E = std::io::Error> = core::result::Result<T, E>;
 
 /// Emits a log line if the `s2n_quic_xdp_trace` cfg option is enabled. Otherwise, the trace is a
@@ -19,18 +17,18 @@ macro_rules! trace {
 /// Default BPF programs to direct QUIC traffic
 pub mod bpf;
 /// Primitive types for AF-XDP kernel APIs
-mod if_xdp;
+pub mod if_xdp;
 /// Implementations of the IO traits from [`s2n_quic_core::io`]
-mod io;
+pub mod io;
 /// Helpers for creating mmap'd regions
-mod mmap;
+pub mod mmap;
 /// Structures for tracking ring cursors and synchronizing with the kernel
-mod ring;
+pub mod ring;
 /// Structure for opening and reference counting an AF-XDP socket
-mod socket;
+pub mod socket;
 /// Helpers for making API calls to AF-XDP sockets
-mod syscall;
+pub mod syscall;
 /// A set of async tasks responsible for managing ring buffer and queue state
-mod task;
+pub mod task;
 /// A shared region of memory for holding frame (packet) data
-mod umem;
+pub mod umem;

--- a/tools/xdp/s2n-quic-xdp/src/ring.rs
+++ b/tools/xdp/s2n-quic-xdp/src/ring.rs
@@ -14,6 +14,7 @@ mod cursor;
 use cursor::Cursor;
 
 #[derive(Debug)]
+#[allow(dead_code)] // we hold on to `area` and `socket` to ensure they live long enough
 struct Ring<T: Copy + fmt::Debug> {
     cursor: Cursor<T>,
     // make the area clonable in test mode

--- a/tools/xdp/s2n-quic-xdp/src/ring/cursor.rs
+++ b/tools/xdp/s2n-quic-xdp/src/ring/cursor.rs
@@ -296,8 +296,9 @@ impl<T: Copy + fmt::Debug> Cursor<T> {
         unsafe { &*self.flags.as_ptr() }
     }
 
-    /// Returns a reference to the flags on the ring
+    /// Returns a mutable reference to the flags on the ring
     #[inline]
+    #[cfg(test)]
     pub fn flags_mut(&mut self) -> &mut RingFlags {
         unsafe { &mut *self.flags.as_ptr() }
     }

--- a/tools/xdp/s2n-quic-xdp/src/umem.rs
+++ b/tools/xdp/s2n-quic-xdp/src/umem.rs
@@ -9,6 +9,9 @@ use crate::{
 use core::ptr::NonNull;
 use std::{os::unix::io::AsRawFd, sync::Arc};
 
+/// The default value for frame sizes
+pub const DEFAULT_FRAME_SIZE: u32 = 4096;
+
 #[derive(Clone, Copy, Debug)]
 pub struct Builder {
     /// The maximum number of bytes a frame can hold (MTU)
@@ -24,7 +27,7 @@ pub struct Builder {
 impl Default for Builder {
     fn default() -> Self {
         Self {
-            frame_size: 4096,
+            frame_size: DEFAULT_FRAME_SIZE,
             frame_count: 1024,
             frame_headroom: 0,
             flags: Default::default(),


### PR DESCRIPTION
### Description of changes: 

This change exports an experimental XDP IO provider in the s2n-quic crate.

### Call-outs:

Because there are many ways to configure AF_XDP sockets, it currently exports a very large API. As we gather more information about how the setup could be made more standardized the exported types can be reduced.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

