### PR TITLE
Expose types to implement custom congestion controllers

### DIFF
--- a/quic/s2n-quic/src/provider/congestion_controller.rs
+++ b/quic/s2n-quic/src/provider/congestion_controller.rs
@@ -1,8 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-pub use s2n_quic_core::recovery::congestion_controller::{
-    CongestionController, Endpoint, PathInfo,
+pub use s2n_quic_core::{
+    random::Generator,
+    recovery::{
+        congestion_controller::{CongestionController, Endpoint, PathInfo, Publisher},
+        RttEstimator,
+    },
+    time::Timestamp,
 };
 
 /// Provides congestion controller support for an endpoint


### PR DESCRIPTION
### Description of changes: 

Previously s2n-quic didn't expose enough types that a CongestionController impl was possible without depending on s2n-quic-core directly. These impls can be useful for debugging congestion control or trying quick alternatives without rebuilding s2n-quic, which slows down iteration.

### Call-outs:

It's not clear whether there's a goal of *allowing* "userspace" experimentation with congestion controllers, but if not then not exposing the Endpoint trait etc at all would make more sense.

### Testing

No particular testing just yet, just went through rustdoc and tried to confirm no s2n-quic-core links were present on the trait impl. I may have missed something.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

