### PR TITLE
feat(s2n-quic-xdp): implement tx/rx traits for shared tokio sockets

### DIFF
--- a/tools/xdp/s2n-quic-xdp/src/task/rx/tokio_impl.rs
+++ b/tools/xdp/s2n-quic-xdp/src/task/rx/tokio_impl.rs
@@ -1,0 +1,99 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+type Fd = tokio::io::unix::AsyncFd<socket::Fd>;
+
+/// Polls read readiness for a tokio socket
+#[inline]
+fn poll<F: FnMut(&mut ring::Rx, &mut Context) -> Option<usize>>(
+    fd: &Fd,
+    rx: &mut ring::Rx,
+    cx: &mut Context,
+    mut on_ready: F,
+) -> Poll<Result<(), ()>> {
+    // limit the number of loops to prevent endless spinning on registering wakers
+    for iteration in 0..10 {
+        trace!("iteration {}", iteration);
+
+        // query socket readiness through tokio's polling facilities
+        match fd.poll_read_ready(cx) {
+            Poll::Ready(Ok(mut guard)) => {
+                // try to acquire entries for the queue
+                let count = rx.acquire(1) as usize;
+
+                trace!("acquired {count} items from RX ring");
+
+                // if we didn't get anything, we need to clear readiness and try again
+                if count == 0 {
+                    guard.clear_ready();
+                    trace!("clearing socket readiness and trying again");
+                    continue;
+                }
+
+                // we have at least one entry so notify the callback
+                match on_ready(rx, cx) {
+                    Some(actual) => {
+                        trace!("consumed {actual} items");
+
+                        // if we consumed all of the acquired items we'll need to poll the
+                        // queue again for readiness so we can register a waker.
+                        if actual >= count {
+                            trace!("clearing socket readiness and trying again");
+                            guard.clear_ready();
+                        }
+
+                        continue;
+                    }
+                    None => {
+                        trace!("on_ready closed; closing receiver");
+
+                        return Poll::Ready(Err(()));
+                    }
+                }
+            }
+            Poll::Ready(Err(err)) => {
+                trace!("socket returned an error while polling: {err:?}; closing poller");
+                return Poll::Ready(Err(()));
+            }
+            Poll::Pending => {
+                trace!("ring out of items; sleeping");
+                return Poll::Pending;
+            }
+        }
+    }
+
+    // if we got here, we iterated 10 times and need to yield so we don't consume the event
+    // loop too much
+    trace!("waking self");
+    cx.waker().wake_by_ref();
+
+    Poll::Pending
+}
+
+/// Polling implementation for an asynchronous socket
+impl Poller for Fd {
+    #[inline]
+    fn poll<F: FnMut(&mut ring::Rx, &mut Context) -> Option<usize>>(
+        &mut self,
+        rx: &mut ring::Rx,
+        cx: &mut Context,
+        on_ready: F,
+    ) -> Poll<Result<(), ()>> {
+        poll(self, rx, cx, on_ready)
+    }
+}
+
+/// Polling implementation for a shared asynchronous socket
+impl Poller for std::sync::Arc<Fd> {
+    #[inline]
+    fn poll<F: FnMut(&mut ring::Rx, &mut Context) -> Option<usize>>(
+        &mut self,
+        rx: &mut ring::Rx,
+        cx: &mut Context,
+        on_ready: F,
+    ) -> Poll<Result<(), ()>> {
+        poll(self, rx, cx, on_ready)
+    }
+}

--- a/tools/xdp/s2n-quic-xdp/src/task/tx/tokio_impl.rs
+++ b/tools/xdp/s2n-quic-xdp/src/task/tx/tokio_impl.rs
@@ -1,0 +1,89 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+type Fd = tokio::io::unix::AsyncFd<socket::Fd>;
+
+/// Notifies the socket that the TX queue has no capacity
+#[inline]
+fn notify_empty(fd: &Fd, tx: &mut ring::Tx, cx: &mut Context) -> Poll<()> {
+    // only notify the socket if it's set the needs wakeup flag
+    if !tx.needs_wakeup() {
+        trace!("TX ring doesn't need wake, returning early");
+        return Poll::Ready(());
+    }
+
+    // limit the number of loops to prevent endless spinning on registering wakers
+    for iteration in 0..10 {
+        trace!("iteration {}", iteration);
+
+        // query socket readiness through tokio's polling facilities
+        match fd.poll_write_ready(cx) {
+            Poll::Ready(Ok(mut guard)) => {
+                // try to acquire entries for the queue
+                let count = tx.acquire(u32::MAX) as usize;
+
+                trace!("acquired {count} items from TX ring");
+
+                // if we didn't acquire all of the capacity, we need to clear readiness and try again
+                if count != tx.capacity() {
+                    guard.clear_ready();
+
+                    // check to see if we need to wake up the socket again
+                    if tx.needs_wakeup() {
+                        let _ = syscall::wake_tx(guard.get_ref());
+                    }
+
+                    trace!("clearing socket readiness and trying again");
+                    continue;
+                }
+
+                return Poll::Ready(());
+            }
+            Poll::Ready(Err(err)) => {
+                trace!("socket returned an error while polling: {err:?}; closing poller");
+                return Poll::Ready(());
+            }
+            Poll::Pending => {
+                trace!("ring out of items; sleeping");
+                return Poll::Pending;
+            }
+        }
+    }
+
+    // if we got here, we iterated 10 times and need to yield so we don't consume the event
+    // loop too much
+    trace!("waking self");
+    cx.waker().wake_by_ref();
+
+    Poll::Pending
+}
+
+/// Polling implementation for an asynchronous socket
+impl Notifier for Fd {
+    #[inline]
+    fn notify(&mut self, tx: &mut ring::Tx, cx: &mut Context, _count: u32) {
+        // try making progress on the socket regardless of transmission count
+        let _ = self.notify_empty(tx, cx);
+    }
+
+    #[inline]
+    fn notify_empty(&mut self, tx: &mut ring::Tx, cx: &mut Context) -> Poll<()> {
+        notify_empty(self, tx, cx)
+    }
+}
+
+/// Polling implementation for a shared asynchronous socket
+impl Notifier for std::sync::Arc<Fd> {
+    #[inline]
+    fn notify(&mut self, tx: &mut ring::Tx, cx: &mut Context, _count: u32) {
+        // try making progress on the socket regardless of transmission count
+        let _ = self.notify_empty(tx, cx);
+    }
+
+    #[inline]
+    fn notify_empty(&mut self, tx: &mut ring::Tx, cx: &mut Context) -> Poll<()> {
+        notify_empty(self, tx, cx)
+    }
+}


### PR DESCRIPTION
### Description of changes: 

This PR implements the tx/rx traits for tokio sockets, including ones behind an `Arc`. This allows TX AF_XDP sockets to be `poll`ed to drive progress rather than `send_to`.

### Call-outs:

I changed the TX trait a bit to better capture the differences between the TX queue sending items and not having capacity to send. I've also refactored the impls into their own module to shorten the length of the file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

