### PR TITLE
feat(s2n-quic): Stabilize congestion control provider and allow for custom congestion controllers

### DIFF
--- a/examples/custom-congestion-controller/.cargo/config.toml
+++ b/examples/custom-congestion-controller/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags=['--cfg', 's2n_quic_unstable']

--- a/examples/custom-congestion-controller/Cargo.toml
+++ b/examples/custom-congestion-controller/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "custom-congestion-controller"
+version = "0.1.0"
+authors = ["AWS s2n"]
+edition = "2021"
+
+[dependencies]
+s2n-quic = { version = "1", path = "../../quic/s2n-quic", features = ["unstable-congestion-controller"] }
+tokio = { version = "1", features = ["full"] }
+
+[workspace]
+members = ["."]

--- a/examples/custom-congestion-controller/README.md
+++ b/examples/custom-congestion-controller/README.md
@@ -1,0 +1,16 @@
+# Custom Congestion Controller
+
+This folder contains an example of implementing and configuring a custom congestion controller in `s2n-quic`. `s2n-quic` includes [CUBIC](https://www.rfc-editor.org/rfc/rfc8312) and [BBRv2](https://datatracker.ietf.org/doc/html/draft-cardwell-iccrg-bbr-congestion-control) congestion controller implementations, but you may
+ implement the `CongestionController` trait, found in [congestion_controller.rs](../../quic/s2n-quic-core/src/recovery/congestion_controller.rs), to provide your own.
+
+# Set-up
+
+The `CongestionController` trait is considered unstable and may be subject to change in a future release. In order to build it you must pass a compiler flag:
+```sh
+export RUSTFLAGS="--cfg s2n_quic_unstable"
+```
+and add this line to your Cargo.toml file:
+```toml
+[dependencies]
+s2n-quic = { version = "1", features = ["unstable-congestion-controller"]}
+```

--- a/examples/custom-congestion-controller/src/bin/main.rs
+++ b/examples/custom-congestion-controller/src/bin/main.rs
@@ -1,0 +1,49 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use custom_congestion_controller::custom_congestion_controller::MyCongestionControllerEndpoint;
+use s2n_quic::Server;
+use std::error::Error;
+
+/// NOTE: this certificate is to be used for demonstration purposes only!
+pub static CERT_PEM: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../quic/s2n-quic-core/certs/cert.pem"
+));
+/// NOTE: this certificate is to be used for demonstration purposes only!
+pub static KEY_PEM: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../quic/s2n-quic-core/certs/key.pem"
+));
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // Build an `s2n_quic::Server`
+    let mut server = Server::builder()
+        .with_tls((CERT_PEM, KEY_PEM))?
+        .with_io("127.0.0.1:4433")?
+        // Specify the custom congestion controller endpoint defined in `custom-congestion-controller/src/lib.rs`
+        .with_congestion_controller(MyCongestionControllerEndpoint::default())?
+        .start()?;
+
+    while let Some(mut connection) = server.accept().await {
+        // spawn a new task for the connection
+        tokio::spawn(async move {
+            eprintln!("Connection accepted from {:?}", connection.remote_addr());
+
+            while let Ok(Some(mut stream)) = connection.accept_bidirectional_stream().await {
+                // spawn a new task for the stream
+                tokio::spawn(async move {
+                    eprintln!("Stream opened from {:?}", stream.connection().remote_addr());
+
+                    // echo any data back to the stream
+                    while let Ok(Some(data)) = stream.receive().await {
+                        stream.send(data).await.expect("stream should be open");
+                    }
+                });
+            }
+        });
+    }
+
+    Ok(())
+}

--- a/examples/custom-congestion-controller/src/lib.rs
+++ b/examples/custom-congestion-controller/src/lib.rs
@@ -1,0 +1,138 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Example implementation of a custom congestion controller algorithm.
+///
+/// NOTE: The `CongestionController` trait is considered unstable and may be subject to change
+///       in a future release.
+pub mod custom_congestion_controller {
+    use s2n_quic::provider::{
+        congestion_controller,
+        congestion_controller::{
+            CongestionController, Publisher, RandomGenerator, RttEstimator, Timestamp,
+        },
+    };
+
+    /// Define a congestion controller containing any state you wish to track.
+    /// For this example, we track the size of the congestion window in bytes and
+    /// the number of bytes in flight.
+    #[derive(Debug, Clone)]
+    pub struct MyCongestionController {
+        congestion_window: u32,
+        bytes_in_flight: u32,
+    }
+
+    /// The following is a simple implementation of the `CongestionController` trait
+    /// that increases the congestion window by the number of bytes acknowledged and
+    /// decreases the congestion window by half when packets are lost.
+    #[allow(unused)]
+    impl CongestionController for MyCongestionController {
+        type PacketInfo = ();
+
+        fn congestion_window(&self) -> u32 {
+            self.congestion_window
+        }
+
+        fn bytes_in_flight(&self) -> u32 {
+            self.bytes_in_flight
+        }
+
+        fn is_congestion_limited(&self) -> bool {
+            self.congestion_window < self.bytes_in_flight
+        }
+
+        fn requires_fast_retransmission(&self) -> bool {
+            false
+        }
+
+        fn on_packet_sent<Pub: Publisher>(
+            &mut self,
+            time_sent: Timestamp,
+            sent_bytes: usize,
+            app_limited: Option<bool>,
+            rtt_estimator: &RttEstimator,
+            publisher: &mut Pub,
+        ) -> Self::PacketInfo {
+            self.bytes_in_flight += sent_bytes as u32;
+        }
+
+        fn on_rtt_update<Pub: Publisher>(
+            &mut self,
+            time_sent: Timestamp,
+            now: Timestamp,
+            rtt_estimator: &RttEstimator,
+            publisher: &mut Pub,
+        ) {
+            // no op
+        }
+
+        fn on_ack<Pub: Publisher>(
+            &mut self,
+            newest_acked_time_sent: Timestamp,
+            bytes_acknowledged: usize,
+            newest_acked_packet_info: Self::PacketInfo,
+            rtt_estimator: &RttEstimator,
+            random_generator: &mut dyn RandomGenerator,
+            ack_receive_time: Timestamp,
+            publisher: &mut Pub,
+        ) {
+            self.bytes_in_flight -= bytes_acknowledged as u32;
+            self.congestion_window + bytes_acknowledged as u32;
+        }
+
+        fn on_packet_lost<Pub: Publisher>(
+            &mut self,
+            lost_bytes: u32,
+            packet_info: Self::PacketInfo,
+            persistent_congestion: bool,
+            new_loss_burst: bool,
+            random_generator: &mut dyn RandomGenerator,
+            timestamp: Timestamp,
+            publisher: &mut Pub,
+        ) {
+            self.bytes_in_flight -= lost_bytes;
+            self.congestion_window = (self.congestion_window as f32 * 0.5) as u32;
+        }
+
+        fn on_explicit_congestion<Pub: Publisher>(
+            &mut self,
+            ce_count: u64,
+            event_time: Timestamp,
+            publisher: &mut Pub,
+        ) {
+            self.congestion_window = (self.congestion_window as f32 * 0.5) as u32;
+        }
+
+        fn on_mtu_update<Pub: Publisher>(&mut self, max_data_size: u16, publisher: &mut Pub) {
+            // no op
+        }
+
+        fn on_packet_discarded<Pub: Publisher>(&mut self, bytes_sent: usize, publisher: &mut Pub) {
+            self.bytes_in_flight -= bytes_sent as u32;
+        }
+
+        fn earliest_departure_time(&self) -> Option<Timestamp> {
+            None
+        }
+    }
+
+    // Define an endpoint for the custom congestion controller so it may be used as a
+    // congestion controller provider to the s2n-quic server or client
+    #[derive(Debug, Default)]
+    pub struct MyCongestionControllerEndpoint {}
+
+    impl congestion_controller::Endpoint for MyCongestionControllerEndpoint {
+        type CongestionController = MyCongestionController;
+
+        // This method will be called whenever a new congestion controller instance is needed.
+        fn new_congestion_controller(
+            &mut self,
+            path_info: congestion_controller::PathInfo,
+        ) -> Self::CongestionController {
+            MyCongestionController {
+                congestion_window: path_info.max_datagram_size as u32,
+                bytes_in_flight: 0,
+            }
+        }
+    }
+}

--- a/examples/custom-congestion-controller/src/lib.rs
+++ b/examples/custom-congestion-controller/src/lib.rs
@@ -77,7 +77,7 @@ pub mod custom_congestion_controller {
             publisher: &mut Pub,
         ) {
             self.bytes_in_flight -= bytes_acknowledged as u32;
-            self.congestion_window + bytes_acknowledged as u32;
+            self.congestion_window += bytes_acknowledged as u32;
         }
 
         fn on_packet_lost<Pub: Publisher>(

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -18,6 +18,8 @@ testing = ["std", "generator", "s2n-codec/testing", "checked-counters", "insta",
 generator = ["bolero-generator"]
 checked-counters = []
 event-tracing = ["tracing"]
+# This feature enables support for third party congestion controller implementations
+unstable-congestion-controller = []
 
 [dependencies]
 atomic-waker = { version = "1", optional = true }
@@ -25,6 +27,7 @@ bolero-generator = { version = "0.9", optional = true }
 byteorder = { version = "1", default-features = false }
 bytes = { version = "1", optional = true, default-features = false }
 cache-padded = { version = "1", optional = true }
+cfg-if = "1"
 hex-literal = "0.4"
 # used for event snapshot testing - needs an internal API so we require a minimum version
 insta = { version = ">=1.12", features = ["json"], optional = true }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -44,8 +44,8 @@ unstable-provider-io-turmoil = ["s2n-quic-platform/turmoil"]
 unstable-provider-packet-interceptor = []
 # This feature enables the random provider
 unstable-provider-random = []
-# This feature enables the congestion controller provider
-unstable-provider-congestion-controller = []
+# This feature enables support for third party congestion controller implementations
+unstable-congestion-controller = ["s2n-quic-core/unstable-congestion-controller"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }

--- a/quic/s2n-quic/src/client/builder.rs
+++ b/quic/s2n-quic/src/client/builder.rs
@@ -269,7 +269,6 @@ impl<Providers: ClientProviders> Builder<Providers> {
         ClientProviders
     );
 
-    #[cfg(any(test, feature = "unstable-provider-congestion-controller"))]
     impl_provider_method!(
         /// Sets the congestion controller provider for the [`Client`]
         with_congestion_controller,

--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -83,7 +83,7 @@ mod tests;
             feature = "unstable-provider-io-turmoil",
             feature = "unstable-provider-packet-interceptor",
             feature = "unstable-provider-random",
-            feature = "unstable-provider-congestion-controller",
+            feature = "unstable-congestion-controller",
         ),
         // any unstable features requires at least one of the following conditions
         not(any(

--- a/quic/s2n-quic/src/provider.rs
+++ b/quic/s2n-quic/src/provider.rs
@@ -8,6 +8,7 @@ use core::fmt;
 mod macros;
 
 pub mod address_token;
+pub mod congestion_controller;
 pub mod connection_id;
 pub mod endpoint_limits;
 pub mod event;
@@ -42,14 +43,6 @@ cfg_if!(
         pub mod datagram;
     } else {
         pub(crate) mod datagram;
-    }
-);
-
-cfg_if!(
-    if #[cfg(any(test, feature = "unstable-provider-congestion-controller"))] {
-        pub mod congestion_controller;
-    } else {
-        pub(crate) mod congestion_controller;
     }
 );
 

--- a/quic/s2n-quic/src/provider/congestion_controller.rs
+++ b/quic/s2n-quic/src/provider/congestion_controller.rs
@@ -1,9 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-pub use s2n_quic_core::recovery::congestion_controller::{
-    CongestionController, Endpoint, PathInfo,
-};
+use cfg_if::cfg_if;
+pub use s2n_quic_core::recovery::congestion_controller::Endpoint;
 
 /// Provides congestion controller support for an endpoint
 pub trait Provider {
@@ -11,6 +10,17 @@ pub trait Provider {
     type Error: 'static + core::fmt::Display;
 
     fn start(self) -> Result<Self::Endpoint, Self::Error>;
+}
+
+cfg_if! {
+    if #[cfg(feature = "unstable-congestion-controller")] {
+        // Export the types needed to implement the CongestionController trait
+        pub use s2n_quic_core::{
+            random::Generator as RandomGenerator,
+            recovery::{congestion_controller::{CongestionController, PathInfo, Publisher}, RttEstimator},
+            time::Timestamp,
+        };
+    }
 }
 
 pub use s2n_quic_core::recovery::{bbr::Endpoint as Bbr, cubic::Endpoint as Cubic};

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -319,7 +319,6 @@ impl<Providers: ServerProviders> Builder<Providers> {
         ServerProviders
     );
 
-    #[cfg(any(test, feature = "unstable-provider-congestion-controller"))]
     impl_provider_method!(
         /// Sets the congestion controller provider for the [`Server`]
         with_congestion_controller,


### PR DESCRIPTION
### Description of changes: 

This change removes the `unstable-provider-congestion-controller` feature that was previously required to use a congestion controller other than the default. In addition, this change introduces a `unstable-congestion-controller` feature to allow users to implement their own congestion controllers. I've also included an example of implementing a custom congestion controller.

### Call-outs:

The [sealed trait](https://rust-lang.github.io/api-guidelines/future-proofing.html#sealed-traits-protect-against-downstream-implementations-c-sealed) pattern is used to prevent implementation of the `CongestionController` trait.

I believe removing the `unstable-provider-congestion-controller` feature is not backward compatible, though since it is unstable that is OK. 

### Testing:

Tested via the included example code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

