### PR TITLE
feat(s2n-quic-core): add IO extensions

### DIFF
--- a/quic/s2n-quic-core/src/io/mod.rs
+++ b/quic/s2n-quic-core/src/io/mod.rs
@@ -4,3 +4,6 @@
 pub mod event_loop;
 pub mod rx;
 pub mod tx;
+
+#[cfg(test)]
+mod testing;

--- a/quic/s2n-quic-core/src/io/rx/pair.rs
+++ b/quic/s2n-quic-core/src/io/rx/pair.rs
@@ -1,0 +1,181 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Rx;
+use crate::{event, inet::datagram};
+use core::task::{Context, Poll};
+
+/// A pair of Rx channels that feed into the same endpoint
+pub struct Channel<A, B>
+where
+    A: Rx,
+    B: Rx<PathHandle = A::PathHandle>,
+{
+    pub(super) a: A,
+    pub(super) b: B,
+}
+
+impl<A, B> Rx for Channel<A, B>
+where
+    A: Rx,
+    B: Rx<PathHandle = A::PathHandle>,
+    A::Queue: 'static,
+    B::Queue: 'static,
+{
+    type PathHandle = A::PathHandle;
+    type Queue = Queue<'static, A::Queue, B::Queue>;
+    type Error = Error<A::Error, B::Error>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        // assume we aren't ready until one channel returns ready
+        let mut is_ready = false;
+
+        macro_rules! ready {
+            ($value:expr, $var:ident) => {
+                match $value {
+                    Poll::Ready(Ok(())) => is_ready = true,
+                    Poll::Ready(Err(err)) => {
+                        // one of the channels returned an error so shut down both
+                        return Err(Error::$var(err)).into();
+                    }
+                    Poll::Pending => {}
+                }
+            };
+        }
+
+        ready!(self.a.poll_ready(cx), A);
+        ready!(self.b.poll_ready(cx), B);
+
+        if is_ready {
+            Poll::Ready(Ok(()))
+        } else {
+            Poll::Pending
+        }
+    }
+
+    #[inline]
+    fn queue<F: FnOnce(&mut Self::Queue)>(&mut self, f: F) {
+        let a = &mut self.a;
+        let b = &mut self.b;
+        a.queue(|a| {
+            b.queue(|b| {
+                let (a, b): (&'static mut _, &'static mut _) = unsafe {
+                    // Safety: As noted in the [transmute examples](https://doc.rust-lang.org/std/mem/fn.transmute.html#examples)
+                    // it can be used to temporarily extend the lifetime of a reference. In this case, we
+                    // don't want to use GATs until the MSRV is >=1.65.0, which means `Self::Queue` is not
+                    // allowed to take generic lifetimes.
+                    //
+                    // We are left with using a `'static` lifetime here and encapsulating it in a private
+                    // field. The `Self::Queue` struct is then borrowed for the lifetime of the `F`
+                    // function. This will prevent the value from escaping beyond the lifetime of `&mut
+                    // self`.
+                    //
+                    // See https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=9a32abe85c666f36fb2ec86496cc41b4
+                    //
+                    // Once https://github.com/aws/s2n-quic/issues/1742 is resolved this code can go away
+                    (core::mem::transmute(a), core::mem::transmute(b))
+                };
+
+                let mut queue = Queue { a, b };
+                f(&mut queue);
+            });
+        });
+    }
+
+    #[inline]
+    fn handle_error<E: event::EndpointPublisher>(self, error: Self::Error, event: &mut E) {
+        // dispatch the error to the appropriate channel
+        match error {
+            Error::A(error) => self.a.handle_error(error, event),
+            Error::B(error) => self.b.handle_error(error, event),
+        }
+    }
+}
+
+/// Tagged error for a pair of channels
+pub enum Error<A, B> {
+    A(A),
+    B(B),
+}
+
+pub struct Queue<'a, A, B>
+where
+    A: super::Queue,
+    B: super::Queue,
+{
+    a: &'a mut A,
+    b: &'a mut B,
+}
+
+impl<'a, A, B> super::Queue for Queue<'a, A, B>
+where
+    A: super::Queue,
+    B: super::Queue<Handle = A::Handle>,
+{
+    type Handle = A::Handle;
+
+    #[inline]
+    fn for_each<F: FnMut(datagram::Header<Self::Handle>, &mut [u8])>(&mut self, mut on_packet: F) {
+        // drain both of the channels
+        self.a.for_each(&mut on_packet);
+        self.b.for_each(&mut on_packet);
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.a.is_empty() && self.b.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::io::{
+        rx::{Queue as _, RxExt as _},
+        testing,
+    };
+    use futures_test::task::noop_waker;
+
+    #[test]
+    fn pair_test() {
+        let channel_a = testing::Channel::default();
+        let channel_b = testing::Channel::default();
+        let mut merged = channel_a.clone().with_pair(channel_b.clone());
+
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let cx = &mut cx;
+
+        for push_a in [false, true] {
+            for push_b in [false, true] {
+                assert!(merged.poll_ready(cx).is_pending());
+
+                let mut expected = 0;
+
+                if push_a {
+                    expected += 1;
+                    channel_a.push(Default::default());
+                }
+
+                if push_b {
+                    expected += 1;
+                    channel_b.push(Default::default());
+                }
+
+                assert_eq!(merged.poll_ready(cx).is_ready(), push_a || push_b);
+
+                let mut actual = 0;
+                merged.queue(|queue| {
+                    assert_eq!(queue.is_empty(), !(push_a || push_b));
+
+                    queue.for_each(|_header, _payload| {
+                        actual += 1;
+                    });
+                });
+
+                assert_eq!(expected, actual);
+            }
+        }
+    }
+}

--- a/quic/s2n-quic-core/src/io/testing.rs
+++ b/quic/s2n-quic-core/src/io/testing.rs
@@ -1,0 +1,172 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    event,
+    inet::datagram,
+    io::{rx, tx},
+    path::Tuple,
+};
+use core::task::{Context, Poll};
+use std::sync::{Arc, Mutex};
+
+pub type Handle = Tuple;
+
+#[derive(Clone, Debug, Default)]
+pub struct Channel {
+    messages: Arc<Mutex<Vec<Message>>>,
+}
+
+impl Channel {
+    pub fn push(&self, message: Message) {
+        self.messages.lock().unwrap().push(message);
+    }
+
+    pub fn pop(&self) -> Option<Message> {
+        self.messages.lock().unwrap().pop()
+    }
+
+    #[inline]
+    fn queue<F: FnOnce(&mut Queue<'static>)>(&mut self, f: F) {
+        if let Ok(mut messages) = self.messages.lock() {
+            let messages: &mut Vec<_> = &mut *messages;
+            let messages: &'static mut _ = unsafe {
+                // Safety: As noted in the [transmute examples](https://doc.rust-lang.org/std/mem/fn.transmute.html#examples)
+                // it can be used to temporarily extend the lifetime of a reference. In this case, we
+                // don't want to use GATs until the MSRV is >=1.65.0, which means `Self::Queue` is not
+                // allowed to take generic lifetimes.
+                //
+                // We are left with using a `'static` lifetime here and encapsulating it in a private
+                // field. The `Self::Queue` struct is then borrowed for the lifetime of the `F`
+                // function. This will prevent the value from escaping beyond the lifetime of `&mut
+                // self`.
+                //
+                // See https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=9a32abe85c666f36fb2ec86496cc41b4
+                //
+                // Once https://github.com/aws/s2n-quic/issues/1742 is resolved this code can go away
+                core::mem::transmute(messages)
+            };
+
+            let mut queue = Queue { messages };
+            f(&mut queue);
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Message {
+    pub header: datagram::Header<Tuple>,
+    pub payload: Vec<u8>,
+}
+
+impl Default for Message {
+    fn default() -> Self {
+        Self {
+            header: datagram::Header {
+                ecn: Default::default(),
+                path: Tuple {
+                    local_address: Default::default(),
+                    remote_address: Default::default(),
+                },
+            },
+            payload: Default::default(),
+        }
+    }
+}
+
+impl tx::Tx for Channel {
+    type PathHandle = Tuple;
+    type Queue = Queue<'static>;
+    type Error = ();
+
+    #[inline]
+    fn poll_ready(&mut self, _cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        // the TX channel is always ready
+        Poll::Pending
+    }
+
+    #[inline]
+    fn queue<F: FnOnce(&mut Self::Queue)>(&mut self, f: F) {
+        Self::queue(self, f)
+    }
+
+    #[inline]
+    fn handle_error<E: event::EndpointPublisher>(self, _error: Self::Error, _event: &mut E) {
+        // nothing to do
+    }
+}
+
+impl rx::Rx for Channel {
+    type PathHandle = Tuple;
+    type Queue = Queue<'static>;
+    type Error = ();
+
+    #[inline]
+    fn poll_ready(&mut self, _cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        let messages = self.messages.lock().map_err(|_| ())?;
+        if messages.is_empty() {
+            Poll::Pending
+        } else {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[inline]
+    fn queue<F: FnOnce(&mut Self::Queue)>(&mut self, f: F) {
+        Self::queue(self, f)
+    }
+
+    #[inline]
+    fn handle_error<E: event::EndpointPublisher>(self, _error: Self::Error, _event: &mut E) {
+        // nothing to do
+    }
+}
+
+pub struct Queue<'a> {
+    messages: &'a mut Vec<Message>,
+}
+
+impl<'a> tx::Queue for Queue<'a> {
+    type Handle = Tuple;
+
+    #[inline]
+    fn push<M: tx::Message<Handle = Self::Handle>>(
+        &mut self,
+        mut message: M,
+    ) -> Result<tx::Outcome, tx::Error> {
+        let mut out = Message::default();
+        out.header.ecn = message.ecn();
+        out.header.path = *message.path_handle();
+
+        out.payload.resize(1500, 0);
+        let buffer = tx::PayloadBuffer::new(&mut out.payload);
+        let len = message.write_payload(buffer, 0)?;
+
+        self.messages.push(out);
+
+        let outcome = tx::Outcome { index: 0, len };
+
+        Ok(outcome)
+    }
+
+    #[inline]
+    fn capacity(&self) -> usize {
+        usize::MAX - self.messages.len()
+    }
+}
+
+impl<'a> rx::Queue for Queue<'a> {
+    type Handle = Tuple;
+
+    #[inline]
+    fn for_each<F: FnMut(datagram::Header<Self::Handle>, &mut [u8])>(&mut self, mut on_packet: F) {
+        for mut message in self.messages.drain(..) {
+            on_packet(message.header, &mut message.payload);
+        }
+    }
+
+    #[inline]
+    fn is_empty(&self) -> bool {
+        self.messages.is_empty()
+    }
+}

--- a/quic/s2n-quic-core/src/io/tx/handle_map.rs
+++ b/quic/s2n-quic-core/src/io/tx/handle_map.rs
@@ -1,0 +1,192 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{event, inet::ExplicitCongestionNotification, io::tx, path};
+use core::{
+    marker::PhantomData,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+pub struct Channel<Map, Tx, U> {
+    pub(super) map: Map,
+    pub(super) tx: Tx,
+    pub(super) handle: PhantomData<U>,
+}
+
+impl<Map, Tx, U> tx::Tx for Channel<Map, Tx, U>
+where
+    Map: 'static + Fn(&U) -> Tx::PathHandle,
+    Tx: tx::Tx,
+    Tx::Queue: 'static,
+    U: path::Handle,
+{
+    type PathHandle = U;
+    type Queue = Queue<'static, Map, Tx::Queue, U>;
+    type Error = Tx::Error;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        self.tx.poll_ready(cx)
+    }
+
+    #[inline]
+    fn queue<F: FnOnce(&mut Self::Queue)>(&mut self, f: F) {
+        let map = &mut self.map;
+        let tx = &mut self.tx;
+        tx.queue(|tx| {
+            let (map, tx): (&'static mut _, &'static mut _) = unsafe {
+                // Safety: As noted in the [transmute examples](https://doc.rust-lang.org/std/mem/fn.transmute.html#examples)
+                // it can be used to temporarily extend the lifetime of a reference. In this case, we
+                // don't want to use GATs until the MSRV is >=1.65.0, which means `Self::Queue` is not
+                // allowed to take generic lifetimes.
+                //
+                // We are left with using a `'static` lifetime here and encapsulating it in a private
+                // field. The `Self::Queue` struct is then borrowed for the lifetime of the `F`
+                // function. This will prevent the value from escaping beyond the lifetime of `&mut
+                // self`.
+                //
+                // See https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=9a32abe85c666f36fb2ec86496cc41b4
+                //
+                // Once https://github.com/aws/s2n-quic/issues/1742 is resolved this code can go away
+                (core::mem::transmute(map), core::mem::transmute(tx))
+            };
+
+            let mut queue = Queue {
+                map,
+                tx,
+                handle: PhantomData,
+            };
+            f(&mut queue);
+        });
+    }
+
+    #[inline]
+    fn handle_error<E: event::EndpointPublisher>(self, error: Self::Error, events: &mut E) {
+        self.tx.handle_error(error, events)
+    }
+}
+
+pub struct Queue<'a, Map, Tx, U>
+where
+    Map: Fn(&U) -> Tx::Handle,
+    Tx: tx::Queue,
+{
+    map: &'a Map,
+    tx: &'a mut Tx,
+    handle: PhantomData<U>,
+}
+
+impl<'a, Map, Tx, U> tx::Queue for Queue<'a, Map, Tx, U>
+where
+    Map: Fn(&U) -> Tx::Handle,
+    Tx: tx::Queue,
+    U: path::Handle,
+{
+    type Handle = U;
+
+    const SUPPORTS_ECN: bool = Tx::SUPPORTS_ECN;
+    const SUPPORTS_PACING: bool = Tx::SUPPORTS_PACING;
+    const SUPPORTS_FLOW_LABELS: bool = Tx::SUPPORTS_FLOW_LABELS;
+
+    #[inline]
+    fn push<M: tx::Message<Handle = Self::Handle>>(
+        &mut self,
+        inner: M,
+    ) -> Result<tx::Outcome, tx::Error> {
+        let handle = (self.map)(inner.path_handle());
+        let message = Message { inner, handle };
+        self.tx.push(message)
+    }
+
+    #[inline]
+    fn capacity(&self) -> usize {
+        self.tx.capacity()
+    }
+
+    #[inline]
+    fn has_capacity(&self) -> bool {
+        self.tx.has_capacity()
+    }
+}
+
+pub struct Message<M, Handle> {
+    inner: M,
+    handle: Handle,
+}
+
+impl<M, Handle> tx::Message for Message<M, Handle>
+where
+    M: tx::Message,
+    Handle: path::Handle,
+{
+    type Handle = Handle;
+
+    #[inline]
+    fn path_handle(&self) -> &Self::Handle {
+        // use the mapped handle instead of the inner type
+        &self.handle
+    }
+
+    #[inline]
+    fn ecn(&mut self) -> ExplicitCongestionNotification {
+        self.inner.ecn()
+    }
+
+    #[inline]
+    fn delay(&mut self) -> Duration {
+        self.inner.delay()
+    }
+
+    #[inline]
+    fn ipv6_flow_label(&mut self) -> u32 {
+        self.inner.ipv6_flow_label()
+    }
+
+    #[inline]
+    fn can_gso(&self, segment_len: usize, segment_count: usize) -> bool {
+        self.inner.can_gso(segment_len, segment_count)
+    }
+
+    #[inline]
+    fn write_payload(
+        &mut self,
+        buffer: tx::PayloadBuffer,
+        gso_offset: usize,
+    ) -> Result<usize, tx::Error> {
+        self.inner.write_payload(buffer, gso_offset)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        io::{
+            testing,
+            tx::{Queue as _, Tx as _, TxExt as _},
+        },
+        path::{Handle as _, RemoteAddress},
+    };
+
+    #[test]
+    fn handle_map_test() {
+        let channel = testing::Channel::default();
+        let mut mapped = channel.clone().with_handle_map(|handle: &RemoteAddress| {
+            let mut handle = testing::Handle::from_remote_address(*handle);
+            handle.local_address.set_port(321);
+            handle
+        });
+
+        mapped.queue(|queue| {
+            let mut handle = RemoteAddress::default();
+            handle.set_port(123);
+            let msg = (handle, &[1, 2, 3][..]);
+            queue.push(msg).unwrap();
+        });
+
+        let msg = channel.pop().unwrap();
+
+        assert_eq!(msg.header.path.remote_address.port(), 123);
+        assert_eq!(msg.header.path.local_address.port(), 321);
+    }
+}

--- a/quic/s2n-quic-core/src/io/tx/router.rs
+++ b/quic/s2n-quic-core/src/io/tx/router.rs
@@ -1,0 +1,235 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{event, io::tx, path};
+use core::task::{Context, Poll};
+
+/// Defines how to route a message between two different channels
+pub trait Router {
+    type Handle: path::Handle;
+
+    fn route<M, A, B>(
+        &mut self,
+        message: M,
+        a: &mut A,
+        b: &mut B,
+    ) -> Result<tx::Outcome, tx::Error>
+    where
+        M: tx::Message<Handle = Self::Handle>,
+        A: tx::Queue<Handle = Self::Handle>,
+        B: tx::Queue<Handle = Self::Handle>;
+}
+
+pub struct Channel<R, A, B> {
+    pub(super) router: R,
+    pub(super) a: A,
+    pub(super) b: B,
+}
+
+impl<R, A, B> tx::Tx for Channel<R, A, B>
+where
+    R: 'static + Router,
+    A: tx::Tx<PathHandle = R::Handle>,
+    B: tx::Tx<PathHandle = R::Handle>,
+    A::Queue: 'static,
+    B::Queue: 'static,
+{
+    type PathHandle = A::PathHandle;
+    type Queue = Queue<'static, R, A::Queue, B::Queue>;
+    type Error = Error<A::Error, B::Error>;
+
+    #[inline]
+    fn poll_ready(&mut self, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
+        // assume we aren't ready until one of the channels says it is
+        let mut is_ready = false;
+
+        macro_rules! ready {
+            ($value:expr, $var:ident) => {
+                match $value {
+                    Poll::Ready(Ok(())) => is_ready = true,
+                    Poll::Ready(Err(err)) => {
+                        // one of the channels returned an error so shut down the task
+                        return Err(Error::$var(err)).into();
+                    }
+                    Poll::Pending => {}
+                }
+            };
+        }
+
+        ready!(self.a.poll_ready(cx), A);
+        ready!(self.b.poll_ready(cx), B);
+
+        if is_ready {
+            Poll::Ready(Ok(()))
+        } else {
+            Poll::Pending
+        }
+    }
+
+    #[inline]
+    fn queue<F: FnOnce(&mut Self::Queue)>(&mut self, f: F) {
+        let router = &mut self.router;
+        let a = &mut self.a;
+        let b = &mut self.b;
+        a.queue(|a| {
+            b.queue(|b| {
+                let (router, a, b): (&'static mut _, &'static mut _, &'static mut _) = unsafe {
+                    // Safety: As noted in the [transmute examples](https://doc.rust-lang.org/std/mem/fn.transmute.html#examples)
+                    // it can be used to temporarily extend the lifetime of a reference. In this case, we
+                    // don't want to use GATs until the MSRV is >=1.65.0, which means `Self::Queue` is not
+                    // allowed to take generic lifetimes.
+                    //
+                    // We are left with using a `'static` lifetime here and encapsulating it in a private
+                    // field. The `Self::Queue` struct is then borrowed for the lifetime of the `F`
+                    // function. This will prevent the value from escaping beyond the lifetime of `&mut
+                    // self`.
+                    //
+                    // See https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=9a32abe85c666f36fb2ec86496cc41b4
+                    //
+                    // Once https://github.com/aws/s2n-quic/issues/1742 is resolved this code can go away
+                    (
+                        core::mem::transmute(router),
+                        core::mem::transmute(a),
+                        core::mem::transmute(b),
+                    )
+                };
+
+                let mut queue = Queue { router, a, b };
+                f(&mut queue);
+            });
+        });
+    }
+
+    #[inline]
+    fn handle_error<E: event::EndpointPublisher>(self, error: Self::Error, events: &mut E) {
+        // dispatch the error into the sub-channels
+        match error {
+            Error::A(error) => self.a.handle_error(error, events),
+            Error::B(error) => self.b.handle_error(error, events),
+        }
+    }
+}
+
+/// Tagged error for a pair of channels
+pub enum Error<A, B> {
+    A(A),
+    B(B),
+}
+
+pub struct Queue<'a, R, A, B>
+where
+    R: Router,
+    A: super::Queue<Handle = R::Handle>,
+    B: super::Queue<Handle = R::Handle>,
+{
+    router: &'a mut R,
+    a: &'a mut A,
+    b: &'a mut B,
+}
+
+impl<'a, R, A, B> super::Queue for Queue<'a, R, A, B>
+where
+    R: Router,
+    A: super::Queue<Handle = R::Handle>,
+    B: super::Queue<Handle = R::Handle>,
+{
+    type Handle = R::Handle;
+
+    const SUPPORTS_ECN: bool = A::SUPPORTS_ECN || B::SUPPORTS_ECN;
+    const SUPPORTS_PACING: bool = A::SUPPORTS_PACING && B::SUPPORTS_PACING;
+    const SUPPORTS_FLOW_LABELS: bool = A::SUPPORTS_FLOW_LABELS || B::SUPPORTS_FLOW_LABELS;
+
+    #[inline]
+    fn push<M: tx::Message<Handle = Self::Handle>>(
+        &mut self,
+        message: M,
+    ) -> Result<tx::Outcome, tx::Error> {
+        // route messages to the appropriate queue
+        self.router.route(message, self.a, self.b)
+    }
+
+    #[inline]
+    fn capacity(&self) -> usize {
+        // take the minimum of the channel capacity, since we don't know where the next message
+        // will go
+        self.a.capacity().min(self.b.capacity())
+    }
+
+    #[inline]
+    fn has_capacity(&self) -> bool {
+        // we only have capacity if both channels do
+        self.a.has_capacity() && self.b.has_capacity()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::io::{
+        testing,
+        tx::{self, Queue as _, Tx as _, TxExt as _},
+    };
+
+    struct Router;
+
+    impl super::Router for Router {
+        type Handle = testing::Handle;
+
+        fn route<M, A, B>(
+            &mut self,
+            message: M,
+            a: &mut A,
+            b: &mut B,
+        ) -> Result<tx::Outcome, tx::Error>
+        where
+            M: tx::Message<Handle = Self::Handle>,
+            A: tx::Queue<Handle = Self::Handle>,
+            B: tx::Queue<Handle = Self::Handle>,
+        {
+            let handle = message.path_handle();
+            if handle.remote_address.port() == 0 {
+                dbg!("a", handle.remote_address);
+                a.push(message)
+            } else {
+                dbg!("b", handle.remote_address);
+                b.push(message)
+            }
+        }
+    }
+
+    #[test]
+    fn router_test() {
+        let channel_a = testing::Channel::default();
+        let channel_b = testing::Channel::default();
+        let mut merged = channel_a.clone().with_router(Router, channel_b.clone());
+
+        for push_a in [false, true] {
+            for push_b in [false, true] {
+                dbg!((push_a, push_b));
+
+                merged.queue(|queue| {
+                    if push_a {
+                        let handle = testing::Handle {
+                            remote_address: Default::default(),
+                            local_address: Default::default(),
+                        };
+                        let msg = (handle, &[1, 2, 3][..]);
+                        queue.push(msg).unwrap();
+                    }
+
+                    if push_b {
+                        let mut handle = testing::Handle {
+                            remote_address: Default::default(),
+                            local_address: Default::default(),
+                        };
+                        handle.remote_address.set_port(1);
+                        let msg = (handle, &[1, 2, 3][..]);
+                        queue.push(msg).unwrap();
+                    }
+                });
+
+                assert_eq!(channel_a.pop().is_some(), push_a);
+                assert_eq!(channel_b.pop().is_some(), push_b);
+            }
+        }
+    }
+}

--- a/tools/xdp/s2n-quic-xdp/src/io.rs
+++ b/tools/xdp/s2n-quic-xdp/src/io.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod router;
 pub mod rx;
 pub mod tx;
 

--- a/tools/xdp/s2n-quic-xdp/src/io/router.rs
+++ b/tools/xdp/s2n-quic-xdp/src/io/router.rs
@@ -17,18 +17,24 @@ pub struct Router(());
 impl router::Router for Router {
     type Handle = path::Tuple;
 
+    /// If the local port is 0 then forward to `AddressUnknown`. Otherwise forward to
+    /// `AddressKnown`.
     #[inline]
-    fn route<M, A, B>(&mut self, message: M, a: &mut A, b: &mut B) -> Result<tx::Outcome, tx::Error>
+    fn route<M, AddressKnown, AddressUnknown>(
+        &mut self,
+        message: M,
+        address_known: &mut AddressKnown,
+        address_unknown: &mut AddressUnknown,
+    ) -> Result<tx::Outcome, tx::Error>
     where
         M: tx::Message<Handle = Self::Handle>,
-        A: tx::Queue<Handle = Self::Handle>,
-        B: tx::Queue<Handle = Self::Handle>,
+        AddressKnown: tx::Queue<Handle = Self::Handle>,
+        AddressUnknown: tx::Queue<Handle = Self::Handle>,
     {
-        // If the local port is 0 then forward to `B`. Otherwise forward to `A`.
         if message.path_handle().local_address().port() == 0 {
-            b.push(message)
+            address_unknown.push(message)
         } else {
-            a.push(message)
+            address_known.push(message)
         }
     }
 }

--- a/tools/xdp/s2n-quic-xdp/src/io/router.rs
+++ b/tools/xdp/s2n-quic-xdp/src/io/router.rs
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_quic_core::{
+    io::tx::{self, router},
+    path::Handle as _,
+    xdp::path,
+};
+
+/// Routes TX messages based on if the local address port is non-zero
+///
+/// This can be used for client IO providers that wish to send the initial packet over a standard
+/// UDP socket in order to offload address resolution to the operating system.
+#[derive(Default)]
+pub struct Router(());
+
+impl router::Router for Router {
+    type Handle = path::Tuple;
+
+    #[inline]
+    fn route<M, A, B>(&mut self, message: M, a: &mut A, b: &mut B) -> Result<tx::Outcome, tx::Error>
+    where
+        M: tx::Message<Handle = Self::Handle>,
+        A: tx::Queue<Handle = Self::Handle>,
+        B: tx::Queue<Handle = Self::Handle>,
+    {
+        // If the local port is 0 then forward to `B`. Otherwise forward to `A`.
+        if message.path_handle().local_address().port() == 0 {
+            b.push(message)
+        } else {
+            a.push(message)
+        }
+    }
+}


### PR DESCRIPTION
### Description of changes: 

This change implements several extensions to the IO channels in order to make it easier to combine multiple types of channels into a single interface:

#### Rx Pair
This channel merges messages received from two channels into a single channel. For example, it can be used to receive from both an AF_XDP socket and standard UDP socket.

#### Tx Handle Map
This channel maps the handle from one type to another. For example, if the endpoint's handle type is the XDP one (with mac addresses) and we want to send a message on a regular UDP socket, we need to remove the mac addresses and convert it into the type the UDP socket expects.

#### Tx Router
This channel uses a `Router` trait to decide which channel to push a message into. For example, this will be used for the client to decide if it needs to send a message on a regular UDP socket for the initial packets until it hears from the server on the AF_XDP socket and can fill in the mac addresses. This PR includes an implementation of this that uses the port to decide between the channels.

### Testing:

Each of the extension types includes a test to make sure it's working as intended.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

