### PR TITLE
fix(s2n-quic-core): skip check in spsc cursors before loading peer value

### DIFF
--- a/quic/s2n-quic-core/src/sync/spsc/recv.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/recv.rs
@@ -170,7 +170,7 @@ impl<'a, T> RecvSlice<'a, T> {
         self.0.cursor.is_empty()
     }
 
-    /// Synchronizes any updates from the peer
+    /// Synchronizes any updates from the sender
     ///
     /// This can be useful for when `slice` is called without polling for entries first.
     #[inline]

--- a/quic/s2n-quic-core/src/sync/spsc/send.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/send.rs
@@ -133,7 +133,7 @@ impl<'a, T> SendSlice<'a, T> {
         self.0.cursor.send_capacity()
     }
 
-    /// Synchronizes any updates from the peer
+    /// Synchronizes any updates from the receiver
     ///
     /// This can be useful for when `slice` is called without polling for entries first.
     #[inline]

--- a/quic/s2n-quic-core/src/sync/spsc/state.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/state.rs
@@ -266,10 +266,6 @@ impl<T> State<T> {
             return Err(ClosedError);
         }
 
-        if !self.cursor.is_full() {
-            return Ok(true);
-        }
-
         // update the cached version
         self.cursor.head = self.head.load(Ordering::Acquire);
 
@@ -284,10 +280,6 @@ impl<T> State<T> {
     /// capacity, `true` is returned. Otherwise `false` is returned.
     #[inline]
     pub fn acquire_filled(&mut self) -> Result<bool> {
-        if !self.cursor.is_empty() {
-            return Ok(true);
-        }
-
         self.cursor.tail = self.tail.load(Ordering::Acquire);
 
         if !self.cursor.is_empty() {


### PR DESCRIPTION

### Description of changes: 

While testing the AF_XDP IO provider, I noticed that the spsc cursors would only reload capacity once they didn't have any capacity. This led to unoptimal situations where we would wake up to only be able to send a single message, when in reality we could have sent more if we would have reloaded the cursor.

### Call-outs:

This is a bit more expensive since we're fetching cursor counts every time we load the slice. However, overall it does make things more efficient since we're not waking up as much and processing messages in bulk.

### Testing:

Since this is an implementation detail, the existing tests should suffice.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

