### PR TITLE
feat(s2n-quic-xdp): implement IO traits for vectors of channel pairs

### DIFF
--- a/tools/xdp/s2n-quic-xdp/src/io.rs
+++ b/tools/xdp/s2n-quic-xdp/src/io.rs
@@ -1,21 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// TODO replace with `core::task::ready` once we bump MSRV to 1.64.0
-// https://doc.rust-lang.org/core/task/macro.ready.html
-//
-// See https://github.com/aws/s2n-quic/issues/1750
-macro_rules! ready {
-    ($value:expr) => {
-        match $value {
-            ::core::task::Poll::Ready(v) => v,
-            ::core::task::Poll::Pending => {
-                return ::core::task::Poll::Pending;
-            }
-        }
-    };
-}
-
 pub mod rx;
 pub mod tx;
 


### PR DESCRIPTION

### Description of changes: 

While integrating the AF_XDP IO provider into the qns application, I needed to have a channel per NIC queue on the TX and RX paths. This drove a refactor of the IO trait impls to handle a vector of channel pairs, rather than a single pair.

### Call-outs:

With a single pair of channels, the behavior should be the exact same.

### Testing:

I've updated the tests to also check for more than one pair of channels.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

