### PR TITLE
build(deps): switch cache-padded to crossbeam-utils

### DIFF
--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["corpus.tar.gz"]
 
 [features]
 default = ["alloc", "std"]
-alloc = ["atomic-waker", "bytes", "cache-padded"]
+alloc = ["atomic-waker", "bytes", "crossbeam-utils"]
 std = ["alloc", "once_cell"]
 testing = ["std", "generator", "s2n-codec/testing", "checked-counters", "insta", "futures-test"]
 generator = ["bolero-generator"]
@@ -26,7 +26,7 @@ atomic-waker = { version = "1", optional = true }
 bolero-generator = { version = "0.9", optional = true }
 byteorder = { version = "1", default-features = false }
 bytes = { version = "1", optional = true, default-features = false }
-cache-padded = { version = "1", optional = true }
+crossbeam-utils = { version = "0.8", optional = true }
 cfg-if = "1"
 hex-literal = "0.4"
 # used for event snapshot testing - needs an internal API so we require a minimum version

--- a/quic/s2n-quic-core/src/sync/spsc/state.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/state.rs
@@ -4,7 +4,6 @@
 use super::{Cell, ClosedError, Result, Slice};
 use crate::sync::primitive::{AtomicBool, AtomicUsize, AtomicWaker, IsZst, Ordering};
 use alloc::alloc::Layout;
-use crossbeam_utils::CachePadded;
 use core::{
     fmt,
     marker::PhantomData,
@@ -12,6 +11,7 @@ use core::{
     panic::{RefUnwindSafe, UnwindSafe},
     ptr::NonNull,
 };
+use crossbeam_utils::CachePadded;
 
 type Pair<'a, T> = super::Pair<Slice<'a, Cell<T>>>;
 

--- a/quic/s2n-quic-core/src/sync/spsc/state.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/state.rs
@@ -4,7 +4,7 @@
 use super::{Cell, ClosedError, Result, Slice};
 use crate::sync::primitive::{AtomicBool, AtomicUsize, AtomicWaker, IsZst, Ordering};
 use alloc::alloc::Layout;
-use cache_padded::CachePadded;
+use crossbeam_utils::CachePadded;
 use core::{
     fmt,
     marker::PhantomData,

--- a/quic/s2n-quic-core/src/sync/worker.rs
+++ b/quic/s2n-quic-core/src/sync/worker.rs
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::sync::primitive::{Arc, AtomicUsize, AtomicWaker, Ordering};
-use crossbeam_utils::CachePadded;
 use core::{
     future::Future,
     pin::Pin,
     task::{Context, Poll},
 };
+use crossbeam_utils::CachePadded;
 
 /// Creates a worker channel with a Sender and Receiver
 pub fn channel() -> (Sender, Receiver) {

--- a/quic/s2n-quic-core/src/sync/worker.rs
+++ b/quic/s2n-quic-core/src/sync/worker.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::sync::primitive::{Arc, AtomicUsize, AtomicWaker, Ordering};
-use cache_padded::CachePadded;
+use crossbeam_utils::CachePadded;
 use core::{
     future::Future,
     pin::Pin,


### PR DESCRIPTION
### Resolved issues:


### Description of changes: 
The cache-padded crate was deprecated in favor of crossbeam-utils crate. This change now gets cache_padded from crossbeam.
### Call-outs:

### Testing:

cargo clippy passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

