### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,6 @@ on:
   pull_request:
     branches:
       - main
-    paths:
-      - ".github/workflows/release.yml"
 
   release:
     types: [published]
@@ -44,6 +42,7 @@ jobs:
 
       - name: Login to Amazon Elastic Container Registry Public
         uses: docker/login-action@v2.1.0
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           registry: public.ecr.aws
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/quic/s2n-quic-qns/etc/Dockerfile.build
+++ b/quic/s2n-quic-qns/etc/Dockerfile.build
@@ -4,6 +4,7 @@ RUN cargo install cargo-chef --version 0.1.23
 COPY Cargo.toml /app
 COPY common /app/common
 COPY quic /app/quic
+COPY tools/xdp /app/tools/xdp
 # Don't include testing crates
 RUN rm -rf quic/s2n-quic-bench quic/s2n-quic-events quic/s2n-quic-sim
 RUN cargo chef prepare  --recipe-path recipe.json
@@ -25,6 +26,7 @@ RUN set -eux; \
 COPY Cargo.toml /app
 COPY common /app/common
 COPY quic /app/quic
+COPY tools/xdp /app/tools/xdp
 # Don't include testing crates
 RUN rm -rf quic/s2n-quic-bench quic/s2n-quic-events quic/s2n-quic-sim
 


### PR DESCRIPTION
### Description of changes: 

In #1749, we added the s2n-quic-xdp crate as an optional dependency to `s2n-quic`. This caused issues for the release workflow since the `tools/xdp` directory wasn't being added to the docker build.

### Testing:

I've enabled the workflow to run on pull requests to prevent this kind of issue in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

