### PR TITLE
chore: give depandabot permissions to update PR status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,14 @@ env:
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100
   S2N_UNSTABLE_CRYPTO_OPT_RX: 100
 
+# By default depandabot only receives read permissions. Explicitly give it write
+# permissions which is needed by the ouzi-dev/commit-status-updater task.
+#
+# Updating status is relatively safe (doesnt modify source code) and caution
+# should we taken before adding more permissions.
+permissions:
+  statuses: write
+
 jobs:
   env:
     runs-on: ubuntu-latest

--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -18,6 +18,14 @@ env:
   RUST_NIGHTLY_TOOLCHAIN: nightly-2022-09-15
   CDN: https://dnglbrstg7yg.cloudfront.net
 
+# By default depandabot only receives read permissions. Explicitly give it write
+# permissions which is needed by the ouzi-dev/commit-status-updater task.
+#
+# Updating status is relatively safe (doesnt modify source code) and caution
+# should we taken before adding more permissions.
+permissions:
+  statuses: write
+
 jobs:
   rustfmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -28,6 +28,14 @@ env:
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100
   S2N_UNSTABLE_CRYPTO_OPT_RX: 100
 
+# By default depandabot only receives read permissions. Explicitly give it write
+# permissions which is needed by the ouzi-dev/commit-status-updater task.
+#
+# Updating status is relatively safe (doesnt modify source code) and caution
+# should we taken before adding more permissions.
+permissions:
+  statuses: write
+
 jobs:
   env:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description of changes: 
Based on [docs](https://docs.github.com/en/enterprise-server@3.4/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events) and a test dependabot [PR](https://github.com/aws/s2n-quic/pull/1617), the `ouzi-dev/commit-status-updater` task is failing.

[ouzi](https://github.com/ouzi-dev/commit-status-updater) requires the `statuses: write` permissions to work, which I add in this PR.

### Testing
Testing this would require one of the two methods:
- merge this to see if it works (recommended)
- try in a separate repo

Since the `statuses: write` is a safe permission and I am pretty certain this should help resolve the issue, I think we should just merge this and test it out. I also compared the [failing CI's permissions ](https://github.com/aws/s2n-quic/actions/runs/4898299734/jobs/8747272108?pr=1617#step:1:29) with a successful CI run and can see that the `Statuses: read`, further confirming my theory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

