### PR TITLE
Use cadical solver for some Kani harnesses

### DIFF
--- a/quic/s2n-quic-core/src/packet/number/tests.rs
+++ b/quic/s2n-quic-core/src/packet/number/tests.rs
@@ -10,7 +10,7 @@ use bolero::{check, generator::*};
 use s2n_codec::{testing::encode, DecoderBuffer};
 
 #[test]
-#[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(kissat))]
+#[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(cadical))]
 fn round_trip() {
     check!()
         .with_generator(

--- a/quic/s2n-quic-core/src/slice.rs
+++ b/quic/s2n-quic-core/src/slice.rs
@@ -132,7 +132,7 @@ mod tests {
     const LEN: usize = if cfg!(kani) { 2 } else { 32 };
 
     #[test]
-    #[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(kissat))]
+    #[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(cadical))]
     #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
     fn vectored_copy_fuzz_test() {
         check!()

--- a/quic/s2n-quic-core/src/varint/tests.rs
+++ b/quic/s2n-quic-core/src/varint/tests.rs
@@ -18,7 +18,7 @@ fn round_trip_bytes_test() {
 }
 
 #[test]
-#[cfg_attr(kani, kani::proof, kani::unwind(10), kani::solver(kissat))]
+#[cfg_attr(kani, kani::proof, kani::unwind(10), kani::solver(cadical))]
 fn round_trip_values_test() {
     check!().with_type().cloned().for_each(|v| {
         if let Ok(v) = VarInt::new(v) {
@@ -91,7 +91,7 @@ sequence_test!(one_byte_sequence_example([0x25], 37));
 // # +------+--------+-------------+-----------------------+
 #[test]
 #[cfg_attr(miri, ignore)]
-#[cfg_attr(kani, kani::proof, kani::unwind(3), kani::solver(kissat))]
+#[cfg_attr(kani, kani::proof, kani::unwind(3), kani::solver(cadical))]
 fn one_byte_sequence_test() {
     bolero::check!()
         .with_type()
@@ -107,7 +107,7 @@ fn one_byte_sequence_test() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-#[cfg_attr(kani, kani::proof, kani::unwind(4), kani::solver(kissat))]
+#[cfg_attr(kani, kani::proof, kani::unwind(4), kani::solver(cadical))]
 fn two_byte_sequence_test() {
     // the s2n-quic implementation always chooses the smallest encoding possible.
     // this means if we wish to test two-byte sequences, we need to encode a number
@@ -130,7 +130,7 @@ fn two_byte_sequence_test() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-#[cfg_attr(kani, kani::proof, kani::unwind(10), kani::solver(kissat))]
+#[cfg_attr(kani, kani::proof, kani::unwind(10), kani::solver(cadical))]
 fn four_byte_sequence_test() {
     // The s2n-quic implementation always chooses the smallest encoding possible.
     // This means if we wish to test the four-byte sequences, we need to encode a number
@@ -153,7 +153,7 @@ fn four_byte_sequence_test() {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-#[cfg_attr(kani, kani::proof, kani::unwind(10), kani::solver(kissat))]
+#[cfg_attr(kani, kani::proof, kani::unwind(10), kani::solver(cadical))]
 fn eight_byte_sequence_test() {
     // The s2n-quic implementation always chooses the smallest encoding possible.
     // This means if we wish to test eight-byte sequences, we need to encode a number

--- a/quic/s2n-quic-core/src/xdp/decoder.rs
+++ b/quic/s2n-quic-core/src/xdp/decoder.rs
@@ -223,7 +223,7 @@ mod tests {
 
     // Tests to ensure memory safety and no panics
     #[test]
-    #[cfg_attr(kani, kani::proof, kani::unwind(258), kani::solver(kissat))]
+    #[cfg_attr(kani, kani::proof, kani::unwind(258), kani::solver(cadical))]
     fn decode_test() {
         check!().for_each(|bytes| {
             let buffer = s2n_codec::DecoderBuffer::new(bytes);


### PR DESCRIPTION
This commit switches the solver from Kissat to Cadical for some of the Kani harnesses, in cases where Cadical is faster and for harnesses that take longer than 1 second to run.

The results of running these 8 harnesses with Cadical, Kissat, and the default solver (where possible) are below.

    quic/varint::tests::round_trip_values_test
      default: avg 1.13 [1.1278493299999997, 1.1265045, 1.1301544999999997]
      cadical: avg 0.89 [0.8822812, 0.9042669, 0.875616]
      kissat: avg 3.25 [3.2597189999999996, 3.24811, 3.2498839999999998]
      speedup default -> cadical: 1.27
    quic/packet::number::tests::round_trip
      default: avg 2.10 [2.0913535, 2.1126869999999998, 2.11061815]
      cadical: avg 1.63 [1.6425245, 1.6270909999999998, 1.6270189]
      kissat: avg 4.62 [4.617643, 4.619624, 4.617560000000001]
      speedup default -> cadical: 1.29
    quic/slice::tests::vectored_copy_fuzz_test
      cadical: avg 51.28 [50.775685, 51.887657, 51.172885]
      kissat: avg 135.28 [134.9685, 135.9937, 134.8742]
      speedup kissat -> cadical: 2.64
    quic/xdp::decoder::tests::decode_test
      default: avg 4.00 [3.99578302, 4.01363883, 3.99889795]
      cadical: avg 0.45 [0.4534163, 0.4407649, 0.46409730000000005]
      kissat: avg 2.48 [2.473933, 2.510846, 2.467708]
      speedup default -> cadical: 8.84
    quic/varint::tests::two_byte_sequence_test
      default: avg 2.68 [2.6952317999999997, 2.7065812, 2.6445627]
      cadical: avg 0.30 [0.305668, 0.29728699999999997, 0.298824]
      kissat: avg 1.04 [1.0396619999999999, 1.041297, 1.0504120000000001]
      speedup default -> cadical: 8.92
    quic/varint::tests::one_byte_sequence_test
      default: avg 1.99 [2.0078329999999998, 2.071973, 1.8890439]
      cadical: avg 0.21 [0.2110008, 0.2108838, 0.20639400000000002]
      kissat: avg 0.93 [0.9261630000000001, 0.933457, 0.931268]
      speedup default -> cadical: 9.50
    quic/varint::tests::four_byte_sequence_test
      default: avg 5.88 [5.8151493, 5.8675217, 5.9605617]
      cadical: avg 0.36 [0.349704, 0.36451, 0.35740000000000005]
      kissat: avg 1.25 [1.243804, 1.2504469999999999, 1.251305]
      speedup default -> cadical: 16.46
    quic/varint::tests::eight_byte_sequence_test
      default: avg 17.49 [17.375778099999998, 17.7345087, 17.3600971]
      cadical: avg 0.62 [0.647882, 0.590768, 0.614203]
      kissat: avg 1.53 [1.530402, 1.526793, 1.534478]
      speedup default -> cadical: 28.32

### Testing:

The harnesses continue to run locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

