### PR TITLE
build: pin more MSRV-breaking dependencies

### DIFF
--- a/quic/s2n-quic-sim/Cargo.toml
+++ b/quic/s2n-quic-sim/Cargo.toml
@@ -23,8 +23,14 @@ s2n-quic = { path = "../s2n-quic", features = ["unstable-provider-io-testing", "
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# >0.6.1 breaks compatibility with 1.63
+# See https://github.com/aws/s2n-quic/issues/1735
+serde_spanned = "=0.6.1"
 structopt = "0.3"
 toml = "0.7"
+# >0.6.1 breaks compatibility with 1.63
+# See https://github.com/aws/s2n-quic/issues/1735
+toml_datetime = "=0.6.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # >0.4.1 breaks compatibility with 1.63


### PR DESCRIPTION
### Description of changes: 

More packages bumped their MSRV so we'll need to pin them until we can go beyond 1.63.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

