### PR TITLE
refactor(s2n-quic-platform): move more syscalls to syscall module

### DIFF
--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -1116,6 +1116,9 @@ pub mod api {
             max_segments: usize,
         },
         #[non_exhaustive]
+        #[doc = " Emitted when receive segment offload was configured"]
+        Gro { enabled: bool },
+        #[non_exhaustive]
         #[doc = " Emitted when ECN support is configured"]
         Ecn { enabled: bool },
         #[non_exhaustive]
@@ -4243,6 +4246,8 @@ pub mod builder {
             #[doc = " If this value not greater than 1, GSO is disabled."]
             max_segments: usize,
         },
+        #[doc = " Emitted when receive segment offload was configured"]
+        Gro { enabled: bool },
         #[doc = " Emitted when ECN support is configured"]
         Ecn { enabled: bool },
         #[doc = " Emitted when the maximum transmission unit is configured"]
@@ -4255,6 +4260,9 @@ pub mod builder {
             match self {
                 Self::Gso { max_segments } => Gso {
                     max_segments: max_segments.into_event(),
+                },
+                Self::Gro { enabled } => Gro {
+                    enabled: enabled.into_event(),
                 },
                 Self::Ecn { enabled } => Ecn {
                     enabled: enabled.into_event(),

--- a/quic/s2n-quic-core/src/inet/datagram.rs
+++ b/quic/s2n-quic-core/src/inet/datagram.rs
@@ -32,4 +32,6 @@ pub struct AncillaryData {
     /// Correctly threading this value through to connections ensures packets end up on the same
     /// network interfaces and thereby have consistent MAC addresses.
     pub local_interface: Option<u32>,
+    /// Set when the packet buffer is an aggregate of multiple received packets
+    pub segment_size: u16,
 }

--- a/quic/s2n-quic-events/events/platform.rs
+++ b/quic/s2n-quic-events/events/platform.rs
@@ -62,6 +62,8 @@ enum PlatformFeatureConfiguration {
         /// If this value not greater than 1, GSO is disabled.
         max_segments: usize,
     },
+    /// Emitted when receive segment offload was configured
+    Gro { enabled: bool },
     /// Emitted when ECN support is configured
     Ecn { enabled: bool },
     /// Emitted when the maximum transmission unit is configured

--- a/quic/s2n-quic-platform/build.rs
+++ b/quic/s2n-quic-platform/build.rs
@@ -19,6 +19,7 @@ fn main() -> Result<(), Error> {
     match env.target_os.as_str() {
         "linux" => {
             supports("gso");
+            supports("gro");
             supports("mtu_disc");
             supports("pktinfo");
             supports("tos");

--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -94,8 +94,6 @@ impl Io {
         let guard = handle.enter();
 
         let rx_socket = if let Some(rx_socket) = rx_socket {
-            // ensure the socket is non-blocking
-            rx_socket.set_nonblocking(true)?;
             rx_socket
         } else if let Some(recv_addr) = recv_addr {
             syscall::bind_udp(recv_addr, reuse_port)?
@@ -106,9 +104,10 @@ impl Io {
             ));
         };
 
+        // ensure the socket is non-blocking
+        rx_socket.set_nonblocking(true)?;
+
         let tx_socket = if let Some(tx_socket) = tx_socket {
-            // ensure the socket is non-blocking
-            tx_socket.set_nonblocking(true)?;
             tx_socket
         } else if let Some(send_addr) = send_addr {
             syscall::bind_udp(send_addr, reuse_port)?
@@ -117,6 +116,9 @@ impl Io {
             // will be a handle to the rx socket.
             rx_socket.try_clone()?
         };
+
+        // ensure the socket is non-blocking
+        tx_socket.set_nonblocking(true)?;
 
         if let Some(size) = send_buffer_size {
             tx_socket.set_send_buffer_size(size)?;

--- a/quic/s2n-quic-platform/src/syscall/mmsg.rs
+++ b/quic/s2n-quic-platform/src/syscall/mmsg.rs
@@ -1,0 +1,136 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(dead_code)] // TODO remove once used
+
+use super::{SocketEvents, SocketType};
+use libc::mmsghdr;
+use std::os::unix::io::AsRawFd;
+
+#[inline]
+pub fn send<Sock: AsRawFd, E: SocketEvents>(
+    socket: &Sock,
+    packets: &mut [mmsghdr],
+    events: &mut E,
+) {
+    if packets.is_empty() {
+        return;
+    }
+
+    // Safety: calling a libc function is inherently unsafe as rust cannot
+    // make any invariant guarantees. This has to be reviewed by humans instead
+    // so the [docs](https://linux.die.net/man/2/sendmmsg) are inlined here:
+
+    // > The sockfd argument is the file descriptor of the socket on which data
+    // > is to be transmitted.
+    let sockfd = socket.as_raw_fd();
+
+    // > The msgvec argument is a pointer to an array of mmsghdr structures.
+    //
+    // > The msg_hdr field is a msghdr structure, as described in sendmsg(2).
+    // > The msg_len field is used to return the number of bytes sent from the
+    // > message in msg_hdr.
+    let msgvec = packets.as_mut_ptr();
+
+    // > The size of this array is specified in vlen.
+    //
+    // > The value specified in vlen is capped to UIO_MAXIOV (1024).
+    let vlen = packets.len().min(1024) as _;
+
+    // > The flags argument contains flags ORed together.
+    //
+    // No flags are currently set
+    let flags = Default::default();
+
+    // > The sendmmsg() system call is an extension of sendmsg(2) that allows
+    // > the caller to transmit multiple messages on a socket using a single
+    // > system call. (This has performance benefits for some applications.)
+    //
+    // > A nonblocking call sends as many messages as possible (up to the limit
+    // > specified by vlen) and returns immediately.
+    //
+    // > On return from sendmmsg(), the msg_len fields of successive elements
+    // > of msgvec are updated to contain the number of bytes transmitted from
+    // > the corresponding msg_hdr. The return value of the call indicates the
+    // > number of elements of msgvec that have been updated.
+    //
+    // > On success, sendmmsg() returns the number of messages sent from msgvec;
+    // > if this is less than vlen, the caller can retry with a further sendmmsg()
+    // > call to send the remaining messages.
+    //
+    // > On error, -1 is returned, and errno is set to indicate the error.
+
+    let res = libc!(sendmmsg(sockfd, msgvec, vlen, flags));
+
+    let _ = match res {
+        Ok(count) => events.on_complete(count as _),
+        Err(error) => events.on_error(error),
+    };
+}
+
+#[inline]
+pub fn recv<Sock: AsRawFd, E: SocketEvents>(
+    socket: &Sock,
+    socket_type: SocketType,
+    packets: &mut [mmsghdr],
+    events: &mut E,
+) {
+    if packets.is_empty() {
+        return;
+    }
+
+    // Safety: calling a libc function is inherently unsafe as rust cannot
+    // make any invariant guarantees. This has to be reviewed by humans instead
+    // so the [docs](https://linux.die.net/man/2/recvmmsg) are inlined here:
+
+    // > The sockfd argument is the file descriptor of the socket to receive data from.
+    let sockfd = socket.as_raw_fd();
+
+    // > The msgvec argument is a pointer to an array of mmsghdr structures.
+    //
+    // > The msg_len field is the number of bytes returned for the message in the entry.
+    let msgvec = packets.as_mut_ptr();
+
+    // > The size of this array is specified in vlen.
+    let vlen = packets.len() as _;
+
+    // > The flags argument contains flags ORed together.
+    //
+    // If the socket is blocking, set the MSG_WAITFORONE flag so we don't hang until the entire
+    // buffer is full.
+    let flags = match socket_type {
+        SocketType::Blocking => libc::MSG_WAITFORONE,
+        SocketType::NonBlocking => libc::MSG_DONTWAIT,
+    };
+
+    // > The timeout argument points to a struct timespec defining a timeout
+    // > (seconds plus nanoseconds) for the receive operation.
+    //
+    // Since we currently only use non-blocking sockets, this isn't needed.
+    // If support is added for non-blocking sockets, this will need to be
+    // updated.
+    let timeout = core::ptr::null_mut();
+
+    // > The recvmmsg() system call is an extension of recvmsg(2)
+    // > that allows the caller to receive multiple messages from a
+    // > socket using a single system call.
+    //
+    // > A nonblocking call reads as many messages as are available
+    // > (up to the limit specified by vlen) and returns immediately.
+    //
+    // > On return from recvmmsg(), successive elements of msgvec are
+    // > updated to contain information about each received message:
+    // > msg_len contains the size of the received message;
+    // > the subfields of msg_hdr are updated as described in recvmsg(2).
+    // > The return value of the call indicates the number of elements of
+    // > msgvec that have been updated.
+    //
+    // > On success, recvmmsg() returns the number of messages received in
+    // > msgvec; on error, -1 is returned, and errno is set to indicate the error.
+    let res = libc!(recvmmsg(sockfd, msgvec, vlen, flags, timeout));
+
+    let _ = match res {
+        Ok(count) => events.on_complete(count as _),
+        Err(error) => events.on_error(error),
+    };
+}

--- a/quic/s2n-quic-platform/src/syscall/msg.rs
+++ b/quic/s2n-quic-platform/src/syscall/msg.rs
@@ -1,0 +1,131 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#![allow(dead_code)] // TODO remove once used
+
+use super::{SocketEvents, SocketType};
+use libc::msghdr;
+use std::os::unix::io::AsRawFd;
+
+#[inline]
+pub fn send<'a, Sock: AsRawFd, P: IntoIterator<Item = &'a mut msghdr>, E: SocketEvents>(
+    socket: &Sock,
+    packets: P,
+    events: &mut E,
+) {
+    for packet in packets {
+        // macOS doesn't like when msg_control have valid pointers but the len is 0
+        //
+        // If that's the case here, then set the `msg_control` to null and restore it after
+        // calling sendmsg.
+        #[cfg(any(target_os = "macos", target_os = "ios", test))]
+        let msg_control = {
+            let msg_control = packet.msg_control;
+
+            if packet.msg_controllen == 0 {
+                packet.msg_control = core::ptr::null_mut();
+            }
+
+            msg_control
+        };
+
+        // Safety: calling a libc function is inherently unsafe as rust cannot
+        // make any invariant guarantees. This has to be reviewed by humans instead
+        // so the [docs](https://linux.die.net/man/2/sendmsg) are inlined here:
+
+        // > The argument sockfd is the file descriptor of the sending socket.
+        let sockfd = socket.as_raw_fd();
+
+        // > The address of the target is given by msg.msg_name, with msg.msg_namelen
+        // > specifying its size.
+        //
+        // > The message is pointed to by the elements of the array msg.msg_iov.
+        // > The sendmsg() call also allows sending ancillary data (also known as
+        // > control information).
+        let msg = packet;
+
+        // > The flags argument is the bitwise OR of zero or more flags.
+        //
+        // No flags are currently set
+        let flags = Default::default();
+
+        // > On success, these calls return the number of characters sent.
+        // > On error, -1 is returned, and errno is set appropriately.
+        let result = libc!(sendmsg(sockfd, msg, flags));
+
+        // restore the msg_control pointer if needed
+        #[cfg(any(target_os = "macos", target_os = "ios", test))]
+        {
+            msg.msg_control = msg_control;
+        }
+
+        let cf = match result {
+            Ok(_) => events.on_complete(1),
+            Err(err) => events.on_error(err),
+        };
+
+        if cf.is_break() {
+            return;
+        }
+    }
+}
+
+#[inline]
+pub fn recv<'a, Sock: AsRawFd, P: IntoIterator<Item = &'a mut msghdr>, E: SocketEvents>(
+    socket: &Sock,
+    socket_type: SocketType,
+    packets: P,
+    events: &mut E,
+) {
+    let mut flags = match socket_type {
+        SocketType::Blocking => Default::default(),
+        SocketType::NonBlocking => libc::MSG_DONTWAIT,
+    };
+
+    for packet in packets {
+        // Safety: calling a libc function is inherently unsafe as rust cannot
+        // make any invariant guarantees. This has to be reviewed by humans instead
+        // so the [docs](https://linux.die.net/man/2/recmsg) are inlined here:
+
+        // > The argument sockfd is the file descriptor of the receiving socket.
+        let sockfd = socket.as_raw_fd();
+
+        // > The recvmsg() call uses a msghdr structure to minimize the number of
+        // > directly supplied arguments.
+        //
+        // > Here msg_name and msg_namelen specify the source address if the
+        // > socket is unconnected.
+        //
+        // > The fields msg_iov and msg_iovlen describe scatter-gather locations
+        //
+        // > When recvmsg() is called, msg_controllen should contain the length
+        // > of the available buffer in msg_control; upon return from a successful
+        // > call it will contain the length of the control message sequence.
+        let msg = packet;
+
+        // > The flags argument to a recv() call is formed by ORing one or more flags
+        //
+        // We set MSG_DONTWAIT if it's nonblocking or there is more than one call
+
+        // > recvmsg() calls are used to receive messages from a socket
+        //
+        // > All three routines return the length of the message on successful completion.
+        // > If a message is too long to fit in the supplied buffer, excess bytes may be
+        // > discarded depending on the type of socket the message is received from.
+        //
+        // > These calls return the number of bytes received, or -1 if an error occurred.
+        let result = libc!(recvmsg(sockfd, msg, flags));
+
+        let cf = match result {
+            Ok(_) => events.on_complete(1),
+            Err(err) => events.on_error(err),
+        };
+
+        if cf.is_break() {
+            return;
+        }
+
+        // don't block the follow-up calls
+        flags = libc::MSG_DONTWAIT;
+    }
+}


### PR DESCRIPTION
### Description of changes: 

Currently, the msg/mmsg syscalls require a particular not-so-flexible interface to be implemented to interact with them. This PR moves the actual syscall to a simple function to make it easier to use in more contexts.

This is needed to separate the endpoint task from the IO operations.

### Call-outs:

I've added a few changes to add GRO support in the syscalls while I was here to minimize the merge conflicts.

I also have _not_ refactored the old syscalls to use the new functions, as that implementation will be deleted in a later PR.

### Testing:

There's not really a great way to test the syscalls on their own, however tests are coming in a later PR that tests them in context of the tokio IO provider.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

