### PR TITLE
refactor(s2n-quic-platform): track GSO segment counts in shared memory

### DIFF
--- a/quic/s2n-quic-platform/src/features.rs
+++ b/quic/s2n-quic-platform/src/features.rs
@@ -1,20 +1,5 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use lazy_static::lazy_static;
-
 pub mod gso;
 pub use gso::Gso;
-
-lazy_static! {
-    static ref FEATURES: Features = Features::default();
-}
-
-pub fn get() -> &'static Features {
-    &FEATURES
-}
-
-#[derive(Debug, Default)]
-pub struct Features {
-    pub gso: Gso,
-}

--- a/quic/s2n-quic-platform/src/message/mmsg.rs
+++ b/quic/s2n-quic-platform/src/message/mmsg.rs
@@ -154,7 +154,7 @@ impl<Payloads: crate::buffer::Buffer + Default> Default for Ring<Payloads> {
     fn default() -> Self {
         Self::new(
             Payloads::default(),
-            crate::features::get().gso.default_max_segments(),
+            crate::features::gso::MaxSegments::DEFAULT.into(),
         )
     }
 }


### PR DESCRIPTION
### Description of changes: 

Currently, we disable GSO if we get an `EIO` error on send. This causes a `disable_gso` function to be called, which overrides the maximum number of GSO segments to `1`. This causes issues when we split the endpoint task from the IO operations, since the endpoint is in charge of assembling packets where the IO operation task is in charge of flushing them to the socket. 

This change refactors the GSO max segment tracking to a shared, atomic variable so it's easier for the two tasks to synchronize their state.

### Call-outs:

The current implementation isn't synchronous but it has been updated to use this for simplicity.

### Testing:

The existing tests should be sufficient to catch any regressions in the refactor.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

