### PR TITLE
fix(s2n-quic-core): add missing inline attributes for into_event

### DIFF
--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -1292,6 +1292,7 @@ pub mod api {
         }
     }
     impl IntoEvent<builder::DuplicatePacketError> for crate::packet::number::SlidingWindowError {
+        #[inline]
         fn into_event(self) -> builder::DuplicatePacketError {
             use crate::packet::number::SlidingWindowError;
             match self {
@@ -1301,6 +1302,7 @@ pub mod api {
         }
     }
     impl IntoEvent<builder::EcnCounts> for crate::frame::ack::EcnCounts {
+        #[inline]
         fn into_event(self) -> builder::EcnCounts {
             builder::EcnCounts {
                 ect_0_count: self.ect_0_count.into_event(),
@@ -1310,11 +1312,13 @@ pub mod api {
         }
     }
     impl IntoEvent<builder::Frame> for &crate::frame::Padding {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::Padding {}
         }
     }
     impl IntoEvent<builder::Frame> for &crate::frame::Ping {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::Ping {}
         }
@@ -1322,6 +1326,7 @@ pub mod api {
     impl<AckRanges: crate::frame::ack::AckRanges> IntoEvent<builder::Frame>
         for &crate::frame::Ack<AckRanges>
     {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::Ack {
                 ecn_counts: self.ecn_counts.map(|val| val.into_event()),
@@ -1331,6 +1336,7 @@ pub mod api {
         }
     }
     impl IntoEvent<builder::Frame> for &crate::frame::ResetStream {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::ResetStream {
                 id: self.stream_id.as_u64(),
@@ -1340,6 +1346,7 @@ pub mod api {
         }
     }
     impl IntoEvent<builder::Frame> for &crate::frame::StopSending {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::StopSending {
                 id: self.stream_id.as_u64(),
@@ -1348,11 +1355,13 @@ pub mod api {
         }
     }
     impl<'a> IntoEvent<builder::Frame> for &crate::frame::NewToken<'a> {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::NewToken {}
         }
     }
     impl IntoEvent<builder::Frame> for &crate::frame::MaxData {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::MaxData {
                 value: self.maximum_data.as_u64(),
@@ -1360,6 +1369,7 @@ pub mod api {
         }
     }
     impl IntoEvent<builder::Frame> for &crate::frame::MaxStreamData {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::MaxStreamData {
                 id: self.stream_id.as_u64(),
@@ -1371,6 +1381,7 @@ pub mod api {
         }
     }
     impl IntoEvent<builder::Frame> for &crate::frame::MaxStreams {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::MaxStreams {
                 stream_type: self.stream_type.into_event(),
@@ -1379,6 +1390,7 @@ pub mod api {
         }
     }
     impl IntoEvent<builder::Frame> for &crate::frame::DataBlocked {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::DataBlocked {
                 data_limit: self.data_limit.as_u64(),
@@ -1386,6 +1398,7 @@ pub mod api {
         }
     }
     impl IntoEvent<builder::Frame> for &crate::frame::StreamDataBlocked {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::StreamDataBlocked {
                 stream_id: self.stream_id.as_u64(),
@@ -1394,6 +1407,7 @@ pub mod api {
         }
     }
     impl IntoEvent<builder::Frame> for &crate::frame::StreamsBlocked {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::StreamsBlocked {
                 stream_type: self.stream_type.into_event(),
@@ -1402,31 +1416,37 @@ pub mod api {
         }
     }
     impl<'a> IntoEvent<builder::Frame> for &crate::frame::NewConnectionId<'a> {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::NewConnectionId {}
         }
     }
     impl IntoEvent<builder::Frame> for &crate::frame::RetireConnectionId {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::RetireConnectionId {}
         }
     }
     impl<'a> IntoEvent<builder::Frame> for &crate::frame::PathChallenge<'a> {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::PathChallenge {}
         }
     }
     impl<'a> IntoEvent<builder::Frame> for &crate::frame::PathResponse<'a> {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::PathResponse {}
         }
     }
     impl<'a> IntoEvent<builder::Frame> for &crate::frame::ConnectionClose<'a> {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::ConnectionClose {}
         }
     }
     impl IntoEvent<builder::Frame> for &crate::frame::HandshakeDone {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::HandshakeDone {}
         }
@@ -1435,6 +1455,7 @@ pub mod api {
     where
         Data: s2n_codec::EncoderValue,
     {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::Stream {
                 id: self.stream_id.as_u64(),
@@ -1448,6 +1469,7 @@ pub mod api {
     where
         Data: s2n_codec::EncoderValue,
     {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::Crypto {
                 offset: self.offset.as_u64(),
@@ -1459,6 +1481,7 @@ pub mod api {
     where
         Data: s2n_codec::EncoderValue,
     {
+        #[inline]
         fn into_event(self) -> builder::Frame {
             builder::Frame::Datagram {
                 len: self.data.encoding_size() as _,
@@ -1466,6 +1489,7 @@ pub mod api {
         }
     }
     impl IntoEvent<builder::StreamType> for &crate::stream::StreamType {
+        #[inline]
         fn into_event(self) -> builder::StreamType {
             match self {
                 crate::stream::StreamType::Bidirectional => builder::StreamType::Bidirectional {},
@@ -1474,6 +1498,7 @@ pub mod api {
         }
     }
     impl builder::PacketHeader {
+        #[inline]
         pub fn new(
             packet_number: crate::packet::number::PacketNumber,
             version: u32,
@@ -1504,6 +1529,7 @@ pub mod api {
         }
     }
     impl IntoEvent<api::EndpointType> for crate::endpoint::Type {
+        #[inline]
         fn into_event(self) -> api::EndpointType {
             match self {
                 Self::Client => api::EndpointType::Client {},
@@ -1512,6 +1538,7 @@ pub mod api {
         }
     }
     impl IntoEvent<builder::EndpointType> for crate::endpoint::Type {
+        #[inline]
         fn into_event(self) -> builder::EndpointType {
             match self {
                 Self::Client => builder::EndpointType::Client {},
@@ -1520,6 +1547,7 @@ pub mod api {
         }
     }
     impl CipherSuite {
+        #[inline]
         pub fn as_str(&self) -> &'static str {
             match self {
                 Self::TLS_AES_128_GCM_SHA256 {} => "TLS_AES_128_GCM_SHA256",

--- a/quic/s2n-quic-core/src/packet/number/packet_number.rs
+++ b/quic/s2n-quic-core/src/packet/number/packet_number.rs
@@ -38,6 +38,7 @@ const PACKET_NUMBER_MASK: u64 = core::u64::MAX >> PACKET_SPACE_BITLEN;
 pub struct PacketNumber(NonZeroU64);
 
 impl IntoEvent<u64> for PacketNumber {
+    #[inline]
     fn into_event(self) -> u64 {
         self.as_u64()
     }

--- a/quic/s2n-quic-core/src/packet/number/packet_number_range.rs
+++ b/quic/s2n-quic-core/src/packet/number/packet_number_range.rs
@@ -44,6 +44,7 @@ impl PacketNumberRange {
 }
 
 impl IntoEvent<RangeInclusive<u64>> for PacketNumberRange {
+    #[inline]
     fn into_event(self) -> RangeInclusive<u64> {
         self.start().into_event()..=self.end().into_event()
     }

--- a/quic/s2n-quic-core/src/path/migration.rs
+++ b/quic/s2n-quic-core/src/path/migration.rs
@@ -28,6 +28,7 @@ pub struct AttemptBuilder<'a> {
 }
 
 impl<'a> From<AttemptBuilder<'a>> for Attempt<'a> {
+    #[inline]
     fn from(builder: AttemptBuilder<'a>) -> Self {
         Self {
             active_path: builder.active_path,
@@ -50,6 +51,7 @@ pub struct PacketInfoBuilder<'a> {
 }
 
 impl<'a> From<PacketInfoBuilder<'a>> for PacketInfo<'a> {
+    #[inline]
     fn from(builder: PacketInfoBuilder<'a>) -> Self {
         Self {
             remote_address: builder.remote_address.into_event(),
@@ -90,6 +92,7 @@ pub enum DenyReason {
 }
 
 impl IntoEvent<event::builder::ConnectionMigrationDenied> for DenyReason {
+    #[inline]
     fn into_event(self) -> event::builder::ConnectionMigrationDenied {
         let reason = match self {
             DenyReason::BlockedPort => event::builder::MigrationDenyReason::BlockedPort,
@@ -117,6 +120,7 @@ pub mod default {
     pub struct Validator;
 
     impl super::Validator for Validator {
+        #[inline]
         fn on_migration_attempt(&mut self, attempt: &Attempt) -> Outcome {
             let active_addr = to_addr(&attempt.active_path.remote_addr);
             let packet_addr = to_addr(&attempt.packet.remote_address);

--- a/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/bandwidth/estimator.rs
@@ -200,6 +200,7 @@ impl RateSample {
 }
 
 impl IntoEvent<event::builder::RateSample> for RateSample {
+    #[inline]
     fn into_event(self) -> event::builder::RateSample {
         event::builder::RateSample {
             interval: self.interval.into_event(),

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -199,6 +199,7 @@ impl State {
 }
 
 impl IntoEvent<event::builder::BbrState> for &State {
+    #[inline]
     fn into_event(self) -> event::builder::BbrState {
         use event::builder::BbrState;
         match self {

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
@@ -104,6 +104,7 @@ impl CyclePhase {
 }
 
 impl IntoEvent<event::builder::BbrState> for CyclePhase {
+    #[inline]
     fn into_event(self) -> event::builder::BbrState {
         use event::builder::BbrState;
         match self {

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -270,6 +270,7 @@ enum DuplicatePacketError {
 }
 
 impl IntoEvent<builder::DuplicatePacketError> for crate::packet::number::SlidingWindowError {
+    #[inline]
     fn into_event(self) -> builder::DuplicatePacketError {
         use crate::packet::number::SlidingWindowError;
         match self {
@@ -294,6 +295,7 @@ struct EcnCounts {
 }
 
 impl IntoEvent<builder::EcnCounts> for crate::frame::ack::EcnCounts {
+    #[inline]
     fn into_event(self) -> builder::EcnCounts {
         builder::EcnCounts {
             ect_0_count: self.ect_0_count.into_event(),
@@ -367,12 +369,14 @@ enum Frame {
 }
 
 impl IntoEvent<builder::Frame> for &crate::frame::Padding {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::Padding {}
     }
 }
 
 impl IntoEvent<builder::Frame> for &crate::frame::Ping {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::Ping {}
     }
@@ -381,6 +385,7 @@ impl IntoEvent<builder::Frame> for &crate::frame::Ping {
 impl<AckRanges: crate::frame::ack::AckRanges> IntoEvent<builder::Frame>
     for &crate::frame::Ack<AckRanges>
 {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::Ack {
             ecn_counts: self.ecn_counts.map(|val| val.into_event()),
@@ -391,6 +396,7 @@ impl<AckRanges: crate::frame::ack::AckRanges> IntoEvent<builder::Frame>
 }
 
 impl IntoEvent<builder::Frame> for &crate::frame::ResetStream {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::ResetStream {
             id: self.stream_id.as_u64(),
@@ -401,6 +407,7 @@ impl IntoEvent<builder::Frame> for &crate::frame::ResetStream {
 }
 
 impl IntoEvent<builder::Frame> for &crate::frame::StopSending {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::StopSending {
             id: self.stream_id.as_u64(),
@@ -410,12 +417,14 @@ impl IntoEvent<builder::Frame> for &crate::frame::StopSending {
 }
 
 impl<'a> IntoEvent<builder::Frame> for &crate::frame::NewToken<'a> {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::NewToken {}
     }
 }
 
 impl IntoEvent<builder::Frame> for &crate::frame::MaxData {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::MaxData {
             value: self.maximum_data.as_u64(),
@@ -424,6 +433,7 @@ impl IntoEvent<builder::Frame> for &crate::frame::MaxData {
 }
 
 impl IntoEvent<builder::Frame> for &crate::frame::MaxStreamData {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::MaxStreamData {
             id: self.stream_id.as_u64(),
@@ -436,6 +446,7 @@ impl IntoEvent<builder::Frame> for &crate::frame::MaxStreamData {
 }
 
 impl IntoEvent<builder::Frame> for &crate::frame::MaxStreams {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::MaxStreams {
             stream_type: self.stream_type.into_event(),
@@ -445,6 +456,7 @@ impl IntoEvent<builder::Frame> for &crate::frame::MaxStreams {
 }
 
 impl IntoEvent<builder::Frame> for &crate::frame::DataBlocked {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::DataBlocked {
             data_limit: self.data_limit.as_u64(),
@@ -453,6 +465,7 @@ impl IntoEvent<builder::Frame> for &crate::frame::DataBlocked {
 }
 
 impl IntoEvent<builder::Frame> for &crate::frame::StreamDataBlocked {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::StreamDataBlocked {
             stream_id: self.stream_id.as_u64(),
@@ -462,6 +475,7 @@ impl IntoEvent<builder::Frame> for &crate::frame::StreamDataBlocked {
 }
 
 impl IntoEvent<builder::Frame> for &crate::frame::StreamsBlocked {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::StreamsBlocked {
             stream_type: self.stream_type.into_event(),
@@ -471,36 +485,42 @@ impl IntoEvent<builder::Frame> for &crate::frame::StreamsBlocked {
 }
 
 impl<'a> IntoEvent<builder::Frame> for &crate::frame::NewConnectionId<'a> {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::NewConnectionId {}
     }
 }
 
 impl IntoEvent<builder::Frame> for &crate::frame::RetireConnectionId {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::RetireConnectionId {}
     }
 }
 
 impl<'a> IntoEvent<builder::Frame> for &crate::frame::PathChallenge<'a> {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::PathChallenge {}
     }
 }
 
 impl<'a> IntoEvent<builder::Frame> for &crate::frame::PathResponse<'a> {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::PathResponse {}
     }
 }
 
 impl<'a> IntoEvent<builder::Frame> for &crate::frame::ConnectionClose<'a> {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::ConnectionClose {}
     }
 }
 
 impl IntoEvent<builder::Frame> for &crate::frame::HandshakeDone {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::HandshakeDone {}
     }
@@ -510,6 +530,7 @@ impl<Data> IntoEvent<builder::Frame> for &crate::frame::Stream<Data>
 where
     Data: s2n_codec::EncoderValue,
 {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::Stream {
             id: self.stream_id.as_u64(),
@@ -524,6 +545,7 @@ impl<Data> IntoEvent<builder::Frame> for &crate::frame::Crypto<Data>
 where
     Data: s2n_codec::EncoderValue,
 {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::Crypto {
             offset: self.offset.as_u64(),
@@ -536,6 +558,7 @@ impl<Data> IntoEvent<builder::Frame> for &crate::frame::Datagram<Data>
 where
     Data: s2n_codec::EncoderValue,
 {
+    #[inline]
     fn into_event(self) -> builder::Frame {
         builder::Frame::Datagram {
             len: self.data.encoding_size() as _,
@@ -549,6 +572,7 @@ enum StreamType {
 }
 
 impl IntoEvent<builder::StreamType> for &crate::stream::StreamType {
+    #[inline]
     fn into_event(self) -> builder::StreamType {
         match self {
             crate::stream::StreamType::Bidirectional => builder::StreamType::Bidirectional {},
@@ -572,6 +596,7 @@ enum PacketHeader {
 }
 
 impl builder::PacketHeader {
+    #[inline]
     pub fn new(
         packet_number: crate::packet::number::PacketNumber,
         version: u32,
@@ -635,6 +660,7 @@ impl core::fmt::Display for EndpointType {
 }
 
 impl IntoEvent<api::EndpointType> for crate::endpoint::Type {
+    #[inline]
     fn into_event(self) -> api::EndpointType {
         match self {
             Self::Client => api::EndpointType::Client {},
@@ -644,6 +670,7 @@ impl IntoEvent<api::EndpointType> for crate::endpoint::Type {
 }
 
 impl IntoEvent<builder::EndpointType> for crate::endpoint::Type {
+    #[inline]
     fn into_event(self) -> builder::EndpointType {
         match self {
             Self::Client => builder::EndpointType::Client {},
@@ -817,6 +844,7 @@ enum CipherSuite {
 }
 
 impl CipherSuite {
+    #[inline]
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::TLS_AES_128_GCM_SHA256 {} => "TLS_AES_128_GCM_SHA256",

--- a/quic/s2n-quic-transport/src/path/ecn.rs
+++ b/quic/s2n-quic-transport/src/path/ecn.rs
@@ -56,6 +56,7 @@ enum State {
 }
 
 impl IntoEvent<event::builder::EcnState> for &State {
+    #[inline]
     fn into_event(self) -> event::builder::EcnState {
         match self {
             State::Testing(_) => event::builder::EcnState::Testing,


### PR DESCRIPTION
### Description of changes: 

I noticed that a bunch of `into_event` impls were missing `#[inline]` and so this PR adds those. Having this attribute is important to ensure that the event framework is truly zero cost for each of the events.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

