### PR TITLE
refactor(s2n-quic-transport): move stream manager behind trait

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -20,7 +20,8 @@ use crate::{
     processed_packet::ProcessedPacket,
     recovery::{recovery_event, RttEstimator},
     space::{PacketSpace, PacketSpaceManager},
-    stream, transmission,
+    stream::{self, Manager as _},
+    transmission,
     transmission::interest::Provider as _,
     wakeup_queue::WakeupHandle,
 };

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -31,7 +31,7 @@ pub trait Config: 'static + Send + Sized + core::fmt::Debug {
     /// The connection limits
     type ConnectionLimits: connection::limits::Limiter;
     /// The type of stream
-    type Stream: stream::StreamTrait;
+    type StreamManager: stream::Manager;
     /// The connection close formatter
     type ConnectionCloseFormatter: connection::close::Formatter;
     /// The event subscriber

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -1169,7 +1169,7 @@ pub mod testing {
         type RandomGenerator = random::testing::Generator;
         type TokenFormat = s2n_quic_core::token::testing::Format;
         type ConnectionLimits = s2n_quic_core::connection::limits::Limits;
-        type Stream = crate::stream::StreamImpl;
+        type StreamManager = crate::stream::DefaultStreamManager;
         type ConnectionCloseFormatter = s2n_quic_core::connection::close::Development;
         type EventSubscriber = Subscriber;
         type PathMigrationValidator = path::migration::default::Validator;
@@ -1199,7 +1199,7 @@ pub mod testing {
         type RandomGenerator = random::testing::Generator;
         type TokenFormat = s2n_quic_core::token::testing::Format;
         type ConnectionLimits = s2n_quic_core::connection::limits::Limits;
-        type Stream = crate::stream::StreamImpl;
+        type StreamManager = crate::stream::DefaultStreamManager;
         type ConnectionCloseFormatter = s2n_quic_core::connection::close::Development;
         type EventSubscriber = Subscriber;
         type PathMigrationValidator = path::migration::default::Validator;

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -9,7 +9,7 @@ use crate::{
     processed_packet::ProcessedPacket,
     recovery,
     space::{datagram, keep_alive::KeepAlive, HandshakeStatus, PacketSpace, TxPacketNumbers},
-    stream::AbstractStreamManager,
+    stream::Manager as _,
     sync::flag,
     transmission,
     transmission::interest::Provider,
@@ -43,7 +43,7 @@ pub struct ApplicationSpace<Config: endpoint::Config> {
     /// Ack manager
     pub ack_manager: AckManager,
     /// All streams that are managed through this connection
-    pub stream_manager: AbstractStreamManager<Config::Stream>,
+    pub stream_manager: Config::StreamManager,
     /// The current state of the Spin bit
     /// TODO: Spin me
     pub spin_bit: SpinBit,
@@ -85,7 +85,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         key: <<Config::TLSEndpoint as tls::Endpoint>::Session as CryptoSuite>::OneRttKey,
         header_key: <<Config::TLSEndpoint as tls::Endpoint>::Session as CryptoSuite>::OneRttHeaderKey,
         now: Timestamp,
-        stream_manager: AbstractStreamManager<Config::Stream>,
+        stream_manager: Config::StreamManager,
         ack_manager: AckManager,
         keep_alive: KeepAlive,
         max_mtu: MaxMtu,
@@ -599,7 +599,7 @@ struct RecoveryContext<'a, Config: endpoint::Config> {
     ack_manager: &'a mut AckManager,
     handshake_status: &'a mut HandshakeStatus,
     ping: &'a mut flag::Ping,
-    stream_manager: &'a mut AbstractStreamManager<Config::Stream>,
+    stream_manager: &'a mut Config::StreamManager,
     local_id_registry: &'a mut connection::LocalIdRegistry,
     path_id: path::Id,
     path_manager: &'a mut path::Manager<Config>,

--- a/quic/s2n-quic-transport/src/space/datagram.rs
+++ b/quic/s2n-quic-transport/src/space/datagram.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     endpoint,
-    stream::{AbstractStreamManager, StreamTrait as Stream},
+    stream::Manager as _,
     transmission::{
         interest::{self, Provider},
         WriteContext,
@@ -42,10 +42,10 @@ impl<Config: endpoint::Config> Manager<Config> {
     }
 
     /// A callback that allows users to write datagrams directly to the packet.
-    pub fn on_transmit<S: Stream, W: WriteContext>(
+    pub fn on_transmit<W: WriteContext>(
         &mut self,
         context: &mut W,
-        stream_manager: &mut AbstractStreamManager<S>,
+        stream_manager: &mut Config::StreamManager,
         datagrams_prioritized: bool,
     ) {
         let mut packet = Packet {

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -7,6 +7,7 @@ use crate::{
     connection, endpoint, path,
     path::{path_event, Path},
     processed_packet::ProcessedPacket,
+    stream::Manager as _,
     transmission,
 };
 use bytes::Bytes;

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -9,7 +9,7 @@ use crate::{
         datagram, keep_alive::KeepAlive, ApplicationSpace, HandshakeSpace, HandshakeStatus,
         InitialSpace,
     },
-    stream::AbstractStreamManager,
+    stream,
 };
 use bytes::Bytes;
 use core::{ops::Not, task::Waker};
@@ -382,7 +382,7 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
         self.local_id_registry
             .set_active_connection_id_limit(active_connection_id_limit.as_u64());
 
-        let stream_manager = AbstractStreamManager::new(
+        let stream_manager = <Config::StreamManager as stream::Manager>::new(
             self.limits,
             Config::ENDPOINT_TYPE,
             self.limits.initial_flow_control_limits(),

--- a/quic/s2n-quic-transport/src/stream/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/stream/manager/tests.rs
@@ -14,6 +14,7 @@ use crate::{
     recovery::RttEstimator,
     stream::{
         controller::MAX_STREAMS_SYNC_FRACTION,
+        manager_api::Manager as _,
         stream_impl::StreamConfig,
         stream_interests::{StreamInterestProvider, StreamInterests},
         testing::*,

--- a/quic/s2n-quic-transport/src/stream/manager_api.rs
+++ b/quic/s2n-quic-transport/src/stream/manager_api.rs
@@ -1,0 +1,140 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    connection,
+    contexts::{ConnectionApiCallContext, OnTransmitError, WriteContext},
+    recovery::RttEstimator,
+    stream::StreamError,
+    transmission,
+};
+use core::task::{Context, Poll};
+use s2n_quic_core::{
+    ack, endpoint,
+    frame::{
+        stream::StreamRef, DataBlocked, MaxData, MaxStreamData, MaxStreams, ResetStream,
+        StopSending, StreamDataBlocked, StreamsBlocked,
+    },
+    stream::{ops, StreamId, StreamType},
+    time::{timer, Timestamp},
+    transport::{self, parameters::InitialFlowControlLimits},
+    varint::VarInt,
+};
+
+pub trait Manager:
+    'static
+    + Send
+    + timer::Provider
+    + transmission::interest::Provider
+    + connection::finalization::Provider
+    + core::fmt::Debug
+{
+    /// Creates a new stream manager using the provided configuration parameters
+    fn new(
+        connection_limits: &connection::Limits,
+        local_endpoint_type: endpoint::Type,
+        initial_local_limits: InitialFlowControlLimits,
+        initial_peer_limits: InitialFlowControlLimits,
+    ) -> Self;
+
+    /// The number of bytes of forward progress the peer has made on incoming streams
+    fn incoming_bytes_progressed(&self) -> VarInt;
+
+    /// The number of bytes of forward progress the local endpoint has made on outgoing streams
+    fn outgoing_bytes_progressed(&self) -> VarInt;
+
+    /// Accepts the next incoming stream of a given type
+    fn poll_accept(
+        &mut self,
+        stream_type: Option<StreamType>,
+        context: &Context,
+    ) -> Poll<Result<Option<StreamId>, connection::Error>>;
+
+    /// Opens the next local initiated stream of a certain type
+    fn poll_open_local_stream(
+        &mut self,
+        stream_type: StreamType,
+        open_token: &mut connection::OpenToken,
+        context: &Context,
+    ) -> Poll<Result<StreamId, connection::Error>>;
+
+    /// This method gets called when a packet delivery got acknowledged
+    fn on_packet_ack<A: ack::Set>(&mut self, ack_set: &A);
+
+    /// This method gets called when a packet loss is reported
+    fn on_packet_loss<A: ack::Set>(&mut self, ack_set: &A);
+
+    /// This method gets called when the RTT estimate is updated for the active path
+    fn on_rtt_update(&mut self, rtt_estimator: &RttEstimator);
+
+    /// Called when the connection timer expires
+    fn on_timeout(&mut self, now: Timestamp);
+
+    /// Closes the manager and resets all streams with the
+    /// given error. The current implementation will still
+    /// allow to forward frames to the contained Streams as well as to query them
+    /// for data. However new Streams can not be created.
+    fn close(&mut self, error: connection::Error);
+
+    /// If the manager is closed, this returns the error which which was
+    /// used to close it.
+    fn close_reason(&self) -> Option<connection::Error>;
+
+    /// Closes the manager, flushes all send streams and resets all receive streams.
+    ///
+    /// This is used for when the application drops the connection but still has pending data to
+    /// transmit.
+    fn flush(&mut self, error: connection::Error) -> Poll<()>;
+
+    /// Queries the component for any outgoing frames that need to get sent
+    fn on_transmit<W: WriteContext>(&mut self, context: &mut W) -> Result<(), OnTransmitError>;
+
+    // Frame reception
+    // These functions are called from the packet delivery thread
+
+    /// This is called when a `STREAM_DATA` frame had been received for
+    /// a stream
+    fn on_data(&mut self, frame: &StreamRef) -> Result<(), transport::Error>;
+
+    /// This is called when a `DATA_BLOCKED` frame had been received
+    fn on_data_blocked(&mut self, frame: DataBlocked) -> Result<(), transport::Error>;
+
+    /// This is called when a `STREAM_DATA_BLOCKED` frame had been received for
+    /// a stream
+    fn on_stream_data_blocked(&mut self, frame: &StreamDataBlocked)
+        -> Result<(), transport::Error>;
+
+    /// This is called when a `RESET_STREAM` frame had been received for
+    /// a stream
+    fn on_reset_stream(&mut self, frame: &ResetStream) -> Result<(), transport::Error>;
+
+    /// This is called when a `MAX_STREAM_DATA` frame had been received for
+    /// a stream
+    fn on_max_stream_data(&mut self, frame: &MaxStreamData) -> Result<(), transport::Error>;
+
+    /// This is called when a `STOP_SENDING` frame had been received for
+    /// a stream
+    fn on_stop_sending(&mut self, frame: &StopSending) -> Result<(), transport::Error>;
+
+    /// This is called when a `MAX_DATA` frame had been received
+    fn on_max_data(&mut self, frame: MaxData) -> Result<(), transport::Error>;
+
+    /// This is called when a `STREAMS_BLOCKED` frame had been received
+    fn on_streams_blocked(&mut self, frame: &StreamsBlocked) -> Result<(), transport::Error>;
+
+    /// This is called when a `MAX_STREAMS` frame had been received
+    fn on_max_streams(&mut self, frame: &MaxStreams) -> Result<(), transport::Error>;
+
+    // User APIs
+
+    fn poll_request(
+        &mut self,
+        stream_id: StreamId,
+        api_call_context: &mut ConnectionApiCallContext,
+        request: &mut ops::Request,
+        context: Option<&Context>,
+    ) -> Result<ops::Response, StreamError>;
+
+    /// Returns whether or not streams have data to send
+    fn has_pending_streams(&self) -> bool;
+}

--- a/quic/s2n-quic-transport/src/stream/mod.rs
+++ b/quic/s2n-quic-transport/src/stream/mod.rs
@@ -7,6 +7,7 @@ mod api;
 mod controller;
 mod incoming_connection_flow_controller;
 mod manager;
+mod manager_api;
 mod outgoing_connection_flow_controller;
 mod receive_stream;
 mod send_stream;
@@ -21,13 +22,12 @@ pub(crate) mod contract;
 pub use api::*;
 pub use controller::Controller;
 pub use manager::AbstractStreamManager;
+pub use manager_api::Manager;
 pub use s2n_quic_core::stream::limits::Limits;
 pub use stream_events::StreamEvents;
 pub use stream_impl::{StreamImpl, StreamTrait};
 
-pub type StreamManager = AbstractStreamManager<StreamImpl>;
-
-// Import all tests
+pub type DefaultStreamManager = AbstractStreamManager<StreamImpl>;
 
 #[cfg(test)]
 mod testing;

--- a/quic/s2n-quic/src/client/providers.rs
+++ b/quic/s2n-quic/src/client/providers.rs
@@ -297,7 +297,7 @@ impl<
     type TLSEndpoint = Tls;
     type TokenFormat = Token;
     type ConnectionLimits = Limits;
-    type Stream = stream::StreamImpl;
+    type StreamManager = stream::DefaultStreamManager;
     type PathMigrationValidator = PathMigration;
     type PacketInterceptor = PacketInterceptor;
     type DatagramEndpoint = Datagram;

--- a/quic/s2n-quic/src/server/providers.rs
+++ b/quic/s2n-quic/src/server/providers.rs
@@ -267,7 +267,7 @@ impl<
     type TLSEndpoint = Tls;
     type TokenFormat = AddressToken;
     type ConnectionLimits = Limits;
-    type Stream = stream::StreamImpl;
+    type StreamManager = stream::DefaultStreamManager;
     type PathMigrationValidator = PathMigration;
     type PacketInterceptor = PacketInterceptor;
     type DatagramEndpoint = Datagram;


### PR DESCRIPTION
### Description of changes: 

I'm planning on experimenting with optimizing the stream manager a bit and making the endpoint generic over the stream manager interface will make this easier.

### Testing:

Since this is just moving the public API to a trait, all of the existing tests show no change in behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

