### PR TITLE
feat(s2n-quic-platform): add socket tasks for sync rings

### DIFF
--- a/quic/s2n-quic-platform/src/socket.rs
+++ b/quic/s2n-quic-platform/src/socket.rs
@@ -9,6 +9,7 @@ pub mod mmsg;
 pub mod msg;
 pub mod ring;
 pub mod std;
+pub mod task;
 
 cfg_if! {
     if #[cfg(s2n_quic_platform_socket_mmsg)] {

--- a/quic/s2n-quic-platform/src/socket/task.rs
+++ b/quic/s2n-quic-platform/src/socket/task.rs
@@ -1,0 +1,9 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod events;
+pub mod rx;
+pub mod tx;
+
+pub use rx::Receiver;
+pub use tx::Sender;

--- a/quic/s2n-quic-platform/src/socket/task/events.rs
+++ b/quic/s2n-quic-platform/src/socket/task/events.rs
@@ -74,7 +74,7 @@ impl crate::syscall::SocketEvents for TxEvents {
                 ControlFlow::Break(())
             }
             #[cfg(s2n_quic_platform_gso)]
-            _ if errno::errno().0 == libc::EIO => {
+            _ if error.raw_os_error() == Some(libc::EIO) => {
                 // on platforms that don't support GSO we need to disable it and mark the packet as
                 // "sent" even though we weren't able to.
                 self.count += 1;

--- a/quic/s2n-quic-platform/src/socket/task/events.rs
+++ b/quic/s2n-quic-platform/src/socket/task/events.rs
@@ -81,11 +81,16 @@ impl crate::syscall::SocketEvents for TxEvents {
 
                 self.gso.disable();
 
+                // We `continue` instead of break because it's very unlikely the message would be
+                // accepted at a later time, so we just discard the packet.
                 ControlFlow::Continue(())
             }
             _ => {
                 // ignore all other errors and just consider the packet sent
                 self.count += 1;
+
+                // We `continue` instead of break because it's very unlikely the message would be
+                // accepted at a later time, so we just discard the packet.
                 ControlFlow::Continue(())
             }
         }

--- a/quic/s2n-quic-platform/src/socket/task/events.rs
+++ b/quic/s2n-quic-platform/src/socket/task/events.rs
@@ -1,0 +1,156 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Some of the functions in these impls are not used on non-unix systems
+#![cfg_attr(not(unix), allow(dead_code))]
+
+use crate::features::Gso;
+use core::ops::ControlFlow;
+
+#[derive(Debug)]
+pub struct TxEvents {
+    count: usize,
+    is_blocked: bool,
+    #[cfg_attr(not(s2n_quic_platform_gso), allow(dead_code))]
+    gso: Gso,
+}
+
+impl TxEvents {
+    #[inline]
+    pub fn new(gso: Gso) -> Self {
+        Self {
+            count: 0,
+            is_blocked: false,
+            gso,
+        }
+    }
+
+    /// Returns if the task is blocked
+    #[inline]
+    pub fn is_blocked(&self) -> bool {
+        self.is_blocked
+    }
+
+    /// Returns if the task was blocked and resets the value
+    #[inline]
+    pub fn take_blocked(&mut self) -> bool {
+        core::mem::take(&mut self.is_blocked)
+    }
+
+    /// Sets the task to blocked
+    #[inline]
+    pub fn blocked(&mut self) {
+        self.is_blocked = true;
+    }
+
+    /// Returns and resets the number of messages sent
+    #[inline]
+    pub fn take_count(&mut self) -> usize {
+        core::mem::take(&mut self.count)
+    }
+}
+
+impl crate::syscall::SocketEvents for TxEvents {
+    #[inline]
+    fn on_complete(&mut self, count: usize) -> ControlFlow<(), ()> {
+        // increment the total sent packets and reset our blocked status
+        self.count += count;
+        self.is_blocked = false;
+        ControlFlow::Continue(())
+    }
+
+    #[inline]
+    fn on_error(&mut self, error: ::std::io::Error) -> ControlFlow<(), ()> {
+        use std::io::ErrorKind::*;
+
+        match error.kind() {
+            WouldBlock => {
+                // record that we're blocked
+                self.is_blocked = true;
+                ControlFlow::Break(())
+            }
+            Interrupted => {
+                // if we got interrupted break and have the task try again
+                ControlFlow::Break(())
+            }
+            #[cfg(s2n_quic_platform_gso)]
+            _ if errno::errno().0 == libc::EIO => {
+                // on platforms that don't support GSO we need to disable it and mark the packet as
+                // "sent" even though we weren't able to.
+                self.count += 1;
+
+                self.gso.disable();
+
+                ControlFlow::Continue(())
+            }
+            _ => {
+                // ignore all other errors and just consider the packet sent
+                self.count += 1;
+                ControlFlow::Continue(())
+            }
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct RxEvents {
+    count: usize,
+    is_blocked: bool,
+}
+
+impl RxEvents {
+    /// Returns if the task is blocked
+    #[inline]
+    pub fn is_blocked(&self) -> bool {
+        self.is_blocked
+    }
+
+    /// Returns if the task was blocked and resets the value
+    #[inline]
+    pub fn take_blocked(&mut self) -> bool {
+        core::mem::take(&mut self.is_blocked)
+    }
+
+    /// Sets the task to blocked
+    #[inline]
+    pub fn blocked(&mut self) {
+        self.is_blocked = true;
+    }
+
+    /// Returns and resets the number of messages sent
+    #[inline]
+    pub fn take_count(&mut self) -> usize {
+        core::mem::take(&mut self.count)
+    }
+}
+
+impl crate::syscall::SocketEvents for RxEvents {
+    #[inline]
+    fn on_complete(&mut self, count: usize) -> ControlFlow<(), ()> {
+        // increment the total sent packets and reset our blocked status
+        self.count += count;
+        self.is_blocked = false;
+        ControlFlow::Continue(())
+    }
+
+    #[inline]
+    fn on_error(&mut self, error: ::std::io::Error) -> ControlFlow<(), ()> {
+        use std::io::ErrorKind::*;
+
+        match error.kind() {
+            WouldBlock => {
+                // record that we're blocked
+                self.is_blocked = true;
+                ControlFlow::Break(())
+            }
+            Interrupted => {
+                // if we got interrupted break and have the task try again
+                ControlFlow::Break(())
+            }
+            _ => {
+                // ignore all other errors and have the task try again
+                ControlFlow::Break(())
+            }
+        }
+    }
+}

--- a/quic/s2n-quic-platform/src/socket/task/rx.rs
+++ b/quic/s2n-quic-platform/src/socket/task/rx.rs
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    message::Message,
+    socket::{ring::Producer, task::events},
+};
+use core::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use futures::ready;
+
+pub trait Socket<T: Message> {
+    type Error;
+
+    fn recv(
+        &mut self,
+        cx: &mut Context,
+        entries: &mut [T],
+        events: &mut events::RxEvents,
+    ) -> Result<(), Self::Error>;
+}
+
+pub struct Receiver<T: Message, S: Socket<T>> {
+    ring: Producer<T>,
+    rx: S,
+    pending: u32,
+}
+
+impl<T, S> Receiver<T, S>
+where
+    T: Message + Unpin,
+    S: Socket<T> + Unpin,
+{
+    #[inline]
+    pub fn new(ring: Producer<T>, rx: S) -> Self {
+        Self {
+            ring,
+            rx,
+            pending: 0,
+        }
+    }
+
+    #[inline]
+    fn poll_ring(&mut self, watermark: u32, cx: &mut Context) -> Poll<Option<usize>> {
+        loop {
+            let count = ready!(self.ring.poll_acquire(watermark, cx));
+
+            // if the number of items increased since last time then yield
+            if count > self.pending {
+                return Some(self.pending as usize).into();
+            }
+
+            // if we didn't get any items we can release the ones that we currently have and poll
+            // again
+            self.release();
+        }
+    }
+
+    #[inline]
+    fn release(&mut self) {
+        let to_release = core::mem::take(&mut self.pending);
+        self.ring.release(to_release);
+    }
+}
+
+impl<T, S> Future for Receiver<T, S>
+where
+    T: Message + Unpin,
+    S: Socket<T> + Unpin,
+{
+    type Output = Option<S::Error>;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        let mut events = events::RxEvents::default();
+
+        while !events.take_blocked() {
+            let pending = match ready!(this.poll_ring(u32::MAX, cx)) {
+                Some(entries) => entries,
+                None => return None.into(),
+            };
+
+            // slice the ring data by the number of items we've already received
+            let entries = &mut this.ring.data()[pending..];
+
+            // perform the recv syscall
+            match this.rx.recv(cx, entries, &mut events) {
+                Ok(()) => {
+                    // increment the number of received messages
+                    this.pending += events.take_count() as u32
+                }
+                Err(err) => return Some(err).into(),
+            }
+        }
+
+        // release any of the messages we wrote back to the consumer
+        this.release();
+
+        Poll::Pending
+    }
+}

--- a/quic/s2n-quic-platform/src/socket/task/tx.rs
+++ b/quic/s2n-quic-platform/src/socket/task/tx.rs
@@ -1,0 +1,106 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    features::Gso,
+    message::Message,
+    socket::{ring::Consumer, task::events},
+};
+use core::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use futures::ready;
+
+pub trait Socket<T: Message> {
+    type Error;
+
+    fn send(
+        &mut self,
+        cx: &mut Context,
+        entries: &mut [T],
+        events: &mut events::TxEvents,
+    ) -> Result<(), Self::Error>;
+}
+
+pub struct Sender<T: Message, S: Socket<T>> {
+    ring: Consumer<T>,
+    tx: S,
+    pending: u32,
+    events: events::TxEvents,
+}
+
+impl<T, S> Sender<T, S>
+where
+    T: Message + Unpin,
+    S: Socket<T> + Unpin,
+{
+    #[inline]
+    pub fn new(ring: Consumer<T>, tx: S, gso: Gso) -> Self {
+        Self {
+            ring,
+            tx,
+            pending: 0,
+            events: events::TxEvents::new(gso),
+        }
+    }
+
+    #[inline]
+    fn poll_ring(&mut self, watermark: u32, cx: &mut Context) -> Poll<Option<usize>> {
+        loop {
+            let count = ready!(self.ring.poll_acquire(watermark, cx));
+
+            // if we got more items than we have pending then yield
+            if count > self.pending {
+                return Some(self.pending as usize).into();
+            }
+
+            // release any of the pending items and try again
+            self.release();
+        }
+    }
+
+    #[inline]
+    fn release(&mut self) {
+        let to_release = core::mem::take(&mut self.pending);
+        self.ring.release(to_release);
+    }
+}
+
+impl<T, S> Future for Sender<T, S>
+where
+    T: Message + Unpin,
+    S: Socket<T> + Unpin,
+{
+    type Output = Option<S::Error>;
+
+    #[inline]
+    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        while !this.events.take_blocked() {
+            let pending = match ready!(this.poll_ring(u32::MAX, cx)) {
+                Some(entries) => entries,
+                None => return None.into(),
+            };
+
+            // slice the ring data by the number of items we've already received
+            let entries = &mut this.ring.data()[pending..];
+
+            // perform the send syscall
+            match this.tx.send(cx, entries, &mut this.events) {
+                Ok(()) => {
+                    // increment the number of received messages
+                    this.pending += this.events.take_count() as u32
+                }
+                Err(err) => return Some(err).into(),
+            }
+        }
+
+        // release any of the messages we wrote back to the consumer
+        this.release();
+
+        Poll::Pending
+    }
+}

--- a/quic/s2n-quic-platform/src/socket/task/tx.rs
+++ b/quic/s2n-quic-platform/src/socket/task/tx.rs
@@ -26,7 +26,11 @@ pub trait Socket<T: Message> {
 
 pub struct Sender<T: Message, S: Socket<T>> {
     ring: Consumer<T>,
+    /// Implementation of a socket that transmits filled slots in the ring buffer
     tx: S,
+    /// The number of messages that have been transmitted but not yet released to the producer.
+    ///
+    /// This value is to avoid calling `release` too much and excessively waking up the producer.
     pending: u32,
     events: events::TxEvents,
 }
@@ -47,16 +51,28 @@ where
     }
 
     #[inline]
-    fn poll_ring(&mut self, watermark: u32, cx: &mut Context) -> Poll<Option<usize>> {
+    fn poll_ring(&mut self, watermark: u32, cx: &mut Context) -> Poll<Result<(), ()>> {
         loop {
-            let count = ready!(self.ring.poll_acquire(watermark, cx));
+            let count = match self.ring.poll_acquire(watermark, cx) {
+                Poll::Ready(count) => count,
+                Poll::Pending if self.pending == 0 => {
+                    return if !self.ring.is_open() {
+                        Err(()).into()
+                    } else {
+                        Poll::Pending
+                    };
+                }
+                Poll::Pending => 0,
+            };
 
-            // if we got more items than we have pending then yield
+            // if the number of free slots increased since last time then yield
             if count > self.pending {
-                return Some(self.pending as usize).into();
+                return Ok(()).into();
             }
 
-            // release any of the pending items and try again
+            // If there is no additional capacity available (i.e. we have filled all slots),
+            // then release those filled slots for the consumer to read from. Once
+            // the consumer reads, we will have spare capacity to populate again.
             self.release();
         }
     }
@@ -80,13 +96,12 @@ where
         let this = self.get_mut();
 
         while !this.events.take_blocked() {
-            let pending = match ready!(this.poll_ring(u32::MAX, cx)) {
-                Some(entries) => entries,
-                None => return None.into(),
-            };
+            if ready!(this.poll_ring(u32::MAX, cx)).is_err() {
+                return None.into();
+            }
 
             // slice the ring data by the number of items we've already received
-            let entries = &mut this.ring.data()[pending..];
+            let entries = &mut this.ring.data()[this.pending as usize..];
 
             // perform the send syscall
             match this.tx.send(cx, entries, &mut this.events) {

--- a/quic/s2n-quic-platform/src/syscall.rs
+++ b/quic/s2n-quic-platform/src/syscall.rs
@@ -23,9 +23,17 @@ pub enum SocketType {
 
 pub trait SocketEvents {
     /// Called when `count` packets are completed
+    ///
+    /// If `Continue` is returned, the socket will assume the packet was acceptable and continue
+    /// with the remaining packets. If `Break` is returned, the syscall stop looping and yield to
+    /// the caller.
     fn on_complete(&mut self, count: usize) -> ControlFlow<(), ()>;
 
     /// Called when an error occurs on a socket
+    ///
+    /// If `Continue` is returned, the socket will discard the packet and continue
+    /// with the remaining packets. If `Break` is returned, the syscall will assume the current
+    /// packet can be retried and yield to the caller.
     fn on_error(&mut self, error: io::Error) -> ControlFlow<(), ()>;
 }
 


### PR DESCRIPTION
### Description of changes: 

Using the socket ring buffer added in #1787, this PR implements async tasks that interact with the syscalls and either send or receive messages into the ring buffer. Note that the tasks are generic over the message/syscall type.


### Call-outs:

The implementation that interacts with the s2n-quic endpoint is in #1788.

### Testing:

In this PR, I don't have explicit tests for these implementations, since it requires a task on the other side of the ring doing something with it. In the final PR, there will be some tests that show it all working end-to-end.

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

