### PR TITLE
ci: use modern rust-toolchain format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Evaluate definitions
         id: definitions
         run: |
-          export MSRV=$(cat rust-toolchain | awk '{$1=$1};1')
+          export MSRV=$(rustup show | awk 'NF' | awk 'END{print $2}')
           echo "msrv=$MSRV"
           echo "msrv=$MSRV" >> $GITHUB_OUTPUT
           export RAW_VERSIONS="stable beta $RUST_NIGHTLY_TOOLCHAIN $MSRV"
@@ -59,7 +59,7 @@ jobs:
           export EXAMPLES=$(find examples/ -maxdepth 1 -mindepth 1 -type d | jq -R | jq -sc)
           echo "examples=$EXAMPLES"
           echo "examples=$EXAMPLES" >> $GITHUB_OUTPUT
-          export CRATES=$(find find quic common -name *Cargo.toml | jq -R | jq -sc)
+          export CRATES=$(find quic common -name *Cargo.toml | jq -R | jq -sc)
           echo "crates=$CRATES"
           echo "crates=$CRATES" >> $GITHUB_OUTPUT
 

--- a/netbench/rust-toolchain
+++ b/netbench/rust-toolchain
@@ -1,1 +1,3 @@
-1.65.0
+[toolchain]
+channel = "1.65.0"
+components = [ "rustc", "clippy", "rustfmt" ]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,3 @@
-1.63.0
+[toolchain]
+channel = "1.63.0"
+components = [ "rustc", "clippy", "rustfmt" ]

--- a/tools/xdp/rust-toolchain
+++ b/tools/xdp/rust-toolchain
@@ -1,1 +1,3 @@
-1.66.0
+[toolchain]
+channel = "1.66.0"
+components = [ "rustc", "clippy", "rustfmt" ]


### PR DESCRIPTION
### Description of changes: 

Dependabot isn't able to read the old `rust-toolchain` file anymore so we aren't getting any updates. This PR uses the modern format instead.

### Call-outs:

The CI workflow had to be updated since we used the `rust-toolchain` file to extract out or MSRV.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

