### PR TITLE
fix(s2n-quic-platform): use custom storage type for messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2023-02-20
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2023-06-12
   CDN: https://dnglbrstg7yg.cloudfront.net
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100
@@ -260,8 +260,9 @@ jobs:
   miri:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        crate: [quic/s2n-quic-core]
+        crate: [quic/s2n-quic-core, quic/s2n-quic-platform]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -679,8 +680,9 @@ jobs:
   kani:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        crate: [quic/s2n-quic-core, tools/xdp/s2n-quic-xdp]
+        crate: [quic/s2n-quic-core, quic/s2n-quic-platform, tools/xdp/s2n-quic-xdp]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/quic/s2n-quic-core/src/io/tx.rs
+++ b/quic/s2n-quic-core/src/io/tx.rs
@@ -184,6 +184,40 @@ impl<Handle: path::Handle, Payload: AsRef<[u8]>> Message for (Handle, Payload) {
     }
 }
 
+impl<Handle: path::Handle, Payload: AsRef<[u8]>> Message
+    for (Handle, ExplicitCongestionNotification, Payload)
+{
+    type Handle = Handle;
+
+    fn path_handle(&self) -> &Self::Handle {
+        &self.0
+    }
+
+    fn ecn(&mut self) -> ExplicitCongestionNotification {
+        self.1
+    }
+
+    fn delay(&mut self) -> Duration {
+        Default::default()
+    }
+
+    fn ipv6_flow_label(&mut self) -> u32 {
+        0
+    }
+
+    fn can_gso(&self, segment_len: usize, _segment_count: usize) -> bool {
+        segment_len >= self.2.as_ref().len()
+    }
+
+    fn write_payload(
+        &mut self,
+        mut buffer: PayloadBuffer,
+        _gso_offset: usize,
+    ) -> Result<usize, Error> {
+        buffer.write(self.2.as_ref())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/quic/s2n-quic-platform/build.rs
+++ b/quic/s2n-quic-platform/build.rs
@@ -16,6 +16,8 @@ fn main() -> Result<(), Error> {
         }
     }
 
+    let is_miri = std::env::var("CARGO_CFG_MIRI").is_ok();
+
     match env.target_os.as_str() {
         "linux" => {
             supports("gso");
@@ -23,10 +25,21 @@ fn main() -> Result<(), Error> {
             supports("mtu_disc");
             supports("pktinfo");
             supports("tos");
+
+            // miri doesn't support the way we detect syscall support so override it
+            if is_miri {
+                supports("socket_msg");
+                supports("socket_mmsg");
+            }
         }
         "macos" => {
             supports("pktinfo");
             supports("tos");
+
+            // miri doesn't support the way we detect syscall support so override it
+            if is_miri {
+                supports("socket_msg");
+            }
         }
         "android" => {
             supports("mtu_disc");

--- a/quic/s2n-quic-platform/src/io/testing/network.rs
+++ b/quic/s2n-quic-platform/src/io/testing/network.rs
@@ -431,6 +431,8 @@ mod tests {
             addrs.push(buffers.generate_addr());
         }
 
-        assert_debug_snapshot!(addrs);
+        if !cfg!(miri) {
+            assert_debug_snapshot!(addrs);
+        }
     }
 }

--- a/quic/s2n-quic-platform/src/io/tokio/tests.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/tests.rs
@@ -9,6 +9,7 @@ use core::{
 use s2n_quic_core::{
     endpoint::{self, CloseError},
     event,
+    inet::ExplicitCongestionNotification,
     io::{rx, tx},
     path::Handle as _,
     time::{Clock, Duration, Timestamp},
@@ -75,7 +76,8 @@ impl<const IS_SERVER: bool> Endpoint for TestEndpoint<IS_SERVER> {
                 _ => {
                     let payload = id.to_be_bytes();
                     let addr = self.handle;
-                    let msg = (addr, payload);
+                    let ecn = ExplicitCongestionNotification::Ect0;
+                    let msg = (addr, ecn, payload);
                     if queue.push(msg).is_ok() {
                         *tx_time = Some(now);
                     } else {
@@ -208,11 +210,13 @@ static IPV4_LOCALHOST: &str = "127.0.0.1:0";
 static IPV6_LOCALHOST: &str = "[::1]:0";
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn ipv4_test() -> io::Result<()> {
     test(IPV4_LOCALHOST, None, IPV4_LOCALHOST, None).await
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn ipv4_two_socket_test() -> io::Result<()> {
     test(
         IPV4_LOCALHOST,
@@ -224,6 +228,7 @@ async fn ipv4_two_socket_test() -> io::Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn ipv6_test() -> io::Result<()> {
     let result = test(IPV6_LOCALHOST, None, IPV6_LOCALHOST, None).await;
 
@@ -237,6 +242,7 @@ async fn ipv6_test() -> io::Result<()> {
 }
 
 #[tokio::test]
+#[cfg_attr(miri, ignore)]
 async fn ipv6_two_socket_test() -> io::Result<()> {
     let result = test(
         IPV6_LOCALHOST,

--- a/quic/s2n-quic-platform/src/message/msg/ext.rs
+++ b/quic/s2n-quic-platform/src/message/msg/ext.rs
@@ -43,8 +43,11 @@ impl Ext for msghdr {
                 let ecn = ecn as libc::c_uchar;
 
                 self.encode_cmsg(libc::IPPROTO_IP, libc::IP_TOS, ecn)
+                    .unwrap()
             }
-            SocketAddress::IpV6(_) => self.encode_cmsg(libc::IPPROTO_IPV6, libc::IPV6_TCLASS, ecn),
+            SocketAddress::IpV6(_) => self
+                .encode_cmsg(libc::IPPROTO_IPV6, libc::IPV6_TCLASS, ecn)
+                .unwrap(),
         };
     }
 

--- a/quic/s2n-quic-platform/src/message/msg/handle.rs
+++ b/quic/s2n-quic-platform/src/message/msg/handle.rs
@@ -46,7 +46,9 @@ impl Handle {
                 let mut pkt_info = unsafe { core::mem::zeroed::<libc::in_pktinfo>() };
                 pkt_info.ipi_spec_dst.s_addr = u32::from_ne_bytes((*ip).into());
 
-                msghdr.encode_cmsg(libc::IPPROTO_IP, libc::IP_PKTINFO, pkt_info);
+                msghdr
+                    .encode_cmsg(libc::IPPROTO_IP, libc::IP_PKTINFO, pkt_info)
+                    .unwrap();
             }
             SocketAddress::IpV6(addr) => {
                 use s2n_quic_core::inet::Unspecified;
@@ -61,7 +63,9 @@ impl Handle {
 
                 pkt_info.ipi6_addr.s6_addr = (*ip).into();
 
-                msghdr.encode_cmsg(libc::IPPROTO_IPV6, libc::IPV6_PKTINFO, pkt_info);
+                msghdr
+                    .encode_cmsg(libc::IPPROTO_IPV6, libc::IPV6_PKTINFO, pkt_info)
+                    .unwrap();
             }
         }
     }

--- a/quic/s2n-quic-platform/src/message/msg/tests.rs
+++ b/quic/s2n-quic-platform/src/message/msg/tests.rs
@@ -3,11 +3,11 @@
 
 use super::*;
 use bolero::check;
+use core::mem::zeroed;
 use s2n_quic_core::inet::{SocketAddress, Unspecified};
 
-#[test]
-fn address_inverse_pair_test() {
-    use core::mem::zeroed;
+fn test_msghdr<F: FnOnce(&mut msghdr)>(f: F) {
+    const PAYLOAD_LEN: usize = 16;
 
     let mut msghdr = unsafe { zeroed::<msghdr>() };
 
@@ -16,24 +16,42 @@ fn address_inverse_pair_test() {
     msghdr.msg_namelen = size_of::<sockaddr_in6>() as _;
 
     let mut iovec = unsafe { zeroed::<iovec>() };
+
+    let mut payload = [0u8; PAYLOAD_LEN];
+    iovec.iov_base = &mut payload as *mut _ as *mut _;
+    iovec.iov_len = 1;
+
     msghdr.msg_iov = &mut iovec;
 
-    let mut message = msghdr;
+    let mut msg_control = cmsg::Storage::default();
+    msghdr.msg_controllen = msg_control.len() as _;
+    msghdr.msg_control = msg_control.as_mut_ptr() as *mut _;
 
+    unsafe {
+        msghdr.reset(PAYLOAD_LEN);
+    }
+
+    f(&mut msghdr);
+}
+
+#[test]
+#[cfg_attr(kani, kani::proof, kani::solver(cadical), kani::unwind(17))]
+fn address_inverse_pair_test() {
     check!()
         .with_type::<SocketAddress>()
         .cloned()
         .for_each(|addr| {
-            unsafe {
-                message.reset(0);
-            }
-            message.set_remote_address(&addr);
+            test_msghdr(|message| {
+                message.set_remote_address(&addr);
 
-            assert_eq!(message.remote_address(), Some(addr));
+                assert_eq!(message.remote_address(), Some(addr));
+            });
         });
 }
 
 #[test]
+#[cfg_attr(kani, kani::proof, kani::solver(cadical), kani::unwind(65))]
+#[cfg(any(not(kani), kani_slow))] // this test isn't able to terminate
 fn handle_get_set_test() {
     check!()
         .with_generator((
@@ -42,46 +60,32 @@ fn handle_get_set_test() {
         ))
         .cloned()
         .for_each(|(handle, segment_size)| {
-            use core::mem::zeroed;
+            test_msghdr(|message| {
+                handle.update_msg_hdr(message);
 
-            let mut msghdr = unsafe { zeroed::<msghdr>() };
+                if segment_size > 1 {
+                    message.set_segment_size(segment_size);
+                }
 
-            let mut msgname = unsafe { zeroed::<sockaddr_in6>() };
-            msghdr.msg_name = &mut msgname as *mut _ as *mut _;
-            msghdr.msg_namelen = size_of::<sockaddr_in6>() as _;
+                let (header, _cmsg) = message.header().unwrap();
 
-            let mut iovec = unsafe { zeroed::<iovec>() };
-            let mut iovec_buf = [0u8; 16];
-            iovec.iov_len = iovec_buf.len() as _;
-            iovec.iov_base = (&mut iovec_buf[0]) as *mut u8 as _;
-            msghdr.msg_iov = &mut iovec;
+                assert_eq!(header.path.remote_address, handle.remote_address);
 
-            let mut cmsg_buf = [0u8; cmsg::MAX_LEN];
-            msghdr.msg_controllen = cmsg_buf.len() as _;
-            msghdr.msg_control = (&mut cmsg_buf[0]) as *mut u8 as _;
+                if cfg!(s2n_quic_platform_pktinfo) && !handle.local_address.ip().is_unspecified() {
+                    assert_eq!(header.path.local_address.ip(), handle.local_address.ip());
+                }
 
-            let mut message = msghdr;
+                // reset the message and ensure everything is zeroed
+                unsafe {
+                    message.reset(0);
+                }
 
-            handle.update_msg_hdr(&mut message);
-
-            if segment_size > 1 {
-                message.set_segment_size(segment_size);
-            }
-
-            let (header, _cmsg) = message.header().unwrap();
-
-            assert_eq!(header.path.remote_address, handle.remote_address);
-
-            if cfg!(s2n_quic_platform_pktinfo) && !handle.local_address.ip().is_unspecified() {
-                assert_eq!(header.path.local_address.ip(), handle.local_address.ip());
-            }
-
-            // reset the message and ensure everything is zeroed
-            unsafe {
-                message.reset(0);
-            }
-
-            let (header, _cmsg) = msghdr.header().unwrap();
-            assert!(header.path.remote_address.is_unspecified());
+                // no need to check this on kani since it has to unwind the loop again
+                #[cfg(not(kani))]
+                {
+                    let (header, _cmsg) = message.header().unwrap();
+                    assert!(header.path.remote_address.is_unspecified());
+                }
+            });
         });
 }

--- a/quic/s2n-quic-platform/src/message/queue.rs
+++ b/quic/s2n-quic-platform/src/message/queue.rs
@@ -269,6 +269,7 @@ mod tests {
         ($name:ident, $ring:path) => {
             /// A VecDeque is used to assert the behavior matches the Queue
             #[test]
+            #[cfg_attr(miri, ignore)]
             fn $name() {
                 check!()
                     .with_generator((0usize..16, gen::<Vec<Operation>>()))


### PR DESCRIPTION
### Description of changes: 

In #1790, @Mark-Simulacrum had some concerns about the code from #1787. This PR aims to address those separately.

### Call-outs:

There were a few violations of stacked borrows in the cmsg module. Unfortunately, they aren't completely solvable, as some of them come from the `libc` crate. I've modified the code to use our own cmsg implementation, which actually simplifies things a bit.

### Testing:

I've added MIRI tests for the `s2n-quic-platform` crate to ensure we don't violate the stacked borrows memory model. I've also added a few Kani tests to increase some confidence in the new cmsg code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

