### PR TITLE
Vectored write for datagrams

### DIFF
--- a/common/s2n-codec/src/encoder/value.rs
+++ b/common/s2n-codec/src/encoder/value.rs
@@ -138,6 +138,25 @@ encoder_value_slice!(&mut [u8], |self| self);
 encoder_value_slice!(DecoderBuffer<'_>, |self| self.as_less_safe_slice());
 encoder_value_slice!(DecoderBufferMut<'_>, |self| self.as_less_safe_slice());
 
+impl EncoderValue for &'_ [&'_ [u8]] {
+    #[inline]
+    fn encode<E: Encoder>(&self, encoder: &mut E) {
+        for slice in self.iter() {
+            encoder.write_slice(slice)
+        }
+    }
+
+    #[inline]
+    fn encoding_size(&self) -> usize {
+        self.iter().map(|s| s.len()).sum()
+    }
+
+    #[inline]
+    fn encoding_size_for_encoder<E: Encoder>(&self, _encoder: &E) -> usize {
+        self.iter().map(|s| s.len()).sum()
+    }
+}
+
 impl EncoderValue for () {
     #[inline]
     fn encode<E: Encoder>(&self, _encoder: &mut E) {}

--- a/quic/s2n-quic-core/src/datagram/default.rs
+++ b/quic/s2n-quic-core/src/datagram/default.rs
@@ -914,10 +914,15 @@ mod tests {
         }
 
         fn write_datagram(&mut self, data: &[u8]) -> Result<(), WriteError> {
-            if data.len() > self.remaining_capacity {
+            self.write_datagram_vectored(&[data])
+        }
+
+        fn write_datagram_vectored(&mut self, data: &[&[u8]]) -> Result<(), WriteError> {
+            let data_len = data.iter().map(|d| d.len()).sum::<usize>();
+            if data_len > self.remaining_capacity {
                 return Err(WriteError::ExceedsPacketCapacity);
             }
-            self.remaining_capacity -= data.len();
+            self.remaining_capacity -= data_len;
             Ok(())
         }
 

--- a/quic/s2n-quic-core/src/datagram/traits.rs
+++ b/quic/s2n-quic-core/src/datagram/traits.rs
@@ -107,6 +107,10 @@ pub trait Packet {
     /// per datagram.
     fn write_datagram(&mut self, data: &[u8]) -> Result<(), WriteError>;
 
+    /// Writes a single datagram to a packet from a collection of buffers. This function should be
+    /// called per datagram.
+    fn write_datagram_vectored(&mut self, data: &[&[u8]]) -> Result<(), WriteError>;
+
     /// Returns whether or not there is reliable data waiting to be sent.
     ///
     /// Use method to decide whether or not to cede the packet space to the stream data.

--- a/quic/s2n-quic-transport/src/endpoint/version.rs
+++ b/quic/s2n-quic-transport/src/endpoint/version.rs
@@ -381,7 +381,7 @@ mod tests {
                 version,
                 destination_connection_id: &[1u8, 2, 3][..],
                 source_connection_id: &[4u8, 5, 6, 7][..],
-                token: &[][..],
+                token: &[0u8; 0][..],
                 packet_number: pn(PacketNumberSpace::Initial),
                 payload: &[1u8, 2, 3, 4, 5][..],
             }
@@ -407,7 +407,7 @@ mod tests {
                 // Maximum length connection IDs that may be valid in future versions
                 destination_connection_id: &[1u8; size_of::<u8>()][..],
                 source_connection_id: &[2u8; size_of::<u8>()][..],
-                token: &[][..],
+                token: &[0u8; 0][..],
                 packet_number: pn(PacketNumberSpace::Initial),
                 payload: payload.as_slice(),
             }

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -267,7 +267,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
             version: context.quic_version,
             destination_connection_id,
             source_connection_id: context.path_manager[context.path_id].local_connection_id,
-            token: &[][..],
+            token: &[0u8; 0][..],
             packet_number,
             payload,
         };

--- a/quic/s2n-quic-transport/src/stream/controller/local_initiated.rs
+++ b/quic/s2n-quic-transport/src/stream/controller/local_initiated.rs
@@ -426,7 +426,7 @@ impl ValueToFrameWriter<()> for OpenNotifyFrameWriter {
             is_last_frame: false,
             is_fin: false,
             offset: VarInt::from_u32(0),
-            data: &[][..],
+            data: &[0u8; 0][..],
         })
     }
 }

--- a/quic/s2n-quic-transport/src/sync/data_sender/writer.rs
+++ b/quic/s2n-quic-transport/src/sync/data_sender/writer.rs
@@ -61,7 +61,7 @@ impl FrameWriter for Stream {
             offset,
             is_last_frame: false,
             is_fin: true,
-            data: &[][..],
+            data: &[0u8; 0][..],
         };
 
         // the length is always 0 so we don't need to trim the data


### PR DESCRIPTION
### Description of changes: 

This lets callers who have "headers" associated with each datagram in separate buffers avoid needing to copy into a buffer just for the write call (which results in another copy into the destination).

No intended functional changes, only more efficient callers.

### Callouts

The EncoderValue implementation for slices isn't using the s2n-quic-core vectored copy implementation - it seems like that would require a new write_vectored_slice or similar. Open to writing that but maybe I missed some implementation that already exists and I can just call into.

### Testing:

No tests added - I was looking for some UDP datagram tests but nothing seems to call write_datagram today? So I assume this works.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

