### PR TITLE
fix(s2n-quic-transport): improve amplification credits on client

### DIFF
--- a/quic/s2n-quic-transport/src/connection/transmission.rs
+++ b/quic/s2n-quic-transport/src/connection/transmission.rs
@@ -175,7 +175,16 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
             // end, so we check that next. Finally, if there is no ApplicationData or Handshake packet
             // to transmit, the Initial packet itself will be padded.
             let mut pn_space_to_pad = {
-                if !has_transmission(space_manager.initial(), transmission_constraint) {
+                let needs_padding = if Config::ENDPOINT_TYPE.is_client() {
+                    // if we're the client and have early data spaces still, we need to pad out packets
+                    // in order to give the server as many amplification credits as possible.
+                    space_manager.initial().is_some() || space_manager.handshake().is_some()
+                } else {
+                    // if we're the server, we only need to pad while we have the initial space
+                    has_transmission(space_manager.initial(), transmission_constraint)
+                };
+
+                if !needs_padding {
                     // There is no Initial packet, so no padding is needed
                     None
                 } else if has_transmission(space_manager.application(), transmission_constraint) {

--- a/quic/s2n-quic-transport/src/connection/transmission.rs
+++ b/quic/s2n-quic-transport/src/connection/transmission.rs
@@ -176,9 +176,9 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
             // to transmit, the Initial packet itself will be padded.
             let mut pn_space_to_pad = {
                 let needs_padding = if Config::ENDPOINT_TYPE.is_client() {
-                    // if we're the client and have early data spaces still, we need to pad out packets
+                    // if we're the client and haven't completed the handshake, we need to pad out packets
                     // in order to give the server as many amplification credits as possible.
-                    space_manager.initial().is_some() || space_manager.handshake().is_some()
+                    !space_manager.is_handshake_confirmed()
                 } else {
                     // if we're the server, we only need to pad while we have the initial space
                     has_transmission(space_manager.initial(), transmission_constraint)

--- a/quic/s2n-quic-transport/src/transmission/early.rs
+++ b/quic/s2n-quic-transport/src/transmission/early.rs
@@ -44,26 +44,25 @@ impl<'a, Config: endpoint::Config> super::Payload for Payload<'a, Config> {
             // send PINGs last, since they might not actually be needed if there's an ack-eliciting
             // frame already present in the payload
             self.recovery_manager.on_transmit(context);
+
+            // In order to trigger the loss recovery mechanisms during the handshake make all packets
+            // ack-eliciting. This is especially true for the client in order to give the server more
+            // amplification credits.
+            //
+            // Only send a PING if:
+            // * We're not congestion limited
+            // * The packet isn't already ack-eliciting
+            // * Another frame was written to the context
+            if !context.ack_elicitation().is_ack_eliciting()
+                && start_capacity != context.remaining_capacity()
+            {
+                let _ = context.write_frame(&Ping);
+            }
         }
 
         if did_send_ack {
             // inform the ack manager the packet is populated
             self.ack_manager.on_transmit_complete(context);
-        }
-
-        // In order to trigger the loss recovery mechanisms during the handshake make all packets
-        // ack-eliciting. This is especially true for the client in order to give the server more
-        // amplification credits.
-        // Only send a PING if:
-        // * We're not congestion limited
-        // * The packet isn't already ack-eliciting
-        // * Another frame was written to the context
-        if !context.transmission_constraint().is_congestion_limited()
-            && !context.ack_elicitation().is_ack_eliciting()
-            && start_capacity != context.remaining_capacity()
-        {
-            // we need to ignore the transmission constraint
-            let _ = context.write_frame(&Ping);
         }
     }
 


### PR DESCRIPTION
### Description of changes: 

I noticed that we had [some scenarios](https://dnglbrstg7yg.cloudfront.net/7f50be7e190a65d9e958a0d23edc8b3821f67cbd/interop/logs/latest/s2n-quic_s2n-quic/amplificationlimit/index.html) on a s2n-quic client where we would stall a handshake if the server was amplification-limited.

The fix is to have the client:

* Pad all packets until the handshake is confirmed. This ensures the server is getting as many credits as possible.
* Make all early packets ACK-eliciting. This ensures the recovery mechanisms kick in for when packets are lost. This is especially important on the client where it doesn't have anything to send and is waiting on the server's CRYPTO frames.

### Testing:

Interop results: https://dnglbrstg7yg.cloudfront.net/169b6c37402b4d9079958306c78c1a9f7cf93901/interop/index.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

