### PR TITLE
fix(s2n-quic-platform): increase cmsg buffer size for multiple pktinfo

### DIFF
--- a/quic/s2n-quic-platform/src/message/cmsg.rs
+++ b/quic/s2n-quic-platform/src/message/cmsg.rs
@@ -38,11 +38,9 @@ pub const MAX_LEN: usize = {
 
     let segment_offload_size = const_max(gso_size, gro_size);
 
+    // rather than taking the max, we add these in case the OS gives us both
     #[cfg(s2n_quic_platform_pktinfo)]
-    let pktinfo_size = const_max(
-        size_of_cmsg::<libc::in_pktinfo>(),
-        size_of_cmsg::<libc::in6_pktinfo>(),
-    );
+    let pktinfo_size = size_of_cmsg::<libc::in_pktinfo>() + size_of_cmsg::<libc::in6_pktinfo>();
     #[cfg(not(s2n_quic_platform_pktinfo))]
     let pktinfo = 0;
 

--- a/quic/s2n-quic-platform/src/message/msg.rs
+++ b/quic/s2n-quic-platform/src/message/msg.rs
@@ -131,6 +131,14 @@ impl MessageTrait for msghdr {
         &mut self,
         local_address: &path::LocalAddress,
     ) -> Option<super::RxMessage<Self::Handle>> {
+        if cfg!(test) {
+            assert_eq!(
+                self.msg_flags & libc::MSG_CTRUNC,
+                0,
+                "control message buffers should always have enough capacity"
+            );
+        }
+
         let (mut header, cmsg) = self.header()?;
 
         // only copy the port if we are told the IP address


### PR DESCRIPTION

### Description of changes: 

In testing, I was seeing ECN markings get disabled. After some digging, this is due to the OS returning both `pktinfo` _and_ `pktinfo6` and the cmsg buffer not having enough capacity for those.

As such, I've added the sizes for both rather than taking the max.

### Testing:

I also added an assertion to make sure the cmsg buffer wasn't truncated in testing. I didn't make it a `debug_assert`, since I'm not sure if the OS will randomly return more cmsgs or not and didn't want the application to panic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

