### PR TITLE
Switch providers to not use opaque types

### DIFF
--- a/quic/s2n-quic/src/provider/macros.rs
+++ b/quic/s2n-quic/src/provider/macros.rs
@@ -175,7 +175,7 @@ macro_rules! impl_provider_method {
             $(
                 #[$($attr)*]
             )*
-            pub fn $name<T, U>(self, $field: T) -> Result<Builder<impl $trait>, T::Error>
+            pub fn $name<T, U>(self, $field: T) -> Result<Builder<U>, T::Error>
             where
                 T: $field::TryInto,
                 U: $trait,


### PR DESCRIPTION
The Rust compiler deals poorly with the signature of our providers, leading to exponential compile times with additional providers. In one real-world case this patch changes `cargo check` compile times from 6 minutes to 20 seconds, which is a significant delta. The tradeoff with the current compiler is somewhat more verbose error messages, but given the potentially massive wins in compile time for users of this crate that seems worth it.

### Testing:

No particular testing - expected to be a no-op at runtime.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

