### PR TITLE
feat(s2n-quic-core): implement std error for MaxMtuError

### DIFF
--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -299,6 +299,9 @@ impl Display for MaxMtuError {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for MaxMtuError {}
+
 //= https://www.rfc-editor.org/rfc/rfc9308#section-8.1
 //# Some UDP protocols are vulnerable to reflection attacks, where an
 //# attacker is able to direct traffic to a third party as a denial of


### PR DESCRIPTION
### Description of changes: 

The MaxMtuError doesn't currently implement `std::error::Error`, which makes it annoying to use in applications. This change implements it.

### Testing:

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

