### PR TITLE
refactor(s2n-quic-core): optimize interval set intersection

### DIFF
--- a/quic/s2n-quic-core/src/interval_set/intersection.rs
+++ b/quic/s2n-quic-core/src/interval_set/intersection.rs
@@ -339,7 +339,6 @@ pub(super) fn apply<T: IntervalBound>(
             (Equal, Equal) => {
                 advance_set_a!();
                 advance_set_b!();
-                continue;
             }
 
             // interval A ends with interval B

--- a/quic/s2n-quic-core/src/interval_set/intersection.rs
+++ b/quic/s2n-quic-core/src/interval_set/intersection.rs
@@ -207,3 +207,205 @@ impl<'a, T: 'a + IntervalBound + Ord> Iterator for Intersection<'a, T> {
         }
     }
 }
+
+/// Apply the intersection of `set_a` with `set_b` to `set_a`
+pub(super) fn apply<T: IntervalBound>(
+    set_a: &mut VecDeque<Interval<T>>,
+    set_b: &VecDeque<Interval<T>>,
+) {
+    use Ordering::*;
+
+    if set_a.is_empty() {
+        return;
+    }
+
+    if set_b.is_empty() {
+        set_a.clear();
+        return;
+    }
+
+    let mut set_b = set_b.iter();
+    let mut interval_b = set_b.next().expect("set_b is not empty");
+    let mut a_index = 0;
+
+    macro_rules! advance_set_a {
+        () => {
+            a_index += 1;
+        };
+    }
+
+    macro_rules! advance_set_b {
+        () => {
+            if let Some(next_interval_b) = set_b.next() {
+                interval_b = next_interval_b;
+            } else {
+                // the remainder of set_a is not in the intersection, since we've
+                // reached the end of set_b
+                set_a.truncate(a_index);
+                return;
+            }
+        };
+    }
+
+    // Inserts a new interval into the next index of set_a that starts where the current interval b
+    // ends (with a gap of 1) and ends where the current interval a ends
+    macro_rules! split_off_a {
+        ($interval_a:ident) => {
+            // step_up_saturating is used because the next intersecting interval should not be
+            // contiguous with the current interval, so we can expect a gap of at least 1.
+            let new_interval_a: Interval<T> =
+                (interval_b.end_exclusive().step_up_saturating()..=$interval_a.end).into();
+
+            if new_interval_a.is_valid() {
+                // if interval_a had only overlapped interval_b by 1, then the new interval
+                // will not be valid and we can skip inserting it
+                // for example: interval_a = [0..=48], interval_b = [0..=47]
+                // new_interval_a = [49..=48] since we know 48 is not in interval_b
+                set_a.insert(a_index + 1, new_interval_a);
+            }
+        };
+    }
+
+    while let Some(interval_a) = set_a.get(a_index) {
+        match (interval_a.start.cmp(&interval_b.start),
+               interval_a.end.cmp(&interval_b.end),
+        ) {
+            // interval A is a subset of interval B
+            //
+            // interval A: |-----|
+            // interval B: |---------|
+            //
+            // End state:
+            //             |-----|
+            // a_index:           ^
+            (Equal, Less) |
+
+            // interval A is a subset of interval B
+            //
+            // interval A:    |----|
+            // interval B: |---------|
+            //
+            // End state:
+            //                |----|
+            // a_index:             ^
+            (Greater, Less) => {
+                advance_set_a!();
+            }
+
+            // interval A contains interval B, spilling over into the next slot
+            //
+            // interval A: |---------|
+            // interval B: |---|
+            //
+            // End state:
+            //             |---| |---|
+            // a_index:          ^
+            (Equal, Greater) |
+
+            // interval A contains interval B, spilling over into the next slot
+            //
+            // interval A: |---------|
+            // interval B:   |---|
+            //
+            // End state:
+            //               |---| |-|
+            // a_index:            ^
+            (Less, Greater) => {
+                // split off the part of interval A that is spilling into the next slot
+                split_off_a!(interval_a);
+                set_a[a_index] = *interval_b;
+                advance_set_a!();
+                advance_set_b!();
+            }
+
+            // interval A is a subset of interval B
+            //
+            // interval A:     |-----|
+            // interval B: |---------|
+            //
+            // End state:
+            //                 |-----|
+            // a_index:               ^
+            (Greater, Equal) |
+
+            // the intervals are equal
+            //
+            // interval A: |---------|
+            // interval B: |---------|
+            //
+            // End state:
+            //             |---------|
+            // a_index:               ^
+            (Equal, Equal) => {
+                advance_set_a!();
+                advance_set_b!();
+                continue;
+            }
+
+            // interval A ends with interval B
+            //
+            // interval A: |---------|
+            // interval B:       |---|
+            //
+            // End state:
+            //                   |---|
+            // a_index:               ^
+            (Less, Equal) => {
+                set_a[a_index].start = interval_b.start;
+                advance_set_a!();
+                advance_set_b!();
+            }
+
+            // interval A overlaps part of interval B.
+            //
+            // interval A:      |--------|
+            // interval B: |--------|
+            //
+            // End state:
+            //                  |---| |--|
+            // a_index:               ^
+            (Greater, Greater) if interval_a.start <= interval_b.end => {
+                // split off the part of interval A that is spilling into the next slot
+                split_off_a!(interval_a);
+                set_a[a_index].end = interval_b.end;
+                advance_set_a!();
+                advance_set_b!();
+            }
+
+            // interval A overlaps part of interval B
+            //
+            // interval A: |--------|
+            // interval B:      |--------|
+            //
+            // End state:
+            //                  |---|
+            // a_index:              ^
+            (Less, Less) if interval_a.end >= interval_b.start => {
+                set_a[a_index].start = interval_b.start;
+                advance_set_a!();
+            }
+
+            // interval A comes later
+            //
+            // interval A:          |-----|
+            // interval B: |----|
+            //
+            // continue to next B
+            //
+            (Greater, Greater) => {
+                advance_set_b!();
+            }
+
+            // interval A comes before interval B
+            //
+            // interval A: |---|
+            // interval B:        |--------|
+            //
+            // remove A and continue to next A
+            //
+            (Less, Less) => {
+                set_a.remove(a_index);
+            }
+        }
+    }
+}

--- a/quic/s2n-quic-core/src/interval_set/intersection.rs
+++ b/quic/s2n-quic-core/src/interval_set/intersection.rs
@@ -209,6 +209,7 @@ impl<'a, T: 'a + IntervalBound + Ord> Iterator for Intersection<'a, T> {
 }
 
 /// Apply the intersection of `set_a` with `set_b` to `set_a`
+#[inline]
 pub(super) fn apply<T: IntervalBound>(
     set_a: &mut VecDeque<Interval<T>>,
     set_b: &VecDeque<Interval<T>>,

--- a/quic/s2n-quic-core/src/interval_set/mod.rs
+++ b/quic/s2n-quic-core/src/interval_set/mod.rs
@@ -464,18 +464,7 @@ impl<T: IntervalBound> IntervalSet<T> {
     /// ```
     #[inline]
     pub fn intersection(&mut self, other: &Self) -> Result<(), IntervalSetError> {
-        if self.is_empty() {
-            return Ok(());
-        }
-
-        if other.is_empty() {
-            self.clear();
-            return Ok(());
-        }
-
-        // TODO optimize this to remove the allocation
-        //      https://github.com/aws/s2n-quic/issues/746
-        self.intervals = self.intersection_iter(other).collect();
+        intersection::apply(&mut self.intervals, &other.intervals);
 
         Ok(())
     }

--- a/quic/s2n-quic-core/src/interval_set/tests.rs
+++ b/quic/s2n-quic-core/src/interval_set/tests.rs
@@ -94,7 +94,16 @@ fn interval_set_test() {
 
             set_op_test!(union, union_ops);
             set_op_test!(difference, difference_ops);
-            set_op_test!(intersection, intersection_ops);
+
+            // Assert that both `intersection` and `intersection_iter`
+            // produce the same results as the oracle
+            let (mut expected, mut actual) = process_operation(intersection_ops);
+            expected.intersection(&oracle);
+            actual.remove_limit();
+            let actual_iter = IntervalSet::from_iter(actual.intersection_iter(&subject));
+            actual.intersection(&subject).expect("invalid op");
+            assert_set_eq!(expected, actual);
+            assert_set_eq!(expected, actual_iter);
         },
     );
 }


### PR DESCRIPTION
### Resolved issues:

resolves #746

### Description of changes: 

This change introduces a method for performing an `IntervalSet` intersection in place, mutating the original interval set instead of allocating a new `VecDeque`. 

### Call-outs:

I left the original `intersection_iter` code in place even though I don't think anything is using it, as I believe we are treating `IntervalSet` as a general purpose data structure, and this `intersection_iter` could be useful for someone that just wants to iterate over the intersection rather than actually apply the intersection.

### Testing:

Updated the existing fuzz tests to compare both `intersection` and `intersection_iter` with the oracle `BTreeSet`. I've run the fuzz test on release mode for > 1 hour (and counting)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

