### PR TITLE
test(s2n-quic-transport): add transmission interest debugger

### DIFF
--- a/quic/s2n-quic-transport/src/transmission/interest.rs
+++ b/quic/s2n-quic-transport/src/transmission/interest.rs
@@ -174,6 +174,50 @@ impl Query for HasTransmissionInterestQuery {
     }
 }
 
+pub struct Debugger;
+
+impl Query for Debugger {
+    #[inline]
+    #[track_caller]
+    fn on_interest(&mut self, interest: Interest) -> Result {
+        eprintln!("  {} - {:?}", core::panic::Location::caller(), interest);
+        Ok(())
+    }
+
+    #[inline]
+    #[track_caller]
+    fn on_new_data(&mut self) -> Result {
+        eprintln!(
+            "  {} - {:?}",
+            core::panic::Location::caller(),
+            Interest::NewData
+        );
+        Ok(())
+    }
+
+    #[inline]
+    #[track_caller]
+    fn on_lost_data(&mut self) -> Result {
+        eprintln!(
+            "  {} - {:?}",
+            core::panic::Location::caller(),
+            Interest::LostData
+        );
+        Ok(())
+    }
+
+    #[inline]
+    #[track_caller]
+    fn on_forced(&mut self) -> Result {
+        eprintln!(
+            "  {} - {:?}",
+            core::panic::Location::caller(),
+            Interest::Forced
+        );
+        Ok(())
+    }
+}
+
 pub struct QueryBreak;
 
 pub type Result<T = (), E = QueryBreak> = core::result::Result<T, E>;


### PR DESCRIPTION
### Description of changes: 

This change adds a transmission interest debugger which prints out which component is wanting to transmit and what type of interest it has. I was using it in testing awhile back and thought it would be useful to have.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

