### PR TITLE
test(s2n-quic-sim): fix the connect delay implementation

### DIFF
--- a/quic/s2n-quic-sim/src/stats.rs
+++ b/quic/s2n-quic-sim/src/stats.rs
@@ -450,6 +450,9 @@ static QUERIES: &[(&str, Type, Q)] = &[
             .checked_sub(conn.start_time.unwrap_or_default().as_duration())?;
         Some(duration.as_secs_f64())
     }),
+    ("conn.id", B, |_params, conn, _conns| {
+        conn.client_id.or(conn.server_id).map(|v| v as f64)
+    }),
     ("conn.client", B, |_params, conn, _conns| {
         Some(if conn.client_id.is_some() { 1.0 } else { 0.0 })
     }),


### PR DESCRIPTION
### Description of changes: 

The current delay code for the sim unintentionally performs a parallel delay when establishing connections. However, the original intent was to make it serial. This fixes that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

