### PR TITLE
fix(s2n-quic-qns): update interop commit to match interop workflow

### DIFF
--- a/scripts/interop/run
+++ b/scripts/interop/run
@@ -22,7 +22,7 @@ if [ ! -d $INTEROP_DIR ]; then
   git clone https://github.com/marten-seemann/quic-interop-runner $INTEROP_DIR
   # make sure to keep this up to date with the interop workflow
   cd $INTEROP_DIR
-  git checkout bdb2c815b8cfd70de4c2efb1bd278b1e87018ff8
+  git checkout e73ec56cdf5423fa6b1576a2b5fec5eb2171ec5d
   git apply --3way ../../.github/interop/runner.patch
   cd ../../
 fi


### PR DESCRIPTION
### Description of changes: 

This change fixes the `quic-interop-runner` commit in the `interop/run` script to match the [qns workflow](https://github.com/aws/s2n-quic/blob/9c144b3078366d8bef158d9f70f91f235f46f079/.github/workflows/qns.yml#L18)

### Testing:

Tested locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

