### PR TITLE
feat(s2n-quic-qns): add xdp client

### DIFF
--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -15,7 +15,7 @@ use tokio::runtime::Handle;
 
 mod builder;
 mod clock;
-mod task;
+pub(crate) mod task;
 #[cfg(test)]
 mod tests;
 

--- a/quic/s2n-quic-platform/src/io/xdp.rs
+++ b/quic/s2n-quic-platform/src/io/xdp.rs
@@ -7,7 +7,7 @@ use s2n_quic_core::{
 };
 
 pub use s2n_quic_core::{
-    io::{rx, tx},
+    io::rx,
     sync::{spsc, worker},
     xdp::path::Tuple as PathHandle,
 };
@@ -35,6 +35,54 @@ pub mod socket {
         socket.bind(&addr.into())?;
 
         Ok(socket.into())
+    }
+}
+
+pub mod tx {
+    pub use s2n_quic_core::io::tx::*;
+
+    pub fn channel(
+        socket: ::std::net::UdpSocket,
+    ) -> (
+        impl Tx<PathHandle = crate::message::default::Handle>,
+        impl core::future::Future<Output = ::std::io::Result<()>>,
+    ) {
+        // Initial packets don't need to be bigger than the minimum
+        let max_mtu = s2n_quic_core::path::MaxMtu::MIN;
+
+        // It's unlikely the initial packets will utilize, so just disable it
+        let gso = crate::features::Gso::default();
+        gso.disable();
+
+        // compute the payload size for each message from the number of GSO segments we can
+        // fill
+        let payload_len = {
+            let max_mtu: u16 = max_mtu.into();
+            (max_mtu as u32 * gso.max_segments() as u32).min(u16::MAX as u32)
+        };
+
+        // 512Kb
+        let tx_buffer_size: u32 = 1 << 19;
+        let entries = tx_buffer_size / payload_len;
+        let entries = if entries.is_power_of_two() {
+            entries
+        } else {
+            // round up to the nearest power of two, since the ring buffers require it
+            entries.next_power_of_two()
+        };
+
+        let mut producers = vec![];
+
+        let (producer, consumer) = crate::socket::ring::pair(entries, payload_len);
+        producers.push(producer);
+
+        // spawn a task that actually flushes the ring buffer to the socket
+        let task = crate::io::tokio::task::tx(socket, consumer, gso.clone());
+
+        // construct the TX side for the endpoint event loop
+        let io = crate::socket::io::tx::Tx::new(producers, gso, max_mtu);
+
+        (io, task)
     }
 }
 

--- a/quic/s2n-quic-platform/src/io/xdp.rs
+++ b/quic/s2n-quic-platform/src/io/xdp.rs
@@ -50,15 +50,14 @@ pub mod tx {
         // Initial packets don't need to be bigger than the minimum
         let max_mtu = s2n_quic_core::path::MaxMtu::MIN;
 
-        // It's unlikely the initial packets will utilize, so just disable it
+        // It's unlikely the initial packets will utilize GSO, so just disable it
         let gso = crate::features::Gso::default();
         gso.disable();
 
-        // compute the payload size for each message from the number of GSO segments we can
-        // fill
+        // compute the payload size for each message from the MaxMtu
         let payload_len = {
             let max_mtu: u16 = max_mtu.into();
-            (max_mtu as u32 * gso.max_segments() as u32).min(u16::MAX as u32)
+            max_mtu as u32
         };
 
         // 512Kb

--- a/quic/s2n-quic-qns/src/io.rs
+++ b/quic/s2n-quic-qns/src/io.rs
@@ -1,0 +1,93 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Result;
+use s2n_quic::provider::io;
+use structopt::StructOpt;
+
+#[derive(Debug, StructOpt)]
+pub struct Server {
+    #[structopt(short, long, default_value = "::")]
+    pub ip: std::net::IpAddr,
+
+    #[structopt(short, long, default_value = "443")]
+    pub port: u16,
+
+    #[structopt(long)]
+    pub disable_gso: bool,
+
+    #[structopt(long, default_value = "9000")]
+    pub max_mtu: u16,
+
+    #[cfg(feature = "xdp")]
+    #[structopt(flatten)]
+    xdp: crate::xdp::Xdp,
+}
+
+impl Server {
+    #[cfg(feature = "xdp")]
+    pub fn build(&self) -> Result<impl io::Provider> {
+        // GSO isn't currently supported for XDP so just read it to avoid a dead_code warning
+        let _ = self.disable_gso;
+        let _ = self.max_mtu;
+
+        let addr = (self.ip, self.port).into();
+
+        self.xdp.server(addr)
+    }
+
+    #[cfg(not(feature = "xdp"))]
+    pub fn build(&self) -> Result<impl io::Provider> {
+        let mut io_builder = io::Default::builder()
+            .with_receive_address((self.ip, self.port).into())?
+            .with_max_mtu(self.max_mtu)?;
+
+        if self.disable_gso {
+            io_builder = io_builder.with_gso_disabled()?;
+        }
+
+        Ok(io_builder.build()?)
+    }
+}
+
+#[derive(Debug, StructOpt)]
+pub struct Client {
+    #[structopt(long)]
+    pub disable_gso: bool,
+
+    #[structopt(long, default_value = "9000")]
+    pub max_mtu: u16,
+
+    #[structopt(short, long, default_value = "::")]
+    pub local_ip: std::net::IpAddr,
+
+    #[cfg(feature = "xdp")]
+    #[structopt(flatten)]
+    xdp: crate::xdp::Xdp,
+}
+
+impl Client {
+    #[cfg(feature = "xdp")]
+    pub fn build(&self) -> Result<impl io::Provider> {
+        // GSO isn't currently supported for XDP so just read it to avoid a dead_code warning
+        let _ = self.disable_gso;
+        let _ = self.max_mtu;
+
+        let addr = (self.local_ip, 0u16).into();
+
+        self.xdp.client(addr)
+    }
+
+    #[cfg(not(feature = "xdp"))]
+    pub fn build(&self) -> Result<impl io::Provider> {
+        let mut io_builder = io::Default::builder()
+            .with_receive_address((self.local_ip, 0u16).into())?
+            .with_max_mtu(self.max_mtu)?;
+
+        if self.disable_gso {
+            io_builder = io_builder.with_gso_disabled()?;
+        }
+
+        Ok(io_builder.build()?)
+    }
+}

--- a/quic/s2n-quic-qns/src/main.rs
+++ b/quic/s2n-quic-qns/src/main.rs
@@ -9,6 +9,7 @@ pub type Result<T, E = Error> = core::result::Result<T, E>;
 mod client;
 mod file;
 mod interop;
+mod io;
 mod perf;
 mod server;
 mod tls;

--- a/quic/s2n-quic-qns/src/xdp.rs
+++ b/quic/s2n-quic-qns/src/xdp.rs
@@ -12,7 +12,9 @@ use s2n_quic::provider::io::{
         bpf, encoder,
         if_xdp::{self, XdpFlags},
         io::{self as xdp_io},
-        ring, socket, syscall, umem, Provider,
+        ring, socket, syscall,
+        tx::{self, TxExt as _},
+        umem, Provider,
     },
 };
 use std::{ffi::CString, net::SocketAddr, os::unix::io::AsRawFd, sync::Arc};
@@ -272,24 +274,32 @@ impl Xdp {
         Ok(())
     }
 
+    fn udp_socket(&self, addr: SocketAddr) -> Result<std::net::UdpSocket> {
+        let interface = CString::new(self.interface.clone())?;
+
+        let udp_socket = socket::bind_udp(&interface, addr)?;
+
+        Ok(udp_socket)
+    }
+
+    fn tx_encoder(&self) -> encoder::Config {
+        let mut encoder = encoder::Config::default();
+        if self.no_checksum {
+            encoder.set_checksum(false);
+        }
+        encoder
+    }
+
     pub fn server(&self, addr: SocketAddr) -> Result<impl io::Provider> {
-        let socket = std::net::UdpSocket::bind(addr)?;
-        let socket = UdpSocket::from_std(socket)?;
+        let udp_socket = self.udp_socket(addr)?;
+        let udp_socket = UdpSocket::from_std(udp_socket)?;
 
         let (umem, rx, rx_fds, tx) = self.setup()?;
 
         self.bpf_task(addr.port(), rx_fds)?;
 
         let io_rx = xdp_io::rx::Rx::new(rx, umem.clone());
-
-        let io_tx = {
-            // use the default encoder configuration
-            let mut encoder = encoder::Config::default();
-            if self.no_checksum {
-                encoder.set_checksum(false);
-            }
-            xdp_io::tx::Tx::new(tx, umem, encoder)
-        };
+        let io_tx = xdp_io::tx::Tx::new(tx, umem, self.tx_encoder());
 
         let provider = Provider::builder()
             .with_rx(io_rx)
@@ -305,13 +315,73 @@ impl Xdp {
         let mut recv_buffer = vec![0; self.frame_size as usize];
         tokio::spawn(async move {
             loop {
-                let result = socket.recv_from(&mut recv_buffer).await;
+                let result = udp_socket.recv_from(&mut recv_buffer).await;
                 eprintln!(
                     "WARNING: received packet on regular UDP socket: {:?}",
                     result
                 );
             }
         });
+
+        Ok(provider)
+    }
+
+    pub fn client(&self, addr: SocketAddr) -> Result<impl io::Provider> {
+        let udp_socket = self.udp_socket(addr)?;
+        // query the actual port that was selected for the socket in case it was `0`
+        let addr = udp_socket.local_addr()?;
+
+        let recv_udp_socket = udp_socket.try_clone();
+
+        let (umem, rx, rx_fds, tx) = self.setup()?;
+
+        self.bpf_task(addr.port(), rx_fds)?;
+
+        let io_rx = xdp_io::rx::Rx::new(rx, umem.clone());
+
+        let io_tx = {
+            let tx = xdp_io::tx::Tx::new(tx, umem, self.tx_encoder());
+
+            let udp_tx = {
+                let (udp_tx, udp_task) = tx::channel(udp_socket);
+
+                tokio::spawn(udp_task);
+
+                udp_tx.with_handle_map(|handle: &io::xdp::PathHandle| {
+                    // convert the XDP handle into the regular UDP handle
+                    handle.into()
+                })
+            };
+
+            // route any initial packets to the UDP socket so we can offload address resolution on
+            // the OS
+            tx.with_router(xdp_io::router::Router::default(), udp_tx)
+        };
+
+        let provider = Provider::builder()
+            .with_rx(io_rx)
+            .with_tx(io_tx)
+            .with_frame_size(self.frame_size as _)?
+            .build();
+
+        if let Ok(udp_socket) = recv_udp_socket {
+            let udp_socket = tokio::net::UdpSocket::from_std(udp_socket)?;
+            // Set up a task to read from the bound UDP socket
+            //
+            // If everything is working properly, this won't ever get a packet, since the AF_XDP socket
+            // is intercepting all packets on this port. If it does start logging, something has gone
+            // wrong with the BPF setup.
+            let mut recv_buffer = vec![0; self.frame_size as usize];
+            tokio::spawn(async move {
+                loop {
+                    let result = udp_socket.recv_from(&mut recv_buffer).await;
+                    eprintln!(
+                        "WARNING: received packet on regular UDP socket: {:?}",
+                        result
+                    );
+                }
+            });
+        }
 
         Ok(provider)
     }

--- a/quic/s2n-quic/src/provider/io/xdp.rs
+++ b/quic/s2n-quic/src/provider/io/xdp.rs
@@ -4,26 +4,21 @@
 //! Provides an implementation of the [`io::Provider`](crate::provider::io::Provider)
 //! using [AF_XDP](https://www.kernel.org/doc/html/latest/networking/af_xdp.html) sockets.
 
-use s2n_quic_core::{
-    endpoint::Endpoint,
-    inet::SocketAddress,
-    io::{rx, tx},
-};
-
+/// Export the platform items
 pub use s2n_quic_platform::io::xdp::*;
 
 impl<Rx, Tx> super::Provider for Provider<Rx, Tx>
 where
-    Rx: 'static + rx::Rx<PathHandle = PathHandle> + Send,
-    Tx: 'static + tx::Tx<PathHandle = PathHandle> + Send,
+    Rx: 'static + s2n_quic_core::io::rx::Rx<PathHandle = PathHandle> + Send,
+    Tx: 'static + s2n_quic_core::io::tx::Tx<PathHandle = PathHandle> + Send,
 {
     type PathHandle = PathHandle;
     type Error = std::io::Error;
 
-    fn start<E: Endpoint<PathHandle = Self::PathHandle>>(
+    fn start<E: s2n_quic_core::endpoint::Endpoint<PathHandle = Self::PathHandle>>(
         self,
         endpoint: E,
-    ) -> Result<SocketAddress, Self::Error> {
+    ) -> Result<s2n_quic_core::inet::SocketAddress, Self::Error> {
         let (_join_handle, local_addr) = Provider::start(self, endpoint)?;
         Ok(local_addr)
     }


### PR DESCRIPTION
### Description of changes: 

Similar to #1765, this change adds a client.

The interesting thing about the client is, since it's the one to initiate the connection, it doesn't know any of the ethernet addresses, or even its own source IP in some cases. So what we do is open a UDP socket to transmit initial packets on. This allows us to offload address resolution onto the OS and not have to re-implement ARP. Once we hear back from the server, we know what all of the address fields are since the server responded with a completely filled-in ethernet/ip/udp packet. We then store the field on the path handle and send all future traffic over the AF_XDP socket instead.

### Call-outs:

I've refactored the IO setup a bit to be in a central module, rather than copy/pasted in each qns command.

### Testing:

The same testing applies as was done in #1765.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

