### PR TITLE
Use aws-lc-rs on all Linux platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ s2n-quic = "1"
 ```
 
 **NOTE**: On unix-like systems, [`s2n-tls`](https://github.com/aws/s2n-tls) will be used as the default TLS provider.
-On `aarch64` linux systems,  [`aws-lc-rs`](https://github.com/awslabs/aws-lc-rs) will be used for cryptographic 
+On linux systems,  [`aws-lc-rs`](https://github.com/awslabs/aws-lc-rs) will be used for cryptographic
 operations. A C compiler and CMake may be required on these systems for installation.
 
 ## Example

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -21,10 +21,10 @@ s2n-codec = { version = "=0.5.0", path = "../../common/s2n-codec", default-featu
 s2n-quic-core = { version = "=0.22.0", path = "../s2n-quic-core", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["derive"] }
 
-[target.'cfg(all(target_os = "linux", target_arch = "aarch64"))'.dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
 aws-lc-rs = { version = "1.0.0", default-features = false, features = ["aws-lc-sys"] }
 
-[target.'cfg(not(all(target_os = "linux", target_arch = "aarch64")))'.dependencies]
+[target.'cfg(not(target_os = "linux"))'.dependencies]
 ring = { version = "0.16.20", default-features = false }
 
 

--- a/quic/s2n-quic-crypto/src/lib.rs
+++ b/quic/s2n-quic-crypto/src/lib.rs
@@ -16,7 +16,7 @@ mod ctr;
 mod ghash;
 mod iv;
 
-#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+#[cfg(target_os = "linux")]
 use aws_lc_rs as ring;
 
 #[doc(hidden)]


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 
Switch from ring to aws-lc-rs for all Linux platforms.

### Call-outs:
The switch had previously been made for Linux/aarch64.

### Testing:
`cargo test` succeeds on my Mac (x86-64) and Linux (x86-64 and aarch64) hosts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

