### PR TITLE
ci: fix qns Docker release

### DIFF
--- a/quic/s2n-quic-qns/etc/Dockerfile.build
+++ b/quic/s2n-quic-qns/etc/Dockerfile.build
@@ -1,26 +1,30 @@
-FROM rust:latest as planner
+FROM rust:latest AS base
+
 WORKDIR app
+
+RUN set -eux; \
+  apt-get update; \
+  apt-get install -y cmake clang;
+
 RUN cargo install cargo-chef --version 0.1.23
+
+FROM base AS planner
 COPY Cargo.toml /app
 COPY common /app/common
 COPY quic /app/quic
 COPY tools/xdp /app/tools/xdp
 # Don't include testing crates
 RUN rm -rf quic/s2n-quic-bench quic/s2n-quic-events quic/s2n-quic-sim
+# apply patch to use forked version of the webpki crate
+# see https://github.com/aws/s2n-quic/issues/1836
+RUN git apply quic/s2n-quic-qns/etc/webpki.patch
 RUN cargo chef prepare  --recipe-path recipe.json
 
-FROM rust:latest as cacher
-WORKDIR app
-RUN cargo install cargo-chef --version 0.1.23
+FROM base AS cacher
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --recipe-path recipe.json
 
-FROM rust:latest AS builder
-WORKDIR app
-
-RUN set -eux; \
-  apt-get update; \
-  apt-get install -y cmake clang;
+FROM base AS builder
 
 # copy sources
 COPY Cargo.toml /app

--- a/quic/s2n-quic-qns/etc/Dockerfile.build
+++ b/quic/s2n-quic-qns/etc/Dockerfile.build
@@ -8,7 +8,8 @@ RUN set -eux; \
 
 RUN cargo install cargo-chef --version 0.1.23
 
-FROM base AS planner
+# create an image for all of the repo sources
+FROM base AS sources
 COPY Cargo.toml /app
 COPY common /app/common
 COPY quic /app/quic
@@ -18,24 +19,18 @@ RUN rm -rf quic/s2n-quic-bench quic/s2n-quic-events quic/s2n-quic-sim
 # apply patch to use forked version of the webpki crate
 # see https://github.com/aws/s2n-quic/issues/1836
 RUN git apply quic/s2n-quic-qns/etc/webpki.patch
+
+# create a planner image that forms the dependencies
+FROM sources AS planner
 RUN cargo chef prepare  --recipe-path recipe.json
 
+# create a cacher image that builds the dependencies
 FROM base AS cacher
 COPY --from=planner /app/recipe.json recipe.json
 RUN cargo chef cook --recipe-path recipe.json
 
-FROM base AS builder
-
-# copy sources
-COPY Cargo.toml /app
-COPY common /app/common
-COPY quic /app/quic
-COPY tools/xdp /app/tools/xdp
-# Don't include testing crates
-RUN rm -rf quic/s2n-quic-bench quic/s2n-quic-events quic/s2n-quic-sim
-# apply patch to use forked version of the webpki crate
-# see https://github.com/aws/s2n-quic/issues/1836
-RUN git apply quic/s2n-quic-qns/etc/webpki.patch
+# create an image that builds the final crate
+FROM sources AS builder
 
 # Copy over the cached dependencies
 COPY --from=cacher /app/target target


### PR DESCRIPTION
### Description of changes: 

In #1840, we switched to using aws-lc-rs for Linux. This requires that cmake is installed on the build target. This wasn't added to our Dockerfile for qns builds so it started failing.

This change adds cmake as a dependency.

### Call-outs:

I also applied the webpki patch in the `prepare` phase of cargo-chef, to ensure it was downloaded and built there, rather than in the `cook` phase.

### Testing:

The `release` CI workflow should now be passing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

