### PR TITLE
feat(s2n-quic-qns): add --streams arg for perf client

### DIFF
--- a/quic/s2n-quic-qns/src/perf.rs
+++ b/quic/s2n-quic-qns/src/perf.rs
@@ -15,7 +15,7 @@ use std::sync::{
 
 /// Drains a receive stream
 pub async fn handle_receive_stream(mut stream: ReceiveStream) -> Result<()> {
-    let mut chunks = vec![Bytes::new(); 64];
+    let mut chunks: [_; 64] = core::array::from_fn(|_| Bytes::new());
 
     loop {
         let (len, is_open) = stream.receive_vectored(&mut chunks).await?;
@@ -35,7 +35,7 @@ pub async fn handle_receive_stream(mut stream: ReceiveStream) -> Result<()> {
 
 /// Sends a specified amount of data on a send stream
 pub async fn handle_send_stream(mut stream: SendStream, len: u64) -> Result<()> {
-    let mut chunks = vec![Bytes::new(); 64];
+    let mut chunks: [_; 64] = core::array::from_fn(|_| Bytes::new());
 
     //= https://tools.ietf.org/id/draft-banks-quic-performance-00#4.1
     //# Since the goal here is to measure the efficiency of the QUIC


### PR DESCRIPTION
### Description of changes: 

When testing stream creation latency, it is helpful to have a command to create streams in a loop, send/recv some data and measure total throughput.

This change adds a `--streams` argument to the qns perf client to accomplish this.

### Call-outs:

Now that `array::from_fn` is stable in 1.63, we can get rid of the Vec allocation for the chunks.

### Testing:

```
$ ./target/release/s2n-quic-qns perf server --ip 192.167.1.10 --port 4433 --stats
```

![flamegraph](https://github.com/aws/s2n-quic/assets/799311/12b9a060-c662-432d-9cca-411c45db5654)


```tsv
Tx Rate	Rx Rate	Max Cwnd	Max Inflight	Lost Packets	Wakeups	Duration	Max RTT	Max SRTT	PTO Count	Max Pacing Rate	Max Delivery Rate
94.37Mbps	93.12Mbps	89.42kB	9.60kB	0	40738	26.04ms	333ms	333ms	0	0bps	0bps
95.85Mbps	94.59Mbps	89.42kB	669B	0	41382	26.038ms	296µs	96.262µs	0	0bps	0bps
97.27Mbps	95.99Mbps	89.42kB	674B	0	41996	26.04ms	300µs	73.638µs	0	0bps	0bps
98.25Mbps	96.96Mbps	89.42kB	669B	0	42417	26.039ms	271µs	70.591µs	0	0bps	0bps
98.35Mbps	97.06Mbps	89.42kB	674B	0	42462	26.038ms	308µs	74.047µs	0	0bps	0bps
97.97Mbps	96.68Mbps	89.42kB	669B	0	42297	26.038ms	292µs	71.769µs	0	0bps	0bps
98.96Mbps	97.66Mbps	89.42kB	674B	0	42727	26.038ms	276µs	70.439µs	0	0bps	0bps
97.94Mbps	96.65Mbps	89.42kB	669B	0	42284	26.039ms	272µs	69.747µs	0	0bps	0bps
98.86Mbps	97.56Mbps	89.42kB	674B	0	42681	26.038ms	340µs	78.593µs	0	0bps	0bps
98.78Mbps	97.48Mbps	89.42kB	669B	0	42645	26.037ms	305µs	82.626µs	0	0bps	0bps
98.59Mbps	97.30Mbps	89.42kB	674B	0	42567	26.038ms	292µs	71.879µs	0	0bps	0bps
98.62Mbps	97.32Mbps	89.42kB	669B	0	42570	26.039ms	443µs	120.519µs	0	0bps	0bps
100.90Mbps	99.57Mbps	89.42kB	674B	0	43561	26.038ms	522µs	101.561µs	0	0bps	0bps
100.93Mbps	99.60Mbps	89.42kB	669B	0	43572	26.039ms	332µs	71.776µs	0	0bps	0bps
99.00Mbps	97.70Mbps	89.42kB	674B	0	42739	26.04ms	270µs	72.659µs	0	0bps	0bps
99.19Mbps	97.88Mbps	89.42kB	669B	0	42823	26.038ms	277µs	70.403µs	0	0bps	0bps
99.32Mbps	98.01Mbps	89.42kB	674B	0	42879	26.039ms	293µs	70.442µs	0	0bps	0bps
99.04Mbps	97.73Mbps	89.42kB	669B	0	42758	26.04ms	266µs	68.966µs	0	0bps	0bps
99.17Mbps	97.86Mbps	89.42kB	674B	0	42813	26.037ms	275µs	73.071µs	0	0bps	0bps
99.49Mbps	98.18Mbps	89.42kB	669B	0	42950	26.037ms	273µs	79.996µs	0	0bps	0bps
99.70Mbps	98.39Mbps	89.42kB	674B	0	43041	26.042ms	2.514ms	349.741µs	0	0bps	0bps
99.64Mbps	98.33Mbps	89.42kB	669B	0	43017	26.037ms	324µs	94.99µs	0	0bps	0bps
100.84Mbps	99.51Mbps	89.42kB	674B	0	43536	24.997ms	317µs	75.032µs	0	0bps	0bps
101.01Mbps	99.68Mbps	89.42kB	669B	0	43603	26.038ms	291µs	72.337µs	0	0bps	0bps
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

