### PR TITLE
docs: add line on conventional commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ To send us a pull request, please:
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
 3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
+4. Commit to your fork using clear commit messages. We follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidance for commit messages.
 5. Send us a pull request, answering any default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 


### PR DESCRIPTION

### Description of changes: 

Advise using conventional commit messages for PRs in the dev guide.

