### PR TITLE
ci: run interop on larger runners

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -165,7 +165,8 @@ jobs:
           path: quinn/
 
   interop:
-    runs-on: ubuntu-latest
+    runs-on:
+      labels: s2n_ubuntu-20.04_8-core
     needs: [env, s2n-quic-qns]
     strategy:
       matrix: ${{ fromJson(needs.env.outputs.matrix) }}


### PR DESCRIPTION
### Description of changes: 

 I've been seeing that some of the interop tests are experiencing period moments where RTTs are drastically increased. For example:

> 32.183223166s s2n_quic:client:conn: recovery_metrics: path=Path { local_addr: 193.167.0.100:51263, local_cid: 0xc4ecfbe12d81e110f0eef951ff7d26d5, remote_addr: 193.167.100.100:443, remote_cid: 0x73671338ecf483a6, id: 0, is_active: true } min_rtt=1.03697s smoothed_rtt=1.03697s latest_rtt=1.03697s rtt_variance=518.485ms max_ack_delay=0ns pto_count=1 congestion_window=8400 bytes_in_flight=1200 congestion_limited=false  

This can cause some interop tests to fail as it inflates PTO probes and sometimes results in the connection timing out. This change is to evaluate if larger GitHub runners can alleviate this issue.

### Testing:

Testing in CI

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

