### PR TITLE
fix(s2n-quic-platform): Fix compilation in non-pktinfo platforms

### DIFF
--- a/quic/s2n-quic-platform/src/message/cmsg.rs
+++ b/quic/s2n-quic-platform/src/message/cmsg.rs
@@ -42,7 +42,7 @@ pub const MAX_LEN: usize = {
     #[cfg(s2n_quic_platform_pktinfo)]
     let pktinfo_size = size_of_cmsg::<libc::in_pktinfo>() + size_of_cmsg::<libc::in6_pktinfo>();
     #[cfg(not(s2n_quic_platform_pktinfo))]
-    let pktinfo = 0;
+    let pktinfo_size = 0;
 
     // This is currently needed due to how we detect if CMSG data has been written or not.
     //


### PR DESCRIPTION
Clearly this was meant to be `pktinfo_size`