### PR TITLE
perf(s2n-quic-core): optimize receive buffer for known final sizes

### DIFF
--- a/quic/s2n-quic-core/src/buffer/receive_buffer.rs
+++ b/quic/s2n-quic-core/src/buffer/receive_buffer.rs
@@ -175,6 +175,12 @@ impl ReceiveBuffer {
         let final_offset = request.end_exclusive();
 
         // make sure if we previously saw a final size that they still match
+        //= https://www.rfc-editor.org/rfc/rfc9000#section-4.5
+        //# Once a final size for a stream is known, it cannot change.  If a
+        //# RESET_STREAM or STREAM frame is received indicating a change in the
+        //# final size for the stream, an endpoint SHOULD respond with an error
+        //# of type FINAL_SIZE_ERROR; see Section 11 for details on error
+        //# handling.
         if self.final_offset != UNKNOWN_FINAL_SIZE && self.final_offset != final_offset {
             return Err(ReceiveBufferError::InvalidFin);
         }
@@ -199,6 +205,12 @@ impl ReceiveBuffer {
         let (mut request, excess) = request.split(self.final_offset);
 
         // make sure the request isn't trying to write beyond the final size
+        //= https://www.rfc-editor.org/rfc/rfc9000#section-4.5
+        //# Once a final size for a stream is known, it cannot change.  If a
+        //# RESET_STREAM or STREAM frame is received indicating a change in the
+        //# final size for the stream, an endpoint SHOULD respond with an error
+        //# of type FINAL_SIZE_ERROR; see Section 11 for details on error
+        //# handling.
         if !excess.is_empty() {
             return Err(ReceiveBufferError::InvalidFin);
         }

--- a/quic/s2n-quic-core/src/buffer/receive_buffer/slot.rs
+++ b/quic/s2n-quic-core/src/buffer/receive_buffer/slot.rs
@@ -152,7 +152,7 @@ mod tests {
     }
 
     fn req(offset: u64, data: &[u8]) -> Request {
-        Request::new(VarInt::new(offset).unwrap(), data).unwrap()
+        Request::new(VarInt::new(offset).unwrap(), data, false).unwrap()
     }
 
     macro_rules! assert_write {


### PR DESCRIPTION
### Description of changes: 

Currently, the receive buffer always allocates chunks for at least 4096 bytes (a page), even if the total receive stream is a single byte. This also causes us to promote the `BytesMut` to shared (which causes another allocation), since the single byte would be split and the other 4097 would remain in the `ReceiveBuffer`.

This change optimizes the receive buffer for when the final size of the receive stream is known. In this case we _only_ allocate exactly what we need.

### Call-outs:

I've moved the final size tracking into the `ReceiveBuffer`, rather than the `ReceiveStream`, in order to not duplicate the logic in both places.

### Testing:

The `ReceiveBuffer` tests have been updated to account for the new `fin` tracking. I've also added some tests to show that the allocations are ideal when the final offset is known.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

