### PR TITLE
ci: run null tls perf tests

### DIFF
--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -186,6 +186,12 @@ jobs:
           sudo chmod +x bpftrace
           sudo mv bpftrace /usr/bin/
 
+      - name: Setup environment
+        run: |
+          # set larger socket buffers
+          sudo sysctl -w net.core.wmem_default=2000000
+          sudo sysctl -w net.core.rmem_default=2000000
+
       - name: Run server
         run: |
           sudo SCENARIO=$SCENARIO S2N_UNSTABLE_CRYPTO_OPT_TX=1 S2N_UNSTABLE_CRYPTO_OPT_RX=1 ./netbench-collector \

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -556,6 +556,8 @@ jobs:
             server: "s2n-quic"
           - client: "s2n-quic"
             server: "s2n-quic"
+          - client: "s2n-quic-null"
+            server: "s2n-quic-null"
 
     steps:
       - uses: actions/checkout@v3
@@ -605,12 +607,17 @@ jobs:
           SHELL: /bin/bash
         run: |
           set -e
+
+          # set larger socket buffers
+          sudo sysctl -w net.core.wmem_default=2000000
+          sudo sysctl -w net.core.rmem_default=2000000
+
           mkdir -p target/perf/results
-          sudo env "PATH=$PATH" "SHELL=$SHELL" ./scripts/perf/test 1000 0 ${{ matrix.server }} ${{ matrix.client }}
-          sudo env "PATH=$PATH" "SHELL=$SHELL" ./scripts/perf/test 750 250 ${{ matrix.server }} ${{ matrix.client }}
-          sudo env "PATH=$PATH" "SHELL=$SHELL" ./scripts/perf/test 500 500 ${{ matrix.server }} ${{ matrix.client }}
-          sudo env "PATH=$PATH" "SHELL=$SHELL" ./scripts/perf/test 250 750 ${{ matrix.server }} ${{ matrix.client }}
-          sudo env "PATH=$PATH" "SHELL=$SHELL" ./scripts/perf/test 0 1000 ${{ matrix.server }} ${{ matrix.client }}
+          sudo env "PATH=$PATH" "SHELL=$SHELL" ./scripts/perf/test 10000 0 ${{ matrix.server }} ${{ matrix.client }}
+          sudo env "PATH=$PATH" "SHELL=$SHELL" ./scripts/perf/test 7500 2500 ${{ matrix.server }} ${{ matrix.client }}
+          sudo env "PATH=$PATH" "SHELL=$SHELL" ./scripts/perf/test 5000 5000 ${{ matrix.server }} ${{ matrix.client }}
+          sudo env "PATH=$PATH" "SHELL=$SHELL" ./scripts/perf/test 2500 7500 ${{ matrix.server }} ${{ matrix.client }}
+          sudo env "PATH=$PATH" "SHELL=$SHELL" ./scripts/perf/test 0 10000 ${{ matrix.server }} ${{ matrix.client }}
           sudo chown -R $(whoami) target/perf/results
 
       - name: Prepare artifacts
@@ -638,6 +645,10 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: perf-results-s2n-quic-s2n-quic
+          path: perf-results/
+      - uses: actions/download-artifact@v3
+        with:
+          name: perf-results-s2n-quic-null-s2n-quic-null
           path: perf-results/
 
       - name: Generate report

--- a/scripts/perf/bin/s2n-quic-null
+++ b/scripts/perf/bin/s2n-quic-null
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+#
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+case "$PS" in
+    server*)
+          ../../target/release/s2n-quic-qns \
+            perf \
+            server \
+            --port $SERVER_PORT \
+            --max-mtu 16000 \
+            --tls null \
+            --stats
+        ;;
+    client*)
+          ../../target/release/s2n-quic-qns \
+            perf \
+            client \
+            --receive "${DOWNLOAD_BYTES}" \
+            --send "${UPLOAD_BYTES}" \
+            --port $SERVER_PORT \
+            --server-name localhost \
+            --max-mtu 16000 \
+            --tls null \
+            --stats
+        ;;
+esac

--- a/scripts/perf/test
+++ b/scripts/perf/test
@@ -7,7 +7,7 @@
 
 set -e
 
-DOWNLOAD_MB=${1:-1000}
+DOWNLOAD_MB=${1:-10000}
 UPLOAD_MB=${2:-0}
 SERVER=${3:-s2n-quic}
 CLIENT=${4:-s2n-quic}


### PR DESCRIPTION
### Resolved issues:

resolves #1857 

### Description of changes: 

In #1834, we added the null TLS provider for analyzing perf outside of the crypto operations. This change adds the perf report to CI so it's continually available.

### Callouts

I've increased the default socket buffer sizes to allow for higher sending throughput. I've also applied the same change to the netbench runs.

### Testing:

The report for this PR is available [here](https://dnglbrstg7yg.cloudfront.net/0cee96e6ee1bed8ada433440f9cb044f72271d97/perf/index.html).

#### Client

![](https://dnglbrstg7yg.cloudfront.net/0cee96e6ee1bed8ada433440f9cb044f72271d97/perf/s2n-quic-null-client-s2n-quic-null-server/0MB-down-10000MB-up.client.svg)

#### Server

![](https://dnglbrstg7yg.cloudfront.net/0cee96e6ee1bed8ada433440f9cb044f72271d97/perf/s2n-quic-null-client-s2n-quic-null-server/0MB-down-10000MB-up.server.svg)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

