### PR TITLE
feat(s2n-quic-platform): Configurable buffer sizes + default tx buffer change

### DIFF
--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -190,7 +190,7 @@ impl Io {
                 (max_mtu as u32 * gso.max_segments() as u32).min(u16::MAX as u32)
             };
 
-            let tx_buffer_size = queue_send_buffer_size.unwrap_or(8 * (1 << 20));
+            let tx_buffer_size = queue_send_buffer_size.unwrap_or(128 * 1024);
             let entries = tx_buffer_size / payload_len;
             let entries = if entries.is_power_of_two() {
                 entries

--- a/quic/s2n-quic-platform/src/io/tokio/tests.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/tests.rs
@@ -25,7 +25,7 @@ struct TestEndpoint<const IS_SERVER: bool> {
 
 impl<const IS_SERVER: bool> TestEndpoint<IS_SERVER> {
     fn new(handle: PathHandle) -> Self {
-        let messages = if IS_SERVER { 0 } else { 1000 };
+        let messages = if IS_SERVER { 0 } else { 30 };
         let messages = (0..messages).map(|id| (id, None)).collect();
         Self {
             handle,

--- a/quic/s2n-quic-platform/src/io/tokio/tests.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/tests.rs
@@ -199,7 +199,7 @@ async fn test<A: ToSocketAddrs>(
     let (client_task, actual_client_addr) = client_io.start(client_endpoint)?;
     assert_eq!(actual_client_addr, client_addr);
 
-    tokio::time::timeout(core::time::Duration::from_secs(10), client_task).await??;
+    tokio::time::timeout(core::time::Duration::from_secs(60), client_task).await??;
 
     server_task.abort();
 


### PR DESCRIPTION
### Resolved issues:

resolves #1811

### Description of changes: 

This exposes new APIs for changing the internal send/receive buffers in the Tokio provider. It also changes the default transmit buffer to 128kb from 8mb, which on some hardware platforms significantly reduces latencies on one workload. (These are overheads from a baseline, which is why negatives can slip in, but should still be roughly comparable, as the baseline and runs with QUIC are the same workload).

* 1.21: p10: 652 / p50: 724 / p80: 770
* 1.23 (8Mb): p10: 1014 / p50: 1082 / p80: 2276
* 1.23 (512kb): p10: 599 / p50: 760 / p80: 903
* 1.23 (128kb): p10: 303 / p50: -84 / p80: 112

### Call-outs:

Not a huge fan of the name of these new methods, happy to change that.

### Testing:

See latency figures above.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

