### PR TITLE
ci: run miri in larger instances

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,7 +258,9 @@ jobs:
           use-cross: ${{ matrix.target != 'native' }}
 
   miri:
-    runs-on: ubuntu-latest
+    # miri needs quite a bit of memory so use a larger instance
+    runs-on:
+      labels: s2n_ubuntu-20.04_8-core
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Description of changes: 

After some recent testing additions to core, the miri tests have started failing in CI due to using too much memory. This change bumps the instance size for these CI jobs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

