### PR TITLE
feat(s2n-quic-qns): move runtime selection to common module

### DIFF
--- a/quic/s2n-quic-qns/src/client/interop.rs
+++ b/quic/s2n-quic-qns/src/client/interop.rs
@@ -45,10 +45,17 @@ pub struct Interop {
 
     #[structopt(flatten)]
     tls: tls::Client,
+
+    #[structopt(flatten)]
+    runtime: crate::runtime::Runtime,
 }
 
 impl Interop {
-    pub async fn run(&self) -> Result<()> {
+    pub fn run(&self) -> Result<()> {
+        self.runtime.build()?.block_on(self.task())
+    }
+
+    async fn task(&self) -> Result<()> {
         let mut client = self.client()?;
 
         let download_dir = Arc::new(self.download_dir.clone());

--- a/quic/s2n-quic-qns/src/client/perf.rs
+++ b/quic/s2n-quic-qns/src/client/perf.rs
@@ -46,10 +46,17 @@ pub struct Perf {
 
     #[structopt(flatten)]
     tls: tls::Client,
+
+    #[structopt(flatten)]
+    runtime: crate::runtime::Runtime,
 }
 
 impl Perf {
-    pub async fn run(&self) -> Result<()> {
+    pub fn run(&self) -> Result<()> {
+        self.runtime.build()?.block_on(self.task())
+    }
+
+    async fn task(&self) -> Result<()> {
         let mut client = self.client()?;
 
         let mut requests = JoinSet::new();

--- a/quic/s2n-quic-qns/src/io.rs
+++ b/quic/s2n-quic-qns/src/io.rs
@@ -19,6 +19,12 @@ pub struct Server {
     #[structopt(long, default_value = "9000")]
     pub max_mtu: u16,
 
+    #[structopt(long)]
+    pub queue_recv_buffer_size: Option<usize>,
+
+    #[structopt(long)]
+    pub queue_send_buffer_size: Option<usize>,
+
     #[cfg(feature = "xdp")]
     #[structopt(flatten)]
     xdp: crate::xdp::Xdp,
@@ -44,6 +50,14 @@ impl Server {
 
         if self.disable_gso {
             io_builder = io_builder.with_gso_disabled()?;
+        }
+
+        if let Some(size) = self.queue_send_buffer_size {
+            io_builder = io_builder.with_internal_send_buffer_size(size)?;
+        }
+
+        if let Some(size) = self.queue_recv_buffer_size {
+            io_builder = io_builder.with_internal_recv_buffer_size(size)?;
         }
 
         Ok(io_builder.build()?)

--- a/quic/s2n-quic-qns/src/main.rs
+++ b/quic/s2n-quic-qns/src/main.rs
@@ -11,6 +11,7 @@ mod file;
 mod interop;
 mod io;
 mod perf;
+mod runtime;
 mod server;
 mod tls;
 #[cfg(feature = "xdp")]
@@ -58,41 +59,16 @@ fn main() {
 }
 
 #[derive(Debug, StructOpt)]
-struct Arguments {
-    #[structopt(long, env = "S2N_QUIC_MULTI_THREAD")]
-    multithread: bool,
-
-    #[structopt(flatten)]
-    program: Program,
-}
-
-impl Arguments {
-    pub fn run(&self) -> Result<()> {
-        let runtime = if self.multithread {
-            tokio::runtime::Builder::new_multi_thread()
-        } else {
-            tokio::runtime::Builder::new_current_thread()
-        }
-        .enable_all()
-        .build()?;
-
-        runtime.block_on(self.program.run())?;
-
-        Ok(())
-    }
-}
-
-#[derive(Debug, StructOpt)]
-enum Program {
+enum Arguments {
     Interop(Interop),
     Perf(Perf),
 }
 
-impl Program {
-    pub async fn run(&self) -> Result<()> {
+impl Arguments {
+    pub fn run(&self) -> Result<()> {
         match self {
-            Self::Interop(subject) => subject.run().await,
-            Self::Perf(subject) => subject.run().await,
+            Self::Interop(subject) => subject.run(),
+            Self::Perf(subject) => subject.run(),
         }
     }
 }
@@ -104,10 +80,10 @@ enum Interop {
 }
 
 impl Interop {
-    pub async fn run(&self) -> Result<()> {
+    pub fn run(&self) -> Result<()> {
         match self {
-            Self::Server(subject) => subject.run().await,
-            Self::Client(subject) => subject.run().await,
+            Self::Server(subject) => subject.run(),
+            Self::Client(subject) => subject.run(),
         }
     }
 }
@@ -119,10 +95,10 @@ enum Perf {
 }
 
 impl Perf {
-    pub async fn run(&self) -> Result<()> {
+    pub fn run(&self) -> Result<()> {
         match self {
-            Self::Server(subject) => subject.run().await,
-            Self::Client(subject) => subject.run().await,
+            Self::Server(subject) => subject.run(),
+            Self::Client(subject) => subject.run(),
         }
     }
 }

--- a/quic/s2n-quic-qns/src/runtime.rs
+++ b/quic/s2n-quic-qns/src/runtime.rs
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Result;
+use structopt::StructOpt;
+use tokio::runtime::Runtime as Rt;
+
+#[derive(Clone, Debug, StructOpt)]
+pub struct Runtime {
+    /// Enables the multi-threaded runtime
+    #[structopt(long)]
+    multithread: Option<Option<bool>>,
+}
+
+impl Runtime {
+    pub fn build(&self) -> Result<Rt> {
+        let runtime = if self.multithread() {
+            tokio::runtime::Builder::new_multi_thread()
+        } else {
+            tokio::runtime::Builder::new_current_thread()
+        }
+        .enable_all()
+        .build()?;
+        Ok(runtime)
+    }
+
+    pub fn multithread(&self) -> bool {
+        match self.multithread {
+            Some(Some(v)) => v,
+            Some(None) => true,
+            None => false,
+        }
+    }
+}

--- a/quic/s2n-quic-qns/src/server/interop.rs
+++ b/quic/s2n-quic-qns/src/server/interop.rs
@@ -36,10 +36,17 @@ pub struct Interop {
 
     #[structopt(flatten)]
     io: crate::io::Server,
+
+    #[structopt(flatten)]
+    runtime: crate::runtime::Runtime,
 }
 
 impl Interop {
-    pub async fn run(&self) -> Result<()> {
+    pub fn run(&self) -> Result<()> {
+        self.runtime.build()?.block_on(self.task())
+    }
+
+    async fn task(&self) -> Result<()> {
         let mut server = self.server()?;
 
         let www_dir: Arc<Path> = Arc::from(self.www_dir.as_path());

--- a/quic/s2n-quic-qns/src/server/perf.rs
+++ b/quic/s2n-quic-qns/src/server/perf.rs
@@ -32,10 +32,17 @@ pub struct Perf {
 
     #[structopt(flatten)]
     io: crate::io::Server,
+
+    #[structopt(flatten)]
+    runtime: crate::runtime::Runtime,
 }
 
 impl Perf {
-    pub async fn run(&self) -> Result<()> {
+    pub fn run(&self) -> Result<()> {
+        self.runtime.build()?.block_on(self.task())
+    }
+
+    async fn task(&self) -> Result<()> {
         let mut server = self.server()?;
 
         if let Some(limit) = self.connections {


### PR DESCRIPTION
### Description of changes: 

The way the multithread selection on the qns application works right now is kind of annoying since you have to pass the argument before the program is selected:

```bash
$ s2n-quic-qns --multithread true perf server --port 4433
```

This change fixes it to allow the `--multithread` flag to be put where all of the other flags go:

```bash
$ s2n-quic-qns perf server --port 4433 --multithread
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

