### PR TITLE
feat(s2n-quic-platform): add option to disable GRO

### DIFF
--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -55,6 +55,7 @@ impl Io {
             queue_send_buffer_size,
             mut max_mtu,
             max_segments,
+            gro_enabled,
             reuse_port,
         } = self.builder;
 
@@ -129,7 +130,7 @@ impl Io {
         });
 
         // Configure the socket with GRO
-        let gro_enabled = syscall::configure_gro(&rx_socket);
+        let gro_enabled = gro_enabled.unwrap_or(true) && syscall::configure_gro(&rx_socket);
 
         publisher.on_platform_feature_configured(event::builder::PlatformFeatureConfigured {
             configuration: event::builder::PlatformFeatureConfiguration::Gro {

--- a/quic/s2n-quic-platform/src/io/tokio/builder.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/builder.rs
@@ -127,7 +127,7 @@ impl Builder {
     /// By default, GRO will be used unless the platform does not support it. If it is known that
     /// GRO is not available, set this option to explicitly disable it.
     pub fn with_gro_disabled(mut self) -> io::Result<Self> {
-        self.gro_enabled = Some(true);
+        self.gro_enabled = Some(false);
         Ok(self)
     }
 

--- a/quic/s2n-quic-platform/src/io/tokio/builder.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/builder.rs
@@ -16,6 +16,7 @@ pub struct Builder {
     pub(super) queue_send_buffer_size: Option<u32>,
     pub(super) max_mtu: MaxMtu,
     pub(super) max_segments: gso::MaxSegments,
+    pub(super) gro_enabled: Option<bool>,
     pub(super) reuse_port: bool,
 }
 
@@ -118,6 +119,15 @@ impl Builder {
     /// GSO fails. If it is known that GSO is not available, set this option to explicitly disable it.
     pub fn with_gso_disabled(mut self) -> io::Result<Self> {
         self.max_segments = 1.try_into().expect("1 is always a valid MaxSegments value");
+        Ok(self)
+    }
+
+    /// Disables Generic Receive Offload (GRO)
+    ///
+    /// By default, GRO will be used unless the platform does not support it. If it is known that
+    /// GRO is not available, set this option to explicitly disable it.
+    pub fn with_gro_disabled(mut self) -> io::Result<Self> {
+        self.gro_enabled = Some(true);
         Ok(self)
     }
 


### PR DESCRIPTION
### Description of changes: 

Currently, if the platform supports GRO, it enables GRO. However, it can be helpful to disable GRO when testing to see how much of a difference it makes. This change adds the ability to do that in the tokio IO provider.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

