### PR TITLE
feat(s2n-quic-qns): add connection concurrency parameter

### DIFF
--- a/quic/s2n-quic-qns/src/client/h09.rs
+++ b/quic/s2n-quic-qns/src/client/h09.rs
@@ -36,9 +36,7 @@ pub(crate) async fn create_connection<R: IntoIterator<Item = Url>>(
     }
 
     while let Some(result) = streams.join_next().await {
-        // `try_join_all` should be returning an Err if any stream fails, but it
-        // seems to just include the Err in the Vec of results. This will force
-        // any Error to bubble up so it can be printed in the output.
+        // bubble up both task-level errors and stream errors so it can be printed out
         result??;
     }
 

--- a/quic/s2n-quic-qns/src/client/h09.rs
+++ b/quic/s2n-quic-qns/src/client/h09.rs
@@ -3,17 +3,16 @@
 
 use crate::Result;
 use bytes::Bytes;
-use futures::future::try_join_all;
 use s2n_quic::{client::Connect, connection::Handle, stream::SendStream, Client};
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
 };
-use tokio::{fs::File, io::AsyncWriteExt, spawn};
+use tokio::{fs::File, io::AsyncWriteExt, task::JoinSet};
 use url::Url;
 
-pub(crate) async fn create_connection<'a, R: IntoIterator<Item = &'a Url>>(
+pub(crate) async fn create_connection<R: IntoIterator<Item = Url>>(
     client: Client,
     connect: Connect,
     requests: R,
@@ -27,20 +26,20 @@ pub(crate) async fn create_connection<'a, R: IntoIterator<Item = &'a Url>>(
         connection.keep_alive(true)?;
     }
 
-    let mut streams = vec![];
+    let mut streams = JoinSet::new();
     for request in requests {
-        streams.push(spawn(create_stream(
+        streams.spawn(create_stream(
             connection.handle(),
             request.path().to_string(),
             download_dir.clone(),
-        )));
+        ));
     }
 
-    for result in try_join_all(streams).await? {
+    while let Some(result) = streams.join_next().await {
         // `try_join_all` should be returning an Err if any stream fails, but it
         // seems to just include the Err in the Vec of results. This will force
         // any Error to bubble up so it can be printed in the output.
-        result?;
+        result??;
     }
 
     if let Some(keep_alive) = keep_alive {

--- a/quic/s2n-quic-qns/src/client/h3.rs
+++ b/quic/s2n-quic-qns/src/client/h3.rs
@@ -15,7 +15,7 @@ use std::{
 use tokio::{fs::File, io::AsyncWriteExt, spawn};
 use url::Url;
 
-pub async fn create_connection<'a, R: IntoIterator<Item = &'a Url>>(
+pub async fn create_connection<R: IntoIterator<Item = Url>>(
     client: Client,
     connect: Connect,
     requests: R,

--- a/quic/s2n-quic-qns/src/client/interop.rs
+++ b/quic/s2n-quic-qns/src/client/interop.rs
@@ -4,7 +4,7 @@
 use crate::{
     client::{h09, h3},
     interop::Testcase,
-    tls, Result,
+    task, tls, Result,
 };
 use core::time::Duration;
 use s2n_quic::{client::Connect, provider::event, Client};
@@ -36,6 +36,9 @@ pub struct Interop {
 
     #[structopt(long, env = "TESTCASE", possible_values = &Testcase::supported(is_supported_testcase))]
     testcase: Option<Testcase>,
+
+    #[structopt(long, default_value = "10")]
+    concurrency: u64,
 
     #[structopt(min_values = 1, required = true)]
     requests: Vec<Url>,
@@ -69,22 +72,28 @@ impl Interop {
 
         let endpoints = self.endpoints().await?;
 
+        let mut tasks = task::Limiter::new(self.concurrency);
+
         // https://github.com/marten-seemann/quic-interop-runner#test-cases
         // Handshake Loss (multiconnect): Tests resilience of the handshake to high loss.
         // The client is expected to establish multiple connections, sequential or in parallel,
         // and use each connection to download a single file.
         if let Some(Testcase::Multiconnect) = self.testcase {
-            for request in &self.requests {
+            for request in self.requests.iter().cloned() {
                 let connect = endpoints.get(&request.host().unwrap()).unwrap().clone();
                 let requests = core::iter::once(request);
-                h09::create_connection(
+
+                let task = h09::create_connection(
                     client.clone(),
                     connect,
                     requests,
                     download_dir.clone(),
                     self.keep_alive,
-                )
-                .await?;
+                );
+
+                if let Some(task) = tasks.spawn(task).await {
+                    task??;
+                }
             }
         } else {
             // establish a connection per endpoint rather than per request
@@ -95,28 +104,39 @@ impl Interop {
                     .requests
                     .iter()
                     .filter(|req| req.host().as_ref() == Some(&host))
+                    .cloned()
                     .collect::<Vec<_>>();
 
-                if let Some(Testcase::Http3) = self.testcase {
-                    h3::create_connection(
+                let prev = if let Some(Testcase::Http3) = self.testcase {
+                    let task = h3::create_connection(
                         client.clone(),
                         connect,
                         requests,
                         download_dir.clone(),
                         self.keep_alive,
-                    )
-                    .await?;
+                    );
+
+                    tasks.spawn(task).await
                 } else {
-                    h09::create_connection(
+                    let task = h09::create_connection(
                         client.clone(),
                         connect,
                         requests,
                         download_dir.clone(),
                         self.keep_alive,
-                    )
-                    .await?;
+                    );
+
+                    tasks.spawn(task).await
+                };
+
+                if let Some(task) = prev {
+                    task??;
                 }
             }
+        }
+
+        while let Some(task) = tasks.join_next().await {
+            task??;
         }
 
         client.wait_idle().await?;

--- a/quic/s2n-quic-qns/src/client/perf.rs
+++ b/quic/s2n-quic-qns/src/client/perf.rs
@@ -21,8 +21,9 @@ pub struct Perf {
     #[structopt(long, default_value = "perf")]
     application_protocols: Vec<String>,
 
-    #[structopt(long)]
-    connections: Option<usize>,
+    /// The total number of connections to open from the client
+    #[structopt(long, default_value = "1")]
+    connections: usize,
 
     /// Defines the number of concurrent connections to open at any given time
     #[structopt(long, default_value = "10")]
@@ -77,7 +78,7 @@ impl Perf {
         }
 
         // TODO support a richer connection strategy
-        for _ in 0..self.connections.unwrap_or(1) {
+        for _ in 0..self.connections {
             let client = client.clone();
             let connect = connect.clone();
 

--- a/quic/s2n-quic-qns/src/main.rs
+++ b/quic/s2n-quic-qns/src/main.rs
@@ -13,6 +13,7 @@ mod io;
 mod perf;
 mod runtime;
 mod server;
+mod task;
 mod tls;
 #[cfg(feature = "xdp")]
 mod xdp;

--- a/quic/s2n-quic-qns/src/task.rs
+++ b/quic/s2n-quic-qns/src/task.rs
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::Result;
+use core::future::Future;
+use tokio::task::JoinSet;
+
+pub struct Limiter<Output> {
+    credits: u64,
+    tasks: JoinSet<Output>,
+}
+
+impl<Output: 'static + Send> Limiter<Output> {
+    pub fn new(credits: u64) -> Self {
+        assert_ne!(credits, 0);
+        Self {
+            credits,
+            tasks: JoinSet::new(),
+        }
+    }
+
+    pub async fn spawn<F>(&mut self, f: F) -> Option<Result<Output>>
+    where
+        F: 'static + Future<Output = Output> + Send,
+    {
+        let prev = if self.credits == 0 {
+            self.join_next().await
+        } else {
+            None
+        };
+
+        self.credits -= 1;
+
+        self.tasks.spawn(f);
+
+        prev
+    }
+
+    pub async fn join_next(&mut self) -> Option<Result<Output>> {
+        let res = self.tasks.join_next().await;
+        self.credits += 1;
+        res.map(|res| res.map_err(|err| err.into()))
+    }
+}


### PR DESCRIPTION
### Description of changes: 

When using the qns application for testing, it can be useful to specify a limit for the total number of concurrent connections. This change allows for just that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

