### PR TITLE
test(s2n-quic-platform): refactor testing IO provider to use tasks/queues

### DIFF
--- a/quic/s2n-quic-platform/src/io/testing/message.rs
+++ b/quic/s2n-quic-platform/src/io/testing/message.rs
@@ -1,0 +1,169 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::message::{self, Message as MessageTrait};
+use core::alloc::Layout;
+use s2n_quic_core::{
+    inet::{datagram, ExplicitCongestionNotification},
+    io::tx,
+    path,
+};
+
+/// A simple message type that holds an address and payload
+///
+/// All other fields are not supported by the platform.
+#[derive(Clone, Copy, Debug)]
+pub struct Message {
+    handle: Handle,
+    ecn: ExplicitCongestionNotification,
+    payload_ptr: *mut u8,
+    payload_len: usize,
+}
+
+impl Message {
+    #[inline]
+    pub(crate) fn handle(&self) -> &Handle {
+        &self.handle
+    }
+
+    #[inline]
+    pub(crate) fn handle_mut(&mut self) -> &mut Handle {
+        &mut self.handle
+    }
+
+    #[inline]
+    pub(crate) fn ecn(&self) -> ExplicitCongestionNotification {
+        self.ecn
+    }
+
+    #[inline]
+    pub(crate) fn ecn_mut(&mut self) -> &mut ExplicitCongestionNotification {
+        &mut self.ecn
+    }
+
+    #[inline]
+    pub(crate) fn payload(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self.payload_ptr, self.payload_len) }
+    }
+}
+
+pub type Handle = path::Tuple;
+
+impl MessageTrait for Message {
+    type Handle = Handle;
+
+    const SUPPORTS_GSO: bool = false;
+    const SUPPORTS_ECN: bool = true;
+    const SUPPORTS_FLOW_LABELS: bool = false;
+
+    #[inline]
+    fn alloc(entries: u32, payload_len: u32, offset: usize) -> message::Storage {
+        unsafe { alloc(entries, payload_len, offset) }
+    }
+
+    #[inline]
+    fn payload_len(&self) -> usize {
+        self.payload_len
+    }
+
+    #[inline]
+    unsafe fn set_payload_len(&mut self, len: usize) {
+        self.payload_len = len;
+    }
+
+    #[inline]
+    unsafe fn reset(&mut self, mtu: usize) {
+        self.set_payload_len(mtu)
+    }
+
+    #[inline]
+    fn payload_ptr_mut(&mut self) -> *mut u8 {
+        self.payload_ptr
+    }
+
+    #[inline]
+    fn validate_replication(source: &Self, dest: &Self) {
+        assert_eq!(source.payload_ptr, dest.payload_ptr);
+    }
+
+    #[inline]
+    fn rx_read(
+        &mut self,
+        _local_address: &path::LocalAddress,
+    ) -> Option<message::RxMessage<Self::Handle>> {
+        let path = self.handle;
+        let header = datagram::Header {
+            path,
+            ecn: Default::default(),
+        };
+        let payload = self.payload_mut();
+
+        let message = message::RxMessage {
+            header,
+            segment_size: payload.len(),
+            payload,
+        };
+
+        Some(message)
+    }
+
+    #[inline]
+    fn tx_write<M: tx::Message<Handle = Self::Handle>>(
+        &mut self,
+        mut message: M,
+    ) -> Result<usize, tx::Error> {
+        let payload = self.payload_mut();
+
+        let len = message.write_payload(tx::PayloadBuffer::new(payload), 0)?;
+
+        unsafe {
+            debug_assert!(len <= payload.len());
+            let len = len.min(payload.len());
+            self.set_payload_len(len);
+        }
+
+        self.handle = *message.path_handle();
+
+        Ok(len)
+    }
+}
+
+#[inline]
+unsafe fn alloc(entries: u32, payload_len: u32, offset: usize) -> message::Storage {
+    let (layout, entry_offset, payload_offset) = layout(entries, payload_len, offset);
+
+    let storage = message::Storage::new(layout);
+
+    {
+        let ptr = storage.as_ptr();
+
+        let mut entry_ptr = ptr.add(entry_offset) as *mut Message;
+        let mut payload_ptr = ptr.add(payload_offset);
+        for _ in 0..entries {
+            let entry = &mut *entry_ptr;
+            entry.payload_ptr = payload_ptr;
+            entry.payload_len = payload_len as _;
+
+            entry_ptr = entry_ptr.add(1);
+            payload_ptr = payload_ptr.add(payload_len as _);
+            storage.check_bounds(entry_ptr);
+            storage.check_bounds(payload_ptr);
+        }
+
+        let primary = ptr.add(entry_offset) as *mut Message;
+        let secondary = primary.add(entries as _);
+        storage.check_bounds(secondary.add(entries as _));
+        core::ptr::copy_nonoverlapping(primary, secondary, entries as _);
+    }
+
+    storage
+}
+
+fn layout(entries: u32, payload_len: u32, offset: usize) -> (Layout, usize, usize) {
+    let cursor = Layout::array::<u8>(offset).unwrap();
+    let payloads = Layout::array::<u8>(entries as usize * payload_len as usize).unwrap();
+    let entries = Layout::array::<Message>((entries * 2) as usize).unwrap();
+    let (layout, entry_offset) = cursor.extend(entries).unwrap();
+    let (layout, payload_offset) = layout.extend(payloads).unwrap();
+    (layout, entry_offset, payload_offset)
+}

--- a/quic/s2n-quic-platform/src/io/testing/model.rs
+++ b/quic/s2n-quic-platform/src/io/testing/model.rs
@@ -311,7 +311,7 @@ impl Network for Model {
 
                 buffers.rx(*packet.path.local_address, |queue| {
                     model.0.current_inflight.fetch_sub(1, Ordering::SeqCst);
-                    queue.receive(packet);
+                    queue.enqueue(packet);
                 });
             });
 

--- a/quic/s2n-quic-platform/src/io/testing/socket.rs
+++ b/quic/s2n-quic-platform/src/io/testing/socket.rs
@@ -1,0 +1,105 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    message::Message,
+    network::{Buffers, HostId},
+};
+use crate::{
+    features::Gso,
+    socket::{
+        ring, task,
+        task::{rx, tx},
+    },
+    syscall::SocketEvents,
+};
+use core::task::Context;
+use std::{io, sync::Arc};
+
+/// A task to receive on a socket
+pub async fn rx(socket: Socket, producer: ring::Producer<Message>) -> io::Result<()> {
+    let result = task::Receiver::new(producer, socket).await;
+    if let Some(err) = result {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+/// A task to send on a socket
+pub async fn tx(socket: Socket, consumer: ring::Consumer<Message>, gso: Gso) -> io::Result<()> {
+    let result = task::Sender::new(consumer, socket, gso).await;
+    if let Some(err) = result {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Clone)]
+pub struct Socket(Arc<State>);
+
+impl Socket {
+    pub(super) fn new(buffers: Buffers, host: HostId) -> Self {
+        Self(Arc::new(State { buffers, host }))
+    }
+
+    /// Returns the current local address
+    pub fn local_addr(&self) -> io::Result<std::net::SocketAddr> {
+        self.0.buffers.lookup_addr(self.0.host)
+    }
+
+    /// Rebinds the address to a new address
+    pub fn rebind(&self, addr: std::net::SocketAddr) {
+        self.0.buffers.rebind(self.0.host, addr);
+    }
+}
+
+struct State {
+    host: HostId,
+    buffers: Buffers,
+}
+
+impl Drop for State {
+    fn drop(&mut self) {
+        self.buffers.close_host(self.host);
+    }
+}
+
+impl tx::Socket<Message> for Socket {
+    type Error = io::Error;
+
+    #[inline]
+    fn send(
+        &mut self,
+        _cx: &mut Context,
+        entries: &mut [Message],
+        events: &mut tx::Events,
+    ) -> io::Result<()> {
+        self.0.buffers.tx_host(self.0.host, |queue| {
+            let count = queue.send(entries);
+            events.on_complete(count);
+        })
+    }
+}
+
+impl rx::Socket<Message> for Socket {
+    type Error = io::Error;
+
+    #[inline]
+    fn recv(
+        &mut self,
+        cx: &mut Context,
+        entries: &mut [Message],
+        events: &mut rx::Events,
+    ) -> io::Result<()> {
+        self.0.buffers.rx_host(self.0.host, |queue| {
+            let count = queue.recv(cx, entries);
+            if count > 0 {
+                events.on_complete(count);
+            } else {
+                events.blocked()
+            }
+        })
+    }
+}


### PR DESCRIPTION
### Description of changes: 

This change refactors the testing IO provider a bit to use the same queues and tasks that the other IO providers use. This brings the implementations a lot closer to have a high fidelity simulation.

### Call-outs:

While I was refactoring the network implementation, I added support for address rebinding. I've got another PR (#1874) that actually adds some tests around it.

### Testing:

All of the existing integration tests should pass as before and show this refactor is working.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

