### PR TITLE
feat(s2n-quic-platform): support features override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,7 @@ jobs:
         rust: ${{ fromJson(needs.env.outputs.rust-versions) }}
         os: [ubuntu-latest, macOS-latest, windows-latest]
         target: [native]
+        env: [default]
         include:
           - os: windows-latest
             # s2n-tls doesn't currently build on windows
@@ -214,6 +215,15 @@ jobs:
           - rust: stable
             os: ubuntu-latest
             target: i686-unknown-linux-gnu
+          # test with different platform features
+          - rust: stable
+            os: ubuntu-latest
+            target: native
+            env: S2N_QUIC_PLATFORM_FEATURES_OVERRIDE=""
+          - rust: stable
+            os: ubuntu-latest
+            target: native
+            env: S2N_QUIC_PLATFORM_FEATURES_OVERRIDE="mtu_disc,pktinfo,tos,socket_msg"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -241,6 +251,10 @@ jobs:
         shell: bash
         run: |
           find . -name 'corpus.tar.gz' -exec dirname {} ';' | xargs -L 1 bash -c 'cd "$0" && rm -rf corpus && tar xf corpus.tar.gz'
+
+      - name: Set environment variables
+        if: ${{ matrix.env != 'default' }}
+        run: echo ${{ matrix.env }} >> $GITHUB_ENV
 
       # Build the tests before running to improve cross compilation speed
       - name: Run cargo build

--- a/quic/s2n-quic-platform/build.rs
+++ b/quic/s2n-quic-platform/build.rs
@@ -4,6 +4,14 @@
 use std::{fs::read_dir, io::Error, path::Path, process::Command};
 
 fn main() -> Result<(), Error> {
+    // allow overriding the detected features with an env variable
+    if let Some(features) = option_env("S2N_QUIC_PLATFORM_FEATURES_OVERRIDE") {
+        for feature in features.split(',') {
+            supports(feature.trim());
+        }
+        return Ok(());
+    }
+
     let env = Env::new();
 
     for feature in read_dir("features")? {
@@ -108,7 +116,10 @@ impl Env {
 }
 
 fn env(name: &str) -> String {
+    option_env(name).unwrap_or_else(|| panic!("build script missing {name:?} environment variable"))
+}
+
+fn option_env(name: &str) -> Option<String> {
     println!("cargo:rerun-if-env-changed={name}");
-    std::env::var(name)
-        .unwrap_or_else(|_| panic!("build script missing {name:?} environment variable"))
+    std::env::var(name).ok()
 }


### PR DESCRIPTION
### Resolved issues:

resolves #1850

### Description of changes: 

As discussed in the issue, it can be useful to override the platform features for a given build if your target environment is different than the build environment.

### Testing:

I added a couple of CI jobs to test fewer features being enabled for Linux than what would be otherwise, to prevent something like #1849 in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

