### PR TITLE
refactor(s2n-quic): Add Send + Sync to StartError

### DIFF
--- a/netbench/netbench/src/lib.rs
+++ b/netbench/netbench/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub type Result<T, E = Error> = core::result::Result<T, E>;
-pub type Error = Box<dyn std::error::Error>;
+pub type Error = Box<dyn std::error::Error + Send + Sync>;
 
 mod checkpoints;
 pub mod client;

--- a/quic/s2n-quic-events/src/main.rs
+++ b/quic/s2n-quic-events/src/main.rs
@@ -4,7 +4,7 @@
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 
-type Error = Box<dyn std::error::Error>;
+type Error = Box<dyn std::error::Error + Send + Sync>;
 type Result<T, E = Error> = core::result::Result<T, E>;
 
 mod parser;

--- a/quic/s2n-quic/src/provider.rs
+++ b/quic/s2n-quic/src/provider.rs
@@ -47,12 +47,12 @@ cfg_if!(
 );
 
 /// An error indicating a failure to start an endpoint
-pub struct StartError(Box<dyn 'static + fmt::Display>);
+pub struct StartError(Box<dyn 'static + fmt::Display + Send + Sync>);
 
 impl std::error::Error for StartError {}
 
 impl StartError {
-    pub(crate) fn new<T: 'static + fmt::Display>(error: T) -> Self {
+    pub(crate) fn new<T: 'static + fmt::Display + Send + Sync>(error: T) -> Self {
         Self(Box::new(error))
     }
 }

--- a/quic/s2n-quic/src/provider/address_token/mod.rs
+++ b/quic/s2n-quic/src/provider/address_token/mod.rs
@@ -7,7 +7,7 @@ pub use s2n_quic_core::token::{Context, Format};
 
 pub trait Provider: 'static {
     type Format: 'static + Format;
-    type Error: 'static + core::fmt::Display;
+    type Error: 'static + core::fmt::Display + Send + Sync;
 
     /// Starts the token provider
     fn start(self) -> Result<Self::Format, Self::Error>;

--- a/quic/s2n-quic/src/provider/congestion_controller.rs
+++ b/quic/s2n-quic/src/provider/congestion_controller.rs
@@ -7,7 +7,7 @@ pub use s2n_quic_core::recovery::congestion_controller::Endpoint;
 /// Provides congestion controller support for an endpoint
 pub trait Provider {
     type Endpoint: Endpoint;
-    type Error: 'static + core::fmt::Display;
+    type Error: 'static + core::fmt::Display + Send + Sync;
 
     fn start(self) -> Result<Self::Endpoint, Self::Error>;
 }

--- a/quic/s2n-quic/src/provider/connection_close_formatter.rs
+++ b/quic/s2n-quic/src/provider/connection_close_formatter.rs
@@ -8,7 +8,7 @@ pub use s2n_quic_core::connection::close::*;
 /// Provider for formatting CONNECTION_CLOSE frames
 pub trait Provider: 'static {
     type Formatter: 'static + Formatter;
-    type Error: core::fmt::Display;
+    type Error: core::fmt::Display + Send + Sync;
 
     /// Starts the token provider
     fn start(self) -> Result<Self::Formatter, Self::Error>;

--- a/quic/s2n-quic/src/provider/connection_id.rs
+++ b/quic/s2n-quic/src/provider/connection_id.rs
@@ -7,7 +7,7 @@ pub use s2n_quic_core::connection::id::{ConnectionInfo, Format, Generator, Local
 
 pub trait Provider: 'static {
     type Format: 'static + Format;
-    type Error: core::fmt::Display;
+    type Error: core::fmt::Display + Send + Sync;
 
     fn start(self) -> Result<Self::Format, Self::Error>;
 }

--- a/quic/s2n-quic/src/provider/datagram.rs
+++ b/quic/s2n-quic/src/provider/datagram.rs
@@ -14,7 +14,7 @@ pub use s2n_quic_core::datagram::{
 
 pub trait Provider {
     type Endpoint: Endpoint;
-    type Error: 'static + core::fmt::Display;
+    type Error: 'static + core::fmt::Display + Send + Sync;
 
     fn start(self) -> Result<Self::Endpoint, Self::Error>;
 }

--- a/quic/s2n-quic/src/provider/endpoint_limits.rs
+++ b/quic/s2n-quic/src/provider/endpoint_limits.rs
@@ -11,7 +11,7 @@ use s2n_quic_core::{event::Timestamp, path::THROTTLED_PORTS_LEN};
 
 pub trait Provider: 'static {
     type Limits: 'static + Limiter;
-    type Error: core::fmt::Display;
+    type Error: core::fmt::Display + Send + Sync;
 
     /// Starts the token provider
     fn start(self) -> Result<Self::Limits, Self::Error>;

--- a/quic/s2n-quic/src/provider/event/mod.rs
+++ b/quic/s2n-quic/src/provider/event/mod.rs
@@ -17,7 +17,7 @@ pub use s2n_quic_core::{
 /// Provides event handling support for an endpoint
 pub trait Provider {
     type Subscriber: 'static + Subscriber;
-    type Error: 'static + core::fmt::Display;
+    type Error: 'static + core::fmt::Display + Send + Sync;
 
     fn start(self) -> Result<Self::Subscriber, Self::Error>;
 }

--- a/quic/s2n-quic/src/provider/io.rs
+++ b/quic/s2n-quic/src/provider/io.rs
@@ -8,7 +8,7 @@ use std::io;
 
 pub trait Provider: 'static {
     type PathHandle: PathHandle;
-    type Error: 'static + core::fmt::Display;
+    type Error: 'static + core::fmt::Display + Send + Sync;
 
     fn start<E: Endpoint<PathHandle = Self::PathHandle>>(
         self,

--- a/quic/s2n-quic/src/provider/limits.rs
+++ b/quic/s2n-quic/src/provider/limits.rs
@@ -7,7 +7,7 @@ pub use s2n_quic_core::connection::limits::{ConnectionInfo, Limiter, Limits};
 
 pub trait Provider {
     type Limits: 'static + Send + Limiter;
-    type Error: 'static + core::fmt::Display;
+    type Error: 'static + core::fmt::Display + Send + Sync;
 
     fn start(self) -> Result<Self::Limits, Self::Error>;
 }

--- a/quic/s2n-quic/src/provider/macros.rs
+++ b/quic/s2n-quic/src/provider/macros.rs
@@ -6,7 +6,7 @@ macro_rules! impl_provider_utils {
         /// Converts a value into a [`Provider`]
         pub trait TryInto {
             type Provider: Provider;
-            type Error: 'static + core::fmt::Display;
+            type Error: 'static + core::fmt::Display + Send + Sync;
 
             fn try_into(self) -> Result<Self::Provider, Self::Error>;
         }

--- a/quic/s2n-quic/src/provider/packet_interceptor.rs
+++ b/quic/s2n-quic/src/provider/packet_interceptor.rs
@@ -8,7 +8,7 @@ pub use s2n_quic_core::packet::interceptor::{
 /// Provides packet_interceptor support for an endpoint
 pub trait Provider: 'static {
     type PacketInterceptor: 'static + PacketInterceptor;
-    type Error: core::fmt::Display;
+    type Error: core::fmt::Display + Send + Sync;
 
     fn start(self) -> Result<Self::PacketInterceptor, Self::Error>;
 }

--- a/quic/s2n-quic/src/provider/path_migration.rs
+++ b/quic/s2n-quic/src/provider/path_migration.rs
@@ -9,7 +9,7 @@ pub use s2n_quic_core::path::migration::{
 /// Provides limits support for an endpoint
 pub trait Provider {
     type Validator: 'static + Send + Validator;
-    type Error: 'static + core::fmt::Display;
+    type Error: 'static + core::fmt::Display + Send + Sync;
 
     fn start(self) -> Result<Self::Validator, Self::Error>;
 }

--- a/quic/s2n-quic/src/provider/random.rs
+++ b/quic/s2n-quic/src/provider/random.rs
@@ -6,7 +6,7 @@ pub use s2n_quic_core::random::Generator;
 /// Provides random number generation support for an endpoint
 pub trait Provider: 'static {
     type Generator: 'static + Generator;
-    type Error: core::fmt::Display;
+    type Error: core::fmt::Display + Send + Sync;
 
     fn start(self) -> Result<Self::Generator, Self::Error>;
 }

--- a/quic/s2n-quic/src/provider/stateless_reset_token.rs
+++ b/quic/s2n-quic/src/provider/stateless_reset_token.rs
@@ -7,7 +7,7 @@ pub use s2n_quic_core::stateless_reset::token::Generator;
 
 pub trait Provider: 'static {
     type Generator: 'static + Generator;
-    type Error: core::fmt::Display;
+    type Error: core::fmt::Display + Send + Sync;
 
     fn start(self) -> Result<Self::Generator, Self::Error>;
 }

--- a/quic/s2n-quic/src/provider/sync.rs
+++ b/quic/s2n-quic/src/provider/sync.rs
@@ -4,7 +4,7 @@
 /// Provides synchronization support for an endpoint
 pub trait Provider {
     type Sync: 'static + Send;
-    type Error: 'static + core::fmt::Display;
+    type Error: 'static + core::fmt::Display + Send + Sync;
 
     fn start(self) -> Result<Self::Sync, Self::Error>;
 }

--- a/quic/s2n-quic/src/provider/tls.rs
+++ b/quic/s2n-quic/src/provider/tls.rs
@@ -9,7 +9,7 @@ use s2n_quic_core::crypto;
 pub trait Provider {
     type Server: 'static + crypto::tls::Endpoint;
     type Client: 'static + crypto::tls::Endpoint;
-    type Error: 'static + core::fmt::Display;
+    type Error: 'static + core::fmt::Display + Send + Sync;
 
     /// Creates a server endpoint for the given provider
     fn start_server(self) -> Result<Self::Server, Self::Error>;
@@ -58,7 +58,7 @@ impl Provider for Default {
 impl Provider for (&std::path::Path, &std::path::Path) {
     type Server = <Default as Provider>::Server;
     type Client = <Default as Provider>::Client;
-    type Error = Box<dyn std::error::Error>;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
 
     fn start_server(self) -> Result<Self::Server, Self::Error> {
         let server = default::Server::builder()
@@ -81,7 +81,7 @@ impl Provider for (&std::path::Path, &std::path::Path) {
 impl Provider for &std::path::Path {
     type Server = <Default as Provider>::Server;
     type Client = <Default as Provider>::Client;
-    type Error = Box<dyn std::error::Error>;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
 
     fn start_server(self) -> Result<Self::Server, Self::Error> {
         let empty_cert: &[u8] = &[];
@@ -102,7 +102,7 @@ impl Provider for &std::path::Path {
 impl Provider for (&[u8], &[u8]) {
     type Server = <Default as Provider>::Server;
     type Client = <Default as Provider>::Client;
-    type Error = Box<dyn std::error::Error>;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
 
     fn start_server(self) -> Result<Self::Server, Self::Error> {
         let server = default::Server::builder()
@@ -125,7 +125,7 @@ impl Provider for (&[u8], &[u8]) {
 impl Provider for &[u8] {
     type Server = <Default as Provider>::Server;
     type Client = <Default as Provider>::Client;
-    type Error = Box<dyn std::error::Error>;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
 
     fn start_server(self) -> Result<Self::Server, Self::Error> {
         let empty_cert = &[][..];
@@ -146,7 +146,7 @@ impl Provider for &[u8] {
 impl Provider for (&str, &str) {
     type Server = <Default as Provider>::Server;
     type Client = <Default as Provider>::Client;
-    type Error = Box<dyn std::error::Error>;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
 
     fn start_server(self) -> Result<Self::Server, Self::Error> {
         let server = default::Server::builder()
@@ -169,7 +169,7 @@ impl Provider for (&str, &str) {
 impl Provider for &str {
     type Server = <Default as Provider>::Server;
     type Client = <Default as Provider>::Client;
-    type Error = Box<dyn std::error::Error>;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
 
     fn start_server(self) -> Result<Self::Server, Self::Error> {
         let empty_cert = "";

--- a/tools/memory-report/src/main.rs
+++ b/tools/memory-report/src/main.rs
@@ -63,7 +63,7 @@ impl Snapshot {
 #[global_allocator]
 static ALLOC: dhat::Alloc = dhat::Alloc;
 
-type Error = Box<dyn std::error::Error>;
+type Error = Box<dyn std::error::Error + Send + Sync>;
 type Result<T = (), E = Error> = core::result::Result<T, E>;
 
 fn main() -> Result {


### PR DESCRIPTION
### Resolved issues:

#1709 

### Description of changes: 

This PR adds Start and Sync to StartError, which also requires adding it to the error types that the providers use.

```
refactor(s2n-quic): Add Send + Sync to StartError

This commit adds Send and Sync bounds to the StartError type. This makes usage of the error across threads and tasks more ergonomic.

BREAKING CHANGE: Adding additional bounds to a public trait is a breaking change. Customers using externally implemented providers will have to add Send and Sync implementations to their error types.
```

### Call-outs:
I think this is a breaking change :(

We are adding additional requirements for a public trait that customers may have implemented. If a customer has written their own EndpointLimits provider that uses an Error type that doesn't implement Send + Sync, they will receive a compile time error when they try and and upgrade their version of quic.

### Testing:

All CI passes. I really wish something _would_ break in our CI, because I'm pretty sure that this is a breaking change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

