### PR TITLE
refactor(s2n-quic-transport): update PTO timer once per transmission burst

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -936,6 +936,13 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                     packet_interceptor,
                 );
 
+                // If anything was transmitted, notify the space manager
+                // that a burst of packets has completed transmission
+                if count > 0 {
+                    self.space_manager
+                        .on_transmit_burst_complete(self.path_manager.active_path(), timestamp);
+                }
+
                 let mut publisher = self.event_context.publisher(timestamp, subscriber);
                 if outcome.bytes_progressed > 0 {
                     publisher.on_tx_stream_progress(TxStreamProgress {

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -167,6 +167,8 @@ impl<Config: endpoint::Config> Manager<Config> {
         context: &mut Ctx,
         publisher: &mut Pub,
     ) {
+        debug_assert!(!self.pto_update_pending);
+
         if self.loss_timer.is_armed() {
             if self.loss_timer.poll_expiration(timestamp).is_ready() {
                 self.detect_and_remove_lost_packets(

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -300,9 +300,10 @@ impl<Config: endpoint::Config> Manager<Config> {
             return;
         }
 
-        let ack_eliciting_packets_in_flight = self.sent_packets.iter().any(|(_, sent_info)| {
-            sent_info.congestion_controlled && sent_info.ack_elicitation.is_ack_eliciting()
-        });
+        let ack_eliciting_packets_in_flight = self
+            .sent_packets
+            .iter()
+            .any(|(_, sent_info)| sent_info.ack_elicitation.is_ack_eliciting());
 
         //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.2.1
         //# it is the client's responsibility to send packets to unblock the server

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -60,6 +60,11 @@ pub struct Manager<Config: endpoint::Config> {
 
     // The total ecn counts for outstanding (unacknowledged) packets
     sent_packet_ecn_counts: EcnCounts,
+
+    // An update to the PTO timer is needed.
+    //
+    // Used for updating the PTO timer at the end of a transmission burst.
+    pto_update_pending: bool,
 }
 
 //= https://www.rfc-editor.org/rfc/rfc9002#section-6.1.1
@@ -124,6 +129,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             time_of_last_ack_eliciting_packet: None,
             baseline_ecn_counts: EcnCounts::default(),
             sent_packet_ecn_counts: EcnCounts::default(),
+            pto_update_pending: false,
         }
     }
 
@@ -251,16 +257,27 @@ impl<Config: endpoint::Config> Manager<Config> {
             .on_packet_sent(ecn, path_event!(path, path_id), publisher);
         self.sent_packet_ecn_counts.increment(ecn);
 
-        if outcome.is_congestion_controlled {
-            if outcome.ack_elicitation.is_ack_eliciting() {
-                self.time_of_last_ack_eliciting_packet = Some(time_sent);
-            }
+        if outcome.ack_elicitation.is_ack_eliciting() {
+            self.time_of_last_ack_eliciting_packet = Some(time_sent);
             //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.1
             //# A sender SHOULD restart its PTO timer every time an ack-eliciting
             //# packet is sent or acknowledged,
-            let is_handshake_confirmed = context.is_handshake_confirmed();
-            let path = context.path_mut_by_id(context.path_id());
-            self.update_pto_timer(path, time_sent, is_handshake_confirmed);
+            self.pto_update_pending = true;
+        }
+    }
+
+    /// Invoked after a burst of packets on the active path has completed transmitting
+    pub fn on_transmit_burst_complete(
+        &mut self,
+        active_path: &Path<Config>,
+        now: Timestamp,
+        is_handshake_confirmed: bool,
+    ) {
+        debug_assert!(active_path.is_active());
+        if self.pto_update_pending {
+            // Update the PTO timer once per transmission burst to reduce CPU cost
+            self.update_pto_timer(active_path, now, is_handshake_confirmed);
+            debug_assert!(!self.pto_update_pending);
         }
     }
 
@@ -271,6 +288,8 @@ impl<Config: endpoint::Config> Manager<Config> {
         now: Timestamp,
         is_handshake_confirmed: bool,
     ) {
+        self.pto_update_pending = false;
+
         //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.2.1
         //# If no additional data can be sent, the server's PTO timer MUST NOT be
         //# armed until datagrams have been received from the client, because

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -268,7 +268,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         }
     }
 
-    /// Invoked after a burst of packets on the active path has completed transmitting
+    /// Invoked after a burst of packets has completed transmitting
     pub fn on_transmit_burst_complete(
         &mut self,
         active_path: &Path<Config>,

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__on_transmit_burst_complete.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__on_transmit_burst_complete.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
+expression: ""
+---
+

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -2664,6 +2664,7 @@ fn on_timeout() {
         &mut context,
         &mut publisher,
     );
+    manager.on_transmit_burst_complete(context.path(), now, true);
 
     // Loss timer is armed and expired, on_packet_loss is called
     manager.loss_timer.set(now - Duration::from_secs(1));

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -254,8 +254,11 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         timestamp: Timestamp,
         is_handshake_confirmed: bool,
     ) {
-        self.recovery_manager
-            .on_transmit_burst_complete(active_path, timestamp, is_handshake_confirmed);
+        self.recovery_manager.on_transmit_burst_complete(
+            active_path,
+            timestamp,
+            is_handshake_confirmed,
+        );
     }
 
     pub(super) fn on_transmit_close<'a>(

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -248,6 +248,16 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         Ok((outcome, buffer))
     }
 
+    pub(super) fn on_transmit_burst_complete(
+        &mut self,
+        active_path: &Path<Config>,
+        timestamp: Timestamp,
+        is_handshake_confirmed: bool,
+    ) {
+        self.recovery_manager
+            .on_transmit_burst_complete(active_path, timestamp, is_handshake_confirmed);
+    }
+
     pub(super) fn on_transmit_close<'a>(
         &mut self,
         context: &mut ConnectionTransmissionContext<Config>,

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -191,8 +191,11 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
         timestamp: Timestamp,
         is_handshake_confirmed: bool,
     ) {
-        self.recovery_manager
-            .on_transmit_burst_complete(active_path, timestamp, is_handshake_confirmed);
+        self.recovery_manager.on_transmit_burst_complete(
+            active_path,
+            timestamp,
+            is_handshake_confirmed,
+        );
     }
 
     pub(super) fn on_transmit_close<'a>(

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -185,6 +185,16 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
         Ok((outcome, buffer))
     }
 
+    pub(super) fn on_transmit_burst_complete(
+        &mut self,
+        active_path: &Path<Config>,
+        timestamp: Timestamp,
+        is_handshake_confirmed: bool,
+    ) {
+        self.recovery_manager
+            .on_transmit_burst_complete(active_path, timestamp, is_handshake_confirmed);
+    }
+
     pub(super) fn on_transmit_close<'a>(
         &mut self,
         context: &mut ConnectionTransmissionContext<Config>,

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -240,8 +240,11 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
         timestamp: Timestamp,
         is_handshake_confirmed: bool,
     ) {
-        self.recovery_manager
-            .on_transmit_burst_complete(active_path, timestamp, is_handshake_confirmed);
+        self.recovery_manager.on_transmit_burst_complete(
+            active_path,
+            timestamp,
+            is_handshake_confirmed,
+        );
     }
 
     pub(super) fn on_transmit_close<'a>(

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -234,6 +234,16 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
         Ok((outcome, buffer))
     }
 
+    pub(super) fn on_transmit_burst_complete(
+        &mut self,
+        active_path: &Path<Config>,
+        timestamp: Timestamp,
+        is_handshake_confirmed: bool,
+    ) {
+        self.recovery_manager
+            .on_transmit_burst_complete(active_path, timestamp, is_handshake_confirmed);
+    }
+
     pub(super) fn on_transmit_close<'a>(
         &mut self,
         context: &mut ConnectionTransmissionContext<Config>,

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -307,7 +307,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         }
     }
 
-    /// Called after a burst of one or more packets sent on the active path have finished being transmitted
+    /// Called after a burst of one or more packets have finished being transmitted
     pub fn on_transmit_burst_complete(&mut self, active_path: &Path<Config>, timestamp: Timestamp) {
         debug_assert!(active_path.is_active());
 

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -307,6 +307,23 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         }
     }
 
+    /// Called after a burst of one or more packets sent on the active path have finished being transmitted
+    pub fn on_transmit_burst_complete(&mut self, active_path: &Path<Config>, timestamp: Timestamp) {
+        debug_assert!(active_path.is_active());
+
+        if let Some((space, handshake_status)) = self.initial_mut() {
+            space.on_transmit_burst_complete(active_path, timestamp, handshake_status.is_confirmed());
+        }
+
+        if let Some((space, handshake_status)) = self.handshake_mut() {
+            space.on_transmit_burst_complete(active_path, timestamp, handshake_status.is_confirmed());
+        }
+
+        if let Some((space, handshake_status)) = self.application_mut() {
+            space.on_transmit_burst_complete(active_path, timestamp, handshake_status.is_confirmed());
+        }
+    }
+
     pub fn requires_probe(&self) -> bool {
         core::iter::empty()
             .chain(self.initial.iter().map(|space| space.requires_probe()))

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -312,15 +312,27 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         debug_assert!(active_path.is_active());
 
         if let Some((space, handshake_status)) = self.initial_mut() {
-            space.on_transmit_burst_complete(active_path, timestamp, handshake_status.is_confirmed());
+            space.on_transmit_burst_complete(
+                active_path,
+                timestamp,
+                handshake_status.is_confirmed(),
+            );
         }
 
         if let Some((space, handshake_status)) = self.handshake_mut() {
-            space.on_transmit_burst_complete(active_path, timestamp, handshake_status.is_confirmed());
+            space.on_transmit_burst_complete(
+                active_path,
+                timestamp,
+                handshake_status.is_confirmed(),
+            );
         }
 
         if let Some((space, handshake_status)) = self.application_mut() {
-            space.on_transmit_burst_complete(active_path, timestamp, handshake_status.is_confirmed());
+            space.on_transmit_burst_complete(
+                active_path,
+                timestamp,
+                handshake_status.is_confirmed(),
+            );
         }
     }
 


### PR DESCRIPTION
### Resolved issues:

resolves #1839

### Description of changes: 

The packet time out (PTO) timer is restarted each time an ack-eliciting packet is sent, as its main function is to trigger probes when tail packets are not ACKed in time:

```
//= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.1
//# A sender SHOULD restart its PTO timer every time an ack-eliciting
//# packet is sent or acknowledged,
```

Previously we were updating this timer on each packet being sent, even if we send several packets in one burst due to aggregation mechanisms like GSO. This was showing up in Flamegraphs, from .1% to 1% of CPU.

With this change we will wait to update the pto timer until the burst of packets has been transmitted. This doesn't change the actual timing of the PTO timer as the timestamp used for each packet within the burst is identical. 

### Call-outs:

I cleaned up some code in `on_packet_sent` and `update_pto_timer` that was checking `is_congestion_controlled` in addition to ack eliciting. Currently, every frame except for `Ack` and `Padding` is congestion controlled, and every frame except for `Ack`, `Padding`, and `ConnectionClose` is ack eliciting, so it shouldn't make a difference not checking for `is_congestion_controlled`. I believe we were checking it previously due to how the code was structured way back when the Recovery Manager was first written.

There is a slight change in behavior when we have both an active path and one or more paths that are pending path validation (for connection migration reasons). The non-active paths have their packets transmitted at the end of `on_transmit`, and since the PTO timer was updated for each individual packet, it would get updated based on the RTT of the non-active path. Now, I am deliberately only updating the PTO based on the active path's RTT, as this RTT should be more accurate as many more packets have been transmitted over the active path. 

### Testing:

Updated/added unit tests

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

