### PR TITLE
feat(s2n-quic-tls): Allow users to configure ClientAuthType for the Client s2n_tls endpoint

### DIFF
--- a/quic/s2n-quic-tls/src/client.rs
+++ b/quic/s2n-quic-tls/src/client.rs
@@ -142,13 +142,6 @@ impl Builder {
         Ok(self)
     }
 
-    /// Optionally, use Optional or None on the Client builder. The default auth type
-    /// without calling this method is ClientAuthType::Required
-    pub fn with_client_auth_type(mut self, auth_type: ClientAuthType) -> Result<Self, Error> {
-        self.config.set_client_auth_type(auth_type)?;
-        Ok(self)
-    }
-
     /// Set the host name verification callback.
     ///
     /// This will be invoked when a server certificate is presented during a TLS

--- a/quic/s2n-quic-tls/src/client.rs
+++ b/quic/s2n-quic-tls/src/client.rs
@@ -142,6 +142,13 @@ impl Builder {
         Ok(self)
     }
 
+    /// Optionally, use Optional or None on the Client builder. The default auth type 
+    /// without calling this method is ClientAuthType::Required
+    pub fn with_client_auth_type(mut self, auth_type: ClientAuthType) -> Result<Self, Error> {
+        self.config.set_client_auth_type(auth_type)?;
+        Ok(self)
+    }
+
     /// Set the host name verification callback.
     ///
     /// This will be invoked when a server certificate is presented during a TLS

--- a/quic/s2n-quic-tls/src/client.rs
+++ b/quic/s2n-quic-tls/src/client.rs
@@ -142,7 +142,7 @@ impl Builder {
         Ok(self)
     }
 
-    /// Optionally, use Optional or None on the Client builder. The default auth type 
+    /// Optionally, use Optional or None on the Client builder. The default auth type
     /// without calling this method is ClientAuthType::Required
     pub fn with_client_auth_type(mut self, auth_type: ClientAuthType) -> Result<Self, Error> {
         self.config.set_client_auth_type(auth_type)?;

--- a/quic/s2n-quic-tls/src/server.rs
+++ b/quic/s2n-quic-tls/src/server.rs
@@ -171,6 +171,17 @@ impl Builder {
         Ok(self)
     }
 
+    /**
+     * Sets whether or not a Client Certificate should be required to complete the TLS Connection.
+     *
+     * If this is set to `Optional` or `None` the server will request a client certificate but allow the client to not provide one.
+     * Rejecting a client certificate when using `Optional` or `None` will terminate the handshake.
+     */
+    pub fn with_client_auth_type(mut self, auth_type: ClientAuthType) -> Result<Self, Error> {
+        self.config.set_client_auth_type(auth_type)?;
+        Ok(self)
+    }
+
     /// Set the application level certificate verification handler which will be invoked on this
     /// server instance when a client certificate is presented during the mutual TLS handshake.
     #[deprecated(note = "use `with_verify_host_name_callback` instead")]

--- a/quic/s2n-quic-tls/src/tests.rs
+++ b/quic/s2n-quic-tls/src/tests.rs
@@ -204,6 +204,26 @@ fn s2n_server_with_client_auth() -> Result<server::Server, Error> {
         .build()
 }
 
+fn s2n_server_with_optional_client_auth() -> Result<server::Server, Error> {
+    server::Builder::default()
+        .with_empty_trust_store()?
+        .with_client_auth_type(ClientAuthType::Optional)?
+        .with_verify_host_name_callback(VerifyHostNameClientCertVerifier::new("qlaws.qlaws"))?
+        .with_certificate(CERT_PEM, KEY_PEM)?
+        .with_trusted_certificate(CERT_PEM)?
+        .build()
+}
+
+fn s2n_server_with_none_client_auth() -> Result<server::Server, Error> {
+    server::Builder::default()
+        .with_empty_trust_store()?
+        .with_client_auth_type(ClientAuthType::None)?
+        .with_verify_host_name_callback(VerifyHostNameClientCertVerifier::new("qlaws.qlaws"))?
+        .with_certificate(CERT_PEM, KEY_PEM)?
+        .with_trusted_certificate(CERT_PEM)?
+        .build()
+}
+
 fn s2n_server_with_client_auth_verifier_rejects_client_certs() -> Result<server::Server, Error> {
     server::Builder::default()
         .with_empty_trust_store()?
@@ -329,6 +349,28 @@ fn s2n_client_no_client_auth_s2n_server_requires_client_auth_test() {
     assert!(test_result.is_err());
     let e = test_result.unwrap_err();
     assert_eq!(e.description().unwrap(), "UNEXPECTED_MESSAGE");
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn s2n_client_no_client_auth_s2n_server_optional_client_auth_test() {
+    let mut client_endpoint = s2n_client();
+    let mut server_endpoint = s2n_server_with_optional_client_auth().unwrap();
+
+    let test_result = run_result(&mut server_endpoint, &mut client_endpoint, None);
+
+    assert!(test_result.is_err());
+    let e = test_result.unwrap_err();
+    assert_eq!(e.description().unwrap(), "UNEXPECTED_MESSAGE");
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn s2n_client_no_client_auth_s2n_server_none_client_auth_test() {
+    let mut client_endpoint = s2n_client();
+    let mut server_endpoint = s2n_server_with_none_client_auth().unwrap();
+
+    run(&mut server_endpoint, &mut client_endpoint, None);
 }
 
 #[test]

--- a/quic/s2n-quic-tls/src/tests.rs
+++ b/quic/s2n-quic-tls/src/tests.rs
@@ -169,24 +169,6 @@ fn s2n_client_with_client_auth() -> Result<client::Client, Error> {
         .build()
 }
 
-fn s2n_client_with_optional_client_auth() -> Result<client::Client, Error> {
-    client::Builder::default()
-        .with_empty_trust_store()?
-        .with_certificate(CERT_PEM)?
-        .with_client_identity(CERT_PEM, KEY_PEM)?
-        .with_client_auth_type(ClientAuthType::Optional)?
-        .build()
-}
-
-fn s2n_client_with_none_client_auth() -> Result<client::Client, Error> {
-    client::Builder::default()
-        .with_empty_trust_store()?
-        .with_certificate(CERT_PEM)?
-        .with_client_identity(CERT_PEM, KEY_PEM)?
-        .with_client_auth_type(ClientAuthType::None)?
-        .build()
-}
-
 fn s2n_client_with_untrusted_client_auth() -> Result<client::Client, Error> {
     client::Builder::default()
         .with_empty_trust_store()?
@@ -362,24 +344,6 @@ fn s2n_client_with_client_auth_s2n_server_does_not_require_client_auth_test() {
     assert!(test_result.is_err());
     let e = test_result.unwrap_err();
     assert_eq!(e.description().unwrap(), "UNEXPECTED_MESSAGE");
-}
-
-#[test]
-#[cfg_attr(miri, ignore)]
-fn s2n_client_with_optional_client_auth_s2n_server_test() {
-    let mut client_endpoint = s2n_client_with_optional_client_auth().unwrap();
-    let mut server_endpoint = s2n_server();
-
-    run(&mut server_endpoint, &mut client_endpoint, None);
-}
-
-#[test]
-#[cfg_attr(miri, ignore)]
-fn s2n_client_with_none_client_auth_s2n_server_test() {
-    let mut client_endpoint = s2n_client_with_none_client_auth().unwrap();
-    let mut server_endpoint = s2n_server();
-
-    run(&mut server_endpoint, &mut client_endpoint, None);
 }
 
 #[test]

--- a/quic/s2n-quic-tls/src/tests.rs
+++ b/quic/s2n-quic-tls/src/tests.rs
@@ -24,6 +24,7 @@ use s2n_tls::{
     callbacks::{ConnectionFuture, VerifyHostNameCallback},
     connection::Connection,
     error::Error,
+    enums::ClientAuthType
 };
 use std::sync::Arc;
 
@@ -165,6 +166,24 @@ fn s2n_client_with_client_auth() -> Result<client::Client, Error> {
         .with_empty_trust_store()?
         .with_certificate(CERT_PEM)?
         .with_client_identity(CERT_PEM, KEY_PEM)?
+        .build()
+}
+
+fn s2n_client_with_optional_client_auth() -> Result<client::Client, Error> {
+    client::Builder::default()
+        .with_empty_trust_store()?
+        .with_certificate(CERT_PEM)?
+        .with_client_identity(CERT_PEM, KEY_PEM)?
+        .with_client_auth_type(ClientAuthType::Optional)?
+        .build()
+}
+
+fn s2n_client_with_none_client_auth() -> Result<client::Client, Error> {
+    client::Builder::default()
+        .with_empty_trust_store()?
+        .with_certificate(CERT_PEM)?
+        .with_client_identity(CERT_PEM, KEY_PEM)?
+        .with_client_auth_type(ClientAuthType::None)?
         .build()
 }
 
@@ -343,6 +362,24 @@ fn s2n_client_with_client_auth_s2n_server_does_not_require_client_auth_test() {
     assert!(test_result.is_err());
     let e = test_result.unwrap_err();
     assert_eq!(e.description().unwrap(), "UNEXPECTED_MESSAGE");
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn s2n_client_with_optional_client_auth_s2n_server_test() {
+    let mut client_endpoint = s2n_client_with_optional_client_auth().unwrap();
+    let mut server_endpoint = s2n_server();
+
+    run(&mut server_endpoint, &mut client_endpoint, None);
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn s2n_client_with_none_client_auth_s2n_server_test() {
+    let mut client_endpoint = s2n_client_with_none_client_auth().unwrap();
+    let mut server_endpoint = s2n_server();
+
+    run(&mut server_endpoint, &mut client_endpoint, None);
 }
 
 #[test]

--- a/quic/s2n-quic-tls/src/tests.rs
+++ b/quic/s2n-quic-tls/src/tests.rs
@@ -23,8 +23,8 @@ use s2n_tls::callbacks::{PrivateKeyCallback, PrivateKeyOperation};
 use s2n_tls::{
     callbacks::{ConnectionFuture, VerifyHostNameCallback},
     connection::Connection,
+    enums::ClientAuthType,
     error::Error,
-    enums::ClientAuthType
 };
 use std::sync::Arc;
 


### PR DESCRIPTION
### Resolved issues:

resolves #1724 

### Description of changes: 

Expose a new API which takes a user provided ClientAuthType and sets the type on the config.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:
Added unit tests, then ran `cargo test`.
<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?


Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

