### PR TITLE
docs: Add conventional commit info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,8 @@ To send us a pull request, please:
 1. Fork the repository.
 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
 3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
+4. We follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) guidance for commit messages and pull request titles.
+5. Send us a pull request and answer the default questions in the pull request interface.
 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
 
 GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and


### PR DESCRIPTION

### Description of changes: 

Clarify that we use conventional commit style for our messages.

### Testing:

Standard CI/CD tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

