### PR TITLE
fix(s2n-quic-transport): handle MaxMtu smaller than Base PLPMTU

### DIFF
--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -36,14 +36,18 @@ pub const UDP_HEADER_LEN: u16 = 8;
 pub const IPV4_MIN_HEADER_LEN: u16 = 20;
 // IPv6 header is always 40 bytes, plus extensions
 pub const IPV6_MIN_HEADER_LEN: u16 = 40;
-#[cfg(feature = "ipv6")]
-const IP_MIN_HEADER_LEN: u16 = IPV6_MIN_HEADER_LEN;
-#[cfg(not(feature = "ipv6"))]
-const IP_MIN_HEADER_LEN: u16 = IPV4_MIN_HEADER_LEN;
 
 // The minimum allowed Max MTU is the minimum UDP datagram size of 1200 bytes plus
 // the UDP header length and minimal IP header length
-const MIN_ALLOWED_MAX_MTU: u16 = MINIMUM_MTU + UDP_HEADER_LEN + IP_MIN_HEADER_LEN;
+const fn const_min(a: u16, b: u16) -> u16 {
+    if a < b {
+        a
+    } else {
+        b
+    }
+}
+const MIN_ALLOWED_MAX_MTU: u16 =
+    MINIMUM_MTU + UDP_HEADER_LEN + const_min(IPV4_MIN_HEADER_LEN, IPV6_MIN_HEADER_LEN);
 
 // Initial PTO backoff multiplier is 1 indicating no additional increase to the backoff.
 pub const INITIAL_PTO_BACKOFF: u32 = 1;


### PR DESCRIPTION
### Description of changes: 

In #1737 we starting disabling MTU probing when the socket cannot support it by setting the `MaxMtu` for the endpoint to `MaxMtu::MIN`. `MaxMtu::MIN` is based on the smaller of the minimal IPv4 and IPv6 header lengths. The `mtu::controller` had a debug assertion that validated that the given `MaxMtu` is larger than a value that was dependent on if the peer socket address was `IPv4` or `IPv6`. This means that an endpoint starting on a platform that cannot support MTU probing but can support IPv6 would fail this debug assertion, as the IPv6 header is larger. This change removes the debug assertion and instead just takes the max with the `BASE_PLPMTU`.

I've also removed some usage of the `IPV6` feature that had previously been removed in #886

### Testing:

Updated unit test, and tested locally on MacOS, which experiences this issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

