### PR TITLE
feat(s2n-quic-transport): discard client initial keys when we have handshake keys

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1219,28 +1219,6 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 packet_interceptor,
                 datagram_endpoint,
             )?;
-
-            if Config::ENDPOINT_TYPE.is_client() && self.space_manager.handshake().is_some() {
-                //= https://www.rfc-editor.org/rfc/rfc9001#section-4.9.1
-                //# Packets protected with Initial secrets (Section 5.2) are not
-                //# authenticated, meaning that an attacker could spoof packets with the
-                //# intent to disrupt a connection. To limit these attacks, Initial
-                //# packet protection keys are discarded more aggressively than other
-                //# keys.
-
-                //= https://www.rfc-editor.org/rfc/rfc9001#section-4.9.1
-                //# a client MUST discard Initial keys when it first sends a
-                //# Handshake packet
-
-                // We aggressively discard initial keys as soon as we have installed
-                // the handshake keys to prevent the attacks mentioned above.
-                self.space_manager.discard_initial(
-                    &mut self.path_manager[path_id],
-                    path_id,
-                    datagram.timestamp,
-                    &mut self.event_context.publisher(datagram.timestamp, subscriber),
-                );
-            }
         }
 
         Ok(())

--- a/quic/s2n-quic-transport/src/connection/transmission.rs
+++ b/quic/s2n-quic-transport/src/connection/transmission.rs
@@ -274,12 +274,6 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
                     encoder,
                 ) {
                     Ok((outcome, encoder)) => {
-                        if Config::ENDPOINT_TYPE.is_client() {
-                            //= https://www.rfc-editor.org/rfc/rfc9001#section-4.9.1
-                            //# a client MUST discard Initial keys when it first sends a
-                            //# Handshake packet
-                            debug_assert!(space_manager.initial().is_none());
-                        }
                         *self.context.outcome += outcome;
                         encoder
                     }
@@ -301,13 +295,24 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
                     }
                 };
 
+                //= https://www.rfc-editor.org/rfc/rfc9001#section-4.9.1
+                //# a client MUST discard Initial keys when it first sends a
+                //# Handshake packet
+                if Config::ENDPOINT_TYPE.is_client() {
+                    space_manager.discard_initial(
+                        &mut self.context.path_manager[self.context.path_id],
+                        self.context.path_id,
+                        self.context.timestamp,
+                        self.context.publisher,
+                    );
+                }
+
                 //= https://www.rfc-editor.org/rfc/rfc9001#section-4.9.2
                 //# An endpoint MUST discard its handshake keys when the TLS handshake is
                 //# confirmed (Section 4.1.2).
                 if space_manager.is_handshake_confirmed() {
-                    let path = &mut self.context.path_manager[self.context.path_id];
                     space_manager.discard_handshake(
-                        path,
+                        &mut self.context.path_manager[self.context.path_id],
                         self.context.path_id,
                         self.context.publisher,
                     );

--- a/quic/s2n-quic-transport/src/connection/transmission.rs
+++ b/quic/s2n-quic-transport/src/connection/transmission.rs
@@ -120,6 +120,14 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
             "the amplification limit should be checked before trying to transmit"
         );
 
+        if Config::ENDPOINT_TYPE.is_client() && space_manager.handshake().is_some() {
+            //= https://www.rfc-editor.org/rfc/rfc9001#section-4.9.1
+            //# a client MUST discard Initial keys when it first sends a
+            //# Handshake packet
+            let path = &mut self.context.path_manager[self.context.path_id];
+            space_manager.discard_initial(path, self.context.path_id, self.context.publisher);
+        }
+
         // limit the number of retries to the MAX_BURST_PACKETS
         for _ in 0..MAX_BURST_PACKETS {
             let encoder = EncoderBuffer::new(&mut buffer[..mtu]);
@@ -274,19 +282,6 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
                     encoder,
                 ) {
                     Ok((outcome, encoder)) => {
-                        //= https://www.rfc-editor.org/rfc/rfc9001#section-4.9.1
-                        //# a client MUST discard Initial keys when it first sends a
-                        //# Handshake packet
-
-                        if Config::ENDPOINT_TYPE.is_client() {
-                            let path = &mut self.context.path_manager[self.context.path_id];
-                            space_manager.discard_initial(
-                                path,
-                                self.context.path_id,
-                                self.context.publisher,
-                            );
-                        }
-
                         *self.context.outcome += outcome;
                         encoder
                     }

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -274,8 +274,7 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
         //# datagram unblocks it, even if none of the packets in the datagram are
         //# successfully processed.  In such a case, the PTO timer will need to
         //# be re-armed.
-        self.recovery_manager
-            .update_pto_timer(path, timestamp, is_handshake_confirmed);
+        self.update_pto_timer(path, timestamp, is_handshake_confirmed);
     }
 
     /// Called when the connection timer expired
@@ -307,6 +306,17 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
         });
         self.recovery_manager
             .on_packet_number_space_discarded(path, path_id, publisher);
+    }
+
+    /// Updates the probe timeout timer
+    pub fn update_pto_timer(
+        &mut self,
+        path: &Path<Config>,
+        now: Timestamp,
+        is_handshake_confirmed: bool,
+    ) {
+        self.recovery_manager
+            .update_pto_timer(path, now, is_handshake_confirmed);
     }
 
     pub fn requires_probe(&self) -> bool {

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -180,7 +180,8 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
                 //# unblock the server until it is certain that the server has finished
                 //# its address validation
 
-                // Arm the PTO timer so the handshake can make progress
+                // Arm the PTO timer on the handshake space so the handshake can make progress
+                // even if no handshake packets have been transmitted or received yet
                 handshake.update_pto_timer(path, now, handshake_status.is_confirmed());
             }
         }
@@ -213,7 +214,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
             path.reset_pto_backoff();
             space.on_discard(path, path_id, publisher);
             // Dropping handshake will clear the PTO timer for the handshake space.
-            // The PTO timer for the application space will be reset when the
+            // The PTO timer for the application space is reset when the
             // handshake is confirmed.
 
             //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.1

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -31,6 +31,7 @@ mod blackhole;
 mod interceptor;
 mod mtu;
 mod no_tls;
+mod pto;
 mod self_test;
 
 // TODO: https://github.com/aws/s2n-quic/issues/1726

--- a/quic/s2n-quic/src/tests/pto.rs
+++ b/quic/s2n-quic/src/tests/pto.rs
@@ -1,0 +1,87 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use s2n_codec::EncoderBuffer;
+use s2n_quic_core::{
+    event::api::{PacketHeader, Subject},
+    packet::interceptor::{Interceptor, Packet},
+};
+
+/// This test ensures the PTO timer in the Handshake space is armed even
+/// when the client does not otherwise receive or send any handshake
+/// packets
+#[test]
+fn handshake_pto_timer_is_armed() {
+    let model = Model::default();
+    let pto_subscriber = recorder::Pto::new();
+    let packet_sent_subscriber = recorder::PacketSent::new();
+    let pto_events = pto_subscriber.events();
+    let packet_sent_events = packet_sent_subscriber.events();
+
+    test(model.clone(), |handle| {
+        let mut server = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(SERVER_CERTS)?
+            .with_packet_interceptor(DropHandshakeTx)?
+            .start()?;
+
+        let addr = server.local_addr()?;
+        spawn(async move {
+            // We would expect this connection to time out since the server
+            // is not able to send any handshake packets
+            assert!(server.accept().await.is_none());
+        });
+
+        let client = Client::builder()
+            .with_io(handle.builder().build().unwrap())?
+            .with_tls(certificates::CERT_PEM)?
+            .with_event((pto_subscriber, packet_sent_subscriber))?
+            .start()?;
+
+        primary::spawn(async move {
+            let connect = Connect::new(addr).with_server_name("localhost");
+            // We would expect this connection to time out since the server
+            // is not able to send any handshake packets
+            assert!(client.connect(connect).await.is_err());
+        });
+
+        Ok(addr)
+    })
+    .unwrap();
+
+    let pto_events = pto_events.lock().unwrap();
+    let pto_count = *pto_events.iter().max().unwrap_or(&0) as usize;
+
+    // Assert that we sent some PTOs
+    assert!(pto_count > 0);
+
+    let packet_sent_events = packet_sent_events.lock().unwrap();
+    let handshake_packets_sent = packet_sent_events
+        .iter()
+        .filter(|&packet_sent| matches!(packet_sent.packet_header, PacketHeader::Handshake { .. }))
+        .count();
+
+    // Assert that all handshake packets that were sent were due to the PTO timer firing.
+    // The first PTO that fires will send a single packet, since there are no packets
+    // in flight. Subsequent PTOs will send two packets.
+    let expected_handshake_packet_count = pto_count * 2 - 1;
+    assert_eq!(expected_handshake_packet_count, handshake_packets_sent);
+}
+
+/// Drops all outgoing handshake packets
+struct DropHandshakeTx;
+
+impl Interceptor for DropHandshakeTx {
+    #[inline]
+    fn intercept_tx_payload(
+        &mut self,
+        _subject: &Subject,
+        packet: &Packet,
+        payload: &mut EncoderBuffer,
+    ) {
+        if packet.number.space().is_handshake() {
+            payload.set_position(0);
+        }
+    }
+}


### PR DESCRIPTION
### Description of changes: 

[QUIC-TLS§4.9.1](https://datatracker.ietf.org/doc/html/rfc9001#section-4.9.1) makes it clear that Initial secrets should be discarded aggressively:

> Packets protected with Initial secrets ([Section 5.2](https://datatracker.ietf.org/doc/html/rfc9001#initial-secrets)) are not authenticated, meaning that an attacker could spoof packets with the intent to disrupt a connection. To limit these attacks, Initial packet protection keys are discarded more aggressively than other keys.
> 
> The successful use of Handshake packets indicates that no more Initial packets need to be exchanged, as these keys can only be produced after receiving all CRYPTO frames from Initial packets. Thus, a client MUST discard Initial keys when it first sends a Handshake packet and a server MUST discard Initial keys when it first successfully processes a Handshake packet. Endpoints MUST NOT send Initial packets after this point.

Currently, the s2n-quic client waits until we have successfully sent a Handshake packet to discard Initial keys. If for some reason we are unable to send the Handshake packet or did not need to send a Handshake packet, the Initial keys are retained, even though they are no longer needed. This could happen, for example, if the Server's Handshake packet was lost.

This change will discard the Initial keys on the client as long as we have installed the Handshake keys, reducing the window in which the type of attacks mentioned in the RFC are possible.  

### Call-outs:

While making this change, I noticed that in the scenario where the server's handshake packet is lost, we do not arm the PTO timer in the `Handshake` space. This violates this requirement from [QUIC-RECOVERY§6.2.2](https://www.rfc-editor.org/rfc/rfc9002.html#section-6.2.2):

> When the PTO fires, the client MUST send a Handshake packet if it has Handshake keys, otherwise it MUST send an Initial packet in a UDP datagram with a payload of at least 1200 bytes.

This becomes more problematic if the Initial space is discarded without sending a Handshake packet, as no PTO timer will be set at all. To address this, I have explicitly reset the PTO timer in the `Handshake` space when the `Initial` space is discarded. This should also address the issues that were previously fixed in [#1818](https://github.com/aws/s2n-quic/pull/1818). Once this PR is merged, we can consider reverting those changes if they are no longer necessary.

### Testing:

Added an integration test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

