### PR TITLE
fix: upgrade rust version for netbench and xdp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -804,7 +804,7 @@ jobs:
       - uses: actions-rs/toolchain@v1.0.7
         id: toolchain
         with:
-          toolchain: 1.66.0
+          toolchain: 1.67.0
           profile: minimal
           override: true
           components: clippy,rustfmt

--- a/.github/workflows/netbench.yml
+++ b/.github/workflows/netbench.yml
@@ -88,7 +88,7 @@ jobs:
       - uses: actions-rs/toolchain@v1.0.7
         id: toolchain
         with:
-          toolchain: 1.65.0
+          toolchain: 1.67.0
           override: true
 
       - uses: camshaft/rust-cache@v1
@@ -120,7 +120,7 @@ jobs:
       - uses: actions-rs/toolchain@v1.0.7
         id: toolchain
         with:
-          toolchain: 1.65.0
+          toolchain: 1.67.0
           override: true
 
       - uses: camshaft/rust-cache@v1

--- a/netbench/rust-toolchain
+++ b/netbench/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.65.0"
+channel = "1.67.0"
 components = [ "rustc", "clippy", "rustfmt" ]

--- a/tools/xdp/rust-toolchain
+++ b/tools/xdp/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.66.0"
+channel = "1.67.0"
 components = [ "rustc", "clippy", "rustfmt" ]


### PR DESCRIPTION
### Description of changes: 

Netbench and XDP no longer build with the following error:
```
package `time-macros v0.2.11` cannot be built because it requires rustc 1.67.0 or newer, while the currently active rustc version is 1.66.0
```

This change upgrades the rust toolchain for Netbench and XDP to 1.67.0

### Testing:

CI


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

