### PR TITLE
fix(s2n-quic-transport): revert "improve amplification credits on client #1818"

### DIFF
--- a/quic/s2n-quic-transport/src/connection/transmission.rs
+++ b/quic/s2n-quic-transport/src/connection/transmission.rs
@@ -175,14 +175,8 @@ impl<'a, 'sub, Config: endpoint::Config> tx::Message for ConnectionTransmission<
             // end, so we check that next. Finally, if there is no ApplicationData or Handshake packet
             // to transmit, the Initial packet itself will be padded.
             let mut pn_space_to_pad = {
-                let needs_padding = if Config::ENDPOINT_TYPE.is_client() {
-                    // if we're the client and haven't completed the handshake, we need to pad out packets
-                    // in order to give the server as many amplification credits as possible.
-                    !space_manager.is_handshake_confirmed()
-                } else {
-                    // if we're the server, we only need to pad while we have the initial space
-                    has_transmission(space_manager.initial(), transmission_constraint)
-                };
+                let needs_padding =
+                    has_transmission(space_manager.initial(), transmission_constraint);
 
                 if !needs_padding {
                     // There is no Initial packet, so no padding is needed


### PR DESCRIPTION
### Description of changes: 

In #1818 we made two changes to improve the success of handshakes succeeding in the face of packet loss and amplification limits on the server. 

These two changes were:
1) Pad all datagrams transmitted by the client until the handshake has been confirmed, regardless of whether an initial packet was included in the datagram
2) Force all packets transmitted during the handshake to be ack-eliciting by including a `Ping` frame in the packet

`1.` Should not be necessary since receipt of a `Handshake` packet on the server removes amplification limits, so padding a solitary `Handshake` packet would only serve to give amplification credits that would no longer be needed. From [QUIC§8,1](https://www.rfc-editor.org/rfc/rfc9000#section-8.1):
> Connection establishment implicitly provides address validation for both endpoints. In particular, receipt of a packet protected with Handshake keys confirms that the peer successfully processed an Initial packet. Once an endpoint has successfully processed a Handshake packet from the peer, it can consider the peer address to have been validated.

`2.` Is addressed by #1894, which arms the `PTO` timer for the handshake regardless of whether the handshake space has any transmission to send (ack-eliciting or otherwise). All `PTO` probes are ack-eliciting. 

### Testing:

Will verify in Interop

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

