### PR TITLE
fix(s2n-quic-transport): decrement handshake count for non-accepted finalized connections

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -65,7 +65,7 @@ use s2n_quic_core::{
 /// Possible states for handing over a connection from the endpoint to the
 /// application.
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-enum AcceptState {
+pub(crate) enum AcceptState {
     /// The connection is handshaking on the server side and not yet visible
     /// to the application.
     Handshaking,
@@ -553,6 +553,10 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
 
     fn is_handshaking(&self) -> bool {
         self.accept_state == AcceptState::Handshaking
+    }
+
+    fn is_accepted(&self) -> bool {
+        self.accept_state == AcceptState::Active
     }
 
     /// Creates a new `Connection` instance with the given configuration

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -51,6 +51,10 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     /// Returns whether the connection is in the handshake state
     fn is_handshaking(&self) -> bool;
 
+    /// Returns true if the handshake has completed and the connection
+    /// has been handed off to the application
+    fn is_accepted(&self) -> bool;
+
     /// Initiates closing the connection as described in
     /// https://www.rfc-editor.org/rfc/rfc9000#section-10
     fn close(


### PR DESCRIPTION
### Description of changes: 

The count of currently handshaking connections in the connection container was not being decremented when a connnection moved from handshaking directly to finalizing. This change corrects this behavior.

### Call-outs:

There is a brief moment between when `update_interests()` is called and `finalize_done_connections()` is called when the `handshake_connections` count is technically incorrect. This is because I decided to account for both handshaking connections and handshaking completed connections in the `update_interests()` method so I would not need to lock the connection multiple times. A connection that is handshaking and finalizing will decrement the `handshake_connections` count, but is not be removed from the connection map until `finalize_done_connections` is called. This meant I had to call `finalize_done_connections()` prior to `ensure_counter_consistency()`. I added some debug assertions in `finalize_done_connections()` to ensure the accounting is still correct.

### Testing:

Updated the connection container fuzz test to trigger this scenario

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

