### PR TITLE
 ci: improve interop resiliency to loss and corruption

### DIFF
--- a/quic/s2n-quic-qns/etc/run_endpoint.sh
+++ b/quic/s2n-quic-qns/etc/run_endpoint.sh
@@ -50,6 +50,17 @@ if [ "$QNS_MODE" == "interop" ]; then
         SERVER_PARAMS+=" --application-protocols h3"
         CLIENT_PARAMS+=" --application-protocols h3"
     fi
+
+    if [ "$TESTCASE" == "ecn" ]; then
+      # The ECN test requires all packets set an ECT codepoint to pass. s2n-quic temporarily
+      # stops setting the ECT codepoint after 10 packets in case faulty equipment drops
+      # ECT marked packets (see https://datatracker.ietf.org/doc/html/rfc9000#section-13.4.2)
+      # To increase the chance this test completes in 10 packets or less, we disable
+      # MTU probing to avoid sending MTU probes that contribute to the 10 packet limit.
+      # 1228 is the minimum allowed MaxMtu, see `s2n_quic_core::path::MaxMtu::MIN`
+      SERVER_PARAMS+=" --max-mtu 1228"
+      CLIENT_PARAMS+=" --max-mtu 1228"
+    fi
 fi
 
 if [ "$QNS_MODE" == "interop" ]; then

--- a/quic/s2n-quic-qns/src/client/interop.rs
+++ b/quic/s2n-quic-qns/src/client/interop.rs
@@ -37,7 +37,7 @@ pub struct Interop {
     #[structopt(long, env = "TESTCASE", possible_values = &Testcase::supported(is_supported_testcase))]
     testcase: Option<Testcase>,
 
-    #[structopt(long, default_value = "10")]
+    #[structopt(long, default_value = "20")]
     concurrency: u64,
 
     #[structopt(min_values = 1, required = true)]

--- a/quic/s2n-quic-qns/src/limits.rs
+++ b/quic/s2n-quic-qns/src/limits.rs
@@ -19,10 +19,10 @@ pub struct Limits {
 
 impl Limits {
     // Increase the MaxHandshakeDuration from the default of 10 seconds
-    const MAX_HANDSHAKE_DURATION: Duration = Duration::from_secs(30);
+    const MAX_HANDSHAKE_DURATION: Duration = Duration::from_secs(60);
 
     // Increase KeepAlivePeriod from the default of 30 seconds
-    const MAX_KEEP_ALIVE_PERIOD: Duration = Duration::from_secs(60);
+    const MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
     pub fn limits(&self) -> s2n_quic::provider::limits::Limits {
         let data_window = self.data_window();
@@ -42,7 +42,7 @@ impl Limits {
             .unwrap()
             .with_max_handshake_duration(Self::MAX_HANDSHAKE_DURATION)
             .unwrap()
-            .with_max_keep_alive_period(Self::MAX_KEEP_ALIVE_PERIOD)
+            .with_max_idle_timeout(Self::MAX_IDLE_TIMEOUT)
             .unwrap();
 
         if let Some(size) = self.stream_send_buffer_size {

--- a/quic/s2n-quic-qns/src/limits.rs
+++ b/quic/s2n-quic-qns/src/limits.rs
@@ -21,7 +21,7 @@ impl Limits {
     // Increase the MaxHandshakeDuration from the default of 10 seconds
     const MAX_HANDSHAKE_DURATION: Duration = Duration::from_secs(60);
 
-    // Increase KeepAlivePeriod from the default of 30 seconds
+    // Increase MaxIdleTimeout from the default of 30 seconds
     const MAX_IDLE_TIMEOUT: Duration = Duration::from_secs(60);
 
     pub fn limits(&self) -> s2n_quic::provider::limits::Limits {

--- a/quic/s2n-quic-qns/src/limits.rs
+++ b/quic/s2n-quic-qns/src/limits.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use core::time::Duration;
+
 #[derive(Debug, structopt::StructOpt)]
 pub struct Limits {
     /// The maximum bits/sec for each connection
@@ -16,6 +18,12 @@ pub struct Limits {
 }
 
 impl Limits {
+    // Increase the MaxHandshakeDuration from the default of 10 seconds
+    const MAX_HANDSHAKE_DURATION: Duration = Duration::from_secs(30);
+
+    // Increase KeepAlivePeriod from the default of 30 seconds
+    const MAX_KEEP_ALIVE_PERIOD: Duration = Duration::from_secs(60);
+
     pub fn limits(&self) -> s2n_quic::provider::limits::Limits {
         let data_window = self.data_window();
 
@@ -31,6 +39,10 @@ impl Limits {
             .with_bidirectional_remote_data_window(data_window)
             .unwrap()
             .with_unidirectional_data_window(data_window)
+            .unwrap()
+            .with_max_handshake_duration(Self::MAX_HANDSHAKE_DURATION)
+            .unwrap()
+            .with_max_keep_alive_period(Self::MAX_KEEP_ALIVE_PERIOD)
             .unwrap();
 
         if let Some(size) = self.stream_send_buffer_size {


### PR DESCRIPTION
### Description of changes: 

This change includes a few small changes to improve the likelihood of interop tests succeeding when they deliberately drop or corrupt packets:

- Increased `MaxHandshakeDuration` from 10 seconds to 60 seconds. Under the heavy loss scenarios tested in interop, a handshake may take longer than 10 seconds to complete
- Increased `MaxIdleTimeout` from 30 seconds to 60 seconds. Under heavy loss, a connection may appear idle for long periods.
- Increased connection concurrency from 10 to 20. With the increased limits above, it is possible the tests may bump into the overall maximum time limit for a single interop test to execute. By handling more requests at the same time, we can attempt to avoid this
- Disable MTU probing for the ECN test. The ECN interop test requires that every packet sent by the client and server are marked as ECN capable. s2n-quic deliberately only marks the first 10 packets it sends as ECN capable (at the suggestion of [QUIC§13.4.2](https://datatracker.ietf.org/doc/html/rfc9000#section-13.4.2)), before stopping marking packets ECN capable briefly while the ECN counts are being validated (see [ecn.rs](https://github.com/aws/s2n-quic/blob/c7e3f517f3267f2e19b605cb53e6bf265e70e5af/quic/s2n-quic-transport/src/path/ecn.rs#L23)). To increase the chance that the ECN test completes prior to hitting this 10 packet limit, we can disable MTU probing so no MTU probes consume from the 10 packet limit. 

### Testing:

Interop testing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

