### PR TITLE
chore: release 1.26.0

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-codec"
-version = "0.6.1"
+version = "0.6.2"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -34,7 +34,7 @@ insta = { version = ">=1.12", features = ["json"], optional = true }
 num-rational = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 pin-project-lite = { version = "0.2" }
-s2n-codec = { version = "=0.6.1", path = "../../common/s2n-codec", default-features = false }
+s2n-codec = { version = "=0.6.2", path = "../../common/s2n-codec", default-features = false }
 subtle = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }
 zerocopy = "0.6"

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-core"
-version = "0.25.0"
+version = "0.26.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -17,7 +17,7 @@ testing = []
 [dependencies]
 cfg-if = "1"
 lazy_static = "1"
-s2n-codec = { version = "=0.6.1", path = "../../common/s2n-codec", default-features = false }
+s2n-codec = { version = "=0.6.2", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.26.0", path = "../s2n-quic-core", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["derive"] }
 

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-crypto"
-version = "0.25.0"
+version = "0.26.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -18,7 +18,7 @@ testing = []
 cfg-if = "1"
 lazy_static = "1"
 s2n-codec = { version = "=0.6.1", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.25.0", path = "../s2n-quic-core", default-features = false }
+s2n-quic-core = { version = "=0.26.0", path = "../s2n-quic-core", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["derive"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-platform"
-version = "0.26.0"
+version = "0.27.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -26,7 +26,7 @@ cfg-if = "1"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 lazy_static = { version = "1", optional = true }
 s2n-quic-core = { version = "=0.26.0", path = "../s2n-quic-core", default-features = false }
-s2n-quic-xdp = { version = "=0.5.0", path = "../../tools/xdp/s2n-quic-xdp", optional = true }
+s2n-quic-xdp = { version = "=0.6.0", path = "../../tools/xdp/s2n-quic-xdp", optional = true }
 socket2 = { version = "0.5", features = ["all"], optional = true }
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt", "time"], optional = true }
 turmoil = { version = "0.5.2", optional = true }

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -25,7 +25,7 @@ bolero-generator = { version = "0.9", optional = true }
 cfg-if = "1"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 lazy_static = { version = "1", optional = true }
-s2n-quic-core = { version = "=0.25.0", path = "../s2n-quic-core", default-features = false }
+s2n-quic-core = { version = "=0.26.0", path = "../s2n-quic-core", default-features = false }
 s2n-quic-xdp = { version = "=0.5.0", path = "../../tools/xdp/s2n-quic-xdp", optional = true }
 socket2 = { version = "0.5", features = ["all"], optional = true }
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt", "time"], optional = true }

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-rustls"
-version = "0.25.0"
+version = "0.26.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -15,8 +15,8 @@ bytes = { version = "1", default-features = false }
 rustls = { version = "0.20", features = ["quic"] }
 rustls-pemfile = "1"
 s2n-codec = { version = "=0.6.1", path = "../../common/s2n-codec", default-features = false, features = ["alloc"] }
-s2n-quic-core = { version = "=0.25.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
-s2n-quic-crypto = { version = "=0.25.0", path = "../s2n-quic-crypto", default-features = false }
+s2n-quic-core = { version = "=0.26.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
+s2n-quic-crypto = { version = "=0.26.0", path = "../s2n-quic-crypto", default-features = false }
 
 [dev-dependencies]
 insta = { version = "1", features = ["json"] }

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["corpus.tar.gz"]
 bytes = { version = "1", default-features = false }
 rustls = { version = "0.20", features = ["quic"] }
 rustls-pemfile = "1"
-s2n-codec = { version = "=0.6.1", path = "../../common/s2n-codec", default-features = false, features = ["alloc"] }
+s2n-codec = { version = "=0.6.2", path = "../../common/s2n-codec", default-features = false, features = ["alloc"] }
 s2n-quic-core = { version = "=0.26.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
 s2n-quic-crypto = { version = "=0.26.0", path = "../s2n-quic-crypto", default-features = false }
 

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-tls-default"
-version = "0.25.0"
+version = "0.26.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 exclude = ["corpus.tar.gz"]
 
 [target.'cfg(unix)'.dependencies]
-s2n-quic-tls = { version = "=0.25.0", path = "../s2n-quic-tls" }
+s2n-quic-tls = { version = "=0.26.0", path = "../s2n-quic-tls" }
 
 [target.'cfg(not(unix))'.dependencies]
-s2n-quic-rustls = { version = "=0.25.0", path = "../s2n-quic-rustls" }
+s2n-quic-rustls = { version = "=0.26.0", path = "../s2n-quic-rustls" }

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -18,7 +18,7 @@ unstable_private_key = []
 bytes = { version = "1", default-features = false }
 errno = "0.3"
 libc = "0.2"
-s2n-codec = { version = "=0.6.1", path = "../../common/s2n-codec", default-features = false }
+s2n-codec = { version = "=0.6.2", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.26.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
 s2n-quic-crypto = { version = "=0.26.0", path = "../s2n-quic-crypto", default-features = false }
 s2n-tls = { version = "=0.0.35", features = ["quic"] }

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-tls"
-version = "0.25.0"
+version = "0.26.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -19,8 +19,8 @@ bytes = { version = "1", default-features = false }
 errno = "0.3"
 libc = "0.2"
 s2n-codec = { version = "=0.6.1", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.25.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
-s2n-quic-crypto = { version = "=0.25.0", path = "../s2n-quic-crypto", default-features = false }
+s2n-quic-core = { version = "=0.26.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
+s2n-quic-crypto = { version = "=0.26.0", path = "../s2n-quic-crypto", default-features = false }
 s2n-tls = { version = "=0.0.35", features = ["quic"] }
 
 [target.'cfg(all(s2n_quic_unstable, s2n_quic_enable_pq_tls))'.dependencies]

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-transport"
-version = "0.25.0"
+version = "0.26.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -22,7 +22,7 @@ hashbrown = "0.13"
 intrusive-collections = "0.9"
 once_cell = "1"
 s2n-codec = { version = "=0.6.1", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
-s2n-quic-core = { version = "=0.25.0", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
+s2n-quic-core = { version = "=0.26.0", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
 siphasher = "0.3"
 smallvec = { version = "1", default-features = false }
 

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -21,7 +21,7 @@ futures-core = { version = "0.3", default-features = false, features = ["alloc"]
 hashbrown = "0.13"
 intrusive-collections = "0.9"
 once_cell = "1"
-s2n-codec = { version = "=0.6.1", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
+s2n-codec = { version = "=0.6.2", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
 s2n-quic-core = { version = "=0.26.0", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
 siphasher = "0.3"
 smallvec = { version = "1", default-features = false }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -64,7 +64,7 @@ rand_chacha = "0.3"
 s2n-codec = { version = "=0.6.1", path = "../../common/s2n-codec" }
 s2n-quic-core = { version = "=0.26.0", path = "../s2n-quic-core" }
 s2n-quic-crypto = { version = "=0.26.0", path = "../s2n-quic-crypto", optional = true }
-s2n-quic-platform = { version = "=0.26.0", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
+s2n-quic-platform = { version = "=0.27.0", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
 s2n-quic-rustls = { version = "=0.26.0", path = "../s2n-quic-rustls", optional = true }
 s2n-quic-tls = { version = "=0.26.0", path = "../s2n-quic-tls", optional = true }
 s2n-quic-tls-default = { version = "=0.26.0", path = "../s2n-quic-tls-default", optional = true }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -61,7 +61,7 @@ hash_hasher = { version = "2", optional = true }
 humansize = { version = "2", optional = true }
 rand = "0.8"
 rand_chacha = "0.3"
-s2n-codec = { version = "=0.6.1", path = "../../common/s2n-codec" }
+s2n-codec = { version = "=0.6.2", path = "../../common/s2n-codec" }
 s2n-quic-core = { version = "=0.26.0", path = "../s2n-quic-core" }
 s2n-quic-crypto = { version = "=0.26.0", path = "../s2n-quic-crypto", optional = true }
 s2n-quic-platform = { version = "=0.27.0", path = "../s2n-quic-platform", features = ["tokio-runtime"] }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic"
-version = "1.25.0"
+version = "1.26.0"
 description = "A Rust implementation of the IETF QUIC protocol"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -62,13 +62,13 @@ humansize = { version = "2", optional = true }
 rand = "0.8"
 rand_chacha = "0.3"
 s2n-codec = { version = "=0.6.1", path = "../../common/s2n-codec" }
-s2n-quic-core = { version = "=0.25.0", path = "../s2n-quic-core" }
-s2n-quic-crypto = { version = "=0.25.0", path = "../s2n-quic-crypto", optional = true }
+s2n-quic-core = { version = "=0.26.0", path = "../s2n-quic-core" }
+s2n-quic-crypto = { version = "=0.26.0", path = "../s2n-quic-crypto", optional = true }
 s2n-quic-platform = { version = "=0.26.0", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
-s2n-quic-rustls = { version = "=0.25.0", path = "../s2n-quic-rustls", optional = true }
-s2n-quic-tls = { version = "=0.25.0", path = "../s2n-quic-tls", optional = true }
-s2n-quic-tls-default = { version = "=0.25.0", path = "../s2n-quic-tls-default", optional = true }
-s2n-quic-transport = { version = "=0.25.0", path = "../s2n-quic-transport" }
+s2n-quic-rustls = { version = "=0.26.0", path = "../s2n-quic-rustls", optional = true }
+s2n-quic-tls = { version = "=0.26.0", path = "../s2n-quic-tls", optional = true }
+s2n-quic-tls-default = { version = "=0.26.0", path = "../s2n-quic-tls-default", optional = true }
+s2n-quic-transport = { version = "=0.26.0", path = "../s2n-quic-transport" }
 tokio = { version = "1", default-features = false }
 zerocopy = { version = "0.6", optional = true }
 zerocopy-derive = { version = "0.6", optional = true }

--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-xdp"
-version = "0.5.0"
+version = "0.6.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -18,7 +18,7 @@ aya = { version = "0.11", default-features = false }
 bitflags = "2"
 errno = "0.3"
 libc = "0.2"
-s2n-codec = { version = "=0.6.1", path = "../../../common/s2n-codec" }
+s2n-codec = { version = "=0.6.2", path = "../../../common/s2n-codec" }
 s2n-quic-core = { version = "=0.26.0", path = "../../../quic/s2n-quic-core" }
 tokio = { version = "1", features = ["net"], optional = true }
 

--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -19,7 +19,7 @@ bitflags = "2"
 errno = "0.3"
 libc = "0.2"
 s2n-codec = { version = "=0.6.1", path = "../../../common/s2n-codec" }
-s2n-quic-core = { version = "=0.25.0", path = "../../../quic/s2n-quic-core" }
+s2n-quic-core = { version = "=0.26.0", path = "../../../quic/s2n-quic-core" }
 tokio = { version = "1", features = ["net"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION

### Description of changes: 

This bumps the crate versions for the v1.26.0 release.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

