### PR TITLE
chore(tools): update udp-attack and xdp rust version

### DIFF
--- a/tools/udp-attack/rust-toolchain
+++ b/tools/udp-attack/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.68.0"
+channel = "1.70.0"

--- a/tools/xdp/rust-toolchain
+++ b/tools/xdp/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.67.0"
+channel = "1.70.0"
 components = [ "rustc", "clippy", "rustfmt" ]


### PR DESCRIPTION
### Description of changes: 

A udp-attack and xdp dependency requires a newer rust version:

```
package `anstream v0.5.0` cannot be built because it requires rustc 1.70.0 or newer, while the currently active rustc version is 1.68.0
```

This change updates udp-attack and xdp to rust 1.70.0

### Testing:

Built locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

