### PR TITLE
docs: add citation for Peer Denial of Service

### DIFF
--- a/examples/dos-mitigation/src/lib.rs
+++ b/examples/dos-mitigation/src/lib.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /// Example mitigation for Slowloris-style Denial of Service attacks. For details on this attack,
-/// see [QUIC Transport RFC](https://www.rfc-editor.org/rfc/rfc9000.html#name-slowloris-attacks).
+/// see [QUIC§21.6](https://www.rfc-editor.org/rfc/rfc9000.html#name-slowloris-attacks).
+///
+/// The Connection Supervisor used in this example may also be used to mitigate the more general
+/// Peer Denial of Service attack described in [QUIC§21.9](https://www.rfc-editor.org/rfc/rfc9000.html#name-peer-denial-of-service).
 pub mod slowloris {
     use s2n_quic::provider::{
         event,

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -488,6 +488,13 @@ impl<Config: endpoint::Config> ConnectionImpl<Config> {
         //# a connection is allowed to have, and restricting the length of time
         //# an endpoint is allowed to stay connected.
 
+        //= https://www.rfc-editor.org/rfc/rfc9000#section-21.9
+        //# While there are legitimate uses for all messages, implementations
+        //# SHOULD track cost of processing relative to progress and treat
+        //# excessive quantities of any non-productive packets as indicative of
+        //# an attack.  Endpoints MAY respond to this condition with a connection
+        //# error or by dropping packets.
+
         // Applications may implement the `on_supervisor_timeout` trait function to
         // close the connection based on data in the supervisor context and in the
         // connection and endpoint events.


### PR DESCRIPTION
### Description of changes: 

[QUIC§21.9](https://www.rfc-editor.org/rfc/rfc9000.html#name-peer-denial-of-service) describes a peer denial of service attack that may be mitigated through tracking connection progress relative to processing:

>While there are legitimate uses for all messages, implementations SHOULD track cost of processing relative to progress and treat excessive quantities of any non-productive packets as indicative of an attack. Endpoints MAY respond to this condition with a connection error or by dropping packets.

The existing "Connection Supervisor" introduced in #1097 is suitable for this purpose. I've added a citation for this, and have also mentioned this section in the slow-loris example code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

