### PR TITLE
feat(s2n-quic-crypto): use scatter API with AWS-LC

### DIFF
--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -22,10 +22,10 @@ s2n-quic-core = { version = "=0.27.0", path = "../s2n-quic-core", default-featur
 zeroize = { version = "1", default-features = false, features = ["derive"] }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-aws-lc-rs = { version = "1.0.0", default-features = false, features = ["aws-lc-sys"] }
+aws-lc-rs = { version = "1.3", default-features = false, features = ["aws-lc-sys"] }
 
 [target.'cfg(not(target_os = "linux"))'.dependencies]
-ring = { version = "0.16.20", default-features = false }
+ring = { version = "0.16", default-features = false }
 
 [dev-dependencies]
 aes = "0.8"

--- a/quic/s2n-quic-crypto/src/aesgcm/ring.rs
+++ b/quic/s2n-quic-crypto/src/aesgcm/ring.rs
@@ -12,6 +12,7 @@ impl aead::Aead for LessSafeKey {
     type Tag = [u8; TAG_LEN];
 
     #[inline]
+    #[cfg(not(target_os = "linux"))]
     fn encrypt(
         &self,
         nonce: &[u8; NONCE_LEN],
@@ -37,11 +38,7 @@ impl aead::Aead for LessSafeKey {
         Ok(())
     }
 
-    /*
-     * TODO: enable this once the scatter API is available in AWS-LC-RS
-     *
-     * https://github.com/aws/aws-lc-rs/pull/206
-     *
+    // use the scatter API if we're using AWS-LC
     #[inline]
     #[cfg(target_os = "linux")]
     fn encrypt(
@@ -63,7 +60,6 @@ impl aead::Aead for LessSafeKey {
 
         Ok(())
     }
-    */
 
     #[inline]
     fn decrypt(


### PR DESCRIPTION
### Resolved issues:

resolves #1684

### Description of changes: 

This PR enables the implementation done in #1899 now that `aws-lc-rs` has released v1.3.0.

### Testing:

As noted in #1899, the copy on the sender has been removed:

#### Before

[
![](https://dnglbrstg7yg.cloudfront.net/d1a0702795ec72b0b0c57c1dcac7788e147cb04b/perf/s2n-quic-client-s2n-quic-server/0MB-down-10000MB-up.client.svg)
](https://dnglbrstg7yg.cloudfront.net/d1a0702795ec72b0b0c57c1dcac7788e147cb04b/perf/s2n-quic-client-s2n-quic-server/0MB-down-10000MB-up.client.svg)

#### After

[
![](https://dnglbrstg7yg.cloudfront.net/1bc618bbaa59b082ddb4dc46907404bf0ff93bfa/perf/s2n-quic-client-s2n-quic-server/0MB-down-10000MB-up.client.svg)
](https://dnglbrstg7yg.cloudfront.net/1bc618bbaa59b082ddb4dc46907404bf0ff93bfa/perf/s2n-quic-client-s2n-quic-server/0MB-down-10000MB-up.client.svg)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

