### PR TITLE
docs: describe mitigations for QUIC§21.11 in stateless reset token provider 

### DIFF
--- a/quic/s2n-quic-core/src/stateless_reset/token.rs
+++ b/quic/s2n-quic-core/src/stateless_reset/token.rs
@@ -95,7 +95,7 @@ impl EncoderValue for Token {
     }
 }
 
-/// A generator for a stateless reset token
+// A generator for a stateless reset token
 pub trait Generator: 'static + Send {
     /// If enabled, a stateless reset packet containing the token generated
     /// by this Generator will be sent when a packet is received that cannot

--- a/quic/s2n-quic/src/provider/stateless_reset_token.rs
+++ b/quic/s2n-quic/src/provider/stateless_reset_token.rs
@@ -12,9 +12,9 @@
 /// does not correspond to any active connection on any endpoint that uses the same static key for
 /// generating stateless reset tokens. This is in accordance with the following requirement:
 ///
-///     More generally, servers MUST NOT generate a stateless reset
-///     if a connection with the corresponding connection ID could
-///     be active on any endpoint using the same static key.
+/// > More generally, servers MUST NOT generate a stateless reset
+/// if a connection with the corresponding connection ID could
+/// be active on any endpoint using the same static key.
 ///
 /// This may require coordination between endpoints and/or careful setup of load balancing and
 /// packet routing, as well as ensuring the connection IDs in use are difficult to guess.

--- a/quic/s2n-quic/src/provider/stateless_reset_token.rs
+++ b/quic/s2n-quic/src/provider/stateless_reset_token.rs
@@ -3,6 +3,25 @@
 
 //! Provides stateless reset token support for an endpoint
 
+/// A generator for a stateless reset token
+///
+/// [QUIC§21.11](https://www.rfc-editor.org/rfc/rfc9000.html#reset-oracle) highlights a denial of service
+/// attack that is possible if an attacker can cause an endpoint to transmit a valid stateless reset
+/// token for a connection ID of the attacker's choosing. This attack may be mitigated by ensuring the
+/// `generate` implementation only returns a valid (non-random) `Token` if the given `local_connection_id`
+/// does not correspond to any active connection on any endpoint that uses the same static key for
+/// generating stateless reset tokens. This is in accordance with the following requirement:
+///
+///     More generally, servers MUST NOT generate a stateless reset
+///     if a connection with the corresponding connection ID could
+///     be active on any endpoint using the same static key.
+///
+/// This may require coordination between endpoints and/or careful setup of load balancing and
+/// packet routing, as well as ensuring the connection IDs in use are difficult to guess.
+///
+/// Take these factors into consideration before enabling the Stateless Reset
+/// Token Generator. By default, stateless resets are not transmitted by s2n-quic endpoints,
+/// see [stateless_reset_token::Default][`crate::provider::stateless_reset_token::Default`].
 pub use s2n_quic_core::stateless_reset::token::Generator;
 
 pub trait Provider: 'static {
@@ -21,6 +40,13 @@ mod random {
     use rand::prelude::*;
     use s2n_quic_core::{frame::new_connection_id::STATELESS_RESET_TOKEN_LEN, stateless_reset};
 
+    /// Randomly generated stateless reset token.
+    ///
+    /// Since a random stateless reset token will not be recognized by the peer, this default
+    /// stateless token generator does not enable stateless resets to be sent to the peer.
+    ///
+    /// To enable stateless reset functionality, the stateless reset token must
+    /// be generated the same for a given `local_connection_id` before and after loss of state.
     #[derive(Debug, Default)]
     pub struct Provider(Generator);
 
@@ -42,19 +68,19 @@ mod random {
         }
     }
 
-    /// Randomly generated stateless reset token.
+    // Randomly generated stateless reset token.
     #[derive(Debug, Default)]
     pub struct Generator {}
 
     impl stateless_reset::token::Generator for Generator {
-        /// Since a random stateless reset token will not be recognized by the peer, this generator
-        /// is not enabled and no stateless reset packet will be sent to the peer.
+        // Since a random stateless reset token will not be recognized by the peer, this generator
+        // is not enabled and no stateless reset packet will be sent to the peer.
         const ENABLED: bool = false;
-        /// This stateless reset token generator produces a random token on each call, and
-        /// thus does not enable stateless reset functionality, as the token provided to the
-        /// peer with a new connection ID will be different than the token sent in a stateless
-        /// reset. To enable stateless reset functionality, the stateless reset token must
-        /// be generated the same for a given `local_connection_id` before and after loss of state.
+        // This stateless reset token generator produces a random token on each call, and
+        // thus does not enable stateless reset functionality, as the token provided to the
+        // peer with a new connection ID will be different than the token sent in a stateless
+        // reset. To enable stateless reset functionality, the stateless reset token must
+        // be generated the same for a given `local_connection_id` before and after loss of state.
         fn generate(&mut self, _local_connection_id: &[u8]) -> stateless_reset::Token {
             let mut token = [0u8; STATELESS_RESET_TOKEN_LEN];
             rand::thread_rng().fill_bytes(&mut token);


### PR DESCRIPTION
### Description of changes: 

[QUIC§21.11](https://www.rfc-editor.org/rfc/rfc9000.html#reset-oracle) highlights a denial of service attack that is possible if an attacker can cause an endpoint to transmit a valid stateless reset token for a connection ID of the attacker's choosing. This attack can be mitigated when implementing a `stateless_reset::token::Generator` by ensuring a valid (non-random) token is only generated if the given `local_connection_id` does not correspond to any active connection on any endpoint that uses the same static key for generating stateless reset tokens.

This change adds some additional documentation for this mitigation to the stateless_reset_token provider.

Rendered [here](https://dnglbrstg7yg.cloudfront.net/1eb5f4144d328bf6fada01896c19744ab1d8a253/doc/s2n_quic/provider/stateless_reset_token/trait.Generator.html)

### Call-outs:

I changed some Rust doc comments to regular comments as they seem to be merged together with the upstream doc comments.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

