### PR TITLE
refactor(s2n-quic-transport): simplify packet processing

### DIFF
--- a/quic/s2n-quic-core/src/connection/error.rs
+++ b/quic/s2n-quic-core/src/connection/error.rs
@@ -469,12 +469,9 @@ impl From<Error> for std::io::ErrorKind {
 /// enum is used to allow for either error type to be returned as appropriate.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ProcessingError {
-    DuplicatePacket,
-    /// Received a Retry packet with SCID field equal to DCID field.
-    RetryScidEqualsDcid,
     ConnectionError(Error),
     CryptoError(CryptoError),
-    NonEmptyRetryToken,
+    Other,
 }
 
 impl From<Error> for ProcessingError {

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -362,6 +362,9 @@ pub mod api {
             reason: RetryDiscardReason<'a>,
             path: Path<'a>,
         },
+        #[non_exhaustive]
+        #[doc = " The received Initial packet was not transported in a datagram of at least 1200 bytes"]
+        UndersizedInitialPacket { path: Path<'a> },
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
@@ -2981,6 +2984,8 @@ pub mod builder {
             reason: RetryDiscardReason<'a>,
             path: Path<'a>,
         },
+        #[doc = " The received Initial packet was not transported in a datagram of at least 1200 bytes"]
+        UndersizedInitialPacket { path: Path<'a> },
     }
     impl<'a> IntoEvent<api::PacketDropReason<'a>> for PacketDropReason<'a> {
         #[inline]
@@ -3020,6 +3025,9 @@ pub mod builder {
                 },
                 Self::RetryDiscarded { reason, path } => RetryDiscarded {
                     reason: reason.into_event(),
+                    path: path.into_event(),
+                },
+                Self::UndersizedInitialPacket { path } => UndersizedInitialPacket {
                     path: path.into_event(),
                 },
             }

--- a/quic/s2n-quic-core/src/packet/encoding.rs
+++ b/quic/s2n-quic-core/src/packet/encoding.rs
@@ -254,10 +254,10 @@ pub trait PacketEncoder<K: CryptoKey, H: HeaderKey, Payload: PacketPayloadEncode
             return Err(PacketEncodingError::EmptyPayload(buffer));
         }
 
-        debug_assert!(
-            payload_len >= minimum_payload_len,
-            "payloads should write at least the minimum_len"
-        );
+        // Ideally we would check that the `paylod_len >= minimum_payload_len`. However, the packet
+        // interceptor may rewrite the packet into something smaller. Instead of preventing that
+        // here, we will rely on the `crate::transmission::Transmission` logic to ensure the
+        // padding is initially written to ensure the minimum is met before interception is applied.
 
         // Update the payload_len cursor with the actual payload len
         let actual_payload_len = buffer.len() + payload_len + key.tag_len() - header_len;

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -754,6 +754,8 @@ enum PacketDropReason<'a> {
         reason: RetryDiscardReason<'a>,
         path: Path<'a>,
     },
+    /// The received Initial packet was not transported in a datagram of at least 1200 bytes
+    UndersizedInitialPacket { path: Path<'a> },
 }
 
 #[deprecated(note = "use on_rx_ack_range_dropped event instead")]

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -546,7 +546,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         // We perform decryption prior to checking for duplicate to avoid short-circuiting
         // and maintain constant-time operation.
         if self.is_duplicate(packet_number, path_id, path, publisher) {
-            return Err(ProcessingError::DuplicatePacket);
+            return Err(ProcessingError::Other);
         }
 
         if decrypted.is_ok() {

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -387,7 +387,7 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
             })?;
 
         if self.is_duplicate(packet.packet_number, path_id, path, publisher) {
-            return Err(ProcessingError::DuplicatePacket);
+            return Err(ProcessingError::Other);
         }
 
         let packet_header =

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -426,7 +426,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
             })?;
 
         if self.is_duplicate(packet.packet_number, path_id, path, publisher) {
-            return Err(ProcessingError::DuplicatePacket);
+            return Err(ProcessingError::Other);
         }
 
         let packet_header =
@@ -452,7 +452,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
                     path: path_event!(path, path_id),
                 },
             });
-            return Err(ProcessingError::NonEmptyRetryToken);
+            return Err(ProcessingError::Other);
         }
 
         Ok(decrypted)

--- a/quic/s2n-quic/src/tests/pto.rs
+++ b/quic/s2n-quic/src/tests/pto.rs
@@ -24,6 +24,7 @@ fn handshake_pto_timer_is_armed() {
             .with_io(handle.builder().build()?)?
             .with_tls(SERVER_CERTS)?
             .with_packet_interceptor(DropHandshakeTx)?
+            .with_event(events())?
             .start()?;
 
         let addr = server.local_addr()?;
@@ -36,7 +37,7 @@ fn handshake_pto_timer_is_armed() {
         let client = Client::builder()
             .with_io(handle.builder().build().unwrap())?
             .with_tls(certificates::CERT_PEM)?
-            .with_event((pto_subscriber, packet_sent_subscriber))?
+            .with_event(((events(), pto_subscriber), packet_sent_subscriber))?
             .start()?;
 
         primary::spawn(async move {


### PR DESCRIPTION
### Description of changes: 

The current packet processing code is spread between the endpoint and connection. This makes it a bit tricky to reason about how packets flow through a connection and how they're checked for validity.

This change refactors this processing code by moving more of this logic into the connection, which simplifies the endpoint logic quite a bit.

### Call-outs:

There was a missing check for initial packets being carried in 1200+ byte packets on the server. This could potentially reduce the path reliability for clients that are misconfigured to send smaller initial datagrams.

### Testing:

I added a new test for the initial datagram check showing that the event is emitted. All of the existing integration tests should show no behavior changes in the rest of the packet processing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

