### PR TITLE
fix(s2n-quic-transport): check initial dcid usage

### DIFF
--- a/quic/s2n-quic-core/src/connection/id.rs
+++ b/quic/s2n-quic-core/src/connection/id.rs
@@ -276,6 +276,26 @@ impl TryFrom<LocalId> for InitialId {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Classification {
+    /// The connection ID was chosen by the client
+    Initial,
+    /// The connection ID was chosen by the local endpoint
+    Local,
+}
+
+impl Classification {
+    #[inline]
+    pub fn is_initial(&self) -> bool {
+        matches!(self, Self::Initial)
+    }
+
+    #[inline]
+    pub fn is_local(&self) -> bool {
+        matches!(self, Self::Local)
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub enum Error {
     InvalidLength,

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -228,6 +228,24 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
+    pub enum PacketType {
+        #[non_exhaustive]
+        Initial {},
+        #[non_exhaustive]
+        Handshake {},
+        #[non_exhaustive]
+        ZeroRtt {},
+        #[non_exhaustive]
+        OneRtt {},
+        #[non_exhaustive]
+        Retry {},
+        #[non_exhaustive]
+        VersionNegotiation {},
+        #[non_exhaustive]
+        StatelessReset {},
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
     pub enum KeyType {
         #[non_exhaustive]
         Initial {},
@@ -365,6 +383,13 @@ pub mod api {
         #[non_exhaustive]
         #[doc = " The received Initial packet was not transported in a datagram of at least 1200 bytes"]
         UndersizedInitialPacket { path: Path<'a> },
+        #[non_exhaustive]
+        #[doc = " The destination connection ID in the packet was the initial connection ID but was in"]
+        #[doc = " a non-initial packet."]
+        InitialConnectionIdInvalidSpace {
+            path: Path<'a>,
+            packet_type: PacketType,
+        },
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
@@ -2817,6 +2842,31 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
+    pub enum PacketType {
+        Initial,
+        Handshake,
+        ZeroRtt,
+        OneRtt,
+        Retry,
+        VersionNegotiation,
+        StatelessReset,
+    }
+    impl IntoEvent<api::PacketType> for PacketType {
+        #[inline]
+        fn into_event(self) -> api::PacketType {
+            use api::PacketType::*;
+            match self {
+                Self::Initial => Initial {},
+                Self::Handshake => Handshake {},
+                Self::ZeroRtt => ZeroRtt {},
+                Self::OneRtt => OneRtt {},
+                Self::Retry => Retry {},
+                Self::VersionNegotiation => VersionNegotiation {},
+                Self::StatelessReset => StatelessReset {},
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
     pub enum KeyType {
         Initial,
         Handshake,
@@ -2986,6 +3036,12 @@ pub mod builder {
         },
         #[doc = " The received Initial packet was not transported in a datagram of at least 1200 bytes"]
         UndersizedInitialPacket { path: Path<'a> },
+        #[doc = " The destination connection ID in the packet was the initial connection ID but was in"]
+        #[doc = " a non-initial packet."]
+        InitialConnectionIdInvalidSpace {
+            path: Path<'a>,
+            packet_type: PacketType,
+        },
     }
     impl<'a> IntoEvent<api::PacketDropReason<'a>> for PacketDropReason<'a> {
         #[inline]
@@ -3030,6 +3086,12 @@ pub mod builder {
                 Self::UndersizedInitialPacket { path } => UndersizedInitialPacket {
                     path: path.into_event(),
                 },
+                Self::InitialConnectionIdInvalidSpace { path, packet_type } => {
+                    InitialConnectionIdInvalidSpace {
+                        path: path.into_event(),
+                        packet_type: packet_type.into_event(),
+                    }
+                }
             }
         }
     }

--- a/quic/s2n-quic-core/src/inet/datagram.rs
+++ b/quic/s2n-quic-core/src/inet/datagram.rs
@@ -19,6 +19,7 @@ pub struct DatagramInfo {
     pub payload_len: usize,
     pub ecn: ExplicitCongestionNotification,
     pub destination_connection_id: connection::LocalId,
+    pub destination_connection_id_classification: connection::id::Classification,
     pub source_connection_id: Option<connection::PeerId>,
 }
 

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -620,6 +620,16 @@ impl builder::PacketHeader {
     }
 }
 
+enum PacketType {
+    Initial,
+    Handshake,
+    ZeroRtt,
+    OneRtt,
+    Retry,
+    VersionNegotiation,
+    StatelessReset,
+}
+
 enum KeyType {
     Initial,
     Handshake,
@@ -756,6 +766,12 @@ enum PacketDropReason<'a> {
     },
     /// The received Initial packet was not transported in a datagram of at least 1200 bytes
     UndersizedInitialPacket { path: Path<'a> },
+    /// The destination connection ID in the packet was the initial connection ID but was in
+    /// a non-initial packet.
+    InitialConnectionIdInvalidSpace {
+        path: Path<'a>,
+        packet_type: PacketType,
+    },
 }
 
 #[deprecated(note = "use on_rx_ack_range_dropped event instead")]

--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -430,6 +430,7 @@ mod tests {
             payload_len: 1200,
             timestamp: NoopClock {}.get_time(),
             destination_connection_id: connection::LocalId::TEST_ID,
+            destination_connection_id_classification: connection::id::Classification::Local,
             source_connection_id: None,
         };
         let mut processed_packet = ProcessedPacket::new(pn, &datagram);
@@ -531,6 +532,7 @@ mod tests {
             payload_len: 1200,
             timestamp: NoopClock {}.get_time(),
             destination_connection_id: connection::LocalId::TEST_ID,
+            destination_connection_id_classification: connection::id::Classification::Local,
             source_connection_id: None,
         }
     }

--- a/quic/s2n-quic-transport/src/ack/tests/endpoint.rs
+++ b/quic/s2n-quic-transport/src/ack/tests/endpoint.rs
@@ -56,6 +56,7 @@ impl Endpoint {
             payload_len: 1200,
             timestamp: self.env.current_time,
             destination_connection_id: connection::LocalId::TEST_ID,
+            destination_connection_id_classification: connection::id::Classification::Local,
             source_connection_id: None,
         };
 

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1335,6 +1335,17 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         //# receiving a server response, so servers SHOULD ignore any such
         //# packets.
 
+        //= https://www.rfc-editor.org/rfc/rfc9000#section-21.2
+        //# Except for Initial and Stateless Resets, an endpoint only accepts
+        //# packets that include a Destination Connection ID field that matches
+        //# a value the endpoint previously chose.
+        if datagram
+            .destination_connection_id_classification
+            .is_initial()
+        {
+            return Err(ProcessingError::Other);
+        }
+
         if let Some((space, handshake_status)) = self.space_manager.handshake_mut() {
             let mut publisher = self.event_context.publisher(datagram.timestamp, subscriber);
 
@@ -1448,6 +1459,17 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             return Ok(());
         }
 
+        //= https://www.rfc-editor.org/rfc/rfc9000#section-21.2
+        //# Except for Initial and Stateless Resets, an endpoint only accepts
+        //# packets that include a Destination Connection ID field that matches
+        //# a value the endpoint previously chose.
+        if datagram
+            .destination_connection_id_classification
+            .is_initial()
+        {
+            return Err(ProcessingError::Other);
+        }
+
         if let Some((space, handshake_status)) = self.space_manager.application_mut() {
             let packet = space.validate_and_decrypt_packet(
                 packet,
@@ -1531,6 +1553,17 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         //= tracking-issue=349
         //# A client MUST discard a Version Negotiation packet that
         //# lists the QUIC version selected by the client.
+
+        //= https://www.rfc-editor.org/rfc/rfc9000#section-21.2
+        //# Except for Initial and Stateless Resets, an endpoint only accepts
+        //# packets that include a Destination Connection ID field that matches
+        //# a value the endpoint previously chose.
+        if datagram
+            .destination_connection_id_classification
+            .is_initial()
+        {
+            return Err(ProcessingError::Other);
+        }
 
         Ok(())
     }

--- a/quic/s2n-quic-transport/src/connection/local_id_registry/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/local_id_registry/tests.rs
@@ -175,7 +175,10 @@ fn connection_mapper_test() {
             .unwrap()
             .retirement_time
     );
-    assert_eq!(Some(id1), mapper.lookup_internal_connection_id(&ext_id_1));
+    assert_eq!(
+        Some((id1, connection::id::Classification::Local,)),
+        mapper.lookup_internal_connection_id(&ext_id_1)
+    );
     assert_eq!(
         TEST_TOKEN_1,
         reg1.get_connection_id_info(&ext_id_1)
@@ -202,15 +205,27 @@ fn connection_mapper_test() {
     assert!(reg2
         .register_connection_id(&ext_id_4, None, TEST_TOKEN_4)
         .is_ok());
-    assert_eq!(Some(id1), mapper.lookup_internal_connection_id(&ext_id_2));
-    assert_eq!(Some(id2), mapper.lookup_internal_connection_id(&ext_id_3));
-    assert_eq!(Some(id2), mapper.lookup_internal_connection_id(&ext_id_4));
+    assert_eq!(
+        Some((id1, connection::id::Classification::Local,)),
+        mapper.lookup_internal_connection_id(&ext_id_2)
+    );
+    assert_eq!(
+        Some((id2, connection::id::Classification::Local,)),
+        mapper.lookup_internal_connection_id(&ext_id_3)
+    );
+    assert_eq!(
+        Some((id2, connection::id::Classification::Local,)),
+        mapper.lookup_internal_connection_id(&ext_id_4)
+    );
 
     // Unregister id 3 (sequence number 0)
     reg2.get_connection_id_info_mut(&ext_id_3).unwrap().status = PendingRemoval(now);
     reg2.unregister_expired_ids(now);
     assert_eq!(None, mapper.lookup_internal_connection_id(&ext_id_3));
-    assert_eq!(Some(id2), mapper.lookup_internal_connection_id(&ext_id_4));
+    assert_eq!(
+        Some((id2, connection::id::Classification::Local,)),
+        mapper.lookup_internal_connection_id(&ext_id_4)
+    );
 
     reg2.get_connection_id_info_mut(&ext_id_4).unwrap().status =
         PendingRetirementConfirmation(Some(now));
@@ -224,15 +239,24 @@ fn connection_mapper_test() {
     assert!(reg2
         .register_connection_id(&ext_id_4, None, TEST_TOKEN_4)
         .is_ok());
-    assert_eq!(Some(id1), mapper.lookup_internal_connection_id(&ext_id_3));
-    assert_eq!(Some(id2), mapper.lookup_internal_connection_id(&ext_id_4));
+    assert_eq!(
+        Some((id1, connection::id::Classification::Local,)),
+        mapper.lookup_internal_connection_id(&ext_id_3)
+    );
+    assert_eq!(
+        Some((id2, connection::id::Classification::Local,)),
+        mapper.lookup_internal_connection_id(&ext_id_4)
+    );
 
     // If a registration is dropped all entries are removed
     drop(reg1);
     assert_eq!(None, mapper.lookup_internal_connection_id(&ext_id_1));
     assert_eq!(None, mapper.lookup_internal_connection_id(&ext_id_2));
     assert_eq!(None, mapper.lookup_internal_connection_id(&ext_id_3));
-    assert_eq!(Some(id2), mapper.lookup_internal_connection_id(&ext_id_4));
+    assert_eq!(
+        Some((id2, connection::id::Classification::Local,)),
+        mapper.lookup_internal_connection_id(&ext_id_4)
+    );
 }
 
 #[test]

--- a/quic/s2n-quic-transport/src/endpoint/version.rs
+++ b/quic/s2n-quic-transport/src/endpoint/version.rs
@@ -339,6 +339,7 @@ mod tests {
                 payload_len,
                 ecn: Default::default(),
                 destination_connection_id: connection::LocalId::TEST_ID,
+                destination_connection_id_classification: connection::id::Classification::Local,
                 source_connection_id: None,
             },
         )

--- a/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
@@ -161,6 +161,7 @@ impl Model {
             payload_len: payload_len as usize,
             ecn: ExplicitCongestionNotification::NotEct,
             destination_connection_id: local_id,
+            destination_connection_id_classification: connection::id::Classification::Local,
             source_connection_id: None,
         };
         let mut migration_validator = path::migration::allow_all::Validator;

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -710,6 +710,7 @@ fn test_adding_new_path() {
         payload_len: 0,
         ecn: ExplicitCongestionNotification::default(),
         destination_connection_id: connection::LocalId::TEST_ID,
+        destination_connection_id_classification: connection::id::Classification::Local,
         source_connection_id: None,
     };
     let (path_id, unblocked) = manager
@@ -769,6 +770,7 @@ fn do_not_add_new_path_if_handshake_not_confirmed() {
         payload_len: 0,
         ecn: ExplicitCongestionNotification::default(),
         destination_connection_id: connection::LocalId::TEST_ID,
+        destination_connection_id_classification: connection::id::Classification::Local,
         source_connection_id: None,
     };
     let handshake_confirmed = false;
@@ -830,6 +832,7 @@ fn do_not_add_new_path_if_client() {
         payload_len: 0,
         ecn: ExplicitCongestionNotification::default(),
         destination_connection_id: connection::LocalId::TEST_ID,
+        destination_connection_id_classification: connection::id::Classification::Local,
         source_connection_id: None,
     };
     let on_datagram_result = manager.on_datagram_received(
@@ -919,6 +922,7 @@ fn limit_number_of_connection_migrations() {
             payload_len: 0,
             ecn: ExplicitCongestionNotification::default(),
             destination_connection_id: connection::LocalId::TEST_ID,
+            destination_connection_id_classification: connection::id::Classification::Local,
             source_connection_id: None,
         };
 
@@ -975,6 +979,7 @@ fn connection_migration_challenge_behavior() {
         payload_len: 0,
         ecn: ExplicitCongestionNotification::default(),
         destination_connection_id: connection::LocalId::TEST_ID,
+        destination_connection_id_classification: connection::id::Classification::Local,
         source_connection_id: None,
     };
 
@@ -1068,6 +1073,7 @@ fn connection_migration_use_max_ack_delay_from_active_path() {
         payload_len: 0,
         ecn: ExplicitCongestionNotification::default(),
         destination_connection_id: connection::LocalId::TEST_ID,
+        destination_connection_id_classification: connection::id::Classification::Local,
         source_connection_id: None,
     };
 
@@ -1146,6 +1152,7 @@ fn connection_migration_new_path_abandon_timer() {
         payload_len: 0,
         ecn: ExplicitCongestionNotification::default(),
         destination_connection_id: connection::LocalId::TEST_ID,
+        destination_connection_id_classification: connection::id::Classification::Local,
         source_connection_id: None,
     };
 
@@ -1397,6 +1404,7 @@ fn temporary_until_authenticated() {
         payload_len: 0,
         ecn: ExplicitCongestionNotification::default(),
         destination_connection_id: connection::LocalId::TEST_ID,
+        destination_connection_id_classification: connection::id::Classification::Local,
         source_connection_id: None,
     };
 

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -3167,6 +3167,7 @@ fn helper_ack_packets_on_path(
         payload_len: 0,
         ecn: Default::default(),
         destination_connection_id: connection::LocalId::TEST_ID,
+        destination_connection_id_classification: connection::id::Classification::Local,
         source_connection_id: None,
     };
 
@@ -3452,6 +3453,7 @@ fn helper_generate_multi_path_manager(
             payload_len: 0,
             ecn: ExplicitCongestionNotification::default(),
             destination_connection_id: connection::LocalId::TEST_ID,
+            destination_connection_id_classification: connection::id::Classification::Local,
             source_connection_id: None,
         };
         let _ = path_manager


### PR DESCRIPTION
### Description of changes: 

The RFC mentions that IDCIDs should only be used in Initial and Stateless Resets.

https://www.rfc-editor.org/rfc/rfc9000#section-21.2
> Except for Initial and Stateless Resets, an endpoint only accepts packets that include a Destination Connection ID field that matches a value the endpoint previously chose.

While it's not a MUST, SHOULD, or even a MAY, it's still good to enforce. Note that this really doesn't do much to prevent a Handshake Denial of Service, since the packets that we check are using cryptographic secrets only the peers know (i.e. Handshake, Application).

### Testing:

I was able to test that this check works correctly by modifying our client to ignore the server's chosen DCID in a self-talk test. However, I'm not sure if we can easily test this with the current testing framework.

In the coming weeks, I will likely be refactoring a lot of the packet processing code to decouple it from the endpoint and connection structs. During that time, I will be setting up a better test environment for unit testing these kinds of checks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

