### PR TITLE
feat(s2n-quic-transport): support exporting from TLS sessions

### DIFF
--- a/examples/resumption/Cargo.toml
+++ b/examples/resumption/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 
 [dependencies]
 s2n-quic = { version = "1", path = "../../quic/s2n-quic", features = ["provider-tls-s2n", "unstable_resumption"]}
-s2n-tls = { version = "=0.0.36", features = ["quic"] }
+s2n-tls = { version = "=0.0.39", features = ["quic"] }
 tokio = { version = "1", features = ["full"] }

--- a/netbench/netbench-driver/Cargo.toml
+++ b/netbench/netbench-driver/Cargo.toml
@@ -16,8 +16,8 @@ netbench = { version = "0.1", path = "../netbench" }
 probe = "0.5"
 s2n-quic = { path = "../../quic/s2n-quic", features = ["provider-tls-s2n"] }
 s2n-quic-core = { path = "../../quic/s2n-quic-core", features = ["testing"] }
-s2n-tls = { version = "0.0.36" }
-s2n-tls-tokio = { version = "0.0.36" }
+s2n-tls = { version = "0.0.39" }
+s2n-tls-tokio = { version = "0.0.39" }
 structopt = "0.3"
 tokio = { version = "1", features = ["io-util", "net", "time", "rt-multi-thread"] }
 tokio-native-tls = "0.3"

--- a/quic/s2n-quic-core/src/crypto/tls/testing.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/testing.rs
@@ -716,6 +716,13 @@ where
         Ok(())
     }
 
+    fn on_tls_exporter_ready(
+        &mut self,
+        _: &impl super::TlsSession,
+    ) -> Result<(), crate::transport::Error> {
+        Ok(())
+    }
+
     fn receive_initial(&mut self, max_len: Option<usize>) -> Option<Bytes> {
         self.log("rx initial");
         self.initial.rx(max_len)

--- a/quic/s2n-quic-core/src/event.rs
+++ b/quic/s2n-quic-core/src/event.rs
@@ -127,3 +127,37 @@ impl IntoEvent<Timestamp> for crate::time::Timestamp {
         Timestamp(self)
     }
 }
+
+#[derive(Clone)]
+pub struct TlsSession<'a> {
+    session: &'a dyn crate::crypto::tls::TlsSession,
+}
+
+impl<'a> TlsSession<'a> {
+    #[doc(hidden)]
+    pub fn new(session: &'a dyn crate::crypto::tls::TlsSession) -> TlsSession<'a> {
+        TlsSession { session }
+    }
+
+    pub fn tls_exporter(
+        &self,
+        label: &[u8],
+        context: &[u8],
+        output: &mut [u8],
+    ) -> Result<(), crate::crypto::tls::TlsExportError> {
+        self.session.tls_exporter(label, context, output)
+    }
+}
+
+impl<'a> crate::event::IntoEvent<TlsSession<'a>> for TlsSession<'a> {
+    #[inline]
+    fn into_event(self) -> Self {
+        self
+    }
+}
+
+impl core::fmt::Debug for TlsSession<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("TlsSession").finish_non_exhaustive()
+    }
+}

--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -258,6 +258,11 @@ struct HandshakeStatusUpdated {
     status: HandshakeStatus,
 }
 
+#[event("connectivity:tls_exporter_ready")]
+struct TlsExporterReady<'a> {
+    session: crate::event::TlsSession<'a>,
+}
+
 #[event("connectivity:path_challenge_updated")]
 /// Path challenge updated
 struct PathChallengeUpdated<'a> {

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -21,7 +21,7 @@ libc = "0.2"
 s2n-codec = { version = "=0.7.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.28.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
 s2n-quic-crypto = { version = "=0.29.0", path = "../s2n-quic-crypto", default-features = false }
-s2n-tls = { version = "=0.0.36", features = ["quic"] }
+s2n-tls = { version = "=0.0.39", features = ["quic"] }
 
 [dev-dependencies]
 checkers = "0.6"

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -457,6 +457,17 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
         Ok(())
     }
 
+    fn on_tls_exporter_ready(
+        &mut self,
+        session: &impl tls::TlsSession,
+    ) -> Result<(), transport::Error> {
+        self.publisher
+            .on_tls_exporter_ready(event::builder::TlsExporterReady {
+                session: s2n_quic_core::event::TlsSession::new(session),
+            });
+        Ok(())
+    }
+
     fn on_handshake_complete(&mut self) -> Result<(), transport::Error> {
         // After the handshake is complete, the handshake crypto stream should be completely
         // finished

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -46,6 +46,7 @@ mod client_handshake_confirm;
 #[cfg(not(target_os = "windows"))]
 mod mtls;
 
+mod exporter;
 mod issue_1361;
 mod issue_1427;
 mod issue_1464;

--- a/quic/s2n-quic/src/tests/exporter.rs
+++ b/quic/s2n-quic/src/tests/exporter.rs
@@ -1,0 +1,120 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module shows an example of an event provider that exports a symmetric key from an s2n-quic
+//! connection on both client and server.
+
+use super::*;
+use crate::provider::event::events::{self, ConnectionInfo, ConnectionMeta, Subscriber};
+
+struct Exporter;
+
+#[derive(Default)]
+struct ExporterContext {
+    key: Option<[u8; 32]>,
+}
+
+impl Subscriber for Exporter {
+    type ConnectionContext = ExporterContext;
+
+    #[inline]
+    fn create_connection_context(
+        &mut self,
+        _: &ConnectionMeta,
+        _info: &ConnectionInfo,
+    ) -> Self::ConnectionContext {
+        ExporterContext::default()
+    }
+
+    fn on_tls_exporter_ready(
+        &mut self,
+        context: &mut Self::ConnectionContext,
+        _meta: &ConnectionMeta,
+        event: &events::TlsExporterReady,
+    ) {
+        let mut key = [0; 32];
+        event
+            .session
+            .tls_exporter(b"EXPERIMENTAL EXPORTER s2n-quic", b"some context", &mut key)
+            .unwrap();
+        context.key = Some(key);
+    }
+}
+
+fn start_server(mut server: Server) -> crate::provider::io::testing::Result<SocketAddr> {
+    let server_addr = server.local_addr()?;
+
+    // accept connections and echo back
+    spawn(async move {
+        while let Some(mut connection) = server.accept().await {
+            let key = connection
+                .query_event_context(|ctx: &ExporterContext| ctx.key.unwrap())
+                .unwrap();
+
+            tracing::debug!("accepted server connection: {}", connection.id());
+            spawn(async move {
+                while let Ok(Some(mut stream)) = connection.accept_bidirectional_stream().await {
+                    tracing::debug!("accepted server stream: {}", stream.id());
+                    spawn(async move {
+                        stream.send(Bytes::from(key.to_vec())).await.unwrap();
+                    });
+                }
+            });
+        }
+    });
+
+    Ok(server_addr)
+}
+
+fn tls_test<C>(f: fn(crate::Connection) -> C)
+where
+    C: 'static + core::future::Future<Output = ()> + Send,
+{
+    let model = Model::default();
+    model.set_delay(Duration::from_millis(50));
+
+    test(model, |handle| {
+        let server = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(SERVER_CERTS)?
+            .with_event((Exporter, tracing_events()))?
+            .start()?;
+
+        let addr = start_server(server)?;
+
+        let client = Client::builder()
+            .with_io(handle.builder().build().unwrap())?
+            .with_tls(certificates::CERT_PEM)?
+            .with_event((Exporter, tracing_events()))?
+            .start()?;
+
+        // show it working for several connections
+        for _ in 0..10 {
+            let client = client.clone();
+            primary::spawn(async move {
+                let connect = Connect::new(addr).with_server_name("localhost");
+                let conn = client.connect(connect).await.unwrap();
+                f(conn).await;
+            });
+        }
+
+        Ok(addr)
+    })
+    .unwrap();
+}
+
+#[test]
+fn happy_case() {
+    tls_test(|mut conn| async move {
+        let client_key = conn
+            .query_event_context(|ctx: &ExporterContext| ctx.key.unwrap())
+            .unwrap();
+
+        let mut stream = conn.open_bidirectional_stream().await.unwrap();
+
+        let server_key = stream.receive().await.unwrap().unwrap();
+
+        // Both the server and the client are expected to derive the same key.
+        assert_eq!(client_key, &server_key[..]);
+    });
+}


### PR DESCRIPTION
### Description of changes: 

This adds support for exporting symmetric keys from the negotiated QUIC connection for use by other applications/protocols. See https://datatracker.ietf.org/doc/html/rfc5705 for some further details.

See s2n-tls upstream (https://github.com/aws/s2n-tls/pull/4230), released as part of s2n-tls 0.0.39 on crate.io. rustls already supports the relevant [API](https://docs.rs/rustls/latest/rustls/struct.ConnectionCommon.html#method.export_keying_material).

### Call-outs:

The event API is somewhat novel as added here, but should be relatively extensible and works out ok.

### Testing:

New test added.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

