### PR TITLE
feat(s2n-quic-transport): add mitigation for optimistic ack attack

### DIFF
--- a/quic/s2n-quic-core/src/ct.rs
+++ b/quic/s2n-quic-core/src/ct.rs
@@ -22,8 +22,6 @@ impl<T> Number<T> {
         self.0.is_some()
     }
 
-    // See https://github.com/rust-lang/rust-clippy/issues/11390
-    #[allow(clippy::unwrap_or_default)]
     pub fn unwrap_or_default(&self) -> T
     where
         T: ConditionallySelectable + Default,

--- a/quic/s2n-quic-core/src/ct.rs
+++ b/quic/s2n-quic-core/src/ct.rs
@@ -28,7 +28,7 @@ impl<T> Number<T> {
     where
         T: ConditionallySelectable + Default,
     {
-        self.0.unwrap_or_else(Default::default)
+        self.0.unwrap_or_else(T::default)
     }
 
     pub fn and_then<U, F, C>(self, f: F) -> Number<U>

--- a/quic/s2n-quic-core/src/ct.rs
+++ b/quic/s2n-quic-core/src/ct.rs
@@ -22,11 +22,13 @@ impl<T> Number<T> {
         self.0.is_some()
     }
 
+    // See https://github.com/rust-lang/rust-clippy/issues/11390
+    #[allow(clippy::unwrap_or_default)]
     pub fn unwrap_or_default(&self) -> T
     where
         T: ConditionallySelectable + Default,
     {
-        self.0.unwrap_or_else(T::default)
+        self.0.unwrap_or_else(Default::default)
     }
 
     pub fn and_then<U, F, C>(self, f: F) -> Number<U>

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -728,6 +728,22 @@ enum KeySpace {
     OneRtt {},
 }
 
+enum PacketSkipReason {
+    //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.4
+    //# If the sender wants to elicit a faster acknowledgement on PTO, it can
+    //# skip a packet number to eliminate the acknowledgment delay.
+    /// Skipped a packet number to elicit a quicker PTO acknowledgment
+    PtoProbe {},
+
+    //= https://www.rfc-editor.org/rfc/rfc9000#section-21.4
+    //# An endpoint that acknowledges packets it has not received might cause
+    //# a congestion controller to permit sending at rates beyond what the
+    //# network supports.  An endpoint MAY skip packet numbers when sending
+    //# packets to detect this behavior.
+    /// Skipped a packet number to detect an Optimistic Ack attack
+    OptimisticAckMitigation {},
+}
+
 enum PacketDropReason<'a> {
     /// A connection error occurred and is no longer able to process packets.
     ConnectionError { path: Path<'a> },

--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -16,6 +16,14 @@ struct ServerNameInformation<'a> {
     chosen_server_name: &'a str,
 }
 
+#[event("transport:packet_skipped")]
+/// Packet was skipped with a given reason
+struct PacketSkipped {
+    number: u64,
+    space: KeySpace,
+    reason: PacketSkipReason,
+}
+
 #[event("transport:packet_sent")]
 //= https://tools.ietf.org/id/draft-marx-qlog-event-definitions-quic-h3-02#5.3.5
 /// Packet was sent by a connection

--- a/quic/s2n-quic-platform/src/socket/task/rx.rs
+++ b/quic/s2n-quic-platform/src/socket/task/rx.rs
@@ -44,7 +44,7 @@ where
             ring,
             rx,
             ring_cooldown: cooldown.clone(),
-            io_cooldown: cooldown.clone(),
+            io_cooldown: cooldown,
         }
     }
 

--- a/quic/s2n-quic-platform/src/socket/task/tx.rs
+++ b/quic/s2n-quic-platform/src/socket/task/tx.rs
@@ -47,7 +47,7 @@ where
             tx,
             events: Events::new(gso),
             ring_cooldown: cooldown.clone(),
-            io_cooldown: cooldown.clone(),
+            io_cooldown: cooldown,
         }
     }
 

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -1155,7 +1155,7 @@ pub trait Context<Config: endpoint::Config> {
         &mut self,
         timestamp: Timestamp,
         packet_number_range: &PacketNumberRange,
-        lowest_tracking_pn: PacketNumber,
+        lowest_tracking_packet_number: PacketNumber,
     ) -> Result<(), transport::Error>;
 
     fn on_new_packet_ack<Pub: event::ConnectionPublisher>(

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -517,7 +517,11 @@ impl<Config: endpoint::Config> Manager<Config> {
                 ack_range: pn_range.into_event(),
             });
 
-            context.validate_packet_ack(timestamp, &pn_range)?;
+            context.validate_packet_ack(
+                timestamp,
+                &pn_range,
+                self.sent_packets.get_range().start(),
+            )?;
             // notify components of packets acked
             context.on_packet_ack(timestamp, &pn_range);
 
@@ -1151,6 +1155,7 @@ pub trait Context<Config: endpoint::Config> {
         &mut self,
         timestamp: Timestamp,
         packet_number_range: &PacketNumberRange,
+        lowest_tracking_pn: PacketNumber,
     ) -> Result<(), transport::Error>;
 
     fn on_new_packet_ack<Pub: event::ConnectionPublisher>(

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -3628,7 +3628,7 @@ impl<'a, Config: endpoint::Config> recovery::Context<Config> for MockContext<'a,
         &mut self,
         _timestamp: Timestamp,
         _packet_number_range: &PacketNumberRange,
-        _lowest_pending_ack: PacketNumber,
+        _lowest_tracking_packet_number: PacketNumber,
     ) -> Result<(), transport::Error> {
         self.validate_packet_ack_count += 1;
         Ok(())

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -3628,6 +3628,7 @@ impl<'a, Config: endpoint::Config> recovery::Context<Config> for MockContext<'a,
         &mut self,
         _timestamp: Timestamp,
         _packet_number_range: &PacketNumberRange,
+        _lowest_pending_ack: PacketNumber,
     ) -> Result<(), transport::Error> {
         self.validate_packet_ack_count += 1;
         Ok(())

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -43,7 +43,6 @@ use s2n_quic_core::{
     time::{timer, Timestamp},
     transport,
 };
-use std::ops::SubAssign;
 
 // Ensure there is a gap between skipped packet numbers
 const MIN_SKIP_COUNTER_VALUE: u32 = MAX_BURST_PACKETS * 3;
@@ -299,7 +298,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
 
         // Decrement the skip_counter on each transmit
         if let Some(skip_counter) = &mut self.skip_counter {
-            skip_counter.sub_assign(1_u32);
+            *skip_counter -= 1_u32;
         }
 
         context

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -8,6 +8,7 @@ use crate::{
     path::{path_event, Path},
     processed_packet::ProcessedPacket,
     recovery,
+    recovery::CongestionController,
     space::{
         datagram, keep_alive::KeepAlive, CryptoStream, HandshakeStatus, PacketSpace,
         TxPacketNumbers,
@@ -21,6 +22,7 @@ use core::{convert::TryInto, fmt, marker::PhantomData};
 use once_cell::sync::OnceCell;
 use s2n_codec::EncoderBuffer;
 use s2n_quic_core::{
+    counter::{Counter, Saturating},
     crypto::{application::KeySet, limited, tls, CryptoSuite},
     event::{self, ConnectionPublisher as _, IntoEvent},
     frame::{
@@ -36,9 +38,15 @@ use s2n_quic_core::{
         short::{CleartextShort, ProtectedShort, Short, SpinBit},
     },
     path::MaxMtu,
+    random::Generator,
+    recovery::MAX_BURST_PACKETS,
     time::{timer, Timestamp},
     transport,
 };
+use std::ops::SubAssign;
+
+// Ensure there is a gap between skipped packet numbers
+const MIN_SKIP_COUNTER_VALUE: u32 = MAX_BURST_PACKETS * 3;
 
 pub struct ApplicationSpace<Config: endpoint::Config> {
     /// Transmission Packet numbers
@@ -68,6 +76,8 @@ pub struct ApplicationSpace<Config: endpoint::Config> {
     processed_packet_numbers: SlidingWindow,
     recovery_manager: recovery::Manager<Config>,
     pub datagram_manager: datagram::Manager<Config>,
+    /// Counter used for detecting an Optimistic Ack attack
+    skip_counter: Option<Counter<u32, Saturating>>,
 }
 
 impl<Config: endpoint::Config> fmt::Debug for ApplicationSpace<Config> {
@@ -110,6 +120,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
             processed_packet_numbers: SlidingWindow::default(),
             recovery_manager: recovery::Manager::new(PacketNumberSpace::ApplicationData),
             datagram_manager,
+            skip_counter: None,
         }
     }
 
@@ -147,7 +158,13 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
     ) -> Result<(transmission::Outcome, EncoderBuffer<'a>), PacketEncodingError<'a>> {
         let mut packet_number = self.tx_packet_numbers.next();
 
+        // This function can return early and not transmit a packet for various reasons
+        // enumerated in PacketEncodingError. Record the intent to skip (de-duping, if
+        // necessary) and record only if a packet is transmitted.
+        let mut skipped_pn = SkippedPacketNumber::default();
+
         if self.recovery_manager.requires_probe() {
+            skipped_pn.pto = Some(packet_number);
             //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.4
             //# If the sender wants to elicit a faster acknowledgement on PTO, it can
             //# skip a packet number to eliminate the acknowledgment delay.
@@ -157,12 +174,32 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
             packet_number = packet_number.next().unwrap();
         }
 
-        let packet_number_encoder = self.packet_number_encoder();
+        if let Some(skip_counter) = &mut self.skip_counter {
+            if *skip_counter == 0 && self.tx_packet_numbers.generate_new_skip_pn() {
+                //= https://www.rfc-editor.org/rfc/rfc9000#section-21.4
+                //# An endpoint that acknowledges packets it has not received might cause
+                //# a congestion controller to permit sending at rates beyond what the
+                //# network supports.  An endpoint MAY skip packet numbers when sending
+                //# packets to detect this behavior.  An endpoint can then immediately
+                //# close the connection with a connection error of type PROTOCOL_VIOLATION
+                //
+                // TODO Does this interact negatively with persistent congestion detection, which
+                //      relies on consecutive packet numbers?
 
+                // dont skip an additional packet if already skipping a packet for PTO probing
+                if let Some(skip_pn) = skipped_pn.pto {
+                    skipped_pn.opt_ack = Some(skip_pn);
+                } else {
+                    skipped_pn.opt_ack = Some(packet_number);
+                    packet_number = packet_number.next().unwrap();
+                }
+            }
+        }
+
+        let packet_number_encoder = self.packet_number_encoder();
         let mut outcome = transmission::Outcome::default();
 
         let destination_connection_id = context.path().peer_connection_id;
-        let timestamp = context.timestamp;
         let transmission_mode = context.transmission_mode;
         let min_packet_len = context.min_packet_len;
         let bytes_progressed = self.stream_manager.outgoing_bytes_progressed();
@@ -184,7 +221,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
                 &mut self.crypto_stream,
                 &mut self.datagram_manager,
             ),
-            timestamp,
+            timestamp: context.timestamp,
             transmission_constraint,
             transmission_mode,
             tx_packet_numbers: &mut self.tx_packet_numbers,
@@ -217,6 +254,25 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         outcome.bytes_progressed +=
             (self.stream_manager.outgoing_bytes_progressed() - bytes_progressed).as_u64() as usize;
 
+        self.on_packet_sent(
+            context,
+            packet_number,
+            outcome,
+            handshake_status,
+            skipped_pn,
+        );
+
+        Ok((outcome, buffer))
+    }
+
+    fn on_packet_sent(
+        &mut self,
+        context: &mut ConnectionTransmissionContext<Config>,
+        packet_number: PacketNumber,
+        outcome: transmission::Outcome,
+        handshake_status: &mut HandshakeStatus,
+        skipped_pn: SkippedPacketNumber,
+    ) {
         let app_limited = self.is_app_limited(context.path(), outcome.bytes_sent);
 
         let (recovery_manager, mut recovery_context) = self.recovery(
@@ -238,7 +294,12 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
 
         // reset the keep alive timer after sending an ack-eliciting packet
         if outcome.ack_elicitation.is_ack_eliciting() {
-            self.keep_alive.reset(timestamp);
+            self.keep_alive.reset(context.timestamp);
+        }
+
+        // Decrement the skip_counter on each transmit
+        if let Some(skip_counter) = &mut self.skip_counter {
+            skip_counter.sub_assign(1_u32);
         }
 
         context
@@ -251,7 +312,36 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
                 packet_len: outcome.bytes_sent,
             });
 
-        Ok((outcome, buffer))
+        if let Some(skip_pn) = skipped_pn.pto {
+            Self::packet_skipped_event(
+                context,
+                skip_pn,
+                event::builder::PacketSkipReason::PtoProbe,
+            );
+        }
+
+        if let Some(skip_pn) = skipped_pn.opt_ack {
+            self.tx_packet_numbers.set_skip_pn(skip_pn);
+            Self::packet_skipped_event(
+                context,
+                skip_pn,
+                event::builder::PacketSkipReason::OptimisticAckMitigation,
+            );
+        }
+    }
+
+    fn packet_skipped_event(
+        context: &mut ConnectionTransmissionContext<Config>,
+        skip_pn: PacketNumber,
+        reason: event::builder::PacketSkipReason,
+    ) {
+        context
+            .publisher
+            .on_packet_skipped(event::builder::PacketSkipped {
+                number: skip_pn.into_event(),
+                space: event::builder::KeySpace::OneRtt,
+                reason,
+            });
     }
 
     pub(super) fn on_transmit_burst_complete(
@@ -389,6 +479,24 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
             publisher,
         );
 
+        match self.skip_counter {
+            Some(skip_counter) if skip_counter == 0 => {
+                if self.tx_packet_numbers.generate_new_skip_pn() {
+                    Self::arm_skip_counter(
+                        &mut self.skip_counter,
+                        path_manager.active_path(),
+                        random_generator,
+                    );
+                }
+            }
+            None => Self::arm_skip_counter(
+                &mut self.skip_counter,
+                path_manager.active_path(),
+                random_generator,
+            ),
+            _ => (),
+        }
+
         self.stream_manager.on_timeout(timestamp);
 
         if self.keep_alive.on_timeout(timestamp).is_ready() {
@@ -399,6 +507,26 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
             // send a ping after timing out
             self.ping();
         }
+    }
+
+    fn arm_skip_counter(
+        skip_counter: &mut Option<Counter<u32, Saturating>>,
+        path: &Path<Config>,
+        random_generator: &mut Config::RandomGenerator,
+    ) {
+        let mut dest = [0; core::mem::size_of::<u32>()];
+        random_generator.public_random_fill(&mut dest);
+        let mut rand = u32::from_le_bytes(dest);
+
+        // bound the random value
+        let pkt_per_cwnd = path.congestion_controller.congestion_window()
+            / path.mtu(transmission::Mode::Normal) as u32;
+        let lower = pkt_per_cwnd / 2;
+        let upper = pkt_per_cwnd.saturating_mul(2);
+        let cardinality = upper - lower + 1;
+        rand = (lower + MIN_SKIP_COUNTER_VALUE).saturating_add(rand % cardinality);
+
+        *skip_counter = Some(Counter::new(rand));
     }
 
     /// Returns `true` if the recovery manager for this packet space requires a probe
@@ -653,9 +781,10 @@ impl<'a, Config: endpoint::Config> recovery::Context<Config> for RecoveryContext
         &mut self,
         timestamp: Timestamp,
         packet_number_range: &PacketNumberRange,
+        lowest_tracking_pn: PacketNumber,
     ) -> Result<(), transport::Error> {
         self.tx_packet_numbers
-            .on_packet_ack(timestamp, packet_number_range)
+            .on_packet_ack(timestamp, packet_number_range, lowest_tracking_pn)
     }
 
     fn on_new_packet_ack<Pub: event::ConnectionPublisher>(
@@ -1012,5 +1141,46 @@ impl<Config: endpoint::Config> PacketSpace<Config> for ApplicationSpace<Config> 
             .expect("packet number was already checked");
 
         Ok(())
+    }
+}
+
+#[derive(Default)]
+struct SkippedPacketNumber {
+    // skipped for PTO probe
+    pto: Option<PacketNumber>,
+    // skipped for Optimistic Ack mitigation
+    opt_ack: Option<PacketNumber>,
+}
+
+#[cfg(any(test, feature = "testing"))]
+mod tests {
+    use super::*;
+    use crate::path::testing::helper_path_server;
+    use s2n_quic_core::random;
+
+    // TODO replace with a bolero test
+    #[test]
+    fn test_arm_skip_counter() {
+        let mut skip_counter = None;
+        let random = &mut random::testing::Generator::default();
+
+        let mut path = helper_path_server();
+        assert_eq!(path.mtu(transmission::Mode::Normal), 1200);
+        let mtu = path.mtu(transmission::Mode::Normal) as u32;
+
+        for cwnd_multiplier in (1..10_000).step_by(300) {
+            for _i in 0..50 {
+                let cwnd = mtu * cwnd_multiplier;
+                path.congestion_controller.congestion_window = cwnd;
+                // calculate the bounds
+                let pkt_per_cwnd = cwnd / mtu;
+                let lower = pkt_per_cwnd / 2;
+                let upper = pkt_per_cwnd * 2;
+                ApplicationSpace::arm_skip_counter(&mut skip_counter, &path, random);
+
+                assert!(lower + MIN_SKIP_COUNTER_VALUE <= *skip_counter.unwrap(),);
+                assert!(*skip_counter.unwrap() <= upper + MIN_SKIP_COUNTER_VALUE,);
+            }
+        }
     }
 }

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -473,10 +473,13 @@ impl<'a, Config: endpoint::Config> recovery::Context<Config> for RecoveryContext
         &mut self,
         timestamp: Timestamp,
         packet_number_range: &PacketNumberRange,
-        lowest_tracking_pn: PacketNumber,
+        lowest_tracking_packet_number: PacketNumber,
     ) -> Result<(), transport::Error> {
-        self.tx_packet_numbers
-            .on_packet_ack(timestamp, packet_number_range, lowest_tracking_pn)
+        self.tx_packet_numbers.on_packet_ack(
+            timestamp,
+            packet_number_range,
+            lowest_tracking_packet_number,
+        )
     }
 
     fn on_new_packet_ack<Pub: event::ConnectionPublisher>(

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -109,6 +109,13 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
         let mut packet_number = self.tx_packet_numbers.next();
 
         if self.recovery_manager.requires_probe() {
+            context
+                .publisher
+                .on_packet_skipped(event::builder::PacketSkipped {
+                    number: packet_number.into_event(),
+                    space: event::builder::KeySpace::Handshake,
+                    reason: event::builder::PacketSkipReason::PtoProbe,
+                });
             //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.4
             //# If the sender wants to elicit a faster acknowledgement on PTO, it can
             //# skip a packet number to eliminate the acknowledgment delay.
@@ -466,9 +473,10 @@ impl<'a, Config: endpoint::Config> recovery::Context<Config> for RecoveryContext
         &mut self,
         timestamp: Timestamp,
         packet_number_range: &PacketNumberRange,
+        lowest_tracking_pn: PacketNumber,
     ) -> Result<(), transport::Error> {
         self.tx_packet_numbers
-            .on_packet_ack(timestamp, packet_number_range)
+            .on_packet_ack(timestamp, packet_number_range, lowest_tracking_pn)
     }
 
     fn on_new_packet_ack<Pub: event::ConnectionPublisher>(

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -597,10 +597,13 @@ impl<'a, Config: endpoint::Config> recovery::Context<Config> for RecoveryContext
         &mut self,
         timestamp: Timestamp,
         packet_number_range: &PacketNumberRange,
-        lowest_tracking_pn: PacketNumber,
+        lowest_tracking_packet_number: PacketNumber,
     ) -> Result<(), transport::Error> {
-        self.tx_packet_numbers
-            .on_packet_ack(timestamp, packet_number_range, lowest_tracking_pn)
+        self.tx_packet_numbers.on_packet_ack(
+            timestamp,
+            packet_number_range,
+            lowest_tracking_packet_number,
+        )
     }
 
     fn on_new_packet_ack<Pub: event::ConnectionPublisher>(

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -157,6 +157,13 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
         let mut packet_number = self.tx_packet_numbers.next();
 
         if self.recovery_manager.requires_probe() {
+            context
+                .publisher
+                .on_packet_skipped(event::builder::PacketSkipped {
+                    number: packet_number.into_event(),
+                    space: event::builder::KeySpace::Initial,
+                    reason: event::builder::PacketSkipReason::PtoProbe,
+                });
             //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.4
             //# If the sender wants to elicit a faster acknowledgement on PTO, it can
             //# skip a packet number to eliminate the acknowledgment delay.
@@ -590,9 +597,10 @@ impl<'a, Config: endpoint::Config> recovery::Context<Config> for RecoveryContext
         &mut self,
         timestamp: Timestamp,
         packet_number_range: &PacketNumberRange,
+        lowest_tracking_pn: PacketNumber,
     ) -> Result<(), transport::Error> {
         self.tx_packet_numbers
-            .on_packet_ack(timestamp, packet_number_range)
+            .on_packet_ack(timestamp, packet_number_range, lowest_tracking_pn)
     }
 
     fn on_new_packet_ack<Pub: event::ConnectionPublisher>(

--- a/quic/s2n-quic-transport/src/space/tx_packet_numbers.rs
+++ b/quic/s2n-quic-transport/src/space/tx_packet_numbers.rs
@@ -75,7 +75,7 @@ impl TxPacketNumbers {
             //
             // For example:
             // Assume we are initially tracking packets 2-9 and have skipped
-            // packet 4 (s). The skip_packet_number + 1 packet is calculated as packet 5 (p).
+            // packet 4. The skip_packet_number + 1 packet is calculated as packet 5 (p).
             // We validate the peer behavior and can clear skip_packet_number once we stop
             // tracking packet 5.
             //
@@ -92,7 +92,7 @@ impl TxPacketNumbers {
             //
             //    RX: AckRange(5)
             //
-            // Verified: peer did not send an ack for (s)
+            // Verified: peer did not send an ack for packet 4
             //    [ 6 7 8 9 ]
             // ```
             let skip_plus_one = skip_packet_number

--- a/quic/s2n-quic-transport/src/space/tx_packet_numbers.rs
+++ b/quic/s2n-quic-transport/src/space/tx_packet_numbers.rs
@@ -14,6 +14,8 @@ use s2n_quic_core::{
 pub struct TxPacketNumbers {
     largest_sent_acked: (PacketNumber, Timestamp),
     next: PacketNumber,
+    // skipped packet number used for detecting an Optimistic Ack attack
+    skip_pn: Option<PacketNumber>,
 }
 
 impl TxPacketNumbers {
@@ -22,6 +24,7 @@ impl TxPacketNumbers {
         Self {
             largest_sent_acked: (initial_packet_number, now),
             next: initial_packet_number,
+            skip_pn: None,
         }
     }
 
@@ -30,6 +33,7 @@ impl TxPacketNumbers {
         &mut self,
         timestamp: Timestamp,
         ack_set: &A,
+        lowest_tracking_pn: PacketNumber,
     ) -> Result<(), transport::Error> {
         let largest = ack_set.largest();
 
@@ -41,6 +45,60 @@ impl TxPacketNumbers {
         if largest >= self.next {
             return Err(transport::Error::PROTOCOL_VIOLATION
                 .with_reason("received an ACK for a packet that was not sent"));
+        }
+
+        if let Some(skip_pn) = self.skip_pn {
+            debug_assert_eq!(
+                skip_pn.space(),
+                PacketNumberSpace::ApplicationData,
+                "only start skipping packets after the handshake is complete"
+            );
+
+            //= https://www.rfc-editor.org/rfc/rfc9000#section-21.4
+            //# An endpoint that acknowledges packets it has not received might cause
+            //# a congestion controller to permit sending at rates beyond what the
+            //# network supports.  An endpoint MAY skip packet numbers when sending
+            //# packets to detect this behavior.  An endpoint can then immediately
+            //# close the connection with a connection error of type PROTOCOL_VIOLATION
+            if ack_set.contains(skip_pn) {
+                return Err(transport::Error::PROTOCOL_VIOLATION
+                    .with_reason("received an ACK for a packet that was not sent"));
+            }
+
+            // Verify the peer didn't send the skipped packet number before clearing it.
+            //
+            // Packet skipping is implemented to mitigate the Optimistic Ack attack. To
+            // correctly detect an attack, we track a skipped packet until all packets
+            // <= skip_pn + 1 have been marked as acknowledged or lost. The assumption
+            // is that the attacker gains little from ACKing a packet less than the
+            // largest packet ACKed.
+            //
+            // For example:
+            // Assume we are initially tracking packets 2-9 and have skipped
+            // packet 4 (s). The skip_pn + 1 packet is calculated as packet 5 (p).
+            // We validate the peer behavior and can clear skip_pn once we stop
+            // tracking packet 5.
+            //
+            // ```
+            // Initial tracking state: skipped packet 4 (s = 4)
+            //    [ 2 3 5 6 7 8 9 ]
+            //          p
+            //
+            //    RX: AckRange(2..4)
+            //
+            // Not verified: still tracking (p)
+            //    [ 5 6 7 8 9 ]
+            //      p
+            //
+            //    RX: AckRange(5)
+            //
+            // Verified: peer did not send an ack for (s)
+            //    [ 6 7 8 9 ]
+            // ```
+            let skip_plus_one = skip_pn.next().expect("expect next pn");
+            if lowest_tracking_pn > skip_plus_one {
+                self.skip_pn = None;
+            }
         }
 
         // record the largest packet acked
@@ -77,5 +135,69 @@ impl TxPacketNumbers {
     /// was ACKed by the peer
     pub fn largest_sent_packet_number_acked(&self) -> PacketNumber {
         self.largest_sent_acked.0
+    }
+
+    // Only skip a packet number after verifying the peer did not send
+    // the previous one.
+    pub fn generate_new_skip_pn(&self) -> bool {
+        self.skip_pn.is_none()
+    }
+
+    pub fn set_skip_pn(&mut self, skip_pn: PacketNumber) {
+        debug_assert_eq!(
+            skip_pn.space(),
+            PacketNumberSpace::ApplicationData,
+            "only start skipping packets after the handshake is complete"
+        );
+        self.skip_pn = Some(skip_pn);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::time::Duration;
+    use s2n_quic_core::packet::number::PacketNumberRange;
+
+    // Test behavior around tracking and clearing skip_pn value.
+    //
+    // Test setup:
+    //   ack_set: [ 2 3 4 5 6]
+    //   skip_pn: 3
+    //   skip_plus_one: 4
+    #[test]
+    fn test_err_on_skip_pn() {
+        let skip_pn = PacketNumberSpace::ApplicationData.new_packet_number(VarInt::from_u8(3));
+        let mut skip_plus_one =
+            PacketNumberSpace::ApplicationData.new_packet_number(VarInt::from_u8(4));
+        let start = PacketNumberSpace::ApplicationData.new_packet_number(VarInt::from_u8(2));
+        let end = PacketNumberSpace::ApplicationData.new_packet_number(VarInt::from_u8(6));
+        let mut ack_set = PacketNumberRange::new(start, end);
+
+        let timestamp = unsafe { Timestamp::from_duration(Duration::from_millis(10)) };
+        let mut tx = TxPacketNumbers::new(PacketNumberSpace::ApplicationData, timestamp);
+        // Set initial tx state. `tx.next` needs to be > than the largest ack received
+        tx.next = end.next().unwrap();
+
+        // Happy case: skip_pn = None
+        assert!(tx.on_packet_ack(timestamp, &ack_set, skip_plus_one).is_ok());
+
+        // Error if ack_set contains skip_pn
+        tx.set_skip_pn(skip_pn);
+        assert!(tx
+            .on_packet_ack(timestamp, &ack_set, skip_plus_one)
+            .is_err());
+
+        // Pass if ack_set doesn't contain skip_pn
+        ack_set = PacketNumberRange::new(skip_plus_one, end);
+        assert!(tx.on_packet_ack(timestamp, &ack_set, skip_plus_one).is_ok());
+
+        // Assert that skip_pn has not been cleared since it has not been verified.
+        assert!(tx.skip_pn.is_some());
+
+        // Assert skip_pn is cleared once we stop tracking the skip_plus_one packet number
+        skip_plus_one = skip_plus_one.next().unwrap();
+        assert!(tx.on_packet_ack(timestamp, &ack_set, skip_plus_one).is_ok());
+        assert!(tx.skip_pn.is_none());
     }
 }

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -34,6 +34,7 @@ mod mtu;
 mod no_tls;
 mod pto;
 mod self_test;
+mod skip_packets;
 
 // TODO: https://github.com/aws/s2n-quic/issues/1726
 //

--- a/quic/s2n-quic/src/tests/client_handshake_confirm.rs
+++ b/quic/s2n-quic/src/tests/client_handshake_confirm.rs
@@ -141,7 +141,8 @@ where
         let server = Server::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(server_tls)?
-            .with_event(events())?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         let addr = start_server(server)?;
@@ -150,7 +151,8 @@ where
         let client = Client::builder()
             .with_io(handle.builder().build().unwrap())?
             .with_tls(client_tls)?
-            .with_event((ClientConfirm, events()))?
+            .with_event((ClientConfirm, tracing_events()))?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         // show it working for several connections

--- a/quic/s2n-quic/src/tests/connection_migration.rs
+++ b/quic/s2n-quic/src/tests/connection_migration.rs
@@ -44,7 +44,8 @@ where
         let server = Server::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(SERVER_CERTS)?
-            .with_event((events(), active_path_sub))?
+            .with_event((tracing_events(), active_path_sub))?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         let client_io = handle.builder().on_socket(on_socket).build()?;
@@ -52,7 +53,8 @@ where
         let client = Client::builder()
             .with_io(client_io)?
             .with_tls(certificates::CERT_PEM)?
-            .with_event(events())?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         let addr = start_server(server)?;
@@ -105,14 +107,16 @@ fn rebind_after_handshake_confirmed() {
         let server = Server::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(SERVER_CERTS)?
-            .with_event(events())?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
             .with_packet_interceptor(RebindPortBeforeLastHandshakePacket::default())?
             .start()?;
 
         let client = Client::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(certificates::CERT_PEM)?
-            .with_event(events())?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         let addr = start_server(server)?;

--- a/quic/s2n-quic/src/tests/interceptor.rs
+++ b/quic/s2n-quic/src/tests/interceptor.rs
@@ -9,7 +9,8 @@ fn intercept_loss(loss: Loss<Random>) {
         let server = Server::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(SERVER_CERTS)?
-            .with_event(events())?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
             .with_packet_interceptor(loss)?
             .start()?;
         let server_address = start_server(server)?;

--- a/quic/s2n-quic/src/tests/issue_1361.rs
+++ b/quic/s2n-quic/src/tests/issue_1361.rs
@@ -13,7 +13,8 @@ fn stream_reset_test() {
         let mut server = Server::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(SERVER_CERTS)?
-            .with_event(events())?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
             .with_limits(
                 provider::limits::Limits::default()
                     // only allow 1 concurrent stream form the peer

--- a/quic/s2n-quic/src/tests/issue_1717.rs
+++ b/quic/s2n-quic/src/tests/issue_1717.rs
@@ -26,6 +26,8 @@ fn increasing_pto_count_under_loss() {
         let mut server = Server::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(SERVER_CERTS)?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         let addr = server.local_addr()?;
@@ -39,7 +41,8 @@ fn increasing_pto_count_under_loss() {
         let client = Client::builder()
             .with_io(handle.builder().build().unwrap())?
             .with_tls(certificates::CERT_PEM)?
-            .with_event(subscriber)?
+            .with_event((tracing_events(), subscriber))?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         primary::spawn(async move {

--- a/quic/s2n-quic/src/tests/issue_954.rs
+++ b/quic/s2n-quic/src/tests/issue_954.rs
@@ -18,11 +18,14 @@ fn client_path_handle_update() {
         let server = Server::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(SERVER_CERTS)?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
             .start()?;
         let client = Client::builder()
             .with_io(handle.builder().build().unwrap())?
             .with_tls(certificates::CERT_PEM)?
-            .with_event(subscriber)?
+            .with_event((tracing_events(), subscriber))?
+            .with_random(Random::with_seed(456))?
             .start()?;
         let addr = start_server(server)?;
         start_client(client, addr, Data::new(1000))?;

--- a/quic/s2n-quic/src/tests/mtls.rs
+++ b/quic/s2n-quic/src/tests/mtls.rs
@@ -21,7 +21,8 @@ fn mtls_happy_case() {
         let mut server = Server::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(server_tls)?
-            .with_event(server_subscriber)?
+            .with_event((tracing_events(), server_subscriber))?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         let addr = server.local_addr()?;
@@ -36,7 +37,8 @@ fn mtls_happy_case() {
         let client = Client::builder()
             .with_io(handle.builder().build().unwrap())?
             .with_tls(client_tls)?
-            .with_event(client_subscriber)?
+            .with_event((tracing_events(), client_subscriber))?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         primary::spawn(async move {
@@ -90,7 +92,8 @@ fn mtls_auth_failure() {
         let mut server = Server::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(server_tls)?
-            .with_event(server_subscriber)?
+            .with_event((tracing_events(), server_subscriber))?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         let addr = server.local_addr()?;
@@ -112,7 +115,8 @@ fn mtls_auth_failure() {
         let client = Client::builder()
             .with_io(handle.builder().build().unwrap())?
             .with_tls(client_tls)?
-            .with_event(client_subscriber)?
+            .with_event((tracing_events(), client_subscriber))?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         primary::spawn(async move {

--- a/quic/s2n-quic/src/tests/mtu.rs
+++ b/quic/s2n-quic/src/tests/mtu.rs
@@ -22,11 +22,14 @@ fn mtu_updates(max_mtu: u16) -> Vec<events::MtuUpdated> {
         let server = Server::builder()
             .with_io(handle.builder().with_max_mtu(max_mtu).build()?)?
             .with_tls(SERVER_CERTS)?
-            .with_event(subscriber)?
+            .with_event((tracing_events(), subscriber))?
+            .with_random(Random::with_seed(456))?
             .start()?;
         let client = Client::builder()
             .with_io(handle.builder().with_max_mtu(max_mtu).build().unwrap())?
             .with_tls(certificates::CERT_PEM)?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
             .start()?;
         let addr = start_server(server)?;
         // we need a large payload to allow for multiple rounds of MTU probing
@@ -92,11 +95,14 @@ fn mtu_loss_no_blackhole() {
         let server = Server::builder()
             .with_io(handle.builder().with_max_mtu(max_mtu).build()?)?
             .with_tls(SERVER_CERTS)?
-            .with_event(subscriber)?
+            .with_event((tracing_events(), subscriber))?
+            .with_random(Random::with_seed(456))?
             .start()?;
         let client = Client::builder()
             .with_io(handle.builder().with_max_mtu(max_mtu).build()?)?
             .with_tls(certificates::CERT_PEM)?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
             .start()?;
         let addr = start_server(server)?;
         // we need a large payload to allow for multiple rounds of MTU probing
@@ -140,11 +146,14 @@ fn mtu_blackhole() {
         let server = Server::builder()
             .with_io(handle.builder().with_max_mtu(max_mtu).build()?)?
             .with_tls(SERVER_CERTS)?
-            .with_event(subscriber)?
+            .with_event((tracing_events(), subscriber))?
+            .with_random(Random::with_seed(456))?
             .start()?;
         let client = Client::builder()
             .with_io(handle.builder().with_max_mtu(max_mtu).build()?)?
             .with_tls(certificates::CERT_PEM)?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
             .start()?;
         let addr = start_server(server)?;
         // we need a large payload to allow for multiple rounds of MTU probing
@@ -181,14 +190,16 @@ fn minimum_initial_packet() {
         let server = Server::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(SERVER_CERTS)?
-            .with_event((events(), subscriber))?
+            .with_event((tracing_events(), subscriber))?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         let client = Client::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(certificates::CERT_PEM)?
             .with_packet_interceptor((EraseClientHello, TruncatePadding))?
-            .with_event(events())?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         let addr = start_server(server)?;

--- a/quic/s2n-quic/src/tests/no_tls.rs
+++ b/quic/s2n-quic/src/tests/no_tls.rs
@@ -30,12 +30,14 @@ fn no_tls_test() {
         let server = Server::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(NoTlsProvider::default())?
-            .with_event(events())?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
             .start()?;
         let client = Client::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(NoTlsProvider::default())?
-            .with_event(events())?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
             .start()?;
         let addr = start_server(server)?;
         start_client(client, addr, Data::new(1000))?;

--- a/quic/s2n-quic/src/tests/pto.rs
+++ b/quic/s2n-quic/src/tests/pto.rs
@@ -24,7 +24,8 @@ fn handshake_pto_timer_is_armed() {
             .with_io(handle.builder().build()?)?
             .with_tls(SERVER_CERTS)?
             .with_packet_interceptor(DropHandshakeTx)?
-            .with_event(events())?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         let addr = server.local_addr()?;
@@ -37,7 +38,8 @@ fn handshake_pto_timer_is_armed() {
         let client = Client::builder()
             .with_io(handle.builder().build().unwrap())?
             .with_tls(certificates::CERT_PEM)?
-            .with_event(((events(), pto_subscriber), packet_sent_subscriber))?
+            .with_event(((tracing_events(), pto_subscriber), packet_sent_subscriber))?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         primary::spawn(async move {

--- a/quic/s2n-quic/src/tests/pto.rs
+++ b/quic/s2n-quic/src/tests/pto.rs
@@ -19,7 +19,7 @@ fn handshake_pto_timer_is_armed() {
     let pto_events = pto_subscriber.events();
     let packet_sent_events = packet_sent_subscriber.events();
 
-    test(model.clone(), |handle| {
+    test(model, |handle| {
         let mut server = Server::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(SERVER_CERTS)?

--- a/quic/s2n-quic/src/tests/recorder.rs
+++ b/quic/s2n-quic/src/tests/recorder.rs
@@ -148,29 +148,8 @@ event_recorder!(
     PacketSkipped,
     PacketSkipped,
     on_packet_skipped,
-    PacketSkipReason,
-    |event: &events::PacketSkipped, storage: &mut Vec<PacketSkipReason>| {
-        if let Ok(reason) = (&event.reason).try_into() {
-            storage.push(reason);
-        }
+    events::PacketSkipReason,
+    |event: &events::PacketSkipped, storage: &mut Vec<events::PacketSkipReason>| {
+        storage.push(event.reason.clone());
     }
 );
-
-pub enum PacketSkipReason {
-    PtoProbe,
-    OptimisticAckMitigation,
-}
-
-impl TryFrom<&events::PacketSkipReason> for PacketSkipReason {
-    type Error = ();
-
-    fn try_from(reason: &events::PacketSkipReason) -> Result<Self, ()> {
-        use events::PacketSkipReason::*;
-
-        Ok(match reason {
-            PtoProbe { .. } => Self::PtoProbe,
-            OptimisticAckMitigation { .. } => Self::OptimisticAckMitigation,
-            _ => return Err(()),
-        })
-    }
-}

--- a/quic/s2n-quic/src/tests/self_test.rs
+++ b/quic/s2n-quic/src/tests/self_test.rs
@@ -24,7 +24,7 @@ fn packet_sent_event_test() {
         let server = Server::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(SERVER_CERTS)?
-            .with_event(subscriber)?
+            .with_event((tracing_events(), subscriber))?
             .start()?;
         let addr = start_server(server)?;
         // store addr in exterior scope so we can use it to filter packets

--- a/quic/s2n-quic/src/tests/setup.rs
+++ b/quic/s2n-quic/src/tests/setup.rs
@@ -15,7 +15,7 @@ use std::net::SocketAddr;
 
 pub static SERVER_CERTS: (&str, &str) = (certificates::CERT_PEM, certificates::KEY_PEM);
 
-pub fn events() -> event::tracing::Subscriber {
+pub fn tracing_events() -> event::tracing::Subscriber {
     use std::sync::Once;
 
     static TRACING: Once = Once::new();
@@ -82,7 +82,7 @@ pub fn build_server(handle: &Handle) -> Result<Server> {
     Ok(Server::builder()
         .with_io(handle.builder().build().unwrap())?
         .with_tls(SERVER_CERTS)?
-        .with_event(events())?
+        .with_event(tracing_events())?
         .with_random(Random::with_seed(123))?
         .start()?)
 }
@@ -127,7 +127,7 @@ pub fn build_client(handle: &Handle) -> Result<Client> {
     Ok(Client::builder()
         .with_io(handle.builder().build().unwrap())?
         .with_tls(certificates::CERT_PEM)?
-        .with_event(events())?
+        .with_event(tracing_events())?
         .with_random(Random::with_seed(123))?
         .start()?)
 }

--- a/quic/s2n-quic/src/tests/setup.rs
+++ b/quic/s2n-quic/src/tests/setup.rs
@@ -83,6 +83,7 @@ pub fn build_server(handle: &Handle) -> Result<Server> {
         .with_io(handle.builder().build().unwrap())?
         .with_tls(SERVER_CERTS)?
         .with_event(events())?
+        .with_random(Random::with_seed(123))?
         .start()?)
 }
 
@@ -127,6 +128,7 @@ pub fn build_client(handle: &Handle) -> Result<Client> {
         .with_io(handle.builder().build().unwrap())?
         .with_tls(certificates::CERT_PEM)?
         .with_event(events())?
+        .with_random(Random::with_seed(123))?
         .start()?)
 }
 
@@ -174,6 +176,26 @@ impl RngCore for Random {
 
     fn next_u64(&mut self) -> u64 {
         self.inner.next_u64()
+    }
+}
+
+impl crate::provider::random::Provider for Random {
+    type Generator = Self;
+
+    type Error = core::convert::Infallible;
+
+    fn start(self) -> Result<Self::Generator, Self::Error> {
+        Ok(self)
+    }
+}
+
+impl crate::provider::random::Generator for Random {
+    fn public_random_fill(&mut self, dest: &mut [u8]) {
+        self.fill_bytes(dest);
+    }
+
+    fn private_random_fill(&mut self, dest: &mut [u8]) {
+        self.fill_bytes(dest);
     }
 }
 

--- a/quic/s2n-quic/src/tests/skip_packets.rs
+++ b/quic/s2n-quic/src/tests/skip_packets.rs
@@ -18,6 +18,7 @@ fn optimistic_ack_mitigation() {
             .with_io(handle.builder().build()?)?
             .with_tls(SERVER_CERTS)?
             .with_event((events(), server_subscriber))?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         let addr = server.local_addr()?;
@@ -32,6 +33,7 @@ fn optimistic_ack_mitigation() {
             .with_io(handle.builder().build().unwrap())?
             .with_tls(certificates::CERT_PEM)?
             .with_event((events(), client_subscriber))?
+            .with_random(Random::with_seed(456))?
             .start()?;
 
         primary::spawn(async move {
@@ -75,11 +77,6 @@ fn optimistic_ack_mitigation() {
 
     // Verify that both client and server are skipping packets for Optimistic
     // Ack attack mitigation.
-    //
-    // The skip rate is influenced by the send rate, which can vary
-    // across machines, so use a buffer for the upper bound.
-    assert!(server_skip_count > 0);
-    assert!(server_skip_count < 8);
-    assert!(client_skip_count > 0);
-    assert!(client_skip_count < 8);
+    assert_eq!(server_skip_count, 5);
+    assert_eq!(client_skip_count, 5);
 }

--- a/quic/s2n-quic/src/tests/skip_packets.rs
+++ b/quic/s2n-quic/src/tests/skip_packets.rs
@@ -17,7 +17,7 @@ fn optimistic_ack_mitigation() {
         let mut server = Server::builder()
             .with_io(handle.builder().build()?)?
             .with_tls(SERVER_CERTS)?
-            .with_event((events(), server_subscriber))?
+            .with_event((tracing_events(), server_subscriber))?
             .with_random(Random::with_seed(456))?
             .start()?;
 
@@ -32,7 +32,7 @@ fn optimistic_ack_mitigation() {
         let client = Client::builder()
             .with_io(handle.builder().build().unwrap())?
             .with_tls(certificates::CERT_PEM)?
-            .with_event((events(), client_subscriber))?
+            .with_event((tracing_events(), client_subscriber))?
             .with_random(Random::with_seed(456))?
             .start()?;
 

--- a/quic/s2n-quic/src/tests/skip_packets.rs
+++ b/quic/s2n-quic/src/tests/skip_packets.rs
@@ -1,0 +1,75 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+#[test]
+fn optimistic_ack_mitigation() {
+    let model = Model::default();
+    model.set_delay(Duration::from_millis(50));
+    const LEN: usize = 1_000_000;
+
+    let server_subscriber = recorder::PacketSkipped::new();
+    let server_events = server_subscriber.events();
+    let client_subscriber = recorder::PacketSkipped::new();
+    let client_events = server_subscriber.events();
+    test(model, |handle| {
+        let mut server = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(SERVER_CERTS)?
+            .with_event((events(), server_subscriber))?
+            .start()?;
+
+        let addr = server.local_addr()?;
+        spawn(async move {
+            let mut conn = server.accept().await.unwrap();
+            let mut stream = conn.open_bidirectional_stream().await.unwrap();
+            stream.send(vec![42; LEN].into()).await.unwrap();
+            stream.flush().await.unwrap();
+        });
+
+        let client = Client::builder()
+            .with_io(handle.builder().build().unwrap())?
+            .with_tls(certificates::CERT_PEM)?
+            .with_event((events(), client_subscriber))?
+            .start()?;
+
+        primary::spawn(async move {
+            let connect = Connect::new(addr).with_server_name("localhost");
+            let mut conn = client.connect(connect).await.unwrap();
+            let mut stream = conn.accept_bidirectional_stream().await.unwrap().unwrap();
+
+            let mut recv_len = 0;
+            while let Some(chunk) = stream.receive().await.unwrap() {
+                recv_len += chunk.len();
+            }
+            assert_eq!(LEN, recv_len);
+        });
+
+        Ok(addr)
+    })
+    .unwrap();
+
+    let server_skip_count = server_events
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|reason| matches!(reason, recorder::PacketSkipReason::OptimisticAckMitigation))
+        .count();
+    let client_skip_count = client_events
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|reason| matches!(reason, recorder::PacketSkipReason::OptimisticAckMitigation))
+        .count();
+
+    // Verify that both client and server are skipping packets for Optimistic
+    // Ack attack mitigation.
+    //
+    // The skip rate is influenced by the send rate, which can vary
+    // across machines, so use a buffer for the upper bound.
+    assert!(server_skip_count > 0);
+    assert!(server_skip_count < 8);
+    assert!(client_skip_count > 0);
+    assert!(client_skip_count < 8);
+}

--- a/quic/s2n-quic/src/tests/skip_packets.rs
+++ b/quic/s2n-quic/src/tests/skip_packets.rs
@@ -54,13 +54,23 @@ fn optimistic_ack_mitigation() {
         .lock()
         .unwrap()
         .iter()
-        .filter(|reason| matches!(reason, recorder::PacketSkipReason::OptimisticAckMitigation))
+        .filter(|reason| {
+            matches!(
+                reason,
+                events::PacketSkipReason::OptimisticAckMitigation { .. }
+            )
+        })
         .count();
     let client_skip_count = client_events
         .lock()
         .unwrap()
         .iter()
-        .filter(|reason| matches!(reason, recorder::PacketSkipReason::OptimisticAckMitigation))
+        .filter(|reason| {
+            matches!(
+                reason,
+                events::PacketSkipReason::OptimisticAckMitigation { .. }
+            )
+        })
         .count();
 
     // Verify that both client and server are skipping packets for Optimistic


### PR DESCRIPTION
### Resolved issues:
https://github.com/aws/s2n-quic/issues/1962

### Description of changes: 
The RFC actually does a decent job of describing the issue:

> An endpoint that acknowledges packets it has not received might cause a congestion controller to permit sending at rates beyond what the network supports. An endpoint MAY skip packet numbers when sending packets to detect this behavior. An endpoint can then immediately close the connection with a connection error of type PROTOCOL_VIOLATION

This PR implements packet skipping for Opt Ack mitigation. I also added events to make this easier to test/introspect upon.

### Callouts
I fixed a few new clippy lints in the PR.

### Testing:
- Unit and integration tests.
- I would also like to add a negative test where we receive an Ack and close the connection. I tested this case manually but need to expose the functionality in the packet_interceptor to write this test. To keep this PR small I'll do this in a followup PR.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

