### PR TITLE
fix(s2n-quic): fix clippy and msrv issues

### DIFF
--- a/quic/s2n-quic-core/src/ct.rs
+++ b/quic/s2n-quic-core/src/ct.rs
@@ -22,6 +22,8 @@ impl<T> Number<T> {
         self.0.is_some()
     }
 
+    // See https://github.com/rust-lang/rust-clippy/issues/11390
+    #[allow(clippy::unwrap_or_default)]
     pub fn unwrap_or_default(&self) -> T
     where
         T: ConditionallySelectable + Default,

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -21,7 +21,6 @@ cfg-if = "1"
 futures = "0.3"
 http = "0.2"
 humansize = "2"
-jobserver = "=0.1.26" # newer versions require rust 1.66, see https://github.com/aws/s2n-quic/issues/1991
 lru = "0.10"
 openssl-sys = { version = "0.9", features = ["vendored"] }
 rand = "0.8"
@@ -48,9 +47,8 @@ s2n-quic = { path = "../s2n-quic", features = ["provider-event-console-perf", "p
 mimalloc = { version = "0.1", default-features = false }
 
 # we don't use openssl-sys directly; it's just here to pin and vendor in dev
-# jobserver is just here to pin as well, it is a dependency of openssl-sys
 [package.metadata.cargo-udeps.ignore]
-normal = [ "openssl-sys", "jobserver" ]
+normal = [ "openssl-sys" ]
 
 # Use unstable s2n-quic features
 # unstable_client_hello and unstable_resumption use s2n-tls, and thus are only enabled for unix platforms

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -21,6 +21,7 @@ cfg-if = "1"
 futures = "0.3"
 http = "0.2"
 humansize = "2"
+jobserver = "=0.1.26" # newer versions require rust 1.66, see https://github.com/aws/s2n-quic/issues/1991
 lru = "0.10"
 openssl-sys = { version = "0.9", features = ["vendored"] }
 rand = "0.8"
@@ -47,8 +48,9 @@ s2n-quic = { path = "../s2n-quic", features = ["provider-event-console-perf", "p
 mimalloc = { version = "0.1", default-features = false }
 
 # we don't use openssl-sys directly; it's just here to pin and vendor in dev
+# jobserver is just here to pin as well, it is a dependency of openssl-sys
 [package.metadata.cargo-udeps.ignore]
-normal = [ "openssl-sys" ]
+normal = [ "openssl-sys", "jobserver" ]
 
 # Use unstable s2n-quic features
 # unstable_client_hello and unstable_resumption use s2n-tls, and thus are only enabled for unix platforms

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -18,7 +18,7 @@ unstable_private_key = []
 bytes = { version = "1", default-features = false }
 errno = "0.3"
 libc = "0.2"
-jobserver = "=0.1.26"
+jobserver = "=0.1.26" # newer versions require rust 1.66, see https://github.com/aws/s2n-quic/issues/1991
 s2n-codec = { version = "=0.7.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.28.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
 s2n-quic-crypto = { version = "=0.29.0", path = "../s2n-quic-crypto", default-features = false }
@@ -37,5 +37,6 @@ s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-rustls = { path = "../s2n-quic-rustls" }
 
 # we don't use openssl-sys directly; it's just here to pin and vendor in dev
+# jobserver is just here to pin as well, it is a dependency of openssl-sys
 [package.metadata.cargo-udeps.ignore]
-development = [ "openssl-sys" ]
+development = [ "openssl-sys", "jobserver" ]

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -18,7 +18,6 @@ unstable_private_key = []
 bytes = { version = "1", default-features = false }
 errno = "0.3"
 libc = "0.2"
-jobserver = "=0.1.26" # newer versions require rust 1.66, see https://github.com/aws/s2n-quic/issues/1991
 s2n-codec = { version = "=0.7.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.28.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
 s2n-quic-crypto = { version = "=0.29.0", path = "../s2n-quic-crypto", default-features = false }
@@ -26,6 +25,7 @@ s2n-tls = { version = "=0.0.36", features = ["quic"] }
 
 [dev-dependencies]
 checkers = "0.6"
+jobserver = "=0.1.26" # newer versions require rust 1.66, see https://github.com/aws/s2n-quic/issues/1991
 pin-project = { version = "1" }
 openssl = { version = "0.10" }
 # Build the vendored version to make it easy to test in dev

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -18,6 +18,7 @@ unstable_private_key = []
 bytes = { version = "1", default-features = false }
 errno = "0.3"
 libc = "0.2"
+jobserver = "=0.1.26"
 s2n-codec = { version = "=0.7.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.28.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
 s2n-quic-crypto = { version = "=0.29.0", path = "../s2n-quic-crypto", default-features = false }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -62,7 +62,6 @@ hash_hasher = { version = "2", optional = true }
 humansize = { version = "2", optional = true }
 rand = "0.8"
 rand_chacha = "0.3"
-regex = "=1.9.6" # newer versions require rust 1.65, see https://github.com/aws/s2n-quic/issues/1993
 s2n-codec = { version = "=0.7.0", path = "../../common/s2n-codec" }
 s2n-quic-core = { version = "=0.28.0", path = "../s2n-quic-core" }
 s2n-quic-crypto = { version = "=0.29.0", path = "../s2n-quic-crypto", optional = true }
@@ -79,6 +78,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 [dev-dependencies]
 backtrace = { version = "=0.3.68" } # pin backtrace to avoid bumping MSRV
 bolero = { version = "0.9" }
+regex = "=1.9.6" # newer versions require rust 1.65, see https://github.com/aws/s2n-quic/issues/1993
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing", "event-tracing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -62,6 +62,7 @@ hash_hasher = { version = "2", optional = true }
 humansize = { version = "2", optional = true }
 rand = "0.8"
 rand_chacha = "0.3"
+regex = "=1.9.6"
 s2n-codec = { version = "=0.7.0", path = "../../common/s2n-codec" }
 s2n-quic-core = { version = "=0.28.0", path = "../s2n-quic-core" }
 s2n-quic-crypto = { version = "=0.29.0", path = "../s2n-quic-crypto", optional = true }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -62,7 +62,7 @@ hash_hasher = { version = "2", optional = true }
 humansize = { version = "2", optional = true }
 rand = "0.8"
 rand_chacha = "0.3"
-regex = "=1.9.6"
+regex = "=1.9.6" # newer versions require rust 1.65, see https://github.com/aws/s2n-quic/issues/1993
 s2n-codec = { version = "=0.7.0", path = "../../common/s2n-codec" }
 s2n-quic-core = { version = "=0.28.0", path = "../s2n-quic-core" }
 s2n-quic-crypto = { version = "=0.29.0", path = "../s2n-quic-crypto", optional = true }


### PR DESCRIPTION
### Description of changes: 

This change pins `regex` and `jobserver` to avoid needing to bump our MSRV. I've also fixed a clippy lint false positive.

I've opened #1991 and #1993 to track removal of the pins

### Testing:

Tested in CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

