### PR TITLE
fix(s2n-quic-transport): don't move path back to amplification limited when closing

### DIFF
--- a/quic/s2n-quic-transport/src/connection/close_sender.rs
+++ b/quic/s2n-quic-transport/src/connection/close_sender.rs
@@ -357,7 +357,6 @@ mod tests {
                     let _ = path.on_bytes_received(MINIMUM_MTU as usize);
                 }
 
-                path.on_closing();
                 sender.close(PACKET.clone(), *close_time, clock.get_time());
 
                 // transmit an initial packet

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -718,8 +718,6 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
 
         // We don't need any timers anymore
         self.timers.cancel();
-        // Let the path manager know we're closing
-        self.path_manager.on_closing();
         // Update the connection state based on the type of error
         self.state = error.into();
         self.error = Err(error);

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -795,12 +795,6 @@ impl<Config: endpoint::Config> Manager<Config> {
         Ok(amplification_outcome)
     }
 
-    /// Notifies the path manager of the connection closing event
-    pub fn on_closing(&mut self) {
-        self.active_path_mut().on_closing();
-        // TODO clean up other paths
-    }
-
     /// true if ALL paths are amplification_limited
     #[inline]
     pub fn is_amplification_limited(&self) -> bool {


### PR DESCRIPTION
### Description of changes: 

Currently, when a connection is in the process of being closed, we switch the active path it is using back to the "Amplification Limited" state. This limits the amount of outgoing packets that can be sent. There is already a limiter in the `close_sender` that limits the amount of packets that a closed connection can send, so this change removes the redundant behavior.  

### Testing:

Tested with quic-attack

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

