### PR TITLE
fix(s2n-quic-transport): send the largest acked for the current path to the congestion controller

### DIFF
--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     event,
-    inet::{SocketAddress, SocketAddressV4, SocketAddressV6},
+    inet::{IpV4Address, IpV6Address, SocketAddress, SocketAddressV4, SocketAddressV6},
 };
 use core::{
     convert::{TryFrom, TryInto},
@@ -126,6 +126,20 @@ macro_rules! impl_addr {
         #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
         #[cfg_attr(any(test, feature = "generator"), derive(TypeGenerator))]
         pub struct $name(pub SocketAddress);
+
+        impl From<event::api::SocketAddress<'_>> for $name {
+            #[inline]
+            fn from(value: event::api::SocketAddress<'_>) -> Self {
+                match value {
+                    event::api::SocketAddress::IpV4 { ip, port } => {
+                        $name(IpV4Address::new(*ip).with_port(port).into())
+                    }
+                    event::api::SocketAddress::IpV6 { ip, port } => {
+                        $name(IpV6Address::new(*ip).with_port(port).into())
+                    }
+                }
+            }
+        }
 
         impl From<SocketAddress> for $name {
             #[inline]

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_congestion_controller.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_congestion_controller.snap
@@ -1,11 +1,8 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
-assertion_line: 668
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
 MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
-AckRangeReceived { packet_header: OneRtt { number: 1 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, ack_range: 1..=1 }
-RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 500ms, smoothed_rtt: 500ms, latest_rtt: 500ms, rtt_variance: 250ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 128, congestion_limited: false }
-AckRangeReceived { packet_header: OneRtt { number: 2 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, ack_range: 2..=2 }
-RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 500ms, smoothed_rtt: 500ms, latest_rtt: 500ms, rtt_variance: 250ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 128, congestion_limited: false }
+AckRangeReceived { packet_header: OneRtt { number: 1 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, ack_range: 1..=2 }
+RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 333ms, smoothed_rtt: 333ms, latest_rtt: 333ms, rtt_variance: 166.5ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 128, congestion_limited: false }


### PR DESCRIPTION
### Description of changes: 

When invoking the congestion controller's `on_ack` method, we currently pass a `newest_acked_packet_info` that is the newest acked packet for the entire `ACK` frame, regardless of whether that packet was sent on the path the congestion controller is attached to. This change fixes this to send the newest/largest newly acked packet that was actually sent on the path the congestion controller is attached to.

### Testing:

Updated some existing tests and added some new assertions in the `MockCongestionController`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

