### PR TITLE
tests(s2n-quic-qns): enable overflow checks in quic-attack

### DIFF
--- a/scripts/quic-attack/run
+++ b/scripts/quic-attack/run
@@ -52,7 +52,7 @@ else
     TIMEOUT="timeout $1s"
 fi
 
-COMMON_ARGS="--max-throughput 10000 --max-handshake-duration 10 --max-idle-timeout 10 --tls null"
+COMMON_ARGS="--max-throughput 10000 --max-handshake-duration 10 --max-idle-timeout 10"
 PERF_APP="./target/release/s2n-quic-qns perf"
 
 RUST_BACKTRACE=1 \

--- a/scripts/quic-attack/run
+++ b/scripts/quic-attack/run
@@ -8,7 +8,7 @@
 set -e
 
 # ensure s2n-quic-qns is built
-RUSTFLAGS="--cfg debug_assertions --cfg s2n_internal_dev -g" cargo +stable build --release --bin s2n-quic-qns
+RUSTFLAGS="--cfg debug_assertions -C overflow_checks --cfg s2n_internal_dev -g" cargo +stable build --release --bin s2n-quic-qns
 
 # ensure ultraman is installed
 if ! command -v ultraman &> /dev/null; then

--- a/scripts/quic-attack/run
+++ b/scripts/quic-attack/run
@@ -8,7 +8,7 @@
 set -e
 
 # ensure s2n-quic-qns is built
-RUSTFLAGS="--cfg debug_assertions -C overflow_checks --cfg s2n_internal_dev -g" cargo +stable build --release --bin s2n-quic-qns
+RUSTFLAGS="-C debug_assertions --cfg s2n_internal_dev -g" cargo +stable build --release --bin s2n-quic-qns
 
 # ensure ultraman is installed
 if ! command -v ultraman &> /dev/null; then


### PR DESCRIPTION
### Description of changes: 

The [rust compiler documentation](https://doc.rust-lang.org/rustc/codegen-options/index.html#overflow-checks) for the `-C debug_assertions` option states that:

> overflow checks are enabled if debug-assertions are enabled, disabled otherwise.

This statement does not apply to the `--cfg debug_assertions` option however. This change switches `quic-attack` to use `-C debug_assertions`.

### Callouts:

I've also switched to using an actual TLS provider (instead of null TLS) as that is more reflective of actual s2n-quic usage

### Testing:

Tested locally with a small proof of concept:

```rust
pub fn test(input: u64) -> u64 {
    0 - input
}

pub fn main() {
    let result = test(5);
    println!("{}", result);
    debug_assert_ne!(result, 18446744073709551611);
}
```

```
$ RUSTFLAGS="--cfg debug_assertions" cargo run --release 
18446744073709551611
thread 'main' panicked at 'assertion failed: `(left != right)`
  left: `18446744073709551611`,
 right: `18446744073709551611`', src/main.rs:8:5

$ RUSTFLAGS="-C debug_assertions" cargo run --release 
     Running `target/release/overflowtest`
thread 'main' panicked at 'attempt to subtract with overflow', src/main.rs:2:5
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

