### PR TITLE
perf(s2n-quic-core): optimize varint encoding

### DIFF
--- a/quic/s2n-quic-bench/src/varint.rs
+++ b/quic/s2n-quic-bench/src/varint.rs
@@ -2,24 +2,141 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::{black_box, BenchmarkId, Criterion};
-use s2n_codec::{DecoderBuffer, EncoderBuffer, EncoderValue};
+use s2n_codec::{DecoderBuffer, Encoder, EncoderBuffer, EncoderValue};
 use s2n_quic_core::varint::VarInt;
 
 pub fn benchmarks(c: &mut Criterion) {
-    round_trip(c);
+    encode(c);
+    decode(c);
 }
 
-fn round_trip(c: &mut Criterion) {
-    let mut group = c.benchmark_group("varint");
+#[inline(always)]
+pub fn encode_n<const N: usize>(inputs: [VarInt; N], buffer: &mut [u8]) {
+    let mut encoder = EncoderBuffer::new(buffer);
+    for input in inputs {
+        if input.encoding_size() > encoder.remaining_capacity() {
+            break;
+        }
+        encoder.encode(&input);
+    }
+}
+
+#[inline(never)]
+pub fn encode_slice(input: VarInt, buffer: &mut [u8]) {
+    encode_n([input], buffer);
+}
+
+#[inline(never)]
+pub fn encode_array(input: VarInt, buffer: &mut [u8; 8]) {
+    encode_n([input], buffer);
+}
+
+#[inline(never)]
+pub fn encode_16_slice(input: VarInt, buffer: &mut [u8]) {
+    encode_n([input; 16], buffer);
+}
+
+#[inline(never)]
+pub fn encode_16_array(input: VarInt, buffer: &mut [u8; 8 * 16]) {
+    encode_n([input; 16], buffer);
+}
+
+#[inline(always)]
+pub fn decode_n<const N: usize>(buffer: &[u8]) -> Option<[VarInt; N]> {
+    let mut buffer = DecoderBuffer::new(buffer);
+    let mut out = [VarInt::default(); N];
+    for out in out.iter_mut() {
+        let (v, remaining) = buffer.decode::<VarInt>().ok()?;
+        *out = v;
+        buffer = remaining;
+    }
+    Some(out)
+}
+
+#[inline(never)]
+pub fn decode_slice(buffer: &[u8]) -> Option<VarInt> {
+    Some(decode_n::<1>(buffer)?[0])
+}
+
+#[inline(never)]
+pub fn decode_array(buffer: &[u8; 8]) -> Option<VarInt> {
+    Some(decode_n::<1>(buffer)?[0])
+}
+
+#[inline(never)]
+pub fn decode_16_slice(buffer: &[u8]) -> Option<[VarInt; 16]> {
+    decode_n(buffer)
+}
+
+#[inline(never)]
+pub fn decode_16_array(buffer: &[u8; 8 * 16]) -> Option<[VarInt; 16]> {
+    decode_n(buffer)
+}
+
+fn encode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("varint/encode");
     for i in [0, 1, 5, 6, 13, 14, 29, 30, 61] {
         let i = VarInt::new(2u64.pow(i)).unwrap();
 
-        group.bench_with_input(BenchmarkId::new("round_trip", i), &i, |b, input| {
-            let mut buffer = vec![0; 8];
+        group.bench_with_input(BenchmarkId::new("array", i), &i, |b, input| {
+            let mut buffer = [0u8; 8];
             b.iter(|| {
-                input.encode(&mut EncoderBuffer::new(&mut buffer));
-                let (actual, _) = DecoderBuffer::new(&buffer).decode::<VarInt>().unwrap();
-                black_box(actual);
+                encode_array(black_box(*input), black_box(&mut buffer));
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("slice", i), &i, |b, input| {
+            let mut buffer = [0u8; 8];
+            b.iter(|| {
+                encode_slice(black_box(*input), black_box(&mut buffer));
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("array_16", i), &i, |b, input| {
+            let mut buffer = [0u8; 8 * 16];
+            b.iter(|| {
+                encode_16_array(black_box(*input), black_box(&mut buffer));
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("slice_16", i), &i, |b, input| {
+            let mut buffer = [0u8; 8 * 16];
+            b.iter(|| {
+                encode_16_slice(black_box(*input), black_box(&mut buffer));
+            });
+        });
+    }
+    group.finish();
+}
+
+fn decode(c: &mut Criterion) {
+    let mut group = c.benchmark_group("varint/decode");
+    for i in [0, 1, 5, 6, 13, 14, 29, 30, 61] {
+        let i = VarInt::new(2u64.pow(i)).unwrap();
+
+        group.bench_with_input(BenchmarkId::new("array", i), &i, |b, input| {
+            let mut buffer = [0; 8];
+            encode_array(black_box(*input), black_box(&mut buffer));
+            b.iter(|| {
+                black_box(decode_array(black_box(&buffer)));
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("slice", i), &i, |b, input| {
+            let mut buffer = [0; 8];
+            encode_slice(black_box(*input), black_box(&mut buffer));
+            b.iter(|| {
+                black_box(decode_slice(black_box(&buffer)));
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("array_16", i), &i, |b, input| {
+            let mut buffer = [0; 8 * 16];
+            encode_16_array(black_box(*input), black_box(&mut buffer));
+            b.iter(|| {
+                black_box(decode_16_array(black_box(&buffer)));
+            });
+        });
+        group.bench_with_input(BenchmarkId::new("slice_16", i), &i, |b, input| {
+            let mut buffer = [0; 8 * 16];
+            encode_16_slice(black_box(*input), black_box(&mut buffer));
+            b.iter(|| {
+                black_box(decode_16_slice(black_box(&buffer)));
             });
         });
     }

--- a/quic/s2n-quic-core/src/varint/mod.rs
+++ b/quic/s2n-quic-core/src/varint/mod.rs
@@ -13,6 +13,7 @@ use bolero_generator::*;
 
 use crate::event::IntoEvent;
 
+mod table;
 #[cfg(test)]
 mod tests;
 
@@ -25,23 +26,6 @@ mod tests;
 //# significant bits of the first byte to encode the base 2 logarithm of
 //# the integer encoding length in bytes.  The integer value is encoded
 //# on the remaining bits, in network byte order.
-
-//= https://www.rfc-editor.org/rfc/rfc9000#section-16
-//# This means that integers are encoded on 1, 2, 4, or 8 bytes and can
-//# encode 6-, 14-, 30-, or 62-bit values, respectively.  Table 4
-//# summarizes the encoding properties.
-//#
-//#        +======+========+=============+=======================+
-//#        | 2MSB | Length | Usable Bits | Range                 |
-//#        +======+========+=============+=======================+
-//#        | 00   | 1      | 6           | 0-63                  |
-//#        +------+--------+-------------+-----------------------+
-//#        | 01   | 2      | 14          | 0-16383               |
-//#        +------+--------+-------------+-----------------------+
-//#        | 10   | 4      | 30          | 0-1073741823          |
-//#        +------+--------+-------------+-----------------------+
-//#        | 11   | 8      | 62          | 0-4611686018427387903 |
-//#        +------+--------+-------------+-----------------------+
 
 pub const MAX_VARINT_VALUE: u64 = 4_611_686_018_427_387_903;
 
@@ -56,65 +40,6 @@ impl fmt::Display for VarIntError {
 
 #[cfg(feature = "std")]
 impl std::error::Error for VarIntError {}
-
-// https://godbolt.org/z/ToTvPD
-#[inline(always)]
-fn read_table(x: u64) -> (u64, usize, u64) {
-    debug_assert!(x <= MAX_VARINT_VALUE);
-
-    macro_rules! table {
-        ($(($two_bit:expr, $length:expr, $usable_bits:expr, $max_value:expr);)*) => {{
-            let mut two_bit = 0;
-            let leading_zeros = x.leading_zeros();
-            $(
-                two_bit += if leading_zeros < (64 - $usable_bits) {
-                    1
-                } else {
-                    0
-                };
-            )*
-
-            let len = 1 << two_bit;
-            let usable_bits = len * 8 - 2;
-
-            debug_assert_eq!(len as usize, encoding_size(x));
-
-            (two_bit, len as usize, usable_bits)
-        }};
-    }
-
-    table! {
-        (0b00, 1, 6 , 63);
-        (0b01, 2, 14, 16_383);
-        (0b10, 4, 30, 1_073_741_823);
-    }
-}
-
-#[inline(always)]
-fn encoding_size(x: u64) -> usize {
-    debug_assert!(x <= MAX_VARINT_VALUE);
-
-    macro_rules! table {
-        ($(($two_bit:expr, $length:expr, $usable_bits:expr, $max_value:expr);)*) => {{
-            let leading_zeros = x.leading_zeros();
-            let mut len = 1;
-
-            $(
-                if leading_zeros < (64 - $usable_bits) {
-                    len = $length * 2;
-                };
-            )*
-
-            len
-        }};
-    }
-
-    table! {
-        (0b00, 1, 6 , 63);
-        (0b01, 2, 14, 16_383);
-        (0b10, 4, 30, 1_073_741_823);
-    }
-}
 
 // === API ===
 
@@ -136,6 +61,7 @@ impl VarInt {
     #[cfg(any(feature = "generator", test))]
     const GENERATOR: core::ops::RangeInclusive<u64> = 0..=MAX_VARINT_VALUE;
 
+    #[inline(always)]
     pub fn new(v: u64) -> Result<Self, VarIntError> {
         if v > MAX_VARINT_VALUE {
             return Err(VarIntError);
@@ -148,22 +74,27 @@ impl VarInt {
     /// # Safety
     ///
     /// Callers need to ensure the value is less than or equal to VarInt::MAX
+    #[inline(always)]
     pub const unsafe fn new_unchecked(value: u64) -> Self {
         Self(value)
     }
 
+    #[inline(always)]
     pub const fn from_u8(v: u8) -> Self {
         Self(v as u64)
     }
 
+    #[inline(always)]
     pub const fn from_u16(v: u16) -> Self {
         Self(v as u64)
     }
 
+    #[inline(always)]
     pub const fn from_u32(v: u32) -> Self {
         Self(v as u64)
     }
 
+    #[inline(always)]
     pub const fn as_u64(self) -> u64 {
         self.0
     }
@@ -216,92 +147,41 @@ impl VarInt {
     #[inline]
     pub fn encode_updated<E: Encoder>(self, replacement: Self, encoder: &mut E) {
         debug_assert!(
-            self.encoding_table_entry().1 >= replacement.encoding_table_entry().1,
+            self.table_entry().len >= replacement.table_entry().len,
             "the replacement encoding_size should not be greater than the previous value"
         );
 
-        replacement.encode_with_table_entry(self.encoding_table_entry(), encoder);
+        // don't use the basic version to avoid overwriting things
+        self.table_entry()
+            .format(replacement.0)
+            .encode_maybe_undersized(encoder)
     }
 
-    #[inline]
-    fn encode_with_table_entry<E: Encoder>(
-        self,
-        (two_bit, len, usable_bits): (u64, usize, u64),
-        encoder: &mut E,
-    ) {
-        encoder.write_sized(len, |buffer| {
-            let bytes = (two_bit << usable_bits | self.0).to_be_bytes();
-
-            unsafe {
-                // Safety: the encoder will have checked the buffer size
-                //         before passing it so we don't need to pay the bounds
-                //         check cost twice.
-
-                // This code looks a little scary so here's some comments describing what
-                // is happening.
-
-                // We bitwise-and the two bit value to ensure the compiler can prove the
-                // `unreachable` is actually unreachable.
-                match two_bit & 0b11 {
-                    0b00 => {
-                        // If the two bit value is 0b00 it means we only have 1 byte to
-                        // encode so we copy the last byte from our big endian encoded value
-                        // into the first byte of the buffer
-                        debug_assert_eq!(buffer.len(), 1);
-                        *buffer.get_unchecked_mut(0) = *bytes.get_unchecked(7);
-                    }
-                    0b01 => {
-                        // If the two bit value is 0b01 it means we have a 2 byte value to
-                        // encode so we copy the last 2 bytes from our big endian encoded value
-                        // into the first 2 bytes of the buffer
-                        debug_assert_eq!(buffer.len(), 2);
-                        buffer
-                            .get_unchecked_mut(..2)
-                            .copy_from_slice(bytes.get_unchecked(6..));
-                    }
-                    0b10 => {
-                        // If the two bit value is 0b10 it means we have a 4 byte value to
-                        // encode so we copy the last 4 bytes from our big endian encoded value
-                        // into the first 4 bytes of the buffer
-                        debug_assert_eq!(buffer.len(), 4);
-                        buffer
-                            .get_unchecked_mut(..4)
-                            .copy_from_slice(bytes.get_unchecked(4..));
-                    }
-                    0b11 => {
-                        // If the two bit value is 0b11 it means we have a 8 byte value to
-                        // encode so we copy all of the bytes into the buffer
-                        debug_assert_eq!(buffer.len(), 8);
-                        buffer
-                            .get_unchecked_mut(..8)
-                            .copy_from_slice(bytes.get_unchecked(..8));
-                    }
-                    _ => unreachable!(),
-                }
-            }
-        })
+    #[inline(always)]
+    fn table_entry(self) -> table::Entry {
+        table::Entry::read(self.0)
     }
 
-    #[inline]
-    fn encoding_table_entry(self) -> (u64, usize, u64) {
-        read_table(self.0)
+    #[inline(always)]
+    fn format(self) -> table::Formatted {
+        table::Formatted::new(self.0)
     }
 }
 
 impl EncoderValue for VarInt {
-    #[inline]
+    #[inline(always)]
     fn encode<E: Encoder>(&self, encoder: &mut E) {
-        self.encode_with_table_entry(self.encoding_table_entry(), encoder);
+        self.format().encode(encoder);
     }
 
-    #[inline]
+    #[inline(always)]
     fn encoding_size(&self) -> usize {
-        encoding_size(self.0)
+        self.format().encoding_size()
     }
 
-    #[inline]
-    fn encoding_size_for_encoder<E: Encoder>(&self, _encoder: &E) -> usize {
-        encoding_size(self.0)
+    #[inline(always)]
+    fn encoding_size_for_encoder<E: Encoder>(&self, encoder: &E) -> usize {
+        self.format().encoding_size_for_encoder(encoder)
     }
 }
 
@@ -338,7 +218,7 @@ decoder_value!(
                     let value = value & (2u64.pow(62) - 1);
                     (Self(value), buffer)
                 }
-                _ => unreachable!(),
+                _ => unsafe { core::hint::unreachable_unchecked() },
             })
         }
     }

--- a/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_0_.snap
+++ b/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_0_.snap
@@ -1,9 +1,20 @@
 ---
-source: quic/s2n-quic-core/src/varint/mod.rs
-expression: read_table(2u64.pow(i))
+source: quic/s2n-quic-core/src/varint/tests.rs
+expression: "table::Entry::read(2u64.pow(i))"
 ---
-(
-    0,
-    1,
-    6,
-)
+Entry {
+    two_bit: 0,
+    two_bit_be: [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ],
+    len: 1,
+    usable_bits: 6,
+    shift: 56,
+}

--- a/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_13_.snap
+++ b/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_13_.snap
@@ -1,9 +1,20 @@
 ---
-source: quic/s2n-quic-core/src/varint/mod.rs
-expression: read_table(2u64.pow(i))
+source: quic/s2n-quic-core/src/varint/tests.rs
+expression: "table::Entry::read(2u64.pow(i))"
 ---
-(
-    1,
-    2,
-    14,
-)
+Entry {
+    two_bit: 1,
+    two_bit_be: [
+        64,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ],
+    len: 2,
+    usable_bits: 14,
+    shift: 48,
+}

--- a/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_14_.snap
+++ b/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_14_.snap
@@ -1,9 +1,20 @@
 ---
-source: quic/s2n-quic-core/src/varint/mod.rs
-expression: read_table(2u64.pow(i))
+source: quic/s2n-quic-core/src/varint/tests.rs
+expression: "table::Entry::read(2u64.pow(i))"
 ---
-(
-    2,
-    4,
-    30,
-)
+Entry {
+    two_bit: 2,
+    two_bit_be: [
+        128,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ],
+    len: 4,
+    usable_bits: 30,
+    shift: 32,
+}

--- a/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_1_.snap
+++ b/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_1_.snap
@@ -1,9 +1,20 @@
 ---
-source: quic/s2n-quic-core/src/varint/mod.rs
-expression: read_table(2u64.pow(i))
+source: quic/s2n-quic-core/src/varint/tests.rs
+expression: "table::Entry::read(2u64.pow(i))"
 ---
-(
-    0,
-    1,
-    6,
-)
+Entry {
+    two_bit: 0,
+    two_bit_be: [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ],
+    len: 1,
+    usable_bits: 6,
+    shift: 56,
+}

--- a/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_29_.snap
+++ b/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_29_.snap
@@ -1,9 +1,20 @@
 ---
-source: quic/s2n-quic-core/src/varint/mod.rs
-expression: read_table(2u64.pow(i))
+source: quic/s2n-quic-core/src/varint/tests.rs
+expression: "table::Entry::read(2u64.pow(i))"
 ---
-(
-    2,
-    4,
-    30,
-)
+Entry {
+    two_bit: 2,
+    two_bit_be: [
+        128,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ],
+    len: 4,
+    usable_bits: 30,
+    shift: 32,
+}

--- a/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_30_.snap
+++ b/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_30_.snap
@@ -1,9 +1,20 @@
 ---
-source: quic/s2n-quic-core/src/varint/mod.rs
-expression: read_table(2u64.pow(i))
+source: quic/s2n-quic-core/src/varint/tests.rs
+expression: "table::Entry::read(2u64.pow(i))"
 ---
-(
-    3,
-    8,
-    62,
-)
+Entry {
+    two_bit: 3,
+    two_bit_be: [
+        192,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ],
+    len: 8,
+    usable_bits: 62,
+    shift: 0,
+}

--- a/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_5_.snap
+++ b/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_5_.snap
@@ -1,9 +1,20 @@
 ---
-source: quic/s2n-quic-core/src/varint/mod.rs
-expression: read_table(2u64.pow(i))
+source: quic/s2n-quic-core/src/varint/tests.rs
+expression: "table::Entry::read(2u64.pow(i))"
 ---
-(
-    0,
-    1,
-    6,
-)
+Entry {
+    two_bit: 0,
+    two_bit_be: [
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ],
+    len: 1,
+    usable_bits: 6,
+    shift: 56,
+}

--- a/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_61_.snap
+++ b/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_61_.snap
@@ -1,9 +1,20 @@
 ---
-source: quic/s2n-quic-core/src/varint/mod.rs
-expression: read_table(2u64.pow(i))
+source: quic/s2n-quic-core/src/varint/tests.rs
+expression: "table::Entry::read(2u64.pow(i))"
 ---
-(
-    3,
-    8,
-    62,
-)
+Entry {
+    two_bit: 3,
+    two_bit_be: [
+        192,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ],
+    len: 8,
+    usable_bits: 62,
+    shift: 0,
+}

--- a/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_6_.snap
+++ b/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__table_2_pow_6_.snap
@@ -1,9 +1,20 @@
 ---
-source: quic/s2n-quic-core/src/varint/mod.rs
-expression: read_table(2u64.pow(i))
+source: quic/s2n-quic-core/src/varint/tests.rs
+expression: "table::Entry::read(2u64.pow(i))"
 ---
-(
-    1,
-    2,
-    14,
-)
+Entry {
+    two_bit: 1,
+    two_bit_be: [
+        64,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    ],
+    len: 2,
+    usable_bits: 14,
+    shift: 48,
+}

--- a/quic/s2n-quic-core/src/varint/table.rs
+++ b/quic/s2n-quic-core/src/varint/table.rs
@@ -1,0 +1,283 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::MAX_VARINT_VALUE;
+use core::fmt;
+use s2n_codec::{Encoder, EncoderValue};
+
+//# The QUIC variable-length integer encoding reserves the two most
+//# significant bits of the first byte to encode the base 2 logarithm of
+//# the integer encoding length in bytes.  The integer value is encoded
+//# on the remaining bits, in network byte order.
+
+//= https://www.rfc-editor.org/rfc/rfc9000#section-16
+//# This means that integers are encoded on 1, 2, 4, or 8 bytes and can
+//# encode 6-, 14-, 30-, or 62-bit values, respectively.  Table 4
+//# summarizes the encoding properties.
+//#
+//#        +======+========+=============+=======================+
+//#        | 2MSB | Length | Usable Bits | Range                 |
+//#        +======+========+=============+=======================+
+//#        | 00   | 1      | 6           | 0-63                  |
+//#        +------+--------+-------------+-----------------------+
+//#        | 01   | 2      | 14          | 0-16383               |
+//#        +------+--------+-------------+-----------------------+
+//#        | 10   | 4      | 30          | 0-1073741823          |
+//#        +------+--------+-------------+-----------------------+
+//#        | 11   | 8      | 62          | 0-4611686018427387903 |
+//#        +------+--------+-------------+-----------------------+
+
+macro_rules! call_table {
+    ($table:ident) => {
+        $table! {
+            (0b10, 4, 30, 1_073_741_823);
+            (0b01, 2, 14, 16_383);
+            (0b00, 1, 6 , 63);
+        }
+    };
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct Entry {
+    /// The two bits to use for this entry, encoding in native-endian
+    pub two_bit: u64,
+    /// The two bits to use for this entry, encoding in big-endian
+    pub two_bit_be: u64,
+    /// The number of bytes required to encode this entry
+    pub len: usize,
+    /// The number of usable bits for the actual value
+    pub usable_bits: u64,
+    /// The number of bits to shift for encoding/decoding
+    pub shift: u64,
+}
+
+impl fmt::Debug for Entry {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Entry")
+            .field("two_bit", &self.two_bit)
+            .field("two_bit_be", &self.two_bit_be.to_ne_bytes())
+            .field("len", &self.len)
+            .field("usable_bits", &self.usable_bits)
+            .field("shift", &self.shift)
+            .finish()
+    }
+}
+
+impl Entry {
+    /// Returns the entry in the table corresponding to the provided value
+    #[inline(always)]
+    pub fn read(x: u64) -> Self {
+        let optimized = Self::read_optimized(x);
+        debug_assert_eq!(optimized, Self::read_rfc(x));
+        optimized
+    }
+
+    /// A simple implementation of the table lookup, mostly based on the RFC table
+    #[inline(always)]
+    pub fn read_rfc(x: u64) -> Self {
+        // write the table from the RFC in a non-optimized format and make sure the
+        // actual results match
+        #[allow(clippy::match_overlapping_arm)]
+        match x {
+            0..=63 => Self {
+                two_bit: 0b00,
+                two_bit_be: 0b00,
+                len: 1,
+                usable_bits: 6,
+                shift: 56,
+            },
+            0..=16383 => Self {
+                two_bit: 0b01,
+                two_bit_be: (0b01u64 << 62).to_be(),
+                len: 2,
+                usable_bits: 14,
+                shift: 48,
+            },
+            0..=1073741823 => Self {
+                two_bit: 0b10,
+                two_bit_be: (0b10u64 << 62).to_be(),
+                len: 4,
+                usable_bits: 30,
+                shift: 32,
+            },
+            0..=4611686018427387903 => Self {
+                two_bit: 0b11,
+                two_bit_be: (0b11u64 << 62).to_be(),
+                len: 8,
+                usable_bits: 62,
+                shift: 0,
+            },
+            _ => unreachable!(),
+        }
+    }
+
+    // https://godbolt.org/z/9xrxd1osd
+    #[inline(always)]
+    pub fn read_optimized(x: u64) -> Self {
+        unsafe {
+            crate::assume!(x <= MAX_VARINT_VALUE);
+        }
+
+        macro_rules! table {
+            ($(($two_bit:expr, $length:expr, $usable_bits:expr, $max_value:expr);)*) => {{
+                let mut shift = 0;
+                let mut usable_bits = 62;
+                let mut two_bit = 0b11u64;
+                let mut two_bit_be = (two_bit << 62).to_be();
+                let mut len = 8;
+
+                $(
+                    if x <= $max_value {
+                        shift = 62 - $usable_bits;
+                        usable_bits = $usable_bits;
+                        two_bit -= 1u64;
+                        two_bit_be -= (1u64 << 62).to_be();
+                        len = $length;
+                    }
+                )*
+
+                Self { two_bit, two_bit_be, len, usable_bits, shift }
+            }};
+        }
+
+        call_table!(table)
+    }
+
+    #[inline(always)]
+    pub fn format(&self, value: u64) -> Formatted {
+        let encoded_be = (value << self.shift).to_be() | self.two_bit_be;
+        let len = self.len;
+        Formatted { encoded_be, len }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Formatted {
+    pub(crate) encoded_be: u64,
+    pub(crate) len: usize,
+}
+
+impl Formatted {
+    #[inline(always)]
+    pub(super) fn new(x: u64) -> Self {
+        unsafe {
+            crate::assume!(x <= MAX_VARINT_VALUE);
+        }
+
+        macro_rules! table {
+            ($(($two_bit:expr, $length:expr, $usable_bits:expr, $max_value:expr);)*) => {{
+                let mut shift = 0;
+                let mut two_bit = (0b11u64 << 62).to_be();
+                let mut len = 8;
+
+                $(
+                    if x <= $max_value {
+                        shift = 62 - $usable_bits;
+                        two_bit -= (1u64 << 62).to_be();
+                        len = $length;
+                    }
+                )*
+
+                #[cfg(debug_assertions)]
+                {
+                    // make sure we end up with the same computed entry
+                    let entry = Entry::read_rfc(x);
+                    assert_eq!(entry.shift, shift);
+                    assert_eq!(entry.two_bit_be, two_bit);
+                    assert_eq!(entry.len, len);
+                }
+
+                let encoded_be = (x << shift).to_be() | two_bit;
+
+                let v = Self { encoded_be, len };
+
+                v.invariants();
+
+                v
+            }};
+        }
+
+        call_table!(table)
+    }
+
+    #[inline(always)]
+    pub(super) fn encode_oversized<E: Encoder>(&self, encoder: &mut E) {
+        debug_assert!(encoder.remaining_capacity() >= 8);
+        self.invariants();
+
+        encoder.write_sized(self.len, |dest| {
+            let dest = dest.as_mut_ptr() as *mut [u8; 8];
+            let bytes = self.encoded_be.to_ne_bytes();
+            unsafe {
+                core::ptr::write(dest, bytes);
+            }
+        });
+    }
+
+    #[inline(always)]
+    pub(super) fn encode_maybe_undersized<E: Encoder>(&self, encoder: &mut E) {
+        self.invariants();
+
+        let len = self.len;
+
+        encoder.write_sized(len, |dst| {
+            let src = self.encoded_be.to_ne_bytes();
+            unsafe {
+                use core::ptr::copy_nonoverlapping as copy;
+
+                crate::assume!(dst.len() == len);
+
+                let src = src.as_ptr();
+                let dst = dst.as_mut_ptr();
+
+                match len {
+                    1 => copy(src, dst, 1),
+                    2 => copy(src, dst, 2),
+                    4 => copy(src, dst, 4),
+                    8 => copy(src, dst, 8),
+                    _ => {
+                        assume!(false, "invalid len: {len}");
+                    }
+                }
+            }
+        });
+    }
+
+    #[inline(always)]
+    pub(super) fn invariants(&self) {
+        unsafe {
+            let len = self.len;
+            // avoid using `contains` since kani wants an unwind for that
+            assume!(len == 1 || len == 2 || len == 4 || len == 8);
+        }
+    }
+}
+
+impl EncoderValue for Formatted {
+    #[inline(always)]
+    fn encode<E: Encoder>(&self, encoder: &mut E) {
+        self.invariants();
+
+        // optimize for the case where we have at least 8 bytes left and just write a full u64 to
+        // the buffer, but incrementing the offset by `self.len`.
+        //
+        // ignore this optimization under miri, since we're technically reading beyond the slice
+        // that the encoder gives us, which miri complains about.
+        if encoder.remaining_capacity() >= 8 && !cfg!(miri) {
+            self.encode_oversized(encoder);
+        } else {
+            self.encode_maybe_undersized(encoder);
+        }
+    }
+
+    #[inline(always)]
+    fn encoding_size(&self) -> usize {
+        self.len
+    }
+
+    #[inline(always)]
+    fn encoding_size_for_encoder<E: Encoder>(&self, _encoder: &E) -> usize {
+        self.len
+    }
+}


### PR DESCRIPTION
### Description of changes: 

This PR focuses on improving varint encoding a bit by:

* improving the table function to be completely branchless (see https://godbolt.org/z/9xrxd1osd)
* Adding a special case when we have at least 8 bytes in the target buffer and just doing a single 64 bit `mov`, rather than having to branch based on our integer size:
  https://github.com/aws/s2n-quic/blob/b84785290f147a8b97616d449ab93632c8842bab/quic/s2n-quic-core/src/varint/table.rs#L262-L271

I've also cleaned the code up a bit by moving the table functions into a separate module with an named struct, rather than a `(u64, usize, u64)`.

Performance has improved by about 30-40%

```
varint/encode/array/1   time:   [1.6209 ns 1.6211 ns 1.6212 ns]
                        change: [-40.046% -39.123% -37.678%] (p = 0.00 < 0.05)
varint/encode/slice/1   time:   [2.4321 ns 2.4329 ns 2.4341 ns]
                        change: [-33.393% -33.335% -33.266%] (p = 0.00 < 0.05)
varint/encode/array_16/1
                        time:   [38.505 ns 38.515 ns 38.529 ns]
                        change: [-31.424% -31.257% -31.005%] (p = 0.00 < 0.05)
varint/encode/slice_16/1
                        time:   [38.676 ns 38.790 ns 38.889 ns]
                        change: [-38.523% -38.430% -38.354%] (p = 0.00 < 0.05)
```

### Testing:

The existing tests should prevent any regressions in behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

