### PR TITLE
Enable handle_get_set_test test in Kani via stubbing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -722,7 +722,7 @@ jobs:
         uses: model-checking/kani-github-action@v1.0
         with:
           working-directory: ${{ matrix.crate }}
-          args: --tests
+          args: --tests -Z stubbing
 
   dhat:
     runs-on: ubuntu-latest

--- a/common/s2n-codec/src/zerocopy.rs
+++ b/common/s2n-codec/src/zerocopy.rs
@@ -297,6 +297,13 @@ macro_rules! zerocopy_network_integer {
             }
         }
 
+        #[cfg(kani)]
+        impl kani::Arbitrary for $name {
+            fn any() -> Self {
+                Self::new(kani::any())
+            }
+        }
+
         zerocopy_value_codec!($name);
     };
 }

--- a/quic/s2n-quic-core/src/inet/datagram.rs
+++ b/quic/s2n-quic-core/src/inet/datagram.rs
@@ -25,6 +25,7 @@ pub struct DatagramInfo {
 
 /// Additional metadata for a datagram sent/received over the network
 #[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[cfg_attr(kani, derive(kani::Arbitrary))]
 pub struct AncillaryData {
     pub ecn: ExplicitCongestionNotification,
     pub local_address: LocalAddress,

--- a/quic/s2n-quic-core/src/inet/ecn.rs
+++ b/quic/s2n-quic-core/src/inet/ecn.rs
@@ -51,6 +51,7 @@ use bolero_generator::*;
 #[repr(u8)]
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 #[cfg_attr(any(test, feature = "generator"), derive(TypeGenerator))]
+#[cfg_attr(kani, derive(kani::Arbitrary))]
 pub enum ExplicitCongestionNotification {
     /// The not-ECT codepoint '00' indicates a packet that is not using ECN.
     NotEct = 0b00,

--- a/quic/s2n-quic-core/src/inet/ip.rs
+++ b/quic/s2n-quic-core/src/inet/ip.rs
@@ -111,6 +111,7 @@ impl<'a> From<&'a IpV6Address> for IpAddressRef<'a> {
 /// The size is also consistent across target operating systems.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(any(test, feature = "generator"), derive(TypeGenerator))]
+#[cfg_attr(kani, derive(kani::Arbitrary))]
 pub enum SocketAddress {
     IpV4(SocketAddressV4),
     IpV6(SocketAddressV6),

--- a/quic/s2n-quic-core/src/inet/macros.rs
+++ b/quic/s2n-quic-core/src/inet/macros.rs
@@ -14,6 +14,7 @@ macro_rules! define_inet_type {
 
         #[derive(Clone, Copy, Default, Eq, PartialEq, PartialOrd, Ord, zerocopy::FromBytes, zerocopy::AsBytes, zerocopy::Unaligned)]
         #[cfg_attr(any(test, feature = "generator"), derive(bolero_generator::TypeGenerator))]
+        #[cfg_attr(kani, derive(kani::Arbitrary))]
         #[repr(C)]
         $($vis)? struct $name {
             $(

--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -125,6 +125,7 @@ macro_rules! impl_addr {
     ($name:ident) => {
         #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Hash)]
         #[cfg_attr(any(test, feature = "generator"), derive(TypeGenerator))]
+        #[cfg_attr(kani, derive(kani::Arbitrary))]
         pub struct $name(pub SocketAddress);
 
         impl From<event::api::SocketAddress<'_>> for $name {

--- a/quic/s2n-quic-platform/src/message/msg/tests.rs
+++ b/quic/s2n-quic-platform/src/message/msg/tests.rs
@@ -40,11 +40,7 @@ mod stubs {
     use s2n_quic_core::inet::AncillaryData;
 
     pub fn decode(_msghdr: &libc::msghdr) -> AncillaryData {
-        let mut ancillary_data = AncillaryData::default();
-        ancillary_data.ecn = kani::any();
-        ancillary_data.local_address = kani::any();
-        ancillary_data.local_interface = Some(kani::any());
-        ancillary_data.segment_size = kani::any();
+        let ancillary_data = kani::any();
 
         ancillary_data
     }
@@ -71,6 +67,7 @@ fn address_inverse_pair_test() {
     kani::proof,
     kani::solver(cadical),
     kani::unwind(65),
+    // it's safe to stub out cmsg::decode since the cmsg result isn't actually checked in this particular test
     kani::stub(cmsg::decode, stubs::decode)
 )]
 fn handle_get_set_test() {


### PR DESCRIPTION


### Resolved issues:

N/A.

### Description of changes: 
We add a stub for cmsg::decode where we return a non-deterministic AncillaryData object. With this stub, the handle_get_set_test harness terminates successfuly, since it doesn't include any assertions (that would be checked by Kani) over the content of the nondet object.

### Call-outs:
Verification time is less than a minute.

### Testing:
N/A.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

