### PR TITLE
refactor(s2n-quic-core): move ack::Ranges from transport

### DIFF
--- a/quic/s2n-quic-core/src/ack.rs
+++ b/quic/s2n-quic-core/src/ack.rs
@@ -1,8 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "alloc")]
+pub mod ranges;
 pub mod set;
 pub mod settings;
 
+#[cfg(feature = "alloc")]
+pub use ranges::Ranges;
 pub use set::Set;
 pub use settings::Settings;

--- a/quic/s2n-quic-core/src/ack/snapshots/s2n_quic_core__ack__ranges__tests__Ranges.snap
+++ b/quic/s2n-quic-core/src/ack/snapshots/s2n_quic_core__ack__ranges__tests__Ranges.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/ack/ranges.rs
+expression: "size_of::<Ranges>()"
+---
+40

--- a/quic/s2n-quic-core/src/packet/number/mod.rs
+++ b/quic/s2n-quic-core/src/packet/number/mod.rs
@@ -62,6 +62,8 @@ pub mod map;
 #[cfg(feature = "alloc")]
 pub use map::Map;
 
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;
 #[cfg(test)]
 mod tests;
 

--- a/quic/s2n-quic-core/src/packet/number/testing.rs
+++ b/quic/s2n-quic-core/src/packet/number/testing.rs
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::varint::VarInt;
+
+pub fn iter(space: PacketNumberSpace) -> impl Iterator<Item = PacketNumber> {
+    core::iter::successors(Some(space.new_packet_number(VarInt::from_u8(0))), |prev| {
+        prev.next()
+    })
+}

--- a/quic/s2n-quic-transport/src/ack/ack_transmission_state.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_transmission_state.rs
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{ack::ack_ranges::AckRanges, transmission};
+use crate::transmission;
+use s2n_quic_core::ack;
 
 #[derive(Clone, Copy, Default, Debug, PartialEq, Eq)]
 pub enum AckTransmissionState {
@@ -64,7 +65,7 @@ impl AckTransmissionState {
     }
 
     /// Notify the transmission state that pending ack ranges has updated
-    pub fn on_update(&mut self, ack_ranges: &AckRanges) -> &mut Self {
+    pub fn on_update(&mut self, ack_ranges: &ack::Ranges) -> &mut Self {
         // no need to transmit anything now
         if ack_ranges.is_empty() {
             *self = AckTransmissionState::Disabled;
@@ -256,7 +257,7 @@ mod tests {
 
     #[test]
     fn update_test() {
-        let mut ack_ranges = AckRanges::new(10);
+        let mut ack_ranges = ack::Ranges::new(10);
         let mut packet_numbers = packet_numbers_iter().step_by(2); // skip every other packet number
 
         assert_eq!(

--- a/quic/s2n-quic-transport/src/ack/mod.rs
+++ b/quic/s2n-quic-transport/src/ack/mod.rs
@@ -6,7 +6,6 @@ pub use s2n_quic_core::ack::*;
 
 mod ack_eliciting_transmission;
 mod ack_manager;
-pub(crate) mod ack_ranges;
 mod ack_transmission_state;
 
 #[cfg(test)]

--- a/quic/s2n-quic-transport/src/ack/snapshots/quic__s2n-quic-transport__src__ack__ack_manager__events__activate.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/quic__s2n-quic-transport__src__ack__ack_manager__events__activate.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/ack/ack_manager.rs
-assertion_line: 430
 expression: ""
-
 ---
 

--- a/quic/s2n-quic-transport/src/ack/snapshots/quic__s2n-quic-transport__src__ack__ack_manager__events__ecn_counts.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/quic__s2n-quic-transport__src__ack__ack_manager__events__ecn_counts.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/ack/ack_manager.rs
-assertion_line: 452
 expression: ""
-
 ---
 

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_eliciting_transmission__tests__AckElicitingTransmission.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_eliciting_transmission__tests__AckElicitingTransmission.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/ack/ack_eliciting_transmission.rs
-assertion_line: 175
 expression: "size_of::<AckElicitingTransmission>()"
-
 ---
 16

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_eliciting_transmission__tests__AckElicitingTransmissionSet.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_eliciting_transmission__tests__AckElicitingTransmissionSet.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/ack/ack_eliciting_transmission.rs
-assertion_line: 179
 expression: "size_of::<AckElicitingTransmissionSet>()"
-
 ---
 32

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__AckManager.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__AckManager.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/ack/ack_manager.rs
-assertion_line: 547
 expression: "size_of::<AckManager>()"
-
 ---
 168

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__client_sending_test.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__client_sending_test.snap
@@ -1,11 +1,10 @@
 ---
 source: quic/s2n-quic-transport/src/ack/ack_manager.rs
-assertion_line: 644
-expression: "Simulation{network:\n               Network{client:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(25),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),\n                       server:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(25),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            empty()).into(),},\n           events: empty().collect(),\n           delay: Duration::from_millis(0),}.run()"
+expression: "Simulation {\n        network: Network {\n            client: Application::new(Endpoint::new(ack::Settings {\n                            max_ack_delay: Duration::from_millis(25),\n                            ack_delay_exponent: 1,\n                            ..Default::default()\n                        }),\n                    [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),\n            server: Application::new(Endpoint::new(ack::Settings {\n                            max_ack_delay: Duration::from_millis(25),\n                            ack_delay_exponent: 1,\n                            ..Default::default()\n                        }), empty()).into(),\n        },\n        events: empty().collect(),\n        delay: Duration::from_millis(0),\n    }.run()"
 ---
 Report {
     client: EndpointReport {
-        pending_ack_ranges: AckRanges(
+        pending_ack_ranges: Ranges(
             {
                 PacketNumber(
                     ApplicationData,
@@ -25,7 +24,7 @@ Report {
         processed_transmissions: 100,
     },
     server: EndpointReport {
-        pending_ack_ranges: AckRanges(
+        pending_ack_ranges: Ranges(
             {
                 PacketNumber(
                     ApplicationData,

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__delayed_client_sending_test.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__delayed_client_sending_test.snap
@@ -1,11 +1,10 @@
 ---
 source: quic/s2n-quic-transport/src/ack/ack_manager.rs
-assertion_line: 677
-expression: "Simulation{network:\n               Network{client:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(25),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),\n                       server:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(25),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            empty()).into(),},\n           events: empty().collect(),\n           delay: Duration::from_millis(100),}.run()"
+expression: "Simulation {\n        network: Network {\n            client: Application::new(Endpoint::new(ack::Settings {\n                            max_ack_delay: Duration::from_millis(25),\n                            ack_delay_exponent: 1,\n                            ..Default::default()\n                        }),\n                    [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),\n            server: Application::new(Endpoint::new(ack::Settings {\n                            max_ack_delay: Duration::from_millis(25),\n                            ack_delay_exponent: 1,\n                            ..Default::default()\n                        }), empty()).into(),\n        },\n        events: empty().collect(),\n        delay: Duration::from_millis(100),\n    }.run()"
 ---
 Report {
     client: EndpointReport {
-        pending_ack_ranges: AckRanges(
+        pending_ack_ranges: Ranges(
             {
                 PacketNumber(
                     ApplicationData,
@@ -25,7 +24,7 @@ Report {
         processed_transmissions: 101,
     },
     server: EndpointReport {
-        pending_ack_ranges: AckRanges(
+        pending_ack_ranges: Ranges(
             {
                 PacketNumber(
                     ApplicationData,

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__high_latency_test.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__high_latency_test.snap
@@ -1,11 +1,10 @@
 ---
 source: quic/s2n-quic-transport/src/ack/ack_manager.rs
-assertion_line: 711
-expression: "Simulation{network:\n               Network{client:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(25),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),\n                       server:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(100),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),},\n           events: empty().collect(),\n           delay: Duration::from_millis(1000),}.run()"
+expression: "Simulation {\n        network: Network {\n            client: Application::new(Endpoint::new(ack::Settings {\n                            max_ack_delay: Duration::from_millis(25),\n                            ack_delay_exponent: 1,\n                            ..Default::default()\n                        }),\n                    [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),\n            server: Application::new(Endpoint::new(ack::Settings {\n                            max_ack_delay: Duration::from_millis(100),\n                            ack_delay_exponent: 1,\n                            ..Default::default()\n                        }),\n                    [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),\n        },\n        events: empty().collect(),\n        delay: Duration::from_millis(1000),\n    }.run()"
 ---
 Report {
     client: EndpointReport {
-        pending_ack_ranges: AckRanges(
+        pending_ack_ranges: Ranges(
             {
                 PacketNumber(
                     ApplicationData,
@@ -25,7 +24,7 @@ Report {
         processed_transmissions: 119,
     },
     server: EndpointReport {
-        pending_ack_ranges: AckRanges(
+        pending_ack_ranges: Ranges(
             {
                 PacketNumber(
                     ApplicationData,

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__lossy_network_test.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_manager__tests__lossy_network_test.snap
@@ -1,11 +1,10 @@
 ---
 source: quic/s2n-quic-transport/src/ack/ack_manager.rs
-assertion_line: 745
-expression: "Simulation{network:\n               Network{client:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(25),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),\n                       server:\n                           Application::new(Endpoint::new(ack::Settings{max_ack_delay:\n                                                                            Duration::from_millis(100),\n                                                                        ack_delay_exponent:\n                                                                            1,\n                                                                                 ..Default::default()}),\n                                            [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),},\n           events:\n               once(NetworkEvent::Pass).cycle().take(4).chain(once(NetworkEvent::Drop)).collect(),\n           delay: Duration::from_millis(0),}.run()"
+expression: "Simulation {\n        network: Network {\n            client: Application::new(Endpoint::new(ack::Settings {\n                            max_ack_delay: Duration::from_millis(25),\n                            ack_delay_exponent: 1,\n                            ..Default::default()\n                        }),\n                    [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),\n            server: Application::new(Endpoint::new(ack::Settings {\n                            max_ack_delay: Duration::from_millis(100),\n                            ack_delay_exponent: 1,\n                            ..Default::default()\n                        }),\n                    [Duration::from_millis(5)].iter().cycle().take(100).cloned()).into(),\n        },\n        events: once(NetworkEvent::Pass).cycle().take(4).chain(once(NetworkEvent::Drop)).collect(),\n        delay: Duration::from_millis(0),\n    }.run()"
 ---
 Report {
     client: EndpointReport {
-        pending_ack_ranges: AckRanges(
+        pending_ack_ranges: Ranges(
             {
                 PacketNumber(
                     ApplicationData,
@@ -25,7 +24,7 @@ Report {
         processed_transmissions: 80,
     },
     server: EndpointReport {
-        pending_ack_ranges: AckRanges(
+        pending_ack_ranges: Ranges(
             {
                 PacketNumber(
                     ApplicationData,

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_ranges__tests__AckRanges.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_ranges__tests__AckRanges.snap
@@ -1,7 +1,0 @@
----
-source: quic/s2n-quic-transport/src/ack/ack_ranges.rs
-assertion_line: 235
-expression: "size_of::<AckRanges>()"
-
----
-40

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_transmission_state__tests__AckTransmissionState.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_transmission_state__tests__AckTransmissionState.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/ack/ack_transmission_state.rs
-assertion_line: 275
 expression: "size_of::<AckTransmissionState>()"
-
 ---
 16

--- a/quic/s2n-quic-transport/src/ack/tests/report.rs
+++ b/quic/s2n-quic-transport/src/ack/tests/report.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ack::ack_ranges::AckRanges;
+use s2n_quic_core::ack;
 
 #[derive(Debug, Default)]
 pub struct Report {
@@ -13,7 +13,7 @@ pub struct Report {
 #[derive(Debug, Default)]
 pub struct EndpointReport {
     /// Final state of the pending AckRanges
-    pub pending_ack_ranges: AckRanges,
+    pub pending_ack_ranges: ack::Ranges,
     /// Total number of transmissions sent
     pub total_transmissions: usize,
     /// Number of transmissions that elicited an ACK

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -3,7 +3,6 @@
 
 use super::*;
 use crate::{
-    ack::ack_ranges::AckRanges,
     connection::{ConnectionIdMapper, InternalConnectionIdGenerator},
     contexts::testing::{MockWriteContext, OutgoingFrameBuffer},
     endpoint::{
@@ -17,7 +16,7 @@ use crate::{
 use bolero::TypeGenerator;
 use core::{ops::RangeInclusive, time::Duration};
 use s2n_quic_core::{
-    connection,
+    ack, connection,
     event::testing::Publisher,
     frame::ack_elicitation::AckElicitation,
     inet::{DatagramInfo, ExplicitCongestionNotification, SocketAddress},
@@ -3148,7 +3147,7 @@ fn helper_ack_packets_on_path(
         source_connection_id: None,
     };
 
-    let mut ack_range = AckRanges::new(acked_packets.count());
+    let mut ack_range = ack::Ranges::new(acked_packets.count());
 
     for acked_packet in acked_packets {
         assert!(ack_range.insert_packet_number(acked_packet).is_ok());


### PR DESCRIPTION
### Description of changes: 

This change moves the ack::Ranges data structure from transport to core. This will make it easier to test and experiment with in different contexts.

### Testing:

Since this is just a move from one crate to the other all of the tests have been moved along with it and should continue to pass.


Note that the `s2n-quic-transport package` CI check is failing since it downloads the s2n-quic-core from crates instead of using the local one. This will continue to fail until we do a new release (which may be something we need to fix in another PR).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

