### PR TITLE
fix(s2n-quic-core): minor fixes for perf and testing

### DIFF
--- a/common/s2n-codec/src/decoder/checked_range.rs
+++ b/common/s2n-codec/src/decoder/checked_range.rs
@@ -13,6 +13,7 @@ pub struct CheckedRange {
 }
 
 impl CheckedRange {
+    #[inline]
     pub(crate) fn new(start: usize, end: usize, original_ptr: *const u8) -> Self {
         #[cfg(not(all(debug_assertions, feature = "checked_range_unsafe")))]
         let _ = original_ptr;

--- a/quic/s2n-quic-core/src/inet/ecn.rs
+++ b/quic/s2n-quic-core/src/inet/ecn.rs
@@ -70,6 +70,7 @@ pub enum ExplicitCongestionNotification {
 }
 
 impl Default for ExplicitCongestionNotification {
+    #[inline]
     fn default() -> Self {
         Self::NotEct
     }
@@ -77,6 +78,7 @@ impl Default for ExplicitCongestionNotification {
 
 impl ExplicitCongestionNotification {
     /// Create a ExplicitCongestionNotification from the ECN field in the IP header
+    #[inline]
     pub fn new(ecn_field: u8) -> Self {
         match ecn_field & 0b11 {
             0b00 => ExplicitCongestionNotification::NotEct,
@@ -88,11 +90,13 @@ impl ExplicitCongestionNotification {
     }
 
     /// Returns true if congestion was experienced by the peer
+    #[inline]
     pub fn congestion_experienced(self) -> bool {
         self == Self::Ce
     }
 
     /// Returns true if ECN is in use
+    #[inline]
     pub fn using_ecn(self) -> bool {
         self != Self::NotEct
     }

--- a/quic/s2n-quic-core/src/lib.rs
+++ b/quic/s2n-quic-core/src/lib.rs
@@ -30,6 +30,16 @@ macro_rules! assume {
     };
 }
 
+/// Checks that the first argument is true, otherwise returns the second value
+#[macro_export]
+macro_rules! ensure {
+    ($cond:expr, $ret:expr) => {
+        if !($cond) {
+            return $ret;
+        }
+    };
+}
+
 /// Implements a future that wraps `T::poll_ready` and yields after ready
 macro_rules! impl_ready_future {
     ($name:ident, $fut:ident, $output:ty) => {

--- a/quic/s2n-quic-core/src/packet/key_phase.rs
+++ b/quic/s2n-quic-core/src/packet/key_phase.rs
@@ -20,6 +20,7 @@ pub enum KeyPhase {
 }
 
 impl Default for KeyPhase {
+    #[inline]
     fn default() -> Self {
         Self::Zero
     }
@@ -27,6 +28,7 @@ impl Default for KeyPhase {
 
 const PHASES: [KeyPhase; 2] = [KeyPhase::Zero, KeyPhase::One];
 impl From<u8> for KeyPhase {
+    #[inline]
     fn from(v: u8) -> Self {
         // Will only be 0 or 1. Invalid phases may result in a failed decryption, still in constant
         // time.
@@ -35,11 +37,13 @@ impl From<u8> for KeyPhase {
 }
 
 impl KeyPhase {
+    #[inline]
     pub fn from_tag(tag: Tag) -> Self {
         let phase = (tag & KEY_PHASE_MASK) >> 2;
         PHASES[phase as usize]
     }
 
+    #[inline]
     pub fn into_packet_tag_mask(self) -> u8 {
         match self {
             Self::One => KEY_PHASE_MASK,
@@ -48,6 +52,7 @@ impl KeyPhase {
     }
 
     #[must_use]
+    #[inline]
     pub fn next_phase(self) -> Self {
         PHASES[(((self as u8) + 1) % 2) as usize]
     }

--- a/quic/s2n-quic-core/src/varint/mod.rs
+++ b/quic/s2n-quic-core/src/varint/mod.rs
@@ -248,6 +248,15 @@ macro_rules! impl_from_lesser {
                 Self(value.into())
             }
         }
+
+        impl TryInto<$ty> for VarInt {
+            type Error = <$ty as TryFrom<u64>>::Error;
+
+            #[inline]
+            fn try_into(self) -> Result<$ty, Self::Error> {
+                self.0.try_into()
+            }
+        }
     };
 }
 

--- a/quic/s2n-quic-platform/src/lib.rs
+++ b/quic/s2n-quic-platform/src/lib.rs
@@ -8,10 +8,10 @@
 
 extern crate alloc;
 
-mod features;
+pub mod features;
 pub mod io;
-mod message;
-mod socket;
-mod syscall;
+pub mod message;
+pub mod socket;
+pub mod syscall;
 #[doc(hidden)] // TODO remove this module: https://github.com/aws/s2n-quic/issues/1738
 pub mod time;

--- a/quic/s2n-quic-platform/src/message.rs
+++ b/quic/s2n-quic-platform/src/message.rs
@@ -5,7 +5,7 @@ use core::{alloc::Layout, ptr::NonNull};
 use s2n_quic_core::{inet::datagram, io::tx, path};
 
 #[cfg(any(s2n_quic_platform_socket_msg, s2n_quic_platform_socket_mmsg))]
-mod cmsg;
+pub mod cmsg;
 #[cfg(s2n_quic_platform_socket_mmsg)]
 pub mod mmsg;
 #[cfg(s2n_quic_platform_socket_msg)]

--- a/quic/s2n-quic-platform/src/message/msg.rs
+++ b/quic/s2n-quic-platform/src/message/msg.rs
@@ -21,8 +21,7 @@ mod handle;
 #[cfg(test)]
 mod tests;
 
-use ext::Ext as _;
-
+pub use ext::Ext;
 pub use handle::Handle;
 pub use libc::msghdr as Message;
 


### PR DESCRIPTION
### Description of changes: 

I've been doing some experimentation with performance and made a few changes that didn't seem like they all warranted their own PR.

* Added `inline` to several functions that were missing it in the hot path
* Added an `ensure!` macro that works similar to s2n-tls's ENSURE macros to make it easier to follow code (instead of saying "if not this, then return an error" it says "ensure this is true, otherwise return an error)
* Exported more of the platform internals. Since this is an internal crate we don't have any stability guarantees.
* impl `TryFrom<VarInt> for {u8,u16,u32}`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

