### PR TITLE
feat(s2n-quic-platform): export IO testing socket construction

### DIFF
--- a/quic/s2n-quic-core/src/frame/ack.rs
+++ b/quic/s2n-quic-core/src/frame/ack.rs
@@ -87,6 +87,7 @@ pub struct Ack<AckRanges> {
 }
 
 impl<AckRanges> Ack<AckRanges> {
+    #[inline]
     pub fn tag(&self) -> u8 {
         if self.ecn_counts.is_some() {
             ACK_W_ECN_TAG
@@ -97,14 +98,17 @@ impl<AckRanges> Ack<AckRanges> {
 }
 
 impl<A: AckRanges> Ack<A> {
+    #[inline]
     pub fn ack_delay(&self) -> core::time::Duration {
         core::time::Duration::from_micros(self.ack_delay.as_u64())
     }
 
+    #[inline]
     pub fn ack_ranges(&self) -> A::Iter {
         self.ack_ranges.ack_ranges()
     }
 
+    #[inline]
     pub fn largest_acknowledged(&self) -> VarInt {
         self.ack_ranges.largest_acknowledged()
     }
@@ -146,6 +150,7 @@ decoder_parameterized_value!(
 );
 
 impl<A: AckRanges> EncoderValue for Ack<A> {
+    #[inline]
     fn encode<E: Encoder>(&self, buffer: &mut E) {
         buffer.encode(&self.tag());
 
@@ -187,6 +192,7 @@ pub trait AckRanges {
 
     fn ack_ranges(&self) -> Self::Iter;
 
+    #[inline]
     fn largest_acknowledged(&self) -> VarInt {
         *self
             .ack_ranges()
@@ -206,6 +212,7 @@ pub struct AckRangesDecoder<'a> {
 impl<'a> AckRanges for AckRangesDecoder<'a> {
     type Iter = AckRangesIter<'a>;
 
+    #[inline]
     fn ack_ranges(&self) -> Self::Iter {
         AckRangesIter {
             largest_acknowledged: self.largest_acknowledged,
@@ -214,12 +221,14 @@ impl<'a> AckRanges for AckRangesDecoder<'a> {
         }
     }
 
+    #[inline]
     fn largest_acknowledged(&self) -> VarInt {
         self.largest_acknowledged
     }
 }
 
 impl<'a> PartialEq for AckRangesDecoder<'a> {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
         self.ack_ranges().eq(other.ack_ranges())
     }
@@ -330,6 +339,7 @@ decoder_parameterized_value!(
 //#
 //# largest = previous_smallest - gap - 2
 
+#[inline]
 fn encode_ack_range<E: Encoder>(
     range: RangeInclusive<VarInt>,
     smallest: VarInt,
@@ -355,6 +365,7 @@ pub struct AckRangesIter<'a> {
 impl<'a> Iterator for AckRangesIter<'a> {
     type Item = RangeInclusive<VarInt>;
 
+    #[inline]
     fn next(&mut self) -> Option<Self::Item> {
         self.ack_range_count = self.ack_range_count.checked_sub(VarInt::from_u8(1))?;
 
@@ -379,6 +390,7 @@ impl<'a> Iterator for AckRangesIter<'a> {
         Some(start..=end)
     }
 
+    #[inline]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let ack_range_count = *self.ack_range_count as usize;
         (ack_range_count, Some(ack_range_count))
@@ -451,6 +463,7 @@ pub struct EcnCounts {
 
 impl EcnCounts {
     /// Increment the count for the given `ExplicitCongestionNotification`
+    #[inline]
     pub fn increment(&mut self, ecn: ExplicitCongestionNotification) {
         match ecn {
             ExplicitCongestionNotification::Ect0 => {
@@ -468,6 +481,7 @@ impl EcnCounts {
 
     /// Gets the `EcnCounts` as an Option that will be `None` if none of the `EcnCounts` have
     /// been incremented.
+    #[inline]
     pub fn as_option(&self) -> Option<EcnCounts> {
         if *self == Default::default() {
             return None;
@@ -478,6 +492,7 @@ impl EcnCounts {
 
     /// Return `EcnCounts` containing the maximum of each individual ECN count
     #[must_use]
+    #[inline]
     pub fn max(self, other: Self) -> Self {
         EcnCounts {
             ect_0_count: self.ect_0_count.max(other.ect_0_count),
@@ -488,6 +503,7 @@ impl EcnCounts {
 }
 
 impl SubAssign for EcnCounts {
+    #[inline]
     fn sub_assign(&mut self, rhs: Self) {
         self.ect_0_count = self.ect_0_count.saturating_sub(rhs.ect_0_count);
         self.ect_1_count = self.ect_1_count.saturating_sub(rhs.ect_1_count);
@@ -498,6 +514,7 @@ impl SubAssign for EcnCounts {
 impl CheckedSub for EcnCounts {
     type Output = EcnCounts;
 
+    #[inline]
     fn checked_sub(self, rhs: Self) -> Option<Self::Output> {
         let ect_0_count = self.ect_0_count.checked_sub(rhs.ect_0_count)?;
         let ect_1_count = self.ect_1_count.checked_sub(rhs.ect_1_count)?;
@@ -530,6 +547,7 @@ decoder_value!(
 );
 
 impl EncoderValue for EcnCounts {
+    #[inline]
     fn encode<E: Encoder>(&self, buffer: &mut E) {
         buffer.encode(&self.ect_0_count);
         buffer.encode(&self.ect_1_count);

--- a/quic/s2n-quic-core/src/frame/connection_close.rs
+++ b/quic/s2n-quic-core/src/frame/connection_close.rs
@@ -72,6 +72,7 @@ pub struct ConnectionClose<'a> {
 }
 
 impl<'a> ConnectionClose<'a> {
+    #[inline]
     pub fn tag(&self) -> u8 {
         if self.frame_type.is_some() {
             QUIC_ERROR_TAG
@@ -84,6 +85,7 @@ impl<'a> ConnectionClose<'a> {
 // If a `ConnectionClose` contains no frame type it was sent by an application and contains
 // an `ApplicationErrorCode`. Otherwise it is an error on the QUIC layer.
 impl<'a> application::error::TryInto for ConnectionClose<'a> {
+    #[inline]
     fn application_error(&self) -> Option<application::Error> {
         if self.frame_type.is_none() {
             Some(self.error_code.into())
@@ -128,6 +130,7 @@ decoder_parameterized_value!(
 );
 
 impl<'a> EncoderValue for ConnectionClose<'a> {
+    #[inline]
     fn encode<E: Encoder>(&self, buffer: &mut E) {
         buffer.encode(&self.tag());
 

--- a/quic/s2n-quic-core/src/frame/crypto.rs
+++ b/quic/s2n-quic-core/src/frame/crypto.rs
@@ -50,11 +50,13 @@ pub struct Crypto<Data> {
 }
 
 impl<Data> Crypto<Data> {
+    #[inline]
     pub const fn tag(&self) -> u8 {
         crypto_tag!()
     }
 
     /// Converts the crypto data from one type to another
+    #[inline]
     pub fn map_data<F: FnOnce(Data) -> Out, Out>(self, map: F) -> Crypto<Out> {
         Crypto {
             offset: self.offset,
@@ -68,6 +70,7 @@ impl<Data: EncoderValue> Crypto<Data> {
     ///
     /// If ok, the new payload length is returned, otherwise the frame cannot
     /// fit.
+    #[inline]
     pub fn try_fit(&self, capacity: usize) -> Result<usize, FitError> {
         let mut fixed_len = 0;
         fixed_len += size_of::<Tag>();
@@ -108,6 +111,7 @@ decoder_parameterized_value!(
 );
 
 impl<Data: EncoderValue> EncoderValue for Crypto<Data> {
+    #[inline]
     fn encode<E: Encoder>(&self, buffer: &mut E) {
         buffer.encode(&self.tag());
         buffer.encode(&self.offset);
@@ -116,18 +120,21 @@ impl<Data: EncoderValue> EncoderValue for Crypto<Data> {
 }
 
 impl<'a> From<Crypto<DecoderBuffer<'a>>> for CryptoRef<'a> {
+    #[inline]
     fn from(s: Crypto<DecoderBuffer<'a>>) -> Self {
         s.map_data(|data| data.into_less_safe_slice())
     }
 }
 
 impl<'a> From<Crypto<DecoderBufferMut<'a>>> for CryptoRef<'a> {
+    #[inline]
     fn from(s: Crypto<DecoderBufferMut<'a>>) -> Self {
         s.map_data(|data| &*data.into_less_safe_slice())
     }
 }
 
 impl<'a> From<Crypto<DecoderBufferMut<'a>>> for CryptoMut<'a> {
+    #[inline]
     fn from(s: Crypto<DecoderBufferMut<'a>>) -> Self {
         s.map_data(|data| data.into_less_safe_slice())
     }

--- a/quic/s2n-quic-core/src/frame/mod.rs
+++ b/quic/s2n-quic-core/src/frame/mod.rs
@@ -150,6 +150,7 @@ macro_rules! frames {
                 fn $handler(&mut self, frame: $module::$ty $(<$($generics)*>)?) -> Result<Self::Output, DecoderError>;
             )*
 
+            #[inline]
             fn handle_extension_frame(&mut self, buffer: DecoderBufferMut<'a>) -> DecoderBufferMutResult<'a, Self::Output> {
                 let _ = buffer;
 

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["corpus.tar.gz"]
 default = ["std", "tokio-runtime"]
 std = ["s2n-quic-core/std", "socket2", "lazy_static"]
 testing = ["std", "generator", "futures/std", "io-testing"] # Testing allows to overwrite the system time
-io-testing = ["bach"]
+io-testing = ["bach", "tracing"]
 generator = ["bolero-generator", "s2n-quic-core/generator"]
 tokio-runtime = ["futures", "tokio"]
 xdp = ["s2n-quic-xdp"]
@@ -29,6 +29,7 @@ s2n-quic-core = { version = "=0.31.0", path = "../s2n-quic-core", default-featur
 s2n-quic-xdp = { version = "=0.31.0", path = "../../tools/xdp/s2n-quic-xdp", optional = true }
 socket2 = { version = "0.5", features = ["all"], optional = true }
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt", "time"], optional = true }
+tracing = { version = "0.1", optional = true }
 turmoil = { version = "0.5.2", optional = true }
 
 [target.'cfg(unix)'.dependencies]
@@ -42,3 +43,4 @@ futures = { version = "0.3", features = ["std"] }
 insta = { version = "1", features = ["json"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }
+tracing = { version = "0.1" }

--- a/quic/s2n-quic-platform/src/io/testing/socket.rs
+++ b/quic/s2n-quic-platform/src/io/testing/socket.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    message::Message,
+    message::{Handle, Message},
     network::{Buffers, HostId},
 };
 use crate::{
@@ -13,8 +13,12 @@ use crate::{
     },
     syscall::SocketEvents,
 };
-use core::task::Context;
-use std::{io, sync::Arc};
+use core::task::{Context, Poll};
+use s2n_quic_core::{
+    inet::{ExplicitCongestionNotification, SocketAddress},
+    path::MaxMtu,
+};
+use std::{fmt, io, sync::Arc};
 
 /// A task to receive on a socket
 pub async fn rx(socket: Socket, producer: ring::Producer<Message>) -> io::Result<()> {
@@ -39,6 +43,28 @@ pub async fn tx(socket: Socket, consumer: ring::Consumer<Message>, gso: Gso) -> 
 #[derive(Clone)]
 pub struct Socket(Arc<State>);
 
+impl fmt::Debug for Socket {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut f = f.debug_struct("Socket");
+
+        f.field("host", &self.0.host);
+
+        if let Ok(addr) = self.local_addr() {
+            f.field("local_addr", &addr);
+        }
+
+        let _ = self.0.buffers.tx_host(self.0.host, |queue| {
+            f.field("tx_queue", &queue.len());
+        });
+
+        let _ = self.0.buffers.rx_host(self.0.host, |queue| {
+            f.field("rx_queue", &queue.len());
+        });
+
+        f.finish()
+    }
+}
+
 impl Socket {
     pub(super) fn new(buffers: Buffers, host: HostId) -> Self {
         Self(Arc::new(State { buffers, host }))
@@ -52,6 +78,161 @@ impl Socket {
     /// Rebinds the address to a new address
     pub fn rebind(&self, addr: std::net::SocketAddr) {
         self.0.buffers.rebind(self.0.host, addr);
+    }
+
+    /// Sends a packet to the provided destination
+    pub fn send_to(
+        &self,
+        addr: std::net::SocketAddr,
+        ecn: ExplicitCongestionNotification,
+        payload: Vec<u8>,
+    ) -> std::io::Result<()> {
+        self.0.buffers.tx_host(self.0.host, |queue| {
+            let path = Handle {
+                local_address: Default::default(),
+                remote_address: SocketAddress::from(addr).into(),
+            };
+            let packet = super::network::Packet { path, ecn, payload };
+            queue.send_packet(packet);
+        })?;
+
+        Ok(())
+    }
+
+    /// Receives a packet from a peer
+    pub async fn recv_from(
+        &self,
+    ) -> std::io::Result<(
+        std::net::SocketAddr,
+        ExplicitCongestionNotification,
+        Vec<u8>,
+    )> {
+        futures::future::poll_fn(|cx| self.poll_recv_from(cx)).await
+    }
+
+    pub fn try_recv_from(
+        &self,
+    ) -> std::io::Result<
+        Option<(
+            std::net::SocketAddr,
+            ExplicitCongestionNotification,
+            Vec<u8>,
+        )>,
+    > {
+        let mut packet = Poll::Pending;
+
+        self.0
+            .buffers
+            .rx_host(self.0.host, |queue| packet = queue.recv_packet(None))?;
+
+        match packet {
+            Poll::Ready(packet) => {
+                let super::network::Packet { path, ecn, payload } = packet;
+                let remote_address = path.remote_address.0.into();
+                Ok(Some((remote_address, ecn, payload)))
+            }
+            Poll::Pending => Ok(None),
+        }
+    }
+
+    pub fn poll_recv_from(
+        &self,
+        cx: &mut Context,
+    ) -> Poll<
+        std::io::Result<(
+            std::net::SocketAddr,
+            ExplicitCongestionNotification,
+            Vec<u8>,
+        )>,
+    > {
+        let mut packet = Poll::Pending;
+
+        if let Err(err) = self
+            .0
+            .buffers
+            .rx_host(self.0.host, |queue| packet = queue.recv_packet(Some(cx)))
+        {
+            return Err(err).into();
+        }
+
+        match packet {
+            Poll::Ready(packet) => {
+                let super::network::Packet { path, ecn, payload } = packet;
+                let remote_address = path.remote_address.0.into();
+                Ok((remote_address, ecn, payload)).into()
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    pub fn rx_task(
+        &self,
+        max_mtu: MaxMtu,
+        queue_recv_buffer_size: Option<u32>,
+    ) -> impl s2n_quic_core::io::rx::Rx<PathHandle = Handle> {
+        let payload_len = {
+            let max_mtu: u16 = max_mtu.into();
+            max_mtu as u32
+        };
+
+        let rx_buffer_size = queue_recv_buffer_size.unwrap_or(8u32 * (1 << 20));
+        let entries = rx_buffer_size / payload_len;
+        let entries = if entries.is_power_of_two() {
+            entries
+        } else {
+            // round up to the nearest power of two, since the ring buffers require it
+            entries.next_power_of_two()
+        };
+
+        let mut consumers = vec![];
+
+        let (producer, consumer) = crate::socket::ring::pair(entries, payload_len);
+        consumers.push(consumer);
+
+        // spawn a task that actually reads from the socket into the ring buffer
+        super::spawn(super::socket::rx(self.clone(), producer));
+
+        // construct the RX side for the endpoint event loop
+        let max_mtu = MaxMtu::try_from(payload_len as u16).unwrap();
+        let handle = self.local_addr().unwrap();
+        let handle = SocketAddress::from(handle);
+        crate::socket::io::rx::Rx::new(consumers, max_mtu, handle.into())
+    }
+
+    pub fn tx_task(
+        &self,
+        max_mtu: MaxMtu,
+        queue_send_buffer_size: Option<u32>,
+    ) -> impl s2n_quic_core::io::tx::Tx<PathHandle = Handle> {
+        let gso = crate::features::Gso::default();
+        gso.disable();
+
+        // compute the payload size for each message from the number of GSO segments we can
+        // fill
+        let payload_len = {
+            let max_mtu: u16 = max_mtu.into();
+            (max_mtu as u32 * gso.max_segments() as u32).min(u16::MAX as u32)
+        };
+
+        let tx_buffer_size = queue_send_buffer_size.unwrap_or(128 * 1024);
+        let entries = tx_buffer_size / payload_len;
+        let entries = if entries.is_power_of_two() {
+            entries
+        } else {
+            // round up to the nearest power of two, since the ring buffers require it
+            entries.next_power_of_two()
+        };
+
+        let mut producers = vec![];
+
+        let (producer, consumer) = crate::socket::ring::pair(entries, payload_len);
+        producers.push(producer);
+
+        // spawn a task that actually flushes the ring buffer to the socket
+        super::spawn(super::socket::tx(self.clone(), consumer, gso.clone()));
+
+        // construct the TX side for the endpoint event loop
+        crate::socket::io::tx::Tx::new(producers, gso, max_mtu)
     }
 }
 


### PR DESCRIPTION
### Description of changes: 

I'm doing some experiments and wanted to have a socket interface for the discrete event sim environment. This change exports some functions for sending/receiving packets.

### Call-outs:

I've also added some tracing events for when packets get dropped to give a better idea about what the simulation decided to do.

There's also a few functions elsewhere that were missing `#[inline]` attributes that should really have them. Rather than making a separate PR for those, I've included it here.

### Testing:

This was mostly just exposing what was already there so the existing tests should be sufficient.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

