### PR TITLE
refactor(s2n-quic-core): move PTO to core

### DIFF
--- a/quic/s2n-quic-core/src/lib.rs
+++ b/quic/s2n-quic-core/src/lib.rs
@@ -33,6 +33,11 @@ macro_rules! assume {
 /// Checks that the first argument is true, otherwise returns the second value
 #[macro_export]
 macro_rules! ensure {
+    ($cond:expr) => {
+        if !($cond) {
+            return;
+        }
+    };
     ($cond:expr, $ret:expr) => {
         if !($cond) {
             return $ret;

--- a/quic/s2n-quic-core/src/recovery/mod.rs
+++ b/quic/s2n-quic-core/src/recovery/mod.rs
@@ -3,6 +3,7 @@
 
 pub use congestion_controller::CongestionController;
 pub use cubic::CubicCongestionController;
+pub use pto::Pto;
 pub use rtt_estimator::*;
 pub use sent_packets::*;
 
@@ -12,6 +13,7 @@ pub mod congestion_controller;
 pub mod cubic;
 mod hybrid_slow_start;
 mod pacing;
+mod pto;
 mod rtt_estimator;
 mod sent_packets;
 

--- a/quic/s2n-quic-core/src/recovery/pto.rs
+++ b/quic/s2n-quic-core/src/recovery/pto.rs
@@ -1,0 +1,294 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    ensure, frame,
+    time::{timer, Timer, Timestamp},
+    transmission::{self, interest::Provider as _},
+};
+use core::{task::Poll, time::Duration};
+
+#[derive(Debug, Default)]
+pub struct Pto {
+    timer: Timer,
+    state: State,
+}
+
+impl Pto {
+    /// Called when a timeout has occurred. Returns `Ready` if the PTO timer had expired.
+    #[inline]
+    pub fn on_timeout(&mut self, packets_in_flight: bool, timestamp: Timestamp) -> Poll<()> {
+        ensure!(
+            self.timer.poll_expiration(timestamp).is_ready(),
+            Poll::Pending
+        );
+
+        //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.4
+        //# When a PTO timer expires, a sender MUST send at least one ack-
+        //# eliciting packet in the packet number space as a probe.
+
+        //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.2.1
+        //# Since the server could be blocked until more datagrams are received
+        //# from the client, it is the client's responsibility to send packets to
+        //# unblock the server until it is certain that the server has finished
+        //# its address validation
+
+        //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.4
+        //# An endpoint
+        //# MAY send up to two full-sized datagrams containing ack-eliciting
+        //# packets to avoid an expensive consecutive PTO expiration due to a
+        //# single lost datagram or to transmit data from multiple packet number
+        //# spaces.
+
+        //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.4
+        //# Sending two packets on PTO
+        //# expiration increases resilience to packet drops, thus reducing the
+        //# probability of consecutive PTO events.
+        let transmission_count = if packets_in_flight { 2 } else { 1 };
+
+        self.state = State::RequiresTransmission(transmission_count);
+
+        Poll::Ready(())
+    }
+
+    //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.1
+    //# A sender SHOULD restart its PTO timer every time an ack-eliciting
+    //# packet is sent or acknowledged, or when Initial or Handshake keys are
+    //# discarded (Section 4.9 of [QUIC-TLS]).
+    #[inline]
+    pub fn update(&mut self, base_timestamp: Timestamp, pto_period: Duration) {
+        self.timer.set(base_timestamp + pto_period);
+    }
+
+    /// Cancels the PTO timer
+    #[inline]
+    pub fn cancel(&mut self) {
+        self.timer.cancel();
+    }
+
+    /// Returns the number of pending transmissions
+    #[inline]
+    pub fn transmissions(&self) -> u8 {
+        self.state.transmissions()
+    }
+}
+
+impl timer::Provider for Pto {
+    #[inline]
+    fn timers<Q: timer::Query>(&self, query: &mut Q) -> timer::Result {
+        self.timer.timers(query)?;
+        Ok(())
+    }
+}
+
+impl transmission::Provider for Pto {
+    #[inline]
+    fn on_transmit<W: transmission::Writer>(&mut self, context: &mut W) {
+        // If we aren't currently in loss recovery probing mode, don't
+        // send a probe. We could be in this state even if PtoState is
+        // RequiresTransmission if we are just transmitting a ConnectionClose
+        // frame.
+        ensure!(context.transmission_mode().is_loss_recovery_probing());
+
+        // Make sure we actually need to transmit
+        ensure!(self.has_transmission_interest());
+
+        //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.4
+        //# All probe packets sent on a PTO MUST be ack-eliciting.
+        if !context.ack_elicitation().is_ack_eliciting() {
+            //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.4
+            //# When there is no data to send, the sender SHOULD send
+            //# a PING or other ack-eliciting frame in a single packet, re-arming the
+            //# PTO timer.
+            let frame = frame::Ping;
+
+            //= https://www.rfc-editor.org/rfc/rfc9002#section-7.5
+            //# Probe packets MUST NOT be blocked by the congestion controller.
+            ensure!(context.write_frame_forced(&frame).is_some());
+        }
+
+        //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.2.1
+        //# When the PTO fires, the client MUST send a Handshake packet if it
+        //# has Handshake keys, otherwise it MUST send an Initial packet in a
+        //# UDP datagram with a payload of at least 1200 bytes.
+
+        //= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.9
+        //# // Client sends an anti-deadlock packet: Initial is padded
+        //# // to earn more anti-amplification credit,
+        //# // a Handshake packet proves address ownership.
+
+        // The early transmission will automatically ensure all initial packets sent by the
+        // client are padded to 1200 bytes
+
+        self.state.on_transmit();
+    }
+}
+
+impl transmission::interest::Provider for Pto {
+    #[inline]
+    fn transmission_interest<Q: transmission::interest::Query>(
+        &self,
+        query: &mut Q,
+    ) -> transmission::interest::Result {
+        if self.transmissions() > 0 {
+            query.on_forced()?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, PartialEq)]
+enum State {
+    Idle,
+    RequiresTransmission(u8),
+}
+
+impl Default for State {
+    #[inline]
+    fn default() -> Self {
+        Self::Idle
+    }
+}
+
+impl State {
+    #[inline]
+    fn transmissions(&self) -> u8 {
+        match self {
+            Self::Idle => 0,
+            Self::RequiresTransmission(count) => *count,
+        }
+    }
+
+    #[inline]
+    fn on_transmit(&mut self) {
+        match self {
+            Self::Idle | Self::RequiresTransmission(0) => {
+                debug_assert!(false, "transmitted pto in idle state");
+            }
+            Self::RequiresTransmission(1) => {
+                *self = Self::Idle;
+            }
+            Self::RequiresTransmission(remaining) => {
+                *remaining -= 1;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        endpoint,
+        time::{Clock as _, NoopClock},
+        transmission::{writer::testing, Provider as _, Writer as _},
+    };
+
+    #[test]
+    fn on_transmit() {
+        let clock = NoopClock;
+
+        let mut frame_buffer = testing::OutgoingFrameBuffer::new();
+        let mut context = testing::Writer::new(
+            clock.get_time(),
+            &mut frame_buffer,
+            transmission::Constraint::CongestionLimited, // Recovery manager ignores constraints
+            transmission::Mode::LossRecoveryProbing,
+            endpoint::Type::Client,
+        );
+
+        let mut pto = Pto::default();
+
+        // Already idle
+        pto.on_transmit(&mut context);
+        assert_eq!(pto.state, State::Idle);
+
+        // No transmissions required
+        pto.state = State::RequiresTransmission(0);
+        pto.on_transmit(&mut context);
+        assert_eq!(pto.state, State::RequiresTransmission(0));
+
+        // One transmission required, not ack eliciting
+        pto.state = State::RequiresTransmission(1);
+        context.write_frame_forced(&frame::Padding { length: 1 });
+        assert!(!context.ack_elicitation().is_ack_eliciting());
+        pto.on_transmit(&mut context);
+
+        //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.4
+        //= type=test
+        //# All probe packets sent on a PTO MUST be ack-eliciting.
+
+        //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.4
+        //= type=test
+        //# When a PTO timer expires, a sender MUST send at least one ack-
+        //# eliciting packet in the packet number space as a probe.
+
+        //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.4
+        //= type=test
+        //# When there is no data to send, the sender SHOULD send
+        //# a PING or other ack-eliciting frame in a single packet, re-arming the
+        //# PTO timer.
+        assert!(context.ack_elicitation().is_ack_eliciting());
+        assert_eq!(pto.state, State::Idle);
+
+        // One transmission required, ack eliciting
+        pto.state = State::RequiresTransmission(1);
+        context.write_frame_forced(&frame::Ping);
+        pto.on_transmit(&mut context);
+        //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.4
+        //= type=test
+        //# All probe packets sent on a PTO MUST be ack-eliciting.
+
+        //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.4
+        //= type=test
+        //# When a PTO timer expires, a sender MUST send at least one ack-
+        //# eliciting packet in the packet number space as a probe.
+        assert!(context.ack_elicitation().is_ack_eliciting());
+        assert_eq!(pto.state, State::Idle);
+
+        // Two transmissions required
+        pto.state = State::RequiresTransmission(2);
+        pto.on_transmit(&mut context);
+        assert_eq!(pto.state, State::RequiresTransmission(1));
+    }
+
+    #[test]
+    fn on_transmit_normal_transmission_mode() {
+        let clock = NoopClock;
+
+        let mut frame_buffer = testing::OutgoingFrameBuffer::new();
+        let mut context = testing::Writer::new(
+            clock.get_time(),
+            &mut frame_buffer,
+            transmission::Constraint::CongestionLimited, // Recovery manager ignores constraints
+            transmission::Mode::Normal,
+            endpoint::Type::Client,
+        );
+
+        let mut pto = Pto {
+            state: State::RequiresTransmission(2),
+            ..Default::default()
+        };
+
+        pto.on_transmit(&mut context);
+        assert_eq!(0, frame_buffer.frames.len());
+        assert_eq!(pto.state, State::RequiresTransmission(2));
+    }
+
+    #[test]
+    fn transmission_interest() {
+        let mut pto = Pto::default();
+
+        assert!(!pto.has_transmission_interest());
+
+        pto.state = State::RequiresTransmission(0);
+        assert!(!pto.has_transmission_interest());
+
+        pto.state = State::RequiresTransmission(1);
+        assert!(pto.has_transmission_interest());
+
+        pto.state = State::RequiresTransmission(2);
+        assert!(pto.has_transmission_interest());
+    }
+}

--- a/quic/s2n-quic-core/src/transmission/mod.rs
+++ b/quic/s2n-quic-core/src/transmission/mod.rs
@@ -7,10 +7,18 @@ use bolero_generator::*;
 use core::ops::AddAssign;
 
 pub mod constraint;
+pub mod interest;
 pub mod mode;
+pub mod writer;
 
 pub use constraint::Constraint;
+pub use interest::Interest;
 pub use mode::Mode;
+pub use writer::Writer;
+
+pub trait Provider {
+    fn on_transmit<W: Writer>(&mut self, context: &mut W);
+}
 
 #[derive(Clone, Copy, Debug, Default)]
 #[cfg_attr(any(test, feature = "generator"), derive(TypeGenerator))]

--- a/quic/s2n-quic-core/src/transmission/writer.rs
+++ b/quic/s2n-quic-core/src/transmission/writer.rs
@@ -1,0 +1,83 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    endpoint,
+    event::{self, IntoEvent},
+    frame::{ack::AckRanges as AckRangesTrait, ack_elicitation::AckElicitation, Ack, FrameTrait},
+    packet::number::PacketNumber,
+    time::Timestamp,
+    transmission,
+};
+use s2n_codec::encoder::EncoderValue;
+
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;
+
+/// Context information that is passed to `on_transmit` calls on Streams
+pub trait Writer {
+    /// Returns the current point of time
+    fn current_time(&self) -> Timestamp;
+
+    /// Returns the transmission constraint for the current packet
+    fn transmission_constraint(&self) -> transmission::Constraint;
+
+    /// Returns the transmission mode for the current packet
+    fn transmission_mode(&self) -> transmission::Mode;
+
+    /// Returns the number of available bytes remaining in the current payload
+    fn remaining_capacity(&self) -> usize;
+
+    /// Attempt to write an ack frame.
+    ///
+    /// If this was successful the number of the packet
+    /// that will be used to send the frame will be returned.
+    #[inline]
+    fn write_ack_frame<AckRanges: AckRangesTrait>(
+        &mut self,
+        ack_frame: &Ack<AckRanges>,
+    ) -> Option<PacketNumber> {
+        self.write_frame(ack_frame)
+    }
+
+    /// Attempt to write a frame.
+    ///
+    /// If this was successful the number of the packet
+    /// that will be used to send the frame will be returned.
+    fn write_frame<Frame>(&mut self, frame: &Frame) -> Option<PacketNumber>
+    where
+        Frame: EncoderValue + FrameTrait,
+        for<'frame> &'frame Frame: IntoEvent<event::builder::Frame>;
+
+    /// Writes a pre-fitted frame.
+    ///
+    /// Callers should ensure the frame fits within the outgoing buffer when using this function.
+    /// The context should panic if otherwise.
+    fn write_fitted_frame<Frame>(&mut self, frame: &Frame) -> PacketNumber
+    where
+        Frame: EncoderValue + FrameTrait,
+        for<'frame> &'frame Frame: IntoEvent<event::builder::Frame>;
+
+    /// Attempt to write a frame, bypassing congestion controller constraint checks.
+    /// If this was successful the number of the packet that will be used to send
+    /// the frame will be returned.
+    fn write_frame_forced<Frame>(&mut self, frame: &Frame) -> Option<PacketNumber>
+    where
+        Frame: EncoderValue + FrameTrait,
+        for<'frame> &'frame Frame: IntoEvent<event::builder::Frame>;
+
+    /// Returns the ack elicitation of the current packet
+    fn ack_elicitation(&self) -> AckElicitation;
+
+    /// Returns the packet number for the current packet
+    fn packet_number(&self) -> PacketNumber;
+
+    /// Returns the local endpoint type (client or server)
+    fn local_endpoint_type(&self) -> endpoint::Type;
+
+    /// Returns the length of the packet header in bytes
+    fn header_len(&self) -> usize;
+
+    /// Returns the length of the authentication tag in bytes
+    fn tag_len(&self) -> usize;
+}

--- a/quic/s2n-quic-core/src/transmission/writer/testing.rs
+++ b/quic/s2n-quic-core/src/transmission/writer/testing.rs
@@ -1,0 +1,316 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    endpoint,
+    event::{self, IntoEvent},
+    frame::{
+        ack_elicitation::{AckElicitable, AckElicitation},
+        FrameMut, FrameTrait,
+    },
+    packet::number::{PacketNumber, PacketNumberSpace},
+    time::Timestamp,
+    transmission,
+    transmission::{Constraint, Mode},
+    varint::VarInt,
+};
+use alloc::collections::VecDeque;
+use s2n_codec::{
+    encoder::{EncoderBuffer, EncoderValue},
+    DecoderBufferMut,
+};
+
+/// A single frame which had been written.
+/// The buffer always stores only a single serialized Frame.
+#[derive(Clone, Debug)]
+pub struct WrittenFrame {
+    pub data: Vec<u8>,
+    pub packet_nr: PacketNumber,
+}
+
+impl WrittenFrame {
+    /// Deserializes a written frame into a quic_frame::Frame type.
+    /// panics if deserialization fails.
+    pub fn as_frame(&mut self) -> FrameMut {
+        let buffer = DecoderBufferMut::new(&mut self.data[..]);
+        let (frame, remaining) = buffer
+            .decode::<FrameMut>()
+            .expect("Buffer contains a valid frame");
+        assert_eq!(0, remaining.len());
+        frame
+    }
+}
+
+/// Stores frames which have been written by components
+#[derive(Clone, Debug)]
+pub struct OutgoingFrameBuffer {
+    pub ack_elicitation: AckElicitation,
+    /// Frames which had been written so far
+    pub frames: VecDeque<WrittenFrame>,
+    /// The PacketNumber which will be returned by the next `write_frame()` call
+    next_packet_nr: PacketNumber,
+    /// If set, this indicates the maximum packet size
+    max_buffer_size: Option<usize>,
+    /// The remaining space in the current packet
+    remaining_packet_space: usize,
+    /// If set, the value indicates after how many `write_frame()` will still be
+    /// permitted before errors are returned on write. This can be used to simulate
+    /// failing write calls.
+    error_after_frames: Option<usize>,
+}
+
+impl Default for OutgoingFrameBuffer {
+    fn default() -> Self {
+        OutgoingFrameBuffer {
+            ack_elicitation: Default::default(),
+            frames: VecDeque::new(),
+            next_packet_nr: PacketNumberSpace::ApplicationData
+                .new_packet_number(VarInt::from_u8(0)),
+            max_buffer_size: None,
+            remaining_packet_space: 0,
+            error_after_frames: None,
+        }
+    }
+}
+
+impl OutgoingFrameBuffer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Clears all frames which have been fully written
+    pub fn clear(&mut self) {
+        self.frames.clear();
+        self.ack_elicitation = Default::default();
+    }
+
+    /// Configures an explicit maximum packet size. If this is configured the
+    /// component will write multiple frames into a single packet.
+    /// Otherwise an individual packet will get written for each frame.
+    pub fn set_max_packet_size(&mut self, max_buffer_size: Option<usize>) {
+        // If we go from one mode to another, we should flush any pending
+        // packets in between.
+        self.flush();
+        self.max_buffer_size = max_buffer_size;
+
+        if let Some(max_buffer_size) = max_buffer_size {
+            self.remaining_packet_space = max_buffer_size;
+        }
+    }
+
+    /// Instructs the `FrameBuffer` to only allow `n` frame writes,
+    /// and to fail the following write attempt
+    pub fn set_error_write_after_n_frames(&mut self, n: usize) {
+        self.error_after_frames = Some(n);
+    }
+
+    /// Returns the amount of written frames
+    pub fn len(&self) -> usize {
+        self.frames.len()
+    }
+
+    /// Returns false if there are written frames
+    pub fn is_empty(&self) -> bool {
+        self.frames.is_empty()
+    }
+
+    /// Returns the oldest written frame
+    pub fn pop_front(&mut self) -> Option<WrittenFrame> {
+        self.frames.pop_front()
+    }
+
+    /// Flushes any pending packet
+    pub fn flush(&mut self) {
+        if let Some(max_buffer_size) = self.max_buffer_size {
+            if self.remaining_packet_space == max_buffer_size {
+                // No frame had been written into this packet
+                return;
+            }
+
+            // Increment the packet number and reset the amount of available
+            // packet space. Thereby frames after that flush will get assigned
+            // a fresh packet number.
+            self.next_packet_nr = self.next_packet_nr.next().unwrap();
+            self.remaining_packet_space = max_buffer_size;
+            self.ack_elicitation = Default::default();
+        }
+    }
+
+    fn remaining_capacity(&self) -> usize {
+        if self.max_buffer_size.is_some() {
+            self.remaining_packet_space
+        } else {
+            core::usize::MAX
+        }
+    }
+
+    fn encode_frame_to_vec<Frame: s2n_codec::EncoderValue>(
+        frame: &Frame,
+        encoded_size: usize,
+    ) -> Vec<u8> {
+        // Create a new buffer for the frame
+        let mut write_buffer = vec![0u8; encoded_size];
+        let mut encoder_buffer = EncoderBuffer::new(&mut write_buffer[..]);
+        frame.encode(&mut encoder_buffer);
+        write_buffer
+    }
+
+    pub fn write_frame<Frame: s2n_codec::EncoderValue + AckElicitable>(
+        &mut self,
+        frame: &Frame,
+    ) -> Option<PacketNumber> {
+        if let Some(error_after_frames) = self.error_after_frames {
+            if error_after_frames == 0 {
+                // No more frames are permitted -> fail the write
+                return None;
+            }
+            // Decrease the amount of permitted writes
+            self.error_after_frames = Some(error_after_frames - 1);
+        }
+
+        let encoded_size = frame.encoding_size();
+
+        if let Some(max_buffer_size) = self.max_buffer_size {
+            if encoded_size > max_buffer_size {
+                // This can never be written
+                return None;
+            }
+
+            if self.remaining_packet_space < encoded_size {
+                // Flush the current packet to make space
+                self.flush();
+            }
+
+            let encoded_frame = Self::encode_frame_to_vec(frame, encoded_size);
+
+            // Store the frame, but don't increase the packet number, since we
+            // might be writing more frames after this.
+            let packet_nr = self.next_packet_nr;
+
+            self.ack_elicitation |= frame.ack_elicitation();
+            self.frames.push_back(WrittenFrame {
+                data: encoded_frame,
+                packet_nr,
+            });
+
+            self.remaining_packet_space -= encoded_size;
+
+            Some(self.next_packet_nr)
+        } else {
+            // There is no write limit configured. This means we directly store
+            // each frame as an individual buffer.
+            let encoded_frame = Self::encode_frame_to_vec(frame, encoded_size);
+
+            let packet_nr = self.next_packet_nr;
+            self.next_packet_nr = self.next_packet_nr.next().unwrap();
+
+            self.ack_elicitation |= frame.ack_elicitation();
+            self.frames.push_back(WrittenFrame {
+                data: encoded_frame,
+                packet_nr,
+            });
+
+            Some(packet_nr)
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Writer<'a> {
+    pub current_time: Timestamp,
+    pub frame_buffer: &'a mut OutgoingFrameBuffer,
+    pub transmission_constraint: Constraint,
+    pub transmission_mode: Mode,
+    pub endpoint: endpoint::Type,
+}
+
+impl<'a> Writer<'a> {
+    pub fn new(
+        current_time: Timestamp,
+        frame_buffer: &'a mut OutgoingFrameBuffer,
+        transmission_constraint: Constraint,
+        transmission_mode: Mode,
+        endpoint: endpoint::Type,
+    ) -> Writer<'a> {
+        Writer {
+            current_time,
+            frame_buffer,
+            transmission_constraint,
+            transmission_mode,
+            endpoint,
+        }
+    }
+}
+
+impl<'a> super::Writer for Writer<'a> {
+    fn current_time(&self) -> Timestamp {
+        self.current_time
+    }
+
+    fn transmission_constraint(&self) -> Constraint {
+        self.transmission_constraint
+    }
+
+    fn transmission_mode(&self) -> Mode {
+        self.transmission_mode
+    }
+
+    fn remaining_capacity(&self) -> usize {
+        self.frame_buffer.remaining_capacity()
+    }
+
+    fn write_frame<Frame>(&mut self, frame: &Frame) -> Option<PacketNumber>
+    where
+        Frame: EncoderValue + FrameTrait,
+        for<'frame> &'frame Frame: IntoEvent<event::builder::Frame>,
+    {
+        match self.transmission_constraint() {
+            transmission::Constraint::AmplificationLimited => {
+                unreachable!("frames should not be written when we're amplification limited")
+            }
+            transmission::Constraint::CongestionLimited => {
+                assert!(!frame.is_congestion_controlled());
+            }
+            transmission::Constraint::RetransmissionOnly => {}
+            transmission::Constraint::None => {}
+        }
+        self.frame_buffer.write_frame(frame)
+    }
+
+    fn write_fitted_frame<Frame>(&mut self, frame: &Frame) -> PacketNumber
+    where
+        Frame: EncoderValue + FrameTrait,
+        for<'frame> &'frame Frame: IntoEvent<event::builder::Frame>,
+    {
+        self.write_frame(frame)
+            .expect("frame should fit in current buffer")
+    }
+
+    fn write_frame_forced<Frame>(&mut self, frame: &Frame) -> Option<PacketNumber>
+    where
+        Frame: EncoderValue + FrameTrait,
+        for<'frame> &'frame Frame: IntoEvent<event::builder::Frame>,
+    {
+        self.frame_buffer.write_frame(frame)
+    }
+
+    fn ack_elicitation(&self) -> AckElicitation {
+        self.frame_buffer.ack_elicitation
+    }
+
+    fn packet_number(&self) -> PacketNumber {
+        self.frame_buffer.next_packet_nr
+    }
+
+    fn local_endpoint_type(&self) -> endpoint::Type {
+        self.endpoint
+    }
+
+    fn header_len(&self) -> usize {
+        0
+    }
+
+    fn tag_len(&self) -> usize {
+        0
+    }
+}

--- a/quic/s2n-quic-transport/src/contexts/mod.rs
+++ b/quic/s2n-quic-transport/src/contexts/mod.rs
@@ -5,81 +5,8 @@
 //! within the connection in order to collect data
 
 use crate::{connection::InternalConnectionId, transmission, wakeup_queue::WakeupHandle};
-use s2n_codec::encoder::EncoderValue;
-use s2n_quic_core::{
-    endpoint,
-    event::{self, IntoEvent},
-    frame::{ack::AckRanges as AckRangesTrait, ack_elicitation::AckElicitation, Ack, FrameTrait},
-    packet::number::PacketNumber,
-    time::Timestamp,
-};
 
-/// Context information that is passed to `on_transmit` calls on Streams
-pub trait WriteContext {
-    /// Returns the current point of time
-    fn current_time(&self) -> Timestamp;
-
-    /// Returns the transmission constraint for the current packet
-    fn transmission_constraint(&self) -> transmission::Constraint;
-
-    /// Returns the transmission mode for the current packet
-    fn transmission_mode(&self) -> transmission::Mode;
-
-    /// Returns the number of available bytes remaining in the current payload
-    fn remaining_capacity(&self) -> usize;
-
-    /// Attempt to write an ack frame.
-    ///
-    /// If this was successful the number of the packet
-    /// that will be used to send the frame will be returned.
-    fn write_ack_frame<AckRanges: AckRangesTrait>(
-        &mut self,
-        ack_frame: &Ack<AckRanges>,
-    ) -> Option<PacketNumber> {
-        self.write_frame(ack_frame)
-    }
-
-    /// Attempt to write a frame.
-    ///
-    /// If this was successful the number of the packet
-    /// that will be used to send the frame will be returned.
-    fn write_frame<Frame>(&mut self, frame: &Frame) -> Option<PacketNumber>
-    where
-        Frame: EncoderValue + FrameTrait,
-        for<'frame> &'frame Frame: IntoEvent<event::builder::Frame>;
-
-    /// Writes a pre-fitted frame.
-    ///
-    /// Callers should ensure the frame fits within the outgoing buffer when using this function.
-    /// The context should panic if otherwise.
-    fn write_fitted_frame<Frame>(&mut self, frame: &Frame) -> PacketNumber
-    where
-        Frame: EncoderValue + FrameTrait,
-        for<'frame> &'frame Frame: IntoEvent<event::builder::Frame>;
-
-    /// Attempt to write a frame, bypassing congestion controller constraint checks.
-    /// If this was successful the number of the packet that will be used to send
-    /// the frame will be returned.
-    fn write_frame_forced<Frame>(&mut self, frame: &Frame) -> Option<PacketNumber>
-    where
-        Frame: EncoderValue + FrameTrait,
-        for<'frame> &'frame Frame: IntoEvent<event::builder::Frame>;
-
-    /// Returns the ack elicitation of the current packet
-    fn ack_elicitation(&self) -> AckElicitation;
-
-    /// Returns the packet number for the current packet
-    fn packet_number(&self) -> PacketNumber;
-
-    /// Returns the local endpoint type (client or server)
-    fn local_endpoint_type(&self) -> endpoint::Type;
-
-    /// Returns the length of the packet header in bytes
-    fn header_len(&self) -> usize;
-
-    /// Returns the length of the authentication tag in bytes
-    fn tag_len(&self) -> usize;
-}
+pub use transmission::Writer as WriteContext;
 
 /// Enumerates error values for `on_transmit` calls
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -115,4 +42,6 @@ impl<'a> ConnectionApiCallContext<'a> {
 }
 
 #[cfg(test)]
-pub mod testing;
+pub mod testing {
+    pub use crate::transmission::writer::testing::{Writer as MockWriteContext, *};
+}

--- a/quic/s2n-quic-transport/src/transmission/mod.rs
+++ b/quic/s2n-quic-transport/src/transmission/mod.rs
@@ -7,10 +7,8 @@ use context::Context;
 pub mod application;
 pub mod connection_close;
 pub mod early;
-pub mod interest;
 
 pub use crate::contexts::WriteContext;
-pub use interest::Interest;
 
 /// re-export core
 pub use s2n_quic_core::transmission::*;


### PR DESCRIPTION
### Description of changes: 

In order to make it easier to test and use in alternative contexts, this change moves the PTO struct to the `s2n-quic-core` crate.

### Call-outs:

I also moved the `transmission::interest` module to `s2n-quic-core` to make it possible to have components in there that are able to transmit.

### Testing:

I moved the applicable recovery manager tests into the PTO module and refactored the recovery manager tests to only use the public interfaces.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

