### PR TITLE
fix: address clippy warnings for 1.74

### DIFF
--- a/quic/s2n-quic-qns/src/server/h09.rs
+++ b/quic/s2n-quic-qns/src/server/h09.rs
@@ -12,7 +12,7 @@ use s2n_quic::{
     stream::{BidirectionalStream, ReceiveStream, SendStream},
     Connection,
 };
-use std::{convert::TryInto, path::Path, sync::Arc, time::Duration};
+use std::{path::Path, sync::Arc, time::Duration};
 use tokio::time::timeout;
 use tracing::debug;
 
@@ -76,7 +76,7 @@ async fn handle_stream(stream: BidirectionalStream, www_dir: Arc<Path>) -> Resul
             }
             Ok(Some(Err(err))) => {
                 eprintln!("error opening {abs_path:?}");
-                tx_stream.reset(1u32.try_into()?)?;
+                tx_stream.reset(1u32.into())?;
                 return Err(err.into());
             }
             Ok(None) => {

--- a/quic/s2n-quic-qns/src/tls.rs
+++ b/quic/s2n-quic-qns/src/tls.rs
@@ -189,13 +189,6 @@ impl FromStr for TlsProviders {
     }
 }
 
-pub mod default {
-    #[cfg(not(unix))]
-    pub use super::rustls::*;
-    #[cfg(unix)]
-    pub use super::s2n_tls::*;
-}
-
 #[cfg(unix)]
 pub mod s2n_tls {
     use super::*;

--- a/quic/s2n-quic-rustls/src/client.rs
+++ b/quic/s2n-quic-rustls/src/client.rs
@@ -110,7 +110,7 @@ impl Builder {
         certificate: C,
     ) -> Result<Self, rustls::Error> {
         let certificates = certificate.into_certificate()?;
-        let root_certificate = certificates.0.get(0).ok_or_else(|| {
+        let root_certificate = certificates.0.first().ok_or_else(|| {
             rustls::Error::General("Certificate chain needs to have at least one entry".to_string())
         })?;
         self.cert_store

--- a/quic/s2n-quic-transport/src/stream/controller.rs
+++ b/quic/s2n-quic-transport/src/stream/controller.rs
@@ -26,6 +26,7 @@ use s2n_quic_core::{
     varint::VarInt,
 };
 
+#[cfg(test)]
 pub use remote_initiated::MAX_STREAMS_SYNC_FRACTION;
 
 /// This component manages stream concurrency limits.

--- a/quic/s2n-quic-transport/src/stream/controller/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/stream/controller/fuzz_target.rs
@@ -273,7 +273,7 @@ impl Model {
         };
         let frame = MaxStreams {
             stream_type,
-            maximum_streams: VarInt::from_u32(maximum_streams.try_into().unwrap()),
+            maximum_streams: VarInt::from_u8(maximum_streams),
         };
         self.subject.on_max_streams(&frame);
         self.oracle.on_max_stream_local(maximum_streams, direction);

--- a/quic/s2n-quic-transport/src/stream/testing.rs
+++ b/quic/s2n-quic-transport/src/stream/testing.rs
@@ -74,8 +74,7 @@ pub fn assert_is_transport_error<T: core::fmt::Debug>(
 /// us to do some simple validation checking whether a receiver received the
 /// expected data without exactly knowing the actual sent data.
 pub fn gen_pattern_test_data(offset: VarInt, len: usize) -> Vec<u8> {
-    let mut data = Vec::new();
-    data.reserve(len);
+    let mut data = Vec::with_capacity(len);
 
     fn data_for_offset(offset: u64) -> u8 {
         (offset % 256) as u8

--- a/quic/s2n-quic-transport/src/sync/mod.rs
+++ b/quic/s2n-quic-transport/src/sync/mod.rs
@@ -12,11 +12,12 @@ mod incremental_value_sync;
 mod once_sync;
 mod periodic_sync;
 
-pub use data_sender::DataSender;
-pub use flag::Flag;
 pub use incremental_value_sync::IncrementalValueSync;
 pub use once_sync::OnceSync;
-pub use periodic_sync::{PeriodicSync, DEFAULT_SYNC_PERIOD};
+pub use periodic_sync::PeriodicSync;
+
+#[cfg(test)]
+pub use periodic_sync::DEFAULT_SYNC_PERIOD;
 
 /// Carries information about the packet in which a frame is transmitted
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]

--- a/quic/s2n-quic-transport/src/wakeup_queue.rs
+++ b/quic/s2n-quic-transport/src/wakeup_queue.rs
@@ -258,9 +258,9 @@ mod tests {
         check_state!(state, 0, false);
 
         // clone and call wake
-        waker1.clone().wake();
+        waker1.wake_by_ref();
         check_state!(state, 1, true);
-        waker2.clone().wake();
+        waker2.wake_by_ref();
         check_state!(state, 2, true);
 
         // drop handle

--- a/quic/s2n-quic/src/provider/path_migration.rs
+++ b/quic/s2n-quic/src/provider/path_migration.rs
@@ -1,8 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// this functionality isn't publicly but should be assumed that it
-// eventually will
+// this functionality isn't public but should be assumed that it
+// eventually will be
 #[allow(unused_imports)]
 pub use s2n_quic_core::path::migration::{
     default::{self, Validator as Default},

--- a/quic/s2n-quic/src/provider/path_migration.rs
+++ b/quic/s2n-quic/src/provider/path_migration.rs
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// this functionality isn't publicly but should be assumed that it
+// eventually will
+#[allow(unused_imports)]
 pub use s2n_quic_core::path::migration::{
     default::{self, Validator as Default},
     disabled, Attempt, Outcome, Validator,

--- a/quic/s2n-quic/src/tests/self_test.rs
+++ b/quic/s2n-quic/src/tests/self_test.rs
@@ -41,11 +41,11 @@ fn packet_sent_event_test() {
         .lock()
         .unwrap()
         .iter()
-        .cloned()
         .filter(|p| {
             let local_socket: SocketAddr = p.path.local_address.0.into();
             local_socket == server_socket
         })
+        .cloned()
         .collect();
 
     // transmitted quic packets may be coalesced into a single datagram (network packet)


### PR DESCRIPTION
### Description of changes: 

A new stable rust release just went out and you know what that means: clippy fixes!

### Testing:

The clippy task is now passing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

