### PR TITLE
feat(s2n-quic-crypto): replace ring with aws-lc on non-windows

### DIFF
--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -21,10 +21,10 @@ s2n-codec = { version = "=0.31.0", path = "../../common/s2n-codec", default-feat
 s2n-quic-core = { version = "=0.31.0", path = "../s2n-quic-core", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["derive"] }
 
-[target.'cfg(target_os = "linux")'.dependencies]
-aws-lc-rs = { version = "1.3", default-features = false, features = ["aws-lc-sys"] }
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+aws-lc-rs = { version = "1.5" }
 
-[target.'cfg(not(target_os = "linux"))'.dependencies]
+[target.'cfg(target_os = "windows")'.dependencies]
 ring = { version = "0.16", default-features = false }
 
 [dev-dependencies]

--- a/quic/s2n-quic-crypto/src/aesgcm/ring.rs
+++ b/quic/s2n-quic-crypto/src/aesgcm/ring.rs
@@ -12,7 +12,7 @@ impl aead::Aead for LessSafeKey {
     type Tag = [u8; TAG_LEN];
 
     #[inline]
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(target_os = "windows")]
     fn encrypt(
         &self,
         nonce: &[u8; NONCE_LEN],
@@ -40,7 +40,7 @@ impl aead::Aead for LessSafeKey {
 
     // use the scatter API if we're using AWS-LC
     #[inline]
-    #[cfg(target_os = "linux")]
+    #[cfg(not(target_os = "windows"))]
     fn encrypt(
         &self,
         nonce: &[u8; NONCE_LEN],

--- a/quic/s2n-quic-crypto/src/lib.rs
+++ b/quic/s2n-quic-crypto/src/lib.rs
@@ -16,7 +16,7 @@ mod ctr;
 mod ghash;
 mod iv;
 
-#[cfg(target_os = "linux")]
+#[cfg(not(target_os = "windows"))]
 use aws_lc_rs as ring;
 
 #[doc(hidden)]


### PR DESCRIPTION
### Description of changes: 

This change removes ring for all platforms except windows. I tried to replace it on windows as well, but ran into issues where NASM is required to be installed, which is a dependency regression from ring. I've opened an issue to track a possible fix: https://github.com/aws/aws-lc-rs/issues/285.

### Testing:

The non-windows builds should continue to pass after the switch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

