### PR TITLE
fix libc recvmmsg paramter type error on musl

### DIFF
--- a/quic/s2n-quic-platform/src/syscall/mmsg.rs
+++ b/quic/s2n-quic-platform/src/syscall/mmsg.rs
@@ -112,7 +112,7 @@ pub fn recv<Sock: AsRawFd, E: SocketEvents>(
         SocketType::Blocking => libc::MSG_WAITFORONE,
         SocketType::NonBlocking => libc::MSG_DONTWAIT,
     };
-    
+
     // some platforms have a mismatch in types for the flag values and the actual parameter so cast
     // it to whatever type the syscall expects.
     let flags = flags as _;
@@ -141,7 +141,6 @@ pub fn recv<Sock: AsRawFd, E: SocketEvents>(
     //
     // > On success, recvmmsg() returns the number of messages received in
     // > msgvec; on error, -1 is returned, and errno is set to indicate the error.
-    //
 
     let res = libc!(recvmmsg(sockfd, msgvec, vlen, flags, timeout));
 

--- a/quic/s2n-quic-platform/src/syscall/mmsg.rs
+++ b/quic/s2n-quic-platform/src/syscall/mmsg.rs
@@ -137,7 +137,16 @@ pub fn recv<Sock: AsRawFd, E: SocketEvents>(
     //
     // > On success, recvmmsg() returns the number of messages received in
     // > msgvec; on error, -1 is returned, and errno is set to indicate the error.
-    let res = libc!(recvmmsg(sockfd, msgvec, vlen, flags, timeout));
+    //
+    // on linux musl, type of paramter flags is c_uint,
+    // MSG_WAITFORONE will never be nagative, just unwarp it.
+    let res = libc!(recvmmsg(
+        sockfd,
+        msgvec,
+        vlen,
+        flags.try_into().unwrap(),
+        timeout
+    ));
 
     let _ = match res {
         Ok(count) => events.on_complete(count as _),


### PR DESCRIPTION
### Resolved issues:

resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.-->

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

