### PR TITLE
 docs(s2n-quic-core): add underutilization citation to BBR

### DIFF
--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -1002,6 +1002,10 @@ impl BbrCongestionController {
     /// Handles when the connection resumes transmitting after an idle period
     #[inline]
     fn handle_restart_from_idle<Pub: Publisher>(&mut self, now: Timestamp, publisher: &mut Pub) {
+        //= https://www.rfc-editor.org/rfc/rfc9002#section-7.8
+        //# A sender MAY implement alternative mechanisms to update its congestion window
+        //# after periods of underutilization, such as those proposed for TCP in [RFC7661].
+
         //= https://tools.ietf.org/id/draft-cardwell-iccrg-bbr-congestion-control-02#4.4.3
         //# BBRHandleRestartFromIdle():
         //#   if (packets_in_flight == 0 and C.app_limited)

--- a/specs/todos/recovery/7.8.toml
+++ b/specs/todos/recovery/7.8.toml
@@ -7,13 +7,3 @@ would have fully utilized the congestion window without pacing delay.
 '''
 feature = "Packet pacing"
 tracking-issue = "146"
-
-[[TODO]]
-quote = '''
-A sender MAY implement alternative mechanisms to update its
-congestion window after periods of under-utilization, such as those
-proposed for TCP in [RFC7661].
-'''
-feature = "Under-utilization"
-tracking-issue = "247"
-


### PR DESCRIPTION
### Resolved issues:

resolves #247

### Description of changes: 

This change adds a citation to BBR pointing out the BBR does implement an alternative mechanism for updating its congestion window (really the pacing rate in this case) after periods of under-utilization

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

