### PR TITLE
refactor(s2n-quic-transport): move loss detection to core

### DIFF
--- a/quic/s2n-quic-core/src/recovery/loss.rs
+++ b/quic/s2n-quic-core/src/recovery/loss.rs
@@ -1,0 +1,72 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    packet::number::{PacketNumber, PacketNumberRange},
+    recovery::SentPacketInfo,
+    time::Timestamp,
+};
+use core::time::Duration;
+
+//= https://www.rfc-editor.org/rfc/rfc9002#section-6.1.1
+//# The RECOMMENDED initial value for the packet reordering threshold
+//# (kPacketThreshold) is 3, based on best practices for TCP loss
+//# detection [RFC5681] [RFC6675].  In order to remain similar to TCP,
+//# implementations SHOULD NOT use a packet threshold less than 3; see
+//# [RFC5681].
+const K_PACKET_THRESHOLD: u64 = 3;
+
+pub enum Outcome {
+    NotLost { lost_time: Timestamp },
+    Lost,
+}
+
+#[derive(Debug, Default)]
+pub struct Detector {}
+
+impl Detector {
+    pub fn check_iter<'a, P: 'a>(
+        sent_packets: impl Iterator<Item = &'a SentPacketInfo<P>>,
+    ) -> Option<PacketNumberRange> {
+        None
+    }
+
+    pub fn check(
+        &self,
+        time_threshold: Duration,
+        time_sent: Timestamp,
+        packet_number: PacketNumber,
+        largest_acked_packet_number: PacketNumber,
+        now: Timestamp,
+    ) -> Outcome {
+        // Calculate at what time this particular packet is considered lost based on the
+        // current path `time_threshold`
+        let packet_lost_time = time_sent + time_threshold;
+
+        // If the `packet_lost_time` exceeds the current time, it's lost
+        let time_threshold_exceeded = packet_lost_time.has_elapsed(now);
+
+        let packet_number_threshold_exceeded = largest_acked_packet_number
+            .checked_distance(packet_number)
+            .expect("largest_acked_packet_number >= packet_number")
+            >= K_PACKET_THRESHOLD;
+
+        //= https://www.rfc-editor.org/rfc/rfc9002#section-6.1
+        //# A packet is declared lost if it meets all of the following
+        //# conditions:
+        //#
+        //#     *  The packet is unacknowledged, in flight, and was sent prior to an
+        //#        acknowledged packet.
+        //#
+        //#     *  The packet was sent kPacketThreshold packets before an
+        //#        acknowledged packet (Section 6.1.1), or it was sent long enough in
+        //#        the past (Section 6.1.2).
+        if time_threshold_exceeded || packet_number_threshold_exceeded {
+            return Outcome::Lost;
+        }
+
+        Outcome::NotLost {
+            lost_time: packet_lost_time,
+        }
+    }
+}

--- a/quic/s2n-quic-core/src/recovery/loss.rs
+++ b/quic/s2n-quic-core/src/recovery/loss.rs
@@ -10,53 +10,164 @@ use core::time::Duration;
 //# detection [RFC5681] [RFC6675].  In order to remain similar to TCP,
 //# implementations SHOULD NOT use a packet threshold less than 3; see
 //# [RFC5681].
-const K_PACKET_THRESHOLD: u64 = 3;
+pub const K_PACKET_THRESHOLD: u64 = 3;
 
+#[derive(Debug, PartialEq, Eq)]
 pub enum Outcome {
-    NotLost { lost_time: Timestamp },
+    /// The packet is not lost yet, but will be considered lost at the
+    /// given `lost_time` if not acknowledged by then
+    NotLostYet { lost_time: Timestamp },
+    /// The packet is lost
     Lost,
 }
 
-#[derive(Debug, Default)]
-pub struct Detector {}
+/// Detect if the given packet number is lost based on how long ago
+/// it was sent and how far from the largest acked packet number it is.
+pub fn detect(
+    time_threshold: Duration,
+    time_sent: Timestamp,
+    packet_number: PacketNumber,
+    largest_acked_packet_number: PacketNumber,
+    now: Timestamp,
+) -> Outcome {
+    debug_assert!(largest_acked_packet_number >= packet_number);
 
-impl Detector {
-    pub fn check(
-        &self,
-        time_threshold: Duration,
-        time_sent: Timestamp,
-        packet_number: PacketNumber,
-        largest_acked_packet_number: PacketNumber,
-        now: Timestamp,
-    ) -> Outcome {
-        // Calculate at what time this particular packet is considered lost based on the
-        // current path `time_threshold`
-        let packet_lost_time = time_sent + time_threshold;
+    // Calculate at what time this particular packet is considered
+    // lost based on the `time_threshold`
+    let packet_lost_time = time_sent + time_threshold;
 
-        // If the `packet_lost_time` exceeds the current time, it's lost
-        let time_threshold_exceeded = packet_lost_time.has_elapsed(now);
+    // If the `packet_lost_time` exceeds the current time, it's lost
+    let time_threshold_exceeded = packet_lost_time.has_elapsed(now);
 
-        let packet_number_threshold_exceeded = largest_acked_packet_number
-            .checked_distance(packet_number)
-            .expect("largest_acked_packet_number >= packet_number")
-            >= K_PACKET_THRESHOLD;
+    let packet_number_threshold_exceeded = largest_acked_packet_number
+        .checked_distance(packet_number)
+        .expect("largest_acked_packet_number >= packet_number")
+        >= K_PACKET_THRESHOLD;
 
-        //= https://www.rfc-editor.org/rfc/rfc9002#section-6.1
-        //# A packet is declared lost if it meets all of the following
-        //# conditions:
-        //#
-        //#     *  The packet is unacknowledged, in flight, and was sent prior to an
-        //#        acknowledged packet.
-        //#
-        //#     *  The packet was sent kPacketThreshold packets before an
-        //#        acknowledged packet (Section 6.1.1), or it was sent long enough in
-        //#        the past (Section 6.1.2).
-        if time_threshold_exceeded || packet_number_threshold_exceeded {
-            return Outcome::Lost;
-        }
+    //= https://www.rfc-editor.org/rfc/rfc9002#section-6.1
+    //# A packet is declared lost if it meets all of the following
+    //# conditions:
+    //#
+    //#     *  The packet is unacknowledged, in flight, and was sent prior to an
+    //#        acknowledged packet.
+    //#
+    //#     *  The packet was sent kPacketThreshold packets before an
+    //#        acknowledged packet (Section 6.1.1), or it was sent long enough in
+    //#        the past (Section 6.1.2).
+    if time_threshold_exceeded || packet_number_threshold_exceeded {
+        return Outcome::Lost;
+    }
 
-        Outcome::NotLost {
-            lost_time: packet_lost_time,
-        }
+    Outcome::NotLostYet {
+        lost_time: packet_lost_time,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{packet::number::PacketNumberSpace, time::testing::now};
+
+    //= https://www.rfc-editor.org/rfc/rfc9002#section-6.1.1
+    //= type=test
+    //# The RECOMMENDED initial value for the packet reordering threshold
+    //# (kPacketThreshold) is 3, based on best practices for TCP loss
+    //# detection [RFC5681] [RFC6675].
+
+    //= https://www.rfc-editor.org/rfc/rfc9002#section-6.1.1
+    //= type=test
+    //# In order to remain similar to TCP,
+    //# implementations SHOULD NOT use a packet threshold less than 3; see
+    //# [RFC5681].
+    #[allow(clippy::assertions_on_constants)]
+    #[test]
+    fn packet_reorder_threshold_at_least_three() {
+        assert!(K_PACKET_THRESHOLD >= 3);
+    }
+
+    #[test]
+    fn time_threshold() {
+        let time_threshold = Duration::from_secs(5);
+        let packet_number = new_packet_number(1);
+        // largest acked is within the K_PACKET_THRESHOLD
+        let largest_acked_packet_number =
+            new_packet_number(packet_number.as_u64() + K_PACKET_THRESHOLD - 1);
+
+        let time_sent = now();
+        let current_time = time_sent + time_threshold;
+
+        let outcome = detect(
+            time_threshold,
+            time_sent,
+            packet_number,
+            largest_acked_packet_number,
+            current_time,
+        );
+
+        assert_eq!(Outcome::Lost, outcome);
+
+        let time_sent = now();
+        let current_time = time_sent + time_threshold - Duration::from_secs(1);
+
+        let outcome = detect(
+            time_threshold,
+            time_sent,
+            packet_number,
+            largest_acked_packet_number,
+            current_time,
+        );
+
+        assert_eq!(
+            Outcome::NotLostYet {
+                lost_time: current_time + Duration::from_secs(1)
+            },
+            outcome
+        );
+    }
+
+    #[test]
+    fn packet_number_threshold() {
+        let time_threshold = Duration::from_secs(5);
+        let time_sent = now();
+        // packet was sent less than the time threshold in the past
+        let current_time = time_sent + time_threshold - Duration::from_secs(1);
+
+        let packet_number = new_packet_number(1);
+        // largest acked is K_PACKET_THRESHOLD larger than the current packet
+        let largest_acked_packet_number =
+            new_packet_number(packet_number.as_u64() + K_PACKET_THRESHOLD);
+
+        let outcome = detect(
+            time_threshold,
+            time_sent,
+            packet_number,
+            largest_acked_packet_number,
+            current_time,
+        );
+
+        assert_eq!(Outcome::Lost, outcome);
+
+        // largest acked is within the K_PACKET_THRESHOLD
+        let largest_acked_packet_number =
+            new_packet_number(packet_number.as_u64() + K_PACKET_THRESHOLD - 1);
+
+        let outcome = detect(
+            time_threshold,
+            time_sent,
+            packet_number,
+            largest_acked_packet_number,
+            current_time,
+        );
+
+        assert_eq!(
+            Outcome::NotLostYet {
+                lost_time: current_time + Duration::from_secs(1)
+            },
+            outcome
+        );
+    }
+
+    fn new_packet_number(packet_number: u64) -> PacketNumber {
+        PacketNumberSpace::ApplicationData.new_packet_number(packet_number.try_into().unwrap())
     }
 }

--- a/quic/s2n-quic-core/src/recovery/loss.rs
+++ b/quic/s2n-quic-core/src/recovery/loss.rs
@@ -1,11 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    packet::number::{PacketNumber, PacketNumberRange},
-    recovery::SentPacketInfo,
-    time::Timestamp,
-};
+use crate::{packet::number::PacketNumber, time::Timestamp};
 use core::time::Duration;
 
 //= https://www.rfc-editor.org/rfc/rfc9002#section-6.1.1
@@ -25,12 +21,6 @@ pub enum Outcome {
 pub struct Detector {}
 
 impl Detector {
-    pub fn check_iter<'a, P: 'a>(
-        sent_packets: impl Iterator<Item = &'a SentPacketInfo<P>>,
-    ) -> Option<PacketNumberRange> {
-        None
-    }
-
     pub fn check(
         &self,
         time_threshold: Duration,

--- a/quic/s2n-quic-core/src/recovery/mod.rs
+++ b/quic/s2n-quic-core/src/recovery/mod.rs
@@ -12,6 +12,7 @@ pub mod bbr;
 pub mod congestion_controller;
 pub mod cubic;
 mod hybrid_slow_start;
+pub mod loss;
 mod pacing;
 pub mod persistent_congestion;
 mod pto;

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -874,6 +874,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             let loss_outcome = loss::detect(
                 time_threshold,
                 unacked_sent_info.time_sent,
+                loss::K_PACKET_THRESHOLD,
                 unacked_packet_number,
                 largest_acked_packet,
                 now,

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -25,6 +25,7 @@ use s2n_quic_core::{
         congestion_controller::testing::mock::{
             CongestionController as MockCongestionController, Endpoint,
         },
+        loss::K_PACKET_THRESHOLD,
         RttEstimator, DEFAULT_INITIAL_RTT, K_GRANULARITY,
     },
     time::{clock::testing as time, testing::now, Clock, NoopClock},
@@ -3147,23 +3148,6 @@ fn probe_packets_count_towards_bytes_in_flight() {
     );
 
     assert_eq!(context.path().congestion_controller.bytes_in_flight, 100);
-}
-
-//= https://www.rfc-editor.org/rfc/rfc9002#section-6.1.1
-//= type=test
-//# The RECOMMENDED initial value for the packet reordering threshold
-//# (kPacketThreshold) is 3, based on best practices for TCP loss
-//# detection [RFC5681] [RFC6675].
-
-//= https://www.rfc-editor.org/rfc/rfc9002#section-6.1.1
-//= type=test
-//# In order to remain similar to TCP,
-//# implementations SHOULD NOT use a packet threshold less than 3; see
-//# [RFC5681].
-#[allow(clippy::assertions_on_constants)]
-#[test]
-fn packet_reorder_threshold_at_least_three() {
-    assert!(K_PACKET_THRESHOLD >= 3);
 }
 
 #[test]


### PR DESCRIPTION
### Description of changes: 

This change moves the detection of whether a packet should be considered lost or not to s2n_quic_core, for use in different contexts.

### Call-outs:

There is a little bit of overlap in the tests between the new code and the `recovery::Manager`, but for now I think its ok to ensure coverage until we have a better idea of how the `recovery::Manager` will evolve.

### Testing:

Added some new tests

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

