### PR TITLE
feat(s2n-quic): allow configuring initial RTT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2023-06-12
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2023-11-27
   CDN: https://dnglbrstg7yg.cloudfront.net
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -9,7 +9,7 @@ use crate::{
         AckDelayExponent, ActiveConnectionIdLimit, InitialFlowControlLimits, InitialMaxData,
         InitialMaxStreamDataBidiLocal, InitialMaxStreamDataBidiRemote, InitialMaxStreamDataUni,
         InitialMaxStreamsBidi, InitialMaxStreamsUni, InitialStreamLimits, MaxAckDelay,
-        MaxDatagramFrameSize, MaxIdleTimeout, TransportParameters, INVALID_MIN_RTT,
+        MaxDatagramFrameSize, MaxIdleTimeout, TransportParameters,
     },
 };
 use core::{convert::TryInto, time::Duration};

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -4,12 +4,14 @@
 use crate::{
     ack,
     event::{api::SocketAddress, IntoEvent},
-    inet, stream,
+    inet, recovery,
+    recovery::MIN_RTT,
+    stream,
     transport::parameters::{
         AckDelayExponent, ActiveConnectionIdLimit, InitialFlowControlLimits, InitialMaxData,
         InitialMaxStreamDataBidiLocal, InitialMaxStreamDataBidiRemote, InitialMaxStreamDataUni,
         InitialMaxStreamsBidi, InitialMaxStreamsUni, InitialStreamLimits, MaxAckDelay,
-        MaxDatagramFrameSize, MaxIdleTimeout, TransportParameters,
+        MaxDatagramFrameSize, MaxIdleTimeout, TransportParameters, INVALID_MIN_RTT,
     },
 };
 use core::{convert::TryInto, time::Duration};
@@ -65,6 +67,7 @@ pub struct Limits {
     pub(crate) max_handshake_duration: Duration,
     pub(crate) max_keep_alive_period: Duration,
     pub(crate) max_datagram_frame_size: MaxDatagramFrameSize,
+    pub(crate) initial_round_trip_time: Duration,
 }
 
 impl Default for Limits {
@@ -107,6 +110,7 @@ impl Limits {
             max_handshake_duration: MAX_HANDSHAKE_DURATION_DEFAULT,
             max_keep_alive_period: MAX_KEEP_ALIVE_PERIOD_DEFAULT,
             max_datagram_frame_size: MaxDatagramFrameSize::DEFAULT,
+            initial_round_trip_time: recovery::DEFAULT_INITIAL_RTT,
         }
     }
 
@@ -219,6 +223,23 @@ impl Limits {
     );
     setter!(with_max_keep_alive_period, max_keep_alive_period, Duration);
 
+    /// Sets the initial round trip time (RTT) for use in recovery mechanisms prior to
+    /// measuring an actual RTT sample.
+    ///
+    /// This is useful for environments where RTTs are mostly predictable (e.g. data centers)
+    /// and are much lower than the default 333 milliseconds.
+    pub fn with_initial_round_trip_time(
+        mut self,
+        value: Duration,
+    ) -> Result<Self, ValidationError> {
+        if value < MIN_RTT {
+            return Err(INVALID_MIN_RTT);
+        }
+
+        self.initial_round_trip_time = value;
+        Ok(self)
+    }
+
     // internal APIs
 
     #[doc(hidden)]
@@ -290,6 +311,12 @@ impl Limits {
     #[inline]
     pub fn max_keep_alive_period(&self) -> Duration {
         self.max_keep_alive_period
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn initial_round_trip_time(&self) -> Duration {
+        self.initial_round_trip_time
     }
 }
 

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -4,9 +4,7 @@
 use crate::{
     ack,
     event::{api::SocketAddress, IntoEvent},
-    inet, recovery,
-    recovery::MIN_RTT,
-    stream,
+    inet, recovery, stream,
     transport::parameters::{
         AckDelayExponent, ActiveConnectionIdLimit, InitialFlowControlLimits, InitialMaxData,
         InitialMaxStreamDataBidiLocal, InitialMaxStreamDataBidiRemote, InitialMaxStreamDataUni,
@@ -232,8 +230,10 @@ impl Limits {
         mut self,
         value: Duration,
     ) -> Result<Self, ValidationError> {
-        if value < MIN_RTT {
-            return Err(INVALID_MIN_RTT);
+        if value < recovery::MIN_RTT {
+            return Err(ValidationError(
+                "provided value must be at least 1 microsecond",
+            ));
         }
 
         self.initial_round_trip_time = value;

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -230,11 +230,12 @@ impl Limits {
         mut self,
         value: Duration,
     ) -> Result<Self, ValidationError> {
-        if value < recovery::MIN_RTT {
-            return Err(ValidationError(
+        ensure!(
+            value >= recovery::MIN_RTT,
+            Err(ValidationError(
                 "provided value must be at least 1 microsecond",
-            ));
-        }
+            ))
+        );
 
         self.initial_round_trip_time = value;
         Ok(self)

--- a/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
@@ -49,6 +49,7 @@ pub struct RttEstimator {
     first_rtt_sample: Option<Timestamp>,
 }
 
+#[cfg(test)]
 impl Default for RttEstimator {
     /// Creates a new RTT Estimator with default initial values
     fn default() -> Self {

--- a/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
@@ -49,7 +49,6 @@ pub struct RttEstimator {
     first_rtt_sample: Option<Timestamp>,
 }
 
-#[cfg(test)]
 impl Default for RttEstimator {
     /// Creates a new RTT Estimator with default initial values
     fn default() -> Self {

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -220,6 +220,9 @@ pub struct ValidationError(&'static str);
 const MAX_ENCODABLE_VALUE: ValidationError =
     ValidationError("provided value exceeds maximum encodable value");
 
+pub const INVALID_MIN_RTT: ValidationError =
+    ValidationError("provided value must be at least 1 microsecond");
+
 impl core::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "{}", self.0)

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -215,7 +215,7 @@ where
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct ValidationError(&'static str);
+pub struct ValidationError(pub &'static str);
 
 const MAX_ENCODABLE_VALUE: ValidationError =
     ValidationError("provided value exceeds maximum encodable value");

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -220,9 +220,6 @@ pub struct ValidationError(&'static str);
 const MAX_ENCODABLE_VALUE: ValidationError =
     ValidationError("provided value exceeds maximum encodable value");
 
-pub const INVALID_MIN_RTT: ValidationError =
-    ValidationError("provided value must be at least 1 microsecond");
-
 impl core::fmt::Display for ValidationError {
     fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
         write!(f, "{}", self.0)

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -215,7 +215,7 @@ where
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
-pub struct ValidationError(pub &'static str);
+pub struct ValidationError(pub(crate) &'static str);
 
 const MAX_ENCODABLE_VALUE: ValidationError =
     ValidationError("provided value exceeds maximum encodable value");

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -584,7 +584,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
 
         // The path manager always starts with a single path containing the known peer and local
         // connection ids.
-        let rtt_estimator = RttEstimator::default();
+        let rtt_estimator =
+            RttEstimator::new_with_initial(parameters.limits.initial_round_trip_time());
         // Assume clients validate the server's address implicitly.
         let peer_validated = Self::Config::ENDPOINT_TYPE.is_server();
 

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -582,13 +582,11 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             quic_version: parameters.quic_version,
         };
 
-        // The path manager always starts with a single path containing the known peer and local
-        // connection ids.
-        let rtt_estimator =
-            RttEstimator::new_with_initial(parameters.limits.initial_round_trip_time());
+        let rtt_estimator = RttEstimator::new(parameters.limits.initial_round_trip_time());
         // Assume clients validate the server's address implicitly.
         let peer_validated = Self::Config::ENDPOINT_TYPE.is_server();
-
+        // The path manager always starts with a single path containing the known peer and local
+        // connection ids.
         let initial_path = path::Path::new(
             parameters.path_handle,
             parameters.peer_connection_id,
@@ -1153,6 +1151,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             congestion_controller_endpoint,
             path_migration,
             max_mtu,
+            self.limits.initial_round_trip_time(),
             &mut publisher,
         )?;
 

--- a/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
@@ -15,6 +15,7 @@ use s2n_quic_core::{
     inet::{DatagramInfo, ExplicitCongestionNotification},
     random,
     random::testing::Generator,
+    recovery::DEFAULT_INITIAL_RTT,
     time::{testing::Clock, Clock as _},
     transport,
 };
@@ -176,6 +177,7 @@ impl Model {
             &mut Default::default(),
             &mut migration_validator,
             MaxMtu::default(),
+            DEFAULT_INITIAL_RTT,
             &mut publisher,
         ) {
             Ok(_) => {

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -1157,7 +1157,7 @@ fn connection_migration_new_path_abandon_timer() {
         new_addr,
         connection::PeerId::try_from_bytes(&[1]).unwrap(),
         connection::LocalId::TEST_ID,
-        RttEstimator::new(Duration::from_millis(30)),
+        RttEstimator::default(),
         Default::default(),
         false,
         DEFAULT_MAX_MTU,
@@ -1214,8 +1214,8 @@ fn connection_migration_new_path_abandon_timer() {
     let first_path_pto = manager[first_path_id].pto_period(PacketNumberSpace::ApplicationData);
     let second_path_pto = manager[second_path_id].pto_period(PacketNumberSpace::ApplicationData);
 
-    assert_eq!(first_path_pto, Duration::from_millis(330));
-    assert_eq!(second_path_pto, Duration::from_millis(1_029));
+    assert_eq!(first_path_pto, Duration::from_millis(300));
+    assert_eq!(second_path_pto, Duration::from_millis(999));
     assert!(second_path_pto > first_path_pto);
 
     // Setup 2:

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -18,7 +18,7 @@ use s2n_quic_core::{
     inet::{DatagramInfo, ExplicitCongestionNotification, SocketAddress},
     path::{migration, RemoteAddress},
     random::{self, Generator},
-    recovery::RttEstimator,
+    recovery::{RttEstimator, DEFAULT_INITIAL_RTT},
     stateless_reset::token::testing::*,
     time::{Clock, NoopClock},
 };
@@ -736,6 +736,7 @@ fn test_adding_new_path() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             DEFAULT_MAX_MTU,
+            DEFAULT_INITIAL_RTT,
             &mut publisher,
         )
         .unwrap();
@@ -796,6 +797,7 @@ fn do_not_add_new_path_if_handshake_not_confirmed() {
         &mut Default::default(),
         &mut migration::allow_all::Validator,
         DEFAULT_MAX_MTU,
+        DEFAULT_INITIAL_RTT,
         &mut publisher,
     );
 
@@ -857,6 +859,7 @@ fn do_not_add_new_path_if_client() {
         &mut Default::default(),
         &mut migration::allow_all::Validator,
         DEFAULT_MAX_MTU,
+        DEFAULT_INITIAL_RTT,
         &mut publisher,
     );
 
@@ -947,6 +950,7 @@ fn limit_number_of_connection_migrations() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             DEFAULT_MAX_MTU,
+            DEFAULT_INITIAL_RTT,
             &mut publisher,
         );
         match res {
@@ -1005,6 +1009,7 @@ fn connection_migration_challenge_behavior() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             DEFAULT_MAX_MTU,
+            DEFAULT_INITIAL_RTT,
             &mut publisher,
         )
         .unwrap();
@@ -1100,6 +1105,7 @@ fn connection_migration_use_max_ack_delay_from_active_path() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             DEFAULT_MAX_MTU,
+            DEFAULT_INITIAL_RTT,
             &mut publisher,
         )
         .unwrap();
@@ -1178,6 +1184,7 @@ fn connection_migration_new_path_abandon_timer() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             DEFAULT_MAX_MTU,
+            DEFAULT_INITIAL_RTT,
             &mut publisher,
         )
         .unwrap();
@@ -1453,6 +1460,7 @@ fn temporary_until_authenticated() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             DEFAULT_MAX_MTU,
+            DEFAULT_INITIAL_RTT,
             &mut publisher,
         )
         .unwrap();
@@ -1475,6 +1483,7 @@ fn temporary_until_authenticated() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             DEFAULT_MAX_MTU,
+            DEFAULT_INITIAL_RTT,
             &mut publisher,
         )
         .unwrap();
@@ -1512,6 +1521,7 @@ fn temporary_until_authenticated() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             DEFAULT_MAX_MTU,
+            DEFAULT_INITIAL_RTT,
             &mut publisher,
         )
         .unwrap();

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -3300,6 +3300,7 @@ fn helper_generate_multi_path_manager(
                 &mut Endpoint::default(),
                 &mut migration::allow_all::Validator,
                 DEFAULT_MAX_MTU,
+                DEFAULT_INITIAL_RTT,
                 publisher,
             )
             .unwrap();

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -47,7 +47,6 @@ type Path = super::Path<ServerConfig>;
 #[test]
 fn one_second_pto_when_no_previous_rtt_available() {
     let space = PacketNumberSpace::Handshake;
-    let max_ack_delay = Duration::from_millis(0);
     let mut manager = ServerManager::new(space);
     let now = time::now();
 
@@ -55,7 +54,7 @@ fn one_second_pto_when_no_previous_rtt_available() {
         Default::default(),
         connection::PeerId::TEST_ID,
         connection::LocalId::TEST_ID,
-        RttEstimator::new(max_ack_delay),
+        RttEstimator::default(),
         Default::default(),
         false,
         DEFAULT_MAX_MTU,
@@ -2591,11 +2590,13 @@ fn update_pto_timer() {
 
     // Reset the path back to not peer validated
     let path_id = unsafe { path::Id::new(0) };
+    let mut rtt_estimator = RttEstimator::default();
+    rtt_estimator.on_max_ack_delay(Duration::from_millis(10).try_into().unwrap());
     context.path_manager[path_id] = Path::new(
         Default::default(),
         connection::PeerId::TEST_ID,
         connection::LocalId::TEST_ID,
-        RttEstimator::new(Duration::from_millis(10)),
+        rtt_estimator,
         MockCongestionController::default(),
         false,
         DEFAULT_MAX_MTU,
@@ -2709,7 +2710,6 @@ fn pto_armed_if_handshake_not_confirmed() {
 #[test]
 fn pto_must_be_at_least_k_granularity() {
     let space = PacketNumberSpace::Handshake;
-    let max_ack_delay = Duration::from_millis(0);
     let mut manager = ServerManager::new(space);
     let now = time::now();
 
@@ -2717,7 +2717,7 @@ fn pto_must_be_at_least_k_granularity() {
         Default::default(),
         connection::PeerId::TEST_ID,
         connection::LocalId::TEST_ID,
-        RttEstimator::new(max_ack_delay),
+        RttEstimator::default(),
         Default::default(),
         false,
         DEFAULT_MAX_MTU,
@@ -3355,11 +3355,13 @@ fn helper_generate_path_manager_with_first_addr(
             InternalConnectionIdGenerator::new().generate_id(),
             connection::PeerId::TEST_ID,
         );
+    let mut rtt_estimator = RttEstimator::default();
+    rtt_estimator.on_max_ack_delay(max_ack_delay.try_into().unwrap());
     let path = Path::new(
         first_addr,
         connection::PeerId::TEST_ID,
         connection::LocalId::TEST_ID,
-        RttEstimator::new(max_ack_delay),
+        rtt_estimator,
         MockCongestionController::new(first_addr),
         true,
         DEFAULT_MAX_MTU,
@@ -3376,11 +3378,13 @@ fn helper_generate_client_path_manager(
 
     let registry = ConnectionIdMapper::new(&mut random_generator, endpoint::Type::Client)
         .create_client_peer_id_registry(InternalConnectionIdGenerator::new().generate_id());
+    let mut rtt_estimator = RttEstimator::default();
+    rtt_estimator.on_max_ack_delay(max_ack_delay.try_into().unwrap());
     let path = super::Path::new(
         first_addr,
         connection::PeerId::TEST_ID,
         connection::LocalId::TEST_ID,
-        RttEstimator::new(max_ack_delay),
+        rtt_estimator,
         MockCongestionController::new(first_addr),
         false,
         DEFAULT_MAX_MTU,

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -47,6 +47,7 @@ mod client_handshake_confirm;
 mod mtls;
 
 mod exporter;
+mod initial_rtt;
 mod issue_1361;
 mod issue_1427;
 mod issue_1464;

--- a/quic/s2n-quic/src/tests/initial_rtt.rs
+++ b/quic/s2n-quic/src/tests/initial_rtt.rs
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use s2n_quic_core::{
+    inet::SocketAddress,
+    recovery::{DEFAULT_INITIAL_RTT, MIN_RTT},
+};
+
+/// This test demonstrates that setting initial RTT to smaller values than the default
+/// results in more PTO packets being sent based on the smaller initial value.
+#[test]
+fn set_initial_rtt() {
+    let pto_count = test_with_initial_rtt(DEFAULT_INITIAL_RTT);
+    assert_eq!(3, pto_count);
+
+    let pto_count = test_with_initial_rtt(Duration::from_millis(1));
+    assert_eq!(11, pto_count);
+
+    let pto_count = test_with_initial_rtt(MIN_RTT);
+    assert_eq!(13, pto_count);
+}
+
+#[should_panic]
+#[test]
+fn invalid_initial_rtt() {
+    test_with_initial_rtt(MIN_RTT - Duration::from_nanos(1));
+}
+
+fn test_with_initial_rtt(initial_rtt: Duration) -> usize {
+    let model = Model::default();
+    let pto_subscriber = recorder::Pto::new();
+    let pto_events = pto_subscriber.events();
+
+    test(model, |handle| {
+        let client = Client::builder()
+            .with_io(handle.builder().build().unwrap())?
+            .with_tls(certificates::CERT_PEM)?
+            .with_event((tracing_events(), pto_subscriber))?
+            .with_random(Random::with_seed(456))?
+            .with_limits(
+                provider::limits::Limits::default()
+                    .with_initial_round_trip_time(initial_rtt)
+                    .unwrap(),
+            )?
+            .start()?;
+
+        primary::spawn(async move {
+            let connect = Connect::new(SocketAddress::default()).with_server_name("localhost");
+            // We would expect this connection to time out since there is no server started
+            assert!(client.connect(connect).await.is_err());
+        });
+
+        Ok(SocketAddress::default())
+    })
+    .unwrap();
+
+    let pto_events = pto_events.lock().unwrap();
+    let pto_count = *pto_events.iter().max().unwrap_or(&0) as usize;
+
+    pto_count
+}


### PR DESCRIPTION
### Resolved issues:

resolves #2041

### Description of changes: 

This change adds the ability to specify an initial round trip value by setting a value on the connection limits provider. 

### Call-outs:

I've updated the nightly toolchain as `udeps` was failing to build on the current version

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

Added an integration test

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

