### PR TITLE
feat(s2n-quic-core): add skip functionality to ReceiveBuffer

### DIFF
--- a/quic/s2n-quic-bench/src/buffer.rs
+++ b/quic/s2n-quic-bench/src/buffer.rs
@@ -1,24 +1,53 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use criterion::{BenchmarkId, Criterion, Throughput};
+use criterion::{black_box, BenchmarkId, Criterion, Throughput};
 use s2n_quic_core::{buffer::ReceiveBuffer, varint::VarInt};
 
 pub fn benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("buffer");
 
-    for size in [1, 100, 1000, 1450] {
+    for size in [1, 100, 1000, 1450, 8500, 9000] {
         let input = vec![42u8; size];
 
         group.throughput(Throughput::Bytes(input.len() as _));
+
+        group.bench_with_input(BenchmarkId::new("skip", size), &input, |b, _input| {
+            let mut buffer = ReceiveBuffer::new();
+            b.iter(move || {
+                buffer.skip(black_box(size)).unwrap();
+            });
+        });
+
         group.bench_with_input(BenchmarkId::new("write_at", size), &input, |b, input| {
             let mut buffer = ReceiveBuffer::new();
             let mut offset = VarInt::from_u8(0);
             let len = VarInt::new(input.len() as _).unwrap();
             b.iter(move || {
                 buffer.write_at(offset, input).unwrap();
+                while buffer.pop().is_some() {}
                 offset += len;
             });
         });
+
+        // we double the writes in the fragment test
+        group.throughput(Throughput::Bytes((input.len() * 2) as _));
+        group.bench_with_input(
+            BenchmarkId::new("write_at_fragmented", size),
+            &input,
+            |b, input| {
+                let mut buffer = ReceiveBuffer::new();
+                let mut offset = VarInt::from_u8(0);
+                let len = VarInt::new(input.len() as _).unwrap();
+                b.iter(move || {
+                    let first_offset = offset + len;
+                    buffer.write_at(first_offset, input).unwrap();
+                    let second_offset = offset;
+                    buffer.write_at(second_offset, input).unwrap();
+                    while buffer.pop().is_some() {}
+                    offset = first_offset + len;
+                });
+            },
+        );
     }
 }

--- a/quic/s2n-quic-core/src/buffer/receive_buffer.rs
+++ b/quic/s2n-quic-core/src/buffer/receive_buffer.rs
@@ -177,7 +177,10 @@ impl ReceiveBuffer {
     pub fn write_at(&mut self, offset: VarInt, data: &[u8]) -> Result<(), ReceiveBufferError> {
         // set the `fin` flag if this write ends at the known final size
         let is_fin = if let Some(final_size) = self.final_size() {
-            offset + data.len() == final_size
+            let end_exclusive = offset
+                .checked_add_usize(data.len())
+                .ok_or(ReceiveBufferError::OutOfRange)?;
+            end_exclusive == final_size
         } else {
             false
         };

--- a/quic/s2n-quic-core/src/buffer/receive_buffer/__fuzz__/buffer__receive_buffer__tests__model/corpus.tar.gz
+++ b/quic/s2n-quic-core/src/buffer/receive_buffer/__fuzz__/buffer__receive_buffer__tests__model/corpus.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:50a8a3411017ead24ca691242c57e0231f37c17a5eabcfb18c5d2d354607b70a
-size 3225600
+oid sha256:22e14ccc5a0b63743cbea23fa11da3918abba2f5cbf49cf37f275ca856562f6a
+size 3491840

--- a/quic/s2n-quic-core/src/buffer/receive_buffer/slot.rs
+++ b/quic/s2n-quic-core/src/buffer/receive_buffer/slot.rs
@@ -141,7 +141,8 @@ impl Slot {
     pub fn skip(&mut self, len: u64) {
         // trim off the data buffer
         unsafe {
-            let len = len.min(usize::MAX as u64) as usize;
+            debug_assert!(len <= 1 << 16, "slot length should never exceed 2^16");
+            let len = len as usize;
 
             // extend the write cursor if the length extends beyond the initialized offset
             if let Some(to_advance) = len.checked_sub(self.data.len()) {
@@ -169,6 +170,7 @@ impl Slot {
     #[inline]
     fn invariants(&self) {
         if cfg!(debug_assertions) {
+            assert!(self.data.capacity() <= 1 << 16, "{:?}", self);
             assert!(self.start() <= self.end(), "{:?}", self);
             assert!(self.start() <= self.end_allocated(), "{:?}", self);
             assert!(self.end() <= self.end_allocated(), "{:?}", self);


### PR DESCRIPTION
### Description of changes: 

The current ReceiveBuffer implementation requires copying all stream data into `BytesMut` buffers to ensure stream data is correctly ordered. This ends up requiring an allocation and a copy, even in scenarios where the stream data being received is at the current offset, and could potentially be copied into an application-provided buffer.

This change adds support for that usecase by adding a `skip(len: usize)` method that allows a caller to increment the current offset by `len` and bypass copying the data into the buffer itself.

### Testing:

I added a `Skip` operation to the fuzz tests, along with a data checker to ensure the data being written to the buffer is the same that is being read. I also updated the committed corpus to include the new input coverage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

