### PR TITLE
feat(s2n-quic-core): add ReceiveBuffer::copy_into_buf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ incremental = false
 lto = true
 codegen-units = 1
 incremental = false
+# improve flamegraph information
+debug = true
 
 [profile.fuzz]
 inherits = "dev"

--- a/quic/s2n-quic-bench/Cargo.toml
+++ b/quic/s2n-quic-bench/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+bytes = "1"
 criterion = { version = "0.4", features = ["html_reports"] }
 crossbeam-channel = { version = "0.5" }
 internet-checksum = "0.2"

--- a/quic/s2n-quic-bench/src/buffer.rs
+++ b/quic/s2n-quic-bench/src/buffer.rs
@@ -25,7 +25,7 @@ pub fn benchmarks(c: &mut Criterion) {
             let len = VarInt::new(input.len() as _).unwrap();
             b.iter(move || {
                 buffer.write_at(offset, input).unwrap();
-                while buffer.pop().is_some() {}
+                buffer.copy_into_buf(&mut NoOpBuf);
                 offset += len;
             });
         });
@@ -44,10 +44,34 @@ pub fn benchmarks(c: &mut Criterion) {
                     buffer.write_at(first_offset, input).unwrap();
                     let second_offset = offset;
                     buffer.write_at(second_offset, input).unwrap();
-                    while buffer.pop().is_some() {}
+                    buffer.copy_into_buf(&mut NoOpBuf);
                     offset = first_offset + len;
                 });
             },
         );
+    }
+}
+
+/// A BufMut implementation that doesn't actually copy data into it
+///
+/// This is used to avoid oversampling the `pop` implementation for
+/// `write_at` benchmarks.
+struct NoOpBuf;
+
+unsafe impl bytes::BufMut for NoOpBuf {
+    #[inline]
+    fn remaining_mut(&self) -> usize {
+        usize::MAX
+    }
+
+    #[inline]
+    unsafe fn advance_mut(&mut self, _cnt: usize) {}
+
+    #[inline]
+    fn put_slice(&mut self, _slice: &[u8]) {}
+
+    #[inline]
+    fn chunk_mut(&mut self) -> &mut bytes::buf::UninitSlice {
+        todo!()
     }
 }

--- a/quic/s2n-quic-bench/src/buffer.rs
+++ b/quic/s2n-quic-bench/src/buffer.rs
@@ -72,6 +72,6 @@ unsafe impl bytes::BufMut for NoOpBuf {
 
     #[inline]
     fn chunk_mut(&mut self) -> &mut bytes::buf::UninitSlice {
-        todo!()
+        unimplemented!()
     }
 }

--- a/scripts/perf/build
+++ b/scripts/perf/build
@@ -27,8 +27,8 @@ if [ ! -f target/perf/quinn/bin/perf_client ] || [ ! -f target/perf/quinn/bin/pe
     perf
 fi
 
-RUSTFLAGS="-g --cfg s2n_quic_unstable" cargo \
+cargo \
   +stable \
   build \
   --bin s2n-quic-qns \
-  --release
+  --profile bench


### PR DESCRIPTION
### Description of changes: 

For an application that needs to copy data out into, for example, a [tokio::io::ReadBuf](https://docs.rs/tokio/latest/tokio/io/struct.ReadBuf.html#), the current `ReceiveBuffer::pop` interface is less than ideal. The way it is implemented, it assumes that the `BytesMut` will be passed around for copy-avoidance. Splitting bytes off from other chunks only to copy it and drop the new reference requires [shared promotion](https://github.com/tokio-rs/bytes/blob/72cbb92e0e53680c67c27b56fabbe1f3ed5dbae9/src/bytes_mut.rs#L973) and refcount increment/decrement.

This change, instead, provides a `copy_into_buf` function that avoids the `split` calls and instead uses `BufMut::advance_mut`, which avoids the previously-mentioned downsides.

### Call-outs:

I updated the benchmarks to use the `copy_into_buf` function instead of `pop` to avoid oversampling on the `pop`, especially since the benchmarks just discard the received chunk.

### Testing:

I've included a unit test showing it all working. Most of the implementation is shared with `pop` via the internal `pop_transform` method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

