### PR TITLE
fix(s2n-quic-transport): set largest acked packet after ack is validated

### DIFF
--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -425,15 +425,6 @@ impl<Config: endpoint::Config> Manager<Config> {
         context: &mut Ctx,
         publisher: &mut Pub,
     ) -> Result<(), transport::Error> {
-        // Update the largest acked packet if the largest packet acked in this frame is larger
-        let acked_new_largest_packet = match self.largest_acked_packet {
-            Some(current_largest) if current_largest > largest_acked_packet_number => false,
-            _ => {
-                self.largest_acked_packet = Some(largest_acked_packet_number);
-                true
-            }
-        };
-
         let mut newly_acked_packets =
             SmallVec::<[PacketDetails<packet_info_type!()>; ACKED_PACKETS_INITIAL_CAPACITY]>::new();
         let (largest_newly_acked, includes_ack_eliciting) = self.process_ack_range(
@@ -444,6 +435,15 @@ impl<Config: endpoint::Config> Manager<Config> {
             context,
             publisher,
         )?;
+
+        // Update the largest acked packet if the largest packet acked in this frame is larger
+        let acked_new_largest_packet = match self.largest_acked_packet {
+            Some(current_largest) if current_largest > largest_acked_packet_number => false,
+            _ => {
+                self.largest_acked_packet = Some(largest_acked_packet_number);
+                true
+            }
+        };
 
         //= https://www.rfc-editor.org/rfc/rfc9002#section-5.1
         //# An endpoint generates an RTT sample on receiving an ACK frame that

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__on_invalid_ack_frame.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__on_invalid_ack_frame.snap
@@ -1,0 +1,10 @@
+---
+source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
+expression: ""
+---
+AckRangeReceived { packet_header: OneRtt { number: 2 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, ack_range: 2..=2 }
+RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 10ms, smoothed_rtt: 10ms, latest_rtt: 10ms, rtt_variance: 5ms, max_ack_delay: 10ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 512, congestion_limited: false }
+AckRangeReceived { packet_header: OneRtt { number: 1 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, ack_range: 1..=5 }
+PacketLost { packet_header: OneRtt { number: 1 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, bytes_lost: 128, is_mtu_probe: false }
+Congestion { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, source: PacketLoss }
+RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 10ms, smoothed_rtt: 10ms, latest_rtt: 10ms, rtt_variance: 5ms, max_ack_delay: 10ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 384, congestion_limited: false }


### PR DESCRIPTION
### Description of changes: 

In #2046, the loss detection algorithm was refactored. As part of the refactor, a debug assertion was added that asserts the following:
```rust
 debug_assert!(
        largest_acked_packet_number > packet_number,
        "only packets sent before the largest acknowledged packet may be considered lost"
    );
```

`quic-attack` encountered a case where `largest_acked_packet_number` == `packet_number`, causing this debug assertion to fail. This shouldn't happen, because the loss detection algorithm should not be invoked for packets that have already been acknowledged, such as the `largest_acked_packet_number`. This can happen, however, if an invalid `Ack` frame was received, as the validation of `Ack` frames occurs after the `largest_acked_packet_number` from that `Ack` frame has been updated. I believe the failure scenario involves an invalid `Ack` frame being received at the same instance the `loss_timer` expires, resulting in the  `largest_acked_packet_number` being set to a packet number that remains within `sent_packets`, followed by a call to `on_timeout`, where the `debug_assert!` above fails.

This change moves the updating of `largest_acked_packet_number` to after the validation of the ack so that this value is only updated for valid `Ack` frames.

### Testing:

Added a unit test and ran quic-attack for 8 hours

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

