### PR TITLE
feat(s2n-quic): allow disabling handshake CID rotation

### DIFF
--- a/quic/s2n-quic-core/src/connection/id.rs
+++ b/quic/s2n-quic-core/src/connection/id.rs
@@ -395,6 +395,15 @@ pub trait Generator {
     fn lifetime(&self) -> Option<core::time::Duration> {
         None
     }
+
+    /// If true (default), the connection ID used during the the handshake
+    /// will be requested to be retired following confirmation of the handshake
+    /// completing. This reduces linkability between information exchanged
+    /// during and after the handshake.
+    #[inline]
+    fn rotate_handshake_connection_id(&self) -> bool {
+        true
+    }
 }
 
 #[derive(Debug, Copy, Clone, Default, PartialEq, Eq, PartialOrd, Ord)]

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -186,7 +186,10 @@ pub mod api {
             stream_limit: u64,
         },
         #[non_exhaustive]
-        NewConnectionId {},
+        NewConnectionId {
+            sequence_number: u64,
+            retire_prior_to: u64,
+        },
         #[non_exhaustive]
         RetireConnectionId {},
         #[non_exhaustive]
@@ -1478,7 +1481,10 @@ pub mod api {
     impl<'a> IntoEvent<builder::Frame> for &crate::frame::NewConnectionId<'a> {
         #[inline]
         fn into_event(self) -> builder::Frame {
-            builder::Frame::NewConnectionId {}
+            builder::Frame::NewConnectionId {
+                sequence_number: self.sequence_number.as_u64(),
+                retire_prior_to: self.retire_prior_to.as_u64(),
+            }
         }
     }
     impl IntoEvent<builder::Frame> for &crate::frame::RetireConnectionId {
@@ -2743,7 +2749,10 @@ pub mod builder {
             stream_type: StreamType,
             stream_limit: u64,
         },
-        NewConnectionId,
+        NewConnectionId {
+            sequence_number: u64,
+            retire_prior_to: u64,
+        },
         RetireConnectionId,
         PathChallenge,
         PathResponse,
@@ -2831,7 +2840,13 @@ pub mod builder {
                     stream_type: stream_type.into_event(),
                     stream_limit: stream_limit.into_event(),
                 },
-                Self::NewConnectionId => NewConnectionId {},
+                Self::NewConnectionId {
+                    sequence_number,
+                    retire_prior_to,
+                } => NewConnectionId {
+                    sequence_number: sequence_number.into_event(),
+                    retire_prior_to: retire_prior_to.into_event(),
+                },
                 Self::RetireConnectionId => RetireConnectionId {},
                 Self::PathChallenge => PathChallenge {},
                 Self::PathResponse => PathResponse {},

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -357,7 +357,10 @@ enum Frame {
         stream_type: StreamType,
         stream_limit: u64,
     },
-    NewConnectionId,
+    NewConnectionId {
+        sequence_number: u64,
+        retire_prior_to: u64,
+    },
     RetireConnectionId,
     PathChallenge,
     PathResponse,
@@ -487,7 +490,10 @@ impl IntoEvent<builder::Frame> for &crate::frame::StreamsBlocked {
 impl<'a> IntoEvent<builder::Frame> for &crate::frame::NewConnectionId<'a> {
     #[inline]
     fn into_event(self) -> builder::Frame {
-        builder::Frame::NewConnectionId {}
+        builder::Frame::NewConnectionId {
+            sequence_number: self.sequence_number.as_u64(),
+            retire_prior_to: self.retire_prior_to.as_u64(),
+        }
     }
 }
 

--- a/quic/s2n-quic-transport/src/connection/connection_id_mapper.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_id_mapper.rs
@@ -340,8 +340,13 @@ impl ConnectionIdMapper {
         &mut self,
         internal_id: InternalConnectionId,
         initial_connection_id: connection::PeerId,
+        rotate_handshake_connection_id: bool,
     ) -> PeerIdRegistry {
-        let mut registry = PeerIdRegistry::new(internal_id, self.state.clone());
+        let mut registry = PeerIdRegistry::new(
+            internal_id,
+            self.state.clone(),
+            rotate_handshake_connection_id,
+        );
 
         registry.register_initial_connection_id(initial_connection_id);
         registry
@@ -355,8 +360,13 @@ impl ConnectionIdMapper {
     pub fn create_client_peer_id_registry(
         &mut self,
         internal_id: InternalConnectionId,
+        rotate_handshake_connection_id: bool,
     ) -> PeerIdRegistry {
-        PeerIdRegistry::new(internal_id, self.state.clone())
+        PeerIdRegistry::new(
+            internal_id,
+            self.state.clone(),
+            rotate_handshake_connection_id,
+        )
     }
 }
 
@@ -373,7 +383,7 @@ mod tests {
         let internal_id = InternalConnectionIdGenerator::new().generate_id();
         let peer_id = id(b"id01");
 
-        let mut registry = mapper.create_client_peer_id_registry(internal_id);
+        let mut registry = mapper.create_client_peer_id_registry(internal_id, true);
         registry.register_initial_connection_id(peer_id);
         registry.register_initial_stateless_reset_token(TEST_TOKEN_1);
 
@@ -390,7 +400,7 @@ mod tests {
             mapper.remove_internal_connection_id_by_stateless_reset_token(&TEST_TOKEN_2)
         );
 
-        let mut registry = mapper.create_client_peer_id_registry(internal_id);
+        let mut registry = mapper.create_client_peer_id_registry(internal_id, true);
         registry.register_initial_connection_id(peer_id);
         registry.register_initial_stateless_reset_token(TEST_TOKEN_3);
 

--- a/quic/s2n-quic-transport/src/connection/connection_id_mapper.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_id_mapper.rs
@@ -319,6 +319,7 @@ impl ConnectionIdMapper {
         initial_connection_id: &connection::LocalId,
         initial_connection_id_expiration_time: Option<Timestamp>,
         local_stateless_reset_token: stateless_reset::Token,
+        rotate_handshake_connection_id: bool,
     ) -> LocalIdRegistry {
         LocalIdRegistry::new(
             internal_id,
@@ -326,6 +327,7 @@ impl ConnectionIdMapper {
             initial_connection_id,
             initial_connection_id_expiration_time,
             local_stateless_reset_token,
+            rotate_handshake_connection_id,
         )
     }
 

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -141,9 +141,14 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                 .rotate_handshake_connection_id(),
         );
 
-        let peer_id_registry = self
-            .connection_id_mapper
-            .create_server_peer_id_registry(internal_connection_id, source_connection_id);
+        let peer_id_registry = self.connection_id_mapper.create_server_peer_id_registry(
+            internal_connection_id,
+            source_connection_id,
+            self.config
+                .context()
+                .connection_id_format
+                .rotate_handshake_connection_id(),
+        );
 
         let wakeup_handle = self
             .wakeup_queue

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -135,6 +135,10 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             &initial_connection_id,
             initial_connection_id_expiration_time,
             stateless_reset_token,
+            self.config
+                .context()
+                .connection_id_format
+                .rotate_handshake_connection_id(),
         );
 
         let peer_id_registry = self

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -967,6 +967,10 @@ impl<Cfg: Config> Endpoint<Cfg> {
                 &local_connection_id,
                 local_connection_id_expiration_time,
                 stateless_reset_token,
+                self.config
+                    .context()
+                    .connection_id_format
+                    .rotate_handshake_connection_id(),
             )
         };
 

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -953,6 +953,12 @@ impl<Cfg: Config> Endpoint<Cfg> {
             .lifetime()
             .map(|duration| timestamp + duration);
 
+        let rotate_handshake_connection_id = self
+            .config
+            .context()
+            .connection_id_format
+            .rotate_handshake_connection_id();
+
         let local_id_registry = {
             // TODO: the client currently generates a random stateless_reset_token but doesnt
             // transmit it. Refactor `create_local_id_registry` to instead accept None for
@@ -967,10 +973,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                 &local_connection_id,
                 local_connection_id_expiration_time,
                 stateless_reset_token,
-                self.config
-                    .context()
-                    .connection_id_format
-                    .rotate_handshake_connection_id(),
+                rotate_handshake_connection_id,
             )
         };
 
@@ -999,7 +1002,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
         // stateless_reset_token.
         let peer_id_registry = self
             .connection_id_mapper
-            .create_client_peer_id_registry(internal_connection_id);
+            .create_client_peer_id_registry(internal_connection_id, rotate_handshake_connection_id);
 
         let congestion_controller = {
             let path_info = congestion_controller::PathInfo::new(&remote_address);

--- a/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
@@ -93,6 +93,7 @@ impl Model {
                     .create_server_peer_id_registry(
                         InternalConnectionIdGenerator::new().generate_id(),
                         zero_path.peer_connection_id,
+                        true,
                     );
 
             Manager::new(zero_path, peer_id_registry)

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -36,6 +36,7 @@ fn manager_server(first_path: ServerPath) -> ServerManager {
         .create_server_peer_id_registry(
             InternalConnectionIdGenerator::new().generate_id(),
             first_path.peer_connection_id,
+            true,
         );
     ServerManager::new(first_path, peer_id_registry)
 }
@@ -44,7 +45,7 @@ fn manager_server(first_path: ServerPath) -> ServerManager {
 fn manager_client(first_path: ClientPath) -> ClientManager {
     let mut random_generator = random::testing::Generator(123);
     let peer_id_registry = ConnectionIdMapper::new(&mut random_generator, endpoint::Type::Client)
-        .create_client_peer_id_registry(InternalConnectionIdGenerator::new().generate_id());
+        .create_client_peer_id_registry(InternalConnectionIdGenerator::new().generate_id(), true);
     ClientManager::new(first_path, peer_id_registry)
 }
 
@@ -1588,6 +1589,7 @@ fn last_known_validated_path_should_update_on_path_response() {
             .create_server_peer_id_registry(
                 InternalConnectionIdGenerator::new().generate_id(),
                 zero_path.peer_connection_id,
+                true,
             );
     assert!(peer_id_registry
         .on_new_connection_id(&first_conn_id, 1, 0, &TEST_TOKEN_1)
@@ -1754,6 +1756,7 @@ pub fn helper_manager_with_paths_base(
             .create_server_peer_id_registry(
                 InternalConnectionIdGenerator::new().generate_id(),
                 zero_path.peer_connection_id,
+                true,
             );
     assert!(peer_id_registry
         .on_new_connection_id(&first_conn_id, 1, 0, &TEST_TOKEN_1)

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -3414,6 +3414,7 @@ fn helper_generate_path_manager_with_first_addr(
         .create_server_peer_id_registry(
             InternalConnectionIdGenerator::new().generate_id(),
             connection::PeerId::TEST_ID,
+            true,
         );
     let mut rtt_estimator = RttEstimator::default();
     rtt_estimator.on_max_ack_delay(max_ack_delay.try_into().unwrap());
@@ -3437,7 +3438,7 @@ fn helper_generate_client_path_manager(
     let mut random_generator = random::testing::Generator(123);
 
     let registry = ConnectionIdMapper::new(&mut random_generator, endpoint::Type::Client)
-        .create_client_peer_id_registry(InternalConnectionIdGenerator::new().generate_id());
+        .create_client_peer_id_registry(InternalConnectionIdGenerator::new().generate_id(), true);
     let mut rtt_estimator = RttEstimator::default();
     rtt_estimator.on_max_ack_delay(max_ack_delay.try_into().unwrap());
     let path = super::Path::new(

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -429,8 +429,8 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         local_id_registry: &mut connection::LocalIdRegistry,
         timestamp: Timestamp,
     ) {
-        // Retire the local connection ID used during the handshake to reduce linkability
-        local_id_registry.retire_handshake_connection_id();
+        // Retire the local connection ID used during the handshake to reduce linkability (if enabled)
+        local_id_registry.on_handshake_confirmed();
 
         //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.1
         //# A sender SHOULD restart its PTO timer every time an ack-eliciting

--- a/quic/s2n-quic/src/provider/connection_id.rs
+++ b/quic/s2n-quic/src/provider/connection_id.rs
@@ -123,7 +123,7 @@ pub mod default {
         /// during and after the handshake.
         pub fn with_handshake_connection_id_rotation_disabled(
             mut self,
-        ) -> Result<Self, connection::id::Error> {
+        ) -> Result<Self, core::convert::Infallible> {
             self.rotate_handshake_connection_id = false;
             Ok(self)
         }

--- a/quic/s2n-quic/src/provider/connection_id.rs
+++ b/quic/s2n-quic/src/provider/connection_id.rs
@@ -115,16 +115,17 @@ pub mod default {
             Ok(self)
         }
 
-        /// Disables rotation of the connection Id used during the handshake
+        /// Enables/disables rotation of the connection Id used during the handshake (default: enabled)
         ///
-        /// By default the connection ID used during the the handshake
+        /// When enabled (the default), the connection ID used during the the handshake
         /// will be requested to be retired following confirmation of the handshake
         /// completing. This reduces linkability between information exchanged
         /// during and after the handshake.
-        pub fn with_handshake_connection_id_rotation_disabled(
+        pub fn with_handshake_connection_id_rotation(
             mut self,
+            enabled: bool,
         ) -> Result<Self, core::convert::Infallible> {
-            self.rotate_handshake_connection_id = false;
+            self.rotate_handshake_connection_id = enabled;
             Ok(self)
         }
 
@@ -228,8 +229,18 @@ pub mod default {
                     .err()
             );
 
+            let format = Format::builder().build().unwrap();
+            assert!(format.rotate_handshake_connection_id());
+
             let format = Format::builder()
-                .with_handshake_connection_id_rotation_disabled()
+                .with_handshake_connection_id_rotation(true)
+                .unwrap()
+                .build()
+                .unwrap();
+            assert!(format.rotate_handshake_connection_id());
+
+            let format = Format::builder()
+                .with_handshake_connection_id_rotation(false)
                 .unwrap()
                 .build()
                 .unwrap();

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -29,6 +29,7 @@ use setup::*;
 
 mod blackhole;
 mod connection_migration;
+mod handshake_cid_rotation;
 mod interceptor;
 mod mtu;
 mod no_tls;

--- a/quic/s2n-quic/src/tests/handshake_cid_rotation.rs
+++ b/quic/s2n-quic/src/tests/handshake_cid_rotation.rs
@@ -1,0 +1,136 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::provider::connection_id;
+use s2n_quic_core::event::api::{Frame, FrameSent};
+
+// Configure the server and client with the given `rotate_handshake_connection_id` setting
+// and complete a handshake
+fn rotate_handshake_test(
+    server_rotate_handshake_connection_id: bool,
+    client_rotate_handshake_connection_id: bool,
+) -> (Vec<events::FrameSent>, Vec<events::FrameSent>) {
+    let model = Model::default();
+
+    let server_subscriber = recorder::FrameSent::new();
+    let server_events = server_subscriber.events();
+    let client_subscriber = recorder::FrameSent::new();
+    let client_events = client_subscriber.events();
+
+    test(model, |handle| {
+        let server_cid_generator = if server_rotate_handshake_connection_id {
+            connection_id::default::Format::builder().build()?
+        } else {
+            connection_id::default::Format::builder()
+                .with_handshake_connection_id_rotation_disabled()?
+                .build()?
+        };
+
+        let client_cid_generator = if client_rotate_handshake_connection_id {
+            connection_id::default::Format::builder().build()?
+        } else {
+            connection_id::default::Format::builder()
+                .with_handshake_connection_id_rotation_disabled()?
+                .build()?
+        };
+
+        let server = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(SERVER_CERTS)?
+            .with_event((tracing_events(), server_subscriber))?
+            .with_random(Random::with_seed(456))?
+            .with_connection_id(server_cid_generator)?
+            .start()?;
+        let client = Client::builder()
+            .with_io(handle.builder().build().unwrap())?
+            .with_tls(certificates::CERT_PEM)?
+            .with_event((tracing_events(), client_subscriber))?
+            .with_random(Random::with_seed(456))?
+            .with_connection_id(client_cid_generator)?
+            .start()?;
+        let addr = start_server(server)?;
+        start_client(client, addr, Data::new(10000))?;
+        Ok(addr)
+    })
+    .unwrap();
+
+    let server_handle = server_events.lock().unwrap();
+    let client_handle = client_events.lock().unwrap();
+    (server_handle.clone(), client_handle.clone())
+}
+
+#[test]
+fn server_enabled_client_enabled() {
+    let (server_events, client_events) = rotate_handshake_test(true, true);
+
+    // Both server and client request to retire the handshake CID
+    assert_retire_prior_to(&server_events, 1);
+    assert_retire_prior_to(&client_events, 1);
+
+    // Both server and client retire the handshake CID as requested
+    assert_retire_connection_id_count(&server_events, 1);
+    assert_retire_connection_id_count(&client_events, 1);
+}
+
+#[test]
+fn server_enabled_client_disabled() {
+    let (server_events, client_events) = rotate_handshake_test(true, false);
+
+    // Only the server requests to retire the handshake CID
+    assert_retire_prior_to(&server_events, 1);
+    assert_retire_prior_to(&client_events, 0);
+
+    // The client retires the handshake CID as requested.
+    // The server still retires the handshake CID because it had rotate_handshake_connection_id enabled
+    assert_retire_connection_id_count(&server_events, 1);
+    assert_retire_connection_id_count(&client_events, 1);
+}
+
+#[test]
+fn server_disabled_client_enabled() {
+    let (server_events, client_events) = rotate_handshake_test(false, true);
+
+    // Only the client requests to retire the handshake CID
+    assert_retire_prior_to(&server_events, 0);
+    assert_retire_prior_to(&client_events, 1);
+
+    // The server retires the handshake CID as requested.
+    // The client still retires the handshake CID because it had rotate_handshake_connection_id enabled
+    assert_retire_connection_id_count(&server_events, 1);
+    assert_retire_connection_id_count(&client_events, 1);
+}
+
+#[test]
+fn server_disabled_client_disabled() {
+    let (server_events, client_events) = rotate_handshake_test(false, false);
+
+    // Neither server nor client requests to retire the handshake CID
+    assert_retire_prior_to(&server_events, 0);
+    assert_retire_prior_to(&client_events, 0);
+
+    // No connection IDs are retired
+    assert_retire_connection_id_count(&server_events, 0);
+    assert_retire_connection_id_count(&client_events, 0);
+}
+
+fn assert_retire_prior_to(events: &Vec<FrameSent>, expected: u64) {
+    for frame_sent in events {
+        match frame_sent.frame {
+            Frame::NewConnectionId {
+                retire_prior_to, ..
+            } => {
+                assert_eq!(retire_prior_to, expected);
+            }
+            _ => {}
+        }
+    }
+}
+
+fn assert_retire_connection_id_count(events: &Vec<FrameSent>, expected: usize) {
+    let retire_connection_id_count = events
+        .iter()
+        .filter(|frame_sent| matches!(frame_sent.frame, Frame::RetireConnectionId { .. }))
+        .count();
+    assert_eq!(retire_connection_id_count, expected);
+}

--- a/quic/s2n-quic/src/tests/handshake_cid_rotation.rs
+++ b/quic/s2n-quic/src/tests/handshake_cid_rotation.rs
@@ -114,20 +114,18 @@ fn server_disabled_client_disabled() {
     assert_retire_connection_id_count(&client_events, 0);
 }
 
-fn assert_retire_prior_to(events: &Vec<FrameSent>, expected: u64) {
+fn assert_retire_prior_to(events: &[FrameSent], expected: u64) {
     for frame_sent in events {
-        match frame_sent.frame {
-            Frame::NewConnectionId {
-                retire_prior_to, ..
-            } => {
-                assert_eq!(retire_prior_to, expected);
-            }
-            _ => {}
+        if let Frame::NewConnectionId {
+            retire_prior_to, ..
+        } = frame_sent.frame
+        {
+            assert_eq!(retire_prior_to, expected);
         }
     }
 }
 
-fn assert_retire_connection_id_count(events: &Vec<FrameSent>, expected: usize) {
+fn assert_retire_connection_id_count(events: &[FrameSent], expected: usize) {
     let retire_connection_id_count = events
         .iter()
         .filter(|frame_sent| matches!(frame_sent.frame, Frame::RetireConnectionId { .. }))

--- a/quic/s2n-quic/src/tests/handshake_cid_rotation.rs
+++ b/quic/s2n-quic/src/tests/handshake_cid_rotation.rs
@@ -19,21 +19,13 @@ fn rotate_handshake_test(
     let client_events = client_subscriber.events();
 
     test(model, |handle| {
-        let server_cid_generator = if server_rotate_handshake_connection_id {
-            connection_id::default::Format::builder().build()?
-        } else {
-            connection_id::default::Format::builder()
-                .with_handshake_connection_id_rotation_disabled()?
-                .build()?
-        };
+        let server_cid_generator = connection_id::default::Format::builder()
+            .with_handshake_connection_id_rotation(server_rotate_handshake_connection_id)?
+            .build()?;
 
-        let client_cid_generator = if client_rotate_handshake_connection_id {
-            connection_id::default::Format::builder().build()?
-        } else {
-            connection_id::default::Format::builder()
-                .with_handshake_connection_id_rotation_disabled()?
-                .build()?
-        };
+        let client_cid_generator = connection_id::default::Format::builder()
+            .with_handshake_connection_id_rotation(client_rotate_handshake_connection_id)?
+            .build()?;
 
         let server = Server::builder()
             .with_io(handle.builder().build()?)?

--- a/quic/s2n-quic/src/tests/recorder.rs
+++ b/quic/s2n-quic/src/tests/recorder.rs
@@ -56,6 +56,7 @@ macro_rules! event_recorder {
     };
 }
 
+event_recorder!(FrameSent, FrameSent, on_frame_sent);
 event_recorder!(PacketSent, PacketSent, on_packet_sent);
 event_recorder!(MtuUpdated, MtuUpdated, on_mtu_updated);
 event_recorder!(


### PR DESCRIPTION
### Description of changes: 

By default, an s2n-quic endpoint will retire the connection ID used during the handshake and will request the peer endpoint to retire the connection ID it used during the handshake as well. This helps reduce linkability between data exchanged during and after the handshake. In certain environments and scenarios, this behavior may not be desired or necessary. This change exposes an option on the `connection::Id` provider to disable handshake connection ID rotation.

### Testing:

Added unit tests and integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

