### PR TITLE
feat(s2n-quic-core): add branch tracing support

### DIFF
--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -17,6 +17,7 @@ std = ["alloc", "once_cell"]
 testing = ["std", "generator", "s2n-codec/testing", "checked-counters", "insta", "futures-test"]
 generator = ["bolero-generator"]
 checked-counters = []
+branch-tracing = ["tracing"]
 event-tracing = ["tracing"]
 # This feature enables support for third party congestion controller implementations
 unstable-congestion-controller = []

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -82,7 +82,7 @@ bolero = { version = "0.10" }
 # in downstream dev-dependencies (in s2n-quic-tls, in this case)
 jobserver = "=0.1.26"
 regex = "=1.9.6" # newer versions require rust 1.65, see https://github.com/aws/s2n-quic/issues/1993
-s2n-quic-core = { path = "../s2n-quic-core", features = ["testing", "event-tracing"] }
+s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "testing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1" }

--- a/quic/s2n-quic/src/tests/setup.rs
+++ b/quic/s2n-quic/src/tests/setup.rs
@@ -41,8 +41,14 @@ pub fn tracing_events() -> event::tracing::Subscriber {
             }
         }
 
+        let level = if std::env::var("TRACE").is_ok() {
+            tracing_subscriber::filter::LevelFilter::TRACE
+        } else {
+            tracing_subscriber::filter::LevelFilter::DEBUG
+        };
+
         tracing_subscriber::fmt()
-            .with_max_level(tracing_subscriber::filter::LevelFilter::DEBUG)
+            .with_max_level(level)
             .event_format(format)
             .with_test_writer()
             .init();

--- a/quic/s2n-quic/src/tests/setup.rs
+++ b/quic/s2n-quic/src/tests/setup.rs
@@ -41,14 +41,14 @@ pub fn tracing_events() -> event::tracing::Subscriber {
             }
         }
 
-        let level = if std::env::var("TRACE").is_ok() {
-            tracing_subscriber::filter::LevelFilter::TRACE
-        } else {
-            tracing_subscriber::filter::LevelFilter::DEBUG
-        };
+        let env_filter = tracing_subscriber::EnvFilter::builder()
+            .with_default_directive(tracing::Level::DEBUG.into())
+            .with_env_var("S2N_LOG")
+            .from_env()
+            .unwrap();
 
         tracing_subscriber::fmt()
-            .with_max_level(level)
+            .with_env_filter(env_filter)
             .event_format(format)
             .with_test_writer()
             .init();


### PR DESCRIPTION
### Description of changes: 

This change adds a `branch-tracing` feature to s2n-quic-core which hooks into the `ensure!` macro and logs each decision point with the outcome and the action it took in case of a failure. This is really useful for debugging why something happened or how often a check occurred.

Here's an example output:

```
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="self.max_recv_offset <= final_offset" result=true file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=212
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="excess.is_empty()" result=true file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=238
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="!request.is_empty()" result=true file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=241
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="!request.is_empty()" result=false outcome="return" file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=522
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="!request.is_empty()" result=false outcome="return" file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=522
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="slot.is_occupied(offset)" result=true file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=492
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="slot.is_occupied(self.prev_end)" result=true file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=682
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="slot.is_occupied(self.prev_end)" result=true file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=682
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="slot.is_occupied(self.prev_end)" result=true file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=682
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="slot.is_occupied(self.prev_end)" result=true file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=682
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="slot.is_occupied(offset)" result=true file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=492
0:00:00.300000 s2n_quic:client:conn: rx_stream_progress: bytes=710 id=0
0:00:00.300000 s2n_quic:client: platform_event_loop_sleep: timeout=Some(25ms) processing_duration=1µs
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="slot.is_occupied(self.prev_end)" result=true file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=682
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="slot.is_occupied(self.start_offset)" result=true file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=452
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="watermark > 0" result=true file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=390
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="len > 0" result=true file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=460
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="slot.is_occupied(offset)" result=false outcome="return offset" file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=492
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="slot.is_occupied(self.prev_end)" result=false outcome="return None" file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=682
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="slot.is_occupied(self.prev_end)" result=false outcome="return None" file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=682
0:00:00.300000 s2n_quic_core::buffer::receive_buffer: branch="slot.is_occupied(self.prev_end)" result=false outcome="return None" file="quic/s2n-quic-core/src/buffer/receive_buffer.rs" line=682
```

### Testing:

I've enabled the feature on the integration tests to make it easy to debug. Note that you do need to pass `S2N_LOG=trace` to get the output.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

