### PR TITLE
 ci: undo cargo package ci task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,6 @@ jobs:
       msrv: ${{ steps.definitions.outputs.msrv }}
       examples: ${{ steps.definitions.outputs.examples }}
       crates: ${{ steps.definitions.outputs.crates }}
-      new-release: ${{ steps.definitions.outputs.new-release }}
     steps:
       - uses: actions/checkout@v4
       # examples is populated by
@@ -64,12 +63,9 @@ jobs:
           export EXAMPLES=$(find examples/ -maxdepth 1 -mindepth 1 -type d | jq -R | jq -sc)
           echo "examples=$EXAMPLES"
           echo "examples=$EXAMPLES" >> $GITHUB_OUTPUT
-          export CRATES=$(cargo metadata --no-deps --format-version 1 | jq --arg PWD "$PWD/" '.packages[] | select(.publish == null).manifest_path | sub($PWD; "")' | jq -s | jq '. += ["tools/xdp/s2n-quic-xdp/Cargo.toml"]' | jq -c)
+          export CRATES=$(find quic common -name *Cargo.toml | jq -R | jq -s | jq '. += ["tools/xdp/s2n-quic-xdp/Cargo.toml"]' | jq -c)
           echo "crates=$CRATES"
           echo "crates=$CRATES" >> $GITHUB_OUTPUT
-          export NEW_RELEASE=$(if $(./scripts/detect-new-release); then echo "true"; else echo "false"; fi)
-          echo "new-release=$NEW_RELEASE"
-          echo "new-release=$NEW_RELEASE" >> $GITHUB_OUTPUT
 
   rustfmt:
     runs-on: ubuntu-latest
@@ -394,12 +390,10 @@ jobs:
           status: "success"
           url: "${{ steps.s3.outputs.URL }}"
 
-  # This CI step will directly build each published crate in common/ and quic/ which is
+  # This CI step will directly build each crate in common/ and quic/ which is
   # useful because it sidesteps the feature resolution that normally occurs in a
   # workspace build. We make sure that the crates build with default features,
-  # otherwise release to crates.io will be blocked. If the current PR is not for a new
-  # release, the cargo package command is used instead of cargo build, as this more closely
-  # matches the verification command that cargo publish executes.
+  # otherwise release to crates.io will be blocked
   crates:
     needs: env
     runs-on: ubuntu-latest
@@ -420,17 +414,9 @@ jobs:
           override: true
 
       - name: build
-        if: ${{ needs.env.outputs.new-release == 'true' }}
         uses: actions-rs/cargo@v1.0.3
         with:
           command: build
-          args: --manifest-path ${{ matrix.crate }}
-
-      - name: package
-        if: ${{ needs.env.outputs.new-release == 'false' }}
-        uses: actions-rs/cargo@v1.0.3
-        with:
-          command: package
           args: --manifest-path ${{ matrix.crate }}
 
   examples:


### PR DESCRIPTION
### Description of changes: 

#2009 added additional checks to the CI that ensure that the cargo package command succeeds on every PR. This was intended to catch build issues that a normal cargo build does not catch prior to publishing the crates. cargo package works by pulling dependencies (including those in the workspace) directly from crates.io, meaning that when changes are made in one crate that depend on another crate, the cargo package command may fail. Until we have a better solution that doesn't fail for this reason, this PR removes this additional check. I opened #2064 to follow up on this.

### Call-outs:

I left the `detect-new-release` script intact, as it could be useful in some other context. 

### Testing:

CI

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

