### PR TITLE
fix(s2n-quic-transport): wakeup connection on locally-created receive streams

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1874,9 +1874,14 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             .application_mut()
             .ok_or_else(connection::Error::unspecified)?;
 
-        space
-            .stream_manager
-            .poll_open_local_stream(stream_type, open_token, context)
+        let mut api_context = ConnectionApiCallContext::from_wakeup_handle(&self.wakeup_handle);
+
+        space.stream_manager.poll_open_local_stream(
+            stream_type,
+            open_token,
+            &mut api_context,
+            context,
+        )
     }
 
     fn application_close(&mut self, error: Option<application::Error>) {

--- a/quic/s2n-quic-transport/src/stream/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/stream/manager/tests.rs
@@ -706,7 +706,6 @@ fn max_streams_replenishes_stream_control_capacity() {
             )
             .is_pending());
 
-
         // The stream controller would already have transmission interest so no additional wakeup is needed
         assert_wakeups(&mut wakeup_queue, 0);
 

--- a/quic/s2n-quic-transport/src/stream/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/stream/manager/tests.rs
@@ -415,11 +415,13 @@ fn try_open(
     stream_type: StreamType,
 ) -> Result<StreamId, connection::Error> {
     let (accept_waker, _accept_wake_counter) = new_count_waker();
+    let (_wakeup_queue, wakeup_handle) = create_wakeup_queue_and_handle();
     let mut token = connection::OpenToken::new();
 
     match manager.poll_open_local_stream(
         stream_type,
         &mut token,
+        &mut ConnectionApiCallContext::from_wakeup_handle(&wakeup_handle),
         &Context::from_waker(&accept_waker),
     ) {
         Poll::Ready(res) => res,
@@ -670,6 +672,7 @@ fn max_data_replenishes_connection_flow_control_window() {
 fn max_streams_replenishes_stream_control_capacity() {
     let mut manager = create_stream_manager(endpoint::Type::Server);
     let (waker, _counter) = new_count_waker();
+    let (mut wakeup_queue, wakeup_handle) = create_wakeup_queue_and_handle();
     let mut token = connection::OpenToken::new();
 
     for stream_type in [StreamType::Bidirectional, StreamType::Unidirectional] {
@@ -695,8 +698,17 @@ fn max_streams_replenishes_stream_control_capacity() {
         }
 
         assert!(manager
-            .poll_open_local_stream(stream_type, &mut token, &Context::from_waker(&waker))
+            .poll_open_local_stream(
+                stream_type,
+                &mut token,
+                &mut ConnectionApiCallContext::from_wakeup_handle(&wakeup_handle),
+                &Context::from_waker(&waker)
+            )
             .is_pending());
+
+
+        // The stream controller would already have transmission interest so no additional wakeup is needed
+        assert_wakeups(&mut wakeup_queue, 0);
 
         for additional_streams in &[VarInt::from_u8(0), VarInt::from_u8(1), VarInt::from_u8(10)] {
             assert!(manager
@@ -714,8 +726,16 @@ fn max_streams_replenishes_stream_control_capacity() {
         }
 
         assert!(manager
-            .poll_open_local_stream(stream_type, &mut token, &Context::from_waker(&waker))
+            .poll_open_local_stream(
+                stream_type,
+                &mut token,
+                &mut ConnectionApiCallContext::from_wakeup_handle(&wakeup_handle),
+                &Context::from_waker(&waker)
+            )
             .is_ready());
+
+        // The stream controller would already have transmission interest so no additional wakeup is needed
+        assert_wakeups(&mut wakeup_queue, 0);
     }
 }
 
@@ -824,13 +844,19 @@ fn send_streams_blocked_frame_when_blocked_by_peer() {
 
     for stream_type in [StreamType::Bidirectional, StreamType::Unidirectional] {
         let (waker, _) = new_count_waker();
+        let (_wakeup_queue, wakeup_handle) = create_wakeup_queue_and_handle();
         let mut token = connection::OpenToken::new();
 
         let mut opened_streams = VarInt::from_u8(0);
 
         // Open streams until blocked
         while manager
-            .poll_open_local_stream(stream_type, &mut token, &Context::from_waker(&waker))
+            .poll_open_local_stream(
+                stream_type,
+                &mut token,
+                &mut ConnectionApiCallContext::from_wakeup_handle(&wakeup_handle),
+                &Context::from_waker(&waker),
+            )
             .is_ready()
         {
             opened_streams += 1;
@@ -928,7 +954,12 @@ fn send_streams_blocked_frame_when_blocked_by_peer() {
 
         // Open streams until blocked
         while manager
-            .poll_open_local_stream(stream_type, &mut token, &Context::from_waker(&waker))
+            .poll_open_local_stream(
+                stream_type,
+                &mut token,
+                &mut ConnectionApiCallContext::from_wakeup_handle(&wakeup_handle),
+                &Context::from_waker(&waker),
+            )
             .is_ready()
         {
             opened_streams += 1;
@@ -956,6 +987,8 @@ fn send_streams_blocked_frame_when_blocked_by_peer() {
 
 #[test]
 fn streams_blocked_period() {
+    let (_wakeup_queue, wakeup_handle) = create_wakeup_queue_and_handle();
+
     for stream_type in [StreamType::Bidirectional, StreamType::Unidirectional] {
         let block_func = |manager: &mut AbstractStreamManager<MockStream>| {
             let (waker, _) = new_count_waker();
@@ -965,7 +998,12 @@ fn streams_blocked_period() {
 
             // Open streams until blocked
             while manager
-                .poll_open_local_stream(stream_type, &mut token, &Context::from_waker(&waker))
+                .poll_open_local_stream(
+                    stream_type,
+                    &mut token,
+                    &mut ConnectionApiCallContext::from_wakeup_handle(&wakeup_handle),
+                    &Context::from_waker(&waker),
+                )
                 .is_ready()
             {
                 opened_streams += 1;
@@ -1230,11 +1268,17 @@ fn blocked_on_local_concurrent_stream_limit() {
         assert!(available_outgoing_stream_capacity < VarInt::from_u32(100_000));
 
         let (waker, wake_counter) = new_count_waker();
+        let (mut wakeup_queue, wakeup_handle) = create_wakeup_queue_and_handle();
         let mut token = connection::OpenToken::new();
 
         for _i in 0..*available_outgoing_stream_capacity {
             assert!(manager
-                .poll_open_local_stream(stream_type, &mut token, &Context::from_waker(&waker))
+                .poll_open_local_stream(
+                    stream_type,
+                    &mut token,
+                    &mut ConnectionApiCallContext::from_wakeup_handle(&wakeup_handle),
+                    &Context::from_waker(&waker)
+                )
                 .is_ready());
         }
 
@@ -1242,12 +1286,19 @@ fn blocked_on_local_concurrent_stream_limit() {
 
         // Cannot open any more streams
         assert!(manager
-            .poll_open_local_stream(stream_type, &mut token, &Context::from_waker(&waker))
+            .poll_open_local_stream(
+                stream_type,
+                &mut token,
+                &mut ConnectionApiCallContext::from_wakeup_handle(&wakeup_handle),
+                &Context::from_waker(&waker)
+            )
             .is_pending());
 
         if stream_type.is_bidirectional() {
             // if we have a bidirectional stream, then the controller should transmit an empty STREAM frame in order
             // to notify the peer of its existence.
+
+            assert_wakeups(&mut wakeup_queue, 1);
 
             let mut frame_buffer = OutgoingFrameBuffer::new();
             let mut write_context = MockWriteContext::new(
@@ -1299,11 +1350,21 @@ fn blocked_on_local_concurrent_stream_limit() {
 
         // One more stream can be opened
         assert!(manager
-            .poll_open_local_stream(stream_type, &mut token, &Context::from_waker(&waker))
+            .poll_open_local_stream(
+                stream_type,
+                &mut token,
+                &mut ConnectionApiCallContext::from_wakeup_handle(&wakeup_handle),
+                &Context::from_waker(&waker)
+            )
             .is_ready());
         assert_eq!(wake_counter, 1);
         assert!(manager
-            .poll_open_local_stream(stream_type, &mut token, &Context::from_waker(&waker))
+            .poll_open_local_stream(
+                stream_type,
+                &mut token,
+                &mut ConnectionApiCallContext::from_wakeup_handle(&wakeup_handle),
+                &Context::from_waker(&waker)
+            )
             .is_pending());
 
         // Close the stream manager and verify the wake counter is incremented
@@ -1395,6 +1456,7 @@ fn asymmetric_stream_limits_local_initiated() {
     let mut initial_local_limits = create_default_initial_flow_control_limits();
     let mut initial_peer_limits = create_default_initial_flow_control_limits();
     let (accept_waker, _accept_wake_counter) = new_count_waker();
+    let (_wakeup_queue, wakeup_handle) = create_wakeup_queue_and_handle();
     let mut token = connection::OpenToken::new();
 
     for local_limit in 0..101 {
@@ -1429,6 +1491,7 @@ fn asymmetric_stream_limits_local_initiated() {
                     let result = manager.poll_open_local_stream(
                         stream_type,
                         &mut token,
+                        &mut ConnectionApiCallContext::from_wakeup_handle(&wakeup_handle),
                         &Context::from_waker(&accept_waker),
                     );
                     assert!(

--- a/quic/s2n-quic-transport/src/stream/manager_api.rs
+++ b/quic/s2n-quic-transport/src/stream/manager_api.rs
@@ -59,6 +59,7 @@ pub trait Manager:
         &mut self,
         stream_type: StreamType,
         open_token: &mut connection::OpenToken,
+        api_call_context: &mut ConnectionApiCallContext,
         context: &Context,
     ) -> Poll<Result<StreamId, connection::Error>>;
 

--- a/quic/s2n-quic/src/tests/issue_1464.rs
+++ b/quic/s2n-quic/src/tests/issue_1464.rs
@@ -44,6 +44,8 @@ fn local_stream_open_notify_test() {
         primary::spawn(async move {
             let connect = Connect::new(server_addr).with_server_name("localhost");
             let mut connection = client.connect(connect).await.unwrap();
+            // Delay for a second to allow expiring timers and packet acks to be cleared out
+            delay(Duration::from_secs(1)).await;
             let mut stream = connection.open_bidirectional_stream().await.unwrap();
 
             let mut recv_len = 0;


### PR DESCRIPTION
### Description of changes: 

In #1467 we added an `open_notify` sender that would send an empty Stream frame from an endpoint that locally opened a bi-directional stream, to signal to the peer that the Stream is created and can start receiving data. Typically the `open_notify` sender would transmit the Stream when the connection is woken up due to a timer firing or a packet being received from the peer, but in case neither of those happen, it is possible the connection will not wake up and send the empty Stream frame, resulting in a deadlock. This change will ensure that the connection wakes up when a stream is created. 

### Testing:

Updated the existing integration test to include a delay before opening the stream. This delay allows for all armed timers to fire and packet ACKs to be received by the time the client opens the stream, to validate that there is no deadlock.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

