### PR TITLE
feat(events): Add cipher suite to TLS Session in the TlsExporterReady event

### DIFF
--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -238,19 +238,14 @@ impl HelloOffsets {
     }
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 #[allow(non_camel_case_types)]
 pub enum CipherSuite {
     TLS_AES_128_GCM_SHA256,
     TLS_AES_256_GCM_SHA384,
     TLS_CHACHA20_POLY1305_SHA256,
+    #[default]
     Unknown,
-}
-
-impl Default for CipherSuite {
-    fn default() -> Self {
-        CipherSuite::Unknown
-    }
 }
 
 impl crate::event::IntoEvent<crate::event::builder::CipherSuite> for CipherSuite {

--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::crypto::tls::CipherSuite::{
+    Unknown, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256,
+};
 #[cfg(feature = "alloc")]
 pub use bytes::{Bytes, BytesMut};
 use core::{convert::TryFrom, fmt::Debug};
@@ -40,6 +43,8 @@ pub trait TlsSession: Send + Sync {
         context: &[u8],
         output: &mut [u8],
     ) -> Result<(), TlsExportError>;
+
+    fn cipher_suite(&self) -> CipherSuite;
 }
 
 //= https://www.rfc-editor.org/rfc/rfc9000#section-4
@@ -263,6 +268,17 @@ impl crate::event::IntoEvent<crate::event::api::CipherSuite> for CipherSuite {
     fn into_event(self) -> crate::event::api::CipherSuite {
         let builder: crate::event::builder::CipherSuite = self.into_event();
         builder.into_event()
+    }
+}
+
+impl From<&str> for CipherSuite {
+    fn from(value: &str) -> Self {
+        match value {
+            "TLS_AES_128_GCM_SHA256" => TLS_AES_128_GCM_SHA256,
+            "TLS_AES_256_GCM_SHA384" => TLS_AES_256_GCM_SHA384,
+            "TLS_CHACHA20_POLY1305_SHA256" => TLS_CHACHA20_POLY1305_SHA256,
+            _ => Unknown,
+        }
     }
 }
 

--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -1,9 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::crypto::tls::CipherSuite::{
-    Unknown, TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256,
-};
 #[cfg(feature = "alloc")]
 pub use bytes::{Bytes, BytesMut};
 use core::{convert::TryFrom, fmt::Debug};
@@ -250,6 +247,12 @@ pub enum CipherSuite {
     Unknown,
 }
 
+impl Default for CipherSuite {
+    fn default() -> Self {
+        CipherSuite::Unknown
+    }
+}
+
 impl crate::event::IntoEvent<crate::event::builder::CipherSuite> for CipherSuite {
     #[inline]
     fn into_event(self) -> crate::event::builder::CipherSuite {
@@ -268,17 +271,6 @@ impl crate::event::IntoEvent<crate::event::api::CipherSuite> for CipherSuite {
     fn into_event(self) -> crate::event::api::CipherSuite {
         let builder: crate::event::builder::CipherSuite = self.into_event();
         builder.into_event()
-    }
-}
-
-impl From<&str> for CipherSuite {
-    fn from(value: &str) -> Self {
-        match value {
-            "TLS_AES_128_GCM_SHA256" => TLS_AES_128_GCM_SHA256,
-            "TLS_AES_256_GCM_SHA384" => TLS_AES_256_GCM_SHA384,
-            "TLS_CHACHA20_POLY1305_SHA256" => TLS_CHACHA20_POLY1305_SHA256,
-            _ => Unknown,
-        }
     }
 }
 

--- a/quic/s2n-quic-core/src/event.rs
+++ b/quic/s2n-quic-core/src/event.rs
@@ -147,6 +147,10 @@ impl<'a> TlsSession<'a> {
     ) -> Result<(), crate::crypto::tls::TlsExportError> {
         self.session.tls_exporter(label, context, output)
     }
+
+    pub fn cipher_suite(&self) -> crate::event::api::CipherSuite {
+        self.session.cipher_suite().into_event()
+    }
 }
 
 impl<'a> crate::event::IntoEvent<TlsSession<'a>> for TlsSession<'a> {

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -508,7 +508,7 @@ pub mod api {
         PacketLoss {},
     }
     #[non_exhaustive]
-    #[derive(Copy, Clone, Debug)]
+    #[derive(Copy, Clone, Debug, Eq, PartialEq)]
     #[allow(non_camel_case_types)]
     pub enum CipherSuite {
         #[non_exhaustive]

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -507,8 +507,8 @@ pub mod api {
         #[doc = " One or more packets were detected lost"]
         PacketLoss {},
     }
-    #[derive(Clone, Debug)]
     #[non_exhaustive]
+    #[derive(Copy, Clone, Debug)]
     #[allow(non_camel_case_types)]
     pub enum CipherSuite {
         #[non_exhaustive]

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -875,6 +875,7 @@ enum CongestionSource {
     PacketLoss,
 }
 
+#[derive(Copy, Clone, Debug)]
 #[allow(non_camel_case_types)] // we prefer to match the standard identifier
 enum CipherSuite {
     TLS_AES_128_GCM_SHA256,

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -875,7 +875,7 @@ enum CongestionSource {
     PacketLoss,
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[allow(non_camel_case_types)] // we prefer to match the standard identifier
 enum CipherSuite {
     TLS_AES_128_GCM_SHA256,

--- a/quic/s2n-quic-rustls/src/session.rs
+++ b/quic/s2n-quic-rustls/src/session.rs
@@ -11,7 +11,7 @@ use rustls::quic::{
 };
 use s2n_quic_core::{
     application::ServerName,
-    crypto::{self, tls, CryptoError},
+    crypto::{self, tls, tls::CipherSuite, CryptoError},
     transport,
 };
 
@@ -39,6 +39,25 @@ impl tls::TlsSession for Session {
         {
             Ok(_) => Ok(()),
             Err(_) => Err(tls::TlsExportError::failure()),
+        }
+    }
+
+    fn cipher_suite(&self) -> CipherSuite {
+        if let Some(rustls_cipher_suite) = self.connection.negotiated_cipher_suite() {
+            match rustls_cipher_suite.suite() {
+                rustls::CipherSuite::TLS13_AES_128_GCM_SHA256 => {
+                    CipherSuite::TLS_AES_128_GCM_SHA256
+                }
+                rustls::CipherSuite::TLS13_AES_256_GCM_SHA384 => {
+                    CipherSuite::TLS_AES_256_GCM_SHA384
+                }
+                rustls::CipherSuite::TLS13_CHACHA20_POLY1305_SHA256 => {
+                    CipherSuite::TLS_CHACHA20_POLY1305_SHA256
+                }
+                _ => CipherSuite::Unknown,
+            }
+        } else {
+            CipherSuite::Unknown
         }
     }
 }

--- a/quic/s2n-quic-tls/src/session.rs
+++ b/quic/s2n-quic-tls/src/session.rs
@@ -6,7 +6,7 @@ use bytes::BytesMut;
 use core::{marker::PhantomData, task::Poll};
 use s2n_quic_core::{
     application::ServerName,
-    crypto::{tls, CryptoError, CryptoSuite},
+    crypto::{tls, tls::CipherSuite, CryptoError, CryptoSuite},
     endpoint, transport,
 };
 use s2n_quic_crypto::Suite;
@@ -87,6 +87,11 @@ impl tls::TlsSession for Session {
         self.connection
             .tls_exporter(label, context, output)
             .map_err(|_| tls::TlsExportError::failure())
+    }
+
+    fn cipher_suite(&self) -> CipherSuite {
+        //todo remove unwrap
+        self.connection.cipher_suite().unwrap().into()
     }
 }
 

--- a/quic/s2n-quic-tls/src/session.rs
+++ b/quic/s2n-quic-tls/src/session.rs
@@ -90,8 +90,11 @@ impl tls::TlsSession for Session {
     }
 
     fn cipher_suite(&self) -> CipherSuite {
-        //todo remove unwrap
-        self.connection.cipher_suite().unwrap().into()
+        if let Ok(cipher_suite) = self.connection.cipher_suite() {
+            cipher_suite.into()
+        } else {
+            CipherSuite::Unknown
+        }
     }
 }
 

--- a/quic/s2n-quic-tls/src/session.rs
+++ b/quic/s2n-quic-tls/src/session.rs
@@ -90,11 +90,7 @@ impl tls::TlsSession for Session {
     }
 
     fn cipher_suite(&self) -> CipherSuite {
-        if let Ok(cipher_suite) = self.connection.cipher_suite() {
-            cipher_suite.into()
-        } else {
-            CipherSuite::Unknown
-        }
+        self.state.cipher_suite()
     }
 }
 

--- a/quic/s2n-quic/src/tests/exporter.rs
+++ b/quic/s2n-quic/src/tests/exporter.rs
@@ -44,7 +44,10 @@ impl Subscriber for Exporter {
     }
 }
 
-fn start_server(mut server: Server) -> crate::provider::io::testing::Result<SocketAddr> {
+fn start_server(
+    mut server: Server,
+    cipher_suite: Arc<Mutex<Option<CipherSuite>>>,
+) -> crate::provider::io::testing::Result<SocketAddr> {
     let server_addr = server.local_addr()?;
 
     // accept connections and echo back
@@ -53,6 +56,12 @@ fn start_server(mut server: Server) -> crate::provider::io::testing::Result<Sock
             let key = connection
                 .query_event_context(|ctx: &ExporterContext| ctx.key.unwrap())
                 .unwrap();
+
+            let _ = cipher_suite.lock().unwrap().insert(
+                connection
+                    .query_event_context(|ctx: &ExporterContext| ctx.cipher_suite.unwrap())
+                    .unwrap(),
+            );
 
             tracing::debug!("accepted server connection: {}", connection.id());
             spawn(async move {
@@ -69,7 +78,7 @@ fn start_server(mut server: Server) -> crate::provider::io::testing::Result<Sock
     Ok(server_addr)
 }
 
-fn tls_test<C>(f: fn(crate::Connection) -> C)
+fn tls_test<C>(f: fn(crate::Connection, CipherSuite) -> C)
 where
     C: 'static + core::future::Future<Output = ()> + Send,
 {
@@ -82,8 +91,9 @@ where
             .with_tls(SERVER_CERTS)?
             .with_event((Exporter, tracing_events()))?
             .start()?;
+        let server_cipher_suite = Arc::new(Mutex::new(None));
 
-        let addr = start_server(server)?;
+        let addr = start_server(server, server_cipher_suite.clone())?;
 
         let client = Client::builder()
             .with_io(handle.builder().build().unwrap())?
@@ -94,10 +104,14 @@ where
         // show it working for several connections
         for _ in 0..10 {
             let client = client.clone();
+            let server_cipher_suite = server_cipher_suite.clone();
             primary::spawn(async move {
                 let connect = Connect::new(addr).with_server_name("localhost");
                 let conn = client.connect(connect).await.unwrap();
-                f(conn).await;
+                delay(Duration::from_millis(250)).await;
+                let server_cipher_suite = server_cipher_suite.lock().unwrap().unwrap();
+                eprintln!("got client cipher suite {:?}", server_cipher_suite);
+                f(conn, server_cipher_suite).await;
             });
         }
 
@@ -108,15 +122,26 @@ where
 
 #[test]
 fn happy_case() {
-    tls_test(|mut conn| async move {
+    tls_test(|mut conn, server_cipher_suite| async move {
+        use s2n_quic_core::event::IntoEvent;
+        eprintln!("inside tls test");
         let client_key = conn
             .query_event_context(|ctx: &ExporterContext| ctx.key.unwrap())
             .unwrap();
 
-        let cipher_suite = conn
+        let client_cipher_suite = conn
             .query_event_context(|ctx: &ExporterContext| ctx.cipher_suite.unwrap())
             .unwrap();
-        eprintln!("HERE {:?}", cipher_suite);
+
+        assert_eq!(client_cipher_suite, server_cipher_suite);
+        assert_ne!(
+            client_cipher_suite,
+            s2n_quic_core::crypto::tls::CipherSuite::Unknown.into_event()
+        );
+        assert_ne!(
+            server_cipher_suite,
+            s2n_quic_core::crypto::tls::CipherSuite::Unknown.into_event()
+        );
 
         let mut stream = conn.open_bidirectional_stream().await.unwrap();
 


### PR DESCRIPTION
### Description of changes: 

#1984 added the ability to export symmetric keys negotiated during the QUIC handshake by adding an `on_tls_exporter_ready` event. This change adds `cipher_suite()` to the TLS session exposed as part of the event for use when using the exported keys.

### Call-outs:

I use `CipherSuite::Unknown` in place of returning an error, it seemed a little more user friendly and I wasn't sure the error would be useful

### Testing:

Updated the exporter integration test to confirm the client and server ciphersuites are the same and neither of them are unknown

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

