### PR TITLE
 feat(s2n-quic): increase max send buffer size default

### DIFF
--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -213,6 +213,17 @@ impl Limits {
     );
     setter!(with_ack_elicitation_interval, ack_elicitation_interval, u8);
     setter!(with_max_ack_ranges, ack_ranges_limit, u8);
+    /// Sets the maximum send buffer size for a Stream
+    ///
+    /// The send buffer contains unacknowledged application data. Constraining the maximum
+    /// size of this buffer limits the amount of memory a given Stream may consume. On
+    /// high bandwidth/high RTT connections this may act as a bottleneck, as the connection may be
+    /// waiting for data to be acknowledged by the peer before allowing more data to be sent.
+    /// Increasing this value should be carefully weighed against the potential downsides
+    /// of additional memory utilization as well as increased latency due to the capacity of the
+    /// send buffer exceeding the rate at which the network link and peer are able to drain from it.
+    /// Ideally, the max_send_buffer_size is configured to the minimum value that can support the
+    /// throughput requirements for the connection.
     setter!(with_max_send_buffer_size, max_send_buffer_size, u32);
     setter!(
         with_max_handshake_duration,

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -75,11 +75,12 @@ impl Default for Limits {
 }
 
 macro_rules! setter {
-    ($name:ident, $field:ident, $inner:ty $(, |$validate_value:ident| $validaiton:block)?) => {
+    ($(#[doc = $doc:literal])* $name:ident, $field:ident, $inner:ty $(, |$validate_value:ident| $validation:block)?) => {
+        $(#[doc = $doc])*
         pub fn $name(mut self, value: $inner) -> Result<Self, ValidationError> {
             $(
                 let $validate_value = value;
-                $validaiton
+                $validation
             )?
             self.$field = value.try_into()?;
             Ok(self)
@@ -213,18 +214,22 @@ impl Limits {
     );
     setter!(with_ack_elicitation_interval, ack_elicitation_interval, u8);
     setter!(with_max_ack_ranges, ack_ranges_limit, u8);
-    /// Sets the maximum send buffer size for a Stream
-    ///
-    /// The send buffer contains unacknowledged application data. Constraining the maximum
-    /// size of this buffer limits the amount of memory a given Stream may consume. On
-    /// high bandwidth/high RTT connections this may act as a bottleneck, as the connection may be
-    /// waiting for data to be acknowledged by the peer before allowing more data to be sent.
-    /// Increasing this value should be carefully weighed against the potential downsides
-    /// of additional memory utilization as well as increased latency due to the capacity of the
-    /// send buffer exceeding the rate at which the network link and peer are able to drain from it.
-    /// Ideally, the max_send_buffer_size is configured to the minimum value that can support the
-    /// throughput requirements for the connection.
-    setter!(with_max_send_buffer_size, max_send_buffer_size, u32);
+    setter!(
+        /// Sets the maximum send buffer size for a Stream
+        ///
+        /// The send buffer contains unacknowledged application data. Constraining the maximum
+        /// size of this buffer limits the amount of memory a given Stream may consume. On
+        /// high bandwidth/high RTT connections this may act as a bottleneck, as the connection may be
+        /// waiting for data to be acknowledged by the peer before allowing more data to be sent.
+        /// Increasing this value should be carefully weighed against the potential downsides
+        /// of additional memory utilization as well as increased latency due to the capacity of the
+        /// send buffer exceeding the rate at which the network link and peer are able to drain from it.
+        /// Ideally, the max_send_buffer_size is configured to the minimum value that can support the
+        /// throughput requirements for the connection.
+        with_max_send_buffer_size,
+        max_send_buffer_size,
+        u32
+    );
     setter!(
         with_max_handshake_duration,
         max_handshake_duration,

--- a/quic/s2n-quic-core/src/stream/limits.rs
+++ b/quic/s2n-quic-core/src/stream/limits.rs
@@ -6,9 +6,10 @@ use crate::{
     varint::VarInt,
 };
 
-// TODO investigate a good default
 /// The default send buffer size for Streams
-const DEFAULT_STREAM_MAX_SEND_BUFFER_SIZE: u32 = 512 * 1024;
+///
+/// This value is based on a common default maximum send buffer size for TCP (net.ipv4.tcp_wmem)
+const DEFAULT_STREAM_MAX_SEND_BUFFER_SIZE: u32 = 4096 * 1024;
 
 pub trait LocalLimits {
     fn as_varint(&self) -> VarInt;


### PR DESCRIPTION
### Description of changes: 

This change increases the default value for the `max_send_buffer_size` to a value commonly used as a maximum for TCP. This can prevent this buffer from acting as a bottleneck in high bandwidth/high RTT connections, but does bring with it additional caveats regarding additional memory consumption and latency. I've added some documentation to the `with_max_send_buffer_size` setting highlighting this tradeoff.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

