### PR TITLE
feat(s2n-quic-qns): Client Resumption Interop test

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -618,5 +618,52 @@
     "s2n-quic": [],
     "s2n-quic-rustls": [],
     "xquic": []
+  },
+  "resumption": {
+    "aioquic": [
+      "client",
+      "server"
+    ],
+    "kwik": [
+      "client",
+      "server"
+    ],
+    "lsquic": [
+      "client",
+      "server"
+    ],
+    "mvfst": [
+      "client",
+      "server"
+    ],
+    "neqo": [
+      "client",
+      "server"
+    ],
+    "ngtcp2": [
+      "client",
+      "server"
+    ],
+    "picoquic": [
+      "client",
+      "server"
+    ],
+    "quic-go": [
+      "client",
+      "server"
+    ],
+    "quiche": [
+      "client",
+      "server"
+    ],
+    "s2n-quic": [
+      "client",
+      "server"
+    ],
+    "s2n-quic-rustls": [],
+    "xquic": [
+      "client",
+      "server"
+    ]
   }
 }

--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -633,7 +633,6 @@
       "server"
     ],
     "mvfst": [
-      "client",
       "server"
     ],
     "neqo": [
@@ -661,9 +660,6 @@
       "server"
     ],
     "s2n-quic-rustls": [],
-    "xquic": [
-      "client",
-      "server"
-    ]
+    "xquic": []
   }
 }

--- a/examples/resumption/README.md
+++ b/examples/resumption/README.md
@@ -1,0 +1,15 @@
+# Session Resumption
+
+This folder contains example code to do resumption handshakes in s2n-quic. This TLS feature allows a client and server to skip the costly certificate authentication step using a saved value from their previous TLS session. Note that currently resumption has only been implemented for the s2n-tls provider and therefore you will have to use s2n-tls rather than rustls to turn on this feature in s2n-quic.
+
+# Set-up
+
+Currently resumption is disabled by default as it is still in development. It can be enabled by passing a compiler flag:
+```sh
+export RUSTFLAGS="--cfg s2n_quic_unstable"
+```
+and adding this line to your Cargo.toml file:
+```toml
+[dependencies]
+s2n-quic = { version = "1", features = ["unstable-resumption"]}
+```

--- a/quic/s2n-quic-qns/src/client/interop.rs
+++ b/quic/s2n-quic-qns/src/client/interop.rs
@@ -97,7 +97,7 @@ impl Interop {
         // Handshake Loss (multiconnect): Tests resilience of the handshake to high loss.
         // The client is expected to establish multiple connections, sequential or in parallel,
         // and use each connection to download a single file.
-        if let Some(Testcase::Multiconnect) | Some(Testcase::Resumption) = self.testcase {
+        if let Some(Testcase::Multiconnect | Testcase::Resumption) = self.testcase {
             for request in self.requests.iter().cloned() {
                 let connect = endpoints.get(&request.host().unwrap()).unwrap().clone();
                 let requests = core::iter::once(request);

--- a/quic/s2n-quic-qns/src/client/interop.rs
+++ b/quic/s2n-quic-qns/src/client/interop.rs
@@ -86,10 +86,11 @@ impl Interop {
         // In the Resumption test, the client needs to start a handshake and complete it before
         // starting a resumption handshake with a session ticket from the first handshake. Therefore,
         // the two handshake requests are run one after another synchronously.
-        let concurrency = if matches!(self.testcase, Some(Testcase::Resumption)) {
-            1
-        } else {
-            self.concurrency
+        let mut concurrency = self.concurrency;
+        let mut keep_alive = self.keep_alive;
+        if matches!(self.testcase, Some(Testcase::Resumption)) {
+            concurrency = 1;
+            keep_alive = Some(Duration::from_millis(500));
         };
         let mut tasks = task::Limiter::new(concurrency);
 
@@ -107,7 +108,7 @@ impl Interop {
                     connect,
                     requests,
                     download_dir.clone(),
-                    self.keep_alive,
+                    keep_alive,
                 );
 
                 if let Some(task) = tasks.spawn(task).await {

--- a/quic/s2n-quic-qns/src/tls.rs
+++ b/quic/s2n-quic-qns/src/tls.rs
@@ -96,15 +96,19 @@ pub struct Client {
 impl Client {
     #[cfg(unix)]
     pub fn build_s2n_tls(&self, alpns: &[String]) -> Result<s2n_tls::Client> {
-        let tls = s2n_tls::Client::builder()
+        let handler = s2n_tls::SessionTicketHandler::default();
+        let mut tls = s2n_tls::Client::builder()
             .with_certificate(s2n_tls::ca(self.ca.as_ref())?)?
             // the "amplificationlimit" tests generates a very large chain so bump the limit
             .with_max_cert_chain_depth(10)?
             .with_application_protocols(alpns.iter().map(String::as_bytes))?
-            .with_key_logging()?
-            .build()?;
+            .with_key_logging()?;
+        let config = tls.config_mut();
+        config
+            .set_session_ticket_callback(handler.clone())?
+            .set_connection_initializer(handler.clone())?;
 
-        Ok(tls)
+        Ok(tls.build()?)
     }
 
     pub fn build_rustls(&self, alpns: &[String]) -> Result<rustls::Client> {
@@ -193,8 +197,16 @@ impl FromStr for TlsProviders {
 pub mod s2n_tls {
     use super::*;
     pub use s2n_quic::provider::tls::s2n_tls::{
+        callbacks::{ConnectionFuture, SessionTicket, SessionTicketCallback},
         certificate::{Certificate, IntoCertificate, IntoPrivateKey, PrivateKey},
+        config::ConnectionInitializer,
+        connection::Connection,
+        error::Error,
         Client, Server,
+    };
+    use std::{
+        pin::Pin,
+        sync::{Arc, Mutex},
     };
 
     pub fn ca(ca: Option<&PathBuf>) -> Result<Certificate> {
@@ -211,6 +223,34 @@ pub mod s2n_tls {
         } else {
             s2n_quic_core::crypto::tls::testing::certificates::KEY_PEM.into_private_key()?
         })
+    }
+
+    #[derive(Default, Clone)]
+    pub struct SessionTicketHandler {
+        stored_ticket: Arc<Mutex<Option<Vec<u8>>>>,
+    }
+
+    impl SessionTicketCallback for SessionTicketHandler {
+        fn on_session_ticket(&self, _connection: &mut Connection, session_ticket: &SessionTicket) {
+            let size = session_ticket.len().unwrap();
+            let mut data = vec![0; size];
+            session_ticket.data(&mut data).unwrap();
+            let mut ticket = (*self.stored_ticket).lock().unwrap();
+            if ticket.is_none() {
+                *ticket = Some(data);
+            }
+        }
+    }
+    impl ConnectionInitializer for SessionTicketHandler {
+        fn initialize_connection(
+            &self,
+            connection: &mut Connection,
+        ) -> Result<Option<Pin<Box<(dyn ConnectionFuture)>>>, Error> {
+            if let Some(ticket) = (*self.stored_ticket).lock().unwrap().as_deref() {
+                connection.set_session_ticket(ticket)?;
+            }
+            Ok(None)
+        }
     }
 }
 

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1535,17 +1535,15 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             // try to process any post-handshake messages
             if Config::ENDPOINT_TYPE.is_client() && processed_packet.contains_crypto {
                 let space_manager = &mut self.space_manager;
-                space_manager
-                    .post_handshake_crypto(
-                        &mut self.path_manager,
-                        &mut self.local_id_registry,
-                        &mut self.limits,
-                        datagram.timestamp,
-                        &self.waker,
-                        &mut publisher,
-                        datagram_endpoint,
-                    )
-                    .map_err(|error| ProcessingError::ConnectionError(error.into()))?;
+                space_manager.post_handshake_crypto(
+                    &mut self.path_manager,
+                    &mut self.local_id_registry,
+                    &mut self.limits,
+                    datagram.timestamp,
+                    &self.waker,
+                    &mut publisher,
+                    datagram_endpoint,
+                )?;
             }
             // notify the connection a packet was processed
             self.on_processed_packet(&processed_packet, subscriber)?;

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1535,15 +1535,17 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             // try to process any post-handshake messages
             if Config::ENDPOINT_TYPE.is_client() && processed_packet.contains_crypto {
                 let space_manager = &mut self.space_manager;
-                space_manager.post_handshake_crypto(
-                    &mut self.path_manager,
-                    &mut self.local_id_registry,
-                    &mut self.limits,
-                    datagram.timestamp,
-                    &self.waker,
-                    &mut publisher,
-                    datagram_endpoint,
-                )?;
+                space_manager
+                    .post_handshake_crypto(
+                        &mut self.path_manager,
+                        &mut self.local_id_registry,
+                        &mut self.limits,
+                        datagram.timestamp,
+                        &self.waker,
+                        &mut publisher,
+                        datagram_endpoint,
+                    )
+                    .map_err(|error| ProcessingError::ConnectionError(error.into()))?;
             }
             // notify the connection a packet was processed
             self.on_processed_packet(&processed_packet, subscriber)?;

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -331,10 +331,10 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 //# that is closing is not required to process any received frame.
                 return Err(error);
             }
-            Err(ProcessingError::CryptoError(_)) => {
+            Err(ProcessingError::DecryptError) => {
                 // NOTE: this reason is emitted by the connection implementation
 
-                // CryptoErrors returned as a result of a packet failing decryption
+                // DecryptErrors returned as a result of a packet failing decryption
                 // will be silently discarded, but are a potential indication of a
                 // stateless reset from the peer
 

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -333,9 +333,8 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                     .map_err(|err| {
                         use connection::ProcessingError;
                         match err {
-                            ProcessingError::CryptoError(err) => err.into(),
                             ProcessingError::ConnectionError(err) => err,
-                            ProcessingError::Other => {
+                            _ => {
                                 // This is the first packet received. If it's invalid, drop the
                                 // connection.
                                 transport::Error::PROTOCOL_VIOLATION.into()


### PR DESCRIPTION
### Resolved issues:

N/A
### Description of changes: 

Adds functionality so that the client resumption feature is added to the interop test. 
Also adds a readme for the resumption example.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

