### PR TITLE
ci: remove crate without Kani proofs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -698,7 +698,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crate: [quic/s2n-quic-core, quic/s2n-quic-platform, tools/xdp/s2n-quic-xdp]
+        crate: [quic/s2n-quic-core, quic/s2n-quic-platform]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.-->

Kani proofs in the `tools/xdp/s2n-quic-xdp` crate were moved to `quic/s2n-quic-core`, so there's no longer a need to run Kani on this crate:

https://github.com/aws/s2n-quic/actions/runs/7453776726/job/20279841353#step:3:425

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

