### PR TITLE
feat(s2n-quic-platform): make TOS features readable at runtime

### DIFF
--- a/quic/s2n-quic-platform/build.rs
+++ b/quic/s2n-quic-platform/build.rs
@@ -84,8 +84,10 @@ impl Features {
             return;
         }
 
-        self.features.insert(name.to_string());
-        println!("cargo:rustc-cfg=s2n_quic_platform_{name}");
+        let newly_inserted = self.features.insert(name.to_string());
+        if newly_inserted {
+            println!("cargo:rustc-cfg=s2n_quic_platform_{name}");
+        }
     }
 
     fn supports(&self, name: &str) -> bool {

--- a/quic/s2n-quic-platform/src/features.rs
+++ b/quic/s2n-quic-platform/src/features.rs
@@ -6,4 +6,6 @@ type c_int = std::os::raw::c_int;
 
 pub mod gro;
 pub mod gso;
+pub mod tos_v4;
+pub mod tos_v6;
 pub use gso::Gso;

--- a/quic/s2n-quic-platform/src/features/tos_v4.rs
+++ b/quic/s2n-quic-platform/src/features/tos_v4.rs
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::c_int;
+
+#[cfg(s2n_quic_platform_tos)]
+mod tos_enabled {
+    use super::*;
+    use libc::{IPPROTO_IP, IP_RECVTOS, IP_TOS};
+
+    pub const LEVEL: Option<c_int> = Some(IPPROTO_IP as _);
+    pub const TYPE: Option<c_int> = Some(IP_TOS as _);
+    pub const SOCKOPT: Option<(c_int, c_int)> = Some((IPPROTO_IP as _, IP_RECVTOS as _));
+    pub const CMSG_SPACE: usize = crate::message::cmsg::size_of_cmsg::<super::Cmsg>();
+
+    #[inline]
+    pub const fn is_match(level: c_int, ty: c_int) -> bool {
+        level == IPPROTO_IP as c_int && (ty == IP_TOS as c_int || ty == IP_RECVTOS as c_int)
+    }
+}
+
+#[cfg(any(not(s2n_quic_platform_tos), test))]
+mod tos_disabled {
+    #![cfg_attr(test, allow(dead_code))]
+    use super::*;
+
+    pub const LEVEL: Option<c_int> = None;
+    pub const TYPE: Option<c_int> = None;
+    pub const SOCKOPT: Option<(c_int, c_int)> = None;
+    pub const CMSG_SPACE: usize = 0;
+
+    #[inline]
+    pub const fn is_match(level: c_int, ty: c_int) -> bool {
+        let _ = level;
+        let _ = ty;
+        false
+    }
+}
+
+mod tos_impl {
+    #[cfg(not(s2n_quic_platform_tos))]
+    pub use super::tos_disabled::*;
+    #[cfg(s2n_quic_platform_tos)]
+    pub use super::tos_enabled::*;
+}
+
+pub use tos_impl::*;
+
+// FreeBSD uses an unsigned_char for IP_TOS
+// see https://svnweb.freebsd.org/base/stable/8/sys/netinet/ip_input.c?view=markup&pathrev=247944#l1716
+#[cfg(target_os = "freebsg")]
+pub type Cmsg = libc::c_uchar;
+#[cfg(not(target_os = "freebsg"))]
+pub type Cmsg = c_int;
+
+pub const IS_SUPPORTED: bool = cfg!(s2n_quic_platform_tos);

--- a/quic/s2n-quic-platform/src/features/tos_v4.rs
+++ b/quic/s2n-quic-platform/src/features/tos_v4.rs
@@ -48,9 +48,9 @@ pub use tos_impl::*;
 
 // FreeBSD uses an unsigned_char for IP_TOS
 // see https://svnweb.freebsd.org/base/stable/8/sys/netinet/ip_input.c?view=markup&pathrev=247944#l1716
-#[cfg(target_os = "freebsg")]
+#[cfg(target_os = "freebsd")]
 pub type Cmsg = libc::c_uchar;
-#[cfg(not(target_os = "freebsg"))]
+#[cfg(not(target_os = "freebsd"))]
 pub type Cmsg = c_int;
 
 pub const IS_SUPPORTED: bool = cfg!(s2n_quic_platform_tos);

--- a/quic/s2n-quic-platform/src/features/tos_v6.rs
+++ b/quic/s2n-quic-platform/src/features/tos_v6.rs
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::c_int;
+
+#[cfg(s2n_quic_platform_tos)]
+mod tos_enabled {
+    use super::*;
+    use libc::{IPPROTO_IPV6, IPV6_RECVTCLASS, IPV6_TCLASS};
+
+    pub const LEVEL: Option<c_int> = Some(IPPROTO_IPV6 as _);
+    pub const TYPE: Option<c_int> = Some(IPV6_TCLASS as _);
+    pub const SOCKOPT: Option<(c_int, c_int)> = Some((IPPROTO_IPV6 as _, IPV6_RECVTCLASS as _));
+    pub const CMSG_SPACE: usize = crate::message::cmsg::size_of_cmsg::<super::Cmsg>();
+
+    #[inline]
+    pub const fn is_match(level: c_int, ty: c_int) -> bool {
+        level == IPPROTO_IPV6 as c_int
+            && (ty == IPV6_TCLASS as c_int || ty == IPV6_RECVTCLASS as c_int)
+    }
+}
+
+#[cfg(any(not(s2n_quic_platform_tos), test))]
+mod tos_disabled {
+    #![cfg_attr(test, allow(dead_code))]
+    use super::*;
+
+    pub const LEVEL: Option<c_int> = None;
+    pub const TYPE: Option<c_int> = None;
+    pub const SOCKOPT: Option<(c_int, c_int)> = None;
+    pub const CMSG_SPACE: usize = 0;
+
+    #[inline]
+    pub const fn is_match(level: c_int, ty: c_int) -> bool {
+        let _ = level;
+        let _ = ty;
+        false
+    }
+}
+
+mod tos_impl {
+    #[cfg(not(s2n_quic_platform_tos))]
+    pub use super::tos_disabled::*;
+    #[cfg(s2n_quic_platform_tos)]
+    pub use super::tos_enabled::*;
+}
+
+pub use tos_impl::*;
+pub type Cmsg = c_int;
+pub const IS_SUPPORTED: bool = cfg!(s2n_quic_platform_tos);


### PR DESCRIPTION
### Description of changes: 

Similar to #2062, this change makes TOS/ECN features readable at runtime in order to reduce the amount of conditional compilation.

### Call-outs:

I split ipv4 and ipv6 into separate features since they use distinct values/types.

### Testing:

This is mostly just a refactor so all of the existing tests should suffice.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

