### PR TITLE
feat(s2n-quic-core): add USDT probe support

### DIFF
--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -19,8 +19,10 @@ generator = ["bolero-generator"]
 checked-counters = []
 branch-tracing = ["tracing"]
 event-tracing = ["tracing"]
+probe-tracing = ["tracing"]
 # This feature enables support for third party congestion controller implementations
 unstable-congestion-controller = []
+usdt = ["dep:probe"]
 
 [dependencies]
 atomic-waker = { version = "1", optional = true }
@@ -35,6 +37,7 @@ insta = { version = ">=1.12", features = ["json"], optional = true }
 num-rational = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 pin-project-lite = { version = "0.2" }
+probe = { version = "0.5", optional = true }
 s2n-codec = { version = "=0.32.0", path = "../../common/s2n-codec", default-features = false }
 subtle = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }

--- a/quic/s2n-quic-core/src/buffer/receive_buffer.rs
+++ b/quic/s2n-quic-core/src/buffer/receive_buffer.rs
@@ -9,6 +9,7 @@ use alloc::collections::{vec_deque, VecDeque};
 use bytes::BytesMut;
 use core::fmt;
 
+mod probe;
 mod request;
 mod slot;
 
@@ -465,6 +466,8 @@ impl ReceiveBuffer {
             // remove empty buffers
             self.slots.pop_front();
         }
+
+        probe::pop(self.start_offset, len);
 
         self.start_offset += len as u64;
 

--- a/quic/s2n-quic-core/src/buffer/receive_buffer/probe.rs
+++ b/quic/s2n-quic-core/src/buffer/receive_buffer/probe.rs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+crate::probe::define!(
+    extern "probe" {
+        /// Emitted when a buffer is allocated for a particular offset
+        #[link_name = s2n_quic_core__buffer__receive_buffer__alloc]
+        pub fn alloc(offset: u64, capacity: usize);
+
+        /// Emitted when a chunk is read from the beginning of the buffer
+        #[link_name = s2n_quic_core__buffer__receive_buffer__pop]
+        pub fn pop(offset: u64, len: usize);
+
+        /// Emitted when a chunk of data is written at an offset
+        #[link_name = s2n_quic_core__buffer__receive_buffer__write]
+        pub fn write(offset: u64, len: usize);
+    }
+);

--- a/quic/s2n-quic-core/src/buffer/receive_buffer/request.rs
+++ b/quic/s2n-quic-core/src/buffer/receive_buffer/request.rs
@@ -62,6 +62,7 @@ impl<'a> Request<'a> {
 
     #[inline]
     pub fn write(self, buffer: &mut BytesMut) {
+        super::probe::write(self.offset, self.data.len());
         let chunk = buffer.chunk_mut();
         unsafe {
             let len = self.data.len();

--- a/quic/s2n-quic-core/src/buffer/receive_buffer/slot.rs
+++ b/quic/s2n-quic-core/src/buffer/receive_buffer/slot.rs
@@ -35,6 +35,7 @@ pub struct Outcome<'a> {
 impl Slot {
     #[inline]
     pub fn new(start: u64, end: u64, data: BytesMut) -> Self {
+        super::probe::alloc(start, data.capacity());
         let v = Self { start, end, data };
         v.invariants();
         v

--- a/quic/s2n-quic-core/src/probe.rs
+++ b/quic/s2n-quic-core/src/probe.rs
@@ -1,0 +1,170 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __probe_define__ {
+    (extern "probe" {
+        $(
+            $(
+                #[doc = $doc:tt]
+            )*
+            #[link_name = $link_name:ident]
+            $vis:vis fn $fun:ident($($arg:ident: $arg_t:ty),* $(,)?);
+        )*
+    }) => {
+        $(
+            $(
+                #[doc = $doc]
+            )*
+            #[inline(always)]
+            $vis fn $fun($($arg: $arg_t),*) {
+                $crate::probe::__trace!(
+                    name: stringify!($fun),
+                    target: concat!(module_path!(), "::", stringify!($fun)),
+                    $(
+                        ?$arg,
+                    )*
+                );
+
+                $crate::probe::__usdt!(
+                    s2n_quic,
+                    $link_name,
+                    $(
+                        $arg
+                    ),*
+                );
+            }
+        )*
+    }
+}
+
+#[doc(inline)]
+pub use __probe_define__ as define;
+
+#[cfg(feature = "probe-tracing")]
+#[doc(hidden)]
+pub use tracing::trace as __trace;
+
+#[cfg(not(feature = "probe-tracing"))]
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __trace_impl__ {
+    ($($fmt:tt)*) => {};
+}
+
+#[cfg(not(feature = "probe-tracing"))]
+#[doc(hidden)]
+pub use __trace_impl__ as __trace;
+
+#[cfg(feature = "usdt")]
+#[doc(hidden)]
+pub use probe::probe as __usdt_emit__;
+
+#[cfg(feature = "usdt")]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __usdt_impl__ {
+    ($provider:ident, $name:ident $(, $arg:ident)* $(,)?) => {{
+        // define a function with inline(never) to consolidate probes to this single location
+        let probe = {
+            #[inline(never)]
+            || {
+                $(
+                    let $arg = $crate::probe::Arg::into_usdt($arg);
+                )*
+                $crate::probe::__usdt_emit__!($provider, $name, $($arg),*);
+            }
+        };
+        probe();
+    }}
+}
+
+#[cfg(not(feature = "usdt"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __usdt_impl__ {
+    ($provider:ident, $name:ident $(, $arg:ident)* $(,)?) => {{
+        // make sure all of the args implement Arg
+        $(
+            let _ = $crate::probe::Arg::into_usdt($arg);
+        )*
+    }}
+}
+
+#[doc(inline)]
+pub use __usdt_impl__ as __usdt;
+
+pub trait Arg {
+    fn into_usdt(self) -> isize;
+}
+
+macro_rules! impl_int_arg {
+    ($($ty:ident),* $(,)?) => {
+        $(
+            impl Arg for $ty {
+                #[inline]
+                fn into_usdt(self) -> isize {
+                    self as _
+                }
+            }
+        )*
+    }
+}
+
+impl_int_arg!(u8, i8, u16, i16, u32, i32, u64, i64, usize, isize);
+
+impl Arg for bool {
+    #[inline]
+    fn into_usdt(self) -> isize {
+        if self {
+            1
+        } else {
+            0
+        }
+    }
+}
+
+impl Arg for core::time::Duration {
+    #[inline]
+    fn into_usdt(self) -> isize {
+        self.as_nanos() as _
+    }
+}
+
+impl Arg for crate::time::Timestamp {
+    #[inline]
+    fn into_usdt(self) -> isize {
+        unsafe { self.as_duration().into_usdt() }
+    }
+}
+
+impl Arg for crate::packet::number::PacketNumber {
+    #[inline]
+    fn into_usdt(self) -> isize {
+        self.as_u64().into_usdt()
+    }
+}
+
+impl Arg for crate::varint::VarInt {
+    #[inline]
+    fn into_usdt(self) -> isize {
+        self.as_u64().into_usdt()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    crate::probe::define!(
+        extern "probe" {
+            /// Testing the probe capability
+            #[link_name = s2n_quic_core__probe__tests__test123]
+            pub fn test123(a: u8, b: core::time::Duration, c: u64);
+        }
+    );
+
+    #[test]
+    fn call_probe_test() {
+        test123(123, core::time::Duration::from_secs(123), 123);
+    }
+}

--- a/quic/s2n-quic-core/src/sync/spsc/tests.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/tests.rs
@@ -397,7 +397,7 @@ fn loom_spin_rx(mut recv: Receiver<u32>, expected: usize) {
 }
 
 fn loom_async_rx(mut recv: Receiver<u32>, expected: usize) {
-    use futures::{future::poll_fn, ready};
+    use futures::future::poll_fn;
 
     loom::future::block_on(async move {
         let mut value = 0u32;
@@ -455,7 +455,7 @@ fn loom_spin_tx(mut send: Sender<u32>, batch_count: usize, batch_size: usize) {
 }
 
 fn loom_async_tx(mut send: Sender<u32>, batch_count: usize, batch_size: usize) {
-    use futures::{future::poll_fn, ready};
+    use futures::future::poll_fn;
 
     loom::future::block_on(async move {
         let max_value = (batch_count * batch_size) as u32;

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 
 [features]
 default = []
+trace = ["s2n-quic-core/branch-tracing", "s2n-quic-core/probe-tracing", "s2n-quic-core/usdt"]
 xdp = ["s2n-quic/unstable-provider-io-xdp", "aya", "aya-log"]
 
 [dependencies]

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -82,7 +82,7 @@ bolero = { version = "0.10" }
 # in downstream dev-dependencies (in s2n-quic-tls, in this case)
 jobserver = "=0.1.26"
 regex = "=1.9.6" # newer versions require rust 1.65, see https://github.com/aws/s2n-quic/issues/1993
-s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "testing"] }
+s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "probe-tracing", "testing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }
 s2n-quic-transport = { version = "=0.32.0", path = "../s2n-quic-transport", features = ["unstable_resumption"] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
### Description of changes: 

This change adds support for defining static probes throughout the codebase:

https://github.com/aws/s2n-quic/blob/cd06c5847574ee37a28370f103a423db1b07892f/quic/s2n-quic-core/src/buffer/receive_buffer/probe.rs#L4-L18

In the code, you can then just call your probes like regular functions - all with autocompletion and strict typing!

https://github.com/aws/s2n-quic/blob/cd06c5847574ee37a28370f103a423db1b07892f/quic/s2n-quic-core/src/buffer/receive_buffer/request.rs#L64-L65

The probe can then be configured through feature flags to:

* emit a `tracing` record
* register as a USDT probe, which can be read by tools like bpftrace.

### Testing:

I've enabled `probe-tracing` on the `s2n-quic` dev-dependencies, so all of the integration tests can be more-easily traced:

```
$ S2N_LOG=trace cargo test -p s2n-quic client_server -- --nocapture | rg receive_buffer::probe
    Finished test [unoptimized + debuginfo] target(s) in 0.11s
     Running unittests src/lib.rs (target/debug/deps/s2n_quic-f075e86750846335)
0:00:00.050000 s2n_quic_core::buffer::receive_buffer::probe::alloc: offset=0 capacity=4096
0:00:00.050000 s2n_quic_core::buffer::receive_buffer::probe::write: offset=0 len=234
0:00:00.050000 s2n_quic_core::buffer::receive_buffer::probe::pop: offset=0 len=4
0:00:00.050000 s2n_quic_core::buffer::receive_buffer::probe::pop: offset=4 len=230
0:00:00.100000 s2n_quic_core::buffer::receive_buffer::probe::alloc: offset=0 capacity=4096
0:00:00.100000 s2n_quic_core::buffer::receive_buffer::probe::write: offset=0 len=90
0:00:00.100000 s2n_quic_core::buffer::receive_buffer::probe::pop: offset=0 len=4
0:00:00.100000 s2n_quic_core::buffer::receive_buffer::probe::pop: offset=4 len=86
0:00:00.100000 s2n_quic_core::buffer::receive_buffer::probe::alloc: offset=0 capacity=4096
0:00:00.100000 s2n_quic_core::buffer::receive_buffer::probe::write: offset=0 len=600
0:00:00.100000 s2n_quic_core::buffer::receive_buffer::probe::pop: offset=0 len=4
0:00:00.100000 s2n_quic_core::buffer::receive_buffer::probe::pop: offset=4 len=88
...
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

