### PR TITLE
feat(s2n-quic-platform): make GSO/GRO configuration more ergonomic

### DIFF
--- a/quic/s2n-quic-platform/src/io/tokio/builder.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/builder.rs
@@ -126,11 +126,12 @@ impl Builder {
     ///
     /// By default, GSO will be used unless the platform does not support it or an attempt to use
     /// GSO fails. If it is known that GSO is not available, set this option to explicitly disable it.
-    pub fn with_gso(mut self, enabled: bool) -> io::Result<Self> {
-        if !enabled {
-            self.max_segments = 1.try_into().expect("1 is always a valid MaxSegments value");
+    pub fn with_gso(self, enabled: bool) -> io::Result<Self> {
+        if enabled {
+            Ok(self)
+        } else {
+            self.with_gso_disabled()
         }
-        Ok(self)
     }
 
     /// Disables Generic Receive Offload (GRO)
@@ -146,11 +147,12 @@ impl Builder {
     ///
     /// By default, GRO will be used unless the platform does not support it. If it is known that
     /// GRO is not available, set this option to explicitly disable it.
-    pub fn with_gro(mut self, enabled: bool) -> io::Result<Self> {
-        if !enabled {
-            self.gro_enabled = Some(false);
+    pub fn with_gro(self, enabled: bool) -> io::Result<Self> {
+        if enabled {
+            Ok(self)
+        } else {
+            self.with_gro_disabled()
         }
-        Ok(self)
     }
 
     /// Enables the port reuse (SO_REUSEPORT) socket option

--- a/quic/s2n-quic-platform/src/io/tokio/builder.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/builder.rs
@@ -122,12 +122,34 @@ impl Builder {
         Ok(self)
     }
 
+    /// Configures Generic Segmentation Offload (GSO)
+    ///
+    /// By default, GSO will be used unless the platform does not support it or an attempt to use
+    /// GSO fails. If it is known that GSO is not available, set this option to explicitly disable it.
+    pub fn with_gso(mut self, enabled: bool) -> io::Result<Self> {
+        if !enabled {
+            self.max_segments = 1.try_into().expect("1 is always a valid MaxSegments value");
+        }
+        Ok(self)
+    }
+
     /// Disables Generic Receive Offload (GRO)
     ///
     /// By default, GRO will be used unless the platform does not support it. If it is known that
     /// GRO is not available, set this option to explicitly disable it.
     pub fn with_gro_disabled(mut self) -> io::Result<Self> {
         self.gro_enabled = Some(false);
+        Ok(self)
+    }
+
+    /// Configures Generic Receive Offload (GRO)
+    ///
+    /// By default, GRO will be used unless the platform does not support it. If it is known that
+    /// GRO is not available, set this option to explicitly disable it.
+    pub fn with_gro(mut self, enabled: bool) -> io::Result<Self> {
+        if !enabled {
+            self.gro_enabled = Some(false);
+        }
         Ok(self)
     }
 

--- a/quic/s2n-quic-qns/src/io.rs
+++ b/quic/s2n-quic-qns/src/io.rs
@@ -46,11 +46,8 @@ impl Server {
     pub fn build(&self) -> Result<impl io::Provider> {
         let mut io_builder = io::Default::builder()
             .with_receive_address((self.ip, self.port).into())?
-            .with_max_mtu(self.max_mtu)?;
-
-        if self.disable_gso {
-            io_builder = io_builder.with_gso_disabled()?;
-        }
+            .with_max_mtu(self.max_mtu)?
+            .with_gso(!self.disable_gso)?;
 
         if let Some(size) = self.queue_send_buffer_size {
             io_builder = io_builder.with_internal_send_buffer_size(size)?;
@@ -102,11 +99,8 @@ impl Client {
     pub fn build(&self) -> Result<impl io::Provider> {
         let mut io_builder = io::Default::builder()
             .with_receive_address((self.local_ip, 0u16).into())?
-            .with_max_mtu(self.max_mtu)?;
-
-        if self.disable_gso {
-            io_builder = io_builder.with_gso_disabled()?;
-        }
+            .with_max_mtu(self.max_mtu)?
+            .with_gso(!self.disable_gso)?;
 
         if let Some(size) = self.queue_send_buffer_size {
             io_builder = io_builder.with_internal_send_buffer_size(size)?;


### PR DESCRIPTION
### Description of changes: 

In #2078, it was suggested that the GSO/GRO configuration methods could be a bit nicer to use. This change adds new methods that take `bool`s which makes it easier to chain.

I've updated the qns application to use the new methods.

### Call-outs:

I think it's fine to keep the old methods. I debated marking them deprecated but I don't think it really hurts anything them being there indefinitely.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

