### PR TITLE
build(deps): bump actions/{download,upload}-artifact from 3 to 4

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -103,7 +103,7 @@ jobs:
           mkdir -p s2n-quic-qns
           cp target/${{ matrix.mode }}/s2n-quic-qns s2n-quic-qns/s2n-quic-qns-${{ matrix.mode }}
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: s2n-quic-qns-${{ matrix.mode }}
           path: s2n-quic-qns/
@@ -118,12 +118,12 @@ jobs:
         with:
           path: s2n-quic
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: s2n-quic-qns-debug
           path: s2n-quic-qns/
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: s2n-quic-qns-release
           path: s2n-quic-qns/
@@ -229,7 +229,7 @@ jobs:
           TARGET="${{ github.sha }}/interop/logs/latest"
           aws s3 sync results/logs "s3://s2n-quic-ci-artifacts/$TARGET" --acl private --follow-symlinks
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: interop-${{ matrix.client }}-client-${{ matrix.server }}-server
           path: quic-interop-runner/results/result.json
@@ -245,7 +245,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           path: results/
 
@@ -378,12 +378,12 @@ jobs:
         if: github.event.pull_request
         run: docker pull public.ecr.aws/s2n/s2n-quic-qns:main
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: s2n-quic-qns-debug
           path: s2n-quic-qns-build/
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: s2n-quic-qns-release
           path: s2n-quic-qns-build/
@@ -446,7 +446,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: s2n-quic-qns-debug
 
@@ -497,7 +497,7 @@ jobs:
         with:
           crate: ultraman
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: s2n-quic-qns-release
           path: target/release/
@@ -532,7 +532,7 @@ jobs:
           zip perf.zip **/*.script
           rm -rf **/*.script
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: perf-results-${{ matrix.server }}-${{ matrix.client }}
           path: target/perf/results
@@ -544,11 +544,11 @@ jobs:
       - uses: actions/checkout@v4
 
       # add any additional perf tests here
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: perf-results-s2n-quic-s2n-quic
           path: perf-results/
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: perf-results-s2n-quic-null-s2n-quic-null
           path: perf-results/
@@ -598,7 +598,7 @@ jobs:
           profile: minimal
           override: true
 
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: s2n-quic-qns-debug
 


### PR DESCRIPTION

### Description of changes: 

Both the upload and download actions need to be bumped together - see #2074 and #2073 for individual details on each action.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

