### PR TITLE
ci: add musl tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -215,6 +215,10 @@ jobs:
           - rust: stable
             os: ubuntu-latest
             target: i686-unknown-linux-gnu
+          - rust: stable
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            args: --features aws-lc-bindgen
           # test with different platform features
           - rust: stable
             os: ubuntu-latest
@@ -261,14 +265,14 @@ jobs:
         uses: actions-rs/cargo@v1.0.3
         with:
           command: build
-          args: --tests ${{ matrix.exclude }} ${{ matrix.target != 'native' && format('--target {0}', matrix.target) || '' }}
+          args: --tests ${{ matrix.exclude }} ${{ matrix.target != 'native' && format('--target {0}', matrix.target) || '' }} ${{ matrix.args }}
           use-cross: ${{ matrix.target != 'native' }}
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1.0.3
         with:
           command: test
-          args: ${{ matrix.exclude }} ${{ matrix.target != 'native' && format('--target {0}', matrix.target) || '' }}
+          args: ${{ matrix.exclude }} ${{ matrix.target != 'native' && format('--target {0}', matrix.target) || '' }} ${{ matrix.args }}
           use-cross: ${{ matrix.target != 'native' }}
 
   miri:

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -12,6 +12,7 @@ exclude = ["corpus.tar.gz"]
 
 [features]
 default = []
+aws-lc-bindgen = ["aws-lc-rs/bindgen"]
 testing = []
 
 [dependencies]


### PR DESCRIPTION
### Description of changes: 

This PR adds a CI job to run our `cargo test` command in a musl environment.

### Call-outs:

This required adding a `aws-lc-bindgen` feature to the `s2n-quic-crypto` crate, since musl doesn't have pregenerated bindings at this time.

### Testing:

The job is passing: https://github.com/aws/s2n-quic/actions/runs/8381808920/job/22954227581?pr=2102

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

