### PR TITLE
chore: MSRV bump

### DIFF
--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -22,7 +22,7 @@ s2n-quic-core = { version = "=0.32.0", path = "../s2n-quic-core", default-featur
 zeroize = { version = "1", default-features = false, features = ["derive"] }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-aws-lc-rs = { version = "1.5" }
+aws-lc-rs = { version = "1.6" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 ring = { version = "0.16", default-features = false }

--- a/quic/s2n-quic-h3/src/s2n_quic.rs
+++ b/quic/s2n-quic-h3/src/s2n_quic.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use bytes::{Buf, Bytes};
-use futures::ready;
+use core::task::ready;
 use h3::quic::{self, Error, StreamId, WriteBuf};
 use s2n_quic::stream::{BidirectionalStream, ReceiveStream};
 use s2n_quic_core::varint::VarInt;

--- a/quic/s2n-quic-platform/src/io/testing/time.rs
+++ b/quic/s2n-quic-platform/src/io/testing/time.rs
@@ -5,10 +5,9 @@ use bach::time::{self, scheduler};
 use core::{
     future::Future,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
     time::Duration,
 };
-use futures::ready;
 use s2n_quic_core::time::{clock, Timestamp};
 
 pub fn now() -> Timestamp {

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -34,7 +34,6 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2"
-regex = { version = "1", features = ["unicode"] }
 
 [target.'cfg(unix)'.dependencies]
 s2n-quic = { path = "../s2n-quic", features = ["provider-event-console-perf", "provider-event-tracing", "provider-tls-rustls", "provider-tls-s2n"] }

--- a/quic/s2n-quic-qns/src/file.rs
+++ b/quic/s2n-quic-qns/src/file.rs
@@ -3,8 +3,8 @@
 
 use crate::Result;
 use bytes::{BufMut, Bytes, BytesMut};
-use core::mem::MaybeUninit;
-use futures::{ready, stream::Stream};
+use core::{mem::MaybeUninit, task::ready};
+use futures::stream::Stream;
 use std::{
     path::{Path, PathBuf},
     pin::Pin,

--- a/quic/s2n-quic-sim/Cargo.toml
+++ b/quic/s2n-quic-sim/Cargo.toml
@@ -35,4 +35,4 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 # >0.4.1 breaks compatibility with 1.63
 # See https://github.com/aws/s2n-quic/issues/1735
-winnow = "=0.4.1"
+winnow = "=0.5"

--- a/quic/s2n-quic-sim/Cargo.toml
+++ b/quic/s2n-quic-sim/Cargo.toml
@@ -23,16 +23,9 @@ s2n-quic = { path = "../s2n-quic", features = ["unstable-provider-io-testing", "
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-# >0.6.1 breaks compatibility with 1.63
-# See https://github.com/aws/s2n-quic/issues/1735
-serde_spanned = "=0.6.1"
+serde_spanned = "0.6"
 structopt = "0.3"
 toml = "0.7"
-# >0.6.1 breaks compatibility with 1.63
-# See https://github.com/aws/s2n-quic/issues/1735
-toml_datetime = "=0.6.1"
+toml_datetime = "0.6"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-# >0.4.1 breaks compatibility with 1.63
-# See https://github.com/aws/s2n-quic/issues/1735
-winnow = "=0.5"

--- a/quic/s2n-quic-sim/Cargo.toml
+++ b/quic/s2n-quic-sim/Cargo.toml
@@ -23,9 +23,6 @@ s2n-quic = { path = "../s2n-quic", features = ["unstable-provider-io-testing", "
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-serde_spanned = "0.6"
 structopt = "0.3"
 toml = "0.7"
-toml_datetime = "0.6"
-tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -17,11 +17,7 @@ s2n-quic-tls = { version = "=0.32.0", path = "../s2n-quic-tls" }
 s2n-quic-rustls = { version = "=0.32.0", path = "../s2n-quic-rustls" }
 
 [target.'cfg(unix)'.dev-dependencies]
-# newer versions require rust 1.66, see https://github.com/aws/s2n-quic/issues/1991
-# this version pin is only needed to prevent verification failures when using
-# cargo package / cargo publish, as those commands do not respect the version pin
-# in downstream dev-dependencies (in s2n-quic-tls, in this case)
-jobserver = "=0.1.26"
+jobserver = "0.1"
 
 # jobserver is just here to pin
 [package.metadata.cargo-udeps.ignore]

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -15,10 +15,3 @@ s2n-quic-tls = { version = "=0.32.0", path = "../s2n-quic-tls" }
 
 [target.'cfg(not(unix))'.dependencies]
 s2n-quic-rustls = { version = "=0.32.0", path = "../s2n-quic-rustls" }
-
-[target.'cfg(unix)'.dev-dependencies]
-jobserver = "0.1"
-
-# jobserver is just here to pin
-[package.metadata.cargo-udeps.ignore]
-development = [ "jobserver" ]

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -25,7 +25,6 @@ s2n-tls = { version = "0.1", features = ["quic"] }
 
 [dev-dependencies]
 checkers = "0.6"
-jobserver = "0.1"
 pin-project = { version = "1" }
 openssl = { version = "0.10" }
 # Build the vendored version to make it easy to test in dev
@@ -37,6 +36,5 @@ s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-rustls = { path = "../s2n-quic-rustls" }
 
 # we don't use openssl-sys directly; it's just here to pin and vendor in dev
-# jobserver is just here to pin as well, it is a dependency of openssl-sys
 [package.metadata.cargo-udeps.ignore]
-development = [ "openssl-sys", "jobserver" ]
+development = [ "openssl-sys" ]

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -25,7 +25,7 @@ s2n-tls = { version = "0.1", features = ["quic"] }
 
 [dev-dependencies]
 checkers = "0.6"
-jobserver = "=0.1.26" # newer versions require rust 1.66, see https://github.com/aws/s2n-quic/issues/1991
+jobserver = "0.1"
 pin-project = { version = "1" }
 openssl = { version = "0.10" }
 # Build the vendored version to make it easy to test in dev

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -19,7 +19,7 @@ unstable_resumption = []
 bytes = { version = "1", default-features = false }
 futures-channel = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-core = { version = "0.3", default-features = false, features = ["alloc"] }
-hashbrown = "0.13"
+hashbrown = "0.14"
 intrusive-collections = "0.9"
 once_cell = "1"
 s2n-codec = { version = "=0.32.0", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }

--- a/quic/s2n-quic-transport/src/stream/api.rs
+++ b/quic/s2n-quic-transport/src/stream/api.rs
@@ -9,7 +9,7 @@ use core::{
     fmt,
     future::Future,
     pin::Pin,
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
 };
 pub use s2n_quic_core::{
     application,
@@ -78,15 +78,6 @@ impl Drop for State {
             let _ = request.poll(None);
         }
     }
-}
-
-macro_rules! ready {
-    ($e:expr $(,)?) => {
-        match $e {
-            core::task::Poll::Ready(t) => t,
-            core::task::Poll::Pending => return core::task::Poll::Pending,
-        }
-    };
 }
 
 macro_rules! tx_stream_apis {

--- a/quic/s2n-quic-transport/src/stream/controller.rs
+++ b/quic/s2n-quic-transport/src/stream/controller.rs
@@ -12,10 +12,9 @@ use crate::{
     transmission::{interest::Provider, WriteContext},
 };
 use core::{
-    task::{Context, Poll},
+    task::{ready, Context, Poll},
     time::Duration,
 };
-use futures_core::ready;
 use s2n_quic_core::{
     ack, endpoint,
     frame::MaxStreams,

--- a/quic/s2n-quic-transport/src/stream/manager.rs
+++ b/quic/s2n-quic-transport/src/stream/manager.rs
@@ -19,10 +19,9 @@ use crate::{
     transmission::{self, interest::Provider as _},
 };
 use core::{
-    task::{Context, Poll, Waker},
+    task::{ready, Context, Poll, Waker},
     time::Duration,
 };
-use futures_core::ready;
 use s2n_quic_core::{
     ack,
     connection::error::Error,

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -81,7 +81,7 @@ bolero = { version = "0.10" }
 # cargo package / cargo publish, as those commands do not respect the version pin
 # in downstream dev-dependencies (in s2n-quic-tls, in this case)
 jobserver = "=0.1.26"
-regex = "=1.9.6" # newer versions require rust 1.65, see https://github.com/aws/s2n-quic/issues/1993
+regex = "1"
 s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "probe-tracing", "testing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }
 s2n-quic-transport = { version = "=0.32.0", path = "../s2n-quic-transport", features = ["unstable_resumption"] }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -76,11 +76,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 [dev-dependencies]
 backtrace = { version = "=0.3.68" } # pin backtrace to avoid bumping MSRV
 bolero = { version = "0.10" }
-# newer versions of jobserver require rust 1.66, see https://github.com/aws/s2n-quic/issues/1991
-# this version pin is only needed to prevent verification failures when using
-# cargo package / cargo publish, as those commands do not respect the version pin
-# in downstream dev-dependencies (in s2n-quic-tls, in this case)
-jobserver = "=0.1.26"
+jobserver = "0.1"
 regex = "1"
 s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "probe-tracing", "testing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -74,17 +74,10 @@ zerocopy = { version = "0.7", optional = true, features = ["derive"] }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-backtrace = { version = "0.3" }
 bolero = { version = "0.10" }
-jobserver = "0.1"
-regex = "1"
 s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "probe-tracing", "testing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }
 s2n-quic-transport = { version = "=0.32.0", path = "../s2n-quic-transport", features = ["unstable_resumption"] }
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-
-# jobserver is just here to pin
-[package.metadata.cargo-udeps.ignore]
-development = [ "jobserver" ]

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -74,7 +74,7 @@ zerocopy = { version = "0.7", optional = true, features = ["derive"] }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-backtrace = { version = "=0.3.68" } # pin backtrace to avoid bumping MSRV
+backtrace = { version = "0.3" }
 bolero = { version = "0.10" }
 jobserver = "0.1"
 regex = "1"

--- a/quic/s2n-quic/src/connection/acceptor.rs
+++ b/quic/s2n-quic/src/connection/acceptor.rs
@@ -55,7 +55,7 @@ macro_rules! impl_accept_api {
             use $crate::stream::{BidirectionalStream, ReceiveStream};
 
             Ok(
-                futures::ready!(self.0.poll_accept(None, cx))?.map(|stream| {
+                core::task::ready!(self.0.poll_accept(None, cx))?.map(|stream| {
                     match stream.id().stream_type() {
                         StreamType::Unidirectional => ReceiveStream::new(stream.into()).into(),
                         StreamType::Bidirectional => BidirectionalStream::new(stream).into(),
@@ -116,7 +116,7 @@ macro_rules! impl_accept_bidirectional_api {
             cx: &mut core::task::Context,
         ) -> core::task::Poll<$crate::connection::Result<Option<$crate::stream::BidirectionalStream>>> {
             Ok(
-                futures::ready!(self
+                core::task::ready!(self
                     .0
                     .poll_accept(Some(s2n_quic_core::stream::StreamType::Bidirectional), cx)
                 )?.map($crate::stream::BidirectionalStream::new)
@@ -170,7 +170,7 @@ macro_rules! impl_accept_receive_api {
             &mut self,
             cx: &mut core::task::Context,
         ) -> core::task::Poll<$crate::connection::Result<Option<$crate::stream::ReceiveStream>>> {
-            Ok(futures::ready!(self
+            Ok(core::task::ready!(self
                 .0
                 .poll_accept(Some(s2n_quic_core::stream::StreamType::Unidirectional), cx))?
             .map(|stream| $crate::stream::ReceiveStream::new(stream.into())))
@@ -228,7 +228,7 @@ impl futures::stream::Stream for StreamAcceptor {
         mut self: core::pin::Pin<&mut Self>,
         cx: &mut core::task::Context<'_>,
     ) -> core::task::Poll<Option<Self::Item>> {
-        match futures::ready!(self.poll_accept(cx)) {
+        match core::task::ready!(self.poll_accept(cx)) {
             Ok(Some(stream)) => Some(Ok(stream)),
             Ok(None) => None,
             Err(err) => Some(Err(err)),
@@ -252,7 +252,7 @@ impl futures::stream::Stream for BidirectionalStreamAcceptor {
         mut self: core::pin::Pin<&mut Self>,
         cx: &mut core::task::Context<'_>,
     ) -> core::task::Poll<Option<Self::Item>> {
-        match futures::ready!(self.poll_accept_bidirectional_stream(cx)) {
+        match core::task::ready!(self.poll_accept_bidirectional_stream(cx)) {
             Ok(Some(stream)) => Some(Ok(stream)),
             Ok(None) => None,
             Err(err) => Some(Err(err)),
@@ -276,7 +276,7 @@ impl futures::stream::Stream for ReceiveStreamAcceptor {
         mut self: core::pin::Pin<&mut Self>,
         cx: &mut core::task::Context<'_>,
     ) -> core::task::Poll<Option<Self::Item>> {
-        match futures::ready!(self.poll_accept_receive_stream(cx)) {
+        match core::task::ready!(self.poll_accept_receive_stream(cx)) {
             Ok(Some(stream)) => Some(Ok(stream)),
             Ok(None) => None,
             Err(err) => Some(Err(err)),

--- a/quic/s2n-quic/src/connection/handle.rs
+++ b/quic/s2n-quic/src/connection/handle.rs
@@ -47,7 +47,7 @@ macro_rules! impl_handle_api {
             use $crate::stream::{BidirectionalStream, SendStream};
 
             Ok(
-                match futures::ready!(self.0.poll_open_stream(stream_type, cx))? {
+                match core::task::ready!(self.0.poll_open_stream(stream_type, cx))? {
                     stream if stream_type == StreamType::Unidirectional => {
                         SendStream::new(stream.into()).into()
                     }
@@ -97,7 +97,8 @@ macro_rules! impl_handle_api {
             use s2n_quic_core::stream::StreamType;
             use $crate::stream::BidirectionalStream;
 
-            let stream = futures::ready!(self.0.poll_open_stream(StreamType::Bidirectional, cx))?;
+            let stream =
+                core::task::ready!(self.0.poll_open_stream(StreamType::Bidirectional, cx))?;
 
             Ok(BidirectionalStream::new(stream)).into()
         }
@@ -132,7 +133,8 @@ macro_rules! impl_handle_api {
             use s2n_quic_core::stream::StreamType;
             use $crate::stream::SendStream;
 
-            let stream = futures::ready!(self.0.poll_open_stream(StreamType::Unidirectional, cx))?;
+            let stream =
+                core::task::ready!(self.0.poll_open_stream(StreamType::Unidirectional, cx))?;
 
             Ok(SendStream::new(stream.into())).into()
         }

--- a/quic/s2n-quic/src/stream/receive.rs
+++ b/quic/s2n-quic/src/stream/receive.rs
@@ -234,7 +234,7 @@ macro_rules! impl_receive_stream_trait {
                 mut self: core::pin::Pin<&mut Self>,
                 cx: &mut core::task::Context<'_>,
             ) -> core::task::Poll<Option<Self::Item>> {
-                match futures::ready!(self.poll_receive(cx)) {
+                match core::task::ready!(self.poll_receive(cx)) {
                     Ok(Some(v)) => Some(Ok(v)),
                     Ok(None) => None,
                     Err(err) => Some(Err(err)),
@@ -267,7 +267,7 @@ macro_rules! impl_receive_stream_trait {
 
                 let high_watermark = buf.len();
 
-                let response = futures::ready!(self
+                let response = core::task::ready!(self
                     .rx_request()?
                     .receive(&mut chunks)
                     // don't receive more than we're capable of storing
@@ -315,7 +315,7 @@ macro_rules! impl_receive_stream_trait {
 
                 let high_watermark = bufs.iter().map(|buf| buf.len()).sum();
 
-                let response = futures::ready!(self
+                let response = core::task::ready!(self
                     .rx_request()?
                     .receive(&mut chunks)
                     // don't receive more than we're capable of storing
@@ -359,7 +359,7 @@ macro_rules! impl_receive_stream_trait {
 
                 let high_watermark = buf.remaining();
 
-                let response = futures::ready!(self
+                let response = core::task::ready!(self
                     .rx_request()?
                     .receive(&mut chunks)
                     // don't receive more than we're capable of storing

--- a/quic/s2n-quic/src/stream/send.rs
+++ b/quic/s2n-quic/src/stream/send.rs
@@ -100,7 +100,7 @@ macro_rules! impl_send_stream_api {
 
             ::futures::future::poll_fn(|cx| {
                 sent_chunks +=
-                    ::futures::ready!(self.poll_send_vectored(&mut chunks[sent_chunks..], cx))?;
+                    ::core::task::ready!(self.poll_send_vectored(&mut chunks[sent_chunks..], cx))?;
                 if sent_chunks == chunks.len() {
                     return Ok(()).into();
                 }
@@ -389,7 +389,7 @@ macro_rules! impl_send_stream_trait {
                 mut self: core::pin::Pin<&mut Self>,
                 cx: &mut core::task::Context<'_>,
             ) -> core::task::Poll<$crate::stream::Result<()>> {
-                futures::ready!(self.poll_send_ready(cx))?;
+                core::task::ready!(self.poll_send_ready(cx))?;
                 Ok(()).into()
             }
 
@@ -428,7 +428,7 @@ macro_rules! impl_send_stream_trait {
                     return Ok(0).into();
                 }
 
-                let len = futures::ready!(self.poll_send_ready(cx))?.min(buf.len());
+                let len = core::task::ready!(self.poll_send_ready(cx))?.min(buf.len());
                 let data = bytes::Bytes::copy_from_slice(&buf[..len]);
                 self.send_data(data)?;
                 Ok(len).into()
@@ -443,7 +443,7 @@ macro_rules! impl_send_stream_trait {
                     return Ok(0).into();
                 }
 
-                let len = futures::ready!(self.poll_send_ready(cx))?;
+                let len = core::task::ready!(self.poll_send_ready(cx))?;
                 let capacity = bufs.iter().map(|buf| buf.len()).sum();
                 let len = len.min(capacity);
 
@@ -469,7 +469,7 @@ macro_rules! impl_send_stream_trait {
                 mut self: core::pin::Pin<&mut Self>,
                 cx: &mut core::task::Context<'_>,
             ) -> core::task::Poll<std::io::Result<()>> {
-                futures::ready!($name::poll_flush(&mut self, cx))?;
+                core::task::ready!($name::poll_flush(&mut self, cx))?;
                 Ok(()).into()
             }
 
@@ -478,7 +478,7 @@ macro_rules! impl_send_stream_trait {
                 mut self: core::pin::Pin<&mut Self>,
                 cx: &mut core::task::Context<'_>,
             ) -> core::task::Poll<std::io::Result<()>> {
-                futures::ready!($name::poll_close(&mut self, cx))?;
+                core::task::ready!($name::poll_close(&mut self, cx))?;
                 Ok(()).into()
             }
         }
@@ -502,7 +502,7 @@ macro_rules! impl_send_stream_trait {
                     return Ok(0).into();
                 }
 
-                let len = futures::ready!(self.poll_send_ready(cx))?;
+                let len = core::task::ready!(self.poll_send_ready(cx))?;
                 let capacity = bufs.iter().map(|buf| buf.len()).sum();
                 let len = len.min(capacity);
 
@@ -541,7 +541,7 @@ macro_rules! impl_send_stream_trait {
                 mut self: core::pin::Pin<&mut Self>,
                 cx: &mut core::task::Context<'_>,
             ) -> core::task::Poll<std::io::Result<()>> {
-                futures::ready!(self.poll_close(cx))?;
+                core::task::ready!(self.poll_close(cx))?;
                 Ok(()).into()
             }
         }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.63.0"
+channel = "1.71.1"
 components = [ "rustc", "clippy", "rustfmt" ]


### PR DESCRIPTION
### Resolved issues:

### Description of changes: 
This PR bumps the MSRV to 1.71.1. It also bumps and unpins many crates that were previously pinned due to a lower MSRV.

### Call-outs:

### Testing:
CI passes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

