### PR TITLE
test(s2n-quic-platform): drain tx packets before closing host

### DIFF
--- a/quic/s2n-quic-platform/src/io/testing.rs
+++ b/quic/s2n-quic-platform/src/io/testing.rs
@@ -23,6 +23,11 @@ pub use time::now;
 
 pub use bach::task::{self, primary, spawn};
 
+// returns `true` if the caller is being executed in a testing environment
+pub fn is_in_env() -> bool {
+    bach::task::scope::try_borrow_with(|scope| scope.is_some())
+}
+
 pub mod rand {
     pub use ::bach::rand::*;
 


### PR DESCRIPTION
### Description of changes: 

The testing environment currently closes a socket on drop. This means that any outstanding packets in the TX queue are not submitted.

This change fixes that by marking the socket as closed and draining it. Once empty, the socket queue is removed from the network.

### Call-outs:

I've also added a small function to know if the caller is running inside of a test environment or not.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

