### PR TITLE
fix: implement custom PartialEq for connection::Error

### DIFF
--- a/quic/s2n-quic-core/src/token.rs
+++ b/quic/s2n-quic-core/src/token.rs
@@ -72,7 +72,7 @@ pub mod testing {
     use crate::crypto::retry;
 
     #[derive(Debug, Default)]
-    pub struct Format(u64);
+    pub struct Format(());
 
     impl super::Format for Format {
         const TOKEN_LEN: usize = retry::example::TOKEN_LEN;
@@ -112,7 +112,7 @@ pub mod testing {
 
     impl Format {
         pub fn new() -> Self {
-            Self(0)
+            Self(())
         }
     }
 }

--- a/quic/s2n-quic-qns/src/server/interop.rs
+++ b/quic/s2n-quic-qns/src/server/interop.rs
@@ -105,7 +105,7 @@ impl Interop {
             .with_endpoint_limits(endpoint_limits)?
             .with_limits(limits)?
             .with_event((
-                EventSubscriber(1),
+                EventSubscriber,
                 s2n_quic::provider::event::tracing::Subscriber::default(),
             ))?;
 
@@ -152,7 +152,7 @@ pub struct MyConnectionContext {
     pub(crate) stream_requests: u64,
 }
 
-pub struct EventSubscriber(usize);
+pub struct EventSubscriber;
 
 impl Subscriber for EventSubscriber {
     type ConnectionContext = MyConnectionContext;

--- a/quic/s2n-quic/src/provider/datagram.rs
+++ b/quic/s2n-quic/src/provider/datagram.rs
@@ -4,6 +4,9 @@
 //! Provides unreliable datagram support
 
 use s2n_quic_core::datagram::Disabled;
+
+// these imports are only accessible if the unstable feature is enabled
+#[allow(unused_imports)]
 pub use s2n_quic_core::datagram::{
     default,
     traits::{


### PR DESCRIPTION
### Description of changes: 

We're currently getting a failure on rustc beta on `main` (and a handful of warnings). This PR addresses those issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

