### PR TITLE
ci: move Kani options to Cargo.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,7 +708,6 @@ jobs:
         uses: model-checking/kani-github-action@v1.1
         with:
           working-directory: ${{ matrix.crate }}
-          args: --tests -Z stubbing
 
   dhat:
     runs-on: ubuntu-latest

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -57,3 +57,7 @@ s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
 
 [target.'cfg(loom)'.dev-dependencies]
 loom = { version = "0.7", features = ["checkpoint", "futures"] }
+
+[package.metadata.kani]
+flags = { tests = true }
+unstable = { stubbing = true }

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -44,3 +44,7 @@ insta = { version = "1", features = ["json"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1" }
+
+[package.metadata.kani]
+flags = { tests = true }
+unstable = { stubbing = true }


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.-->

Move the options to Kani from `ci.yml` to each package's `Cargo.toml`. This allows one to run `cargo kani` in the package directly, without having to specify the options.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

