### PR TITLE
chore(s2n-quic-transport): pin ahash to 0.8.7

### DIFF
--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -16,6 +16,7 @@ std = ["futures-channel/std"]
 unstable_resumption = []
 
 [dependencies]
+ahash = { version = "=0.8.7" } # ahash 0.8.8 requires rust 1.72, see https://github.com/aws/s2n-quic/issues/2118
 bytes = { version = "1", default-features = false }
 futures-channel = { version = "0.3", default-features = false, features = ["alloc"] }
 futures-core = { version = "0.3", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
### Description of changes: 

ahash 0.8.8 requires rust 1.72, see https://github.com/aws/s2n-quic/issues/2118

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

