### PR TITLE
chore(s2n-quic): pin ahash in s2n-quic

### DIFF
--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -74,6 +74,7 @@ zerocopy = { version = "0.7", optional = true, features = ["derive"] }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
+ahash = { version = "=0.8.7" } # ahash 0.8.8 requires rust 1.72, see https://github.com/aws/s2n-quic/issues/2118
 bolero = { version = "0.10" }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "probe-tracing", "testing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }


### PR DESCRIPTION
### Description of changes: 

The pinned `ahash` dev-dependency in `s2n-quic-transport` is not respected during the build process that `cargo publish` executes (see #2009 for a similar issue). This change pins `ahash` in the s2n-quic cargo.toml as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

