### PR TITLE
refactor(s2n-quic-core): move ack::Transmission to core

### DIFF
--- a/quic/s2n-quic-core/src/ack.rs
+++ b/quic/s2n-quic-core/src/ack.rs
@@ -5,8 +5,13 @@
 pub mod ranges;
 pub mod set;
 pub mod settings;
+pub mod transmission;
 
 #[cfg(feature = "alloc")]
 pub use ranges::Ranges;
 pub use set::Set;
 pub use settings::Settings;
+pub use transmission::Transmission;
+
+#[cfg(any(test, feature = "testing"))]
+pub mod testing;

--- a/quic/s2n-quic-core/src/ack/snapshots/s2n_quic_core__ack__transmission__tests__Set.snap
+++ b/quic/s2n-quic-core/src/ack/snapshots/s2n_quic_core__ack__transmission__tests__Set.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/ack/transmission.rs
+expression: "size_of::<Set>()"
+---
+32

--- a/quic/s2n-quic-core/src/ack/snapshots/s2n_quic_core__ack__transmission__tests__Transmission.snap
+++ b/quic/s2n-quic-core/src/ack/snapshots/s2n_quic_core__ack__transmission__tests__Transmission.snap
@@ -1,0 +1,5 @@
+---
+source: quic/s2n-quic-core/src/ack/transmission.rs
+expression: "size_of::<Transmission>()"
+---
+16

--- a/quic/s2n-quic-core/src/ack/testing.rs
+++ b/quic/s2n-quic-core/src/ack/testing.rs
@@ -1,0 +1,23 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    ack::transmission::Transmission,
+    packet::number::{PacketNumber, PacketNumberSpace},
+    varint::VarInt,
+};
+
+/// Generates AckElicitingTransmissions from increasing packet numbers
+pub fn transmissions_iter() -> impl Iterator<Item = Transmission> {
+    packet_numbers_iter().map(|pn| Transmission {
+        sent_in_packet: pn,
+        largest_received_packet_number_acked: pn,
+    })
+}
+
+/// Generates increasing packet numbers
+pub fn packet_numbers_iter() -> impl Iterator<Item = PacketNumber> {
+    Iterator::map(0u32.., |pn| {
+        PacketNumberSpace::ApplicationData.new_packet_number(VarInt::from_u32(pn))
+    })
+}

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__ack.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__ack.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
 expression: values
-
 ---
 [
     Ack(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__connection_close.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__connection_close.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     ConnectionClose(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__crypto.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__crypto.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     Crypto(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__data_blocked.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__data_blocked.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     DataBlocked(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__datagram.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__datagram.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-assertion_line: 231
 expression: values
 ---
 [

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__handshake_done.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__handshake_done.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     HandshakeDone(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__max_data.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__max_data.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     MaxData(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__max_stream_data.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__max_stream_data.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     MaxStreamData(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__max_streams.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__max_streams.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     MaxStreams(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__new_connection_id.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__new_connection_id.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
 expression: values
-
 ---
 [
     NewConnectionId(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__new_token.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__new_token.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     NewToken(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__padding.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__padding.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     Padding(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__path_challenge.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__path_challenge.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     PathChallenge(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__path_response.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__path_response.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     PathResponse(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__ping.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__ping.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     Ping(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__reset_stream.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__reset_stream.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     ResetStream(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__retire_connection_id.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__retire_connection_id.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
 expression: values
-
 ---
 [
     RetireConnectionId(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__stop_sending.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__stop_sending.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     StopSending(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__stream.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__stream.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     Stream(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__stream_data_blocked.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__stream_data_blocked.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     StreamDataBlocked(

--- a/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__streams_blocked.snap
+++ b/quic/s2n-quic-core/src/frame/snapshots/s2n_quic_core__frame__snapshots__streams_blocked.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/frame/mod.rs
-expression: frames
+expression: values
 ---
 [
     StreamsBlocked(

--- a/quic/s2n-quic-core/src/packet/number/snapshots/s2n_quic_core__packet__number__tests__PacketNumber.snap
+++ b/quic/s2n-quic-core/src/packet/number/snapshots/s2n_quic_core__packet__number__tests__PacketNumber.snap
@@ -1,6 +1,5 @@
 ---
-source: quic/s2n-quic-core/src/packet/number/mod.rs
+source: quic/s2n-quic-core/src/packet/number/tests.rs
 expression: "size_of::<PacketNumber>()"
-
 ---
 8

--- a/quic/s2n-quic-core/src/packet/number/snapshots/s2n_quic_core__packet__number__tests__PacketNumberLen.snap
+++ b/quic/s2n-quic-core/src/packet/number/snapshots/s2n_quic_core__packet__number__tests__PacketNumberLen.snap
@@ -1,6 +1,5 @@
 ---
-source: quic/s2n-quic-core/src/packet/number/mod.rs
+source: quic/s2n-quic-core/src/packet/number/tests.rs
 expression: "size_of::<PacketNumberLen>()"
-
 ---
 2

--- a/quic/s2n-quic-core/src/packet/number/snapshots/s2n_quic_core__packet__number__tests__PacketNumberSpace.snap
+++ b/quic/s2n-quic-core/src/packet/number/snapshots/s2n_quic_core__packet__number__tests__PacketNumberSpace.snap
@@ -1,6 +1,5 @@
 ---
-source: quic/s2n-quic-core/src/packet/number/mod.rs
+source: quic/s2n-quic-core/src/packet/number/tests.rs
 expression: "size_of::<PacketNumberSpace>()"
-
 ---
 1

--- a/quic/s2n-quic-core/src/packet/number/snapshots/s2n_quic_core__packet__number__tests__ProtectedPacketNumber.snap
+++ b/quic/s2n-quic-core/src/packet/number/snapshots/s2n_quic_core__packet__number__tests__ProtectedPacketNumber.snap
@@ -1,6 +1,5 @@
 ---
-source: quic/s2n-quic-core/src/packet/number/mod.rs
+source: quic/s2n-quic-core/src/packet/number/tests.rs
 expression: "size_of::<ProtectedPacketNumber>()"
-
 ---
 0

--- a/quic/s2n-quic-core/src/packet/number/snapshots/s2n_quic_core__packet__number__tests__TruncatedPacketNumber.snap
+++ b/quic/s2n-quic-core/src/packet/number/snapshots/s2n_quic_core__packet__number__tests__TruncatedPacketNumber.snap
@@ -1,6 +1,5 @@
 ---
-source: quic/s2n-quic-core/src/packet/number/mod.rs
+source: quic/s2n-quic-core/src/packet/number/tests.rs
 expression: "size_of::<TruncatedPacketNumber>()"
-
 ---
 12

--- a/quic/s2n-quic-core/src/packet/snapshots/s2n_quic_core__packet__snapshots__zero_rtt.snap
+++ b/quic/s2n-quic-core/src/packet/snapshots/s2n_quic_core__packet__snapshots__zero_rtt.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/packet/mod.rs
 expression: values
-
 ---
 [
     ZeroRtt(

--- a/quic/s2n-quic-core/src/probe.rs
+++ b/quic/s2n-quic-core/src/probe.rs
@@ -23,7 +23,7 @@ macro_rules! __probe_define__ {
                     name: stringify!($fun),
                     target: concat!(module_path!(), "::", stringify!($fun)),
                     $(
-                        ?$arg,
+                        $arg = ?$arg,
                     )*
                 );
 

--- a/quic/s2n-quic-core/src/recovery/snapshots/s2n_quic_core__recovery__simulation__MinimumWindow-CubicCongestionController.snap
+++ b/quic/s2n-quic-core/src/recovery/snapshots/s2n_quic_core__recovery__simulation__MinimumWindow-CubicCongestionController.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-core/src/recovery/simulation.rs
-assertion_line: 149
 expression: self
 ---
 Simulation {

--- a/quic/s2n-quic-core/src/recovery/snapshots/s2n_quic_core__recovery__simulation__SlowStartUnlimited-CubicCongestionController.snap
+++ b/quic/s2n-quic-core/src/recovery/snapshots/s2n_quic_core__recovery__simulation__SlowStartUnlimited-CubicCongestionController.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-core/src/recovery/simulation.rs
-assertion_line: 149
 expression: self
 ---
 Simulation {

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__ServerTransportParameters__default.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__ServerTransportParameters__default.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/tests.rs
-assertion_line: 50
 expression: default_value
 ---
 TransportParameters {

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__client_snapshot_test.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__client_snapshot_test.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/tests.rs
-assertion_line: 132
 expression: encoded_output
 ---
 [

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__load_server_limits.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__load_server_limits.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/tests.rs
-assertion_line: 147
 expression: params
 ---
 TransportParameters {

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__server_snapshot_test.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__server_snapshot_test.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/tests.rs
-assertion_line: 95
 expression: encoded_output
 ---
 [

--- a/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__max_value.snap
+++ b/quic/s2n-quic-core/src/varint/snapshots/s2n_quic_core__varint__tests__max_value.snap
@@ -1,5 +1,5 @@
 ---
-source: quic/s2n-quic-core/src/varint/mod.rs
+source: quic/s2n-quic-core/src/varint/tests.rs
 expression: MAX_VARINT_VALUE
 ---
 4611686018427387903

--- a/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__aes128_gcm__confidentiality_tls_aes_128_gcm_sha256_test.snap
+++ b/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__aes128_gcm__confidentiality_tls_aes_128_gcm_sha256_test.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-crypto/src/cipher_suite.rs
-assertion_line: 288
 expression: "u64::pow(2, 23)"
 ---
 8388608

--- a/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__aes128_gcm__integrity_tls_aes_128_gcm_sha256_test.snap
+++ b/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__aes128_gcm__integrity_tls_aes_128_gcm_sha256_test.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-crypto/src/cipher_suite.rs
-assertion_line: 288
 expression: "u64::pow(2, 52)"
 ---
 4503599627370496

--- a/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__aes256_gcm__confidentiality_tls_aes_256_gcm_sha384_test.snap
+++ b/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__aes256_gcm__confidentiality_tls_aes_256_gcm_sha384_test.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-crypto/src/cipher_suite.rs
-assertion_line: 251
 expression: "u64::pow(2, 23)"
 ---
 8388608

--- a/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__aes256_gcm__integrity_tls_aes_256_gcm_sha384_test.snap
+++ b/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__aes256_gcm__integrity_tls_aes_256_gcm_sha384_test.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-crypto/src/cipher_suite.rs
-assertion_line: 251
 expression: "u64::pow(2, 52)"
 ---
 4503599627370496

--- a/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__chacha20_poly1305__confidentiality_tls_chacha20_poly1305_sha256_test.snap
+++ b/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__chacha20_poly1305__confidentiality_tls_chacha20_poly1305_sha256_test.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-crypto/src/cipher_suite.rs
-assertion_line: 271
 expression: "u64::pow(2, 62)"
 ---
 4611686018427387904

--- a/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__chacha20_poly1305__integrity_tls_chacha20_poly1305_sha256_test.snap
+++ b/quic/s2n-quic-crypto/src/snapshots/s2n_quic_crypto__cipher_suite__chacha20_poly1305__integrity_tls_chacha20_poly1305_sha256_test.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-crypto/src/cipher_suite.rs
-assertion_line: 271
 expression: "u64::pow(2, 36)"
 ---
 68719476736

--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -2,13 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    ack::{
-        ack_eliciting_transmission::{AckElicitingTransmission, AckElicitingTransmissionSet},
-        ack_transmission_state::AckTransmissionState,
-    },
-    contexts::WriteContext,
-    processed_packet::ProcessedPacket,
-    transmission,
+    ack::ack_transmission_state::AckTransmissionState, contexts::WriteContext,
+    processed_packet::ProcessedPacket, transmission,
 };
 use s2n_quic_core::{
     ack,
@@ -46,7 +41,7 @@ pub struct AckManager {
     ack_delay_timer: Timer,
 
     /// Used to track the ACK-eliciting transmissions sent from the AckManager
-    ack_eliciting_transmissions: AckElicitingTransmissionSet,
+    ack_eliciting_transmissions: ack::transmission::Set,
 
     /// All of the processed AckRanges that need to be ACKed
     pub(super) ack_ranges: ack::Ranges,
@@ -77,7 +72,7 @@ impl AckManager {
     pub fn new(packet_space: PacketNumberSpace, ack_settings: ack::Settings) -> Self {
         Self {
             ack_delay_timer: Timer::default(),
-            ack_eliciting_transmissions: AckElicitingTransmissionSet::default(),
+            ack_eliciting_transmissions: Default::default(),
             ack_settings,
             ack_ranges: ack::Ranges::new(ack_settings.ack_ranges_limit as usize),
             largest_received_packet_number_acked: packet_space
@@ -163,7 +158,7 @@ impl AckManager {
             //# When a packet containing an ACK frame is sent, the Largest
             //# Acknowledged field in that frame can be saved.
             self.ack_eliciting_transmissions
-                .on_transmit(AckElicitingTransmission {
+                .on_transmit(ack::Transmission {
                     sent_in_packet: context.packet_number(),
                     largest_received_packet_number_acked: self.largest_received_packet_number_acked,
                 });

--- a/quic/s2n-quic-transport/src/ack/mod.rs
+++ b/quic/s2n-quic-transport/src/ack/mod.rs
@@ -4,7 +4,6 @@
 pub use ack_manager::*;
 pub use s2n_quic_core::ack::*;
 
-mod ack_eliciting_transmission;
 mod ack_manager;
 mod ack_transmission_state;
 

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_eliciting_transmission__tests__AckElicitingTransmission.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_eliciting_transmission__tests__AckElicitingTransmission.snap
@@ -1,5 +1,0 @@
----
-source: quic/s2n-quic-transport/src/ack/ack_eliciting_transmission.rs
-expression: "size_of::<AckElicitingTransmission>()"
----
-16

--- a/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_eliciting_transmission__tests__AckElicitingTransmissionSet.snap
+++ b/quic/s2n-quic-transport/src/ack/snapshots/s2n_quic_transport__ack__ack_eliciting_transmission__tests__AckElicitingTransmissionSet.snap
@@ -1,5 +1,0 @@
----
-source: quic/s2n-quic-transport/src/ack/ack_eliciting_transmission.rs
-expression: "size_of::<AckElicitingTransmissionSet>()"
----
-32

--- a/quic/s2n-quic-transport/src/ack/tests/mod.rs
+++ b/quic/s2n-quic-transport/src/ack/tests/mod.rs
@@ -1,26 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ack::ack_eliciting_transmission::AckElicitingTransmission;
-use s2n_quic_core::{
-    packet::number::{PacketNumber, PacketNumberSpace},
-    varint::VarInt,
-};
-
-/// Generates AckElicitingTransmissions from increasing packet numbers
-pub fn transmissions_iter() -> impl Iterator<Item = AckElicitingTransmission> {
-    packet_numbers_iter().map(|pn| AckElicitingTransmission {
-        sent_in_packet: pn,
-        largest_received_packet_number_acked: pn,
-    })
-}
-
-/// Generates increasing packet numbers
-pub fn packet_numbers_iter() -> impl Iterator<Item = PacketNumber> {
-    Iterator::map(0u32.., |pn| {
-        PacketNumberSpace::ApplicationData.new_packet_number(VarInt::from_u32(pn))
-    })
-}
+pub use s2n_quic_core::ack::testing::packet_numbers_iter;
 
 pub mod application;
 pub mod endpoint;

--- a/quic/s2n-quic-transport/src/endpoint/snapshots/quic__s2n-quic-transport__src__endpoint__version__events__client_test.snap
+++ b/quic/s2n-quic-transport/src/endpoint/snapshots/quic__s2n-quic-transport__src__endpoint__version__events__client_test.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/endpoint/version.rs
 expression: ""
-
 ---
 

--- a/quic/s2n-quic-transport/src/endpoint/snapshots/quic__s2n-quic-transport__src__endpoint__version__events__server_future_version_initial_test.snap
+++ b/quic/s2n-quic-transport/src/endpoint/snapshots/quic__s2n-quic-transport__src__endpoint__version__events__server_future_version_initial_test.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/endpoint/version.rs
 expression: ""
-
 ---
 VersionInformation { server_versions: [1], client_versions: [123], chosen_version: None }

--- a/quic/s2n-quic-transport/src/endpoint/snapshots/quic__s2n-quic-transport__src__endpoint__version__events__server_initial_test.snap
+++ b/quic/s2n-quic-transport/src/endpoint/snapshots/quic__s2n-quic-transport__src__endpoint__version__events__server_initial_test.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/endpoint/version.rs
 expression: ""
-
 ---
 VersionInformation { server_versions: [1], client_versions: [123], chosen_version: None }

--- a/quic/s2n-quic-transport/src/endpoint/snapshots/quic__s2n-quic-transport__src__endpoint__version__events__server_max_peers_test.snap
+++ b/quic/s2n-quic-transport/src/endpoint/snapshots/quic__s2n-quic-transport__src__endpoint__version__events__server_max_peers_test.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/endpoint/version.rs
 expression: ""
-
 ---
 VersionInformation { server_versions: [1], client_versions: [123], chosen_version: None }
 VersionInformation { server_versions: [1], client_versions: [123], chosen_version: None }

--- a/quic/s2n-quic-transport/src/endpoint/snapshots/quic__s2n-quic-transport__src__endpoint__version__events__server_other_packets_test.snap
+++ b/quic/s2n-quic-transport/src/endpoint/snapshots/quic__s2n-quic-transport__src__endpoint__version__events__server_other_packets_test.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/endpoint/version.rs
 expression: ""
-
 ---
 

--- a/quic/s2n-quic-transport/src/endpoint/snapshots/quic__s2n-quic-transport__src__endpoint__version__events__server_undersized_test.snap
+++ b/quic/s2n-quic-transport/src/endpoint/snapshots/quic__s2n-quic-transport__src__endpoint__version__events__server_undersized_test.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/endpoint/version.rs
 expression: ""
-
 ---
 VersionInformation { server_versions: [1], client_versions: [123], chosen_version: None }

--- a/quic/s2n-quic-transport/src/endpoint/snapshots/quic__s2n-quic-transport__src__endpoint__version__events__server_zerortt_test.snap
+++ b/quic/s2n-quic-transport/src/endpoint/snapshots/quic__s2n-quic-transport__src__endpoint__version__events__server_zerortt_test.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/endpoint/version.rs
 expression: ""
-
 ---
 VersionInformation { server_versions: [1], client_versions: [123], chosen_version: None }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__abandon_all_path_challenges.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__abandon_all_path_challenges.snap
@@ -1,8 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
-assertion_line: 591
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__abandon_path_challenges_if_new_path_is_validated.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__abandon_path_challenges_if_new_path_is_validated.snap
@@ -1,8 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
-assertion_line: 560
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__amplification_limited_false_if_any_paths_amplificaiton_limited.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__amplification_limited_false_if_any_paths_amplificaiton_limited.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__amplification_limited_true_if_all_paths_amplificaiton_limited.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__amplification_limited_true_if_all_paths_amplificaiton_limited.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__can_transmit_false_if_no_path_can_transmit.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__can_transmit_false_if_no_path_can_transmit.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__can_transmit_true_if_any_path_can_transmit.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__can_transmit_true_if_any_path_can_transmit.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__do_not_add_new_path_if_client.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__do_not_add_new_path_if_client.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__do_not_add_new_path_if_handshake_not_confirmed.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__do_not_add_new_path_if_handshake_not_confirmed.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__dont_abandon_path_challenge_if_new_path_is_not_validated.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__dont_abandon_path_challenge_if_new_path_is_not_validated.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__dont_promote_non_validated_path_to_last_known_validated_path.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__dont_promote_non_validated_path_to_last_known_validated_path.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__dont_update_path_to_active_path_if_no_connection_id_available.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__dont_update_path_to_active_path_if_no_connection_id_available.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__dont_validate_path_if_path_challenge_is_abandoned.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__dont_validate_path_if_path_challenge_is_abandoned.snap
@@ -1,8 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
-assertion_line: 376
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__initiate_path_challenge_if_new_path_is_not_validated.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__initiate_path_challenge_if_new_path_is_not_validated.snap
@@ -1,8 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
-assertion_line: 428
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__invalid_path_fallback.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__invalid_path_fallback.snap
@@ -1,8 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
-assertion_line: 94
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x000102030405, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x000102030405, id: 1, is_active: true } }
 PathChallengeUpdated { path_challenge_status: Abandoned, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x000102030405, id: 1, is_active: true }, challenge_data: [0, 0, 0, 0, 0, 0, 0, 0] }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__last_known_validated_path_should_update_on_path_response.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__last_known_validated_path_should_update_on_path_response.snap
@@ -1,8 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
-assertion_line: 1533
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x02, id: 2, is_active: true } }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__non_probing_should_update_path_to_active_path.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__non_probing_should_update_path_to_active_path.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__pending_paths_should_return_paths_pending_validation.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__pending_paths_should_return_paths_pending_validation.snap
@@ -1,8 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
-assertion_line: 1332
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__probing_should_not_update_path_to_active_path.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__probing_should_not_update_path_to_active_path.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__promote_validated_path_to_last_known_validated_path.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__promote_validated_path_to_last_known_validated_path.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__set_path_challenge_on_active_path_on_connection_migration.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__set_path_challenge_on_active_path_on_connection_migration.snap
@@ -1,8 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
-assertion_line: 253
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__silently_return_when_there_is_no_valid_path.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__silently_return_when_there_is_no_valid_path.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
-assertion_line: 477
 expression: ""
-
 ---
 PathChallengeUpdated { path_challenge_status: Abandoned, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 0, is_active: true }, challenge_data: [0, 0, 0, 0, 0, 0, 0, 0] }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__stop_using_a_retired_connection_id.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__stop_using_a_retired_connection_id.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x69643031, current: 0x69643032 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__switch_destination_connection_id_after_first_server_response.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__switch_destination_connection_id_after_first_server_response.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__update_path_to_active_path.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__update_path_to_active_path.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__validate_path_before_challenge_expiration.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__validate_path_before_challenge_expiration.snap
@@ -1,8 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/path/manager/tests.rs
-assertion_line: 299
 expression: ""
-
 ---
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x00, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x01, id: 1, is_active: true } }
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x00, current: 0x01 }

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__challenge__events__cancel_abandon_timer_on_abandon.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__challenge__events__cancel_abandon_timer_on_abandon.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/path/challenge.rs
-assertion_line: 508
 expression: ""
-
 ---
 PathChallengeUpdated { path_challenge_status: Abandoned, path: Path { local_addr: 127.0.0.1:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: false }, challenge_data: [0, 0, 0, 0, 0, 0, 0, 0] }

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__challenge__events__challenge_must_remains_abandoned_once_abandoned.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__challenge__events__challenge_must_remains_abandoned_once_abandoned.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/path/challenge.rs
-assertion_line: 385
 expression: ""
-
 ---
 PathChallengeUpdated { path_challenge_status: Abandoned, path: Path { local_addr: 127.0.0.1:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: false }, challenge_data: [0, 0, 0, 0, 0, 0, 0, 0] }

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__challenge__events__dont_abandon_a_validated_challenge.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__challenge__events__dont_abandon_a_validated_challenge.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/path/challenge.rs
-assertion_line: 496
 expression: ""
-
 ---
 

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__challenge__events__dont_abandon_disabled_state.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__challenge__events__dont_abandon_disabled_state.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/path/challenge.rs
-assertion_line: 427
 expression: ""
-
 ---
 

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__challenge__events__is_abandoned.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__challenge__events__is_abandoned.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/path/challenge.rs
-assertion_line: 451
 expression: ""
-
 ---
 PathChallengeUpdated { path_challenge_status: Abandoned, path: Path { local_addr: 127.0.0.1:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: false }, challenge_data: [0, 0, 0, 0, 0, 0, 0, 0] }

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__challenge__events__on_timeout.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__challenge__events__on_timeout.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/path/challenge.rs
-assertion_line: 351
 expression: ""
-
 ---
 PathChallengeUpdated { path_challenge_status: Abandoned, path: Path { local_addr: 127.0.0.1:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: false }, challenge_data: [0, 0, 0, 0, 0, 0, 0, 0] }

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mod__events__abandon_challenge.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mod__events__abandon_challenge.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/path/mod.rs
-assertion_line: 786
 expression: ""
-
 ---
 PathChallengeUpdated { path_challenge_status: Abandoned, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x, id: 0, is_active: false }, challenge_data: [0, 0, 0, 0, 0, 0, 0, 0] }

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mod__events__failed_validation.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mod__events__failed_validation.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/path/mod.rs
-assertion_line: 747
 expression: ""
-
 ---
 PathChallengeUpdated { path_challenge_status: Abandoned, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x, id: 0, is_active: false }, challenge_data: [0, 0, 0, 0, 0, 0, 0, 0] }

--- a/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mod__events__on_timeout_should_set_challenge_to_none_on_challenge_abandonment.snap
+++ b/quic/s2n-quic-transport/src/path/snapshots/quic__s2n-quic-transport__src__path__mod__events__on_timeout_should_set_challenge_to_none_on_challenge_abandonment.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/path/mod.rs
-assertion_line: 680
 expression: ""
-
 ---
 PathChallengeUpdated { path_challenge_status: Abandoned, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x, id: 0, is_active: false }, challenge_data: [0, 0, 0, 0, 0, 0, 0, 0] }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__detect_and_remove_lost_packets.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__detect_and_remove_lost_packets.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 PacketLost { packet_header: OneRtt { number: 0 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, bytes_lost: 1, is_mtu_probe: false }
 PacketLost { packet_header: OneRtt { number: 7 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, bytes_lost: 1, is_mtu_probe: false }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__detect_and_remove_lost_packets_mtu_probe.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__detect_and_remove_lost_packets_mtu_probe.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 PacketLost { packet_header: OneRtt { number: 2 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, bytes_lost: 1201, is_mtu_probe: true }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__detect_and_remove_lost_packets_nothing_lost.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__detect_and_remove_lost_packets_nothing_lost.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__no_rtt_update_when_not_acknowledging_the_largest_acknowledged_packet.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__no_rtt_update_when_not_acknowledging_the_largest_acknowledged_packet.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
-assertion_line: 1079
 expression: ""
 ---
 AckRangeReceived { packet_header: OneRtt { number: 1 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, ack_range: 1..=1 }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__no_rtt_update_when_receiving_packet_on_different_path.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__no_rtt_update_when_receiving_packet_on_different_path.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
-assertion_line: 1167
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__packet_declared_lost_less_than_1_ms_from_loss_threshold.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__packet_declared_lost_less_than_1_ms_from_loss_threshold.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 PacketLost { packet_header: OneRtt { number: 1 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, bytes_lost: 100, is_mtu_probe: false }
 Congestion { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, source: PacketLoss }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__persistent_congestion_period_does_not_start_until_rtt_sample.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__persistent_congestion_period_does_not_start_until_rtt_sample.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
-assertion_line: 2207
 expression: ""
 ---
 AckRangeReceived { packet_header: OneRtt { number: 3 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, ack_range: 3..=3 }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__probe_packets_count_towards_bytes_in_flight.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__probe_packets_count_towards_bytes_in_flight.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_failed_ecn_validation_does_not_cause_congestion_event.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_failed_ecn_validation_does_not_cause_congestion_event.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
-assertion_line: 1022
 expression: ""
 ---
 EcnStateChanged { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 0.0.0.0:0, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, state: Unknown }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_pto_timer.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_pto_timer.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
-assertion_line: 797
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_update_pto_timer.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_update_pto_timer.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
-assertion_line: 552
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__rtt_update_when_receiving_ack_from_multiple_paths.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__rtt_update_when_receiving_ack_from_multiple_paths.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
-assertion_line: 1281
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__update_pto_timer.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__update_pto_timer.snap
@@ -1,6 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
-
 ---
 

--- a/quic/s2n-quic-transport/src/space/snapshots/quic__s2n-quic-transport__src__space__handshake_status__events__client_test.snap
+++ b/quic/s2n-quic-transport/src/space/snapshots/quic__s2n-quic-transport__src__space__handshake_status__events__client_test.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/space/handshake_status.rs
 expression: ""
-
 ---
 HandshakeStatusUpdated { status: Complete }
 HandshakeStatusUpdated { status: HandshakeDoneAcked }

--- a/quic/s2n-quic-transport/src/space/snapshots/quic__s2n-quic-transport__src__space__handshake_status__events__server_test.snap
+++ b/quic/s2n-quic-transport/src/space/snapshots/quic__s2n-quic-transport__src__space__handshake_status__events__server_test.snap
@@ -1,7 +1,6 @@
 ---
 source: quic/s2n-quic-transport/src/space/handshake_status.rs
 expression: ""
-
 ---
 HandshakeStatusUpdated { status: Complete }
 HandshakeStatusUpdated { status: Confirmed }

--- a/quic/s2n-quic-transport/src/sync/data_sender/snapshots/s2n_quic_transport__sync__data_sender__transmissions__tests__transmission_entry_size.snap
+++ b/quic/s2n-quic-transport/src/sync/data_sender/snapshots/s2n_quic_transport__sync__data_sender__transmissions__tests__transmission_entry_size.snap
@@ -1,7 +1,5 @@
 ---
 source: quic/s2n-quic-transport/src/sync/data_sender/transmissions.rs
-assertion_line: 519
 expression: "size_of::<TransmissionSlabEntry>()"
-
 ---
 24


### PR DESCRIPTION
### Description of changes: 

Similar to #2016, this change moves ACK Transmission to s2n-quic-core.

### Call-outs:

Since I had to regenerate snapshots, I removed all of them and regenerated all of them. The format has changed a bit (basically with less information to avoid commit churn).

### Testing:

All of the tests were moved with the refactor.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

