### PR TITLE
feat(s2n-codec): add bytes methods for unaligned types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -698,7 +698,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crate: [quic/s2n-quic-core, quic/s2n-quic-platform]
+        crate: [common/s2n-codec, quic/s2n-quic-core, quic/s2n-quic-platform]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -23,3 +23,11 @@ bolero-generator = { version = "0.10", default-features = false, optional = true
 byteorder = { version = "1.1", default-features = false }
 bytes = { version = "1", default-features = false, optional = true }
 zerocopy = { version = "0.7", features = ["derive"] }
+
+[dev-dependencies]
+bolero = "0.10"
+bolero-generator = "0.10"
+
+[package.metadata.kani]
+flags = { tests = true }
+unstable = { stubbing = true }

--- a/common/s2n-codec/src/decoder/checked_range.rs
+++ b/common/s2n-codec/src/decoder/checked_range.rs
@@ -43,6 +43,23 @@ impl CheckedRange {
         &slice[self.start..self.end]
     }
 
+    #[cfg(feature = "checked_range_unsafe")]
+    #[inline]
+    pub fn get_mut<'a>(&self, slice: &'a mut [u8]) -> &'a mut [u8] {
+        unsafe {
+            #[cfg(debug_assertions)]
+            debug_assert_eq!(slice.as_ptr().add(self.start), self.original_ptr);
+
+            slice.get_unchecked_mut(self.start..self.end)
+        }
+    }
+
+    #[cfg(not(feature = "checked_range_unsafe"))]
+    #[inline]
+    pub fn get_mut<'a>(&self, slice: &'a mut [u8]) -> &'a mut [u8] {
+        &mut slice[self.start..self.end]
+    }
+
     #[inline]
     pub fn len(&self) -> usize {
         self.end - self.start

--- a/common/s2n-codec/src/decoder/mod.rs
+++ b/common/s2n-codec/src/decoder/mod.rs
@@ -413,7 +413,7 @@ pub use buffer_mut::*;
 pub use checked_range::*;
 pub use value::*;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum DecoderError {
     UnexpectedEof(usize),
     UnexpectedBytes(usize),

--- a/common/s2n-codec/src/decoder/value.rs
+++ b/common/s2n-codec/src/decoder/value.rs
@@ -87,7 +87,7 @@ macro_rules! decoder_value_unaligned_integer {
                     let (value, buffer) = buffer.decode_slice($bitsize / 8)?;
                     let value = value.as_less_safe_slice();
                     let value = NetworkEndian::$call(value);
-                    Ok(($ty(value), buffer))
+                    Ok(($ty::new_truncated(value), buffer))
                 }
             }
         );

--- a/common/s2n-codec/src/encoder/value.rs
+++ b/common/s2n-codec/src/encoder/value.rs
@@ -180,6 +180,24 @@ impl EncoderValue for () {
     }
 }
 
+impl<A: EncoderValue, B: EncoderValue> EncoderValue for (A, B) {
+    #[inline]
+    fn encode<E: Encoder>(&self, encoder: &mut E) {
+        self.0.encode(encoder);
+        self.1.encode(encoder);
+    }
+
+    #[inline]
+    fn encoding_size(&self) -> usize {
+        self.0.encoding_size() + self.1.encoding_size()
+    }
+
+    #[inline]
+    fn encoding_size_for_encoder<E: Encoder>(&self, encoder: &E) -> usize {
+        self.0.encoding_size_for_encoder(encoder) + self.1.encoding_size_for_encoder(encoder)
+    }
+}
+
 impl<T: EncoderValue> EncoderValue for Option<T> {
     #[inline]
     fn encode<E: Encoder>(&self, buffer: &mut E) {

--- a/common/s2n-codec/src/unaligned.rs
+++ b/common/s2n-codec/src/unaligned.rs
@@ -16,19 +16,34 @@ use core::{
 //
 // 48-bit integers are also implemented for completeness.
 macro_rules! unaligned_integer_type {
-    ($name:ident, $bitsize:expr, $storage_type:ty, [$($additional_conversions:ty),*]) => {
+    ($name:ident, $bitsize:expr, $storage_type:ty, $min:expr, $max:expr, [$($additional_conversions:ty),*]) => {
         #[allow(non_camel_case_types)]
         #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash, Default)]
-        pub struct $name(pub(crate) $storage_type);
+        pub struct $name($storage_type);
 
         impl $name {
+            pub const ZERO: Self = Self(0);
+            pub const MIN: Self = Self($min);
+            pub const MAX: Self = Self($max);
+
             /// Truncate the storage value into the allowed range
+            #[inline]
             pub fn new_truncated(value: $storage_type) -> Self {
                 Self(value & ((1 << $bitsize) - 1))
             }
+
+            #[inline]
+            pub fn from_be_bytes(bytes: [u8; ($bitsize / 8)]) -> Self {
+                Self(UnalignedBytes::be_bytes_to_storage(bytes) as _)
+            }
+
+            #[inline]
+            pub fn to_be_bytes(self) -> [u8; ($bitsize / 8)] {
+                UnalignedBytes::storage_to_be_bytes(self.0 as _)
+            }
         }
 
-        #[cfg(feature = "generator")]
+        #[cfg(any(test, feature = "generator"))]
         impl bolero_generator::TypeGenerator for $name {
             fn generate<D: bolero_generator::Driver>(driver: &mut D) -> Option<Self> {
                 Some(Self::new_truncated(driver.gen()?))
@@ -38,6 +53,7 @@ macro_rules! unaligned_integer_type {
         impl TryFrom<$storage_type> for $name {
             type Error = TryFromIntError;
 
+            #[inline]
             fn try_from(value: $storage_type) -> Result<Self, Self::Error> {
                 if value < (1 << $bitsize) {
                     Ok(Self(value))
@@ -48,6 +64,7 @@ macro_rules! unaligned_integer_type {
         }
 
         impl From<$name> for $storage_type {
+            #[inline]
             fn from(value: $name) -> $storage_type {
                 value.0
             }
@@ -55,12 +72,14 @@ macro_rules! unaligned_integer_type {
 
         $(
             impl From<$additional_conversions> for $name {
+                #[inline]
                 fn from(value: $additional_conversions) -> Self {
                     $name(value.into())
                 }
             }
 
             impl From<$name> for $additional_conversions {
+                #[inline]
                 fn from(value: $name) -> Self {
                     value.0 as $additional_conversions
                 }
@@ -70,6 +89,7 @@ macro_rules! unaligned_integer_type {
         impl Deref for $name {
             type Target = $storage_type;
 
+            #[inline]
             fn deref(&self) -> &Self::Target {
                 &self.0
             }
@@ -77,12 +97,80 @@ macro_rules! unaligned_integer_type {
     };
 }
 
-unaligned_integer_type!(u24, 24, u32, [u8, u16]);
-unaligned_integer_type!(i24, 24, i32, [u8, i8, u16, i16]);
+/// A trait defining how to convert between storage types and unaligned bytes
+trait UnalignedBytes: Sized {
+    type Storage;
+
+    fn storage_to_be_bytes(storage: Self::Storage) -> Self;
+    fn be_bytes_to_storage(self) -> Self::Storage;
+}
+
+impl UnalignedBytes for [u8; 3] {
+    type Storage = u32;
+
+    #[inline]
+    fn storage_to_be_bytes(storage: Self::Storage) -> Self {
+        let [_, a, b, c] = storage.to_be_bytes();
+        [a, b, c]
+    }
+
+    #[inline]
+    fn be_bytes_to_storage(self) -> Self::Storage {
+        let [a, b, c] = self;
+        let bytes = [0, a, b, c];
+        Self::Storage::from_be_bytes(bytes)
+    }
+}
+
+impl UnalignedBytes for [u8; 6] {
+    type Storage = u64;
+
+    #[inline]
+    fn storage_to_be_bytes(storage: Self::Storage) -> Self {
+        let [_, _, a, b, c, d, e, f] = storage.to_be_bytes();
+        [a, b, c, d, e, f]
+    }
+
+    #[inline]
+    fn be_bytes_to_storage(self) -> Self::Storage {
+        let [a, b, c, d, e, f] = self;
+        let bytes = [0, 0, a, b, c, d, e, f];
+        Self::Storage::from_be_bytes(bytes)
+    }
+}
+
+macro_rules! signed_min {
+    ($bitsize:expr) => {
+        -(1 << ($bitsize - 1))
+    };
+}
+
+macro_rules! signed_max {
+    ($bitsize:expr) => {
+        ((1 << ($bitsize - 1)) - 1)
+    };
+}
+
+#[test]
+fn signed_min_max_test() {
+    assert_eq!(i8::MIN as i16, signed_min!(8));
+    assert_eq!(i8::MAX as i16, signed_max!(8));
+}
+
+unaligned_integer_type!(u24, 24, u32, 0, (1 << 24) - 1, [u8, u16]);
+unaligned_integer_type!(
+    i24,
+    24,
+    i32,
+    signed_min!(24),
+    signed_max!(24),
+    [u8, i8, u16, i16]
+);
 
 impl TryFrom<u64> for u24 {
     type Error = TryFromIntError;
 
+    #[inline]
     fn try_from(value: u64) -> Result<Self, Self::Error> {
         let storage_value: u32 = value.try_into()?;
         storage_value.try_into()
@@ -90,18 +178,27 @@ impl TryFrom<u64> for u24 {
 }
 
 impl From<u24> for u64 {
+    #[inline]
     fn from(value: u24) -> u64 {
         value.0.into()
     }
 }
 
-unaligned_integer_type!(u48, 24, u64, [u8, u16, u32]);
-unaligned_integer_type!(i48, 24, i64, [u8, i8, u16, i16, u32, i32]);
+unaligned_integer_type!(u48, 48, u64, 0, (1 << 48) - 1, [u8, u16, u32]);
+unaligned_integer_type!(
+    i48,
+    48,
+    i64,
+    signed_min!(48),
+    signed_max!(48),
+    [u8, i8, u16, i16, u32, i32]
+);
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct TryFromIntError(());
 
 impl From<core::num::TryFromIntError> for TryFromIntError {
+    #[inline]
     fn from(_: core::num::TryFromIntError) -> Self {
         Self(())
     }


### PR DESCRIPTION
### Description of changes: 

The `unaligned` types in `s2n-codec` currently don't have `to_be_bytes` and `from_be_bytes` methods. This change adds them.

### Testing:

I've included round trip tests for all of the integer types to show this working.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

