### PR TITLE
chore(s2n-quic): pin ahash to 0.8.6

### DIFF
--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -28,7 +28,7 @@ siphasher = "1.0"
 smallvec = { version = "1", default-features = false }
 
 [dev-dependencies]
-ahash = { version = "=0.8.7" } # ahash 0.8.8 requires rust 1.72, see https://github.com/aws/s2n-quic/issues/2118
+ahash = { version = "=0.8.6" } # ahash 0.8.7 requires rust 1.72, see https://github.com/aws/s2n-quic/issues/2118
 bolero = "0.10"
 futures-test = "0.3" # For testing Waker interactions
 insta = { version = "1", features = ["json"] }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -74,7 +74,7 @@ zerocopy = { version = "0.7", optional = true, features = ["derive"] }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-ahash = { version = "=0.8.7" } # ahash 0.8.8 requires rust 1.72, see https://github.com/aws/s2n-quic/issues/2118
+ahash = { version = "=0.8.6" } # ahash 0.8.7 requires rust 1.72, see https://github.com/aws/s2n-quic/issues/2118
 bolero = { version = "0.10" }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "probe-tracing", "testing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }


### PR DESCRIPTION
### Description of changes: 

ahash 0.8.7+ requires rust 1.72 on aarch64-apple-darwin. This change pins ahash to 0.8.6 in dev-dependencys. Applications consuming s2n-quic will still need to pin ahash in their own `Cargo.toml` if they need to build on rust < 1.72

See #2125 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

