### PR TITLE
test(s2n-quic-core): use a smaller length in the Kani test

### DIFF
--- a/quic/s2n-quic-core/src/inet/checksum.rs
+++ b/quic/s2n-quic-core/src/inet/checksum.rs
@@ -401,13 +401,18 @@ mod tests {
         }
     }
 
+    // Reduce the length to 4 for Kani until
+    // https://github.com/model-checking/kani/issues/3030 is fixed
+    #[cfg(any(kani, miri))]
+    const LEN: usize = if cfg!(kani) { 4 } else { 32 };
+
     /// * Compares the implementation to a port of the C code defined in the RFC
     /// * Ensures partial writes are correctly handled, even if they're not at a 16 bit boundary
     #[test]
-    #[cfg_attr(kani, kani::proof, kani::unwind(17), kani::solver(kissat))]
+    #[cfg_attr(kani, kani::proof, kani::unwind(9), kani::solver(cadical))]
     fn differential() {
         #[cfg(any(kani, miri))]
-        type Bytes = crate::testing::InlineVec<u8, 16>;
+        type Bytes = crate::testing::InlineVec<u8, LEN>;
         #[cfg(not(any(kani, miri)))]
         type Bytes = Vec<u8>;
 


### PR DESCRIPTION
### Resolved issues:

This fixes the issue of Kani going out of memory in CI on the `inet::checksum::tests::differential` test, e.g.

https://github.com/aws/s2n-quic/actions/runs/7892365794/job/21538690964

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.-->

The current length used in the `inet::checksum::tests::differential` test is 16, which causes Kani's latest version (v0.46.0) to run out of memory (see https://github.com/model-checking/kani/issues/3030). Until this issue is fixed, reducing the length to 4 to allow a smaller unwinding depth to prevent the OOM issue.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

