### PR TITLE
test(s2n-quic-core): only check IntervalSet integrity in tests

### DIFF
--- a/quic/s2n-quic-core/src/interval_set/mod.rs
+++ b/quic/s2n-quic-core/src/interval_set/mod.rs
@@ -659,10 +659,13 @@ impl<T: IntervalBound> IntervalSet<T> {
         }
     }
 
-    /// Internal check for integrity - only used when debug_assertions are enabled
+    /// Internal check for integrity - only used when `cfg(test)` is enabled
     #[inline]
     fn check_integrity(&self) {
-        if cfg!(debug_assertions) {
+        // When using this data structure outside of this crate, these checks are quite expensive.
+        // Rather than using `cfg(debug_assertions)`, we limit it to `cfg(test)`, which will just
+        // turn them on when testing this crate.
+        if cfg!(test) {
             let mut prev_end: Option<T> = None;
 
             for interval in self.intervals.iter() {


### PR DESCRIPTION
### Description of changes: 

When using the IntervalSet in tests outside of `s2n-quic-core`, you currently incur the cost of internal consistency checking. This change replaces `cfg(debug_assertions)` with `cfg(test)` to avoid these costs.

### Testing:

The existing tests will still ensure these checks stay consistent.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

