### PR TITLE
feat(s2n-quic-core): add Cached clock implementation

### DIFF
--- a/quic/s2n-quic-core/src/time/timer.rs
+++ b/quic/s2n-quic-core/src/time/timer.rs
@@ -215,6 +215,19 @@ impl<F: FnMut(&Timer) -> Result> Query for ForEach<F> {
     }
 }
 
+#[cfg(feature = "tracing")]
+pub struct Debugger;
+
+#[cfg(feature = "tracing")]
+impl Query for Debugger {
+    #[inline]
+    #[track_caller]
+    fn on_timer(&mut self, timer: &Timer) -> Result {
+        tracing::trace!(location = %core::panic::Location::caller(), timer = ?timer);
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
### Description of changes: 

This adds a mechanism to cache the clock value after the first call. This can reduce the number of times we read from the system clock, where we don't care about high precision between events.

### Call-outs:

I've also added a timer debugger that you can query all of the locations in the timer tree that print where they are and if they're armed or not.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

