### PR TITLE
 ci: don't require mvfst client interop tests to succeed

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -56,7 +56,6 @@
       "server"
     ],
     "mvfst": [
-      "client",
       "server"
     ],
     "neqo": [
@@ -145,7 +144,6 @@
       "server"
     ],
     "mvfst": [
-      "client",
       "server"
     ],
     "neqo": [
@@ -447,9 +445,7 @@
       "client",
       "server"
     ],
-    "mvfst": [
-      "client"
-    ],
+    "mvfst": [],
     "neqo": [
       "client",
       "server"
@@ -510,9 +506,7 @@
       "client",
       "server"
     ],
-    "mvfst": [
-      "client"
-    ],
+    "mvfst": [],
     "neqo": [
       "client",
       "server"


### PR DESCRIPTION
### Description of changes: 

`mvfst` seems to have made some change that has caused most (but not all) of the interop tests with their client to start failing to handshake. Until that is fixed, this change will not require the mvfst client tests to succeed

### Testing:

CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

