### PR TITLE
chore(s2n-quic-core): use cadical for `weighted_average_test`

### DIFF
--- a/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
@@ -788,7 +788,7 @@ mod test {
     }
 
     #[test]
-    #[cfg_attr(kani, kani::proof, kani::unwind(3), kani::solver(kissat))]
+    #[cfg_attr(kani, kani::proof, kani::unwind(3), kani::solver(cadical))]
     #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
     fn weighted_average_test() {
         bolero::check!()


### PR DESCRIPTION
### Description of changes: 

This PR changes the SAT solver for `weighted_average_test` from `kissat` to `cadical`. Therefore, it only changes the s2n-quic's behavior when it's being analyzed with Kani.

We're proposing this change because we've observed +33% SAT solving time in https://github.com/model-checking/kani/pull/3052 for this test after a Rust Toolchain Upgrade (RTU). The RTU didn't cause changes in the SAT problem w.r.t. size nor other properties. During our investigation, we also tested `weighted_average_test` with `cadical` and the results showed a lower overall times in addition to lower increases:

| | before RTU (s) | after RTU (s)| increase (%) |
| --- | --- | --- | --- |
| kissat | 150.85266 | 200.95573 |  +33.2 |
| cadical | 113.84968 |  116.03474 | +1.9 |

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

