### PR TITLE
Add Flag for XDP Scatter-gather mode

### DIFF
--- a/tools/xdp/s2n-quic-xdp/src/if_xdp.rs
+++ b/tools/xdp/s2n-quic-xdp/src/if_xdp.rs
@@ -11,7 +11,7 @@ use std::{ffi::CStr, os::unix::io::AsRawFd};
 bitflags!(
     /// Options for the `flags` field in [`Address`]
     ///
-    /// See [if_xdp.h](https://github.com/torvalds/linux/blob/2bac7dc169af3cd4a0cb5200aa1f7b89affa042a/include/uapi/linux/if_xdp.h#L16-L27)
+    /// See [if_xdp.h](https://github.com/torvalds/linux/blob/11614723af26e7c32fcb704d8f30fdf60c1122dc/include/uapi/linux/if_xdp.h#L16-L33)
     ///
     /// Note that the size of the value is specified in the [sxdp_flags field](
     /// https://github.com/torvalds/linux/blob/0d3eb744aed40ffce820cded61d7eac515199165/include/uapi/linux/if_xdp.h#L34).
@@ -31,6 +31,11 @@ bitflags!(
         /// core, you should use this option so that the kernel will yield to the user space
         /// application.
         const USE_NEED_WAKEUP = 1 << 3;
+        /// By setting this option, userspace application indicates that it can
+        /// handle multiple descriptors per packet thus enabling AF_XDP to split
+        /// multi-buffer XDP frames into multiple Rx descriptors. Without this set
+        /// such frames will be dropped
+        const XDP_USE_SG = 1 << 4;
     }
 );
 

--- a/tools/xdp/s2n-quic-xdp/src/if_xdp.rs
+++ b/tools/xdp/s2n-quic-xdp/src/if_xdp.rs
@@ -270,6 +270,25 @@ bitflags!(
 pub const XSK_UNALIGNED_BUF_ADDR_MASK: u64 = (1 << XSK_UNALIGNED_BUF_OFFSET_SHIFT) - 1;
 pub const XSK_UNALIGNED_BUF_OFFSET_SHIFT: u64 = 48;
 
+bitflags!(
+    /// Flags set on Descriptor `options`` field
+    ///
+    /// See [if_xdp.h](https://github.com/torvalds/linux/blob/11614723af26e7c32fcb704d8f30fdf60c1122dc/include/uapi/linux/if_xdp.h#L164-L167)
+    ///
+    #[derive(Clone, Copy, Debug, Default)]
+    #[repr(transparent)]
+    pub struct DescriptorFlags: u32 {
+        /// If set, the packet continues in subsequent descriptors
+        const XDP_PKT_CONTD = 1 << 0;
+
+        /// TX packet carries valid metadata.
+        const XDP_TX_METADATA = 1 << 1;
+
+        /// Drivers may have drier specific options
+        const _ = !0;
+    }
+);
+
 /// Rx/Tx descriptor
 ///
 /// See [if_xdp.h](https://github.com/torvalds/linux/blob/2bac7dc169af3cd4a0cb5200aa1f7b89affa042a/include/uapi/linux/if_xdp.h#L103-L107)
@@ -281,7 +300,7 @@ pub struct RxTxDescriptor {
     /// Length of the packet
     pub len: u32,
     /// Options set on the descriptor
-    pub options: u32,
+    pub options: DescriptorFlags,
 }
 
 /// Umem Descriptor
@@ -301,7 +320,7 @@ impl UmemDescriptor {
         RxTxDescriptor {
             address: self.address,
             len,
-            options: 0,
+            options: Default::default(),
         }
     }
 }


### PR DESCRIPTION
### Description of changes: 

Adds the `XDP_USE_SG` flag to the set of XDP flags, introduced in [81470b5c3c6649eef8e5f282cd06793f788ae165](https://github.com/torvalds/linux/commit/341ac980eab90ac1f6c22ee9f9da83ed9604d899)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

