### PR TITLE
Add flag to force umem hugepage allocation

### DIFF
--- a/tools/xdp/s2n-quic-xdp/src/ring.rs
+++ b/tools/xdp/s2n-quic-xdp/src/ring.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     if_xdp::{MmapOffsets, RingFlags, RingOffsetV2, RxTxDescriptor, UmemDescriptor},
-    mmap::Mmap,
+    mmap::{Mmap, MmapOptions},
     socket, syscall,
 };
 use core::{fmt, mem::size_of, ptr::NonNull};
@@ -94,7 +94,7 @@ macro_rules! impl_producer {
             // Use the hard-coded offset of the ring type
             let offset = MmapOffsets::$offset;
 
-            let area = Mmap::new(len, offset, Some(socket.as_raw_fd()))?;
+            let area = Mmap::new(len, offset, Some(MmapOptions::Fd(socket.as_raw_fd())))?;
 
             let (cursor, flags) = unsafe {
                 // Safety: `area` lives as long as `cursor`
@@ -193,7 +193,7 @@ macro_rules! impl_consumer {
             // Use the hard-coded offset of the ring type
             let offset = MmapOffsets::$offset;
 
-            let area = Mmap::new(len, offset, Some(socket.as_raw_fd()))?;
+            let area = Mmap::new(len, offset, Some(MmapOptions::Fd(socket.as_raw_fd())))?;
 
             let (cursor, flags) = unsafe {
                 // Safety: `area` lives as long as `cursor`

--- a/tools/xdp/s2n-quic-xdp/src/syscall.rs
+++ b/tools/xdp/s2n-quic-xdp/src/syscall.rs
@@ -195,12 +195,15 @@ pub fn busy_poll<Fd: AsRawFd>(fd: &Fd) -> Result<u32> {
 ///
 /// See [xsk.c](https://github.com/xdp-project/xdp-tools/blob/a76e7a2b156b8cfe38992206abe9df1df0a29e38/lib/libxdp/xsk.c#L273).
 #[inline]
-pub fn mmap(len: usize, offset: usize, fd: Option<RawFd>) -> Result<NonNull<c_void>> {
-    let flags = if fd.is_some() {
+pub fn mmap(len: usize, offset: usize, fd: Option<RawFd>, huge: bool) -> Result<NonNull<c_void>> {
+    let mut flags = if fd.is_some() {
         libc::MAP_SHARED | libc::MAP_POPULATE
     } else {
         libc::MAP_PRIVATE | libc::MAP_ANONYMOUS
     };
+    if huge {
+        flags |= libc::MAP_HUGETLB;
+    }
 
     // See:
     // * Fill https://github.com/xdp-project/xdp-tools/blob/a76e7a2b156b8cfe38992206abe9df1df0a29e38/lib/libxdp/xsk.c#L273


### PR DESCRIPTION
### Description of changes: 

Modifies the XDP Umem builder to include a new flag `hugepage`, which when set, sets the `MAP_HUGETLB` flag in the mmap syscall. 

Umem is required to be backed by a hugepage, but the current allocation method doesn't guaranteed that, it relies on kernel transparent huge-pages, and if non is available, silently falls back to a non huge page allocation. This new flag forces hugepage allocation, and will fail if non is avilable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

