### PR TITLE
Expose XDP umem ptr

### DIFF
--- a/tools/xdp/s2n-quic-xdp/src/umem.rs
+++ b/tools/xdp/s2n-quic-xdp/src/umem.rs
@@ -121,6 +121,12 @@ impl Umem {
         self.area.len()
     }
 
+    /// Returns the pointer to the umem memory region
+    #[inline]
+    pub fn as_ptr(&self) -> *mut u8 {
+        self.mem.as_ptr()
+    }
+
     /// Returns `true` if the Umem is empty
     #[inline]
     pub fn is_empty(&self) -> bool {
@@ -178,7 +184,7 @@ impl Umem {
             desc.address + desc.len as u64 <= self.area.len() as u64,
             "pointer out of bounds"
         );
-        unsafe { self.mem.as_ptr().add(desc.address as _) }
+        unsafe { self.as_ptr().add(desc.address as _) }
     }
 
     #[inline]
@@ -187,7 +193,7 @@ impl Umem {
             desc.address + self.frame_size as u64 <= self.area.len() as u64,
             "pointer out of bounds"
         );
-        unsafe { self.mem.as_ptr().add(desc.address as _) }
+        unsafe { self.as_ptr().add(desc.address as _) }
     }
 }
 


### PR DESCRIPTION
### Description of changes: 

Provides a method on Umem to expose the raw pointer to the memory mapped memory. This is necessary backdoor for 3rd party use, for instance to use madvise on the memory region, or to expose to other crates. Any such use would require the user to caveat it as unsafe (de-referencing a pointer)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

