### PR TITLE
build(s2n-quic-xdp): update toolchain and dependencies

### DIFF
--- a/common/s2n-codec/src/encoder/mod.rs
+++ b/common/s2n-codec/src/encoder/mod.rs
@@ -10,8 +10,6 @@ pub use buffer::*;
 pub use estimator::*;
 pub use value::*;
 
-use core::convert::TryFrom;
-
 pub trait Encoder: Sized {
     /// Set to `true` if the particular encoder specializes on the bytes implementation
     #[cfg(feature = "bytes")]

--- a/common/s2n-codec/src/encoder/value.rs
+++ b/common/s2n-codec/src/encoder/value.rs
@@ -6,7 +6,7 @@ use crate::{
     i24, i48, u24, u48, DecoderBuffer, DecoderBufferMut,
 };
 use byteorder::{ByteOrder, NetworkEndian};
-use core::{convert::TryFrom, mem::size_of};
+use core::mem::size_of;
 
 pub trait EncoderValue: Sized {
     /// Encodes the value into the encoder

--- a/common/s2n-codec/src/unaligned.rs
+++ b/common/s2n-codec/src/unaligned.rs
@@ -1,10 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use core::{
-    convert::{TryFrom, TryInto},
-    ops::Deref,
-};
+use core::ops::Deref;
 
 // Unaligned integer types are integers which Rust does not provide natively.
 // This macro attempts to create wrapper types around the rounded up type

--- a/quic/s2n-quic-core/src/ack/settings.rs
+++ b/quic/s2n-quic-core/src/ack/settings.rs
@@ -5,7 +5,7 @@ use crate::{
     transport::parameters::{AckDelayExponent, MaxAckDelay},
     varint::VarInt,
 };
-use core::{convert::TryInto, time::Duration};
+use core::time::Duration;
 
 // After running simulations, this seemed to be a good baseline
 // TODO experiment more with this

--- a/quic/s2n-quic-core/src/application/error.rs
+++ b/quic/s2n-quic-core/src/application/error.rs
@@ -7,7 +7,7 @@ use crate::{
     frame::ConnectionClose,
     varint::{VarInt, VarIntError},
 };
-use core::{convert::TryFrom, fmt, ops};
+use core::{fmt, ops};
 
 //= https://www.rfc-editor.org/rfc/rfc9000#section-20.2
 //# The management of application error codes is left to application

--- a/quic/s2n-quic-core/src/connection/error.rs
+++ b/quic/s2n-quic-core/src/connection/error.rs
@@ -4,7 +4,7 @@
 use crate::{
     application, connection, crypto::packet_protection, endpoint, frame::ConnectionClose, transport,
 };
-use core::{convert::TryInto, fmt, panic, time::Duration};
+use core::{fmt, panic, time::Duration};
 
 /// Errors that a connection can encounter.
 #[derive(Debug, Copy, Clone)]

--- a/quic/s2n-quic-core/src/connection/id.rs
+++ b/quic/s2n-quic-core/src/connection/id.rs
@@ -7,10 +7,7 @@ use crate::{
     event::{api::SocketAddress, IntoEvent},
     inet, transport,
 };
-use core::{
-    convert::{TryFrom, TryInto},
-    time::Duration,
-};
+use core::time::Duration;
 use s2n_codec::{decoder_value, Encoder, EncoderValue};
 
 #[cfg(any(test, feature = "generator"))]

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -12,7 +12,7 @@ use crate::{
         MaxDatagramFrameSize, MaxIdleTimeout, TransportParameters,
     },
 };
-use core::{convert::TryInto, time::Duration};
+use core::time::Duration;
 use s2n_codec::decoder_invariant;
 
 pub use crate::transport::parameters::ValidationError;

--- a/quic/s2n-quic-core/src/counter.rs
+++ b/quic/s2n-quic-core/src/counter.rs
@@ -5,7 +5,7 @@ use crate::number::{
     CheckedAddAssign, CheckedMulAssign, CheckedSubAssign, SaturatingAddAssign, SaturatingMulAssign,
     SaturatingSubAssign, UpcastFrom,
 };
-use core::{cmp::Ordering, convert::TryFrom, marker::PhantomData, ops};
+use core::{cmp::Ordering, marker::PhantomData, ops};
 
 /// A checked-overflow counter
 ///

--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -3,7 +3,7 @@
 
 #[cfg(feature = "alloc")]
 pub use bytes::{Bytes, BytesMut};
-use core::{convert::TryFrom, fmt::Debug};
+use core::fmt::Debug;
 use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
 
 mod error;

--- a/quic/s2n-quic-core/src/havoc.rs
+++ b/quic/s2n-quic-core/src/havoc.rs
@@ -6,7 +6,7 @@ use crate::{
     stream::StreamType,
     varint,
 };
-use core::{convert::TryInto, ops::Range};
+use core::ops::Range;
 pub use s2n_codec::{Encoder, EncoderBuffer, EncoderValue};
 
 pub trait Random {

--- a/quic/s2n-quic-core/src/packet/decoding.rs
+++ b/quic/s2n-quic-core/src/packet/decoding.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     varint::VarInt,
 };
-use core::{convert::TryInto, mem::size_of};
+use core::mem::size_of;
 use s2n_codec::{CheckedRange, DecoderBuffer, DecoderBufferMut, DecoderError, DecoderValue};
 
 pub struct HeaderDecoder<'a> {

--- a/quic/s2n-quic-core/src/packet/long.rs
+++ b/quic/s2n-quic-core/src/packet/long.rs
@@ -5,7 +5,6 @@ use crate::{
     packet::{encoding::PacketPayloadLenCursor, number::TruncatedPacketNumber},
     varint::VarInt,
 };
-use core::convert::TryFrom;
 use s2n_codec::{
     decoder_invariant, CheckedRange, DecoderError, Encoder, EncoderBuffer, EncoderValue,
 };

--- a/quic/s2n-quic-core/src/packet/retry.rs
+++ b/quic/s2n-quic-core/src/packet/retry.rs
@@ -16,7 +16,7 @@ use crate::{
     },
     random, token,
 };
-use core::{convert::TryInto, mem::size_of, ops::Range};
+use core::{mem::size_of, ops::Range};
 use retry::INTEGRITY_TAG_LEN;
 use s2n_codec::{
     decoder_invariant, DecoderBufferMut, DecoderBufferMutResult, Encoder, EncoderBuffer,

--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -6,7 +6,6 @@ use crate::{
     inet::{IpV4Address, IpV6Address, SocketAddress, SocketAddressV4, SocketAddressV6},
 };
 use core::{
-    convert::{TryFrom, TryInto},
     fmt,
     fmt::{Display, Formatter},
     num::NonZeroU16,

--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     counter::{Counter, Saturating},
-    ensure, event,
+    event,
     event::{builder::MtuUpdatedCause, IntoEvent},
     frame,
     inet::SocketAddress,

--- a/quic/s2n-quic-core/src/recovery/bbr.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr.rs
@@ -21,7 +21,6 @@ use crate::{
 };
 use core::{
     cmp::{max, min},
-    convert::TryInto,
     time::Duration,
 };
 use num_rational::Ratio;

--- a/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/probe_bw.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     time::Timestamp,
 };
-use core::{convert::TryInto, time::Duration};
+use core::time::Duration;
 use num_rational::Ratio;
 use num_traits::One;
 

--- a/quic/s2n-quic-core/src/recovery/persistent_congestion.rs
+++ b/quic/s2n-quic-core/src/recovery/persistent_congestion.rs
@@ -1,9 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    ensure, packet::number::PacketNumber, path, recovery::SentPacketInfo, time::Timestamp,
-};
+use crate::{packet::number::PacketNumber, path, recovery::SentPacketInfo, time::Timestamp};
 use core::time::Duration;
 
 #[derive(Debug)]

--- a/quic/s2n-quic-core/src/recovery/pto.rs
+++ b/quic/s2n-quic-core/src/recovery/pto.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    ensure, frame,
+    frame,
     time::{timer, Timer, Timestamp},
     transmission::{self, interest::Provider as _},
 };

--- a/quic/s2n-quic-core/src/recovery/sent_packets.rs
+++ b/quic/s2n-quic-core/src/recovery/sent_packets.rs
@@ -5,7 +5,6 @@ use crate::{
     frame::ack_elicitation::AckElicitation, inet::ExplicitCongestionNotification, path,
     time::Timestamp, transmission,
 };
-use core::convert::TryInto;
 
 //= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.1
 

--- a/quic/s2n-quic-core/src/stateless_reset/token.rs
+++ b/quic/s2n-quic-core/src/stateless_reset/token.rs
@@ -3,7 +3,6 @@
 
 //! Defines the Stateless Reset token
 
-use core::convert::{TryFrom, TryInto};
 use s2n_codec::{decoder_value, Encoder, EncoderValue};
 use subtle::ConstantTimeEq;
 

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -9,11 +9,7 @@ use crate::{
     stream::{StreamId, StreamType},
     varint::VarInt,
 };
-use core::{
-    convert::{TryFrom, TryInto},
-    mem::size_of,
-    time::Duration,
-};
+use core::{mem::size_of, time::Duration};
 use s2n_codec::{
     decoder_invariant, decoder_value, DecoderBuffer, DecoderBufferMut, DecoderBufferMutResult,
     DecoderBufferResult, DecoderError, DecoderValue, DecoderValueMut, Encoder, EncoderValue,

--- a/quic/s2n-quic-core/src/varint/mod.rs
+++ b/quic/s2n-quic-core/src/varint/mod.rs
@@ -1,11 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use core::{
-    convert::{TryFrom, TryInto},
-    fmt,
-    ops::Deref,
-};
+use core::{fmt, ops::Deref};
 use s2n_codec::{decoder_value, Encoder, EncoderValue};
 
 #[cfg(any(test, feature = "generator"))]

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -14,9 +14,8 @@ trace = ["s2n-quic-core/branch-tracing", "s2n-quic-core/probe-tracing", "s2n-qui
 xdp = ["s2n-quic/unstable-provider-io-xdp", "aya", "aya-log"]
 
 [dependencies]
-# TODO use the crates.io version once https://github.com/aya-rs/aya/pull/527 is merged
-aya = { git = "https://github.com/camshaft/aya", branch = "xdpmaps", optional = true }
-aya-log = { git = "https://github.com/camshaft/aya", branch = "xdpmaps", optional = true }
+aya = { version = "0.12", optional = true }
+aya-log = { version = "0.2", optional = true }
 bytes = { version = "1", default-features = false }
 cfg-if = "1"
 futures = "0.3"

--- a/tools/xdp/ebpf/Cargo.toml
+++ b/tools/xdp/ebpf/Cargo.toml
@@ -5,9 +5,8 @@ edition = "2021"
 
 [dependencies]
 # These crates are not published so use a git dependency for now. See https://github.com/aya-rs/aya/issues/464
-# TODO switch to the main repo once the xdpmaps are available - https://github.com/aya-rs/aya/pull/527
-aya-bpf = { git = "https://github.com/camshaft/aya", branch = "xdpmaps" }
-aya-log-ebpf = { git = "https://github.com/camshaft/aya", branch = "xdpmaps" }
+aya-bpf = { git = "https://github.com/aya-rs/aya", tag = "aya-v0.12.0" }
+aya-log-ebpf = { git = "https://github.com/aya-rs/aya", tag = "aya-v0.12.0" }
 s2n-quic-core = { path = "../../../quic/s2n-quic-core", default-features = false }
 
 [features]

--- a/tools/xdp/ebpf/rust-toolchain.toml
+++ b/tools/xdp/ebpf/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # pin the version to prevent random breakage
-channel = "nightly-2023-06-21"
+channel = "nightly-2024-03-05"
 # The source code of rustc, provided by the rust-src component, is needed for
 # building eBPF programs.
 components = [ "rustc", "cargo", "rust-src" ]

--- a/tools/xdp/rust-toolchain
+++ b/tools/xdp/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.71.1"
+channel = "1.74.1"
 components = [ "rustc", "clippy", "rustfmt" ]

--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["corpus.tar.gz"]
 default = ["tokio"]
 
 [dependencies]
-aya = { version = "0.11", default-features = false }
+aya = { version = "0.12", default-features = false }
 bitflags = "2"
 errno = "0.3"
 libc = "0.2"

--- a/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfeb-trace.ebpf
+++ b/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfeb-trace.ebpf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a7d65741a689e3aafe2cf9c84249183f96f77462ec68fab00929d534e5c832a4
-size 7312
+oid sha256:fba47c364fb19e71609e40466441fc29af5e511a8396e6e4bb32d06b4391f4c7
+size 9040

--- a/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfeb.ebpf
+++ b/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfeb.ebpf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:54247e6e8eeb1f35dc0cd0260c39d140674b4b6ea08821920e3780721d467b38
-size 2480
+oid sha256:9e09f4d5daf0c71f144778deff4983187c543d2cc1e65df37cd7f17e54a96e62
+size 2568

--- a/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfel-trace.ebpf
+++ b/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfel-trace.ebpf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:868d79fe6912a6f42c539bed2b9dd1e808b7d6b02e8181da869adf484e1e3005
-size 7336
+oid sha256:09e64ffe8cf1e6fef0ecab3addff835faec61784e3e887fa3977c1ba703eba63
+size 9072

--- a/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfel.ebpf
+++ b/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfel.ebpf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4f65a558f76a2b883361486db733dbdecb5ab6f692bb466af3198e624505faec
-size 2512
+oid sha256:742fc28f3d94b579a18ae4f466c7577565e4eaaf88693c221fd670d2b2f51b4e
+size 2600

--- a/tools/xdp/s2n-quic-xdp/src/io/rx.rs
+++ b/tools/xdp/s2n-quic-xdp/src/io/rx.rs
@@ -94,8 +94,8 @@ impl<D: Driver> Driver for WithCooldown<D> {
         }
 
         match self.cooldown.on_pending_task(cx) {
-            cooldown::Outcome::Loop => return Some(0),
-            cooldown::Outcome::Sleep => return self.driver.poll(rx, fill, cx),
+            cooldown::Outcome::Loop => Some(0),
+            cooldown::Outcome::Sleep => self.driver.poll(rx, fill, cx),
         }
     }
 }

--- a/tools/xdp/s2n-quic-xdp/src/io/tx.rs
+++ b/tools/xdp/s2n-quic-xdp/src/io/tx.rs
@@ -280,7 +280,7 @@ impl<D: Driver> tx::Tx for Tx<D> {
 
         // use the first channel that had entries, otherwise return the length, which will indicate
         // the queue has no free items
-        let channel_index = first_channel_with_entries.unwrap_or_else(|| channels.len());
+        let channel_index = first_channel_with_entries.unwrap_or(channels.len());
 
         let mut queue = Queue {
             channels,

--- a/tools/xdp/s2n-quic-xdp/src/umem.rs
+++ b/tools/xdp/s2n-quic-xdp/src/umem.rs
@@ -194,7 +194,14 @@ impl Umem {
 /// Specifies an indexable value, which relies on the caller to guarantee borrowing rules are not
 /// violated.
 pub trait UnsafeIndex<T> {
+    /// # Safety
+    ///
+    /// Callers need to guarantee the reference is not already exclusively borrowed
     unsafe fn index(&self, idx: T) -> &[u8];
+
+    /// # Safety
+    ///
+    /// Callers need to guarantee the reference is not already exclusively borrowed
     #[allow(clippy::mut_from_ref)] // interior mutability safety is enforced by the caller
     unsafe fn index_mut(&self, idx: T) -> &mut [u8];
 }

--- a/tools/xdp/tester/Cargo.toml
+++ b/tools/xdp/tester/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aya = { version = ">=0.11", features = ["async_tokio"] }
-aya-log = "0.1"
+aya = { version = "0.12", features = ["async_tokio"] }
+aya-log = "0.2"
 clap = { version = "4.1", features = ["derive"] }
 anyhow = "1.0.68"
-env_logger = "0.10"
+env_logger = "0.11"
 log = "0.4"
 s2n-quic-xdp = { path = "../s2n-quic-xdp" }
 tokio = { version = "1.24", features = ["macros", "rt", "rt-multi-thread", "net", "signal"] }


### PR DESCRIPTION
### Description of changes: 

This change updates the XDP dependencies and addresses all of the clippy issues highlighted in the latest nightly rust.

### Testing:

The CI job is now passing: https://github.com/aws/s2n-quic/actions/runs/8176612535/job/22356439836?pr=2147

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

