### PR TITLE
fix(s2n-quic-platform): don't reduce rx MTU when tx MTU is reduced

### DIFF
--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -157,7 +157,9 @@ impl Io {
             let payload_len = if gro_enabled {
                 u16::MAX
             } else {
-                max_mtu.into()
+                // Use the originally configured MTU to allow larger packets to be received
+                // even if the tx MTU has been reduced due to configure_mtu_disc failing
+                self.builder.max_mtu.into()
             } as u32;
 
             let rx_buffer_size = queue_recv_buffer_size.unwrap_or(8 * (1 << 20));


### PR DESCRIPTION
### Resolved issues:

resolves #2155

### Description of changes: 

Previously, when the syscall to configure MTU discovery failed, we would reduce the MTU used for both transmitting and receiving packets to the minimum MTU. This can prevent receiving packets from peers that are using a larger MTU. This change will only reduce the MTU for transmitting packets, leaving the rx MTU at the originally configured value.

### Testing:

Tested locally on MacOS, where the configure_mtu_disc syscall fails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

