### PR TITLE
build: fix clippy warnings for 1.77

### DIFF
--- a/examples/async-client-hello-callback/src/bin/quic_async_client_hello_callback_server.rs
+++ b/examples/async-client-hello-callback/src/bin/quic_async_client_hello_callback_server.rs
@@ -108,7 +108,7 @@ impl ClientHelloCallback for ConfigCache {
                     .into();
                 Ok(config)
             });
-            fut.await.map(|config| config.clone())
+            fut.await.cloned()
         };
 
         // return `Some(ConnectionFuture)` if the Config wasn't found in the

--- a/quic/s2n-quic/src/provider/packet_interceptor.rs
+++ b/quic/s2n-quic/src/provider/packet_interceptor.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+// this is only exposed as an unstable provider so we get warnings without this
+#[allow(unused_imports)]
 pub use s2n_quic_core::packet::interceptor::{
     loss, Disabled, Havoc, Interceptor as PacketInterceptor, Loss,
 };


### PR DESCRIPTION
### Description of changes: 

A new version of rustc dropped with new clippy checks. This PR fixes those.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

