### PR TITLE
ci: update wireshark to v4

### DIFF
--- a/.github/Dockerfile.tshark
+++ b/.github/Dockerfile.tshark
@@ -1,19 +1,21 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN \
   set -eux; \
   apt-get -o Acquire::Retries=3 update; \
-  apt-get -o Acquire::Retries=3 install -y cmake libglib2.0-dev libc-ares-dev libgcrypt20-dev flex bison byacc libpcap-dev ninja-build wget build-essential;
+  apt-get -o Acquire::Retries=3 install -y cmake libglib2.0-dev libc-ares-dev libgcrypt20-dev flex bison byacc libpcap-dev ninja-build wget build-essential libc-ares-dev;
 
-ARG version="4.0.2"
+ARG version="4.4.2"
 
 RUN \
   set -eux; \
   wget https://www.wireshark.org/download/src/all-versions/wireshark-${version}.tar.xz; \
   tar xf wireshark-${version}.tar.xz; \
   cd wireshark-${version}; \
-  cmake -GNinja -DBUILD_wireshark=0 -DBUILD_qtshark=0 -DBUILD_editcap=1 -DBUILD_capinfos=0 -DBUILD_text2pcap=0 -DBUILD_rawshark=0 -DBUILD_sdjournal=0 -DBUILD_sshdump=0 -DBUILD_ciscodump=0 -DENABLE_STATIC=1 -DENABLE_PLUGINS=0 -DENABLE_LIBXML2=0 -DUSE_STATIC=1 -DENABLE_GNUTLS=1 .; \
+  cmake -GNinja \
+    -DBUILD_wireshark=0 -DBUILD_qtshark=0 -DBUILD_editcap=1 -DBUILD_capinfos=0 -DBUILD_text2pcap=0 -DBUILD_rawshark=0 -DBUILD_sdjournal=0 -DBUILD_sshdump=0 -DBUILD_ciscodump=0 -DBUILD_androiddump=0 -DBUILD_captype=0 -DBUILD_dcerpcidl2wrs=0 -DBUILD_sharkd=0 -DBUILD_wifidump=0 -DBUILD_randpktdump=0 -DBUILD_mmdbresolve=0 -DBUILD_udpdump=0 \
+    -DENABLE_STATIC=1 -DENABLE_LTO=1 -DENABLE_PCAP=0 -DENABLE_PLUGINS=0 -DENABLE_LIBXML2=0 -DUSE_STATIC=1 -DENABLE_GNUTLS=1 -DENABLE_SBC=0 -DENABLE_SPANDSP=0 -DENABLE_BCG729=0 .; \
   ninja; \
   cp run/tshark run/editcap /usr/local/bin/;

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -19,7 +19,7 @@ env:
   # This should be updated when updating wesleyrosenblum/quic-network-simulator
   NETWORK_SIMULATOR_REF: sha256:e102cb0e4b9457f510faf4ca888b4f7f6211aa109b68bfaaa1aa639059fcfc96
   IPERF_ENDPOINT_REF: sha256:cb50cc8019d45d9cad5faecbe46a3c21dd5e871949819a5175423755a9045106
-  WIRESHARK_VERSION: 3.7.1
+  WIRESHARK_VERSION: 4.4.2
   CDN: https://dnglbrstg7yg.cloudfront.net
   LOG_URL: logs/latest/SERVER_CLIENT/TEST/index.html
 
@@ -163,10 +163,14 @@ jobs:
 
       - name: Install tshark
         run: |
-          wget --no-verbose https://dnglbrstg7yg.cloudfront.net/tshark/v$WIRESHARK_VERSION/tshark
-          chmod +x tshark
-          sudo mv tshark /usr/bin
-          /usr/bin/tshark -v
+          function install() {
+            wget --no-verbose $CDN/tshark/v$WIRESHARK_VERSION/$1
+            chmod +x $1
+            sudo mv $1 /usr/bin/$1
+            /usr/bin/$1 -v
+          }
+          install tshark
+          install editcap
 
       - name: Install dependencies
         working-directory: quic-interop-runner

--- a/.github/workflows/tshark.yml
+++ b/.github/workflows/tshark.yml
@@ -23,7 +23,7 @@ on:
       version:
         description: 'wireshark version'
         required: true
-        default: '3.7.1'
+        default: '4.4.2'
         type: string
 
 # Updating status is relatively safe (doesnt modify source code) and caution
@@ -32,12 +32,11 @@ permissions:
   statuses: write
   id-token: write # This is required for requesting the JWT/OIDC
 
-
 jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      WIRESHARK_VERSION: ${{ inputs.version || '3.7.1' }}
+      WIRESHARK_VERSION: ${{ inputs.version || '4.4.2' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -53,14 +52,13 @@ jobs:
             cp /usr/local/bin/tshark /usr/local/bin/editcap /host-dir/
 
       - uses: aws-actions/configure-aws-credentials@v4.0.2
-        if: github.event_name == 'schedule' || github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: github.event_name == 'schedule' || github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.repository == github.event.pull_request.head.repo.full_name
         run: |
           aws s3 sync target/tshark "s3://s2n-quic-ci-artifacts/tshark" --acl private --follow-symlinks
-

--- a/scripts/interop/README.md
+++ b/scripts/interop/README.md
@@ -26,9 +26,9 @@
 ## Modifying the runner.patch
 
 ```
-git clone git@github.com:marten-seemann/quic-interop-runner.git
+git clone https://github.com/marten-seemann/quic-interop-runner.git
 cd quic-interop-runner
-gco b21b8a55de227f665d2381f3e63174a83a3bc66c
+gco 601c9fca5042d9a5f49c3caad3a2bfd1136b31bf
 
 cp <s2n-quic_proj_dir>.runner.patch .
 git apply --3way runner.patch # apply the current patch


### PR DESCRIPTION
### Description of changes: 

This updates the wireshark version to the latest. We also install `editcap` so the interop runner can take advantage of embedding key log files in pcaps.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

