### PR TITLE
ci: publish to GitHub Container Registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,15 +28,16 @@ jobs:
       - name: Compute tags
         id: tags
         run: |
-          DOCKER_IMAGE=public.ecr.aws/s2n/s2n-quic-qns
+          ECR_IMAGE=public.ecr.aws/s2n/s2n-quic-qns
+          GHCR_IMAGE=ghcr.io/aws/s2n-quic/s2n-quic-qns
           VERSION=main
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/v}
           fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          TAGS="${ECR_IMAGE}:${VERSION},${GHCR_IMAGE}:${VERSION}"
           # mark the latest on release
           if [[ $VERSION =~ ^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:latest"
+            TAGS="$TAGS,${ECR_IMAGE}:latest,${GHCR_IMAGE}:latest"
           fi
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 
@@ -47,6 +48,14 @@ jobs:
           registry: public.ecr.aws
           username: ${{ secrets.AWS_ACCESS_KEY_ID }}
           password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3.1.0
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
### Description of changes: 

This change will publish the `s2n-quic-qns` image to the GitHub container registry, in addition to Amazon ECR. 

I followed the instructions from https://docs.docker.com/build/ci/github-actions/push-multi-registries/ for pushing to multiple registries. #1189 contains the change to move to ECR originally, I took the GitHub Container Registry values from that PR.

### Testing:

Will verify once this is merged to main

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

