### PR TITLE
ci: ignore yaml-rust advisory

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -5,6 +5,7 @@ notice = "deny"
 yanked = "deny"
 ignore = [
     "RUSTSEC-2021-0139", # criterion, structopt, and tracing-subscriber (test dependencies) use ansi_term
+    "RUSTSEC-2024-0320", # insta (test dependency) uses yaml-rust
 ]
 
 [bans]


### PR DESCRIPTION
### Description of changes: 

Advisory `RUSTSEC-2024-0320` was opened as the `yaml-rust` packet has been unmaintained for years. It is not clear what the path forward for yaml-rust is, but since we only use it for `insta`, a test dependency, this change ignores this advisory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

