### PR TITLE
Revert "feat(s2n-quic-rustls): update rustls from 0.21 to 0.23 (#2143)"

### DIFF
--- a/examples/rustls-mtls/Cargo.toml
+++ b/examples/rustls-mtls/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Rick Richardson <rick.richardson@gmail.com>", "AWS s2n"]
 [dependencies]
 # Remove the `provider-tls-default` feature and add `provider-tls-rustls` in order to use the rustls backend
 s2n-quic = { version = "1", path = "../../quic/s2n-quic", default-features = false, features = ["provider-address-token-default", "provider-tls-rustls", "provider-event-tracing"] }
-rustls-pemfile = "2"
+rustls-pemfile = "1"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi"] }

--- a/examples/rustls-mtls/src/lib.rs
+++ b/examples/rustls-mtls/src/lib.rs
@@ -1,19 +1,21 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use s2n_quic::provider::tls::{
-    self as s2n_quic_tls_provider,
-    rustls::rustls::{
-        // types from the external rustls crate
-        pki_types::{CertificateDer, PrivateKeyDer},
-        server::WebPkiClientVerifier,
-        Error as RustlsError,
-        RootCertStore,
-    },
+use rustls::{
+    cipher_suite, ClientConfig, Error, RootCertStore, ServerConfig, SupportedCipherSuite,
 };
+use s2n_quic::provider::{tls, tls::rustls::rustls};
 use std::{io::Cursor, path::Path, sync::Arc};
 use tokio::{fs::File, io::AsyncReadExt};
 use tracing::Level;
+
+static PROTOCOL_VERSIONS: &[&rustls::SupportedProtocolVersion] = &[&rustls::version::TLS13];
+
+pub static DEFAULT_CIPHERSUITES: &[SupportedCipherSuite] = &[
+    cipher_suite::TLS13_AES_128_GCM_SHA256,
+    cipher_suite::TLS13_AES_256_GCM_SHA384,
+    cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+];
 
 pub fn initialize_logger(endpoint: &str) {
     use std::sync::Once;
@@ -38,26 +40,23 @@ pub fn initialize_logger(endpoint: &str) {
 }
 
 pub struct MtlsProvider {
-    root_store: RootCertStore,
-    my_cert_chain: Vec<CertificateDer<'static>>,
-    my_private_key: PrivateKeyDer<'static>,
+    root_store: rustls::RootCertStore,
+    my_cert_chain: Vec<rustls::Certificate>,
+    my_private_key: rustls::PrivateKey,
 }
 
-impl s2n_quic_tls_provider::Provider for MtlsProvider {
-    type Server = s2n_quic_tls_provider::rustls::Server;
-    type Client = s2n_quic_tls_provider::rustls::Client;
-    type Error = RustlsError;
+impl tls::Provider for MtlsProvider {
+    type Server = tls::rustls::Server;
+    type Client = tls::rustls::Client;
+    type Error = rustls::Error;
 
     fn start_server(self) -> Result<Self::Server, Self::Error> {
-        let default_crypto_provider = s2n_quic_tls_provider::rustls::default_crypto_provider()?;
-        let verifier = WebPkiClientVerifier::builder_with_provider(
-            Arc::new(self.root_store),
-            default_crypto_provider.into(),
-        )
-        .build()
-        .unwrap();
-        let mut cfg = s2n_quic_tls_provider::rustls::server_config_builder()?
-            .with_client_cert_verifier(verifier)
+        let verifier = rustls::server::AllowAnyAuthenticatedClient::new(self.root_store);
+        let mut cfg = ServerConfig::builder()
+            .with_cipher_suites(DEFAULT_CIPHERSUITES)
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(PROTOCOL_VERSIONS)?
+            .with_client_cert_verifier(Arc::new(verifier))
             .with_single_cert(self.my_cert_chain, self.my_private_key)?;
 
         cfg.ignore_client_order = true;
@@ -67,7 +66,10 @@ impl s2n_quic_tls_provider::Provider for MtlsProvider {
     }
 
     fn start_client(self) -> Result<Self::Client, Self::Error> {
-        let mut cfg = s2n_quic_tls_provider::rustls::client_config_builder()?
+        let mut cfg = ClientConfig::builder()
+            .with_cipher_suites(DEFAULT_CIPHERSUITES)
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(PROTOCOL_VERSIONS)?
             .with_root_certificates(self.root_store)
             .with_client_auth_cert(self.my_cert_chain, self.my_private_key)?;
 
@@ -82,88 +84,71 @@ impl MtlsProvider {
         ca_cert_pem: A,
         my_cert_pem: B,
         my_key_pem: C,
-    ) -> Result<Self, RustlsError> {
+    ) -> Result<Self, Error> {
         let root_store = into_root_store(ca_cert_pem.as_ref()).await?;
         let cert_chain = into_certificate(my_cert_pem.as_ref()).await?;
         let private_key = into_private_key(my_key_pem.as_ref()).await?;
         Ok(MtlsProvider {
             root_store,
-            my_cert_chain: cert_chain.into_iter().map(CertificateDer::from).collect(),
-            my_private_key: private_key,
+            my_cert_chain: cert_chain.into_iter().map(rustls::Certificate).collect(),
+            my_private_key: rustls::PrivateKey(private_key),
         })
     }
 }
 
-async fn read_file(path: &Path) -> Result<Vec<u8>, RustlsError> {
+async fn into_certificate(path: &Path) -> Result<Vec<Vec<u8>>, Error> {
     let mut f = File::open(path)
         .await
-        .map_err(|e| RustlsError::General(format!("Failed to load file: {}", e)))?;
+        .map_err(|e| Error::General(format!("Failed to load file: {}", e)))?;
     let mut buf = Vec::new();
     f.read_to_end(&mut buf)
         .await
-        .map_err(|e| RustlsError::General(format!("Failed to read file: {}", e)))?;
-    Ok(buf)
-}
-
-async fn into_certificate(path: &Path) -> Result<Vec<CertificateDer<'static>>, RustlsError> {
-    let buf = &read_file(path).await?;
+        .map_err(|e| Error::General(format!("Failed to read file: {}", e)))?;
     let mut cursor = Cursor::new(buf);
-    rustls_pemfile::certs(&mut cursor)
-        .map(|cert| {
-            cert.map_err(|_| RustlsError::General("Could not read certificate".to_string()))
-        })
-        .collect()
+    let certs = rustls_pemfile::certs(&mut cursor)
+        .map(|certs| certs.into_iter().collect())
+        .map_err(|_| Error::General("Could not read certificate".to_string()))?;
+    Ok(certs)
 }
 
-async fn into_root_store(path: &Path) -> Result<RootCertStore, RustlsError> {
-    let ca_certs: Vec<CertificateDer<'static>> = into_certificate(path)
-        .await
-        .map(|certs| certs.into_iter().map(CertificateDer::from))?
-        .collect();
+async fn into_root_store(path: &Path) -> Result<RootCertStore, Error> {
+    let ca_certs = into_certificate(path).await?;
     let mut cert_store = RootCertStore::empty();
-    cert_store.add_parsable_certificates(ca_certs);
+    cert_store.add_parsable_certificates(ca_certs.as_slice());
     Ok(cert_store)
 }
 
-async fn into_private_key(path: &Path) -> Result<PrivateKeyDer<'static>, RustlsError> {
-    let buf = &read_file(path).await?;
+async fn into_private_key(path: &Path) -> Result<Vec<u8>, Error> {
+    let mut f = File::open(path)
+        .await
+        .map_err(|e| Error::General(format!("Failed to load file: {}", e)))?;
+    let mut buf = Vec::new();
+    f.read_to_end(&mut buf)
+        .await
+        .map_err(|e| Error::General(format!("Failed to read file: {}", e)))?;
     let mut cursor = Cursor::new(buf);
 
-    macro_rules! parse_key {
-        ($parser:ident, $key_type:expr) => {
-            cursor.set_position(0);
+    let parsers = [
+        rustls_pemfile::rsa_private_keys,
+        rustls_pemfile::pkcs8_private_keys,
+    ];
+    for parser in parsers.iter() {
+        cursor.set_position(0);
 
-            let keys: Result<Vec<_>, RustlsError> = rustls_pemfile::$parser(&mut cursor)
-                .map(|key| {
-                    key.map_err(|_| {
-                        RustlsError::General("Could not load any private keys".to_string())
-                    })
-                })
-                .collect();
-            match keys {
-                // try the next parser
-                Err(_) => (),
-                // try the next parser
-                Ok(keys) if keys.is_empty() => (),
-                Ok(mut keys) if keys.len() == 1 => {
-                    return Ok($key_type(keys.pop().unwrap()));
-                }
-                Ok(keys) => {
-                    return Err(RustlsError::General(format!(
-                        "Unexpected number of keys: {} (only 1 supported)",
-                        keys.len()
-                    )));
-                }
+        match parser(&mut cursor) {
+            Ok(keys) if keys.is_empty() => continue,
+            Ok(mut keys) if keys.len() == 1 => return Ok(rustls::PrivateKey(keys.pop().unwrap()).0),
+            Ok(keys) => {
+                return Err(Error::General(format!(
+                    "Unexpected number of keys: {} (only 1 supported)",
+                    keys.len()
+                )));
             }
-        };
+            // try the next parser
+            Err(_) => continue,
+        }
     }
-
-    // attempt to parse PKCS8 encoded key. Returns early if a key is found
-    parse_key!(pkcs8_private_keys, PrivateKeyDer::Pkcs8);
-    // attempt to parse RSA key. Returns early if a key is found
-    parse_key!(rsa_private_keys, PrivateKeyDer::Pkcs1);
-
-    Err(RustlsError::General(
+    Err(Error::General(
         "could not load any valid private keys".to_string(),
     ))
 }

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -23,6 +23,8 @@ http = "1.0"
 humansize = "2"
 lru = "0.10"
 rand = "0.8"
+# dangerous_configuration is used to allow for cert verification to be disabled for the amplification limit interop test
+rustls = { version = "0.21", features = ["dangerous_configuration", "quic"] }
 s2n-codec = { path = "../../common/s2n-codec" }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-h3 = { path = "../s2n-quic-h3" }

--- a/quic/s2n-quic-qns/src/tls.rs
+++ b/quic/s2n-quic-qns/src/tls.rs
@@ -1,8 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{tls::rustls::DisabledVerifier, Result};
-use s2n_quic::provider::tls::{self as s2n_quic_tls_provider, rustls::rustls as rustls_crate};
+use crate::Result;
 use std::{path::PathBuf, str::FromStr};
 use structopt::StructOpt;
 
@@ -114,12 +113,14 @@ impl Client {
 
     pub fn build_rustls(&self, alpns: &[String]) -> Result<rustls::Client> {
         let tls = if self.disable_cert_verification {
-            use rustls_crate::KeyLogFile;
+            use ::rustls::{version, ClientConfig, KeyLogFile};
             use std::sync::Arc;
 
-            let mut config = s2n_quic_tls_provider::rustls::client_config_builder()?
-                .dangerous()
-                .with_custom_certificate_verifier(Arc::new(DisabledVerifier))
+            let mut config = ClientConfig::builder()
+                .with_cipher_suites(rustls::DEFAULT_CIPHERSUITES)
+                .with_safe_default_kx_groups()
+                .with_protocol_versions(&[&version::TLS13])?
+                .with_custom_certificate_verifier(Arc::new(rustls::DisabledVerifier))
                 .with_no_client_auth();
             config.max_fragment_size = None;
             config.alpn_protocols = alpns.iter().map(|p| p.as_bytes().to_vec()).collect();
@@ -264,13 +265,9 @@ pub mod s2n_tls {
 
 pub mod rustls {
     use super::*;
-    use rustls_crate::{
-        client::danger,
-        pki_types::{CertificateDer, ServerName, UnixTime},
-    };
     pub use s2n_quic::provider::tls::rustls::{
         certificate::{Certificate, IntoCertificate, IntoPrivateKey, PrivateKey},
-        default_crypto_provider, Client, Server,
+        Client, Server, DEFAULT_CIPHERSUITES,
     };
 
     pub fn ca(ca: Option<&PathBuf>) -> Result<Certificate> {
@@ -289,54 +286,19 @@ pub mod rustls {
         })
     }
 
-    #[derive(Debug)]
     pub struct DisabledVerifier;
 
-    impl danger::ServerCertVerifier for DisabledVerifier {
+    impl ::rustls::client::ServerCertVerifier for DisabledVerifier {
         fn verify_server_cert(
             &self,
-            _end_entity: &CertificateDer<'_>,
-            _intermediates: &[CertificateDer<'_>],
-            _server_name: &ServerName,
+            _end_entity: &::rustls::Certificate,
+            _intermediates: &[::rustls::Certificate],
+            _server_name: &::rustls::ServerName,
+            _scts: &mut dyn Iterator<Item = &[u8]>,
             _ocsp_response: &[u8],
-            _now: UnixTime,
-        ) -> Result<danger::ServerCertVerified, rustls_crate::Error> {
-            Ok(danger::ServerCertVerified::assertion())
-        }
-
-        fn verify_tls12_signature(
-            &self,
-            message: &[u8],
-            cert: &CertificateDer<'_>,
-            dss: &rustls_crate::DigitallySignedStruct,
-        ) -> Result<danger::HandshakeSignatureValid, rustls_crate::Error> {
-            rustls_crate::crypto::verify_tls12_signature(
-                message,
-                cert,
-                dss,
-                &default_crypto_provider()?.signature_verification_algorithms,
-            )
-        }
-
-        fn verify_tls13_signature(
-            &self,
-            message: &[u8],
-            cert: &CertificateDer<'_>,
-            dss: &rustls_crate::DigitallySignedStruct,
-        ) -> Result<danger::HandshakeSignatureValid, rustls_crate::Error> {
-            rustls_crate::crypto::verify_tls13_signature(
-                message,
-                cert,
-                dss,
-                &default_crypto_provider()?.signature_verification_algorithms,
-            )
-        }
-
-        fn supported_verify_schemes(&self) -> Vec<rustls_crate::SignatureScheme> {
-            default_crypto_provider()
-                .unwrap()
-                .signature_verification_algorithms
-                .supported_schemes()
+            _now: std::time::SystemTime,
+        ) -> Result<::rustls::client::ServerCertVerified, ::rustls::Error> {
+            Ok(::rustls::client::ServerCertVerified::assertion())
         }
     }
 }

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -12,8 +12,8 @@ exclude = ["corpus.tar.gz"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-rustls = "0.23"
-rustls-pemfile = "2"
+rustls = { version = "0.21", features = ["quic"] }
+rustls-pemfile = "1"
 s2n-codec = { version = "=0.35.0", path = "../../common/s2n-codec", default-features = false, features = ["alloc"] }
 s2n-quic-core = { version = "=0.35.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
 s2n-quic-crypto = { version = "=0.35.0", path = "../s2n-quic-crypto", default-features = false }

--- a/quic/s2n-quic-rustls/src/certificate.rs
+++ b/quic/s2n-quic-rustls/src/certificate.rs
@@ -102,6 +102,7 @@ mod pem {
         let parsers = [
             rustls_pemfile::rsa_private_keys,
             rustls_pemfile::pkcs8_private_keys,
+            rustls_pemfile::ec_private_keys,
         ];
 
         for parser in parsers.iter() {

--- a/quic/s2n-quic-rustls/src/cipher_suite.rs
+++ b/quic/s2n-quic-rustls/src/cipher_suite.rs
@@ -1,24 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use rustls::{
-    crypto::{aws_lc_rs, CryptoProvider},
-    quic, CipherSuite, SupportedCipherSuite,
-};
+use rustls::{cipher_suite as ciphers, quic, CipherSuite, SupportedCipherSuite};
 use s2n_codec::Encoder;
 use s2n_quic_core::crypto::{self, packet_protection, scatter, tls, HeaderProtectionMask, Key};
 
-/// `aws_lc_rs` is the default crypto provider since that is also the
-/// default used by rustls.
-pub fn default_crypto_provider() -> Result<CryptoProvider, rustls::Error> {
-    Ok(CryptoProvider {
-        cipher_suites: DEFAULT_CIPHERSUITES.to_vec(),
-        ..aws_lc_rs::default_provider()
-    })
-}
-
 pub struct PacketKey {
-    key: Box<dyn quic::PacketKey>,
+    key: quic::PacketKey,
     cipher_suite: tls::CipherSuite,
 }
 
@@ -171,7 +159,7 @@ impl crypto::Key for PacketKeys {
 
 impl crypto::HandshakeKey for PacketKeys {}
 
-pub struct HeaderProtectionKey(Box<dyn quic::HeaderProtectionKey>);
+pub struct HeaderProtectionKey(quic::HeaderProtectionKey);
 
 impl HeaderProtectionKey {
     /// Returns the header protection mask for the given ciphertext sample
@@ -343,10 +331,10 @@ impl crypto::OneRttKey for OneRttKey {
 //# negotiated unless a header protection scheme is defined for the
 //# cipher suite.
 // All of the cipher_suites from the current exported list have HP schemes for QUIC
-static DEFAULT_CIPHERSUITES: &[SupportedCipherSuite] = &[
-    aws_lc_rs::cipher_suite::TLS13_AES_128_GCM_SHA256,
-    aws_lc_rs::cipher_suite::TLS13_AES_256_GCM_SHA384,
-    aws_lc_rs::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
+pub static DEFAULT_CIPHERSUITES: &[SupportedCipherSuite] = &[
+    ciphers::TLS13_AES_128_GCM_SHA256,
+    ciphers::TLS13_AES_256_GCM_SHA384,
+    ciphers::TLS13_CHACHA20_POLY1305_SHA256,
 ];
 
 #[test]

--- a/quic/s2n-quic-rustls/src/client.rs
+++ b/quic/s2n-quic-rustls/src/client.rs
@@ -1,22 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{certificate, cipher_suite::default_crypto_provider, session::Session};
+use crate::{certificate, session::Session};
 use core::convert::TryFrom;
-use rustls::{ClientConfig, ConfigBuilder, WantsVerifier};
+use rustls::ClientConfig;
 use s2n_codec::EncoderValue;
 use s2n_quic_core::{application::ServerName, crypto::tls};
 use std::sync::Arc;
-
-/// Create a QUIC client specific [rustls::ConfigBuilder].
-///
-/// Uses aws_lc_rs as the crypto provider and sets QUIC specific protocol versions.
-pub fn default_config_builder() -> Result<ConfigBuilder<ClientConfig, WantsVerifier>, rustls::Error>
-{
-    let tls13_cipher_suite_crypto_provider = default_crypto_provider()?;
-    ClientConfig::builder_with_provider(tls13_cipher_suite_crypto_provider.into())
-        .with_protocol_versions(crate::PROTOCOL_VERSIONS)
-}
 
 #[derive(Clone)]
 pub struct Client {
@@ -75,8 +65,8 @@ impl tls::Endpoint for Client {
         //# Endpoints MUST send the quic_transport_parameters extension;
         let transport_parameters = transport_parameters.encode_to_vec();
 
-        let rustls_server_name = rustls::pki_types::ServerName::try_from(server_name.to_string())
-            .expect("invalid server name");
+        let rustls_server_name =
+            rustls::ServerName::try_from(server_name.as_ref()).expect("invalid server name");
 
         let session = rustls::quic::ClientConnection::new(
             self.config.clone(),
@@ -124,7 +114,7 @@ impl Builder {
             rustls::Error::General("Certificate chain needs to have at least one entry".to_string())
         })?;
         self.cert_store
-            .add(root_certificate.to_owned())
+            .add(root_certificate)
             .map_err(|err| rustls::Error::General(err.to_string()))?;
         Ok(self)
     }
@@ -158,7 +148,10 @@ impl Builder {
             ));
         }
 
-        let mut config = default_config_builder()?
+        let mut config = ClientConfig::builder()
+            .with_cipher_suites(crate::cipher_suite::DEFAULT_CIPHERSUITES)
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(crate::PROTOCOL_VERSIONS)?
             .with_root_certificates(self.cert_store)
             .with_no_client_auth();
 

--- a/quic/s2n-quic-rustls/src/error.rs
+++ b/quic/s2n-quic-rustls/src/error.rs
@@ -12,6 +12,7 @@ pub fn reason(error: rustls::Error) -> &'static str {
         Error::DecryptError => "cannot decrypt peer's message",
         Error::EncryptError => "cannot encrypt local message",
         Error::AlertReceived(_) => "received fatal alert",
+        Error::InvalidSct(_) => "invalid certificate timestamp",
         Error::FailedToGetCurrentTime => "failed to get current time",
         Error::FailedToGetRandomBytes => "failed to get random bytes",
         Error::HandshakeNotComplete => "handshake not complete",
@@ -19,12 +20,6 @@ pub fn reason(error: rustls::Error) -> &'static str {
         Error::NoApplicationProtocol => "peer doesn't support any known protocol",
         Error::BadMaxFragmentSize => "bad max fragment size",
         Error::General(_) => "unexpected error",
-        Error::InvalidMessage(_) => "invalid message received",
-        Error::PeerIncompatible(_) => "peer doesn't support a protocol version/feature",
-        Error::PeerMisbehaved(_) => "peer TLS protocol error",
-        Error::InvalidCertificate(_) => "invalid certificate",
-        Error::InvalidCertRevocationList(_) => "invalid crl",
-        Error::Other(_) => "some other error occurred",
         // rustls may add a new variant in the future that breaks us so do a wildcard
         #[allow(unreachable_patterns)]
         _ => "unexpected error",

--- a/quic/s2n-quic-rustls/src/lib.rs
+++ b/quic/s2n-quic-rustls/src/lib.rs
@@ -3,8 +3,7 @@
 
 #![forbid(unsafe_code)]
 
-// re-export rustls
-pub use rustls;
+pub use rustls::{self, Certificate, PrivateKey};
 
 mod cipher_suite;
 mod error;
@@ -14,9 +13,9 @@ pub mod certificate;
 pub mod client;
 pub mod server;
 
-pub use cipher_suite::default_crypto_provider;
-pub use client::{default_config_builder as client_config_builder, Client};
-pub use server::{default_config_builder as server_config_builder, Server};
+pub use cipher_suite::DEFAULT_CIPHERSUITES;
+pub use client::Client;
+pub use server::Server;
 
 //= https://www.rfc-editor.org/rfc/rfc9001#section-4.2
 //# Clients MUST NOT offer TLS versions older than 1.3.
@@ -40,52 +39,6 @@ mod tests {
 
         let mut server = server::Builder::new()
             .with_certificate(CERT_PEM, KEY_PEM)
-            .unwrap()
-            .build()
-            .unwrap();
-
-        let mut pair = tls::testing::Pair::new(&mut server, &mut client, "localhost".into());
-
-        while pair.is_handshaking() {
-            pair.poll(None).unwrap();
-        }
-
-        pair.finish();
-    }
-
-    #[test]
-    fn client_server_der_test() {
-        let mut client = client::Builder::new()
-            .with_certificate(CERT_DER)
-            .unwrap()
-            .build()
-            .unwrap();
-
-        let mut server = server::Builder::new()
-            .with_certificate(CERT_DER, KEY_DER)
-            .unwrap()
-            .build()
-            .unwrap();
-
-        let mut pair = tls::testing::Pair::new(&mut server, &mut client, "localhost".into());
-
-        while pair.is_handshaking() {
-            pair.poll(None).unwrap();
-        }
-
-        pair.finish();
-    }
-
-    #[test]
-    fn client_server_pkcs1_test() {
-        let mut client = client::Builder::new()
-            .with_certificate(CERT_PKCS1_PEM)
-            .unwrap()
-            .build()
-            .unwrap();
-
-        let mut server = server::Builder::new()
-            .with_certificate(CERT_PKCS1_PEM, KEY_PKCS1_PEM)
             .unwrap()
             .build()
             .unwrap();

--- a/quic/s2n-quic-rustls/src/server.rs
+++ b/quic/s2n-quic-rustls/src/server.rs
@@ -1,21 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{certificate, cipher_suite::default_crypto_provider, session::Session};
-use rustls::{crypto::aws_lc_rs, ConfigBuilder, ServerConfig, WantsVerifier};
+use crate::{certificate, session::Session};
+use rustls::ServerConfig;
 use s2n_codec::EncoderValue;
 use s2n_quic_core::{application::ServerName, crypto::tls};
 use std::sync::Arc;
-
-/// Create a QUIC server specific [rustls::ConfigBuilder].
-///
-/// Uses aws_lc_rs as the crypto provider and sets QUIC specific protocol versions.
-pub fn default_config_builder() -> Result<ConfigBuilder<ServerConfig, WantsVerifier>, rustls::Error>
-{
-    let tls13_cipher_suite_crypto_provider = default_crypto_provider()?;
-    ServerConfig::builder_with_provider(tls13_cipher_suite_crypto_provider.into())
-        .with_protocol_versions(crate::PROTOCOL_VERSIONS)
-}
 
 #[derive(Clone)]
 pub struct Server {
@@ -143,7 +133,11 @@ impl Builder {
     }
 
     pub fn build(self) -> Result<Server, rustls::Error> {
-        let builder = default_config_builder()?.with_no_client_auth();
+        let builder = ServerConfig::builder()
+            .with_cipher_suites(crate::cipher_suite::DEFAULT_CIPHERSUITES)
+            .with_safe_default_kx_groups()
+            .with_protocol_versions(crate::PROTOCOL_VERSIONS)?
+            .with_no_client_auth();
 
         let mut config = if let Some(cert_resolver) = self.cert_resolver {
             builder.with_cert_resolver(cert_resolver)
@@ -165,7 +159,6 @@ impl Builder {
     }
 }
 
-#[derive(Debug)]
 struct AlwaysResolvesChain(Arc<rustls::sign::CertifiedKey>);
 
 impl AlwaysResolvesChain {
@@ -173,7 +166,7 @@ impl AlwaysResolvesChain {
         chain: certificate::Certificate,
         priv_key: certificate::PrivateKey,
     ) -> Result<Self, rustls::Error> {
-        let key = aws_lc_rs::sign::any_supported_type(&priv_key.0)
+        let key = rustls::sign::any_supported_type(&priv_key.0)
             .map_err(|_| rustls::Error::General("invalid private key".into()))?;
         Ok(Self(Arc::new(rustls::sign::CertifiedKey::new(
             chain.0, key,

--- a/quic/s2n-quic-rustls/src/session.rs
+++ b/quic/s2n-quic-rustls/src/session.rs
@@ -6,7 +6,9 @@ use crate::cipher_suite::{
 };
 use bytes::Bytes;
 use core::{fmt, fmt::Debug, task::Poll};
-use rustls::quic::{self, Connection};
+use rustls::quic::{
+    Connection, {self},
+};
 use s2n_quic_core::{
     application::ServerName,
     crypto::{self, tls, tls::CipherSuite},
@@ -102,12 +104,9 @@ impl Session {
 
                 self.connection
                     .alert()
-                    .map(|alert| {
-                        // Explicitly annotate the type to detect if rustls starts
-                        // returning a large array
-                        let code: [u8; 1] = alert.to_array();
-                        let code = code[0];
-                        tls::Error { code, reason }
+                    .map(|alert| tls::Error {
+                        code: alert.get_u8(),
+                        reason,
                     })
                     .unwrap_or(tls::Error::INTERNAL_ERROR)
             })?;


### PR DESCRIPTION
This reverts commit 15f234c495f98cf61652cf70e8dbc3c7565098b4.


### Description of changes: 
See https://github.com/aws/s2n-quic/issues/2173 for more details.

### Call-outs:

Needed to add a new pem parser, `rustls_pemfile::ec_private_keys`, since the interop runner has started using new EC based keys and we were [not able to parse them](https://github.com/aws/s2n-quic/actions/runs/8573119698/job/23497429453?pr=2174#step:13:156). But also because this prob should have been present from the beginning.

### Testing:
Existing CI should pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

