### PR TITLE
 feat(s2n-quic): allow disabling active connection migration support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-03-21
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-04-16
   CDN: https://dnglbrstg7yg.cloudfront.net
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -111,7 +111,7 @@ impl Limits {
             max_keep_alive_period: MAX_KEEP_ALIVE_PERIOD_DEFAULT,
             max_datagram_frame_size: MaxDatagramFrameSize::DEFAULT,
             initial_round_trip_time: recovery::DEFAULT_INITIAL_RTT,
-            migration_support: MigrationSupport::default(),
+            migration_support: MigrationSupport::RECOMMENDED,
         }
     }
 
@@ -242,7 +242,10 @@ impl Limits {
     ///
     /// If set to false, the `disable_active_migration` transport parameter will be sent to the
     /// peer, and any attempt by the peer to perform an active connection migration will be ignored.
-    pub fn with_connection_migration(mut self, enabled: bool) -> Result<Self, ValidationError> {
+    pub fn with_active_connection_migration(
+        mut self,
+        enabled: bool,
+    ) -> Result<Self, ValidationError> {
         if enabled {
             self.migration_support = MigrationSupport::Enabled
         } else {

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -238,7 +238,7 @@ impl Limits {
         Duration
     );
     setter!(with_max_keep_alive_period, max_keep_alive_period, Duration);
-    /// Sets if active connection migration is supported for a server endpoint (default: true)
+    /// Sets whether active connection migration is supported for a server endpoint (default: true)
     ///
     /// If set to false, the `disable_active_migration` transport parameter will be sent to the
     /// peer, and any attempt by the peer to perform an active connection migration will be ignored.

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -9,7 +9,7 @@ use crate::{
         AckDelayExponent, ActiveConnectionIdLimit, InitialFlowControlLimits, InitialMaxData,
         InitialMaxStreamDataBidiLocal, InitialMaxStreamDataBidiRemote, InitialMaxStreamDataUni,
         InitialMaxStreamsBidi, InitialMaxStreamsUni, InitialStreamLimits, MaxAckDelay,
-        MaxDatagramFrameSize, MaxIdleTimeout, TransportParameters,
+        MaxDatagramFrameSize, MaxIdleTimeout, MigrationSupport, TransportParameters,
     },
 };
 use core::time::Duration;
@@ -66,6 +66,7 @@ pub struct Limits {
     pub(crate) max_keep_alive_period: Duration,
     pub(crate) max_datagram_frame_size: MaxDatagramFrameSize,
     pub(crate) initial_round_trip_time: Duration,
+    pub(crate) migration_support: MigrationSupport,
 }
 
 impl Default for Limits {
@@ -110,6 +111,7 @@ impl Limits {
             max_keep_alive_period: MAX_KEEP_ALIVE_PERIOD_DEFAULT,
             max_datagram_frame_size: MaxDatagramFrameSize::DEFAULT,
             initial_round_trip_time: recovery::DEFAULT_INITIAL_RTT,
+            migration_support: MigrationSupport::default(),
         }
     }
 
@@ -236,6 +238,18 @@ impl Limits {
         Duration
     );
     setter!(with_max_keep_alive_period, max_keep_alive_period, Duration);
+    /// Sets if active connection migration is supported for a server endpoint (default: true)
+    ///
+    /// If set to false, the `disable_active_migration` transport parameter will be sent to the
+    /// peer, and any attempt by the peer to perform an active connection migration will be ignored.
+    pub fn with_connection_migration(mut self, enabled: bool) -> Result<Self, ValidationError> {
+        if enabled {
+            self.migration_support = MigrationSupport::Enabled
+        } else {
+            self.migration_support = MigrationSupport::Disabled
+        }
+        Ok(self)
+    }
 
     /// Sets the initial round trip time (RTT) for use in recovery mechanisms prior to
     /// measuring an actual RTT sample.
@@ -334,6 +348,12 @@ impl Limits {
     #[inline]
     pub fn initial_round_trip_time(&self) -> Duration {
         self.initial_round_trip_time
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn active_migration_enabled(&self) -> bool {
+        matches!(self.migration_support, MigrationSupport::Enabled)
     }
 }
 

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -853,11 +853,16 @@ impl TransportParameterValidator for MaxAckDelay {
 //#    active connection migration (Section 9) on the address being used
 //#    during the handshake.
 
-#[derive(Clone, Copy, Debug, Default, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum MigrationSupport {
-    #[default]
     Enabled,
     Disabled,
+}
+
+impl MigrationSupport {
+    pub const fn default() -> Self {
+        MigrationSupport::Enabled
+    }
 }
 
 impl TransportParameter for MigrationSupport {
@@ -878,7 +883,7 @@ impl TransportParameter for MigrationSupport {
     }
 
     fn default_value() -> Self {
-        MigrationSupport::Enabled
+        Self::default()
     }
 }
 
@@ -1462,5 +1467,6 @@ impl<
         load!(ack_delay_exponent, ack_delay_exponent);
         load!(max_active_connection_ids, active_connection_id_limit);
         load!(max_datagram_frame_size, max_datagram_frame_size);
+        load!(migration_support, migration_support);
     }
 }

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -853,16 +853,15 @@ impl TransportParameterValidator for MaxAckDelay {
 //#    active connection migration (Section 9) on the address being used
 //#    during the handshake.
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum MigrationSupport {
+    #[default]
     Enabled,
     Disabled,
 }
 
 impl MigrationSupport {
-    pub const fn default() -> Self {
-        MigrationSupport::Enabled
-    }
+    pub const RECOMMENDED: Self = Self::Enabled;
 }
 
 impl TransportParameter for MigrationSupport {

--- a/quic/s2n-quic-tls/src/tests.rs
+++ b/quic/s2n-quic-tls/src/tests.rs
@@ -403,7 +403,7 @@ fn s2n_client_no_client_auth_s2n_server_requires_client_auth_test() {
     // but the client does not support it.
     assert!(test_result.is_err());
     let e = test_result.unwrap_err();
-    assert_eq!(e.description().unwrap(), "UNEXPECTED_MESSAGE");
+    assert_eq!(e.description().unwrap(), "CERTIFICATE_REQUIRED");
 }
 
 #[test]

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1154,7 +1154,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             congestion_controller_endpoint,
             path_migration,
             mtu_config,
-            self.limits.initial_round_trip_time(),
+            &self.limits,
             &mut publisher,
         )?;
 

--- a/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
@@ -15,7 +15,6 @@ use s2n_quic_core::{
     inet::{DatagramInfo, ExplicitCongestionNotification},
     random,
     random::testing::Generator,
-    recovery::DEFAULT_INITIAL_RTT,
     time::{testing::Clock, Clock as _},
     transport,
 };
@@ -178,7 +177,7 @@ impl Model {
             &mut Default::default(),
             &mut migration_validator,
             mtu::Config::default(),
-            DEFAULT_INITIAL_RTT,
+            &Limits::default(),
             &mut publisher,
         ) {
             Ok(_) => {

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__active_connection_migration_disabled.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__active_connection_migration_disabled.snap
@@ -1,0 +1,7 @@
+---
+source: quic/s2n-quic-transport/src/path/manager/tests.rs
+expression: ""
+---
+ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x01, current: 0x69643032 }
+PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:1, remote_cid: 0x69643032, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x69643032, remote_addr: 127.0.0.2:1, remote_cid: 0x69643033, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__active_connection_migration_disabled.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__active_connection_migration_disabled.snap
@@ -5,3 +5,5 @@ expression: ""
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x01, current: 0x69643032 }
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:1, remote_cid: 0x69643032, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x69643032, remote_addr: 127.0.0.2:1, remote_cid: 0x69643033, id: 1, is_active: false } }
 MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:1, remote_cid: 0x69643032, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.3:1, remote_cid: 0x69643032, id: 2, is_active: false } }
+MtuUpdated { path_id: 2, mtu: 1200, cause: NewPath }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__active_connection_migration_disabled_passive_migration.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__active_connection_migration_disabled_passive_migration.snap
@@ -1,0 +1,6 @@
+---
+source: quic/s2n-quic-transport/src/path/manager/tests.rs
+expression: ""
+---
+PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:1, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:1, remote_cid: 0x01, id: 1, is_active: false } }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__active_connection_migration_disabled_passive_migration.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__active_connection_migration_disabled_passive_migration.snap
@@ -1,6 +1,0 @@
----
-source: quic/s2n-quic-transport/src/path/manager/tests.rs
-expression: ""
----
-PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:1, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:1, remote_cid: 0x01, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -1021,7 +1021,9 @@ fn active_connection_migration_disabled() {
         &mut migration::allow_all::Validator,
         mtu::Config::default(),
         // Active connection migration is disabled
-        &Limits::default().with_active_connection_migration(false).unwrap(),
+        &Limits::default()
+            .with_active_connection_migration(false)
+            .unwrap(),
         &mut publisher,
     );
 
@@ -1063,7 +1065,9 @@ fn active_connection_migration_disabled() {
         &mut migration::allow_all::Validator,
         mtu::Config::default(),
         // Active connection migration is disabled
-        &Limits::default().with_active_connection_migration(false).unwrap(),
+        &Limits::default()
+            .with_active_connection_migration(false)
+            .unwrap(),
         &mut publisher,
     );
 

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -1021,7 +1021,7 @@ fn active_connection_migration_disabled() {
         &mut migration::allow_all::Validator,
         mtu::Config::default(),
         // Active connection migration is disabled
-        &Limits::default().with_connection_migration(false).unwrap(),
+        &Limits::default().with_active_connection_migration(false).unwrap(),
         &mut publisher,
     );
 
@@ -1063,7 +1063,7 @@ fn active_connection_migration_disabled() {
         &mut migration::allow_all::Validator,
         mtu::Config::default(),
         // Active connection migration is disabled
-        &Limits::default().with_connection_migration(false).unwrap(),
+        &Limits::default().with_active_connection_migration(false).unwrap(),
         &mut publisher,
     );
 

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -1011,6 +1011,7 @@ fn active_connection_migration_disabled() {
         source_connection_id: None,
     };
 
+    // First try an active migration with active migration disabled
     let res = manager.handle_connection_migration(
         &new_addr,
         &datagram,
@@ -1022,13 +1023,14 @@ fn active_connection_migration_disabled() {
         &mut publisher,
     );
 
+    // The active migration is rejected
     assert!(matches!(
         res,
         Err(DatagramDropReason::RejectedConnectionMigration)
     ));
     assert_eq!(1, manager.paths.len());
 
-    // Active connection migration is enabled (default)
+    // Try an active connection migration with active migration enabled (default)
     let res = manager.handle_connection_migration(
         &new_addr,
         &datagram,
@@ -1039,10 +1041,11 @@ fn active_connection_migration_disabled() {
         &mut publisher,
     );
 
+    // The migration succeeds
     assert!(res.is_ok());
     assert_eq!(2, manager.paths.len());
 
-    // Now try a non-active (passive) migration
+    // Now try a non-active (passive) migration, with active migration disabled
     // the same CID is used, so it's not an active migration
     datagram.destination_connection_id = connection::LocalId::TEST_ID;
     let new_addr: SocketAddr = "127.0.0.3:1".parse().unwrap();
@@ -1062,6 +1065,7 @@ fn active_connection_migration_disabled() {
         &mut publisher,
     );
 
+    // The passive migration succeeds
     assert!(res.is_ok());
     assert_eq!(3, manager.paths.len());
 }

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -988,6 +988,8 @@ fn active_connection_migration_disabled() {
     );
     let mut manager = manager_server(first_path);
     // Give the path manager some new CIDs so it's able to use one for an active migration
+    // id_2 will be moved to `InUse` immediately due to the handshake CID rotation feature,
+    // so id_3 is added as well to have an unused CID available for connection migration
     let id_2 = connection::PeerId::try_from_bytes(b"id02").unwrap();
     assert!(manager
         .on_new_connection_id(&id_2, 1, 0, &TEST_TOKEN_1, &mut publisher)

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -987,7 +987,7 @@ fn active_connection_migration_disabled() {
         mtu::Config::default(),
     );
     let mut manager = manager_server(first_path);
-    // Give the path manager soms new CIDs so it's able to use one for an active migration
+    // Give the path manager some new CIDs so it's able to use one for an active migration
     let id_2 = connection::PeerId::try_from_bytes(b"id02").unwrap();
     assert!(manager
         .on_new_connection_id(&id_2, 1, 0, &TEST_TOKEN_1, &mut publisher)

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -987,7 +987,7 @@ fn active_connection_migration_disabled() {
         mtu::Config::default(),
     );
     let mut manager = manager_server(first_path);
-    // Give the path manager some new CIDs so it's able to use one for an active migration
+    // Give the path manager some new CIDs so it's able to use one for an active migration.
     // id_2 will be moved to `InUse` immediately due to the handshake CID rotation feature,
     // so id_3 is added as well to have an unused CID available for connection migration
     let id_2 = connection::PeerId::try_from_bytes(b"id02").unwrap();

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -17,7 +17,7 @@ use s2n_quic_core::{
     inet::{DatagramInfo, ExplicitCongestionNotification, SocketAddress},
     path::{migration, RemoteAddress},
     random::{self, Generator},
-    recovery::{RttEstimator, DEFAULT_INITIAL_RTT},
+    recovery::RttEstimator,
     stateless_reset::token::testing::*,
     time::{Clock, NoopClock},
 };
@@ -736,7 +736,7 @@ fn test_adding_new_path() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default(),
-            DEFAULT_INITIAL_RTT,
+            &Limits::default(),
             &mut publisher,
         )
         .unwrap();
@@ -797,7 +797,7 @@ fn do_not_add_new_path_if_handshake_not_confirmed() {
         &mut Default::default(),
         &mut migration::allow_all::Validator,
         mtu::Config::default(),
-        DEFAULT_INITIAL_RTT,
+        &Limits::default(),
         &mut publisher,
     );
 
@@ -859,7 +859,7 @@ fn do_not_add_new_path_if_client() {
         &mut Default::default(),
         &mut migration::allow_all::Validator,
         mtu::Config::default(),
-        DEFAULT_INITIAL_RTT,
+        &Limits::default(),
         &mut publisher,
     );
 
@@ -950,7 +950,7 @@ fn limit_number_of_connection_migrations() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default(),
-            DEFAULT_INITIAL_RTT,
+            &Limits::default(),
             &mut publisher,
         );
         match res {
@@ -968,6 +968,130 @@ fn limit_number_of_connection_migrations() {
         }
     }
     assert_eq!(total_paths, MAX_ALLOWED_PATHS);
+}
+
+#[test]
+fn active_connection_migration_disabled() {
+    // Setup:
+    let mut publisher = Publisher::snapshot();
+    let new_addr: SocketAddr = "127.0.0.1:1".parse().unwrap();
+    let new_addr = SocketAddress::from(new_addr);
+    let new_addr = RemoteAddress::from(new_addr);
+    let first_path = ServerPath::new(
+        new_addr,
+        connection::PeerId::try_from_bytes(&[1]).unwrap(),
+        connection::LocalId::TEST_ID,
+        RttEstimator::default(),
+        Default::default(),
+        false,
+        mtu::Config::default(),
+    );
+    let mut manager = manager_server(first_path);
+    // Give the path manager soms new CIDs so it's able to use one for an active migration
+    let id_2 = connection::PeerId::try_from_bytes(b"id02").unwrap();
+    assert!(manager
+        .on_new_connection_id(&id_2, 1, 0, &TEST_TOKEN_1, &mut publisher)
+        .is_ok());
+    let id_3 = connection::PeerId::try_from_bytes(b"id03").unwrap();
+    assert!(manager
+        .on_new_connection_id(&id_3, 2, 0, &TEST_TOKEN_2, &mut publisher)
+        .is_ok());
+
+    let new_addr: SocketAddr = "127.0.0.2:1".parse().unwrap();
+    let new_addr = SocketAddress::from(new_addr);
+    let new_addr = RemoteAddress::from(new_addr);
+    let new_cid = connection::LocalId::try_from_bytes(b"id02").unwrap();
+    let now = NoopClock {}.get_time();
+    let datagram = DatagramInfo {
+        timestamp: now,
+        payload_len: 0,
+        ecn: ExplicitCongestionNotification::default(),
+        destination_connection_id: new_cid,
+        destination_connection_id_classification: connection::id::Classification::Local,
+        source_connection_id: None,
+    };
+
+    // Active connection migration is disabled
+    let limits = Limits::default().with_connection_migration(false).unwrap();
+
+    let res = manager.handle_connection_migration(
+        &new_addr,
+        &datagram,
+        &mut Default::default(),
+        &mut migration::allow_all::Validator,
+        mtu::Config::default(),
+        &limits,
+        &mut publisher,
+    );
+
+    assert!(matches!(
+        res,
+        Err(DatagramDropReason::RejectedConnectionMigration)
+    ));
+    assert_eq!(1, manager.paths.len());
+
+    // Active connection migration is enabled (default)
+    let res = manager.handle_connection_migration(
+        &new_addr,
+        &datagram,
+        &mut Default::default(),
+        &mut migration::allow_all::Validator,
+        mtu::Config::default(),
+        &Limits::default(),
+        &mut publisher,
+    );
+
+    assert!(res.is_ok());
+    assert_eq!(2, manager.paths.len());
+}
+
+#[test]
+fn active_connection_migration_disabled_passive_migration() {
+    // Setup:
+    let mut publisher = Publisher::snapshot();
+    let new_addr: SocketAddr = "127.0.0.1:1".parse().unwrap();
+    let new_addr = SocketAddress::from(new_addr);
+    let new_addr = RemoteAddress::from(new_addr);
+    let first_path = ServerPath::new(
+        new_addr,
+        connection::PeerId::try_from_bytes(&[1]).unwrap(),
+        connection::LocalId::TEST_ID,
+        RttEstimator::default(),
+        Default::default(),
+        false,
+        mtu::Config::default(),
+    );
+    let mut manager = manager_server(first_path);
+
+    let new_addr: SocketAddr = "127.0.0.2:1".parse().unwrap();
+    let new_addr = SocketAddress::from(new_addr);
+    let new_addr = RemoteAddress::from(new_addr);
+    let now = NoopClock {}.get_time();
+    let datagram = DatagramInfo {
+        timestamp: now,
+        payload_len: 0,
+        ecn: ExplicitCongestionNotification::default(),
+        // the same CID is used, so it's not an active migration
+        destination_connection_id: connection::LocalId::TEST_ID,
+        destination_connection_id_classification: connection::id::Classification::Local,
+        source_connection_id: None,
+    };
+
+    // Active connection migration is disabled
+    let limits = Limits::default().with_connection_migration(false).unwrap();
+
+    let res = manager.handle_connection_migration(
+        &new_addr,
+        &datagram,
+        &mut Default::default(),
+        &mut migration::allow_all::Validator,
+        mtu::Config::default(),
+        &limits,
+        &mut publisher,
+    );
+
+    assert!(res.is_ok());
+    assert_eq!(2, manager.paths.len());
 }
 
 #[test]
@@ -1009,7 +1133,7 @@ fn connection_migration_challenge_behavior() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default(),
-            DEFAULT_INITIAL_RTT,
+            &Limits::default(),
             &mut publisher,
         )
         .unwrap();
@@ -1105,7 +1229,7 @@ fn connection_migration_use_max_ack_delay_from_active_path() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default(),
-            DEFAULT_INITIAL_RTT,
+            &Limits::default(),
             &mut publisher,
         )
         .unwrap();
@@ -1184,7 +1308,7 @@ fn connection_migration_new_path_abandon_timer() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default(),
-            DEFAULT_INITIAL_RTT,
+            &Limits::default(),
             &mut publisher,
         )
         .unwrap();
@@ -1460,7 +1584,7 @@ fn temporary_until_authenticated() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default(),
-            DEFAULT_INITIAL_RTT,
+            &Limits::default(),
             &mut publisher,
         )
         .unwrap();
@@ -1483,7 +1607,7 @@ fn temporary_until_authenticated() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default(),
-            DEFAULT_INITIAL_RTT,
+            &Limits::default(),
             &mut publisher,
         )
         .unwrap();
@@ -1521,7 +1645,7 @@ fn temporary_until_authenticated() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default(),
-            DEFAULT_INITIAL_RTT,
+            &Limits::default(),
             &mut publisher,
         )
         .unwrap();

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -14,6 +14,7 @@ use bolero::TypeGenerator;
 use core::{ops::RangeInclusive, time::Duration};
 use s2n_quic_core::{
     ack, connection,
+    connection::Limits,
     event::testing::Publisher,
     frame::ack_elicitation::AckElicitation,
     inet::{DatagramInfo, ExplicitCongestionNotification, SocketAddress},
@@ -3359,7 +3360,7 @@ fn helper_generate_multi_path_manager(
                 &mut Endpoint::default(),
                 &mut migration::allow_all::Validator,
                 mtu::Config::default(),
-                DEFAULT_INITIAL_RTT,
+                &Limits::default(),
                 publisher,
             )
             .unwrap();

--- a/tools/xdp/ebpf/rust-toolchain.toml
+++ b/tools/xdp/ebpf/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # pin the version to prevent random breakage
-channel = "nightly-2024-03-05"
+channel = "nightly-2024-04-16"
 # The source code of rustc, provided by the rust-src component, is needed for
 # building eBPF programs.
 components = [ "rustc", "cargo", "rust-src" ]


### PR DESCRIPTION
### Description of changes: 

This change adds a `with_connection_migration(enabled: bool)` setting to the default connection limiter provider. When set to `false`, the `disable_active_migration` transport parameter will be sent to the peer, and any attempt by the peer to perform an active connection migration will be ignored.

The definition of "active connection migration" is the peer sending from a different source address while also changing the destination connection ID it was using previously. This is in contrast to a passive cnonection migration (caused by a NAT rebind or similar), where the peer would not know its source address changed, and thus would not change the destination connection ID.

### Call-outs:

I went back and forth on whether this belonged in the path migration validator provider, but ultimately decided against it since: 
1) The path migration validator provider is not currently exposed as an option when building an endpoint
2) Even if it was exposed, the logic of determining if a connection migration attempt was "active" or not is not something that should be left up to the application, as it is internal to QUIC. 

### Testing:

Added unit tests

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

