### PR TITLE
feat(s2n-quic-core): Add ability to create an incremental reader initialized with an offset

### DIFF
--- a/quic/s2n-quic-core/src/buffer/reader/incremental.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/incremental.rs
@@ -12,7 +12,7 @@ use crate::{
 
 /// Implements an incremental [`Reader`] that joins to temporary [`Storage`] as the stream data
 ///
-/// This is useful for scenarios where the the stream isn't completely buffered in memory and
+/// This is useful for scenarios where the stream isn't completely buffered in memory and
 /// data come in gradually.
 #[derive(Debug, Default)]
 pub struct Incremental {
@@ -21,6 +21,14 @@ pub struct Incremental {
 }
 
 impl Incremental {
+    #[inline]
+    pub fn new(current_offset: VarInt) -> Self {
+        Self {
+            current_offset,
+            final_offset: None,
+        }
+    }
+
     #[inline]
     pub fn with_storage<'a, C: Storage>(
         &'a mut self,

--- a/quic/s2n-quic-core/src/buffer/reader/incremental.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/incremental.rs
@@ -180,5 +180,8 @@ mod tests {
             assert!(reader.buffer_is_empty());
             assert!(reader.is_consumed());
         }
+
+        let incremental = Incremental::new(VarInt::from_u8(100));
+        assert_eq!(incremental.current_offset(), VarInt::from_u8(100));
     }
 }


### PR DESCRIPTION
### Description of changes: 

This change adds a `new` method to the incremental `reader` to allow starting at an offset other than 0. 

### Testing:

Added to existing unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

