### PR TITLE
feat(s2n-quic-provider): make some message methods public

### DIFF
--- a/quic/s2n-quic-platform/src/message.rs
+++ b/quic/s2n-quic-platform/src/message.rs
@@ -46,13 +46,13 @@ impl Storage {
     }
 
     #[inline]
-    pub(crate) fn as_ptr(&self) -> *mut u8 {
+    pub fn as_ptr(&self) -> *mut u8 {
         self.ptr.as_ptr()
     }
 
     /// Asserts that the pointer is in bounds of the allocation
     #[inline]
-    pub(crate) fn check_bounds<T: Sized>(&self, ptr: *mut T) {
+    pub fn check_bounds<T: Sized>(&self, ptr: *mut T) {
         let start = self.as_ptr();
         let end = unsafe {
             // Safety: pointer is allocated with the self.layout

--- a/quic/s2n-quic-platform/src/message/simple.rs
+++ b/quic/s2n-quic-platform/src/message/simple.rs
@@ -21,12 +21,12 @@ pub struct Message {
 
 impl Message {
     #[inline]
-    pub(crate) fn remote_address(&self) -> &SocketAddress {
+    pub fn remote_address(&self) -> &SocketAddress {
         &self.address
     }
 
     #[inline]
-    pub(crate) fn set_remote_address(&mut self, remote_address: &SocketAddress) {
+    pub fn set_remote_address(&mut self, remote_address: &SocketAddress) {
         let remote_address = *remote_address;
 
         self.address = remote_address;


### PR DESCRIPTION
The need is described in https://github.com/aws/s2n-quic/issues/2188.

This is the minimal change I needed to implement my own custom io provider. 

### Resolved issues:

resolves #2188

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

