### PR TITLE
Remove --cfg s2n_quic_unstable

### DIFF
--- a/examples/custom-congestion-controller/README.md
+++ b/examples/custom-congestion-controller/README.md
@@ -5,11 +5,9 @@ This folder contains an example of implementing and configuring a custom congest
 
 # Set-up
 
-The `CongestionController` trait is considered unstable and may be subject to change in a future release. In order to build it you must pass a compiler flag:
-```sh
-export RUSTFLAGS="--cfg s2n_quic_unstable"
-```
-and add this line to your Cargo.toml file:
+The `CongestionController` trait is considered unstable and may be subject to change in a future release. In order to build it you must
+add this line to your Cargo.toml file:
+
 ```toml
 [dependencies]
 s2n-quic = { version = "1", features = ["unstable-congestion-controller"]}

--- a/examples/post-quantum/README.md
+++ b/examples/post-quantum/README.md
@@ -1,16 +1,16 @@
 # post-quantum example
 
-When using `s2n-tls` as the TLS provider, `s2n-quic` supports post-quantum key shares. However, because the key share algorithms are going through the standardization process, this functionality is disabled by default. It can be enabled by passing a few compiler flags:
+When using `s2n-tls` as the TLS provider, `s2n-quic` supports post-quantum key shares. However, because the key share algorithms are going through the standardization process, this functionality is disabled by default. It can be enabled by passing a compiler flag:
 
 ```sh
-export RUSTFLAGS=`--cfg s2n_quic_unstable --cfg s2n_quic_enable_pq_tls`
+export RUSTFLAGS=`--cfg s2n_quic_enable_pq_tls`
 ```
 
 You can also add a `.cargo/config.toml` to the project (as done in this example):
 
 ```toml
 [build]
-rustflags=['--cfg', 's2n_quic_unstable', '--cfg', 's2n_quic_enable_pq_tls']
+rustflags=['--cfg', 's2n_quic_enable_pq_tls']
 ```
 
 ## Running the example

--- a/examples/resumption/README.md
+++ b/examples/resumption/README.md
@@ -4,11 +4,8 @@ This folder contains example code to do resumption handshakes in s2n-quic. This 
 
 # Set-up
 
-Currently resumption is disabled by default as it is still in development. It can be enabled by passing a compiler flag:
-```sh
-export RUSTFLAGS="--cfg s2n_quic_unstable"
-```
-and adding this line to your Cargo.toml file:
+Currently resumption is disabled by default as it is still in development. It can be enabled by adding this line to your Cargo.toml file:
+
 ```toml
 [dependencies]
 s2n-quic = { version = "1", features = ["unstable-resumption"]}

--- a/examples/unreliable-datagram/README.md
+++ b/examples/unreliable-datagram/README.md
@@ -8,11 +8,9 @@ This folder contains an example of sending and receiving an 'unreliable datagram
 
 # Set-up
 
-Currently the unreliable datagram functionality is disabled by default as it is still in development. It can be enabled by passing a compiler flag:
-```sh
-export RUSTFLAGS="--cfg s2n_quic_unstable"
-```
-and adding this line to your Cargo.toml file:
+Currently the unreliable datagram functionality is disabled by default as it is still in development,
+it can be enabled with a Cargo feature set in your Cargo.toml file:
+
 ```toml
 [dependencies]
 s2n-quic = { version = "1", features = ["unstable-provider-datagram"]}

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -46,7 +46,7 @@ mimalloc = { version = "0.1", default-features = false }
 
 # Use unstable s2n-quic features
 # unstable_client_hello and unstable_resumption use s2n-tls, and thus are only enabled for unix platforms
-[target.'cfg(all(any(s2n_quic_unstable, s2n_internal_dev), unix))'.dependencies]
+[target.'cfg(all(s2n_internal_dev, unix))'.dependencies]
 s2n-quic = { path = "../s2n-quic", features = ["unstable_client_hello", "unstable_resumption"] }
-[target.'cfg(any(s2n_quic_unstable, s2n_internal_dev))'.dependencies]
+[target.'cfg(s2n_internal_dev)'.dependencies]
 s2n-quic = { path = "../s2n-quic", features = ["unstable-provider-packet-interceptor"] }

--- a/quic/s2n-quic-qns/src/server.rs
+++ b/quic/s2n-quic-qns/src/server.rs
@@ -5,7 +5,7 @@ mod h09;
 mod h3;
 pub mod interop;
 pub mod perf;
-#[cfg(all(s2n_quic_unstable, feature = "unstable_client_hello"))]
+#[cfg(feature = "unstable_client_hello")]
 mod unstable;
 
 pub use interop::Interop;

--- a/quic/s2n-quic-qns/src/tls.rs
+++ b/quic/s2n-quic-qns/src/tls.rs
@@ -37,10 +37,9 @@ impl Server {
             .with_key_logging()?;
 
         cfg_if::cfg_if! {
-            if #[cfg(all(
-                s2n_quic_unstable,
+            if #[cfg(
                 feature = "unstable_client_hello"
-            ))] {
+            )] {
                 use super::unstable::MyClientHelloHandler;
                 let tls = tls.with_client_hello_handler(MyClientHelloHandler {})?;
             }

--- a/quic/s2n-quic-tls/src/certificate.rs
+++ b/quic/s2n-quic-tls/src/certificate.rs
@@ -109,5 +109,5 @@ macro_rules! cert_type {
 cert_type!(PrivateKey, IntoPrivateKey, into_private_key);
 cert_type!(Certificate, IntoCertificate, into_certificate);
 
-#[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_private_key")))]
+#[cfg(any(test, feature = "unstable_private_key"))]
 pub const OFFLOAD_PRIVATE_KEY: PrivateKey = PrivateKey(Format::None);

--- a/quic/s2n-quic-tls/src/lib.rs
+++ b/quic/s2n-quic-tls/src/lib.rs
@@ -8,9 +8,9 @@ use s2n_quic_core::application::ServerName;
 #[global_allocator]
 static ALLOCATOR: checkers::Allocator = checkers::Allocator::system();
 
-#[cfg(all(s2n_quic_unstable, s2n_quic_enable_pq_tls))]
+#[cfg(s2n_quic_enable_pq_tls)]
 static DEFAULT_POLICY: &s2n_tls::security::Policy = &s2n_tls::security::TESTING_PQ;
-#[cfg(not(all(s2n_quic_unstable, s2n_quic_enable_pq_tls)))]
+#[cfg(not(s2n_quic_enable_pq_tls))]
 static DEFAULT_POLICY: &s2n_tls::security::Policy = &s2n_tls::security::DEFAULT_TLS13;
 
 #[non_exhaustive]

--- a/quic/s2n-quic-tls/src/server.rs
+++ b/quic/s2n-quic-tls/src/server.rs
@@ -10,9 +10,9 @@ use crate::{
 };
 use s2n_codec::EncoderValue;
 use s2n_quic_core::{application::ServerName, crypto::tls, endpoint};
-#[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_client_hello")))]
+#[cfg(any(test, feature = "unstable_client_hello"))]
 use s2n_tls::callbacks::ClientHelloCallback;
-#[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_private_key")))]
+#[cfg(any(test, feature = "unstable_private_key"))]
 use s2n_tls::callbacks::PrivateKeyCallback;
 use s2n_tls::{
     callbacks::VerifyHostNameCallback,
@@ -98,7 +98,7 @@ impl Builder {
         &mut self.config
     }
 
-    #[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_client_hello")))]
+    #[cfg(any(test, feature = "unstable_client_hello"))]
     pub fn with_client_hello_handler<T: 'static + ClientHelloCallback>(
         mut self,
         handler: T,
@@ -107,7 +107,7 @@ impl Builder {
         Ok(self)
     }
 
-    #[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_private_key")))]
+    #[cfg(any(test, feature = "unstable_private_key"))]
     pub fn with_private_key_handler<T: 'static + PrivateKeyCallback>(
         mut self,
         handler: T,

--- a/quic/s2n-quic-tls/src/tests.rs
+++ b/quic/s2n-quic-tls/src/tests.rs
@@ -16,9 +16,9 @@ use s2n_quic_core::{
     },
     transport,
 };
-#[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_client_hello")))]
+#[cfg(any(test, feature = "unstable_client_hello"))]
 use s2n_tls::callbacks::ClientHelloCallback;
-#[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_client_hello")))]
+#[cfg(any(test, feature = "unstable_client_hello"))]
 use s2n_tls::callbacks::{PrivateKeyCallback, PrivateKeyOperation};
 use s2n_tls::{
     callbacks::{ConnectionFuture, VerifyHostNameCallback},
@@ -41,7 +41,7 @@ impl MyCallbackHandler {
     }
 }
 
-#[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_client_hello")))]
+#[cfg(any(test, feature = "unstable_client_hello"))]
 impl ClientHelloCallback for MyCallbackHandler {
     fn on_client_hello(
         &self,
@@ -100,7 +100,7 @@ impl crate::ConfigLoader for ResumptionConfig {
     }
 }
 
-#[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_private_key")))]
+#[cfg(any(test, feature = "unstable_private_key"))]
 impl PrivateKeyCallback for MyCallbackHandler {
     fn handle_operation(
         &self,
@@ -263,7 +263,7 @@ fn s2n_server_with_client_auth_verifier_rejects_client_certs() -> Result<server:
         .build()
 }
 
-#[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_client_hello")))]
+#[cfg(any(test, feature = "unstable_client_hello"))]
 fn s2n_server_with_client_hello_callback(wait_counter: u8) -> (server::Server, Arc<AtomicBool>) {
     let handle = MyCallbackHandler::new(wait_counter);
     let done = handle.done.clone();
@@ -277,7 +277,7 @@ fn s2n_server_with_client_hello_callback(wait_counter: u8) -> (server::Server, A
     (tls, done)
 }
 
-#[cfg(any(test, all(s2n_quic_unstable, feature = "unstable_private_key")))]
+#[cfg(any(test, feature = "unstable_private_key"))]
 fn s2n_server_with_private_key_callback(wait_counter: u8) -> (server::Server, Arc<AtomicBool>) {
     let handle = MyCallbackHandler::new(wait_counter);
     let done = handle.done.clone();

--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -71,34 +71,3 @@ pub use server::Server;
 
 #[cfg(test)]
 mod tests;
-
-// Require `--cfg s2n_quic_unstable` is set when using unstable features
-#[cfg(
-    all(
-        // add new unstable features to this list
-        any(
-            feature = "unstable_client_hello",
-            feature = "unstable-provider-datagram",
-            feature = "unstable-provider-io-testing",
-            feature = "unstable-provider-io-turmoil",
-            feature = "unstable-provider-io-xdp",
-            feature = "unstable-provider-packet-interceptor",
-            feature = "unstable-provider-random",
-            feature = "unstable-congestion-controller",
-            feature = "unstable_resumption",
-        ),
-        // any unstable features requires at least one of the following conditions
-        not(any(
-            // we're running tests
-            test,
-            doctest,
-            // we're compiling docs for docs.rs
-            docsrs,
-            // we're developing s2n-quic
-            s2n_internal_dev,
-            // the application has explicitly opted into unstable features
-            s2n_quic_unstable,
-        ))
-    )
-)]
-std::compile_error!("Application must be built with RUSTFLAGS=\"--cfg s2n_quic_unstable\" to use unstable features.");


### PR DESCRIPTION
This cfg (intentionally) prevents a downstream library from wrapping s2n-quic unstable API internally without the final build explicitly opting into that instability. Unfortunately, with s2n-quic-dc, we want to do exactly that. Essentially we'll be treating `s2n-quic` from `s2n-quic-dc` the same way we treat `s2n-quic-core` from `s2n-quic`.

For the time being drop the cfg entirely. Since it's only set to allow unstable features, we should technically be able to revert this change at some point (e.g., if dc stops depending on unstable surface area): it would be fairly similar to just breaking consumers of those unstable features, which is already allowed.

### Call-outs:

Not sure I caught everything in this -- mostly relying on a grep for s2n_quic_unstable and just blindly updating cfgs.

### Testing:

None.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

