### PR TITLE
ci: Remove neqo from required resumption test clients

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -648,7 +648,6 @@
       "server"
     ],
     "neqo": [
-      "client",
       "server"
     ],
     "ngtcp2": [


### PR DESCRIPTION
### Description of changes: 

The neqo client has started to fail the resumption interop test with the s2n-quic server. This PR temporarily removes neqo from the list of required client implementations for the resumption test, until we finish investigating the cause of the failure.

After resolving the issue, we should revert this change. See https://github.com/aws/s2n-quic/issues/2192.

### Testing:

The interop job should succeed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

