### PR TITLE
feat(s2n-quic): provider-crypto-fips feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,25 @@ jobs:
         run: |
           ${{ matrix.target != 'native' && 'cross' || 'cargo' }} test --workspace ${{ matrix.exclude }} ${{ matrix.target != 'native' && format('--target {0}', matrix.target) || '' }} ${{ matrix.args }}
 
+  fips:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Install rust stable toolchain
+        id: stable-toolchain
+        run: |
+          rustup toolchain install stable
+          rustup override set stable
+
+      - uses: camshaft/rust-cache@v1
+
+      - name: Run test
+        run: |
+          cargo test --features provider-tls-fips
+
   miri:
     # miri needs quite a bit of memory so use a larger instance
     runs-on:

--- a/quic/s2n-quic-core/src/crypto/application/limited.rs
+++ b/quic/s2n-quic-core/src/crypto/application/limited.rs
@@ -102,7 +102,7 @@ impl<K: OneRttKey> Key<K> {
     }
 
     #[inline]
-    pub fn key(&self) -> &K {
-        &self.key
+    pub fn key_mut(&mut self) -> &mut K {
+        &mut self.key
     }
 }

--- a/quic/s2n-quic-core/src/crypto/key.rs
+++ b/quic/s2n-quic-core/src/crypto/key.rs
@@ -16,7 +16,7 @@ pub trait Key: Send {
 
     /// Encrypt a payload
     fn encrypt(
-        &self,
+        &mut self,
         packet_number: u64,
         header: &[u8],
         payload: &mut scatter::Buffer,
@@ -88,7 +88,7 @@ pub mod testing {
 
         /// Encrypt a payload
         fn encrypt(
-            &self,
+            &mut self,
             _packet_number: u64,
             _header: &[u8],
             payload: &mut scatter::Buffer,

--- a/quic/s2n-quic-core/src/crypto/mod.rs
+++ b/quic/s2n-quic-core/src/crypto/mod.rs
@@ -206,7 +206,7 @@ pub fn unprotect<'a, K: HeaderKey>(
 /// Encrypts a cleartext payload with a crypto key into a `EncryptedPayload`
 #[inline]
 pub fn encrypt<'a, K: Key>(
-    key: &K,
+    key: &mut K,
     packet_number: PacketNumber,
     packet_number_len: PacketNumberLen,
     header_len: usize,

--- a/quic/s2n-quic-core/src/crypto/tests.rs
+++ b/quic/s2n-quic-core/src/crypto/tests.rs
@@ -86,7 +86,7 @@ fn fuzz_protect(
     let packet_number_len = truncated_packet_number.len();
 
     let (payload, _remaining) = crate::crypto::encrypt(
-        &FuzzCrypto,
+        &mut FuzzCrypto,
         packet_number,
         packet_number_len,
         header_len,
@@ -117,7 +117,7 @@ impl Key for FuzzCrypto {
     }
 
     fn encrypt<'a>(
-        &self,
+        &mut self,
         packet_number: u64,
         _header: &[u8],
         payload: &mut scatter::Buffer,

--- a/quic/s2n-quic-core/src/crypto/tls/null.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/null.rs
@@ -310,7 +310,7 @@ mod key {
 
         #[inline(always)]
         fn encrypt(
-            &self,
+            &mut self,
             _packet_number: u64,
             _header: &[u8],
             payload: &mut scatter::Buffer,

--- a/quic/s2n-quic-core/src/crypto/tls/testing.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/testing.rs
@@ -281,8 +281,8 @@ impl<S: tls::Session, C: tls::Session> Pair<S, C> {
     }
 
     /// Finished the test
-    pub fn finish(&self) {
-        self.client.context.finish(&self.server.context);
+    pub fn finish(&mut self) {
+        self.client.context.finish(&mut self.server.context);
 
         assert_eq!(
             self.client.context.transport_parameters.as_ref().unwrap(),
@@ -442,7 +442,7 @@ where
     }
 
     /// Finishes the test and asserts consistency
-    pub fn finish<O: CryptoSuite, OS: Debug, OP>(&self, other: &Context<O, OS, OP>)
+    pub fn finish<O: CryptoSuite, OS: Debug, OP>(&mut self, other: &mut Context<O, OS, OP>)
     where
         for<'a> OP: DecoderValue<'a>,
     {
@@ -464,9 +464,9 @@ where
             "0-rtt keys are not consistent between endpoints"
         );
 
-        self.initial.finish(&other.initial);
-        self.handshake.finish(&other.handshake);
-        self.application.finish(&other.application);
+        self.initial.finish(&mut other.initial);
+        self.handshake.finish(&mut other.handshake);
+        self.application.finish(&mut other.application);
     }
 
     fn assert_done(&self) {
@@ -566,9 +566,9 @@ impl<K: Key, Hk: HeaderKey> Space<K, Hk> {
         }
     }
 
-    fn finish<O: Key, Ohk: HeaderKey>(&self, other: &Space<O, Ohk>) {
-        let (crypto_a, crypto_a_hk) = self.crypto.as_ref().expect("missing crypto");
-        let (crypto_b, crypto_b_hk) = other.crypto.as_ref().expect("missing crypto");
+    fn finish<O: Key, Ohk: HeaderKey>(&mut self, other: &mut Space<O, Ohk>) {
+        let (crypto_a, crypto_a_hk) = self.crypto.as_mut().expect("missing crypto");
+        let (crypto_b, crypto_b_hk) = other.crypto.as_mut().expect("missing crypto");
 
         // ensure payloads can be encrypted and decrypted in both directions
         seal_open(crypto_a, crypto_b);
@@ -582,7 +582,7 @@ impl<K: Key, Hk: HeaderKey> Space<K, Hk> {
     }
 }
 
-fn seal_open<S: Key, O: Key>(sealer: &S, opener: &O) {
+fn seal_open<S: Key, O: Key>(sealer: &mut S, opener: &O) {
     let packet_number = 123;
     let header = &[1, 2, 3, 4, 5, 6];
 

--- a/quic/s2n-quic-core/src/packet/encoding.rs
+++ b/quic/s2n-quic-core/src/packet/encoding.rs
@@ -114,7 +114,7 @@ pub trait PacketEncoder<K: CryptoKey, H: HeaderKey, Payload: PacketPayloadEncode
     // Encodes, encrypts, and header-protects a packet into a buffer
     fn encode_packet<'a>(
         mut self,
-        key: &K,
+        key: &mut K,
         header_key: &H,
         largest_acknowledged_packet_number: PacketNumber,
         min_packet_len: Option<usize>,

--- a/quic/s2n-quic-core/src/packet/tests.rs
+++ b/quic/s2n-quic-core/src/packet/tests.rs
@@ -125,14 +125,14 @@ fn encode_packet<'a>(packet: CleartextPacket, mut encoder: EncoderBuffer<'a>) ->
     use CleartextPacket::*;
     let result = match packet {
         Handshake(packet) => packet.encode_packet(
-            &testing::Key::new(),
+            &mut testing::Key::new(),
             &testing::HeaderKey::new(),
             PacketNumberSpace::Handshake.new_packet_number(Default::default()),
             None,
             encoder,
         ),
         Initial(packet) => packet.encode_packet(
-            &testing::Key::new(),
+            &mut testing::Key::new(),
             &testing::HeaderKey::new(),
             PacketNumberSpace::Initial.new_packet_number(Default::default()),
             None,
@@ -143,14 +143,14 @@ fn encode_packet<'a>(packet: CleartextPacket, mut encoder: EncoderBuffer<'a>) ->
             return encoder;
         }
         Short(packet) => packet.encode_packet(
-            &testing::Key::new(),
+            &mut testing::Key::new(),
             &testing::HeaderKey::new(),
             PacketNumberSpace::ApplicationData.new_packet_number(Default::default()),
             None,
             encoder,
         ),
         ZeroRtt(packet) => packet.encode_packet(
-            &testing::Key::new(),
+            &mut testing::Key::new(),
             &testing::HeaderKey::new(),
             PacketNumberSpace::ApplicationData.new_packet_number(Default::default()),
             None,

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -13,6 +13,7 @@ exclude = ["corpus.tar.gz"]
 [features]
 default = []
 aws-lc-bindgen = ["aws-lc-rs/bindgen"]
+fips = ["aws-lc-rs/fips"]
 testing = []
 
 [dependencies]

--- a/quic/s2n-quic-crypto/src/aead/default.rs
+++ b/quic/s2n-quic-crypto/src/aead/default.rs
@@ -1,24 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ring_aead::{Aad, LessSafeKey, Nonce, MAX_TAG_LEN, NONCE_LEN};
-pub use s2n_quic_core::crypto::{packet_protection::Error, scatter};
-pub type Result<T = (), E = Error> = core::result::Result<T, E>;
-
-pub trait Aead {
-    type Nonce;
-    type Tag;
-
-    fn encrypt(&self, nonce: &Self::Nonce, aad: &[u8], payload: &mut scatter::Buffer) -> Result;
-
-    fn decrypt(
-        &self,
-        nonce: &Self::Nonce,
-        aad: &[u8],
-        payload: &mut [u8],
-        tag: &Self::Tag,
-    ) -> Result;
-}
+use crate::{
+    aead::{Aead, Result},
+    ring_aead::{Aad, LessSafeKey, Nonce, MAX_TAG_LEN, NONCE_LEN},
+};
+use s2n_quic_core::crypto::{packet_protection::Error, scatter};
 
 impl Aead for LessSafeKey {
     type Nonce = [u8; NONCE_LEN];
@@ -27,7 +14,7 @@ impl Aead for LessSafeKey {
     #[inline]
     #[cfg(target_os = "windows")]
     fn encrypt(
-        &self,
+        &mut self,
         nonce: &[u8; NONCE_LEN],
         aad: &[u8],
         payload: &mut scatter::Buffer,
@@ -55,7 +42,7 @@ impl Aead for LessSafeKey {
     #[inline]
     #[cfg(not(target_os = "windows"))]
     fn encrypt(
-        &self,
+        &mut self,
         nonce: &[u8; NONCE_LEN],
         aad: &[u8],
         payload: &mut scatter::Buffer,

--- a/quic/s2n-quic-crypto/src/aead/fips.rs
+++ b/quic/s2n-quic-crypto/src/aead/fips.rs
@@ -1,0 +1,95 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    aead::{Aead, Result},
+    ring_aead::{
+        self, Aad, Nonce, TlsProtocolId, TlsRecordOpeningKey, TlsRecordSealingKey, MAX_TAG_LEN,
+        NONCE_LEN,
+    },
+};
+use s2n_quic_core::crypto::{packet_protection::Error, scatter};
+
+/// Encryption keys backed by FIPS certified cryptography.
+///
+/// FipsKey is backed by [`TlsRecordSealingKey`], which enforces that nonces used with `seal_*`
+/// operations are unique.
+pub struct FipsKey {
+    opener: TlsRecordOpeningKey,
+    sealer: TlsRecordSealingKey,
+}
+
+impl FipsKey {
+    #[inline]
+    pub fn new(algorithm: &'static ring_aead::Algorithm, key_bytes: &[u8]) -> Result<Self> {
+        let opener = TlsRecordOpeningKey::new(algorithm, TlsProtocolId::TLS13, key_bytes)
+            .expect("key size verified");
+        let sealer = TlsRecordSealingKey::new(algorithm, TlsProtocolId::TLS13, key_bytes)
+            .expect("key size verified");
+        Ok(FipsKey { opener, sealer })
+    }
+}
+
+impl Aead for FipsKey {
+    type Nonce = [u8; NONCE_LEN];
+    type Tag = [u8; MAX_TAG_LEN];
+
+    #[inline]
+    fn encrypt(
+        &mut self,
+        nonce: &[u8; NONCE_LEN],
+        aad: &[u8],
+        payload: &mut scatter::Buffer,
+    ) -> Result {
+        use s2n_codec::Encoder;
+
+        let nonce = Nonce::assume_unique_for_key(*nonce);
+        let aad = Aad::from(aad);
+
+        let buffer = payload.flatten();
+
+        let tag = {
+            let (input, _) = buffer.split_mut();
+
+            self.sealer
+                .seal_in_place_separate_tag(nonce, aad, input)
+                .map_err(|_| Error::INTERNAL_ERROR)?
+        };
+
+        buffer.write_slice(tag.as_ref());
+
+        Ok(())
+    }
+
+    #[inline]
+    fn decrypt(
+        &self,
+        nonce: &[u8; NONCE_LEN],
+        aad: &[u8],
+        input: &mut [u8],
+        tag: &[u8; MAX_TAG_LEN],
+    ) -> Result {
+        let nonce = Nonce::assume_unique_for_key(*nonce);
+        let aad = Aad::from(aad);
+        let input = unsafe {
+            // ring requires that the input and tag be passed as a single slice
+            // so we extend the input slice here.
+            // This is only safe if they are contiguous
+            debug_assert_eq!(
+                if input.is_empty() {
+                    (*input).as_ptr()
+                } else {
+                    (&input[input.len() - 1] as *const u8).add(1)
+                },
+                (*tag).as_ptr()
+            );
+            let ptr = input.as_mut_ptr();
+            let len = input.len() + MAX_TAG_LEN;
+            core::slice::from_raw_parts_mut(ptr, len)
+        };
+        self.opener
+            .open_in_place(nonce, aad, input)
+            .map_err(|_| Error::DECRYPT_ERROR)?;
+        Ok(())
+    }
+}

--- a/quic/s2n-quic-crypto/src/aead/mod.rs
+++ b/quic/s2n-quic-crypto/src/aead/mod.rs
@@ -1,0 +1,26 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_quic_core::crypto::{packet_protection::Error, scatter};
+
+mod default;
+#[cfg(feature = "fips")]
+pub mod fips;
+
+pub type Result<T = (), E = Error> = core::result::Result<T, E>;
+
+pub trait Aead {
+    type Nonce;
+    type Tag;
+
+    fn encrypt(&mut self, nonce: &Self::Nonce, aad: &[u8], payload: &mut scatter::Buffer)
+        -> Result;
+
+    fn decrypt(
+        &self,
+        nonce: &Self::Nonce,
+        aad: &[u8],
+        payload: &mut [u8],
+        tag: &Self::Tag,
+    ) -> Result;
+}

--- a/quic/s2n-quic-crypto/src/cipher_suite.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite.rs
@@ -150,7 +150,7 @@ macro_rules! impl_cipher_suite {
 
                 #[inline]
                 fn encrypt(
-                    &self,
+                    &mut self,
                     packet_number: u64,
                     header: &[u8],
                     payload: &mut scatter::Buffer,

--- a/quic/s2n-quic-crypto/src/cipher_suite/negotiated.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite/negotiated.rs
@@ -95,7 +95,7 @@ impl crypto::Key for NegotiatedCipherSuite {
 
     #[inline]
     fn encrypt(
-        &self,
+        &mut self,
         packet_number: u64,
         header: &[u8],
         payload: &mut scatter::Buffer,

--- a/quic/s2n-quic-crypto/src/cipher_suite/ring.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite/ring.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Use keys backed by FIPs-approved cryptography if the `fips` flag is set.
-macro_rules! key_cipher_supports_fips {
+macro_rules! key {
     ($name:ident, $ring_cipher:path, $key_size:expr, $tag_len:expr) => {
         pub mod $name {
             use super::super::$name::{KEY_LEN, NONCE_LEN, TAG_LEN};
@@ -39,7 +39,7 @@ macro_rules! key_cipher_supports_fips {
     };
 }
 
-macro_rules! key {
+macro_rules! key_no_fips_support {
     ($name:ident, $ring_cipher:path, $key_size:expr, $tag_len:expr) => {
         pub mod $name {
             use super::super::$name::{KEY_LEN, NONCE_LEN, TAG_LEN};
@@ -124,11 +124,11 @@ macro_rules! key_impl {
     };
 }
 
-key_cipher_supports_fips!(aes128_gcm, aead::AES_128_GCM, 128 / 8, 16);
-key_cipher_supports_fips!(aes256_gcm, aead::AES_256_GCM, 256 / 8, 16);
+key!(aes128_gcm, aead::AES_128_GCM, 128 / 8, 16);
+key!(aes256_gcm, aead::AES_256_GCM, 256 / 8, 16);
 // FipsKey is backed by TlsRecordSealingKey/TlsRecordOpeningKey which doesn't
 // support CHACHA20_POLY1305.
 //
 // https://docs.rs/aws-lc-rs/latest/aws_lc_rs/aead/struct.TlsRecordSealingKey.html
 // https://docs.rs/aws-lc-rs/latest/aws_lc_rs/aead/struct.TlsRecordOpeningKey.html
-key!(chacha20_poly1305, aead::CHACHA20_POLY1305, 256 / 8, 16);
+key_no_fips_support!(chacha20_poly1305, aead::CHACHA20_POLY1305, 256 / 8, 16);

--- a/quic/s2n-quic-crypto/src/cipher_suite/ring.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite/ring.rs
@@ -1,84 +1,130 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-macro_rules! key {
+macro_rules! fips_supported_key {
     ($name:ident, $ring_cipher:path, $key_size:expr, $tag_len:expr) => {
         pub mod $name {
             use super::super::$name::{KEY_LEN, NONCE_LEN, TAG_LEN};
-            use crate::ring_aead::{self as aead, LessSafeKey, UnboundKey};
+            use crate::ring_aead::{self as aead};
             use s2n_quic_core::crypto::scatter;
             use zeroize::Zeroize;
 
             pub struct Key {
-                key: LessSafeKey,
+                #[cfg(feature = "fips")]
+                key: crate::aead::fips::FipsKey,
+                #[cfg(not(feature = "fips"))]
+                key: aead::LessSafeKey,
             }
 
             impl Key {
-                #[inline]
+                #[cfg(feature = "fips")]
                 pub fn new(secret: &[u8; KEY_LEN]) -> Self {
-                    let unbound_key =
-                        UnboundKey::new(&$ring_cipher, secret).expect("key size verified");
-                    let key = LessSafeKey::new(unbound_key);
+                    let key = crate::aead::fips::FipsKey::new(&$ring_cipher, secret)
+                        .expect("key successfully created");
                     Self { key }
                 }
 
-                #[inline]
-                #[allow(dead_code)] // this is to maintain compatibility between implementations
-                pub fn should_update_pmtu(&self, _mtu: u16) -> bool {
-                    // ring doesn't implement precomputed tables
-                    false
-                }
-
-                #[inline]
-                #[allow(dead_code)] // this is to maintain compatibility between implementations
-                pub fn update(&self, secret: &[u8; KEY_LEN]) -> Self {
-                    // no state to persist
-                    Self::new(secret)
-                }
-
-                #[inline]
-                #[allow(dead_code)] // this is to maintain compatibility between implementations
-                pub fn update_pmtu(&mut self, _secret: &[u8; KEY_LEN], _mtu: u16) {
-                    unimplemented!();
+                #[cfg(not(feature = "fips"))]
+                pub fn new(secret: &[u8; KEY_LEN]) -> Self {
+                    let unbound_key =
+                        aead::UnboundKey::new(&$ring_cipher, secret).expect("key size verified");
+                    let key = aead::LessSafeKey::new(unbound_key);
+                    Self { key }
                 }
             }
 
-            impl Zeroize for Key {
-                fn zeroize(&mut self) {
-                    // ring doesn't provide a way to zeroize keys currently
-                    // https://github.com/briansmith/ring/issues/15
+            key_impl!($name, $ring_cipher, $key_size, $tag_len);
+        }
+    };
+}
+
+macro_rules! key {
+    ($name:ident, $ring_cipher:path, $key_size:expr, $tag_len:expr) => {
+        pub mod $name {
+            use super::super::$name::{KEY_LEN, NONCE_LEN, TAG_LEN};
+            use crate::ring_aead::{self as aead};
+            use s2n_quic_core::crypto::scatter;
+            use zeroize::Zeroize;
+
+            pub struct Key {
+                key: aead::LessSafeKey,
+            }
+
+            impl Key {
+                pub fn new(secret: &[u8; KEY_LEN]) -> Self {
+                    let unbound_key =
+                        aead::UnboundKey::new(&$ring_cipher, secret).expect("key size verified");
+                    let key = aead::LessSafeKey::new(unbound_key);
+                    Self { key }
                 }
             }
 
-            impl crate::aead::Aead for Key {
-                type Nonce = [u8; NONCE_LEN];
-                type Tag = [u8; TAG_LEN];
+            key_impl!($name, $ring_cipher, $key_size, $tag_len);
+        }
+    };
+}
 
-                #[inline]
-                fn encrypt(
-                    &self,
-                    nonce: &[u8; NONCE_LEN],
-                    aad: &[u8],
-                    payload: &mut scatter::Buffer,
-                ) -> crate::aead::Result {
-                    self.key.encrypt(nonce, aad, payload)
-                }
+macro_rules! key_impl {
+    ($name:ident, $ring_cipher:path, $key_size:expr, $tag_len:expr) => {
+        impl Key {
+            #[inline]
+            #[allow(dead_code)] // this is to maintain compatibility between implementations
+            pub fn should_update_pmtu(&self, _mtu: u16) -> bool {
+                // ring doesn't implement precomputed tables
+                false
+            }
 
-                #[inline]
-                fn decrypt(
-                    &self,
-                    nonce: &[u8; NONCE_LEN],
-                    aad: &[u8],
-                    input: &mut [u8],
-                    tag: &[u8; TAG_LEN],
-                ) -> crate::aead::Result {
-                    self.key.decrypt(nonce, aad, input, tag)
-                }
+            #[inline]
+            #[allow(dead_code)] // this is to maintain compatibility between implementations
+            pub fn update(&self, secret: &[u8; KEY_LEN]) -> Self {
+                // no state to persist
+                Self::new(secret)
+            }
+
+            #[inline]
+            #[allow(dead_code)] // this is to maintain compatibility between implementations
+            pub fn update_pmtu(&mut self, _secret: &[u8; KEY_LEN], _mtu: u16) {
+                unimplemented!();
+            }
+        }
+
+        impl Zeroize for Key {
+            fn zeroize(&mut self) {
+                // ring doesn't provide a way to zeroize keys currently
+                // https://github.com/briansmith/ring/issues/15
+            }
+        }
+
+        impl crate::aead::Aead for Key {
+            type Nonce = [u8; NONCE_LEN];
+            type Tag = [u8; TAG_LEN];
+
+            #[inline]
+            fn encrypt(
+                &mut self,
+                nonce: &[u8; NONCE_LEN],
+                aad: &[u8],
+                payload: &mut scatter::Buffer,
+            ) -> crate::aead::Result {
+                self.key.encrypt(nonce, aad, payload)
+            }
+
+            #[inline]
+            fn decrypt(
+                &self,
+                nonce: &[u8; NONCE_LEN],
+                aad: &[u8],
+                input: &mut [u8],
+                tag: &[u8; TAG_LEN],
+            ) -> crate::aead::Result {
+                self.key.decrypt(nonce, aad, input, tag)
             }
         }
     };
 }
 
-key!(aes128_gcm, aead::AES_128_GCM, 128 / 8, 16);
-key!(aes256_gcm, aead::AES_256_GCM, 256 / 8, 16);
+fips_supported_key!(aes128_gcm, aead::AES_128_GCM, 128 / 8, 16);
+fips_supported_key!(aes256_gcm, aead::AES_256_GCM, 256 / 8, 16);
+// Don't create a FipsKey for CHACHA20_POLY1305 since TlsRecordSealingKey and
+// TlsRecordOpeningKey don't support CHACHA20_POLY1305
 key!(chacha20_poly1305, aead::CHACHA20_POLY1305, 256 / 8, 16);

--- a/quic/s2n-quic-crypto/src/initial.rs
+++ b/quic/s2n-quic-crypto/src/initial.rs
@@ -92,7 +92,7 @@ impl Key for InitialKey {
 
     #[inline]
     fn encrypt(
-        &self,
+        &mut self,
         packet_number: u64,
         header: &[u8],
         payload: &mut scatter::Buffer,
@@ -142,7 +142,7 @@ mod tests {
     #[test]
     fn rfc_example_server_test() {
         test_round_trip(
-            &InitialKey::new_client(&EXAMPLE_DCID),
+            &mut InitialKey::new_client(&EXAMPLE_DCID),
             &InitialKey::new_server(&EXAMPLE_DCID),
             &EXAMPLE_CLIENT_INITIAL_PROTECTED_PACKET,
             &EXAMPLE_CLIENT_INITIAL_PAYLOAD,
@@ -152,7 +152,7 @@ mod tests {
     #[test]
     fn rfc_example_client_test() {
         test_round_trip(
-            &InitialKey::new_server(&EXAMPLE_DCID),
+            &mut InitialKey::new_server(&EXAMPLE_DCID),
             &InitialKey::new_client(&EXAMPLE_DCID),
             &EXAMPLE_SERVER_INITIAL_PROTECTED_PACKET,
             &EXAMPLE_SERVER_INITIAL_PAYLOAD,
@@ -160,7 +160,7 @@ mod tests {
     }
 
     fn test_round_trip(
-        sealer: &(InitialKey, InitialHeaderKey),
+        sealer: &mut (InitialKey, InitialHeaderKey),
         opener: &(InitialKey, InitialHeaderKey),
         protected_packet: &[u8],
         cleartext_payload: &[u8],

--- a/quic/s2n-quic-crypto/src/lib.rs
+++ b/quic/s2n-quic-crypto/src/lib.rs
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(all(feature = "fips", target_os = "windows"))]
+std::compile_error!("feature `fips` is not supported on windows");
+
 #[macro_use]
 mod negotiated;
 #[macro_use]

--- a/quic/s2n-quic-crypto/src/negotiated.rs
+++ b/quic/s2n-quic-crypto/src/negotiated.rs
@@ -63,7 +63,7 @@ impl Key for KeyPair {
 
     #[inline]
     fn encrypt(
-        &self,
+        &mut self,
         packet_number: u64,
         header: &[u8],
         payload: &mut scatter::Buffer,
@@ -150,7 +150,7 @@ macro_rules! negotiated_crypto {
 
             #[inline]
             fn encrypt(
-                &self,
+                &mut self,
                 packet_number: u64,
                 header: &[u8],
                 payload: &mut s2n_quic_core::crypto::scatter::Buffer,

--- a/quic/s2n-quic-crypto/src/one_rtt.rs
+++ b/quic/s2n-quic-crypto/src/one_rtt.rs
@@ -95,7 +95,7 @@ mod tests {
         ];
 
         for (secret, ku_secret, should_match) in tests {
-            let (next_cipher, expected_next_cipher) = generate_ciphers(secret, ku_secret);
+            let (mut next_cipher, mut expected_next_cipher) = generate_ciphers(secret, ku_secret);
 
             // Encrypt two empty blocks to verify the ciphers are the same
             let mut next_cipher_output = [0; 32];

--- a/quic/s2n-quic-crypto/src/retry.rs
+++ b/quic/s2n-quic-crypto/src/retry.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{constant_time, ring_aead as aead};
-use core::convert::TryInto;
 use s2n_quic_core::crypto::{
     self, packet_protection,
     retry::{IntegrityTag, NONCE_BYTES, SECRET_KEY_BYTES},

--- a/quic/s2n-quic-crypto/src/zero_rtt.rs
+++ b/quic/s2n-quic-crypto/src/zero_rtt.rs
@@ -30,7 +30,7 @@ impl Key for ZeroRttKey {
     }
 
     fn encrypt(
-        &self,
+        &mut self,
         packet_number: u64,
         header: &[u8],
         payload: &mut scatter::Buffer,

--- a/quic/s2n-quic-rustls/src/cipher_suite.rs
+++ b/quic/s2n-quic-rustls/src/cipher_suite.rs
@@ -41,7 +41,7 @@ impl crypto::Key for PacketKey {
 
     #[inline]
     fn encrypt(
-        &self,
+        &mut self,
         packet_number: u64,
         header: &[u8],
         payload: &mut scatter::Buffer,
@@ -128,7 +128,7 @@ impl crypto::Key for PacketKeys {
 
     #[inline]
     fn encrypt(
-        &self,
+        &mut self,
         packet_number: u64,
         header: &[u8],
         payload: &mut scatter::Buffer,
@@ -268,7 +268,7 @@ impl crypto::Key for OneRttKey {
 
     #[inline]
     fn encrypt(
-        &self,
+        &mut self,
         packet_number: u64,
         header: &[u8],
         payload: &mut scatter::Buffer,

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["corpus.tar.gz"]
 
 [features]
 # The [`?`](https://doc.rust-lang.org/cargo/reference/features.html?highlight=addative#dependency-features)
-# syntax only enable `fips` for `s2n-quic-tls` if something else enables `s2n-quic-tls`. This
+# syntax only enables `fips` for `s2n-quic-tls` if something else enables `s2n-quic-tls`. This
 # preserves the selective compilation of the two tls crates.
 fips = ["s2n-quic-tls?/fips"]
 

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -10,6 +10,22 @@ license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]
 
+[features]
+# The [`?`](https://doc.rust-lang.org/cargo/reference/features.html?highlight=addative#dependency-features)
+# syntax only enable `fips` for `s2n-quic-tls` if something else enables `s2n-quic-tls`. This
+# preserves the selective compilation of the two tls crates.
+fips = ["s2n-quic-tls?/fips"]
+
+# Declare `s2n-quic-tls` as an optional dependency since the `?` syntax for features requires
+# the dependency be optional.
+#
+# It is not possible to enable a feature flag based on target since Cargo currently doesn't
+# support platform specific feature flags: https://github.com/rust-lang/cargo/issues/1197. In
+# order to support the `?` syntax, we declare s2n-quic-tls as an optional dependency.
+# `s2n-quic-tls` only gets enabled based on the target.
+[dependencies]
+s2n-quic-tls = { path = "../s2n-quic-tls", optional = true }
+
 [target.'cfg(unix)'.dependencies]
 s2n-quic-tls = { version = "=0.37.0", path = "../s2n-quic-tls" }
 

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 exclude = ["corpus.tar.gz"]
 
 [features]
+fips = ["s2n-quic-crypto/fips"]
 unstable_client_hello = []
 unstable_private_key = []
 

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -157,7 +157,7 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
         };
 
         let (_protected_packet, buffer) = packet.encode_packet(
-            &self.key,
+            &mut self.key,
             &self.header_key,
             packet_number_encoder,
             context.min_packet_len,
@@ -243,7 +243,7 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
         };
 
         let (_protected_packet, buffer) = packet.encode_packet(
-            &self.key,
+            &mut self.key,
             &self.header_key,
             packet_number_encoder,
             context.min_packet_len,

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -206,7 +206,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
         };
 
         let (_protected_packet, buffer) = packet.encode_packet(
-            &self.key,
+            &mut self.key,
             &self.header_key,
             packet_number_encoder,
             context.min_packet_len,
@@ -293,7 +293,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
         };
 
         let (_protected_packet, buffer) = packet.encode_packet(
-            &self.key,
+            &mut self.key,
             &self.header_key,
             packet_number_encoder,
             context.min_packet_len,

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -15,7 +15,10 @@ default = [
     "provider-address-token-default",
     "provider-tls-default",
 ]
-
+provider-tls-fips = [
+    "s2n-quic-tls-default?/fips",
+    "s2n-quic-tls?/fips",
+]
 provider-address-token-default = [
     "cuckoofilter",
     "hash_hasher",

--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -52,10 +52,11 @@
 //!
 //! ### `provider-tls-fips`
 //!
-//! FIPS mode is currently only supported with the [`s2n-tls`][s2n-tls] TLS provider.
+//! FIPS mode is only supported with the [`s2n-tls`][s2n-tls] TLS provider on
+//! non-windows platforms.
 //! Applications wanting to use FIPS-approved cryptography with s2n-quic should:
 //!
-//! 1. Use enable the following features:
+//! 1. Enable the following features:
 //!
 //!```ignore
 //! s2n-quic = { version = "1", features = ["provider-tls-fips", "provider-tls-s2n"] }

--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -64,18 +64,22 @@
 //! 2. Build a custom s2n-tls TLS provider configured with a FIPS approved
 //! [security policy](https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html):
 //!
-//!```rust,no_run
+//!```ignore
 //! use s2n_quic::provider::tls::s2n_tls;
 //! use s2n_quic::provider::tls::s2n_tls::security::Policy;
 //!
 //! let mut tls = s2n_tls::Server::builder();
-//! let policy = Policy::from_version("select_a_fips_security_policy").unwrap();
-//! tls.config_mut().set_security_policy(&policy).unwrap();
-//! let tls = tls.build().unwrap();
+//! let policy = Policy::from_version("select_a_fips_security_policy")?;
+//! tls.config_mut().set_security_policy(&policy)?;
+//! let tls = tls
+//!     .with_certificate(..)?
+//!     ...
+//!     .build()?;
 //!
 //! let mut server = s2n_quic::Server::builder()
-//!     .with_tls(tls).unwrap()
-//!     .start().unwrap();
+//!     .with_tls(tls)?
+//!     ...
+//!     .start()?;
 //!```
 //!
 //! [s2n-tls]: https://github.com/aws/s2n-tls

--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -50,6 +50,34 @@
 //!
 //! **NOTE**: this will override the platform detection and always use [`s2n-tls`][s2n-tls] by default.
 //!
+//! ### `provider-tls-fips`
+//!
+//! FIPS mode is currently only supported with the [`s2n-tls`][s2n-tls] TLS provider.
+//! Applications wanting to use FIPS-approved cryptography with s2n-quic should:
+//!
+//! 1. Use enable the following features:
+//!
+//!```ignore
+//! s2n-quic = { version = "1", features = ["provider-tls-fips", "provider-tls-s2n"] }
+//!```
+//!
+//! 2. Build a custom s2n-tls TLS provider configured with a FIPS approved
+//! [security policy](https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html):
+//!
+//!```rust,no_run
+//! use s2n_quic::provider::tls::s2n_tls;
+//! use s2n_quic::provider::tls::s2n_tls::security::Policy;
+//!
+//! let mut tls = s2n_tls::Server::builder();
+//! let policy = Policy::from_version("select_a_fips_security_policy").unwrap();
+//! tls.config_mut().set_security_policy(&policy).unwrap();
+//! let tls = tls.build().unwrap();
+//!
+//! let mut server = s2n_quic::Server::builder()
+//!     .with_tls(tls).unwrap()
+//!     .start().unwrap();
+//!```
+//!
 //! [s2n-tls]: https://github.com/aws/s2n-tls
 //! [rustls]: https://github.com/rustls/rustls
 


### PR DESCRIPTION
### Description of changes: 
This PR exposed a new `provider-fips-crypto` feature flag and makes the necessary changes for s2n-quic to use FIPS-approved cryptography for encryption.

We want to support fips mode for:
- if s2n-quic-crypto `fips` flag is set (compile time check)
- target_os != windows (compile time check)
- negotiated cipher is not CHACHA20_POLY1305  (runtime check)

To avoid branching on the `fips` and windows, I throw a compiler error if the `fips` flag is set on windows:
```
#[cfg(all(feature = "fips", target_os = "windows"))]
std::compile_error!("feature `fips` is not supported on windows");
```

To avoid branching on the CHACHA20_POLY1305 I don't derive FipsKeys when using this cipher. This was a macro level change (`key!`) rather than code branching, which helps with readability imo. 


### Call-outs:
A lot of the changes are simply converting the encrypt function to take a `&mut self`, which I captured in the first [commit](https://github.com/aws/s2n-quic/pull/2194/commits/8294359504ee7c0e4805b889fcb28f731e95a271). The interesting changes are in the second commit [FipsKey](https://github.com/aws/s2n-quic/pull/2194/commits/85f4bc8cb9a4bf19523986cf01467507769094a5).

### Testing:
New CI task to test with `provider-fips-crypto` feature enabled

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

