### PR TITLE
feat(s2n-quic-rustls): update rustls from 0.21 to 0.23

### DIFF
--- a/examples/rustls-mtls/Cargo.toml
+++ b/examples/rustls-mtls/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Rick Richardson <rick.richardson@gmail.com>", "AWS s2n"]
 [dependencies]
 # Remove the `provider-tls-default` feature and add `provider-tls-rustls` in order to use the rustls backend
 s2n-quic = { version = "1", path = "../../quic/s2n-quic", default-features = false, features = ["provider-address-token-default", "provider-tls-rustls", "provider-event-tracing"] }
-rustls-pemfile = "1"
+rustls-pemfile = "2"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi"] }

--- a/examples/rustls-mtls/src/lib.rs
+++ b/examples/rustls-mtls/src/lib.rs
@@ -1,23 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use rustls::{
-    cipher_suite, ClientConfig, Error, RootCertStore, ServerConfig, SupportedCipherSuite,
-};
-use s2n_quic::provider::tls;
+use s2n_quic::provider::tls as s2n_quic_tls_provider;
 #[allow(deprecated)]
-use s2n_quic::provider::tls::rustls::rustls;
+use s2n_quic::provider::tls::rustls::rustls::{
+    pki_types::{CertificateDer, PrivateKeyDer},
+    server::WebPkiClientVerifier,
+    Error as RustlsError, RootCertStore,
+};
 use std::{io::Cursor, path::Path, sync::Arc};
 use tokio::{fs::File, io::AsyncReadExt};
 use tracing::Level;
-
-static PROTOCOL_VERSIONS: &[&rustls::SupportedProtocolVersion] = &[&rustls::version::TLS13];
-
-pub static DEFAULT_CIPHERSUITES: &[SupportedCipherSuite] = &[
-    cipher_suite::TLS13_AES_128_GCM_SHA256,
-    cipher_suite::TLS13_AES_256_GCM_SHA384,
-    cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,
-];
 
 pub fn initialize_logger(endpoint: &str) {
     use std::sync::Once;
@@ -42,23 +35,26 @@ pub fn initialize_logger(endpoint: &str) {
 }
 
 pub struct MtlsProvider {
-    root_store: rustls::RootCertStore,
-    my_cert_chain: Vec<rustls::Certificate>,
-    my_private_key: rustls::PrivateKey,
+    root_store: RootCertStore,
+    my_cert_chain: Vec<CertificateDer<'static>>,
+    my_private_key: PrivateKeyDer<'static>,
 }
 
-impl tls::Provider for MtlsProvider {
-    type Server = tls::rustls::Server;
-    type Client = tls::rustls::Client;
-    type Error = rustls::Error;
+impl s2n_quic_tls_provider::Provider for MtlsProvider {
+    type Server = s2n_quic_tls_provider::rustls::Server;
+    type Client = s2n_quic_tls_provider::rustls::Client;
+    type Error = RustlsError;
 
     fn start_server(self) -> Result<Self::Server, Self::Error> {
-        let verifier = rustls::server::AllowAnyAuthenticatedClient::new(self.root_store);
-        let mut cfg = ServerConfig::builder()
-            .with_cipher_suites(DEFAULT_CIPHERSUITES)
-            .with_safe_default_kx_groups()
-            .with_protocol_versions(PROTOCOL_VERSIONS)?
-            .with_client_cert_verifier(Arc::new(verifier))
+        let default_crypto_provider = s2n_quic_tls_provider::rustls::default_crypto_provider()?;
+        let verifier = WebPkiClientVerifier::builder_with_provider(
+            Arc::new(self.root_store),
+            default_crypto_provider.into(),
+        )
+        .build()
+        .unwrap();
+        let mut cfg = s2n_quic_tls_provider::rustls::server_config_builder()?
+            .with_client_cert_verifier(verifier)
             .with_single_cert(self.my_cert_chain, self.my_private_key)?;
 
         cfg.ignore_client_order = true;
@@ -68,10 +64,7 @@ impl tls::Provider for MtlsProvider {
     }
 
     fn start_client(self) -> Result<Self::Client, Self::Error> {
-        let mut cfg = ClientConfig::builder()
-            .with_cipher_suites(DEFAULT_CIPHERSUITES)
-            .with_safe_default_kx_groups()
-            .with_protocol_versions(PROTOCOL_VERSIONS)?
+        let mut cfg = s2n_quic_tls_provider::rustls::client_config_builder()?
             .with_root_certificates(self.root_store)
             .with_client_auth_cert(self.my_cert_chain, self.my_private_key)?;
 
@@ -86,71 +79,90 @@ impl MtlsProvider {
         ca_cert_pem: A,
         my_cert_pem: B,
         my_key_pem: C,
-    ) -> Result<Self, Error> {
+    ) -> Result<Self, RustlsError> {
         let root_store = into_root_store(ca_cert_pem.as_ref()).await?;
         let cert_chain = into_certificate(my_cert_pem.as_ref()).await?;
         let private_key = into_private_key(my_key_pem.as_ref()).await?;
         Ok(MtlsProvider {
             root_store,
-            my_cert_chain: cert_chain.into_iter().map(rustls::Certificate).collect(),
-            my_private_key: rustls::PrivateKey(private_key),
+            my_cert_chain: cert_chain.into_iter().map(CertificateDer::from).collect(),
+            my_private_key: private_key,
         })
     }
 }
 
-async fn into_certificate(path: &Path) -> Result<Vec<Vec<u8>>, Error> {
+async fn read_file(path: &Path) -> Result<Vec<u8>, RustlsError> {
     let mut f = File::open(path)
         .await
-        .map_err(|e| Error::General(format!("Failed to load file: {}", e)))?;
+        .map_err(|e| RustlsError::General(format!("Failed to load file: {}", e)))?;
     let mut buf = Vec::new();
     f.read_to_end(&mut buf)
         .await
-        .map_err(|e| Error::General(format!("Failed to read file: {}", e)))?;
-    let mut cursor = Cursor::new(buf);
-    let certs = rustls_pemfile::certs(&mut cursor)
-        .map(|certs| certs.into_iter().collect())
-        .map_err(|_| Error::General("Could not read certificate".to_string()))?;
-    Ok(certs)
+        .map_err(|e| RustlsError::General(format!("Failed to read file: {}", e)))?;
+    Ok(buf)
 }
 
-async fn into_root_store(path: &Path) -> Result<RootCertStore, Error> {
-    let ca_certs = into_certificate(path).await?;
+async fn into_certificate(path: &Path) -> Result<Vec<CertificateDer<'static>>, RustlsError> {
+    let buf = &read_file(path).await?;
+    let mut cursor = Cursor::new(buf);
+    rustls_pemfile::certs(&mut cursor)
+        .map(|cert| {
+            cert.map_err(|_| RustlsError::General("Could not read certificate".to_string()))
+        })
+        .collect()
+}
+
+async fn into_root_store(path: &Path) -> Result<RootCertStore, RustlsError> {
+    let ca_certs: Vec<CertificateDer<'static>> = into_certificate(path)
+        .await
+        .map(|certs| certs.into_iter().map(CertificateDer::from))?
+        .collect();
     let mut cert_store = RootCertStore::empty();
-    cert_store.add_parsable_certificates(ca_certs.as_slice());
+    cert_store.add_parsable_certificates(ca_certs);
     Ok(cert_store)
 }
 
-async fn into_private_key(path: &Path) -> Result<Vec<u8>, Error> {
-    let mut f = File::open(path)
-        .await
-        .map_err(|e| Error::General(format!("Failed to load file: {}", e)))?;
-    let mut buf = Vec::new();
-    f.read_to_end(&mut buf)
-        .await
-        .map_err(|e| Error::General(format!("Failed to read file: {}", e)))?;
+async fn into_private_key(path: &Path) -> Result<PrivateKeyDer<'static>, RustlsError> {
+    let buf = &read_file(path).await?;
     let mut cursor = Cursor::new(buf);
 
-    let parsers = [
-        rustls_pemfile::rsa_private_keys,
-        rustls_pemfile::pkcs8_private_keys,
-    ];
-    for parser in parsers.iter() {
-        cursor.set_position(0);
+    macro_rules! parse_key {
+        ($parser:ident, $key_type:expr) => {
+            cursor.set_position(0);
 
-        match parser(&mut cursor) {
-            Ok(keys) if keys.is_empty() => continue,
-            Ok(mut keys) if keys.len() == 1 => return Ok(rustls::PrivateKey(keys.pop().unwrap()).0),
-            Ok(keys) => {
-                return Err(Error::General(format!(
-                    "Unexpected number of keys: {} (only 1 supported)",
-                    keys.len()
-                )));
+            let keys: Result<Vec<_>, RustlsError> = rustls_pemfile::$parser(&mut cursor)
+                .map(|key| {
+                    key.map_err(|_| {
+                        RustlsError::General("Could not load any private keys".to_string())
+                    })
+                })
+                .collect();
+            match keys {
+                // try the next parser
+                Err(_) => (),
+                // try the next parser
+                Ok(keys) if keys.is_empty() => (),
+                Ok(mut keys) if keys.len() == 1 => {
+                    return Ok($key_type(keys.pop().unwrap()));
+                }
+                Ok(keys) => {
+                    return Err(RustlsError::General(format!(
+                        "Unexpected number of keys: {} (only 1 supported)",
+                        keys.len()
+                    )));
+                }
             }
-            // try the next parser
-            Err(_) => continue,
-        }
+        };
     }
-    Err(Error::General(
+
+    // attempt to parse PKCS8 encoded key. Returns early if a key is found
+    parse_key!(pkcs8_private_keys, PrivateKeyDer::Pkcs8);
+    // attempt to parse RSA key. Returns early if a key is found
+    parse_key!(rsa_private_keys, PrivateKeyDer::Pkcs1);
+    // attempt to parse a SEC1-encoded EC key. Returns early if a key is found
+    parse_key!(ec_private_keys, PrivateKeyDer::Sec1);
+
+    Err(RustlsError::General(
         "could not load any valid private keys".to_string(),
     ))
 }

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -23,8 +23,6 @@ http = "1.0"
 humansize = "2"
 lru = "0.10"
 rand = "0.8"
-# dangerous_configuration is used to allow for cert verification to be disabled for the amplification limit interop test
-rustls = { version = "0.21", features = ["dangerous_configuration", "quic"] }
 s2n-codec = { path = "../../common/s2n-codec" }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-h3 = { path = "../s2n-quic-h3" }

--- a/quic/s2n-quic-qns/src/tls.rs
+++ b/quic/s2n-quic-qns/src/tls.rs
@@ -1,7 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::Result;
+use crate::{tls::rustls::DisabledVerifier, Result};
+use s2n_quic::provider::tls as s2n_quic_tls_provider;
+#[allow(deprecated)]
+use s2n_quic::provider::tls::rustls::rustls as rustls_crate;
 use std::{path::PathBuf, str::FromStr};
 use structopt::StructOpt;
 
@@ -112,16 +115,12 @@ impl Client {
 
     pub fn build_rustls(&self, alpns: &[String]) -> Result<rustls::Client> {
         let tls = if self.disable_cert_verification {
-            use ::rustls::{version, ClientConfig, KeyLogFile};
+            use rustls_crate::KeyLogFile;
             use std::sync::Arc;
 
-            #[allow(deprecated)]
-            let cipher_suites = rustls::DEFAULT_CIPHERSUITES;
-            let mut config = ClientConfig::builder()
-                .with_cipher_suites(cipher_suites)
-                .with_safe_default_kx_groups()
-                .with_protocol_versions(&[&version::TLS13])?
-                .with_custom_certificate_verifier(Arc::new(rustls::DisabledVerifier))
+            let mut config = s2n_quic_tls_provider::rustls::client_config_builder()?
+                .dangerous()
+                .with_custom_certificate_verifier(Arc::new(DisabledVerifier))
                 .with_no_client_auth();
             config.max_fragment_size = None;
             config.alpn_protocols = alpns.iter().map(|p| p.as_bytes().to_vec()).collect();
@@ -268,11 +267,13 @@ pub mod s2n_tls {
 
 pub mod rustls {
     use super::*;
-    #[allow(deprecated)]
-    pub use s2n_quic::provider::tls::rustls::DEFAULT_CIPHERSUITES;
+    use rustls_crate::{
+        client::danger,
+        pki_types::{CertificateDer, ServerName, UnixTime},
+    };
     pub use s2n_quic::provider::tls::rustls::{
         certificate::{Certificate, IntoCertificate, IntoPrivateKey, PrivateKey},
-        Client, Server,
+        default_crypto_provider, Client, Server,
     };
 
     pub fn ca(ca: Option<&PathBuf>) -> Result<Certificate> {
@@ -291,19 +292,54 @@ pub mod rustls {
         })
     }
 
+    #[derive(Debug)]
     pub struct DisabledVerifier;
 
-    impl ::rustls::client::ServerCertVerifier for DisabledVerifier {
+    impl danger::ServerCertVerifier for DisabledVerifier {
         fn verify_server_cert(
             &self,
-            _end_entity: &::rustls::Certificate,
-            _intermediates: &[::rustls::Certificate],
-            _server_name: &::rustls::ServerName,
-            _scts: &mut dyn Iterator<Item = &[u8]>,
+            _end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
+            _server_name: &ServerName,
             _ocsp_response: &[u8],
-            _now: std::time::SystemTime,
-        ) -> Result<::rustls::client::ServerCertVerified, ::rustls::Error> {
-            Ok(::rustls::client::ServerCertVerified::assertion())
+            _now: UnixTime,
+        ) -> Result<danger::ServerCertVerified, rustls_crate::Error> {
+            Ok(danger::ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &rustls_crate::DigitallySignedStruct,
+        ) -> Result<danger::HandshakeSignatureValid, rustls_crate::Error> {
+            rustls_crate::crypto::verify_tls12_signature(
+                message,
+                cert,
+                dss,
+                &default_crypto_provider()?.signature_verification_algorithms,
+            )
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            message: &[u8],
+            cert: &CertificateDer<'_>,
+            dss: &rustls_crate::DigitallySignedStruct,
+        ) -> Result<danger::HandshakeSignatureValid, rustls_crate::Error> {
+            rustls_crate::crypto::verify_tls13_signature(
+                message,
+                cert,
+                dss,
+                &default_crypto_provider()?.signature_verification_algorithms,
+            )
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<rustls_crate::SignatureScheme> {
+            default_crypto_provider()
+                .unwrap()
+                .signature_verification_algorithms
+                .supported_schemes()
         }
     }
 }

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -12,8 +12,8 @@ exclude = ["corpus.tar.gz"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-rustls = { version = "0.21", features = ["quic"] }
-rustls-pemfile = "1"
+rustls = "0.23"
+rustls-pemfile = "2"
 s2n-codec = { version = "=0.37.0", path = "../../common/s2n-codec", default-features = false, features = ["alloc"] }
 s2n-quic-core = { version = "=0.37.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
 s2n-quic-crypto = { version = "=0.37.0", path = "../s2n-quic-crypto", default-features = false }

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -12,7 +12,8 @@ exclude = ["corpus.tar.gz"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-rustls = "0.23"
+# By [default](https://docs.rs/crate/rustls/latest/features) rustls includes the `tls12` feature.
+rustls = { version = "0.23", default-features = false, features=["std", "aws-lc-rs", "logging"] }
 rustls-pemfile = "2"
 s2n-codec = { version = "=0.37.0", path = "../../common/s2n-codec", default-features = false, features = ["alloc"] }
 s2n-quic-core = { version = "=0.37.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }

--- a/quic/s2n-quic-rustls/src/certificate.rs
+++ b/quic/s2n-quic-rustls/src/certificate.rs
@@ -55,8 +55,8 @@ macro_rules! cert_type {
             fn $method(self) -> Result<$name, Error> {
                 match self.extension() {
                     Some(ext) if ext == "der" => {
-                        let pem = std::fs::read(self)?;
-                        pem.$method()
+                        let der = std::fs::read(self)?;
+                        der.$method()
                     }
                     _ => {
                         let pem = std::fs::read_to_string(self)?;
@@ -72,13 +72,13 @@ cert_type!(
     PrivateKey,
     IntoPrivateKey,
     into_private_key,
-    rustls::PrivateKey
+    rustls::pki_types::PrivateKeyDer<'static>
 );
 cert_type!(
     Certificate,
     IntoCertificate,
     into_certificate,
-    Vec<rustls::Certificate>
+    Vec<rustls::pki_types::CertificateDer<'static>>
 );
 
 impl IntoCertificate for Vec<Vec<u8>> {
@@ -93,58 +93,81 @@ impl IntoCertificate for Vec<Vec<u8>> {
 }
 
 mod pem {
-    use super::*;
+    use rustls::{
+        pki_types::{CertificateDer, PrivateKeyDer},
+        Error,
+    };
 
-    pub fn into_certificate(contents: &[u8]) -> Result<Vec<rustls::Certificate>, Error> {
+    pub fn into_certificate(contents: &[u8]) -> Result<Vec<CertificateDer<'static>>, Error> {
         let mut cursor = std::io::Cursor::new(contents);
-        let certs = rustls_pemfile::certs(&mut cursor)
-            .map(|certs| certs.into_iter().map(rustls::Certificate).collect())?;
-        Ok(certs)
+        rustls_pemfile::certs(&mut cursor)
+            .map(|cert| cert.map_err(|_| Error::General("Could not read certificate".to_string())))
+            .collect()
     }
 
-    pub fn into_private_key(contents: &[u8]) -> Result<rustls::PrivateKey, Error> {
+    pub fn into_private_key(contents: &[u8]) -> Result<PrivateKeyDer<'static>, Error> {
         let mut cursor = std::io::Cursor::new(contents);
 
-        let parsers = [
-            rustls_pemfile::rsa_private_keys,
-            rustls_pemfile::pkcs8_private_keys,
-            rustls_pemfile::ec_private_keys,
-        ];
+        macro_rules! parse_key {
+            ($parser:ident, $key_type:expr) => {
+                cursor.set_position(0);
 
-        for parser in parsers.iter() {
-            cursor.set_position(0);
-
-            match parser(&mut cursor) {
-                Ok(keys) if keys.is_empty() => continue,
-                Ok(mut keys) if keys.len() == 1 => {
-                    return Ok(rustls::PrivateKey(keys.pop().unwrap()))
+                let keys: Result<Vec<_>, Error> = rustls_pemfile::$parser(&mut cursor)
+                    .map(|key| {
+                        key.map_err(|_| {
+                            Error::General("Could not load any private keys".to_string())
+                        })
+                    })
+                    .collect();
+                match keys {
+                    // try the next parser
+                    Err(_) => (),
+                    // try the next parser
+                    Ok(keys) if keys.is_empty() => (),
+                    Ok(mut keys) if keys.len() == 1 => {
+                        return Ok($key_type(keys.pop().unwrap()));
+                    }
+                    Ok(keys) => {
+                        return Err(Error::General(format!(
+                            "Unexpected number of keys: {} (only 1 supported)",
+                            keys.len()
+                        )));
+                    }
                 }
-                Ok(keys) => {
-                    return Err(rustls::Error::General(format!(
-                        "Unexpected number of keys: {} (only 1 supported)",
-                        keys.len()
-                    ))
-                    .into());
-                }
-                // try the next parser
-                Err(_) => continue,
-            }
+            };
         }
 
-        Err(rustls::Error::General("could not load any valid private keys".to_string()).into())
+        // attempt to parse PKCS8 encoded key. Returns early if a key is found
+        parse_key!(pkcs8_private_keys, PrivateKeyDer::Pkcs8);
+        // attempt to parse RSA key. Returns early if a key is found
+        parse_key!(rsa_private_keys, PrivateKeyDer::Pkcs1);
+        // attempt to parse a SEC1-encoded EC key. Returns early if a key is found
+        parse_key!(ec_private_keys, PrivateKeyDer::Sec1);
+
+        Err(Error::General(
+            "could not load any valid private keys".to_string(),
+        ))
     }
 }
 
 mod der {
-    use super::*;
+    use rustls::{
+        pki_types::{CertificateDer, PrivateKeyDer},
+        Error,
+    };
 
-    pub fn into_certificate(contents: Vec<u8>) -> Result<Vec<rustls::Certificate>, Error> {
+    pub fn into_certificate(contents: Vec<u8>) -> Result<Vec<CertificateDer<'static>>, Error> {
         // der files only have a single cert
-        Ok(vec![rustls::Certificate(contents)])
+        Ok(vec![CertificateDer::from(contents)])
     }
 
-    pub fn into_private_key(contents: Vec<u8>) -> Result<rustls::PrivateKey, Error> {
-        Ok(rustls::PrivateKey(contents))
+    pub fn into_private_key(contents: Vec<u8>) -> Result<PrivateKeyDer<'static>, Error> {
+        // PKCS #8 is used since it's capable of encoding RSA as well as other key
+        // types (eg. ECDSA). Additionally, multiple attacks have been discovered
+        // against PKCS #1 so PKCS #8 should be preferred.
+        //
+        // https://stackoverflow.com/a/48960291
+        Ok(PrivateKeyDer::Pkcs8(contents.into()))
     }
 }
 
@@ -154,11 +177,18 @@ mod tests {
     use s2n_quic_core::crypto::tls::testing::certificates::*;
 
     #[test]
-    fn load() {
+    fn load_pem() {
         let _ = CERT_PEM.into_certificate().unwrap();
-        let _ = CERT_DER.into_certificate().unwrap();
-
+        let _ = CERT_PKCS1_PEM.into_certificate().unwrap();
+        // PKCS #8 encoded key
         let _ = KEY_PEM.into_private_key().unwrap();
+        // PKCS #1 encoded key
+        let _ = KEY_PKCS1_PEM.into_private_key().unwrap();
+    }
+
+    #[test]
+    fn load_der() {
+        let _ = CERT_DER.into_certificate().unwrap();
         let _ = KEY_DER.into_private_key().unwrap();
     }
 }

--- a/quic/s2n-quic-rustls/src/cipher_suite.rs
+++ b/quic/s2n-quic-rustls/src/cipher_suite.rs
@@ -10,7 +10,7 @@ use s2n_quic_core::crypto::{self, packet_protection, scatter, tls, HeaderProtect
 
 /// `aws_lc_rs` is the default crypto provider since that is also the
 /// default used by rustls.
-pub fn default_crypto_provider() -> Result<CryptoProvider, rustls::Error> {
+pub(crate) fn default_crypto_provider() -> Result<CryptoProvider, rustls::Error> {
     Ok(CryptoProvider {
         cipher_suites: DEFAULT_CIPHERSUITES.to_vec(),
         ..aws_lc_rs::default_provider()
@@ -343,7 +343,7 @@ impl crypto::OneRttKey for OneRttKey {
 //# negotiated unless a header protection scheme is defined for the
 //# cipher suite.
 // All of the cipher_suites from the current exported list have HP schemes for QUIC
-static DEFAULT_CIPHERSUITES: &[SupportedCipherSuite] = &[
+pub static DEFAULT_CIPHERSUITES: &[SupportedCipherSuite] = &[
     aws_lc_rs::cipher_suite::TLS13_AES_128_GCM_SHA256,
     aws_lc_rs::cipher_suite::TLS13_AES_256_GCM_SHA384,
     aws_lc_rs::cipher_suite::TLS13_CHACHA20_POLY1305_SHA256,

--- a/quic/s2n-quic-rustls/src/client.rs
+++ b/quic/s2n-quic-rustls/src/client.rs
@@ -1,12 +1,22 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{certificate, session::Session, Error};
+use crate::{certificate, cipher_suite::default_crypto_provider, session::Session, Error};
 use core::convert::TryFrom;
-use rustls::ClientConfig;
+use rustls::{ClientConfig, ConfigBuilder, WantsVerifier};
 use s2n_codec::EncoderValue;
 use s2n_quic_core::{application::ServerName, crypto::tls};
 use std::sync::Arc;
+
+/// Create a QUIC client specific [rustls::ConfigBuilder].
+///
+/// Uses aws_lc_rs as the crypto provider and sets QUIC specific protocol versions.
+pub fn default_config_builder() -> Result<ConfigBuilder<ClientConfig, WantsVerifier>, rustls::Error>
+{
+    let tls13_cipher_suite_crypto_provider = default_crypto_provider()?;
+    ClientConfig::builder_with_provider(tls13_cipher_suite_crypto_provider.into())
+        .with_protocol_versions(crate::PROTOCOL_VERSIONS)
+}
 
 #[derive(Clone)]
 pub struct Client {
@@ -68,8 +78,8 @@ impl tls::Endpoint for Client {
         //# Endpoints MUST send the quic_transport_parameters extension;
         let transport_parameters = transport_parameters.encode_to_vec();
 
-        let rustls_server_name =
-            rustls::ServerName::try_from(server_name.as_ref()).expect("invalid server name");
+        let rustls_server_name = rustls::pki_types::ServerName::try_from(server_name.to_string())
+            .expect("invalid server name");
 
         let session = rustls::quic::ClientConnection::new(
             self.config.clone(),
@@ -117,7 +127,7 @@ impl Builder {
             rustls::Error::General("Certificate chain needs to have at least one entry".to_string())
         })?;
         self.cert_store
-            .add(root_certificate)
+            .add(root_certificate.to_owned())
             .map_err(|err| rustls::Error::General(err.to_string()))?;
         Ok(self)
     }
@@ -151,10 +161,7 @@ impl Builder {
             );
         }
 
-        let mut config = ClientConfig::builder()
-            .with_cipher_suites(crate::cipher_suite::DEFAULT_CIPHERSUITES)
-            .with_safe_default_kx_groups()
-            .with_protocol_versions(crate::PROTOCOL_VERSIONS)?
+        let mut config = default_config_builder()?
             .with_root_certificates(self.cert_store)
             .with_no_client_auth();
 

--- a/quic/s2n-quic-rustls/src/client.rs
+++ b/quic/s2n-quic-rustls/src/client.rs
@@ -23,6 +23,13 @@ pub struct Client {
 }
 
 impl Client {
+    /// Build a Client using a custom [rustls::ClientConfig]
+    ///
+    /// In addition to necessary configuration, the applications is responsible for correctly
+    /// setting:
+    /// - QUIC compliant application_protocol
+    /// - QUIC compliant TLS protocol version
+    /// - QUIC compliant ciphersuites
     #[deprecated = "client and server builders should be used instead"]
     pub fn new(config: ClientConfig) -> Self {
         Self {

--- a/quic/s2n-quic-rustls/src/client.rs
+++ b/quic/s2n-quic-rustls/src/client.rs
@@ -11,8 +11,7 @@ use std::sync::Arc;
 /// Create a QUIC client specific [rustls::ConfigBuilder].
 ///
 /// Uses aws_lc_rs as the crypto provider and sets QUIC specific protocol versions.
-pub fn default_config_builder() -> Result<ConfigBuilder<ClientConfig, WantsVerifier>, rustls::Error>
-{
+fn default_config_builder() -> Result<ConfigBuilder<ClientConfig, WantsVerifier>, rustls::Error> {
     let tls13_cipher_suite_crypto_provider = default_crypto_provider()?;
     ClientConfig::builder_with_provider(tls13_cipher_suite_crypto_provider.into())
         .with_protocol_versions(crate::PROTOCOL_VERSIONS)

--- a/quic/s2n-quic-rustls/src/error.rs
+++ b/quic/s2n-quic-rustls/src/error.rs
@@ -12,7 +12,6 @@ pub fn reason(error: rustls::Error) -> &'static str {
         Error::DecryptError => "cannot decrypt peer's message",
         Error::EncryptError => "cannot encrypt local message",
         Error::AlertReceived(_) => "received fatal alert",
-        Error::InvalidSct(_) => "invalid certificate timestamp",
         Error::FailedToGetCurrentTime => "failed to get current time",
         Error::FailedToGetRandomBytes => "failed to get random bytes",
         Error::HandshakeNotComplete => "handshake not complete",
@@ -20,6 +19,12 @@ pub fn reason(error: rustls::Error) -> &'static str {
         Error::NoApplicationProtocol => "peer doesn't support any known protocol",
         Error::BadMaxFragmentSize => "bad max fragment size",
         Error::General(_) => "unexpected error",
+        Error::InvalidMessage(_) => "invalid message received",
+        Error::PeerIncompatible(_) => "peer doesn't support a protocol version/feature",
+        Error::PeerMisbehaved(_) => "peer TLS protocol error",
+        Error::InvalidCertificate(_) => "invalid certificate",
+        Error::InvalidCertRevocationList(_) => "invalid crl",
+        Error::Other(_) => "some other error occurred",
         // rustls may add a new variant in the future that breaks us so do a wildcard
         #[allow(unreachable_patterns)]
         _ => "unexpected error",

--- a/quic/s2n-quic-rustls/src/lib.rs
+++ b/quic/s2n-quic-rustls/src/lib.rs
@@ -3,6 +3,14 @@
 
 #![forbid(unsafe_code)]
 
+//! This crate depends on [rustls](https://github.com/rustls/rustls) which is currently
+//! 0.x and has not stabilized its APIs. Applications depending on the rustls provider
+//! should expect breaking changes to methods marked "deprecated" when the underlying
+//! rustls dependency is updated.
+
+// WARNING: Avoid adding new APIs which directly expose the underlying rustls API. If
+//          it's absolutely necessary, all rustls types must be marked as `#[deprecated]`
+//          since it's possible for those types to change in newer rustls versions.
 #[deprecated = "client and server builders should be used instead"]
 pub mod rustls {
     pub use ::rustls::*;

--- a/quic/s2n-quic-rustls/src/lib.rs
+++ b/quic/s2n-quic-rustls/src/lib.rs
@@ -8,6 +8,10 @@ pub mod rustls {
     pub use ::rustls::*;
 }
 
+#[deprecated = "client and server builders should be used instead"]
+pub static DEFAULT_CIPHERSUITES: &[rustls::SupportedCipherSuite] =
+    cipher_suite::DEFAULT_CIPHERSUITES;
+
 /// Wrap error types in Box to avoid leaking rustls types
 type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
 
@@ -19,9 +23,8 @@ pub mod certificate;
 pub mod client;
 pub mod server;
 
-pub use cipher_suite::default_crypto_provider;
-pub use client::{default_config_builder as client_config_builder, Client};
-pub use server::{default_config_builder as server_config_builder, Server};
+pub use client::Client;
+pub use server::Server;
 
 //= https://www.rfc-editor.org/rfc/rfc9001#section-4.2
 //# Clients MUST NOT offer TLS versions older than 1.3.

--- a/quic/s2n-quic-rustls/src/server.rs
+++ b/quic/s2n-quic-rustls/src/server.rs
@@ -22,6 +22,13 @@ pub struct Server {
 }
 
 impl Server {
+    /// Build a Server using a custom [rustls::ServerConfig]
+    ///
+    /// In addition to necessary configuration, the applications is responsible for correctly
+    /// setting:
+    /// - QUIC compliant application_protocol
+    /// - QUIC compliant TLS protocol version
+    /// - QUIC compliant ciphersuites
     #[deprecated = "client and server builders should be used instead"]
     pub fn new(config: ServerConfig) -> Self {
         Self {

--- a/quic/s2n-quic-rustls/src/server.rs
+++ b/quic/s2n-quic-rustls/src/server.rs
@@ -10,8 +10,7 @@ use std::sync::Arc;
 /// Create a QUIC server specific [rustls::ConfigBuilder].
 ///
 /// Uses aws_lc_rs as the crypto provider and sets QUIC specific protocol versions.
-pub fn default_config_builder() -> Result<ConfigBuilder<ServerConfig, WantsVerifier>, rustls::Error>
-{
+fn default_config_builder() -> Result<ConfigBuilder<ServerConfig, WantsVerifier>, rustls::Error> {
     let tls13_cipher_suite_crypto_provider = default_crypto_provider()?;
     ServerConfig::builder_with_provider(tls13_cipher_suite_crypto_provider.into())
         .with_protocol_versions(crate::PROTOCOL_VERSIONS)

--- a/quic/s2n-quic-rustls/src/server.rs
+++ b/quic/s2n-quic-rustls/src/server.rs
@@ -1,11 +1,21 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{certificate, session::Session, Error};
-use rustls::ServerConfig;
+use crate::{certificate, cipher_suite::default_crypto_provider, session::Session, Error};
+use rustls::{crypto::aws_lc_rs, ConfigBuilder, ServerConfig, WantsVerifier};
 use s2n_codec::EncoderValue;
 use s2n_quic_core::{application::ServerName, crypto::tls};
 use std::sync::Arc;
+
+/// Create a QUIC server specific [rustls::ConfigBuilder].
+///
+/// Uses aws_lc_rs as the crypto provider and sets QUIC specific protocol versions.
+pub fn default_config_builder() -> Result<ConfigBuilder<ServerConfig, WantsVerifier>, rustls::Error>
+{
+    let tls13_cipher_suite_crypto_provider = default_crypto_provider()?;
+    ServerConfig::builder_with_provider(tls13_cipher_suite_crypto_provider.into())
+        .with_protocol_versions(crate::PROTOCOL_VERSIONS)
+}
 
 #[derive(Clone)]
 pub struct Server {
@@ -147,11 +157,7 @@ impl Builder {
     }
 
     pub fn build(self) -> Result<Server, Error> {
-        let builder = ServerConfig::builder()
-            .with_cipher_suites(crate::cipher_suite::DEFAULT_CIPHERSUITES)
-            .with_safe_default_kx_groups()
-            .with_protocol_versions(crate::PROTOCOL_VERSIONS)?
-            .with_no_client_auth();
+        let builder = default_config_builder()?.with_no_client_auth();
 
         let mut config = if let Some(cert_resolver) = self.cert_resolver {
             builder.with_cert_resolver(cert_resolver)
@@ -175,6 +181,7 @@ impl Builder {
     }
 }
 
+#[derive(Debug)]
 struct AlwaysResolvesChain(Arc<rustls::sign::CertifiedKey>);
 
 impl AlwaysResolvesChain {
@@ -182,7 +189,7 @@ impl AlwaysResolvesChain {
         chain: certificate::Certificate,
         priv_key: certificate::PrivateKey,
     ) -> Result<Self, rustls::Error> {
-        let key = rustls::sign::any_supported_type(&priv_key.0)
+        let key = aws_lc_rs::sign::any_supported_type(&priv_key.0)
             .map_err(|_| rustls::Error::General("invalid private key".into()))?;
         Ok(Self(Arc::new(rustls::sign::CertifiedKey::new(
             chain.0, key,

--- a/quic/s2n-quic-rustls/src/session.rs
+++ b/quic/s2n-quic-rustls/src/session.rs
@@ -6,9 +6,7 @@ use crate::cipher_suite::{
 };
 use bytes::Bytes;
 use core::{fmt, fmt::Debug, task::Poll};
-use rustls::quic::{
-    Connection, {self},
-};
+use rustls::quic::{self, Connection};
 use s2n_quic_core::{
     application::ServerName,
     crypto::{self, tls, tls::CipherSuite},
@@ -104,9 +102,12 @@ impl Session {
 
                 self.connection
                     .alert()
-                    .map(|alert| tls::Error {
-                        code: alert.get_u8(),
-                        reason,
+                    .map(|alert| {
+                        // Explicitly annotate the type to detect if rustls starts
+                        // returning a large array
+                        let code: [u8; 1] = alert.to_array();
+                        let code = code[0];
+                        tls::Error { code, reason }
                     })
                     .unwrap_or(tls::Error::INTERNAL_ERROR)
             })?;


### PR DESCRIPTION
**DO NOT MERGE** this PR introduces a change since we now build with aws-lc-rs rather than ring. We should figure out who this impacts before merging this.

This PR reverts the revert PR to upgrade rustls:
- Original PR: (#2143)
- Revert PR: (#2174)

### Description of changes: 
One noteworthy change: rustls now has a concept of crypto providers (ring or aws-lc-rs) and by default uses aws-lc-rs. For this reason I choose to use aws-lc-rs also, which is a change in behavior since previously we used ring. In the future we could expose the option for s2n-quic customers to choose their own crypto provider.

### Call-outs:
I removed some deprecated exports because either:
- they no longer exist (`::rustls::{Certificate, PrivateKey}`)
- they are not useful (`pub static DEFAULT_CIPHERSUITES: &[rustls::SupportedCipherSuite]`)

### Testing:
Existing unit tests and examples pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

