### PR TITLE
Respect rustls default crypto provider after upgrading rustls to 0.23

### DIFF
--- a/examples/rustls-mtls/Cargo.toml
+++ b/examples/rustls-mtls/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Rick Richardson <rick.richardson@gmail.com>", "AWS s2n"]
 # Remove the `provider-tls-default` feature and add `provider-tls-rustls` in order to use the rustls backend
 s2n-quic = { version = "1", path = "../../quic/s2n-quic", default-features = false, features = ["provider-address-token-default", "provider-tls-rustls", "provider-event-tracing"] }
 rustls-pemfile = "2"
+rustls = "0.23"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["ansi"] }

--- a/examples/rustls-mtls/src/bin/quic_echo_client.rs
+++ b/examples/rustls-mtls/src/bin/quic_echo_client.rs
@@ -13,6 +13,7 @@ pub static MY_KEY_PEM: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/certs/client
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     initialize_logger("client");
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let provider = MtlsProvider::new(CACERT_PEM, MY_CERT_PEM, MY_KEY_PEM).await?;
     let client = Client::builder()
         .with_event(s2n_quic::provider::event::tracing::Subscriber::default())?

--- a/examples/rustls-mtls/src/bin/quic_echo_server.rs
+++ b/examples/rustls-mtls/src/bin/quic_echo_server.rs
@@ -13,6 +13,7 @@ pub static MY_KEY_PEM: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/certs/server
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     initialize_logger("server");
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
     let provider = MtlsProvider::new(CACERT_PEM, MY_CERT_PEM, MY_KEY_PEM).await?;
     let mut server = Server::builder()
         .with_event(s2n_quic::provider::event::tracing::Subscriber::default())?

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -12,7 +12,7 @@ exclude = ["corpus.tar.gz"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-rustls = "0.23"
+rustls = { version = "0.23", default-features = false, features=["std", "logging"] }
 rustls-pemfile = "2"
 s2n-codec = { version = "=0.37.0", path = "../../common/s2n-codec", default-features = false, features = ["alloc"] }
 s2n-quic-core = { version = "=0.37.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
@@ -21,3 +21,4 @@ s2n-quic-crypto = { version = "=0.37.0", path = "../s2n-quic-crypto", default-fe
 [dev-dependencies]
 insta = { version = "1", features = ["json"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
+rustls = { version = "0.23", default-features=true }

--- a/quic/s2n-quic-rustls/src/cipher_suite.rs
+++ b/quic/s2n-quic-rustls/src/cipher_suite.rs
@@ -20,12 +20,14 @@ pub fn default_crypto_provider() -> Result<CryptoProvider, rustls::Error> {
 
     // Remove unwanted cipher suite and sort them in our preferred order
 
-    let tmp = tmp.into_iter().map(|scs| {
+    let mut tmp = tmp.into_iter().map(|scs| {
         (DEFAULT_CIPHERSUITES.iter().position(|x| *x == scs.suite()), scs)
     }).filter_map(|(pos, scs)| pos.map(|pos| (pos, scs))).fold(Vec::new(), |mut vec, (pos, scs)| {
         vec.push((pos, scs));
         vec
     });
+
+    tmp.sort_by_key(|(pos, _)| *pos);
 
     provider.cipher_suites = tmp.into_iter().map(|(_, scs)| scs).collect();
 

--- a/quic/s2n-quic-rustls/src/cipher_suite.rs
+++ b/quic/s2n-quic-rustls/src/cipher_suite.rs
@@ -6,6 +6,7 @@ use rustls::{
     crypto::{CryptoProvider},
     quic, CipherSuite
 };
+use rustls::crypto::aws_lc_rs;
 use s2n_codec::Encoder;
 use s2n_quic_core::crypto::{self, packet_protection, scatter, tls, HeaderProtectionMask, Key};
 
@@ -370,4 +371,12 @@ static DEFAULT_CIPHERSUITES: &[CipherSuite] = &[
 #[test]
 fn test_default_cipher_suites() {
     insta::assert_debug_snapshot!("default_cipher_suites", DEFAULT_CIPHERSUITES);
+}
+
+
+#[test]
+fn test_default_crypto_provider() {
+    let _ = aws_lc_rs::default_provider().install_default();
+    let provider = default_crypto_provider().unwrap();
+    assert_eq!(provider.cipher_suites.iter().map(|scs| scs.suite()).collect::<Vec<_>>().as_slice(), DEFAULT_CIPHERSUITES);
 }

--- a/quic/s2n-quic-rustls/src/client.rs
+++ b/quic/s2n-quic-rustls/src/client.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 
 /// Create a QUIC client specific [rustls::ConfigBuilder].
 ///
-/// Uses aws_lc_rs as the crypto provider and sets QUIC specific protocol versions.
+/// Uses the default rustls crypto provider and sets QUIC specific protocol versions.
 pub fn default_config_builder() -> Result<ConfigBuilder<ClientConfig, WantsVerifier>, rustls::Error>
 {
     let tls13_cipher_suite_crypto_provider = default_crypto_provider()?;

--- a/quic/s2n-quic-rustls/src/lib.rs
+++ b/quic/s2n-quic-rustls/src/lib.rs
@@ -37,6 +37,7 @@ mod tests {
 
     #[test]
     fn client_server_test() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
         let mut client = client::Builder::new()
             .with_certificate(CERT_PEM)
             .unwrap()
@@ -60,6 +61,8 @@ mod tests {
 
     #[test]
     fn client_server_der_test() {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
         let mut client = client::Builder::new()
             .with_certificate(CERT_DER)
             .unwrap()
@@ -83,6 +86,8 @@ mod tests {
 
     #[test]
     fn client_server_pkcs1_test() {
+        let _ =  rustls::crypto::aws_lc_rs::default_provider().install_default();
+
         let mut client = client::Builder::new()
             .with_certificate(CERT_PKCS1_PEM)
             .unwrap()

--- a/quic/s2n-quic-tls/src/tests.rs
+++ b/quic/s2n-quic-tls/src/tests.rs
@@ -26,6 +26,7 @@ use s2n_tls::{
     error::Error,
 };
 use std::{sync::Arc, time::SystemTime};
+use s2n_quic_rustls::rustls::crypto::aws_lc_rs;
 
 pub struct MyCallbackHandler {
     done: Arc<AtomicBool>,
@@ -332,6 +333,7 @@ fn s2n_client_s2n_server_pkey_callback_test() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn s2n_client_s2n_server_test() {
+
     let mut client_endpoint = s2n_client();
     let mut server_endpoint = s2n_server();
 
@@ -354,6 +356,8 @@ fn s2n_client_s2n_server_resumption_test() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn rustls_client_s2n_server_resumption_test() {
+    let _ = aws_lc_rs::default_provider().install_default();
+
     let mut client_endpoint = rustls_client();
     let mut server_endpoint = s2n_server_with_resumption();
 
@@ -367,6 +371,8 @@ fn rustls_client_s2n_server_resumption_test() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn rustls_client_s2n_server_test() {
+    let _ = aws_lc_rs::default_provider().install_default();
+
     let mut client_endpoint = rustls_client();
     let mut server_endpoint = s2n_server();
 
@@ -376,6 +382,8 @@ fn rustls_client_s2n_server_test() {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn s2n_client_rustls_server_test() {
+    let _ = aws_lc_rs::default_provider().install_default();
+
     let mut client_endpoint = s2n_client();
     let mut server_endpoint = rustls_server();
 


### PR DESCRIPTION
### Description of changes: 

This is a follow up of #2200, making s2n-quic-rustls respect the `CryptoProvider::get_default()`.

### Call-outs:

Code that relying on aws_lc_rs directly was replaced with `CryptoProvider::get_default().unwrap()`.

### Testing:

Existing unit tests and examples pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

