### PR TITLE
feat(s2n-quic-core): add state construction

### DIFF
--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -20,6 +20,7 @@ checked-counters = []
 branch-tracing = ["tracing"]
 event-tracing = ["tracing"]
 probe-tracing = ["tracing"]
+state-tracing = ["tracing"]
 # This feature enables support for third party congestion controller implementations
 unstable-congestion-controller = []
 usdt = ["dep:probe"]

--- a/quic/s2n-quic-core/src/lib.rs
+++ b/quic/s2n-quic-core/src/lib.rs
@@ -6,165 +6,9 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
-/// Asserts that a boolean expression is true at runtime, only if debug_assertions are enabled.
-///
-/// Otherwise, the compiler is told to assume that the expression is always true and can perform
-/// additional optimizations.
-///
-/// # Safety
-///
-/// The caller _must_ ensure this condition is never possible, otherwise the compiler
-/// may optimize based on false assumptions and behave incorrectly.
-#[macro_export]
-macro_rules! assume {
-    (false) => {
-        assume!(false, "assumption failed")
-    };
-    (false $(, $fmtarg:expr)* $(,)?) => {{
-        if cfg!(not(debug_assertions)) {
-            core::hint::unreachable_unchecked();
-        }
-
-        panic!($($fmtarg),*)
-    }};
-    ($cond:expr) => {
-        $crate::assume!($cond, "assumption failed: {}", stringify!($cond));
-    };
-    ($cond:expr $(, $fmtarg:expr)* $(,)?) => {
-        let v = $cond;
-
-        debug_assert!(v $(, $fmtarg)*);
-        if cfg!(not(debug_assertions)) && !v {
-            core::hint::unreachable_unchecked();
-        }
-    };
-}
-
+#[macro_use]
 #[doc(hidden)]
-#[cfg(feature = "branch-tracing")]
-pub use tracing::trace as _trace;
-
-#[cfg(not(feature = "branch-tracing"))]
-#[macro_export]
-#[doc(hidden)]
-macro_rules! _trace {
-    ($($fmt:tt)*) => {};
-}
-
-/// Traces a branch value if the `branch-tracing` feature is enabled. Otherwise it is a no-op.
-#[macro_export]
-macro_rules! branch {
-    ($cond:expr) => {{
-        let result = $cond;
-        $crate::_trace!(
-            branch = stringify!($cond),
-            result,
-            file = file!(),
-            line = line!(),
-        );
-        result
-    }};
-    ($cond:expr, $outcome:expr) => {
-        $crate::branch!($cond, stringify!($cond), stringify!($outcome))
-    };
-    ($cond:expr, $branch:expr, $outcome:expr) => {{
-        let result = $cond;
-        if result {
-            $crate::_trace!(branch = $branch, result, file = file!(), line = line!(),);
-        } else {
-            $crate::_trace!(
-                branch = $branch,
-                result,
-                outcome = $outcome,
-                file = file!(),
-                line = line!(),
-            );
-        }
-        result
-    }};
-}
-
-#[macro_export]
-macro_rules! ready {
-    ($expr:expr) => {
-        match $expr {
-            ::core::task::Poll::Pending => {
-                $crate::branch!(false, stringify!($expr), "return Poll::Pending");
-                return ::core::task::Poll::Pending;
-            }
-            ::core::task::Poll::Ready(v) => {
-                $crate::branch!(true, stringify!($expr), "");
-                v
-            }
-        }
-    };
-}
-
-/// Checks that the first argument is true, otherwise returns the second value
-#[macro_export]
-macro_rules! ensure {
-    (let $pat:pat = $expr:expr, continue) => {
-        let $pat = $expr else {
-            $crate::branch!(false, stringify!(let $pat = $expr), stringify!(continue));
-            continue;
-        };
-        $crate::branch!(true, stringify!(let $pat = $expr), "");
-    };
-    (let $pat:pat = $expr:expr, break $($ret:expr)?) => {
-        let $pat = $expr else {
-            $crate::branch!(false, stringify!(let $pat = $expr), stringify!(break $($ret)?));
-            break $($ret)?;
-        };
-        $crate::branch!(true, stringify!(let $pat = $expr), "");
-    };
-    (let $pat:pat = $expr:expr, return $($ret:expr)?) => {
-        let $pat = $expr else {
-            $crate::branch!(false, stringify!(let $pat = $expr), stringify!(return $($ret)?));
-            return $($ret)?;
-        };
-        $crate::branch!(true, stringify!(let $pat = $expr), "");
-    };
-    (let $pat:pat = $expr:expr $(, $ret:expr)?) => {
-        $crate::ensure!(let $pat = $expr, return $($ret)?)
-    };
-    ($cond:expr, continue) => {
-        if !$crate::branch!($cond, continue) {
-            continue;
-        }
-    };
-    ($cond:expr, break $($expr:expr)?) => {
-        if !$crate::branch!($cond, break $($expr)?) {
-            break $($expr)?;
-        }
-    };
-    ($cond:expr, return $($expr:expr)?) => {
-        if !$crate::branch!($cond, return $($expr)?) {
-            return $($expr)?;
-        }
-    };
-    ($cond:expr $(, $ret:expr)?) => {
-        $crate::ensure!($cond, return $($ret)?);
-    };
-}
-
-/// Implements a future that wraps `T::poll_ready` and yields after ready
-macro_rules! impl_ready_future {
-    ($name:ident, $fut:ident, $output:ty) => {
-        pub struct $fut<'a, T>(&'a mut T);
-
-        impl<'a, T: $name> core::future::Future for $fut<'a, T> {
-            type Output = $output;
-
-            #[inline]
-            fn poll(
-                mut self: core::pin::Pin<&mut Self>,
-                cx: &mut core::task::Context,
-            ) -> core::task::Poll<Self::Output> {
-                self.0.poll_ready(cx)
-            }
-        }
-    };
-}
+pub mod macros;
 
 #[macro_use]
 pub mod probe;
@@ -194,6 +38,7 @@ pub mod query;
 pub mod random;
 pub mod recovery;
 pub mod slice;
+pub mod state;
 pub mod stateless_reset;
 pub mod stream;
 pub mod sync;

--- a/quic/s2n-quic-core/src/macros.rs
+++ b/quic/s2n-quic-core/src/macros.rs
@@ -1,0 +1,170 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Asserts that a boolean expression is true at runtime, only if debug_assertions are enabled.
+///
+/// Otherwise, the compiler is told to assume that the expression is always true and can perform
+/// additional optimizations.
+///
+/// # Safety
+///
+/// The caller _must_ ensure this condition is never possible, otherwise the compiler
+/// may optimize based on false assumptions and behave incorrectly.
+#[macro_export]
+macro_rules! assume {
+    (false) => {
+        assume!(false, "assumption failed")
+    };
+    (false $(, $fmtarg:expr)* $(,)?) => {{
+        if cfg!(not(debug_assertions)) {
+            core::hint::unreachable_unchecked();
+        }
+
+        panic!($($fmtarg),*)
+    }};
+    ($cond:expr) => {
+        $crate::assume!($cond, "assumption failed: {}", stringify!($cond));
+    };
+    ($cond:expr $(, $fmtarg:expr)* $(,)?) => {
+        let v = $cond;
+
+        debug_assert!(v $(, $fmtarg)*);
+        if cfg!(not(debug_assertions)) && !v {
+            core::hint::unreachable_unchecked();
+        }
+    };
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __tracing_noop__ {
+    ($($fmt:tt)*) => {};
+}
+
+#[doc(hidden)]
+#[cfg(feature = "branch-tracing")]
+pub use tracing::trace as _trace_branch;
+
+#[doc(hidden)]
+#[cfg(not(feature = "branch-tracing"))]
+pub use __tracing_noop__ as _trace_branch;
+
+/// Traces a branch value if the `branch-tracing` feature is enabled. Otherwise it is a no-op.
+#[macro_export]
+macro_rules! branch {
+    ($cond:expr) => {{
+        let result = $cond;
+        $crate::macros::_trace_branch!(
+            branch = stringify!($cond),
+            result,
+            file = file!(),
+            line = line!(),
+        );
+        result
+    }};
+    ($cond:expr, $outcome:expr) => {
+        $crate::branch!($cond, stringify!($cond), stringify!($outcome))
+    };
+    ($cond:expr, $branch:expr, $outcome:expr) => {{
+        let result = $cond;
+        if result {
+            $crate::macros::_trace_branch!(
+                branch = $branch,
+                result,
+                file = file!(),
+                line = line!(),
+            );
+        } else {
+            $crate::macros::_trace_branch!(
+                branch = $branch,
+                result,
+                outcome = $outcome,
+                file = file!(),
+                line = line!(),
+            );
+        }
+        result
+    }};
+}
+
+#[macro_export]
+macro_rules! ready {
+    ($expr:expr) => {
+        match $expr {
+            ::core::task::Poll::Pending => {
+                $crate::branch!(false, stringify!($expr), "return Poll::Pending");
+                return ::core::task::Poll::Pending;
+            }
+            ::core::task::Poll::Ready(v) => {
+                $crate::branch!(true, stringify!($expr), "");
+                v
+            }
+        }
+    };
+}
+
+/// Checks that the first argument is true, otherwise returns the second value
+#[macro_export]
+macro_rules! ensure {
+    (let $pat:pat = $expr:expr, continue) => {
+        let $pat = $expr else {
+            $crate::branch!(false, stringify!(let $pat = $expr), stringify!(continue));
+            continue;
+        };
+        $crate::branch!(true, stringify!(let $pat = $expr), "");
+    };
+    (let $pat:pat = $expr:expr, break $($ret:expr)?) => {
+        let $pat = $expr else {
+            $crate::branch!(false, stringify!(let $pat = $expr), stringify!(break $($ret)?));
+            break $($ret)?;
+        };
+        $crate::branch!(true, stringify!(let $pat = $expr), "");
+    };
+    (let $pat:pat = $expr:expr, return $($ret:expr)?) => {
+        let $pat = $expr else {
+            $crate::branch!(false, stringify!(let $pat = $expr), stringify!(return $($ret)?));
+            return $($ret)?;
+        };
+        $crate::branch!(true, stringify!(let $pat = $expr), "");
+    };
+    (let $pat:pat = $expr:expr $(, $ret:expr)?) => {
+        $crate::ensure!(let $pat = $expr, return $($ret)?)
+    };
+    ($cond:expr, continue) => {
+        if !$crate::branch!($cond, continue) {
+            continue;
+        }
+    };
+    ($cond:expr, break $($expr:expr)?) => {
+        if !$crate::branch!($cond, break $($expr)?) {
+            break $($expr)?;
+        }
+    };
+    ($cond:expr, return $($expr:expr)?) => {
+        if !$crate::branch!($cond, return $($expr)?) {
+            return $($expr)?;
+        }
+    };
+    ($cond:expr $(, $ret:expr)?) => {
+        $crate::ensure!($cond, return $($ret)?);
+    };
+}
+
+/// Implements a future that wraps `T::poll_ready` and yields after ready
+macro_rules! impl_ready_future {
+    ($name:ident, $fut:ident, $output:ty) => {
+        pub struct $fut<'a, T>(&'a mut T);
+
+        impl<'a, T: $name> core::future::Future for $fut<'a, T> {
+            type Output = $output;
+
+            #[inline]
+            fn poll(
+                mut self: core::pin::Pin<&mut Self>,
+                cx: &mut core::task::Context,
+            ) -> core::task::Poll<Self::Output> {
+                self.0.poll_ready(cx)
+            }
+        }
+    };
+}

--- a/quic/s2n-quic-core/src/state.rs
+++ b/quic/s2n-quic-core/src/state.rs
@@ -1,0 +1,210 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::fmt;
+
+pub type Result<T> = core::result::Result<(), Error<T>>;
+
+#[cfg(feature = "state-tracing")]
+#[doc(hidden)]
+pub use tracing::debug as _debug;
+
+#[cfg(not(feature = "state-tracing"))]
+#[doc(hidden)]
+pub use crate::__tracing_noop__ as _debug;
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __state_transition__ {
+    ($state:ident, $valid:pat => $target:expr) => {
+        $crate::state::transition!(_, $state, $valid => $target)
+    };
+    ($event:ident, $state:ident, $valid:pat => $target:expr) => {{
+        if *$state == $target {
+            // if transitioning to itself is not called out, then return an error
+            $crate::ensure!(
+                matches!($state, $valid),
+                Err($crate::state::Error::NoOp { current: $target })
+            );
+            return Ok(());
+        }
+
+        // make sure the transition is valid
+        $crate::ensure!(
+            matches!($state, $valid),
+            Err($crate::state::Error::InvalidTransition {
+                current: $state.clone(),
+                target: $target
+            })
+        );
+
+        let __event__ = stringify!($event);
+        if __event__.is_empty() || __event__ == "_" {
+            $crate::state::_debug!(prev = ?$state, next = ?$target);
+        } else {
+            $crate::state::_debug!(event = %__event__, prev = ?$state, next = ?$target);
+        }
+
+        *$state = $target;
+        Ok(())
+    }};
+}
+
+pub use crate::__state_transition__ as transition;
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __state_event__ {
+    ($(#[doc = $doc:literal])* $event:ident ($($valid:ident)|* => $target:ident)) => {
+        $(
+            #[doc = $doc]
+        )*
+        #[inline]
+        pub fn $event(&mut self) -> $crate::state::Result<Self> {
+            $crate::state::transition!($event, self, $(Self::$valid)|* => Self::$target)
+        }
+    };
+    ($( $(#[doc = $doc:literal])* $event:ident ($($valid:ident)|* => $target:ident) ;)*) => {
+        $(
+            $crate::state::event!($(#[doc = $doc])* $event($($valid)|* => $target));
+        )*
+
+        /// Generates a dot graph of all state transitions
+        pub fn dot() -> impl ::core::fmt::Display {
+            struct Dot;
+
+            impl ::core::fmt::Display for Dot {
+                fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
+                    writeln!(f, "digraph {{")?;
+
+                    let mut all_states = [
+                        // collect all of the states we've observed
+                        $(
+                            $(
+                                stringify!($valid),
+                            )*
+                            stringify!($target),
+                        )*
+                    ];
+
+                    let all_states = $crate::state::dedup_states(&mut all_states);
+
+                    for state in all_states {
+                        writeln!(f, "  {state};")?;
+                    }
+
+                    $(
+                        $(
+                            writeln!(
+                                f,
+                                "  {} -> {} [label = {:?}];",
+                                stringify!($valid),
+                                stringify!($target),
+                                stringify!($event),
+                            )?;
+                        )*
+                    )*
+
+                    writeln!(f, "}}")?;
+                    Ok(())
+                }
+            }
+
+            Dot
+        }
+    }
+}
+
+pub use crate::__state_event__ as event;
+
+#[doc(hidden)]
+pub fn dedup_states<'a>(states: &'a mut [&'a str]) -> &'a mut [&'a str] {
+    // TODO replace with
+    // https://doc.rust-lang.org/std/primitive.slice.html#method.partition_dedup
+    // when stable
+    //
+    // For now, we've just inlined their implementation
+
+    let len = states.len();
+    if len <= 1 {
+        return states;
+    }
+
+    // sort the states before deduping
+    states.sort_unstable();
+
+    let ptr = states.as_mut_ptr();
+    let mut next_read: usize = 1;
+    let mut next_write: usize = 1;
+
+    // SAFETY: the `while` condition guarantees `next_read` and `next_write`
+    // are less than `len`, thus are inside `self`. `prev_ptr_write` points to
+    // one element before `ptr_write`, but `next_write` starts at 1, so
+    // `prev_ptr_write` is never less than 0 and is inside the slice.
+    // This fulfils the requirements for dereferencing `ptr_read`, `prev_ptr_write`
+    // and `ptr_write`, and for using `ptr.add(next_read)`, `ptr.add(next_write - 1)`
+    // and `prev_ptr_write.offset(1)`.
+    //
+    // `next_write` is also incremented at most once per loop at most meaning
+    // no element is skipped when it may need to be swapped.
+    //
+    // `ptr_read` and `prev_ptr_write` never point to the same element. This
+    // is required for `&mut *ptr_read`, `&mut *prev_ptr_write` to be safe.
+    // The explanation is simply that `next_read >= next_write` is always true,
+    // thus `next_read > next_write - 1` is too.
+    unsafe {
+        // Avoid bounds checks by using raw pointers.
+        while next_read < len {
+            let ptr_read = ptr.add(next_read);
+            let prev_ptr_write = ptr.add(next_write - 1);
+            if *ptr_read != *prev_ptr_write {
+                if next_read != next_write {
+                    let ptr_write = prev_ptr_write.add(1);
+                    core::ptr::swap(ptr_read, ptr_write);
+                }
+                next_write += 1;
+            }
+            next_read += 1;
+        }
+    }
+
+    &mut states[..next_write]
+}
+
+#[macro_export]
+#[doc(hidden)]
+macro_rules! __state_is__ {
+    ($(#[doc = $doc:literal])* $function:ident, $($state:ident)|+) => {
+        $(
+            #[doc = $doc]
+        )*
+        #[inline]
+        pub fn $function(&self) -> bool {
+            matches!(self, $(Self::$state)|*)
+        }
+    };
+}
+
+pub use crate::__state_is__ as is;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Error<T> {
+    NoOp { current: T },
+    InvalidTransition { current: T, target: T },
+}
+
+impl<T: fmt::Debug> fmt::Display for Error<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NoOp { current } => {
+                write!(f, "state is already set to {current:?}")
+            }
+            Self::InvalidTransition { current, target } => {
+                write!(f, "invalid transition from {current:?} to {target:?}",)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl<T: fmt::Debug> std::error::Error for Error<T> {}

--- a/quic/s2n-quic-core/src/stream/state.rs
+++ b/quic/s2n-quic-core/src/stream/state.rs
@@ -1,61 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::ensure;
-use core::fmt;
-
-pub type Result<T> = core::result::Result<(), Error<T>>;
-
-macro_rules! transition {
-    ($state:ident, $valid:pat => $target:expr) => {{
-        ensure!(*$state != $target, Err(Error::NoOp { current: $target }));
-        ensure!(
-            matches!($state, $valid),
-            Err(Error::InvalidTransition {
-                current: $state.clone(),
-                target: $target
-            })
-        );
-        #[cfg(feature = "tracing")]
-        {
-            tracing::debug!(prev = ?$state, next = ?$target);
-        }
-        *$state = $target;
-        Ok(())
-    }};
-}
-
-macro_rules! is {
-    ($($state:ident)|+, $function:ident) => {
-        #[inline]
-        pub fn $function(&self) -> bool {
-            matches!(self, $(Self::$state)|*)
-        }
-    };
-}
-
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Error<T> {
-    NoOp { current: T },
-    InvalidTransition { current: T, target: T },
-}
-
-impl<T: fmt::Debug> fmt::Display for Error<T> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::NoOp { current } => {
-                write!(f, "state is already set to {current:?}")
-            }
-            Self::InvalidTransition { current, target } => {
-                write!(f, "invalid transition from {current:?} to {target:?}",)
-            }
-        }
-    }
-}
-
-#[cfg(feature = "std")]
-impl<T: fmt::Debug> std::error::Error for Error<T> {}
-
 mod recv;
 mod send;
 

--- a/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__recv__tests__dot_test.snap
+++ b/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__recv__tests__dot_test.snap
@@ -1,0 +1,18 @@
+---
+source: quic/s2n-quic-core/src/stream/state/recv.rs
+expression: "Receiver::dot()"
+---
+digraph {
+  DataRead;
+  DataRecvd;
+  Recv;
+  ResetRead;
+  ResetRecvd;
+  SizeKnown;
+  Recv -> SizeKnown [label = "on_receive_fin"];
+  SizeKnown -> DataRecvd [label = "on_receive_all_data"];
+  DataRecvd -> DataRead [label = "on_app_read_all_data"];
+  Recv -> ResetRecvd [label = "on_reset"];
+  SizeKnown -> ResetRecvd [label = "on_reset"];
+  ResetRecvd -> ResetRead [label = "on_app_read_reset"];
+}

--- a/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__send__tests__dot_test.snap
+++ b/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__send__tests__dot_test.snap
@@ -1,0 +1,26 @@
+---
+source: quic/s2n-quic-core/src/stream/state/send.rs
+expression: "Sender::dot()"
+---
+digraph {
+  DataRecvd;
+  DataSent;
+  Ready;
+  ResetQueued;
+  ResetRecvd;
+  ResetSent;
+  Send;
+  Ready -> Send [label = "on_send_stream"];
+  Ready -> DataSent [label = "on_send_fin"];
+  Send -> DataSent [label = "on_send_fin"];
+  DataSent -> DataRecvd [label = "on_recv_all_acks"];
+  ResetQueued -> DataRecvd [label = "on_recv_all_acks"];
+  Ready -> ResetQueued [label = "on_queue_reset"];
+  Send -> ResetQueued [label = "on_queue_reset"];
+  DataSent -> ResetQueued [label = "on_queue_reset"];
+  Ready -> ResetSent [label = "on_send_reset"];
+  Send -> ResetSent [label = "on_send_reset"];
+  DataSent -> ResetSent [label = "on_send_reset"];
+  ResetQueued -> ResetSent [label = "on_send_reset"];
+  ResetSent -> ResetRecvd [label = "on_recv_reset_ack"];
+}


### PR DESCRIPTION
### Description of changes: 

This change exposes the `stream/state` macros to be more general and used outside of the core crate. As a bonus, we get free dot graphs:

#### Send
![image](https://github.com/aws/s2n-quic/assets/799311/66979695-b7e3-4c8e-a895-1f9da4276ddc)

#### Recv
![image](https://github.com/aws/s2n-quic/assets/799311/cb7d3448-3407-4147-97f3-96e047971d46)


### Call-outs:

I moved all of the root-level macros into a `macros` module to keep the root a bit cleaner.

### Testing:

The existing snapshot tests of the stream state impls should prevent any regressions in behavior. I've also added new snapshot tests for the dot output.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

