### PR TITLE
chore(s2n-quic-core): update frame round trip fuzz corpus

### DIFF
--- a/quic/s2n-quic-core/src/frame/__fuzz__/frame__tests__round_trip/corpus.tar.gz
+++ b/quic/s2n-quic-core/src/frame/__fuzz__/frame__tests__round_trip/corpus.tar.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:deef7a663c55f7b334a6fc0ed2d4d601d8e2a18201b392394bd9e1be132ff80d
-size 890109
+oid sha256:e0cca0bd6f2648c3a7ad634b337e3effde00b48735aaadd7383323fc8b2adf5f
+size 1255256


### PR DESCRIPTION
### Description of changes: 

With the new frame introduced in https://github.com/aws/s2n-quic/pull/2198, I fuzz tested the frame code for a couple hours. This change updates the corpus from that fuzzing. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

