### PR TITLE
Rustls dangerous

### DIFF
--- a/quic/s2n-quic-rustls/src/client.rs
+++ b/quic/s2n-quic-rustls/src/client.rs
@@ -182,13 +182,13 @@ impl Builder {
                 )
                 .into());
             }
-            (true, Some(_)) => {
+            (false, Some(_)) => {
                 return Err(rustls::Error::General(
                     "custom certificate verifier and certificate(s) provided".to_string(),
                 )
                 .into());
             }
-            (false, Some(verifier)) => cfg_builder
+            (true, Some(verifier)) => cfg_builder
                 .dangerous()
                 .with_custom_certificate_verifier(verifier),
             (false, None) => cfg_builder.with_root_certificates(self.cert_store),

--- a/quic/s2n-quic-rustls/src/lib.rs
+++ b/quic/s2n-quic-rustls/src/lib.rs
@@ -114,4 +114,95 @@ mod tests {
 
         pair.finish();
     }
+
+    use ::rustls::client::danger::*;
+    use ::rustls::pki_types::*;
+    use ::rustls::{DigitallySignedStruct, SignatureScheme};
+
+    #[derive(Debug)]
+    struct AllowAllCertsVerifier;
+
+    impl rustls::client::danger::ServerCertVerifier for AllowAllCertsVerifier {
+        fn verify_server_cert(
+            &self,
+            _end_entity: &CertificateDer<'_>,
+            _intermediates: &[CertificateDer<'_>],
+            _server_name: &ServerName<'_>,
+            _ocsp_response: &[u8],
+            _now: UnixTime,
+        ) -> Result<ServerCertVerified, ::rustls::Error> {
+            Ok(ServerCertVerified::assertion())
+        }
+
+        fn verify_tls12_signature(
+            &self,
+            _message: &[u8],
+            _cert: &CertificateDer<'_>,
+            _dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, ::rustls::Error> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+
+        fn verify_tls13_signature(
+            &self,
+            _message: &[u8],
+            _cert: &CertificateDer<'_>,
+            _dss: &DigitallySignedStruct,
+        ) -> Result<HandshakeSignatureValid, ::rustls::Error> {
+            Ok(HandshakeSignatureValid::assertion())
+        }
+
+        fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+            vec![
+                SignatureScheme::RSA_PKCS1_SHA1,
+                SignatureScheme::ECDSA_SHA1_Legacy,
+                SignatureScheme::RSA_PKCS1_SHA256,
+                SignatureScheme::ECDSA_NISTP256_SHA256,
+                SignatureScheme::RSA_PKCS1_SHA384,
+                SignatureScheme::ECDSA_NISTP384_SHA384,
+                SignatureScheme::RSA_PKCS1_SHA512,
+                SignatureScheme::ECDSA_NISTP521_SHA512,
+                SignatureScheme::RSA_PSS_SHA256,
+                SignatureScheme::RSA_PSS_SHA384,
+                SignatureScheme::RSA_PSS_SHA512,
+                SignatureScheme::ED25519,
+                SignatureScheme::ED448,
+            ]
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn client_custom_verifier_and_certs() {
+        client::Builder::new()
+            .with_certificate(CERT_PKCS1_PEM)
+            .unwrap()
+            .with_custom_certificate_verifier(AllowAllCertsVerifier)
+            .unwrap()
+            .build()
+            .unwrap();
+    }
+
+    #[test]
+    fn client_custom_verifier() {
+        let mut client = client::Builder::new()
+            .with_custom_certificate_verifier(AllowAllCertsVerifier)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let mut server = server::Builder::new()
+            .with_certificate(CERT_PKCS1_PEM, KEY_PKCS1_PEM)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let mut pair = tls::testing::Pair::new(&mut server, &mut client, "localhost".into());
+
+        while pair.is_handshaking() {
+            pair.poll(None).unwrap();
+        }
+
+        pair.finish();
+    }
 }


### PR DESCRIPTION
### Resolved issues:

Resolves this [comment](https://github.com/aws/s2n-quic/issues/2178#issuecomment-2073020524)

### Description of changes: 

Currently, s2n-quic provides no method of doing custom certificate validation. This presents a challenge for a variety of scenarios where the client may want to perform more complex logic around the certificate verification. This PR attempts to resolve this by exposing rustls's `ServerCertVerifier` trait and a corresponding method in the client `Builder`.

### Call-outs:

IMO custom certificate validation and certificate validation built-in via rustls should be mutually exclusive. After all, it's unclear when the client should use custom validation or built-in validation. Towards that end, the builder fails if both `with_certificate` and `with_custom_certificate_verifier` are provided.

### Testing:

Two new tests have been added to `s2n-quic-rustls/src/lib.rs` to validate these changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

