### PR TITLE
feat(s2n-quic-tls, s2n-quic-rustls): pass `fips` flag to tls backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -284,9 +284,13 @@ jobs:
 
       - uses: camshaft/rust-cache@v1
 
-      - name: Run test
+      - name: Run test (rustls)
         run: |
-          cargo test --features provider-tls-fips
+          cargo test --no-default-features --features "provider-tls-fips provider-tls-rustls"
+
+      - name: Run test (s2n-tls)
+        run: |
+          cargo test --no-default-features --features "provider-tls-fips provider-tls-s2n"
 
   miri:
     # miri needs quite a bit of memory so use a larger instance

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -10,8 +10,12 @@ license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]
 
+[features]
+fips = ["s2n-quic-crypto/fips", "rustls/fips"]
+
 [dependencies]
 bytes = { version = "1", default-features = false }
+cfg-if = "1"
 # By [default](https://docs.rs/crate/rustls/latest/features) rustls includes the `tls12` feature.
 rustls = { version = "0.23", default-features = false, features=["std", "aws-lc-rs", "logging"] }
 rustls-pemfile = "2"

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -15,7 +15,6 @@ fips = ["s2n-quic-crypto/fips", "rustls/fips"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-cfg-if = "1"
 # By [default](https://docs.rs/crate/rustls/latest/features) rustls includes the `tls12` feature.
 rustls = { version = "0.23", default-features = false, features=["std", "aws-lc-rs", "logging"] }
 rustls-pemfile = "2"

--- a/quic/s2n-quic-rustls/src/cipher_suite.rs
+++ b/quic/s2n-quic-rustls/src/cipher_suite.rs
@@ -16,7 +16,6 @@ pub(crate) fn default_crypto_provider() -> Result<CryptoProvider, rustls::Error>
         if #[cfg(feature = "fips")] {
             let crypto = rustls::crypto::default_fips_provider();
             assert!(crypto.fips());
-            panic!("test rustls");
         } else {
             let crypto = aws_lc_rs::default_provider();
         }

--- a/quic/s2n-quic-rustls/src/cipher_suite.rs
+++ b/quic/s2n-quic-rustls/src/cipher_suite.rs
@@ -1,7 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use cfg_if::cfg_if;
 use rustls::{
     crypto::{aws_lc_rs, CryptoProvider},
     quic, CipherSuite, SupportedCipherSuite,
@@ -12,14 +11,9 @@ use s2n_quic_core::crypto::{self, packet_protection, scatter, tls, HeaderProtect
 /// `aws_lc_rs` is the default crypto provider since that is also the
 /// default used by rustls.
 pub(crate) fn default_crypto_provider() -> Result<CryptoProvider, rustls::Error> {
-    cfg_if!(
-        if #[cfg(feature = "fips")] {
-            let crypto = rustls::crypto::default_fips_provider();
-            assert!(crypto.fips());
-        } else {
-            let crypto = aws_lc_rs::default_provider();
-        }
-    );
+    let crypto = aws_lc_rs::default_provider();
+    #[cfg(feature = "fips")]
+    assert!(crypto.fips());
 
     Ok(CryptoProvider {
         cipher_suites: DEFAULT_CIPHERSUITES.to_vec(),

--- a/quic/s2n-quic-rustls/src/cipher_suite.rs
+++ b/quic/s2n-quic-rustls/src/cipher_suite.rs
@@ -16,6 +16,7 @@ pub(crate) fn default_crypto_provider() -> Result<CryptoProvider, rustls::Error>
         if #[cfg(feature = "fips")] {
             let crypto = rustls::crypto::default_fips_provider();
             assert!(crypto.fips());
+            panic!("test rustls");
         } else {
             let crypto = aws_lc_rs::default_provider();
         }

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 exclude = ["corpus.tar.gz"]
 
 [features]
-fips = ["s2n-quic-crypto/fips"]
+fips = ["s2n-quic-crypto/fips", "s2n-tls/fips"]
 unstable_client_hello = []
 unstable_private_key = []
 

--- a/quic/s2n-quic-tls/src/client.rs
+++ b/quic/s2n-quic-tls/src/client.rs
@@ -188,8 +188,6 @@ impl Builder {
     pub fn build(self) -> Result<Client, Error> {
         #[cfg(feature = "fips")]
         assert!(s2n_tls::init::fips_mode()?.is_enabled());
-        #[cfg(feature = "fips")]
-        panic!("test s2n-tls");
 
         Ok(Client {
             loader: self.config.build()?,

--- a/quic/s2n-quic-tls/src/client.rs
+++ b/quic/s2n-quic-tls/src/client.rs
@@ -186,6 +186,9 @@ impl Builder {
     }
 
     pub fn build(self) -> Result<Client, Error> {
+        #[cfg(feature = "fips")]
+        assert!(s2n_tls::init::fips_mode()?.is_enabled());
+
         Ok(Client {
             loader: self.config.build()?,
             keylog: self.keylog,

--- a/quic/s2n-quic-tls/src/client.rs
+++ b/quic/s2n-quic-tls/src/client.rs
@@ -188,6 +188,8 @@ impl Builder {
     pub fn build(self) -> Result<Client, Error> {
         #[cfg(feature = "fips")]
         assert!(s2n_tls::init::fips_mode()?.is_enabled());
+        #[cfg(feature = "fips")]
+        panic!("test s2n-tls");
 
         Ok(Client {
             loader: self.config.build()?,

--- a/quic/s2n-quic-tls/src/server.rs
+++ b/quic/s2n-quic-tls/src/server.rs
@@ -219,6 +219,9 @@ impl Builder {
     }
 
     pub fn build(self) -> Result<Server, Error> {
+        #[cfg(feature = "fips")]
+        assert!(s2n_tls::init::fips_mode()?.is_enabled());
+
         Ok(Server {
             loader: self.config.build()?,
             keylog: self.keylog,

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -18,6 +18,7 @@ default = [
 provider-tls-fips = [
     "s2n-quic-tls-default?/fips",
     "s2n-quic-tls?/fips",
+    "s2n-quic-rustls?/fips",
 ]
 provider-address-token-default = [
     "cuckoofilter",


### PR DESCRIPTION
### Description of changes: 
This PR passes the `fips` flag down to the tls libraries. We also `assert` that each tls library is built with a fips-approved libcrypto when the `provider-tls-fips` is enabled for s2n-quic.

### Testing:
Extended the fips testing to rustls. The failing commits validate that we are in fact testing both s2n-tls and rustls in fips mode.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

