### PR TITLE
feat(s2n-quic): unstable dc provider

### DIFF
--- a/quic/s2n-quic-core/src/dc.rs
+++ b/quic/s2n-quic-core/src/dc.rs
@@ -3,19 +3,19 @@
 
 use crate::{
     connection::Limits,
-    crypto::tls::TlsSession,
     event::{api::SocketAddress, IntoEvent as _},
     inet,
     path::MaxMtu,
-    stateless_reset,
     transport::parameters::InitialFlowControlLimits,
     varint::VarInt,
 };
 use core::time::Duration;
 
-pub use disabled::*;
-
 mod disabled;
+mod traits;
+
+pub use disabled::*;
+pub use traits::*;
 
 // dc versions supported by this code, in order of preference (SUPPORTED_VERSIONS[0] is most preferred)
 const SUPPORTED_VERSIONS: &[u32] = &[0x0];
@@ -28,63 +28,6 @@ pub fn select_version(client_supported_versions: &[u32]) -> Option<u32> {
         .iter()
         .find(|&supported_version| client_supported_versions.contains(supported_version))
         .copied()
-}
-
-/// The `dc::Endpoint` trait provides a way to support dc functionality
-pub trait Endpoint: 'static + Send {
-    /// If enabled, a dc version will attempt to be negotiated and dc-specific frames
-    /// will be processed. Otherwise, no dc version will be negotiated and dc-specific
-    /// frames received will result in a connection error.
-    const ENABLED: bool = true;
-
-    type Path: Path;
-
-    /// Called when a dc version has been negotiated for the given `ConnectionInfo`
-    fn new_path(&mut self, connection_info: &ConnectionInfo) -> Self::Path;
-}
-
-/// A dc path
-pub trait Path: 'static + Send {
-    /// Called when path secrets are ready to be derived from the given `TlsSession`
-    fn on_path_secrets_ready(&mut self, session: &impl TlsSession);
-
-    /// Called when a `DC_STATELESS_RESET_TOKENS` frame has been received from the peer
-    fn on_peer_stateless_reset_tokens<'a>(
-        &mut self,
-        stateless_reset_tokens: impl Iterator<Item = &'a stateless_reset::Token>,
-    );
-
-    /// Returns the stateless reset tokens to include in a `DC_STATELESS_RESET_TOKENS`
-    /// frame sent to the peer.
-    fn stateless_reset_tokens(&mut self) -> &[stateless_reset::Token];
-}
-
-impl<P: Path> Path for Option<P> {
-    #[inline]
-    fn on_path_secrets_ready(&mut self, session: &impl TlsSession) {
-        if let Some(path) = self {
-            path.on_path_secrets_ready(session)
-        }
-    }
-
-    #[inline]
-    fn on_peer_stateless_reset_tokens<'a>(
-        &mut self,
-        stateless_reset_tokens: impl Iterator<Item = &'a stateless_reset::Token>,
-    ) {
-        if let Some(path) = self {
-            path.on_peer_stateless_reset_tokens(stateless_reset_tokens)
-        }
-    }
-
-    #[inline]
-    fn stateless_reset_tokens(&mut self) -> &[stateless_reset::Token] {
-        if let Some(path) = self {
-            path.stateless_reset_tokens()
-        } else {
-            &[]
-        }
-    }
 }
 
 /// Information about the connection that may be used

--- a/quic/s2n-quic-core/src/dc/disabled.rs
+++ b/quic/s2n-quic-core/src/dc/disabled.rs
@@ -13,25 +13,27 @@ pub struct Disabled(());
 impl Endpoint for Disabled {
     const ENABLED: bool = false;
 
-    type Path = DisabledPath;
+    type Path = ();
 
-    fn new_path(&mut self, _connection_info: &ConnectionInfo) -> Self::Path {
-        DisabledPath(())
+    fn new_path(&mut self, _connection_info: &ConnectionInfo) -> Option<Self::Path> {
+        None
     }
 }
 
-pub struct DisabledPath(());
-
-impl Path for DisabledPath {
-    fn on_path_secrets_ready(&mut self, _session: &impl TlsSession) {}
+// The Disabled Endpoint returns `None`, so this is not used
+impl Path for () {
+    fn on_path_secrets_ready(&mut self, _session: &impl TlsSession) {
+        unimplemented!()
+    }
 
     fn on_peer_stateless_reset_tokens<'a>(
         &mut self,
         _stateless_reset_tokens: impl Iterator<Item = &'a Token>,
     ) {
+        unimplemented!()
     }
 
     fn stateless_reset_tokens(&mut self) -> &[Token] {
-        &[]
+        unimplemented!()
     }
 }

--- a/quic/s2n-quic-core/src/dc/disabled.rs
+++ b/quic/s2n-quic-core/src/dc/disabled.rs
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    crypto::tls::TlsSession,
+    dc::{ConnectionInfo, Endpoint, Path},
+    stateless_reset::Token,
+};
+
+#[derive(Debug, Default)]
+pub struct Disabled(());
+
+impl Endpoint for Disabled {
+    const ENABLED: bool = false;
+
+    type Path = DisabledPath;
+
+    fn new_path(&mut self, _connection_info: &ConnectionInfo) -> Self::Path {
+        DisabledPath(())
+    }
+}
+
+pub struct DisabledPath(());
+
+impl Path for DisabledPath {
+    fn on_path_secrets_ready(&mut self, _session: &impl TlsSession) {}
+
+    fn on_peer_stateless_reset_tokens<'a>(
+        &mut self,
+        _stateless_reset_tokens: impl Iterator<Item = &'a Token>,
+    ) {
+    }
+
+    fn stateless_reset_tokens(&mut self) -> &[Token] {
+        &[]
+    }
+}

--- a/quic/s2n-quic-core/src/dc/mod.rs
+++ b/quic/s2n-quic-core/src/dc/mod.rs
@@ -1,0 +1,146 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    connection::Limits,
+    crypto::tls::TlsSession,
+    event::{api::SocketAddress, IntoEvent as _},
+    inet,
+    path::MaxMtu,
+    stateless_reset,
+    transport::parameters::InitialFlowControlLimits,
+    varint::VarInt,
+};
+use core::time::Duration;
+
+pub use disabled::*;
+
+mod disabled;
+
+// dc versions supported by this code, in order of preference (SUPPORTED_VERSIONS[0] is most preferred)
+const SUPPORTED_VERSIONS: &[u32] = &[0x0];
+
+/// Called on the server to select the dc version to use (if any)
+///
+/// The server's version preference takes precedence
+pub fn select_version(client_supported_versions: &[u32]) -> Option<u32> {
+    SUPPORTED_VERSIONS
+        .iter()
+        .find(|&supported_version| client_supported_versions.contains(supported_version))
+        .copied()
+}
+
+/// The `dc::Endpoint` trait provides a way to support dc functionality
+pub trait Endpoint: 'static + Send {
+    /// If enabled, a dc version will attempt to be negotiated and dc-specific frames
+    /// will be processed. Otherwise, no dc version will be negotiated and dc-specific
+    /// frames received will result in a connection error.
+    const ENABLED: bool = true;
+
+    type Path: Path;
+
+    /// Called when a dc version has been negotiated for the given `ConnectionInfo`
+    fn new_path(&mut self, connection_info: &ConnectionInfo) -> Self::Path;
+}
+
+/// A dc path
+pub trait Path: 'static + Send {
+    /// Called when path secrets are ready to be derived from the given `TlsSession`
+    fn on_path_secrets_ready(&mut self, session: &impl TlsSession);
+
+    /// Called when a `DC_STATELESS_RESET_TOKENS` frame has been received from the peer
+    fn on_peer_stateless_reset_tokens<'a>(
+        &mut self,
+        stateless_reset_tokens: impl Iterator<Item = &'a stateless_reset::Token>,
+    );
+
+    /// Returns the stateless reset tokens to include in a `DC_STATELESS_RESET_TOKENS`
+    /// frame sent to the peer.
+    fn stateless_reset_tokens(&mut self) -> &[stateless_reset::Token];
+}
+
+impl<P: Path> Path for Option<P> {
+    #[inline]
+    fn on_path_secrets_ready(&mut self, session: &impl TlsSession) {
+        if let Some(path) = self {
+            path.on_path_secrets_ready(session)
+        }
+    }
+
+    #[inline]
+    fn on_peer_stateless_reset_tokens<'a>(
+        &mut self,
+        stateless_reset_tokens: impl Iterator<Item = &'a stateless_reset::Token>,
+    ) {
+        if let Some(path) = self {
+            path.on_peer_stateless_reset_tokens(stateless_reset_tokens)
+        }
+    }
+
+    #[inline]
+    fn stateless_reset_tokens(&mut self) -> &[stateless_reset::Token] {
+        if let Some(path) = self {
+            path.stateless_reset_tokens()
+        } else {
+            &[]
+        }
+    }
+}
+
+/// Information about the connection that may be used
+/// when create a new dc path
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct ConnectionInfo<'a> {
+    /// The address (IP + Port) of the remote peer
+    pub remote_address: SocketAddress<'a>,
+    /// The dc version that has been negotiated
+    pub dc_version: u32,
+    /// Various settings relevant to the dc path
+    pub application_params: ApplicationParams,
+}
+
+impl<'a> ConnectionInfo<'a> {
+    #[inline]
+    #[doc(hidden)]
+    pub fn new(
+        remote_address: &'a inet::SocketAddress,
+        dc_version: u32,
+        application_params: ApplicationParams,
+    ) -> Self {
+        Self {
+            remote_address: remote_address.into_event(),
+            dc_version,
+            application_params,
+        }
+    }
+}
+
+/// Various settings relevant to the dc path
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct ApplicationParams {
+    pub max_mtu: MaxMtu,
+    pub remote_max_data: VarInt,
+    pub local_send_max_data: VarInt,
+    pub local_recv_max_data: VarInt,
+    pub max_idle_timeout: Option<Duration>,
+    pub max_ack_delay: Duration,
+}
+
+impl ApplicationParams {
+    pub fn new(
+        max_mtu: MaxMtu,
+        peer_flow_control_limits: &InitialFlowControlLimits,
+        limits: &Limits,
+    ) -> Self {
+        Self {
+            max_mtu,
+            remote_max_data: peer_flow_control_limits.max_data,
+            local_send_max_data: limits.initial_stream_limits().max_data_bidi_local,
+            local_recv_max_data: limits.initial_stream_limits().max_data_bidi_remote,
+            max_idle_timeout: limits.max_idle_timeout(),
+            max_ack_delay: limits.max_ack_delay.into(),
+        }
+    }
+}

--- a/quic/s2n-quic-core/src/dc/traits.rs
+++ b/quic/s2n-quic-core/src/dc/traits.rs
@@ -13,7 +13,9 @@ pub trait Endpoint: 'static + Send {
     type Path: Path;
 
     /// Called when a dc version has been negotiated for the given `ConnectionInfo`
-    fn new_path(&mut self, connection_info: &dc::ConnectionInfo) -> Self::Path;
+    ///
+    /// Return `None` if dc should not be used for this path
+    fn new_path(&mut self, connection_info: &dc::ConnectionInfo) -> Option<Self::Path>;
 }
 
 /// A dc path

--- a/quic/s2n-quic-core/src/dc/traits.rs
+++ b/quic/s2n-quic-core/src/dc/traits.rs
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{crypto::tls::TlsSession, dc, stateless_reset};
+
+/// The `dc::Endpoint` trait provides a way to support dc functionality
+pub trait Endpoint: 'static + Send {
+    /// If enabled, a dc version will attempt to be negotiated and dc-specific frames
+    /// will be processed. Otherwise, no dc version will be negotiated and dc-specific
+    /// frames received will result in a connection error.
+    const ENABLED: bool = true;
+
+    type Path: Path;
+
+    /// Called when a dc version has been negotiated for the given `ConnectionInfo`
+    fn new_path(&mut self, connection_info: &dc::ConnectionInfo) -> Self::Path;
+}
+
+/// A dc path
+pub trait Path: 'static + Send {
+    /// Called when path secrets are ready to be derived from the given `TlsSession`
+    fn on_path_secrets_ready(&mut self, session: &impl TlsSession);
+
+    /// Called when a `DC_STATELESS_RESET_TOKENS` frame has been received from the peer
+    fn on_peer_stateless_reset_tokens<'a>(
+        &mut self,
+        stateless_reset_tokens: impl Iterator<Item = &'a stateless_reset::Token>,
+    );
+
+    /// Returns the stateless reset tokens to include in a `DC_STATELESS_RESET_TOKENS`
+    /// frame sent to the peer.
+    fn stateless_reset_tokens(&mut self) -> &[stateless_reset::Token];
+}
+
+impl<P: Path> Path for Option<P> {
+    #[inline]
+    fn on_path_secrets_ready(&mut self, session: &impl TlsSession) {
+        if let Some(path) = self {
+            path.on_path_secrets_ready(session)
+        }
+    }
+
+    #[inline]
+    fn on_peer_stateless_reset_tokens<'a>(
+        &mut self,
+        stateless_reset_tokens: impl Iterator<Item = &'a stateless_reset::Token>,
+    ) {
+        if let Some(path) = self {
+            path.on_peer_stateless_reset_tokens(stateless_reset_tokens)
+        }
+    }
+
+    #[inline]
+    fn stateless_reset_tokens(&mut self) -> &[stateless_reset::Token] {
+        if let Some(path) = self {
+            path.stateless_reset_tokens()
+        } else {
+            &[]
+        }
+    }
+}

--- a/quic/s2n-quic-core/src/lib.rs
+++ b/quic/s2n-quic-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod counter;
 pub mod crypto;
 pub mod ct;
 pub mod datagram;
+pub mod dc;
 pub mod endpoint;
 pub mod event;
 pub mod frame;

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -133,6 +133,7 @@ impl connection::Trait for TestConnection {
         _timestamp: Timestamp,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         _datagram: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
+        _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
     ) -> Result<(), connection::Error> {
         Ok(())
     }
@@ -146,6 +147,7 @@ impl connection::Trait for TestConnection {
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         _datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
+        _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -160,6 +162,7 @@ impl connection::Trait for TestConnection {
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         _datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
+        _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -174,6 +177,7 @@ impl connection::Trait for TestConnection {
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         _datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
+        _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -188,6 +192,7 @@ impl connection::Trait for TestConnection {
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         _datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
+        _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -110,6 +110,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         timestamp: Timestamp,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         datagram: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
+        dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
     ) -> Result<(), connection::Error>;
 
     // Packet handling
@@ -125,6 +126,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
+        dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
     ) -> Result<(), ProcessingError>;
 
     /// Is called when an unprotected initial packet had been received
@@ -138,6 +140,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
+        dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
     ) -> Result<(), ProcessingError>;
 
     /// Is called when a handshake packet had been received
@@ -151,6 +154,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
+        dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
     ) -> Result<(), ProcessingError>;
 
     /// Is called when a short packet had been received
@@ -164,6 +168,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
+        dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
     ) -> Result<(), ProcessingError>;
 
     /// Is called when a version negotiation packet had been received
@@ -225,6 +230,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
+        dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
         check_for_stateless_reset: &mut bool,
     ) -> Result<(), connection::Error> {
         macro_rules! emit_drop_reason {
@@ -285,6 +291,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 subscriber,
                 packet_interceptor,
                 datagram_endpoint,
+                dc_endpoint,
             ),
             ProtectedPacket::VersionNegotiation(packet) => self.handle_version_negotiation_packet(
                 datagram,
@@ -301,6 +308,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 subscriber,
                 packet_interceptor,
                 datagram_endpoint,
+                dc_endpoint,
             ),
             ProtectedPacket::ZeroRtt(packet) => self.handle_zero_rtt_packet(
                 datagram,
@@ -317,6 +325,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 subscriber,
                 packet_interceptor,
                 datagram_endpoint,
+                dc_endpoint,
             ),
             ProtectedPacket::Retry(packet) => {
                 self.handle_retry_packet(datagram, path_id, packet, subscriber, packet_interceptor)
@@ -375,6 +384,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
+        dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
         check_for_stateless_reset: &mut bool,
     ) -> Result<(), connection::Error> {
         macro_rules! emit_drop_reason {
@@ -428,6 +438,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 subscriber,
                 packet_interceptor,
                 datagram_endpoint,
+                dc_endpoint,
                 check_for_stateless_reset,
             );
 

--- a/quic/s2n-quic-transport/src/connection/mod.rs
+++ b/quic/s2n-quic-transport/src/connection/mod.rs
@@ -78,8 +78,10 @@ pub struct Parameters<'a, Cfg: endpoint::Config> {
     pub event_context: <Cfg::EventSubscriber as event::Subscriber>::ConnectionContext,
     /// The context passed to the connection supervisor
     pub supervisor_context: &'a supervisor::Context<'a>,
-    // The datagram provider for the endpoint
+    /// The datagram provider for the endpoint
     pub datagram_endpoint: &'a mut Cfg::DatagramEndpoint,
+    /// The dc provider for the endpoint
+    pub dc_endpoint: &'a mut Cfg::DcEndpoint,
     /// The event subscriber for the endpoint
     pub event_subscriber: &'a mut Cfg::EventSubscriber,
 }

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -5,8 +5,8 @@
 
 use crate::{connection, stream};
 use s2n_quic_core::{
-    crypto::tls, datagram, endpoint, event, packet, path, random, recovery::congestion_controller,
-    stateless_reset,
+    crypto::tls, datagram, dc, endpoint, event, packet, path, random,
+    recovery::congestion_controller, stateless_reset,
 };
 
 /// Configuration parameters for a QUIC endpoint
@@ -44,6 +44,8 @@ pub trait Config: 'static + Send + Sized + core::fmt::Debug {
     type PacketInterceptor: packet::interceptor::Interceptor;
     /// The datagram implementation for the endpoint
     type DatagramEndpoint: datagram::Endpoint;
+    /// The dc implementation for the endpoint
+    type DcEndpoint: dc::Endpoint;
 
     /// The type of the local endpoint
     const ENDPOINT_TYPE: endpoint::Type;
@@ -87,4 +89,6 @@ pub struct Context<'a, Cfg: Config> {
     pub packet_interceptor: &'a mut Cfg::PacketInterceptor,
 
     pub datagram: &'a mut Cfg::DatagramEndpoint,
+
+    pub dc: &'a mut Cfg::DcEndpoint,
 }

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -294,6 +294,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             supervisor_context: &supervisor_context,
             event_subscriber: endpoint_context.event_subscriber,
             datagram_endpoint: endpoint_context.datagram,
+            dc_endpoint: endpoint_context.dc,
         };
 
         let mut connection = <Config as endpoint::Config>::Connection::new(connection_parameters)?;
@@ -338,6 +339,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                         endpoint_context.event_subscriber,
                         endpoint_context.packet_interceptor,
                         endpoint_context.datagram,
+                        endpoint_context.dc,
                     )
                     .map_err(|err| {
                         use connection::ProcessingError;
@@ -361,6 +363,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                     endpoint_context.event_subscriber,
                     endpoint_context.packet_interceptor,
                     endpoint_context.datagram,
+                    endpoint_context.dc,
                     &mut false,
                 )?;
 

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -213,6 +213,7 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
                     timestamp,
                     endpoint_context.event_subscriber,
                     endpoint_context.datagram,
+                    endpoint_context.dc,
                 ) {
                     conn.close(
                         error,
@@ -592,6 +593,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                     endpoint_context.event_subscriber,
                     endpoint_context.packet_interceptor,
                     endpoint_context.datagram,
+                    endpoint_context.dc,
                     &mut check_for_stateless_reset,
                 ) {
                     //= https://www.rfc-editor.org/rfc/rfc9000#section-10.2.1
@@ -617,6 +619,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                     endpoint_context.event_subscriber,
                     endpoint_context.packet_interceptor,
                     endpoint_context.datagram,
+                    endpoint_context.dc,
                     &mut check_for_stateless_reset,
                 ) {
                     //= https://www.rfc-editor.org/rfc/rfc9000#section-10.2.1
@@ -1115,6 +1118,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
             supervisor_context: &supervisor_context,
             event_subscriber: endpoint_context.event_subscriber,
             datagram_endpoint: endpoint_context.datagram,
+            dc_endpoint: endpoint_context.dc,
         };
         let connection = <Cfg as crate::endpoint::Config>::Connection::new(connection_parameters)?;
         self.connections
@@ -1150,6 +1154,7 @@ pub mod testing {
         type PathMigrationValidator = path::migration::allow_all::Validator;
         type PacketInterceptor = s2n_quic_core::packet::interceptor::Disabled;
         type DatagramEndpoint = s2n_quic_core::datagram::Disabled;
+        type DcEndpoint = s2n_quic_core::dc::Disabled;
 
         fn context(&mut self) -> super::Context<Self> {
             todo!()
@@ -1180,6 +1185,7 @@ pub mod testing {
         type PathMigrationValidator = path::migration::allow_all::Validator;
         type PacketInterceptor = s2n_quic_core::packet::interceptor::Disabled;
         type DatagramEndpoint = s2n_quic_core::datagram::Disabled;
+        type DcEndpoint = s2n_quic_core::dc::Disabled;
 
         fn context(&mut self) -> super::Context<Self> {
             todo!()

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -248,6 +248,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         waker: &Waker,
         publisher: &mut Pub,
         datagram: &mut Config::DatagramEndpoint,
+        dc: &mut Config::DcEndpoint,
     ) -> Poll<Result<(), transport::Error>> {
         if let Some(session_info) = self.session_info.as_mut() {
             let mut context: SessionContext<Config, Pub> = SessionContext {
@@ -267,6 +268,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
                 waker,
                 publisher,
                 datagram,
+                dc,
             };
 
             match session_info.session.poll(&mut context)? {
@@ -294,6 +296,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         waker: &Waker,
         publisher: &mut Pub,
         datagram: &mut Config::DatagramEndpoint,
+        dc: &mut Config::DcEndpoint,
     ) -> Result<(), transport::Error> {
         if let Some(session_info) = self.session_info.as_mut() {
             let mut context: SessionContext<Config, Pub> = SessionContext {
@@ -313,6 +316,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
                 waker,
                 publisher,
                 datagram,
+                dc,
             };
 
             session_info

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -56,6 +56,7 @@ pub struct SessionContext<'a, Config: endpoint::Config, Pub: event::ConnectionPu
     pub waker: &'a Waker,
     pub publisher: &'a mut Pub,
     pub datagram: &'a mut Config::DatagramEndpoint,
+    pub dc: &'a mut Config::DcEndpoint,
 }
 
 impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
@@ -409,6 +410,8 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
             datagram_receiver,
             datagram_limits.max_datagram_payload,
         );
+
+        // TODO: call self.dc.new_path(..)
 
         self.path_manager
             .active_path_mut()

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -49,6 +49,8 @@ unstable-provider-io-xdp = ["s2n-quic-platform/xdp"]
 unstable-provider-packet-interceptor = []
 # This feature enables the random provider
 unstable-provider-random = []
+# This feature enables the dc provider
+unstable-provider-dc = []
 # This feature enables support for third party congestion controller implementations
 unstable-congestion-controller = ["s2n-quic-core/unstable-congestion-controller"]
 

--- a/quic/s2n-quic/src/client/builder.rs
+++ b/quic/s2n-quic/src/client/builder.rs
@@ -269,6 +269,14 @@ impl<Providers: ClientProviders> Builder<Providers> {
         ClientProviders
     );
 
+    #[cfg(feature = "unstable-provider-dc")]
+    impl_provider_method!(
+        /// Sets the dc provider for the [`Client`]
+        with_dc,
+        dc,
+        ClientProviders
+    );
+
     impl_provider_method!(
         /// Sets the congestion controller provider for the [`Client`]
         with_congestion_controller,

--- a/quic/s2n-quic/src/provider.rs
+++ b/quic/s2n-quic/src/provider.rs
@@ -52,6 +52,15 @@ cfg_if!(
     }
 );
 
+cfg_if!(
+    if #[cfg(any(test, feature = "unstable-provider-dc"))] {
+        pub mod dc;
+    } else {
+        #[allow(dead_code)]
+        pub(crate) mod dc;
+    }
+);
+
 /// An error indicating a failure to start an endpoint
 pub struct StartError(Box<dyn 'static + fmt::Display + Send + Sync>);
 

--- a/quic/s2n-quic/src/provider/dc.rs
+++ b/quic/s2n-quic/src/provider/dc.rs
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_quic_core::dc::{Disabled, Endpoint};
+
+/// Provider for dc support
+pub trait Provider {
+    type Endpoint: Endpoint;
+    type Error: 'static + core::fmt::Display + Send + Sync;
+
+    /// Starts the dc provider
+    fn start(self) -> Result<Self::Endpoint, Self::Error>;
+}
+
+// This provider is disabled by default
+pub type Default = Disabled;
+
+impl_provider_utils!();
+
+impl<T: 'static + Send + Endpoint> Provider for T {
+    type Endpoint = T;
+    type Error = core::convert::Infallible;
+
+    fn start(self) -> Result<Self::Endpoint, Self::Error> {
+        Ok(self)
+    }
+}

--- a/quic/s2n-quic/src/provider/dc.rs
+++ b/quic/s2n-quic/src/provider/dc.rs
@@ -1,9 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use s2n_quic_core::dc::{Disabled, Endpoint};
+//! Provides dc support
 
-/// Provider for dc support
+use s2n_quic_core::dc::Disabled;
+
+// these imports are only accessible if the unstable feature is enabled
+#[allow(unused_imports)]
+pub use s2n_quic_core::dc::{ApplicationParams, ConnectionInfo, Endpoint, Path};
+
 pub trait Provider {
     type Endpoint: Endpoint;
     type Error: 'static + core::fmt::Display + Send + Sync;

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -319,6 +319,14 @@ impl<Providers: ServerProviders> Builder<Providers> {
         ServerProviders
     );
 
+    #[cfg(feature = "unstable-provider-dc")]
+    impl_provider_method!(
+        /// Sets the dc provider for the [`Server`]
+        with_dc,
+        dc,
+        ServerProviders
+    );
+
     impl_provider_method!(
         /// Sets the congestion controller provider for the [`Server`]
         with_congestion_controller,


### PR DESCRIPTION
### Description of changes: 

This change adds an unstable dc provider for configuring dc functionality. The provider will not actually be used until subsequent PRs. 

### Call-outs:

I've implemented `Path` for `Option<P>` as I was planning to have the `dc::Manager` operate on an `Option<Path>` rather than just `Path`. This is because dc can end up disabled for a path in 2 ways: 
1) by not configuring a provider, in which case the `Disabled` provider is used (which has an associated type of `DisabledPath`)
2) by not being able to negotiate a dc version. In this case, the associated `Path` type of the dc provider is used but shouldn't actually do anything. 

I didn't want the implementor of the provider to have to handle when no dc version is negotiated, so instead I'll have the `dc::Manager` handle that case.

### Testing:

Will add tests after further integration of the provider

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

