### PR TITLE
feat(s2n-quic-core): allow for branching states on common events

### DIFF
--- a/quic/s2n-quic-core/src/state.rs
+++ b/quic/s2n-quic-core/src/state.rs
@@ -3,6 +3,9 @@
 
 use core::fmt;
 
+#[cfg(test)]
+mod tests;
+
 pub type Result<T> = core::result::Result<(), Error<T>>;
 
 #[cfg(feature = "state-tracing")]
@@ -17,36 +20,43 @@ pub use crate::__tracing_noop__ as _debug;
 #[doc(hidden)]
 macro_rules! __state_transition__ {
     ($state:ident, $valid:pat => $target:expr) => {
-        $crate::state::transition!(_, $state, $valid => $target)
+        $crate::state::transition!(@build [], _, $state, [$valid => $target])
     };
-    ($event:ident, $state:ident, $valid:pat => $target:expr) => {{
-        if *$state == $target {
-            // if transitioning to itself is not called out, then return an error
-            $crate::ensure!(
-                matches!($state, $valid),
-                Err($crate::state::Error::NoOp { current: $target })
-            );
-            return Ok(());
-        }
+    (@build [$($targets:expr),*], $event:ident, $state:ident, [$valid:pat => $target:expr] $($remaining:tt)*) => {{
+        // if the transition is valid, then perform it
+        if matches!($state, $valid) {
+            let __event__ = stringify!($event);
+            if __event__.is_empty() || __event__ == "_" {
+                $crate::state::_debug!(prev = ?$state, next = ?$target);
+            } else {
+                $crate::state::_debug!(event = %__event__, prev = ?$state, next = ?$target);
+            }
 
-        // make sure the transition is valid
-        $crate::ensure!(
-            matches!($state, $valid),
+            *$state = $target;
+            Ok(())
+        } else {
+            $crate::state::transition!(
+                @build [$($targets,)* $target],
+                $event,
+                $state,
+                $($remaining)*
+            )
+        }
+    }};
+    (@build [$($targets:expr),*], $event:ident, $state:ident $(,)?) => {{
+        let targets = [$($targets),*];
+
+        // if we only have a single target and the current state matches it, then return a no-op
+        if targets.len() == 1 && targets[0].eq($state) {
+            let current = targets[0].clone();
+            Err($crate::state::Error::NoOp { current })
+        } else {
+            // if we didn't get a valid match then error out
             Err($crate::state::Error::InvalidTransition {
                 current: $state.clone(),
-                target: $target
+                event: stringify!($event),
             })
-        );
-
-        let __event__ = stringify!($event);
-        if __event__.is_empty() || __event__ == "_" {
-            $crate::state::_debug!(prev = ?$state, next = ?$target);
-        } else {
-            $crate::state::_debug!(event = %__event__, prev = ?$state, next = ?$target);
         }
-
-        *$state = $target;
-        Ok(())
     }};
 }
 
@@ -55,18 +65,44 @@ pub use crate::__state_transition__ as transition;
 #[macro_export]
 #[doc(hidden)]
 macro_rules! __state_event__ {
-    ($(#[doc = $doc:literal])* $event:ident ($($valid:ident)|* => $target:ident)) => {
+    (
+        $(#[doc = $doc:literal])*
+        $event:ident (
+            $(
+                $($valid:ident)|* => $target:ident
+            ),*
+            $(,)?
+        )
+    ) => {
         $(
             #[doc = $doc]
         )*
         #[inline]
         pub fn $event(&mut self) -> $crate::state::Result<Self> {
-            $crate::state::transition!($event, self, $(Self::$valid)|* => Self::$target)
+            $crate::state::transition!(
+                @build [],
+                $event,
+                self,
+                $(
+                    [$(Self::$valid)|* => Self::$target]
+                )*
+            )
         }
     };
-    ($( $(#[doc = $doc:literal])* $event:ident ($($valid:ident)|* => $target:ident) ;)*) => {
+    ($(
+        $(#[doc = $doc:literal])*
+        $event:ident (
+            $(
+                $($valid:ident)|* => $target:ident
+            ),*
+            $(,)?
+        );
+    )*) => {
         $(
-            $crate::state::event!($(#[doc = $doc])* $event($($valid)|* => $target));
+            $crate::state::event!(
+                $(#[doc = $doc])*
+                $event($($($valid)|* => $target),*)
+            );
         )*
 
         /// Generates a dot graph of all state transitions
@@ -79,21 +115,22 @@ macro_rules! __state_event__ {
 
                     let mut all_states = [
                         // collect all of the states we've observed
-                        $(
+                        $($(
                             $(
                                 stringify!($valid),
                             )*
                             stringify!($target),
-                        )*
+                        )*)*
                     ];
 
-                    let all_states = $crate::state::dedup_states(&mut all_states);
+                    all_states.sort_unstable();
+                    let (all_states, _) = $crate::slice::partition_dedup(&mut all_states);
 
                     for state in all_states {
                         writeln!(f, "  {state};")?;
                     }
 
-                    $(
+                    $($(
                         $(
                             writeln!(
                                 f,
@@ -103,7 +140,7 @@ macro_rules! __state_event__ {
                                 stringify!($event),
                             )?;
                         )*
-                    )*
+                    )*)*
 
                     writeln!(f, "}}")?;
                     Ok(())
@@ -116,60 +153,6 @@ macro_rules! __state_event__ {
 }
 
 pub use crate::__state_event__ as event;
-
-#[doc(hidden)]
-pub fn dedup_states<'a>(states: &'a mut [&'a str]) -> &'a mut [&'a str] {
-    // TODO replace with
-    // https://doc.rust-lang.org/std/primitive.slice.html#method.partition_dedup
-    // when stable
-    //
-    // For now, we've just inlined their implementation
-
-    let len = states.len();
-    if len <= 1 {
-        return states;
-    }
-
-    // sort the states before deduping
-    states.sort_unstable();
-
-    let ptr = states.as_mut_ptr();
-    let mut next_read: usize = 1;
-    let mut next_write: usize = 1;
-
-    // SAFETY: the `while` condition guarantees `next_read` and `next_write`
-    // are less than `len`, thus are inside `self`. `prev_ptr_write` points to
-    // one element before `ptr_write`, but `next_write` starts at 1, so
-    // `prev_ptr_write` is never less than 0 and is inside the slice.
-    // This fulfils the requirements for dereferencing `ptr_read`, `prev_ptr_write`
-    // and `ptr_write`, and for using `ptr.add(next_read)`, `ptr.add(next_write - 1)`
-    // and `prev_ptr_write.offset(1)`.
-    //
-    // `next_write` is also incremented at most once per loop at most meaning
-    // no element is skipped when it may need to be swapped.
-    //
-    // `ptr_read` and `prev_ptr_write` never point to the same element. This
-    // is required for `&mut *ptr_read`, `&mut *prev_ptr_write` to be safe.
-    // The explanation is simply that `next_read >= next_write` is always true,
-    // thus `next_read > next_write - 1` is too.
-    unsafe {
-        // Avoid bounds checks by using raw pointers.
-        while next_read < len {
-            let ptr_read = ptr.add(next_read);
-            let prev_ptr_write = ptr.add(next_write - 1);
-            if *ptr_read != *prev_ptr_write {
-                if next_read != next_write {
-                    let ptr_write = prev_ptr_write.add(1);
-                    core::ptr::swap(ptr_read, ptr_write);
-                }
-                next_write += 1;
-            }
-            next_read += 1;
-        }
-    }
-
-    &mut states[..next_write]
-}
 
 #[macro_export]
 #[doc(hidden)]
@@ -190,7 +173,7 @@ pub use crate::__state_is__ as is;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Error<T> {
     NoOp { current: T },
-    InvalidTransition { current: T, target: T },
+    InvalidTransition { current: T, event: &'static str },
 }
 
 impl<T: fmt::Debug> fmt::Display for Error<T> {
@@ -199,8 +182,8 @@ impl<T: fmt::Debug> fmt::Display for Error<T> {
             Self::NoOp { current } => {
                 write!(f, "state is already set to {current:?}")
             }
-            Self::InvalidTransition { current, target } => {
-                write!(f, "invalid transition from {current:?} to {target:?}",)
+            Self::InvalidTransition { current, event } => {
+                write!(f, "invalid event {event:?} for state {current:?}")
             }
         }
     }

--- a/quic/s2n-quic-core/src/state/snapshots/s2n_quic_core__state__tests__dot_test.snap
+++ b/quic/s2n-quic-core/src/state/snapshots/s2n_quic_core__state__tests__dot_test.snap
@@ -1,0 +1,19 @@
+---
+source: quic/s2n-quic-core/src/state/tests.rs
+expression: "State::dot()"
+---
+digraph {
+  Init;
+  Left;
+  LeftLeft;
+  LeftRight;
+  Right;
+  RightLeft;
+  RightRight;
+  Init -> Left [label = "on_left"];
+  Left -> LeftLeft [label = "on_left"];
+  Right -> RightLeft [label = "on_left"];
+  Init -> Right [label = "on_right"];
+  Left -> LeftRight [label = "on_right"];
+  Right -> RightRight [label = "on_right"];
+}

--- a/quic/s2n-quic-core/src/state/snapshots/s2n_quic_core__state__tests__snapshots.snap
+++ b/quic/s2n-quic-core/src/state/snapshots/s2n_quic_core__state__tests__snapshots.snap
@@ -1,0 +1,128 @@
+---
+source: quic/s2n-quic-core/src/state/tests.rs
+expression: outcomes
+---
+[
+    (
+        Init,
+        "on_left",
+        Ok(
+            Left,
+        ),
+    ),
+    (
+        Init,
+        "on_right",
+        Ok(
+            Right,
+        ),
+    ),
+    (
+        Left,
+        "on_left",
+        Ok(
+            LeftLeft,
+        ),
+    ),
+    (
+        Left,
+        "on_right",
+        Ok(
+            LeftRight,
+        ),
+    ),
+    (
+        Right,
+        "on_left",
+        Ok(
+            RightLeft,
+        ),
+    ),
+    (
+        Right,
+        "on_right",
+        Ok(
+            RightRight,
+        ),
+    ),
+    (
+        LeftLeft,
+        "on_left",
+        Err(
+            InvalidTransition {
+                current: LeftLeft,
+                event: "on_left",
+            },
+        ),
+    ),
+    (
+        LeftLeft,
+        "on_right",
+        Err(
+            InvalidTransition {
+                current: LeftLeft,
+                event: "on_right",
+            },
+        ),
+    ),
+    (
+        LeftRight,
+        "on_left",
+        Err(
+            InvalidTransition {
+                current: LeftRight,
+                event: "on_left",
+            },
+        ),
+    ),
+    (
+        LeftRight,
+        "on_right",
+        Err(
+            InvalidTransition {
+                current: LeftRight,
+                event: "on_right",
+            },
+        ),
+    ),
+    (
+        RightLeft,
+        "on_left",
+        Err(
+            InvalidTransition {
+                current: RightLeft,
+                event: "on_left",
+            },
+        ),
+    ),
+    (
+        RightLeft,
+        "on_right",
+        Err(
+            InvalidTransition {
+                current: RightLeft,
+                event: "on_right",
+            },
+        ),
+    ),
+    (
+        RightRight,
+        "on_left",
+        Err(
+            InvalidTransition {
+                current: RightRight,
+                event: "on_left",
+            },
+        ),
+    ),
+    (
+        RightRight,
+        "on_right",
+        Err(
+            InvalidTransition {
+                current: RightRight,
+                event: "on_right",
+            },
+        ),
+    ),
+]

--- a/quic/s2n-quic-core/src/state/tests.rs
+++ b/quic/s2n-quic-core/src/state/tests.rs
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use insta::{assert_debug_snapshot, assert_snapshot};
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+enum State {
+    #[default]
+    Init,
+    Left,
+    Right,
+    LeftLeft,
+    LeftRight,
+    RightLeft,
+    RightRight,
+}
+
+impl State {
+    event! {
+        on_left(
+            Init => Left,
+            Left => LeftLeft,
+            Right => RightLeft,
+        );
+        on_right(
+            Init => Right,
+            Left => LeftRight,
+            Right => RightRight,
+        );
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn snapshots() {
+    let mut outcomes = vec![];
+    let states = [
+        State::Init,
+        State::Left,
+        State::Right,
+        State::LeftLeft,
+        State::LeftRight,
+        State::RightLeft,
+        State::RightRight,
+    ];
+    for state in states {
+        macro_rules! push {
+            ($event:ident) => {
+                let mut target = state.clone();
+                let result = target.$event().map(|_| target);
+                outcomes.push((state.clone(), stringify!($event), result));
+            };
+        }
+        push!(on_left);
+        push!(on_right);
+    }
+
+    assert_debug_snapshot!(outcomes);
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn dot_test() {
+    assert_snapshot!(State::dot());
+}

--- a/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__recv__tests__snapshots.snap
+++ b/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__recv__tests__snapshots.snap
@@ -16,7 +16,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: Recv,
-                target: DataRecvd,
+                event: "on_receive_all_data",
             },
         ),
     ),
@@ -26,7 +26,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: Recv,
-                target: DataRead,
+                event: "on_app_read_all_data",
             },
         ),
     ),
@@ -43,7 +43,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: Recv,
-                target: ResetRead,
+                event: "on_app_read_reset",
             },
         ),
     ),
@@ -69,7 +69,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: SizeKnown,
-                target: DataRead,
+                event: "on_app_read_all_data",
             },
         ),
     ),
@@ -86,7 +86,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: SizeKnown,
-                target: ResetRead,
+                event: "on_app_read_reset",
             },
         ),
     ),
@@ -96,7 +96,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: DataRecvd,
-                target: SizeKnown,
+                event: "on_receive_fin",
             },
         ),
     ),
@@ -122,7 +122,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: DataRecvd,
-                target: ResetRecvd,
+                event: "on_reset",
             },
         ),
     ),
@@ -132,7 +132,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: DataRecvd,
-                target: ResetRead,
+                event: "on_app_read_reset",
             },
         ),
     ),
@@ -142,7 +142,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: DataRead,
-                target: SizeKnown,
+                event: "on_receive_fin",
             },
         ),
     ),
@@ -152,7 +152,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: DataRead,
-                target: DataRecvd,
+                event: "on_receive_all_data",
             },
         ),
     ),
@@ -171,7 +171,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: DataRead,
-                target: ResetRecvd,
+                event: "on_reset",
             },
         ),
     ),
@@ -181,7 +181,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: DataRead,
-                target: ResetRead,
+                event: "on_app_read_reset",
             },
         ),
     ),
@@ -191,7 +191,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetRecvd,
-                target: SizeKnown,
+                event: "on_receive_fin",
             },
         ),
     ),
@@ -201,7 +201,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetRecvd,
-                target: DataRecvd,
+                event: "on_receive_all_data",
             },
         ),
     ),
@@ -211,7 +211,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetRecvd,
-                target: DataRead,
+                event: "on_app_read_all_data",
             },
         ),
     ),
@@ -237,7 +237,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetRead,
-                target: SizeKnown,
+                event: "on_receive_fin",
             },
         ),
     ),
@@ -247,7 +247,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetRead,
-                target: DataRecvd,
+                event: "on_receive_all_data",
             },
         ),
     ),
@@ -257,7 +257,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetRead,
-                target: DataRead,
+                event: "on_app_read_all_data",
             },
         ),
     ),
@@ -267,7 +267,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetRead,
-                target: ResetRecvd,
+                event: "on_reset",
             },
         ),
     ),

--- a/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__send__tests__snapshots.snap
+++ b/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__send__tests__snapshots.snap
@@ -37,7 +37,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: Ready,
-                target: DataRecvd,
+                event: "on_recv_all_acks",
             },
         ),
     ),
@@ -47,7 +47,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: Ready,
-                target: ResetRecvd,
+                event: "on_recv_reset_ack",
             },
         ),
     ),
@@ -87,7 +87,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: Send,
-                target: DataRecvd,
+                event: "on_recv_all_acks",
             },
         ),
     ),
@@ -97,7 +97,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: Send,
-                target: ResetRecvd,
+                event: "on_recv_reset_ack",
             },
         ),
     ),
@@ -107,7 +107,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: DataSent,
-                target: Send,
+                event: "on_send_stream",
             },
         ),
     ),
@@ -147,7 +147,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: DataSent,
-                target: ResetRecvd,
+                event: "on_recv_reset_ack",
             },
         ),
     ),
@@ -157,7 +157,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: DataRecvd,
-                target: Send,
+                event: "on_send_stream",
             },
         ),
     ),
@@ -167,7 +167,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: DataRecvd,
-                target: DataSent,
+                event: "on_send_fin",
             },
         ),
     ),
@@ -177,7 +177,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: DataRecvd,
-                target: ResetQueued,
+                event: "on_queue_reset",
             },
         ),
     ),
@@ -187,7 +187,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: DataRecvd,
-                target: ResetSent,
+                event: "on_send_reset",
             },
         ),
     ),
@@ -206,7 +206,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: DataRecvd,
-                target: ResetRecvd,
+                event: "on_recv_reset_ack",
             },
         ),
     ),
@@ -216,7 +216,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetQueued,
-                target: Send,
+                event: "on_send_stream",
             },
         ),
     ),
@@ -226,7 +226,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetQueued,
-                target: DataSent,
+                event: "on_send_fin",
             },
         ),
     ),
@@ -259,7 +259,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetQueued,
-                target: ResetRecvd,
+                event: "on_recv_reset_ack",
             },
         ),
     ),
@@ -269,7 +269,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetSent,
-                target: Send,
+                event: "on_send_stream",
             },
         ),
     ),
@@ -279,7 +279,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetSent,
-                target: DataSent,
+                event: "on_send_fin",
             },
         ),
     ),
@@ -289,7 +289,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetSent,
-                target: ResetQueued,
+                event: "on_queue_reset",
             },
         ),
     ),
@@ -308,7 +308,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetSent,
-                target: DataRecvd,
+                event: "on_recv_all_acks",
             },
         ),
     ),
@@ -325,7 +325,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetRecvd,
-                target: Send,
+                event: "on_send_stream",
             },
         ),
     ),
@@ -335,7 +335,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetRecvd,
-                target: DataSent,
+                event: "on_send_fin",
             },
         ),
     ),
@@ -345,7 +345,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetRecvd,
-                target: ResetQueued,
+                event: "on_queue_reset",
             },
         ),
     ),
@@ -355,7 +355,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetRecvd,
-                target: ResetSent,
+                event: "on_send_reset",
             },
         ),
     ),
@@ -365,7 +365,7 @@ expression: outcomes
         Err(
             InvalidTransition {
                 current: ResetRecvd,
-                target: DataRecvd,
+                event: "on_recv_all_acks",
             },
         ),
     ),


### PR DESCRIPTION
### Description of changes: 

This adds a mechanism for the state machine macro to allow for multiple states to react to the same events. I've added an example test to show the behavior:

```rust
#[derive(Clone, Debug, Default, PartialEq, Eq)]
enum State {
    #[default]
    Init,
    Left,
    Right,
    LeftLeft,
    LeftRight,
    RightLeft,
    RightRight,
}

impl State {
    event! {
        on_left(
            Init => Left,
            Left => LeftLeft,
            Right => RightLeft,
        );
        on_right(
            Init => Right,
            Left => LeftRight,
            Right => RightRight,
        );
    }
}
```

![image](https://github.com/aws/s2n-quic/assets/799311/7aacf9f8-dfe8-45ce-8c75-f16a46594eed)

### Testing:

The example is being used as a test with snapshot tests for the dot output as well as each state+event combination.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

