### PR TITLE
feat(s2n-quic-core): generate state reactions to events

### DIFF
--- a/quic/s2n-quic-core/src/state/snapshots/s2n_quic_core__state__tests__snapshots.snap
+++ b/quic/s2n-quic-core/src/state/snapshots/s2n_quic_core__state__tests__snapshots.snap
@@ -1,128 +1,86 @@
 ---
 source: quic/s2n-quic-core/src/state/tests.rs
-expression: outcomes
+expression: "State::test_transitions()"
 ---
-[
-    (
-        Init,
-        "on_left",
-        Ok(
+{
+    Init: {
+        on_left: Ok(
             Left,
         ),
-    ),
-    (
-        Init,
-        "on_right",
-        Ok(
+        on_right: Ok(
             Right,
         ),
-    ),
-    (
-        Left,
-        "on_left",
-        Ok(
+    },
+    Left: {
+        on_left: Ok(
             LeftLeft,
         ),
-    ),
-    (
-        Left,
-        "on_right",
-        Ok(
+        on_right: Ok(
             LeftRight,
         ),
-    ),
-    (
-        Right,
-        "on_left",
-        Ok(
+    },
+    LeftLeft: {
+        on_left: Err(
+            InvalidTransition {
+                current: LeftLeft,
+                event: "on_left",
+            },
+        ),
+        on_right: Err(
+            InvalidTransition {
+                current: LeftLeft,
+                event: "on_right",
+            },
+        ),
+    },
+    LeftRight: {
+        on_left: Err(
+            InvalidTransition {
+                current: LeftRight,
+                event: "on_left",
+            },
+        ),
+        on_right: Err(
+            InvalidTransition {
+                current: LeftRight,
+                event: "on_right",
+            },
+        ),
+    },
+    Right: {
+        on_left: Ok(
             RightLeft,
         ),
-    ),
-    (
-        Right,
-        "on_right",
-        Ok(
+        on_right: Ok(
             RightRight,
         ),
-    ),
-    (
-        LeftLeft,
-        "on_left",
-        Err(
-            InvalidTransition {
-                current: LeftLeft,
-                event: "on_left",
-            },
-        ),
-    ),
-    (
-        LeftLeft,
-        "on_right",
-        Err(
-            InvalidTransition {
-                current: LeftLeft,
-                event: "on_right",
-            },
-        ),
-    ),
-    (
-        LeftRight,
-        "on_left",
-        Err(
-            InvalidTransition {
-                current: LeftRight,
-                event: "on_left",
-            },
-        ),
-    ),
-    (
-        LeftRight,
-        "on_right",
-        Err(
-            InvalidTransition {
-                current: LeftRight,
-                event: "on_right",
-            },
-        ),
-    ),
-    (
-        RightLeft,
-        "on_left",
-        Err(
+    },
+    RightLeft: {
+        on_left: Err(
             InvalidTransition {
                 current: RightLeft,
                 event: "on_left",
             },
         ),
-    ),
-    (
-        RightLeft,
-        "on_right",
-        Err(
+        on_right: Err(
             InvalidTransition {
                 current: RightLeft,
                 event: "on_right",
             },
         ),
-    ),
-    (
-        RightRight,
-        "on_left",
-        Err(
+    },
+    RightRight: {
+        on_left: Err(
             InvalidTransition {
                 current: RightRight,
                 event: "on_left",
             },
         ),
-    ),
-    (
-        RightRight,
-        "on_right",
-        Err(
+        on_right: Err(
             InvalidTransition {
                 current: RightRight,
                 event: "on_right",
             },
         ),
-    ),
-]
+    },
+}

--- a/quic/s2n-quic-core/src/state/tests.rs
+++ b/quic/s2n-quic-core/src/state/tests.rs
@@ -34,29 +34,7 @@ impl State {
 #[test]
 #[cfg_attr(miri, ignore)]
 fn snapshots() {
-    let mut outcomes = vec![];
-    let states = [
-        State::Init,
-        State::Left,
-        State::Right,
-        State::LeftLeft,
-        State::LeftRight,
-        State::RightLeft,
-        State::RightRight,
-    ];
-    for state in states {
-        macro_rules! push {
-            ($event:ident) => {
-                let mut target = state.clone();
-                let result = target.$event().map(|_| target);
-                outcomes.push((state.clone(), stringify!($event), result));
-            };
-        }
-        push!(on_left);
-        push!(on_right);
-    }
-
-    assert_debug_snapshot!(outcomes);
+    assert_debug_snapshot!(State::test_transitions());
 }
 
 #[test]

--- a/quic/s2n-quic-core/src/stream/state/recv.rs
+++ b/quic/s2n-quic-core/src/stream/state/recv.rs
@@ -74,31 +74,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn snapshots() {
-        let mut outcomes = vec![];
-        let states = [
-            Receiver::Recv,
-            Receiver::SizeKnown,
-            Receiver::DataRecvd,
-            Receiver::DataRead,
-            Receiver::ResetRecvd,
-            Receiver::ResetRead,
-        ];
-        for state in states {
-            macro_rules! push {
-                ($event:ident) => {
-                    let mut target = state.clone();
-                    let result = target.$event().map(|_| target);
-                    outcomes.push((state.clone(), stringify!($event), result));
-                };
-            }
-            push!(on_receive_fin);
-            push!(on_receive_all_data);
-            push!(on_app_read_all_data);
-            push!(on_reset);
-            push!(on_app_read_reset);
-        }
-
-        assert_debug_snapshot!(outcomes);
+        assert_debug_snapshot!(Receiver::test_transitions());
     }
 
     #[test]

--- a/quic/s2n-quic-core/src/stream/state/send.rs
+++ b/quic/s2n-quic-core/src/stream/state/send.rs
@@ -80,33 +80,7 @@ mod tests {
     #[test]
     #[cfg_attr(miri, ignore)]
     fn snapshots() {
-        let mut outcomes = vec![];
-        let states = [
-            Sender::Ready,
-            Sender::Send,
-            Sender::DataSent,
-            Sender::DataRecvd,
-            Sender::ResetQueued,
-            Sender::ResetSent,
-            Sender::ResetRecvd,
-        ];
-        for state in states {
-            macro_rules! push {
-                ($event:ident) => {
-                    let mut target = state.clone();
-                    let result = target.$event().map(|_| target);
-                    outcomes.push((state.clone(), stringify!($event), result));
-                };
-            }
-            push!(on_send_stream);
-            push!(on_send_fin);
-            push!(on_queue_reset);
-            push!(on_send_reset);
-            push!(on_recv_all_acks);
-            push!(on_recv_reset_ack);
-        }
-
-        assert_debug_snapshot!(outcomes);
+        assert_debug_snapshot!(Sender::test_transitions());
     }
 
     #[test]

--- a/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__recv__tests__snapshots.snap
+++ b/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__recv__tests__snapshots.snap
@@ -1,283 +1,175 @@
 ---
 source: quic/s2n-quic-core/src/stream/state/recv.rs
-expression: outcomes
+expression: "Receiver::test_transitions()"
 ---
-[
-    (
-        Recv,
-        "on_receive_fin",
-        Ok(
-            SizeKnown,
-        ),
-    ),
-    (
-        Recv,
-        "on_receive_all_data",
-        Err(
+{
+    DataRead: {
+        on_receive_fin: Err(
             InvalidTransition {
-                current: Recv,
+                current: DataRead,
+                event: "on_receive_fin",
+            },
+        ),
+        on_receive_all_data: Err(
+            InvalidTransition {
+                current: DataRead,
                 event: "on_receive_all_data",
             },
         ),
-    ),
-    (
-        Recv,
-        "on_app_read_all_data",
-        Err(
-            InvalidTransition {
-                current: Recv,
-                event: "on_app_read_all_data",
-            },
-        ),
-    ),
-    (
-        Recv,
-        "on_reset",
-        Ok(
-            ResetRecvd,
-        ),
-    ),
-    (
-        Recv,
-        "on_app_read_reset",
-        Err(
-            InvalidTransition {
-                current: Recv,
-                event: "on_app_read_reset",
-            },
-        ),
-    ),
-    (
-        SizeKnown,
-        "on_receive_fin",
-        Err(
+        on_app_read_all_data: Err(
             NoOp {
-                current: SizeKnown,
+                current: DataRead,
             },
         ),
-    ),
-    (
-        SizeKnown,
-        "on_receive_all_data",
-        Ok(
-            DataRecvd,
-        ),
-    ),
-    (
-        SizeKnown,
-        "on_app_read_all_data",
-        Err(
+        on_reset: Err(
             InvalidTransition {
-                current: SizeKnown,
-                event: "on_app_read_all_data",
+                current: DataRead,
+                event: "on_reset",
             },
         ),
-    ),
-    (
-        SizeKnown,
-        "on_reset",
-        Ok(
-            ResetRecvd,
-        ),
-    ),
-    (
-        SizeKnown,
-        "on_app_read_reset",
-        Err(
+        on_app_read_reset: Err(
             InvalidTransition {
-                current: SizeKnown,
+                current: DataRead,
                 event: "on_app_read_reset",
             },
         ),
-    ),
-    (
-        DataRecvd,
-        "on_receive_fin",
-        Err(
+    },
+    DataRecvd: {
+        on_receive_fin: Err(
             InvalidTransition {
                 current: DataRecvd,
                 event: "on_receive_fin",
             },
         ),
-    ),
-    (
-        DataRecvd,
-        "on_receive_all_data",
-        Err(
+        on_receive_all_data: Err(
             NoOp {
                 current: DataRecvd,
             },
         ),
-    ),
-    (
-        DataRecvd,
-        "on_app_read_all_data",
-        Ok(
+        on_app_read_all_data: Ok(
             DataRead,
         ),
-    ),
-    (
-        DataRecvd,
-        "on_reset",
-        Err(
+        on_reset: Err(
             InvalidTransition {
                 current: DataRecvd,
                 event: "on_reset",
             },
         ),
-    ),
-    (
-        DataRecvd,
-        "on_app_read_reset",
-        Err(
+        on_app_read_reset: Err(
             InvalidTransition {
                 current: DataRecvd,
                 event: "on_app_read_reset",
             },
         ),
-    ),
-    (
-        DataRead,
-        "on_receive_fin",
-        Err(
-            InvalidTransition {
-                current: DataRead,
-                event: "on_receive_fin",
-            },
+    },
+    Recv: {
+        on_receive_fin: Ok(
+            SizeKnown,
         ),
-    ),
-    (
-        DataRead,
-        "on_receive_all_data",
-        Err(
+        on_receive_all_data: Err(
             InvalidTransition {
-                current: DataRead,
+                current: Recv,
                 event: "on_receive_all_data",
             },
         ),
-    ),
-    (
-        DataRead,
-        "on_app_read_all_data",
-        Err(
+        on_app_read_all_data: Err(
+            InvalidTransition {
+                current: Recv,
+                event: "on_app_read_all_data",
+            },
+        ),
+        on_reset: Ok(
+            ResetRecvd,
+        ),
+        on_app_read_reset: Err(
+            InvalidTransition {
+                current: Recv,
+                event: "on_app_read_reset",
+            },
+        ),
+    },
+    ResetRead: {
+        on_receive_fin: Err(
+            InvalidTransition {
+                current: ResetRead,
+                event: "on_receive_fin",
+            },
+        ),
+        on_receive_all_data: Err(
+            InvalidTransition {
+                current: ResetRead,
+                event: "on_receive_all_data",
+            },
+        ),
+        on_app_read_all_data: Err(
+            InvalidTransition {
+                current: ResetRead,
+                event: "on_app_read_all_data",
+            },
+        ),
+        on_reset: Err(
+            InvalidTransition {
+                current: ResetRead,
+                event: "on_reset",
+            },
+        ),
+        on_app_read_reset: Err(
             NoOp {
-                current: DataRead,
+                current: ResetRead,
             },
         ),
-    ),
-    (
-        DataRead,
-        "on_reset",
-        Err(
-            InvalidTransition {
-                current: DataRead,
-                event: "on_reset",
-            },
-        ),
-    ),
-    (
-        DataRead,
-        "on_app_read_reset",
-        Err(
-            InvalidTransition {
-                current: DataRead,
-                event: "on_app_read_reset",
-            },
-        ),
-    ),
-    (
-        ResetRecvd,
-        "on_receive_fin",
-        Err(
+    },
+    ResetRecvd: {
+        on_receive_fin: Err(
             InvalidTransition {
                 current: ResetRecvd,
                 event: "on_receive_fin",
             },
         ),
-    ),
-    (
-        ResetRecvd,
-        "on_receive_all_data",
-        Err(
+        on_receive_all_data: Err(
             InvalidTransition {
                 current: ResetRecvd,
                 event: "on_receive_all_data",
             },
         ),
-    ),
-    (
-        ResetRecvd,
-        "on_app_read_all_data",
-        Err(
+        on_app_read_all_data: Err(
             InvalidTransition {
                 current: ResetRecvd,
                 event: "on_app_read_all_data",
             },
         ),
-    ),
-    (
-        ResetRecvd,
-        "on_reset",
-        Err(
+        on_reset: Err(
             NoOp {
                 current: ResetRecvd,
             },
         ),
-    ),
-    (
-        ResetRecvd,
-        "on_app_read_reset",
-        Ok(
+        on_app_read_reset: Ok(
             ResetRead,
         ),
-    ),
-    (
-        ResetRead,
-        "on_receive_fin",
-        Err(
-            InvalidTransition {
-                current: ResetRead,
-                event: "on_receive_fin",
+    },
+    SizeKnown: {
+        on_receive_fin: Err(
+            NoOp {
+                current: SizeKnown,
             },
         ),
-    ),
-    (
-        ResetRead,
-        "on_receive_all_data",
-        Err(
-            InvalidTransition {
-                current: ResetRead,
-                event: "on_receive_all_data",
-            },
+        on_receive_all_data: Ok(
+            DataRecvd,
         ),
-    ),
-    (
-        ResetRead,
-        "on_app_read_all_data",
-        Err(
+        on_app_read_all_data: Err(
             InvalidTransition {
-                current: ResetRead,
+                current: SizeKnown,
                 event: "on_app_read_all_data",
             },
         ),
-    ),
-    (
-        ResetRead,
-        "on_reset",
-        Err(
+        on_reset: Ok(
+            ResetRecvd,
+        ),
+        on_app_read_reset: Err(
             InvalidTransition {
-                current: ResetRead,
-                event: "on_reset",
+                current: SizeKnown,
+                event: "on_app_read_reset",
             },
         ),
-    ),
-    (
-        ResetRead,
-        "on_app_read_reset",
-        Err(
-            NoOp {
-                current: ResetRead,
-            },
-        ),
-    ),
-]
+    },
+}

--- a/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__send__tests__snapshots.snap
+++ b/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__send__tests__snapshots.snap
@@ -1,381 +1,227 @@
 ---
 source: quic/s2n-quic-core/src/stream/state/send.rs
-expression: outcomes
+expression: "Sender::test_transitions()"
 ---
-[
-    (
-        Ready,
-        "on_send_stream",
-        Ok(
+{
+    DataRecvd: {
+        on_send_stream: Err(
+            InvalidTransition {
+                current: DataRecvd,
+                event: "on_send_stream",
+            },
+        ),
+        on_send_fin: Err(
+            InvalidTransition {
+                current: DataRecvd,
+                event: "on_send_fin",
+            },
+        ),
+        on_recv_all_acks: Err(
+            NoOp {
+                current: DataRecvd,
+            },
+        ),
+        on_queue_reset: Err(
+            InvalidTransition {
+                current: DataRecvd,
+                event: "on_queue_reset",
+            },
+        ),
+        on_send_reset: Err(
+            InvalidTransition {
+                current: DataRecvd,
+                event: "on_send_reset",
+            },
+        ),
+        on_recv_reset_ack: Err(
+            InvalidTransition {
+                current: DataRecvd,
+                event: "on_recv_reset_ack",
+            },
+        ),
+    },
+    DataSent: {
+        on_send_stream: Err(
+            InvalidTransition {
+                current: DataSent,
+                event: "on_send_stream",
+            },
+        ),
+        on_send_fin: Err(
+            NoOp {
+                current: DataSent,
+            },
+        ),
+        on_recv_all_acks: Ok(
+            DataRecvd,
+        ),
+        on_queue_reset: Ok(
+            ResetQueued,
+        ),
+        on_send_reset: Ok(
+            ResetSent,
+        ),
+        on_recv_reset_ack: Err(
+            InvalidTransition {
+                current: DataSent,
+                event: "on_recv_reset_ack",
+            },
+        ),
+    },
+    Ready: {
+        on_send_stream: Ok(
             Send,
         ),
-    ),
-    (
-        Ready,
-        "on_send_fin",
-        Ok(
+        on_send_fin: Ok(
             DataSent,
         ),
-    ),
-    (
-        Ready,
-        "on_queue_reset",
-        Ok(
-            ResetQueued,
-        ),
-    ),
-    (
-        Ready,
-        "on_send_reset",
-        Ok(
-            ResetSent,
-        ),
-    ),
-    (
-        Ready,
-        "on_recv_all_acks",
-        Err(
+        on_recv_all_acks: Err(
             InvalidTransition {
                 current: Ready,
                 event: "on_recv_all_acks",
             },
         ),
-    ),
-    (
-        Ready,
-        "on_recv_reset_ack",
-        Err(
+        on_queue_reset: Ok(
+            ResetQueued,
+        ),
+        on_send_reset: Ok(
+            ResetSent,
+        ),
+        on_recv_reset_ack: Err(
             InvalidTransition {
                 current: Ready,
                 event: "on_recv_reset_ack",
             },
         ),
-    ),
-    (
-        Send,
-        "on_send_stream",
-        Err(
-            NoOp {
-                current: Send,
-            },
-        ),
-    ),
-    (
-        Send,
-        "on_send_fin",
-        Ok(
-            DataSent,
-        ),
-    ),
-    (
-        Send,
-        "on_queue_reset",
-        Ok(
-            ResetQueued,
-        ),
-    ),
-    (
-        Send,
-        "on_send_reset",
-        Ok(
-            ResetSent,
-        ),
-    ),
-    (
-        Send,
-        "on_recv_all_acks",
-        Err(
+    },
+    ResetQueued: {
+        on_send_stream: Err(
             InvalidTransition {
-                current: Send,
-                event: "on_recv_all_acks",
-            },
-        ),
-    ),
-    (
-        Send,
-        "on_recv_reset_ack",
-        Err(
-            InvalidTransition {
-                current: Send,
-                event: "on_recv_reset_ack",
-            },
-        ),
-    ),
-    (
-        DataSent,
-        "on_send_stream",
-        Err(
-            InvalidTransition {
-                current: DataSent,
+                current: ResetQueued,
                 event: "on_send_stream",
             },
         ),
-    ),
-    (
-        DataSent,
-        "on_send_fin",
-        Err(
-            NoOp {
-                current: DataSent,
-            },
-        ),
-    ),
-    (
-        DataSent,
-        "on_queue_reset",
-        Ok(
-            ResetQueued,
-        ),
-    ),
-    (
-        DataSent,
-        "on_send_reset",
-        Ok(
-            ResetSent,
-        ),
-    ),
-    (
-        DataSent,
-        "on_recv_all_acks",
-        Ok(
-            DataRecvd,
-        ),
-    ),
-    (
-        DataSent,
-        "on_recv_reset_ack",
-        Err(
+        on_send_fin: Err(
             InvalidTransition {
-                current: DataSent,
-                event: "on_recv_reset_ack",
-            },
-        ),
-    ),
-    (
-        DataRecvd,
-        "on_send_stream",
-        Err(
-            InvalidTransition {
-                current: DataRecvd,
-                event: "on_send_stream",
-            },
-        ),
-    ),
-    (
-        DataRecvd,
-        "on_send_fin",
-        Err(
-            InvalidTransition {
-                current: DataRecvd,
+                current: ResetQueued,
                 event: "on_send_fin",
             },
         ),
-    ),
-    (
-        DataRecvd,
-        "on_queue_reset",
-        Err(
+        on_recv_all_acks: Ok(
+            DataRecvd,
+        ),
+        on_queue_reset: Err(
+            NoOp {
+                current: ResetQueued,
+            },
+        ),
+        on_send_reset: Ok(
+            ResetSent,
+        ),
+        on_recv_reset_ack: Err(
             InvalidTransition {
-                current: DataRecvd,
+                current: ResetQueued,
+                event: "on_recv_reset_ack",
+            },
+        ),
+    },
+    ResetRecvd: {
+        on_send_stream: Err(
+            InvalidTransition {
+                current: ResetRecvd,
+                event: "on_send_stream",
+            },
+        ),
+        on_send_fin: Err(
+            InvalidTransition {
+                current: ResetRecvd,
+                event: "on_send_fin",
+            },
+        ),
+        on_recv_all_acks: Err(
+            InvalidTransition {
+                current: ResetRecvd,
+                event: "on_recv_all_acks",
+            },
+        ),
+        on_queue_reset: Err(
+            InvalidTransition {
+                current: ResetRecvd,
                 event: "on_queue_reset",
             },
         ),
-    ),
-    (
-        DataRecvd,
-        "on_send_reset",
-        Err(
+        on_send_reset: Err(
             InvalidTransition {
-                current: DataRecvd,
+                current: ResetRecvd,
                 event: "on_send_reset",
             },
         ),
-    ),
-    (
-        DataRecvd,
-        "on_recv_all_acks",
-        Err(
+        on_recv_reset_ack: Err(
             NoOp {
-                current: DataRecvd,
+                current: ResetRecvd,
             },
         ),
-    ),
-    (
-        DataRecvd,
-        "on_recv_reset_ack",
-        Err(
-            InvalidTransition {
-                current: DataRecvd,
-                event: "on_recv_reset_ack",
-            },
-        ),
-    ),
-    (
-        ResetQueued,
-        "on_send_stream",
-        Err(
-            InvalidTransition {
-                current: ResetQueued,
-                event: "on_send_stream",
-            },
-        ),
-    ),
-    (
-        ResetQueued,
-        "on_send_fin",
-        Err(
-            InvalidTransition {
-                current: ResetQueued,
-                event: "on_send_fin",
-            },
-        ),
-    ),
-    (
-        ResetQueued,
-        "on_queue_reset",
-        Err(
-            NoOp {
-                current: ResetQueued,
-            },
-        ),
-    ),
-    (
-        ResetQueued,
-        "on_send_reset",
-        Ok(
-            ResetSent,
-        ),
-    ),
-    (
-        ResetQueued,
-        "on_recv_all_acks",
-        Ok(
-            DataRecvd,
-        ),
-    ),
-    (
-        ResetQueued,
-        "on_recv_reset_ack",
-        Err(
-            InvalidTransition {
-                current: ResetQueued,
-                event: "on_recv_reset_ack",
-            },
-        ),
-    ),
-    (
-        ResetSent,
-        "on_send_stream",
-        Err(
+    },
+    ResetSent: {
+        on_send_stream: Err(
             InvalidTransition {
                 current: ResetSent,
                 event: "on_send_stream",
             },
         ),
-    ),
-    (
-        ResetSent,
-        "on_send_fin",
-        Err(
+        on_send_fin: Err(
             InvalidTransition {
                 current: ResetSent,
                 event: "on_send_fin",
             },
         ),
-    ),
-    (
-        ResetSent,
-        "on_queue_reset",
-        Err(
-            InvalidTransition {
-                current: ResetSent,
-                event: "on_queue_reset",
-            },
-        ),
-    ),
-    (
-        ResetSent,
-        "on_send_reset",
-        Err(
-            NoOp {
-                current: ResetSent,
-            },
-        ),
-    ),
-    (
-        ResetSent,
-        "on_recv_all_acks",
-        Err(
+        on_recv_all_acks: Err(
             InvalidTransition {
                 current: ResetSent,
                 event: "on_recv_all_acks",
             },
         ),
-    ),
-    (
-        ResetSent,
-        "on_recv_reset_ack",
-        Ok(
+        on_queue_reset: Err(
+            InvalidTransition {
+                current: ResetSent,
+                event: "on_queue_reset",
+            },
+        ),
+        on_send_reset: Err(
+            NoOp {
+                current: ResetSent,
+            },
+        ),
+        on_recv_reset_ack: Ok(
             ResetRecvd,
         ),
-    ),
-    (
-        ResetRecvd,
-        "on_send_stream",
-        Err(
-            InvalidTransition {
-                current: ResetRecvd,
-                event: "on_send_stream",
+    },
+    Send: {
+        on_send_stream: Err(
+            NoOp {
+                current: Send,
             },
         ),
-    ),
-    (
-        ResetRecvd,
-        "on_send_fin",
-        Err(
-            InvalidTransition {
-                current: ResetRecvd,
-                event: "on_send_fin",
-            },
+        on_send_fin: Ok(
+            DataSent,
         ),
-    ),
-    (
-        ResetRecvd,
-        "on_queue_reset",
-        Err(
+        on_recv_all_acks: Err(
             InvalidTransition {
-                current: ResetRecvd,
-                event: "on_queue_reset",
-            },
-        ),
-    ),
-    (
-        ResetRecvd,
-        "on_send_reset",
-        Err(
-            InvalidTransition {
-                current: ResetRecvd,
-                event: "on_send_reset",
-            },
-        ),
-    ),
-    (
-        ResetRecvd,
-        "on_recv_all_acks",
-        Err(
-            InvalidTransition {
-                current: ResetRecvd,
+                current: Send,
                 event: "on_recv_all_acks",
             },
         ),
-    ),
-    (
-        ResetRecvd,
-        "on_recv_reset_ack",
-        Err(
-            NoOp {
-                current: ResetRecvd,
+        on_queue_reset: Ok(
+            ResetQueued,
+        ),
+        on_send_reset: Ok(
+            ResetSent,
+        ),
+        on_recv_reset_ack: Err(
+            InvalidTransition {
+                current: Send,
+                event: "on_recv_reset_ack",
             },
         ),
-    ),
-]
+    },
+}


### PR DESCRIPTION
### Description of changes: 

This change adds a test helper method for state machine implementations that prints out each state and its reaction to an event, i.e. if it is successful or if it's an invalid transition. This was being done manually for the current state implementations so each of those were cleaned up as part of this.

### Testing:

The existing snapshot tests have been updated to use the new helper method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

