### PR TITLE
test(s2n-quic-core): add microwave state example

### DIFF
--- a/quic/s2n-quic-core/src/state.rs
+++ b/quic/s2n-quic-core/src/state.rs
@@ -190,11 +190,12 @@ macro_rules! __state_event__ {
 
         /// Generates a dot graph of all state transitions
         pub fn dot() -> impl ::core::fmt::Display {
-            struct Dot;
+            struct Dot(&'static str);
 
             impl ::core::fmt::Display for Dot {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
                     writeln!(f, "digraph {{")?;
+                    writeln!(f, "  label = {:?};", self.0)?;
 
                     let mut all_states = [
                         // collect all of the states we've observed
@@ -230,7 +231,7 @@ macro_rules! __state_event__ {
                 }
             }
 
-            Dot
+            Dot(::core::any::type_name::<Self>())
         }
     }
 }

--- a/quic/s2n-quic-core/src/state/snapshots/s2n_quic_core__state__tests__lr_dot_test.snap
+++ b/quic/s2n-quic-core/src/state/snapshots/s2n_quic_core__state__tests__lr_dot_test.snap
@@ -1,8 +1,9 @@
 ---
 source: quic/s2n-quic-core/src/state/tests.rs
-expression: "State::dot()"
+expression: "Lr::dot()"
 ---
 digraph {
+  label = "s2n_quic_core::state::tests::Lr";
   Init;
   Left;
   LeftLeft;

--- a/quic/s2n-quic-core/src/state/snapshots/s2n_quic_core__state__tests__lr_snapshots.snap
+++ b/quic/s2n-quic-core/src/state/snapshots/s2n_quic_core__state__tests__lr_snapshots.snap
@@ -1,6 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/state/tests.rs
-expression: "State::test_transitions()"
+expression: "Lr::test_transitions()"
 ---
 {
     Init: {

--- a/quic/s2n-quic-core/src/state/snapshots/s2n_quic_core__state__tests__microwave_dot_test.snap
+++ b/quic/s2n-quic-core/src/state/snapshots/s2n_quic_core__state__tests__microwave_dot_test.snap
@@ -1,0 +1,35 @@
+---
+source: quic/s2n-quic-core/src/state/tests.rs
+expression: "Microwave::dot()"
+---
+digraph {
+  label = "s2n_quic_core::state::tests::Microwave";
+  Idle;
+  OpenIdle;
+  OpenPaused;
+  OpenSettingTime;
+  Paused;
+  Running;
+  SettingTime;
+  Idle -> SettingTime [label = "on_number"];
+  SettingTime -> SettingTime [label = "on_number"];
+  OpenSettingTime -> OpenSettingTime [label = "on_number"];
+  Idle -> Idle [label = "on_cancel"];
+  SettingTime -> Idle [label = "on_cancel"];
+  Paused -> Idle [label = "on_cancel"];
+  Running -> Idle [label = "on_cancel"];
+  OpenIdle -> OpenIdle [label = "on_cancel"];
+  OpenSettingTime -> OpenIdle [label = "on_cancel"];
+  OpenPaused -> OpenIdle [label = "on_cancel"];
+  SettingTime -> Running [label = "on_start"];
+  Paused -> Running [label = "on_start"];
+  Running -> Running [label = "on_start"];
+  Idle -> OpenIdle [label = "on_door_open"];
+  SettingTime -> OpenSettingTime [label = "on_door_open"];
+  Paused -> OpenPaused [label = "on_door_open"];
+  Running -> OpenPaused [label = "on_door_open"];
+  OpenIdle -> Idle [label = "on_door_close"];
+  OpenSettingTime -> SettingTime [label = "on_door_close"];
+  OpenPaused -> Paused [label = "on_door_close"];
+  Running -> Idle [label = "on_time_finished"];
+}

--- a/quic/s2n-quic-core/src/state/snapshots/s2n_quic_core__state__tests__microwave_snapshots.snap
+++ b/quic/s2n-quic-core/src/state/snapshots/s2n_quic_core__state__tests__microwave_snapshots.snap
@@ -1,0 +1,208 @@
+---
+source: quic/s2n-quic-core/src/state/tests.rs
+expression: "Microwave::test_transitions()"
+---
+{
+    Idle: {
+        on_number: Ok(
+            SettingTime,
+        ),
+        on_cancel: Ok(
+            Idle,
+        ),
+        on_start: Err(
+            InvalidTransition {
+                current: Idle,
+                event: "on_start",
+            },
+        ),
+        on_door_open: Ok(
+            OpenIdle,
+        ),
+        on_door_close: Err(
+            InvalidTransition {
+                current: Idle,
+                event: "on_door_close",
+            },
+        ),
+        on_time_finished: Err(
+            NoOp {
+                current: Idle,
+            },
+        ),
+    },
+    OpenIdle: {
+        on_number: Err(
+            InvalidTransition {
+                current: OpenIdle,
+                event: "on_number",
+            },
+        ),
+        on_cancel: Ok(
+            OpenIdle,
+        ),
+        on_start: Err(
+            InvalidTransition {
+                current: OpenIdle,
+                event: "on_start",
+            },
+        ),
+        on_door_open: Err(
+            InvalidTransition {
+                current: OpenIdle,
+                event: "on_door_open",
+            },
+        ),
+        on_door_close: Ok(
+            Idle,
+        ),
+        on_time_finished: Err(
+            InvalidTransition {
+                current: OpenIdle,
+                event: "on_time_finished",
+            },
+        ),
+    },
+    OpenPaused: {
+        on_number: Err(
+            InvalidTransition {
+                current: OpenPaused,
+                event: "on_number",
+            },
+        ),
+        on_cancel: Ok(
+            OpenIdle,
+        ),
+        on_start: Err(
+            InvalidTransition {
+                current: OpenPaused,
+                event: "on_start",
+            },
+        ),
+        on_door_open: Err(
+            InvalidTransition {
+                current: OpenPaused,
+                event: "on_door_open",
+            },
+        ),
+        on_door_close: Ok(
+            Paused,
+        ),
+        on_time_finished: Err(
+            InvalidTransition {
+                current: OpenPaused,
+                event: "on_time_finished",
+            },
+        ),
+    },
+    OpenSettingTime: {
+        on_number: Ok(
+            OpenSettingTime,
+        ),
+        on_cancel: Ok(
+            OpenIdle,
+        ),
+        on_start: Err(
+            InvalidTransition {
+                current: OpenSettingTime,
+                event: "on_start",
+            },
+        ),
+        on_door_open: Err(
+            InvalidTransition {
+                current: OpenSettingTime,
+                event: "on_door_open",
+            },
+        ),
+        on_door_close: Ok(
+            SettingTime,
+        ),
+        on_time_finished: Err(
+            InvalidTransition {
+                current: OpenSettingTime,
+                event: "on_time_finished",
+            },
+        ),
+    },
+    Paused: {
+        on_number: Err(
+            InvalidTransition {
+                current: Paused,
+                event: "on_number",
+            },
+        ),
+        on_cancel: Ok(
+            Idle,
+        ),
+        on_start: Ok(
+            Running,
+        ),
+        on_door_open: Ok(
+            OpenPaused,
+        ),
+        on_door_close: Err(
+            InvalidTransition {
+                current: Paused,
+                event: "on_door_close",
+            },
+        ),
+        on_time_finished: Err(
+            InvalidTransition {
+                current: Paused,
+                event: "on_time_finished",
+            },
+        ),
+    },
+    Running: {
+        on_number: Err(
+            InvalidTransition {
+                current: Running,
+                event: "on_number",
+            },
+        ),
+        on_cancel: Ok(
+            Idle,
+        ),
+        on_start: Ok(
+            Running,
+        ),
+        on_door_open: Ok(
+            OpenPaused,
+        ),
+        on_door_close: Err(
+            InvalidTransition {
+                current: Running,
+                event: "on_door_close",
+            },
+        ),
+        on_time_finished: Ok(
+            Idle,
+        ),
+    },
+    SettingTime: {
+        on_number: Ok(
+            SettingTime,
+        ),
+        on_cancel: Ok(
+            Idle,
+        ),
+        on_start: Ok(
+            Running,
+        ),
+        on_door_open: Ok(
+            OpenSettingTime,
+        ),
+        on_door_close: Err(
+            InvalidTransition {
+                current: SettingTime,
+                event: "on_door_close",
+            },
+        ),
+        on_time_finished: Err(
+            InvalidTransition {
+                current: SettingTime,
+                event: "on_time_finished",
+            },
+        ),
+    },
+}

--- a/quic/s2n-quic-core/src/state/tests.rs
+++ b/quic/s2n-quic-core/src/state/tests.rs
@@ -5,7 +5,7 @@ use super::*;
 use insta::{assert_debug_snapshot, assert_snapshot};
 
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
-enum State {
+enum Lr {
     #[default]
     Init,
     Left,
@@ -16,7 +16,7 @@ enum State {
     RightRight,
 }
 
-impl State {
+impl Lr {
     event! {
         on_left(
             Init => Left,
@@ -33,12 +33,65 @@ impl State {
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn snapshots() {
-    assert_debug_snapshot!(State::test_transitions());
+fn lr_snapshots() {
+    assert_debug_snapshot!(Lr::test_transitions());
 }
 
 #[test]
 #[cfg_attr(miri, ignore)]
-fn dot_test() {
-    assert_snapshot!(State::dot());
+fn lr_dot_test() {
+    assert_snapshot!(Lr::dot());
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+enum Microwave {
+    #[default]
+    Idle,
+    OpenIdle,
+    SettingTime,
+    OpenSettingTime,
+    Paused,
+    OpenPaused,
+    Running,
+}
+
+impl Microwave {
+    event! {
+        on_number(
+            Idle | SettingTime => SettingTime,
+            OpenSettingTime => OpenSettingTime,
+        );
+        on_cancel(
+            Idle | SettingTime | Paused | Running => Idle,
+            OpenIdle | OpenSettingTime | OpenPaused => OpenIdle,
+        );
+        on_start(
+            SettingTime | Paused | Running => Running,
+        );
+        on_door_open(
+            Idle => OpenIdle,
+            SettingTime => OpenSettingTime,
+            Paused | Running => OpenPaused,
+        );
+        on_door_close(
+            OpenIdle => Idle,
+            OpenSettingTime => SettingTime,
+            OpenPaused => Paused,
+        );
+        on_time_finished(
+            Running => Idle,
+        );
+    }
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn microwave_snapshots() {
+    assert_debug_snapshot!(Microwave::test_transitions());
+}
+
+#[test]
+#[cfg_attr(miri, ignore)]
+fn microwave_dot_test() {
+    assert_snapshot!(Microwave::dot());
 }

--- a/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__recv__tests__dot_test.snap
+++ b/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__recv__tests__dot_test.snap
@@ -3,6 +3,7 @@ source: quic/s2n-quic-core/src/stream/state/recv.rs
 expression: "Receiver::dot()"
 ---
 digraph {
+  label = "s2n_quic_core::stream::state::recv::Receiver";
   DataRead;
   DataRecvd;
   Recv;

--- a/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__send__tests__dot_test.snap
+++ b/quic/s2n-quic-core/src/stream/state/snapshots/s2n_quic_core__stream__state__send__tests__dot_test.snap
@@ -3,6 +3,7 @@ source: quic/s2n-quic-core/src/stream/state/send.rs
 expression: "Sender::dot()"
 ---
 digraph {
+  label = "s2n_quic_core::stream::state::send::Sender";
   DataRecvd;
   DataSent;
   Ready;


### PR DESCRIPTION
### Description of changes: 

I wanted to get a bit better coverage on the state machine macro for a more complicated example so this adds a test for a microwave state machine.

### Testing:

![image](https://github.com/aws/s2n-quic/assets/799311/1e2168d8-001c-4195-88f7-b668df715685)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

