### PR TITLE
chore(s2n-quic-transport): update dc manager dot snapshot

### DIFF
--- a/quic/s2n-quic-transport/src/dc/manager/snapshots/s2n_quic_transport__dc__manager__tests__dot_test.snap
+++ b/quic/s2n-quic-transport/src/dc/manager/snapshots/s2n_quic_transport__dc__manager__tests__dot_test.snap
@@ -3,6 +3,7 @@ source: quic/s2n-quic-transport/src/dc/manager/tests.rs
 expression: "State::dot()"
 ---
 digraph {
+  label = "s2n_quic_transport::dc::manager::State";
   ClientPathSecretsReady;
   Complete;
   InitClient;


### PR DESCRIPTION
### Description of changes: 

#2222 changed the dot snapshot format a bit, but didn't have the latest dc manager code pulled in, so the snapshot test was failing in main. This fixes the snapshot 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

