### PR TITLE
 chore: release 1.38.1

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-codec"
-version = "0.38.0"
+version = "0.38.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]

--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-dc"
-version = "0.38.0"
+version = "0.38.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -21,9 +21,9 @@ crossbeam-channel = "0.5"
 libc = "0.2"
 num-rational = { version = "0.4", default-features = false }
 once_cell = "1"
-s2n-codec = { version = "=0.38.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.38.0", path = "../../quic/s2n-quic-core", default-features = false }
-s2n-quic-platform = { version = "=0.38.0", path = "../../quic/s2n-quic-platform" }
+s2n-codec = { version = "=0.38.1", path = "../../common/s2n-codec", default-features = false }
+s2n-quic-core = { version = "=0.38.1", path = "../../quic/s2n-quic-core", default-features = false }
+s2n-quic-platform = { version = "=0.38.1", path = "../../quic/s2n-quic-platform" }
 thiserror = "1"
 tokio = { version = "1", features = ["io-util"], optional = true }
 tracing = "0.1"

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-core"
-version = "0.38.0"
+version = "0.38.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -41,7 +41,7 @@ num-rational = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 pin-project-lite = { version = "0.2" }
 probe = { version = "0.5", optional = true }
-s2n-codec = { version = "=0.38.0", path = "../../common/s2n-codec", default-features = false }
+s2n-codec = { version = "=0.38.1", path = "../../common/s2n-codec", default-features = false }
 subtle = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }
 zerocopy = { version = "0.7", features = ["derive"] }

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-crypto"
-version = "0.38.0"
+version = "0.38.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -19,8 +19,8 @@ testing = []
 [dependencies]
 cfg-if = "1"
 lazy_static = "1"
-s2n-codec = { version = "=0.38.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.38.0", path = "../s2n-quic-core", default-features = false }
+s2n-codec = { version = "=0.38.1", path = "../../common/s2n-codec", default-features = false }
+s2n-quic-core = { version = "=0.38.1", path = "../s2n-quic-core", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["derive"] }
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-platform"
-version = "0.38.0"
+version = "0.38.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -25,8 +25,8 @@ bolero-generator = { version = "0.10", optional = true }
 cfg-if = "1"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 lazy_static = { version = "1", optional = true }
-s2n-quic-core = { version = "=0.38.0", path = "../s2n-quic-core", default-features = false }
-s2n-quic-xdp = { version = "=0.38.0", path = "../../tools/xdp/s2n-quic-xdp", optional = true }
+s2n-quic-core = { version = "=0.38.1", path = "../s2n-quic-core", default-features = false }
+s2n-quic-xdp = { version = "=0.38.1", path = "../../tools/xdp/s2n-quic-xdp", optional = true }
 socket2 = { version = "0.5", features = ["all"], optional = true }
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt", "time"], optional = true }
 tracing = { version = "0.1", optional = true }

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-rustls"
-version = "0.38.0"
+version = "0.38.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -18,9 +18,9 @@ bytes = { version = "1", default-features = false }
 # By [default](https://docs.rs/crate/rustls/latest/features) rustls includes the `tls12` feature.
 rustls = { version = "0.23", default-features = false, features=["std", "aws-lc-rs", "logging"] }
 rustls-pemfile = "2"
-s2n-codec = { version = "=0.38.0", path = "../../common/s2n-codec", default-features = false, features = ["alloc"] }
-s2n-quic-core = { version = "=0.38.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
-s2n-quic-crypto = { version = "=0.38.0", path = "../s2n-quic-crypto", default-features = false }
+s2n-codec = { version = "=0.38.1", path = "../../common/s2n-codec", default-features = false, features = ["alloc"] }
+s2n-quic-core = { version = "=0.38.1", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
+s2n-quic-crypto = { version = "=0.38.1", path = "../s2n-quic-crypto", default-features = false }
 
 [dev-dependencies]
 insta = { version = "1", features = ["json"] }

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-tls-default"
-version = "0.38.0"
+version = "0.38.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -24,10 +24,10 @@ fips = ["s2n-quic-tls?/fips"]
 # order to support the `?` syntax, we declare s2n-quic-tls as an optional dependency.
 # `s2n-quic-tls` only gets enabled based on the target.
 [dependencies]
-s2n-quic-tls = { path = "../s2n-quic-tls", optional = true }
+s2n-quic-tls = { version = "=0.38.1", path = "../s2n-quic-tls", optional = true }
 
 [target.'cfg(unix)'.dependencies]
-s2n-quic-tls = { version = "=0.38.0", path = "../s2n-quic-tls" }
+s2n-quic-tls = { version = "=0.38.1", path = "../s2n-quic-tls" }
 
 [target.'cfg(not(unix))'.dependencies]
-s2n-quic-rustls = { version = "=0.38.0", path = "../s2n-quic-rustls" }
+s2n-quic-rustls = { version = "=0.38.1", path = "../s2n-quic-rustls" }

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-tls"
-version = "0.38.0"
+version = "0.38.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -19,9 +19,9 @@ unstable_private_key = []
 bytes = { version = "1", default-features = false }
 errno = "0.3"
 libc = "0.2"
-s2n-codec = { version = "=0.38.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.38.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
-s2n-quic-crypto = { version = "=0.38.0", path = "../s2n-quic-crypto", default-features = false }
+s2n-codec = { version = "=0.38.1", path = "../../common/s2n-codec", default-features = false }
+s2n-quic-core = { version = "=0.38.1", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
+s2n-quic-crypto = { version = "=0.38.1", path = "../s2n-quic-crypto", default-features = false }
 s2n-tls = { version = "0.2", features = ["quic"] }
 
 [dev-dependencies]

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-transport"
-version = "0.38.0"
+version = "0.38.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -22,8 +22,8 @@ futures-core = { version = "0.3", default-features = false, features = ["alloc"]
 hashbrown = "0.14"
 intrusive-collections = "0.9"
 once_cell = "1"
-s2n-codec = { version = "=0.38.0", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
-s2n-quic-core = { version = "=0.38.0", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
+s2n-codec = { version = "=0.38.1", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
+s2n-quic-core = { version = "=0.38.1", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
 siphasher = "1.0"
 smallvec = { version = "1", default-features = false }
 

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic"
-version = "1.38.0"
+version = "1.38.1"
 description = "A Rust implementation of the IETF QUIC protocol"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -69,14 +69,14 @@ hash_hasher = { version = "2", optional = true }
 humansize = { version = "2", optional = true }
 rand = "0.8"
 rand_chacha = "0.3"
-s2n-codec = { version = "=0.38.0", path = "../../common/s2n-codec" }
-s2n-quic-core = { version = "=0.38.0", path = "../s2n-quic-core" }
-s2n-quic-crypto = { version = "=0.38.0", path = "../s2n-quic-crypto", optional = true }
-s2n-quic-platform = { version = "=0.38.0", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
-s2n-quic-rustls = { version = "=0.38.0", path = "../s2n-quic-rustls", optional = true }
-s2n-quic-tls = { version = "=0.38.0", path = "../s2n-quic-tls", optional = true }
-s2n-quic-tls-default = { version = "=0.38.0", path = "../s2n-quic-tls-default", optional = true }
-s2n-quic-transport = { version = "=0.38.0", path = "../s2n-quic-transport" }
+s2n-codec = { version = "=0.38.1", path = "../../common/s2n-codec" }
+s2n-quic-core = { version = "=0.38.1", path = "../s2n-quic-core" }
+s2n-quic-crypto = { version = "=0.38.1", path = "../s2n-quic-crypto", optional = true }
+s2n-quic-platform = { version = "=0.38.1", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
+s2n-quic-rustls = { version = "=0.38.1", path = "../s2n-quic-rustls", optional = true }
+s2n-quic-tls = { version = "=0.38.1", path = "../s2n-quic-tls", optional = true }
+s2n-quic-tls-default = { version = "=0.38.1", path = "../s2n-quic-tls-default", optional = true }
+s2n-quic-transport = { version = "=0.38.1", path = "../s2n-quic-transport" }
 tokio = { version = "1", default-features = false }
 zerocopy = { version = "0.7", optional = true, features = ["derive"] }
 zeroize = { version = "1", optional = true, default-features = false }
@@ -85,7 +85,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 bolero = { version = "0.10" }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "probe-tracing", "testing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }
-s2n-quic-transport = { version = "=0.38.0", path = "../s2n-quic-transport", features = ["unstable_resumption"] }
+s2n-quic-transport = { version = "=0.38.1", path = "../s2n-quic-transport", features = ["unstable_resumption"] }
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-xdp"
-version = "0.38.0"
+version = "0.38.1"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -18,8 +18,8 @@ aya = { version = "0.12", default-features = false }
 bitflags = "2"
 errno = "0.3"
 libc = "0.2"
-s2n-codec = { version = "=0.38.0", path = "../../../common/s2n-codec" }
-s2n-quic-core = { version = "=0.38.0", path = "../../../quic/s2n-quic-core" }
+s2n-codec = { version = "=0.38.1", path = "../../../common/s2n-codec" }
+s2n-quic-core = { version = "=0.38.1", path = "../../../quic/s2n-quic-core" }
 tokio = { version = "1", features = ["net"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
### Description of changes: 

Version bump for 1.38.1 release

### Call-outs:

I added a version to the optional `s2n-quic-tls` dependency in the `s2n-quic-tls-default` crate, as it is required to publish to crates.io

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

