### PR TITLE
feat(s2n-quic): expose mtu provider

### DIFF
--- a/quic/s2n-quic-core/src/connection/error.rs
+++ b/quic/s2n-quic-core/src/connection/error.rs
@@ -87,9 +87,9 @@ pub enum Error {
         source: &'static panic::Location<'static>,
     },
 
-    /// The connection was closed due to a validation failure
+    /// The connection was closed due to invalid Application provided configuration
     #[non_exhaustive]
-    Validation {
+    InvalidConfiguration {
         reason: &'static str,
         source: &'static panic::Location<'static>,
     },
@@ -156,7 +156,7 @@ impl fmt::Display for Error {
             Self::EndpointClosing { .. } => {
                 write!(f, "The connection attempt was rejected because the endpoint is closing")
             }
-            Self::Validation {reason, ..} => write!(
+            Self::InvalidConfiguration {reason, ..} => write!(
                 f,
                 "The connection was closed due to: {reason}"
             ),
@@ -246,7 +246,7 @@ impl Error {
             Error::MaxHandshakeDurationExceeded { source, .. } => source,
             Error::ImmediateClose { source, .. } => source,
             Error::EndpointClosing { source } => source,
-            Error::Validation { source, .. } => source,
+            Error::InvalidConfiguration { source, .. } => source,
             Error::Unspecified { source } => source,
         }
     }
@@ -354,9 +354,9 @@ impl Error {
     #[inline]
     #[track_caller]
     #[doc(hidden)]
-    pub fn validation(reason: &'static str) -> Error {
+    pub fn invalid_configuration(reason: &'static str) -> Error {
         let source = panic::Location::caller();
-        Error::Validation { source, reason }
+        Error::InvalidConfiguration { source, reason }
     }
 
     #[inline]
@@ -460,7 +460,7 @@ pub fn as_frame<'a, F: connection::close::Formatter>(
         Error::MaxHandshakeDurationExceeded { .. } => None,
         Error::ImmediateClose { .. } => None,
         Error::EndpointClosing { .. } => None,
-        Error::Validation { .. } => None,
+        Error::InvalidConfiguration { .. } => None,
         Error::Unspecified { .. } => {
             let error =
                 transport::Error::INTERNAL_ERROR.with_reason("an unspecified error occurred");
@@ -539,7 +539,7 @@ impl From<Error> for std::io::ErrorKind {
             Error::MaxHandshakeDurationExceeded { .. } => ErrorKind::TimedOut,
             Error::ImmediateClose { .. } => ErrorKind::Other,
             Error::EndpointClosing { .. } => ErrorKind::Other,
-            Error::Validation { .. } => ErrorKind::Other,
+            Error::InvalidConfiguration { .. } => ErrorKind::Other,
             Error::Unspecified { .. } => ErrorKind::Other,
         }
     }

--- a/quic/s2n-quic-core/src/crypto/application/limited.rs
+++ b/quic/s2n-quic-core/src/crypto/application/limited.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{crypto::OneRttKey, path::MaxMtu};
+use crate::crypto::OneRttKey;
 
 //= https://www.rfc-editor.org/rfc/rfc9001#section-6.6
 //# Endpoints MUST count the number of encrypted packets for each set of
@@ -21,21 +21,12 @@ pub struct Key<K> {
 pub struct Limits {
     /// The number of packets before the limit at which a key update will be scheduled
     pub key_update_window: u64,
-    /// The number of packets at which the sealer key will be optimized
-    pub sealer_optimization_threshold: u64,
-    /// The number of packets at which the opener key will be optimized
-    pub opener_optimization_threshold: u64,
-    /// The maximum MTU the connection will ever encrypt/decrypt
-    pub max_mtu: MaxMtu,
 }
 
 impl Default for Limits {
     fn default() -> Self {
         Self {
             key_update_window: KEY_UPDATE_WINDOW,
-            sealer_optimization_threshold: 100,
-            opener_optimization_threshold: 100,
-            max_mtu: MaxMtu::default(),
         }
     }
 }
@@ -84,21 +75,13 @@ impl<K: OneRttKey> Key<K> {
     }
 
     #[inline]
-    pub fn on_packet_encryption(&mut self, limits: &Limits) {
+    pub fn on_packet_encryption(&mut self, _limits: &Limits) {
         self.encrypted_packets += 1;
-
-        if self.encrypted_packets == limits.sealer_optimization_threshold {
-            self.key.update_sealer_pmtu(limits.max_mtu.into());
-        }
     }
 
     #[inline]
-    pub fn on_packet_decryption(&mut self, limits: &Limits) {
+    pub fn on_packet_decryption(&mut self, _limits: &Limits) {
         self.decrypted_packets += 1;
-
-        if self.decrypted_packets == limits.opener_optimization_threshold {
-            self.key.update_opener_pmtu(limits.max_mtu.into());
-        }
     }
 
     #[inline]

--- a/quic/s2n-quic-core/src/crypto/key.rs
+++ b/quic/s2n-quic-core/src/crypto/key.rs
@@ -137,9 +137,6 @@ pub mod testing {
                 fail_on_decrypt: self.fail_on_decrypt,
             }
         }
-
-        fn update_sealer_pmtu(&mut self, _pmtu: u16) {}
-        fn update_opener_pmtu(&mut self, _pmtu: u16) {}
     }
     impl ZeroRttKey for Key {}
     impl RetryKey for Key {

--- a/quic/s2n-quic-core/src/crypto/one_rtt.rs
+++ b/quic/s2n-quic-core/src/crypto/one_rtt.rs
@@ -11,9 +11,6 @@ use crate::crypto::{HeaderKey, Key};
 pub trait OneRttKey: Key {
     #[must_use]
     fn derive_next_key(&self) -> Self;
-
-    fn update_sealer_pmtu(&mut self, pmtu: u16);
-    fn update_opener_pmtu(&mut self, pmtu: u16);
 }
 
 /// Types for which are able to perform 1-RTT header cryptography.

--- a/quic/s2n-quic-core/src/crypto/tls/null.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/null.rs
@@ -394,16 +394,6 @@ mod key {
         fn derive_next_key(&self) -> Self {
             NoCrypto
         }
-
-        #[inline(always)]
-        fn update_sealer_pmtu(&mut self, _pmtu: u16) {
-            // Do nothing
-        }
-
-        #[inline(always)]
-        fn update_opener_pmtu(&mut self, _pmtu: u16) {
-            // Do nothing
-        }
     }
 
     impl crypto::OneRttHeaderKey for NoCrypto {}

--- a/quic/s2n-quic-core/src/dc.rs
+++ b/quic/s2n-quic-core/src/dc.rs
@@ -8,7 +8,6 @@ use crate::{
         IntoEvent as _,
     },
     inet,
-    path::MaxMtu,
     transport::parameters::{DcSupportedVersions, InitialFlowControlLimits},
     varint::VarInt,
 };
@@ -76,7 +75,6 @@ impl<'a> ConnectionInfo<'a> {
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct ApplicationParams {
-    pub max_mtu: MaxMtu,
     pub remote_max_data: VarInt,
     pub local_send_max_data: VarInt,
     pub local_recv_max_data: VarInt,
@@ -85,13 +83,8 @@ pub struct ApplicationParams {
 }
 
 impl ApplicationParams {
-    pub fn new(
-        max_mtu: MaxMtu,
-        peer_flow_control_limits: &InitialFlowControlLimits,
-        limits: &Limits,
-    ) -> Self {
+    pub fn new(peer_flow_control_limits: &InitialFlowControlLimits, limits: &Limits) -> Self {
         Self {
-            max_mtu,
             remote_max_data: peer_flow_control_limits.max_data,
             local_send_max_data: limits.initial_stream_limits().max_data_bidi_local,
             local_recv_max_data: limits.initial_stream_limits().max_data_bidi_remote,

--- a/quic/s2n-quic-core/src/dc.rs
+++ b/quic/s2n-quic-core/src/dc.rs
@@ -8,6 +8,7 @@ use crate::{
         IntoEvent as _,
     },
     inet,
+    path::MaxMtu,
     transport::parameters::{DcSupportedVersions, InitialFlowControlLimits},
     varint::VarInt,
 };
@@ -75,6 +76,7 @@ impl<'a> ConnectionInfo<'a> {
 #[derive(Clone, Debug)]
 #[non_exhaustive]
 pub struct ApplicationParams {
+    pub max_mtu: MaxMtu,
     pub remote_max_data: VarInt,
     pub local_send_max_data: VarInt,
     pub local_recv_max_data: VarInt,
@@ -83,8 +85,13 @@ pub struct ApplicationParams {
 }
 
 impl ApplicationParams {
-    pub fn new(peer_flow_control_limits: &InitialFlowControlLimits, limits: &Limits) -> Self {
+    pub fn new(
+        max_mtu: MaxMtu,
+        peer_flow_control_limits: &InitialFlowControlLimits,
+        limits: &Limits,
+    ) -> Self {
         Self {
+            max_mtu,
             remote_max_data: peer_flow_control_limits.max_data,
             local_send_max_data: limits.initial_stream_limits().max_data_bidi_local,
             local_recv_max_data: limits.initial_stream_limits().max_data_bidi_remote,

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -308,6 +308,12 @@ pub mod api {
         #[doc = " The peer sent an invalid Source Connection Id."]
         InvalidSourceConnectionId {},
         #[non_exhaustive]
+        #[doc = " Application provided invalid MTU configuration."]
+        InvalidMtuConfiguration {
+            #[doc = " MTU configuration for the endpoint"]
+            endpoint_mtu_config: MtuConfig,
+        },
+        #[non_exhaustive]
         #[doc = " The Destination Connection Id is unknown and does not map to a Connection."]
         #[doc = ""]
         #[doc = " Connections are mapped to Destination Connections Ids (DCID) and packets"]
@@ -333,12 +339,6 @@ pub mod api {
         #[non_exhaustive]
         #[doc = " The peer initiated a connection migration without supplying enough connection IDs to use."]
         InsufficientConnectionIds {},
-        #[non_exhaustive]
-        #[doc = " Application provided invalid MTU configuration."]
-        MtuValidation {
-            #[doc = " MTU configuration for the endpoint"]
-            endpoint_mtu_config: MtuConfig,
-        },
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
@@ -3106,6 +3106,11 @@ pub mod builder {
         InvalidDestinationConnectionId,
         #[doc = " The peer sent an invalid Source Connection Id."]
         InvalidSourceConnectionId,
+        #[doc = " Application provided invalid MTU configuration."]
+        InvalidMtuConfiguration {
+            #[doc = " MTU configuration for the endpoint"]
+            endpoint_mtu_config: MtuConfig,
+        },
         #[doc = " The Destination Connection Id is unknown and does not map to a Connection."]
         #[doc = ""]
         #[doc = " Connections are mapped to Destination Connections Ids (DCID) and packets"]
@@ -3125,11 +3130,6 @@ pub mod builder {
         PathLimitExceeded,
         #[doc = " The peer initiated a connection migration without supplying enough connection IDs to use."]
         InsufficientConnectionIds,
-        #[doc = " Application provided invalid MTU configuration."]
-        MtuValidation {
-            #[doc = " MTU configuration for the endpoint"]
-            endpoint_mtu_config: MtuConfig,
-        },
     }
     impl IntoEvent<api::DatagramDropReason> for DatagramDropReason {
         #[inline]
@@ -3141,6 +3141,11 @@ pub mod builder {
                 Self::UnsupportedVersion => UnsupportedVersion {},
                 Self::InvalidDestinationConnectionId => InvalidDestinationConnectionId {},
                 Self::InvalidSourceConnectionId => InvalidSourceConnectionId {},
+                Self::InvalidMtuConfiguration {
+                    endpoint_mtu_config,
+                } => InvalidMtuConfiguration {
+                    endpoint_mtu_config: endpoint_mtu_config.into_event(),
+                },
                 Self::UnknownDestinationConnectionId => UnknownDestinationConnectionId {},
                 Self::RejectedConnectionAttempt => RejectedConnectionAttempt {},
                 Self::UnknownServerAddress => UnknownServerAddress {},
@@ -3148,11 +3153,6 @@ pub mod builder {
                 Self::RejectedConnectionMigration => RejectedConnectionMigration {},
                 Self::PathLimitExceeded => PathLimitExceeded {},
                 Self::InsufficientConnectionIds => InsufficientConnectionIds {},
-                Self::MtuValidation {
-                    endpoint_mtu_config,
-                } => MtuValidation {
-                    endpoint_mtu_config: endpoint_mtu_config.into_event(),
-                },
             }
         }
     }

--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -14,7 +14,7 @@ pub mod ecn;
 pub mod migration;
 pub mod mtu;
 
-pub use mtu::*;
+pub use mtu::{BaseMtu, Config, Endpoint, InitialMtu, MaxMtu, MINIMUM_MAX_DATAGRAM_SIZE};
 
 // Initial PTO backoff multiplier is 1 indicating no additional increase to the backoff.
 pub const INITIAL_PTO_BACKOFF: u32 = 1;

--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -14,7 +14,7 @@ pub mod ecn;
 pub mod migration;
 pub mod mtu;
 
-pub use mtu::{BaseMtu, Config, Endpoint, InitialMtu, MaxMtu, MINIMUM_MAX_DATAGRAM_SIZE};
+pub use mtu::{BaseMtu, Config, Endpoint, InitialMtu, MaxMtu, MtuError, MINIMUM_MAX_DATAGRAM_SIZE};
 
 // Initial PTO backoff multiplier is 1 indicating no additional increase to the backoff.
 pub const INITIAL_PTO_BACKOFF: u32 = 1;

--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -239,31 +239,31 @@ impl Display for MtuError {
 #[cfg(feature = "std")]
 impl std::error::Error for MtuError {}
 
-/// Information about the connection that may be used when generating or
+/// Information about the path that may be used when generating or
 /// validating MTU configuration.
-pub struct ConnectionInfo<'a> {
+pub struct PathInfo<'a> {
     pub remote_address: event::api::SocketAddress<'a>,
     pub endpoint_config: Config,
 }
 
-impl<'a> ConnectionInfo<'a> {
+impl<'a> PathInfo<'a> {
     #[inline]
     #[doc(hidden)]
     pub fn new(remote_address: &'a inet::SocketAddress, endpoint_mtu_config: Config) -> Self {
-        ConnectionInfo {
+        PathInfo {
             remote_address: remote_address.into_event(),
             endpoint_config: endpoint_mtu_config,
         }
     }
 }
 
-/// Creates MTU config for the given connection.
+/// Creates MTU config for the given path.
 pub trait Endpoint: 'static + Send {
-    /// Provide connection specific MTU config.
+    /// Provide path specific MTU config.
     ///
     /// Application must ensure that `max_mtu <= info.endpoint_config.max_mtu`.
     /// By default this uses the MTU config specified on the IO provider.
-    fn on_connection(&mut self, info: &mtu::ConnectionInfo) -> mtu::Config {
+    fn on_path(&mut self, info: &mtu::PathInfo) -> mtu::Config {
         info.endpoint_config
     }
 }
@@ -320,7 +320,7 @@ pub struct CheckedConfig(Config);
 
 impl CheckedConfig {
     // Check that the Application provided MTU values are valid for this endpoint.
-    pub fn new(config: Config, info: &mtu::ConnectionInfo) -> Result<CheckedConfig, MtuError> {
+    pub fn new(config: Config, info: &mtu::PathInfo) -> Result<CheckedConfig, MtuError> {
         ensure!(config.is_valid(), Err(MtuError::Validation));
         ensure!(
             u16::from(config.max_mtu) <= u16::from(info.endpoint_config.max_mtu),

--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -268,6 +268,7 @@ pub trait Endpoint: 'static + Send {
     }
 }
 
+/// MTU configuration.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Config {
     initial_mtu: InitialMtu,

--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -249,14 +249,14 @@ impl<'a> PathInfo<'a> {
 
 /// MTU configuration manager.
 #[derive(Copy, Clone, Debug)]
-pub struct MtuManager<E: mtu::Endpoint> {
+pub struct Manager<E: mtu::Endpoint> {
     provider: E,
     endpoint_mtu_config: Config,
 }
 
-impl<E: mtu::Endpoint> MtuManager<E> {
+impl<E: mtu::Endpoint> Manager<E> {
     pub fn new(provider: E) -> Self {
-        MtuManager {
+        Manager {
             provider,
             // Instantiate the Manager with default values since the endpoint is
             // create before the IO provider (which sets the actual config `set_mtu_config()`).

--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -255,6 +255,15 @@ pub struct MtuManager<E: mtu::Endpoint> {
     endpoint_mtu_config: Config,
 }
 
+impl<E: mtu::Endpoint> MtuManager<E> {
+    pub fn new(endpoint: &mut E, endpoint_mtu_config: Config) -> MtuManager<E> {
+        MtuManager {
+            // storing &mut E means this has a lifetime associated with it.
+            //
+            // we are borrowing from the endpoint so we lose Copy and Clone
+            //
+            // this now become more complicated to store and pollutes the codebase
+            endpoint: todo!(),
             endpoint_mtu_config,
         }
     }

--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -233,6 +233,7 @@ impl std::error::Error for MtuError {}
 
 /// Information about the path that may be used when generating or
 /// validating MTU configuration.
+#[non_exhaustive]
 pub struct PathInfo<'a> {
     pub remote_address: event::api::SocketAddress<'a>,
 }

--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -312,8 +312,6 @@ impl Config {
 pub struct CheckedConfig {
     // The active mtu config for the path
     active: Config,
-    // The max mtu configured on the Endpoint
-    pub endpoint: Config,
 }
 
 impl CheckedConfig {
@@ -325,10 +323,7 @@ impl CheckedConfig {
             Err(MtuError)
         );
 
-        Ok(CheckedConfig {
-            active: config,
-            endpoint: info.endpoint_config,
-        })
+        Ok(CheckedConfig { active: config })
     }
 
     pub fn initial_mtu(&self) -> InitialMtu {
@@ -340,10 +335,7 @@ impl CheckedConfig {
 #[cfg(any(test, feature = "testing"))]
 impl From<Config> for CheckedConfig {
     fn from(value: Config) -> Self {
-        CheckedConfig {
-            active: value,
-            endpoint: value,
-        }
+        CheckedConfig { active: value }
     }
 }
 

--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -296,7 +296,7 @@ pub trait Endpoint: 'static + Send {
     /// connection. Returning `None` means that the path should inherit
     /// the endpoint configured values.
     ///
-    /// Application must ensure that `max_mtu <= endpoint_mtu_config.mtu_config.max_mtu`.
+    /// Application must ensure that `max_mtu <= endpoint_mtu_config.max_mtu()`.
     fn on_path(&mut self, info: &mtu::PathInfo, endpoint_mtu_config: Config)
         -> Option<mtu::Config>;
 }
@@ -414,7 +414,7 @@ impl Builder {
 
     /// Sets the largest maximum transmission unit (MTU) that can be sent on a path (default: 1500)
     ///
-    /// Application must ensure that max_mtu <= endpoint_mtu_config.mtu_config.max_mtu. For a detailed
+    /// Application must ensure that max_mtu <= endpoint_mtu_config.max_mtu(). For a detailed
     /// description see the [with_max_mtu] documentation in the IO provider.
     ///
     /// [with_max_mtu]: https://docs.rs/s2n-quic/latest/s2n_quic/provider/io/tokio/struct.Builder.html#method.with_max_mtu

--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -258,7 +258,7 @@ impl<'a> ConnectionInfo<'a> {
 }
 
 /// Creates MTU config for the given connection.
-pub trait Configurator: 'static + Send {
+pub trait Endpoint: 'static + Send {
     /// Provide connection specific MTU config.
     ///
     /// Application must ensure that `max_mtu <= info.endpoint_config.max_mtu`.
@@ -275,7 +275,7 @@ pub struct Config {
     max_mtu: MaxMtu,
 }
 
-impl Configurator for Config {}
+impl Endpoint for Config {}
 
 impl Config {
     pub const MIN: Self = Self {

--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -259,7 +259,7 @@ impl<E: mtu::Endpoint> Manager<E> {
         Manager {
             provider,
             // Instantiate the Manager with default values since the endpoint is
-            // create before the IO provider (which sets the actual config `set_mtu_config()`).
+            // created before the IO provider (IO provider sets the actual config `set_mtu_config()`).
             endpoint_mtu_config: Default::default(),
         }
     }
@@ -292,8 +292,6 @@ pub trait Endpoint: 'static + Send {
     /// Provide path specific MTU config.
     ///
     /// Application must ensure that `max_mtu <= info.mtu_config.max_mtu`.
-    /// By default this uses the MTU config specified on the IO provider.
-    // The default implementation doesn't use `info` and simply returns the endpoint_mtu_config
     fn on_path(&mut self, info: &mtu::PathInfo, endpoint_mtu_config: Config)
         -> Option<mtu::Config>;
 }

--- a/quic/s2n-quic-core/src/path/mtu/tests.rs
+++ b/quic/s2n-quic-core/src/path/mtu/tests.rs
@@ -121,51 +121,52 @@ fn mtu_config_builder() {
     assert_eq!(Some(MtuError), result.err());
 }
 
-#[test]
-fn checked_mtu_config() {
-    let remote = inet::SocketAddress::default();
-    let endpoint_config = mtu::Config::builder().build().unwrap();
-    assert!(endpoint_config.is_valid());
-    let info = PathInfo::new(&remote, endpoint_config);
+// TODO add new test
+// #[test]
+// fn checked_mtu_config() {
+//     let remote = inet::SocketAddress::default();
+//     let endpoint_config = mtu::Config::builder().build().unwrap();
+//     assert!(endpoint_config.is_valid());
+//     let info = PathInfo::new(&remote);
 
-    // valid: with Default config
-    let conn_config = mtu::Config::builder().build().unwrap();
-    assert!(conn_config.is_valid());
-    CheckedConfig::new(conn_config, &info).unwrap();
+//     // valid: with Default config
+//     let conn_config = mtu::Config::builder().build().unwrap();
+//     assert!(conn_config.is_valid());
+//     CheckedConfig::new(conn_config, &info).unwrap();
 
-    // valid: max_mtu == endpoint_config.max_mtu
-    let conn_config = mtu::Config::builder()
-        .with_max_mtu(DEFAULT_MAX_MTU.into())
-        .unwrap()
-        .build()
-        .unwrap();
-    assert!(conn_config.is_valid());
-    CheckedConfig::new(conn_config, &info).unwrap();
+//     // valid: max_mtu == endpoint_config.max_mtu
+//     let conn_config = mtu::Config::builder()
+//         .with_max_mtu(DEFAULT_MAX_MTU.into())
+//         .unwrap()
+//         .build()
+//         .unwrap();
+//     assert!(conn_config.is_valid());
+//     CheckedConfig::new(conn_config, &info).unwrap();
 
-    // invalid: !conn_config.is_valid()
-    let conn_config = mtu::Config {
-        initial_mtu: InitialMtu::MIN,
-        base_mtu: BaseMtu(NonZeroU16::new(1500).unwrap()),
-        max_mtu: MaxMtu::MIN,
-    };
-    assert!(!conn_config.is_valid());
-    assert_eq!(
-        CheckedConfig::new(conn_config, &info).unwrap_err(),
-        MtuError
-    );
+//     // invalid: !conn_config.is_valid()
+//     let conn_config = mtu::Config {
+//         initial_mtu: InitialMtu::MIN,
+//         base_mtu: BaseMtu(NonZeroU16::new(1500).unwrap()),
+//         max_mtu: MaxMtu::MIN,
+//     };
+//     assert!(!conn_config.is_valid());
+//     assert_eq!(
+//         CheckedConfig::new(conn_config, &info).unwrap_err(),
+//         MtuError
+//     );
 
-    // invalid: conn_config.max_mtu > endpoint_config.max_mtu
-    let conn_config = mtu::Config::builder()
-        .with_max_mtu(1501)
-        .unwrap()
-        .build()
-        .unwrap();
-    assert!(conn_config.is_valid());
-    assert_eq!(
-        CheckedConfig::new(conn_config, &info).unwrap_err(),
-        MtuError
-    );
-}
+//     // invalid: conn_config.max_mtu > endpoint_config.max_mtu
+//     let conn_config = mtu::Config::builder()
+//         .with_max_mtu(1501)
+//         .unwrap()
+//         .build()
+//         .unwrap();
+//     assert!(conn_config.is_valid());
+//     assert_eq!(
+//         CheckedConfig::new(conn_config, &info).unwrap_err(),
+//         MtuError
+//     );
+// }
 
 #[test]
 fn base_plpmtu_is_1200() {

--- a/quic/s2n-quic-core/src/path/mtu/tests.rs
+++ b/quic/s2n-quic-core/src/path/mtu/tests.rs
@@ -8,7 +8,7 @@ use crate::{
     frame::Frame,
     inet::{IpV4Address, SocketAddressV4},
     packet::number::PacketNumberSpace,
-    path::{mtu, mtu::MtuManager},
+    path::{mtu, mtu::Manager},
     recovery::congestion_controller::testing::mock::CongestionController,
     time::{clock::testing::now, timer::Provider as _},
     transmission::{
@@ -131,7 +131,7 @@ fn mtu_manager() {
     // valid: with Default config
     let mtu_provider = mtu::Config::builder().build().unwrap();
     assert!(mtu_provider.is_valid());
-    let mut manager: MtuManager<Config> = MtuManager::new(mtu_provider);
+    let mut manager: Manager<Config> = Manager::new(mtu_provider);
     manager.config(&info).unwrap();
 
     // valid: max_mtu == endpoint_config.max_mtu
@@ -141,7 +141,7 @@ fn mtu_manager() {
         .build()
         .unwrap();
     assert!(mtu_provider.is_valid());
-    let mut manager: MtuManager<Config> = MtuManager::new(mtu_provider);
+    let mut manager: Manager<Config> = Manager::new(mtu_provider);
     manager.config(&info).unwrap();
 
     // invalid: !mtu_provider.is_valid()
@@ -151,7 +151,7 @@ fn mtu_manager() {
         max_mtu: MaxMtu::MIN,
     };
     assert!(!mtu_provider.is_valid());
-    let mut manager: MtuManager<Config> = MtuManager::new(mtu_provider);
+    let mut manager: Manager<Config> = Manager::new(mtu_provider);
     assert_eq!(manager.config(&info).unwrap_err(), MtuError);
 
     // invalid: mtu_provider.max_mtu > endpoint_config.max_mtu
@@ -161,7 +161,7 @@ fn mtu_manager() {
         .build()
         .unwrap();
     assert!(mtu_provider.is_valid());
-    let mut manager: MtuManager<Config> = MtuManager::new(mtu_provider);
+    let mut manager: Manager<Config> = Manager::new(mtu_provider);
     assert_eq!(manager.config(&info).unwrap_err(), MtuError);
 }
 

--- a/quic/s2n-quic-core/src/path/mtu/tests.rs
+++ b/quic/s2n-quic-core/src/path/mtu/tests.rs
@@ -80,7 +80,7 @@ fn mtu_config_builder() {
         .with_base_mtu(DEFAULT_MAX_MTU.0.get() + 1_u16)
         .unwrap()
         .build();
-    assert_eq!(Some(MtuError::Validation), result.err());
+    assert_eq!(Some(MtuError), result.err());
 
     // Setting the initial MTU higher than the default max MTU results in an error
     let builder = mtu::Config::builder();
@@ -88,37 +88,37 @@ fn mtu_config_builder() {
         .with_initial_mtu(DEFAULT_MAX_MTU.0.get() + 1_u16)
         .unwrap()
         .build();
-    assert_eq!(Some(MtuError::Validation), result.err());
+    assert_eq!(Some(MtuError), result.err());
 
     // Setting the base MTU higher than the configured initial MTU results in an error
     let builder = mtu::Config::builder();
     let result = builder.with_initial_mtu(1300).unwrap().with_base_mtu(1301);
-    assert_eq!(Some(MtuError::Validation), result.err());
+    assert_eq!(Some(MtuError), result.err());
 
     // Setting the max MTU lower than the configured initial MTU results in an error
     let builder = mtu::Config::builder();
     let result = builder.with_initial_mtu(1300).unwrap().with_max_mtu(1299);
-    assert_eq!(Some(MtuError::Validation), result.err());
+    assert_eq!(Some(MtuError), result.err());
 
     // Setting the initial MTU lower than the configured base MTU results in an error
     let builder = mtu::Config::builder();
     let result = builder.with_base_mtu(1300).unwrap().with_initial_mtu(1299);
-    assert_eq!(Some(MtuError::Validation), result.err());
+    assert_eq!(Some(MtuError), result.err());
 
     // Setting the initial MTU higher than the configured max MTU results in an error
     let builder = mtu::Config::builder();
     let result = builder.with_max_mtu(1300).unwrap().with_initial_mtu(1301);
-    assert_eq!(Some(MtuError::Validation), result.err());
+    assert_eq!(Some(MtuError), result.err());
 
     // Setting the base MTU higher than the configured max MTU results in an error
     let builder = mtu::Config::builder();
     let result = builder.with_max_mtu(1300).unwrap().with_base_mtu(1301);
-    assert_eq!(Some(MtuError::Validation), result.err());
+    assert_eq!(Some(MtuError), result.err());
 
     // Setting the max MTU lower than the configured base MTU results in an error
     let builder = mtu::Config::builder();
     let result = builder.with_base_mtu(1300).unwrap().with_max_mtu(1299);
-    assert_eq!(Some(MtuError::Validation), result.err());
+    assert_eq!(Some(MtuError), result.err());
 }
 
 #[test]
@@ -151,7 +151,7 @@ fn checked_mtu_config() {
     assert!(!conn_config.is_valid());
     assert_eq!(
         CheckedConfig::new(conn_config, &info).unwrap_err(),
-        MtuError::Validation
+        MtuError
     );
 
     // invalid: conn_config.max_mtu > endpoint_config.max_mtu
@@ -163,7 +163,7 @@ fn checked_mtu_config() {
     assert!(conn_config.is_valid());
     assert_eq!(
         CheckedConfig::new(conn_config, &info).unwrap_err(),
-        MtuError::Validation
+        MtuError
     );
 }
 

--- a/quic/s2n-quic-core/src/path/mtu/tests.rs
+++ b/quic/s2n-quic-core/src/path/mtu/tests.rs
@@ -126,13 +126,12 @@ fn mtu_manager() {
     let remote = inet::SocketAddress::default();
     let endpoint_config = mtu::Config::builder().build().unwrap();
     assert!(endpoint_config.is_valid());
-    let info = PathInfo::new(&remote);
 
     // valid: with Default config
     let mtu_provider = mtu::Config::builder().build().unwrap();
     assert!(mtu_provider.is_valid());
     let mut manager: Manager<Config> = Manager::new(mtu_provider);
-    manager.config(&info).unwrap();
+    manager.config(&remote).unwrap();
 
     // valid: max_mtu == endpoint_config.max_mtu
     let mtu_provider = mtu::Config::builder()
@@ -142,7 +141,7 @@ fn mtu_manager() {
         .unwrap();
     assert!(mtu_provider.is_valid());
     let mut manager: Manager<Config> = Manager::new(mtu_provider);
-    manager.config(&info).unwrap();
+    manager.config(&remote).unwrap();
 
     // invalid: !mtu_provider.is_valid()
     let mtu_provider = mtu::Config {
@@ -152,7 +151,7 @@ fn mtu_manager() {
     };
     assert!(!mtu_provider.is_valid());
     let mut manager: Manager<Config> = Manager::new(mtu_provider);
-    assert_eq!(manager.config(&info).unwrap_err(), MtuError);
+    assert_eq!(manager.config(&remote).unwrap_err(), MtuError);
 
     // invalid: mtu_provider.max_mtu > endpoint_config.max_mtu
     let mtu_provider = mtu::Config::builder()
@@ -162,7 +161,7 @@ fn mtu_manager() {
         .unwrap();
     assert!(mtu_provider.is_valid());
     let mut manager: Manager<Config> = Manager::new(mtu_provider);
-    assert_eq!(manager.config(&info).unwrap_err(), MtuError);
+    assert_eq!(manager.config(&remote).unwrap_err(), MtuError);
 }
 
 #[test]

--- a/quic/s2n-quic-core/src/path/mtu/tests.rs
+++ b/quic/s2n-quic-core/src/path/mtu/tests.rs
@@ -126,7 +126,7 @@ fn checked_mtu_config() {
     let remote = inet::SocketAddress::default();
     let endpoint_config = mtu::Config::builder().build().unwrap();
     assert!(endpoint_config.is_valid());
-    let info = ConnectionInfo::new(&remote, endpoint_config);
+    let info = PathInfo::new(&remote, endpoint_config);
 
     // valid: with Default config
     let conn_config = mtu::Config::builder().build().unwrap();

--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -9,7 +9,7 @@ use crate::{
         IntoEvent,
     },
     inet, path,
-    path::CheckedConfig,
+    path::Config,
     random,
     recovery::{
         bandwidth::{Bandwidth, RateSample},
@@ -37,7 +37,7 @@ pub struct PathInfo<'a> {
 
 impl<'a> PathInfo<'a> {
     #[allow(deprecated)]
-    pub fn new(mtu_config: &CheckedConfig, remote_address: &'a inet::SocketAddress) -> Self {
+    pub fn new(mtu_config: &Config, remote_address: &'a inet::SocketAddress) -> Self {
         Self {
             remote_address: remote_address.into_event(),
             application_protocol: None,

--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -9,7 +9,7 @@ use crate::{
         IntoEvent,
     },
     inet, path,
-    path::InitialMtu,
+    path::CheckedConfig,
     random,
     recovery::{
         bandwidth::{Bandwidth, RateSample},
@@ -37,11 +37,11 @@ pub struct PathInfo<'a> {
 
 impl<'a> PathInfo<'a> {
     #[allow(deprecated)]
-    pub fn new(initial_mtu: InitialMtu, remote_address: &'a inet::SocketAddress) -> Self {
+    pub fn new(mtu_config: &CheckedConfig, remote_address: &'a inet::SocketAddress) -> Self {
         Self {
             remote_address: remote_address.into_event(),
             application_protocol: None,
-            max_datagram_size: initial_mtu.max_datagram_size(remote_address),
+            max_datagram_size: mtu_config.initial_mtu().max_datagram_size(remote_address),
         }
     }
 }

--- a/quic/s2n-quic-crypto/src/cipher_suite.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite.rs
@@ -82,14 +82,6 @@ macro_rules! impl_cipher_suite {
                     Self { secret, iv, key }
                 }
 
-                #[inline]
-                pub fn update_pmtu(&mut self, mtu: u16) {
-                    if self.key.should_update_pmtu(mtu) {
-                        let secret = Self::new_key_secret(&self.secret);
-                        self.key.update_pmtu(&*secret, mtu);
-                    }
-                }
-
                 fn new_key_secret(secret: &hkdf::Prk) -> Zeroizing<[u8; KEY_LEN]> {
                     let mut key = Zeroizing::new([0u8; KEY_LEN]);
 

--- a/quic/s2n-quic-crypto/src/cipher_suite/negotiated.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite/negotiated.rs
@@ -71,11 +71,6 @@ impl NegotiatedCipherSuite {
     pub fn update(&self) -> Self {
         dispatch!(self, |cipher| cipher.update().into())
     }
-
-    /// Updates the configured maximum transmission unit
-    pub fn update_pmtu(&mut self, pmtu: u16) {
-        dispatch!(self, |cipher| cipher.update_pmtu(pmtu))
-    }
 }
 
 impl crypto::Key for NegotiatedCipherSuite {

--- a/quic/s2n-quic-crypto/src/cipher_suite/ring.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite/ring.rs
@@ -70,22 +70,9 @@ macro_rules! key_impl {
         impl Key {
             #[inline]
             #[allow(dead_code)] // this is to maintain compatibility between implementations
-            pub fn should_update_pmtu(&self, _mtu: u16) -> bool {
-                // ring doesn't implement precomputed tables
-                false
-            }
-
-            #[inline]
-            #[allow(dead_code)] // this is to maintain compatibility between implementations
             pub fn update(&self, secret: &[u8; KEY_LEN]) -> Self {
                 // no state to persist
                 Self::new(secret)
-            }
-
-            #[inline]
-            #[allow(dead_code)] // this is to maintain compatibility between implementations
-            pub fn update_pmtu(&mut self, _secret: &[u8; KEY_LEN], _mtu: u16) {
-                unimplemented!();
             }
         }
 

--- a/quic/s2n-quic-crypto/src/one_rtt.rs
+++ b/quic/s2n-quic-crypto/src/one_rtt.rs
@@ -12,16 +12,6 @@ impl crypto::OneRttKey for OneRttKey {
     fn derive_next_key(&self) -> Self {
         Self(self.0.update())
     }
-
-    #[inline]
-    fn update_sealer_pmtu(&mut self, pmtu: u16) {
-        self.0.sealer.update_pmtu(pmtu)
-    }
-
-    #[inline]
-    fn update_opener_pmtu(&mut self, pmtu: u16) {
-        self.0.opener.update_pmtu(pmtu)
-    }
 }
 
 impl crypto::OneRttHeaderKey for OneRttHeaderKey {}

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -739,8 +739,9 @@ enum DatagramDropReason {
         /// MTU configuration for the endpoint
         endpoint_mtu_config: MtuConfig,
         // TODO expose connection level mtu config.
+        // TODO expose the remote address.
+        // https://github.com/aws/s2n-quic/issues/2254
         // error from mtu::Config
-        // TODO expose the remote address
         // remote_addr: SocketAddress<'a>,
     },
 }

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -715,6 +715,16 @@ enum DatagramDropReason {
     InvalidDestinationConnectionId,
     /// The peer sent an invalid Source Connection Id.
     InvalidSourceConnectionId,
+    /// Application provided invalid MTU configuration.
+    InvalidMtuConfiguration {
+        /// MTU configuration for the endpoint
+        endpoint_mtu_config: MtuConfig,
+        // TODO expose connection level mtu config.
+        // TODO expose the remote address.
+        // https://github.com/aws/s2n-quic/issues/2254
+        // error from mtu::Config
+        // remote_addr: SocketAddress<'a>,
+    },
     /// The Destination Connection Id is unknown and does not map to a Connection.
     ///
     /// Connections are mapped to Destination Connections Ids (DCID) and packets
@@ -734,16 +744,6 @@ enum DatagramDropReason {
     PathLimitExceeded,
     /// The peer initiated a connection migration without supplying enough connection IDs to use.
     InsufficientConnectionIds,
-    /// Application provided invalid MTU configuration.
-    MtuValidation {
-        /// MTU configuration for the endpoint
-        endpoint_mtu_config: MtuConfig,
-        // TODO expose connection level mtu config.
-        // TODO expose the remote address.
-        // https://github.com/aws/s2n-quic/issues/2254
-        // error from mtu::Config
-        // remote_addr: SocketAddress<'a>,
-    },
 }
 
 struct MtuConfig {

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -734,6 +734,32 @@ enum DatagramDropReason {
     PathLimitExceeded,
     /// The peer initiated a connection migration without supplying enough connection IDs to use.
     InsufficientConnectionIds,
+    /// Application provided invalid MTU configuration.
+    MtuValidation {
+        /// MTU configuration for the endpoint
+        endpoint_mtu_config: MtuConfig,
+        // TODO expose connection level mtu config.
+        // error from mtu::Config
+        // TODO expose the remote address
+        // remote_addr: SocketAddress<'a>,
+    },
+}
+
+struct MtuConfig {
+    initial_mtu: u16,
+    base_mtu: u16,
+    max_mtu: u16,
+}
+
+impl<'a> IntoEvent<builder::MtuConfig> for &'a crate::path::mtu::Config {
+    #[inline]
+    fn into_event(self) -> builder::MtuConfig {
+        builder::MtuConfig {
+            initial_mtu: self.initial_mtu().into(),
+            base_mtu: self.base_mtu().into(),
+            max_mtu: self.max_mtu().into(),
+        }
+    }
 }
 
 enum KeySpace {

--- a/quic/s2n-quic-platform/src/io/testing.rs
+++ b/quic/s2n-quic-platform/src/io/testing.rs
@@ -316,7 +316,7 @@ impl Io {
 
         let handle = address.unwrap_or_else(|| buffers.generate_addr());
 
-        let socket = buffers.register(handle, mtu_config_builder.build().unwrap().max_mtu);
+        let socket = buffers.register(handle, mtu_config_builder.build().unwrap().max_mtu());
 
         if let Some(on_socket) = on_socket {
             on_socket(socket.clone());
@@ -342,9 +342,9 @@ impl Io {
 
         let handle = address.unwrap_or_else(|| buffers.generate_addr());
 
-        let socket = buffers.register(handle, mtu_config.max_mtu);
-        let tx = socket.tx_task(mtu_config.max_mtu, queue_send_buffer_size);
-        let rx = socket.rx_task(mtu_config.max_mtu, queue_recv_buffer_size);
+        let socket = buffers.register(handle, mtu_config.max_mtu());
+        let tx = socket.tx_task(mtu_config.max_mtu(), queue_send_buffer_size);
+        let rx = socket.rx_task(mtu_config.max_mtu(), queue_recv_buffer_size);
 
         if let Some(on_socket) = on_socket {
             on_socket(socket);

--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -122,7 +122,7 @@ impl Io {
         let mut mtu_config = mtu_config_builder
             .build()
             .map_err(|err| io::Error::new(ErrorKind::InvalidInput, format!("{err}")))?;
-        let original_max_mtu = mtu_config.max_mtu;
+        let original_max_mtu = mtu_config.max_mtu();
 
         // Configure MTU discovery
         if !syscall::configure_mtu_disc(&tx_socket) {
@@ -132,19 +132,19 @@ impl Io {
 
         publisher.on_platform_feature_configured(event::builder::PlatformFeatureConfigured {
             configuration: event::builder::PlatformFeatureConfiguration::BaseMtu {
-                mtu: mtu_config.base_mtu.into(),
+                mtu: mtu_config.base_mtu().into(),
             },
         });
 
         publisher.on_platform_feature_configured(event::builder::PlatformFeatureConfigured {
             configuration: event::builder::PlatformFeatureConfiguration::InitialMtu {
-                mtu: mtu_config.initial_mtu.into(),
+                mtu: mtu_config.initial_mtu().into(),
             },
         });
 
         publisher.on_platform_feature_configured(event::builder::PlatformFeatureConfigured {
             configuration: event::builder::PlatformFeatureConfiguration::MaxMtu {
-                mtu: mtu_config.max_mtu.into(),
+                mtu: mtu_config.max_mtu().into(),
             },
         });
 
@@ -222,7 +222,7 @@ impl Io {
             // compute the payload size for each message from the number of GSO segments we can
             // fill
             let payload_len = {
-                let max_mtu: u16 = mtu_config.max_mtu.into();
+                let max_mtu: u16 = mtu_config.max_mtu().into();
                 (max_mtu as u32 * gso.max_segments() as u32).min(u16::MAX as u32)
             };
 
@@ -263,7 +263,7 @@ impl Io {
             }
 
             // construct the TX side for the endpoint event loop
-            socket::io::tx::Tx::new(producers, gso, mtu_config.max_mtu)
+            socket::io::tx::Tx::new(producers, gso, mtu_config.max_mtu())
         };
 
         // Notify the endpoint of the MTU that we chose

--- a/quic/s2n-quic-platform/src/io/turmoil.rs
+++ b/quic/s2n-quic-platform/src/io/turmoil.rs
@@ -75,7 +75,7 @@ impl Io {
 
         let local_addr = socket.local_addr()?;
         let local_addr: inet::SocketAddress = local_addr.into();
-        let payload_len: usize = mtu_config.max_mtu.into();
+        let payload_len: usize = mtu_config.max_mtu().into();
         let payload_len = payload_len as u32;
 
         // This number is somewhat arbitrary but it's a decent number of messages without it consuming
@@ -89,7 +89,7 @@ impl Io {
             let (producer, consumer) = ring::pair(entries, payload_len);
             consumers.push(consumer);
 
-            let rx = rx::Rx::new(consumers, mtu_config.max_mtu, local_addr.into());
+            let rx = rx::Rx::new(consumers, mtu_config.max_mtu(), local_addr.into());
 
             (rx, producer)
         };
@@ -105,7 +105,7 @@ impl Io {
             // GSO is not supported by turmoil so disable it
             gso.disable();
 
-            let tx = tx::Tx::new(producers, gso, mtu_config.max_mtu);
+            let tx = tx::Tx::new(producers, gso, mtu_config.max_mtu());
 
             (tx, consumer)
         };

--- a/quic/s2n-quic-rustls/src/cipher_suite.rs
+++ b/quic/s2n-quic-rustls/src/cipher_suite.rs
@@ -332,14 +332,6 @@ impl crypto::OneRttKey for OneRttKey {
             secrets,
         }
     }
-
-    fn update_sealer_pmtu(&mut self, _pmtu: u16) {
-        // rustls doesn't have any ptmu specialization
-    }
-
-    fn update_opener_pmtu(&mut self, _pmtu: u16) {
-        // rustls doesn't have any ptmu specialization
-    }
 }
 
 //= https://www.rfc-editor.org/rfc/rfc9001#section-5.3

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -240,7 +240,7 @@ impl connection::Trait for TestConnection {
         _datagram: &DatagramInfo,
         _congestion_controller_endpoint: &mut <Self::Config as endpoint::Config>::CongestionControllerEndpoint,
         _path_migration: &mut <Self::Config as endpoint::Config>::PathMigrationValidator,
-        _mtu_config: mtu::Config,
+        _mtu_config: mtu::CheckedConfig,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) -> Result<path::Id, DatagramDropReason> {
         todo!()

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -240,7 +240,7 @@ impl connection::Trait for TestConnection {
         _datagram: &DatagramInfo,
         _congestion_controller_endpoint: &mut <Self::Config as endpoint::Config>::CongestionControllerEndpoint,
         _path_migration: &mut <Self::Config as endpoint::Config>::PathMigrationValidator,
-        _mtu: &mut mtu::MtuManager<<Self::Config as endpoint::Config>::Mtu>,
+        _mtu: &mut mtu::Manager<<Self::Config as endpoint::Config>::Mtu>,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) -> Result<path::Id, DatagramDropReason> {
         todo!()

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -240,7 +240,8 @@ impl connection::Trait for TestConnection {
         _datagram: &DatagramInfo,
         _congestion_controller_endpoint: &mut <Self::Config as endpoint::Config>::CongestionControllerEndpoint,
         _path_migration: &mut <Self::Config as endpoint::Config>::PathMigrationValidator,
-        _mtu_config: mtu::CheckedConfig,
+        _mtu_config: mtu::Config,
+        _mtu_provider: &mut <Self::Config as endpoint::Config>::Mtu,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) -> Result<path::Id, DatagramDropReason> {
         todo!()

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -240,7 +240,7 @@ impl connection::Trait for TestConnection {
         _datagram: &DatagramInfo,
         _congestion_controller_endpoint: &mut <Self::Config as endpoint::Config>::CongestionControllerEndpoint,
         _path_migration: &mut <Self::Config as endpoint::Config>::PathMigrationValidator,
-        mtu: &mut mtu::MtuManager<<Self::Config as endpoint::Config>::Mtu>,
+        _mtu: &mut mtu::MtuManager<<Self::Config as endpoint::Config>::Mtu>,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) -> Result<path::Id, DatagramDropReason> {
         todo!()

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -240,8 +240,7 @@ impl connection::Trait for TestConnection {
         _datagram: &DatagramInfo,
         _congestion_controller_endpoint: &mut <Self::Config as endpoint::Config>::CongestionControllerEndpoint,
         _path_migration: &mut <Self::Config as endpoint::Config>::PathMigrationValidator,
-        _mtu_config: mtu::Config,
-        _mtu_provider: &mut <Self::Config as endpoint::Config>::Mtu,
+        mtu: &mut mtu::MtuManager<<Self::Config as endpoint::Config>::Mtu>,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) -> Result<path::Id, DatagramDropReason> {
         todo!()

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1134,7 +1134,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         datagram: &DatagramInfo,
         congestion_controller_endpoint: &mut Config::CongestionControllerEndpoint,
         path_migration: &mut Config::PathMigrationValidator,
-        mtu_config: mtu::Config,
+        mtu_config: mtu::CheckedConfig,
         subscriber: &mut Config::EventSubscriber,
     ) -> Result<path::Id, DatagramDropReason> {
         let mut publisher = self.event_context.publisher(datagram.timestamp, subscriber);

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -600,8 +600,11 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             parameters.limits.anti_amplification_multiplier(),
         );
 
-        let max_mtu = parameters.mtu_config.endpoint.max_mtu();
-        let path_manager = path::Manager::new(initial_path, parameters.peer_id_registry, max_mtu);
+        let path_manager = path::Manager::new(
+            initial_path,
+            parameters.peer_id_registry,
+            parameters.mtu_config,
+        );
 
         let mut publisher =
             event_context.publisher(parameters.timestamp, parameters.event_subscriber);

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -600,7 +600,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             parameters.limits.anti_amplification_multiplier(),
         );
 
-        let path_manager = path::Manager::new(initial_path, parameters.peer_id_registry);
+        let max_mtu = parameters.mtu_config.endpoint.max_mtu();
+        let path_manager = path::Manager::new(initial_path, parameters.peer_id_registry, max_mtu);
 
         let mut publisher =
             event_context.publisher(parameters.timestamp, parameters.event_subscriber);

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1134,7 +1134,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         datagram: &DatagramInfo,
         congestion_controller_endpoint: &mut Config::CongestionControllerEndpoint,
         path_migration: &mut Config::PathMigrationValidator,
-        mtu: &mut mtu::MtuManager<Config::Mtu>,
+        mtu: &mut mtu::Manager<Config::Mtu>,
         subscriber: &mut Config::EventSubscriber,
     ) -> Result<path::Id, DatagramDropReason> {
         let mut publisher = self.event_context.publisher(datagram.timestamp, subscriber);

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -600,11 +600,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             parameters.limits.anti_amplification_multiplier(),
         );
 
-        let path_manager = path::Manager::new(
-            initial_path,
-            parameters.peer_id_registry,
-            parameters.mtu_config,
-        );
+        let path_manager = path::Manager::new(initial_path, parameters.peer_id_registry);
 
         let mut publisher =
             event_context.publisher(parameters.timestamp, parameters.event_subscriber);

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1134,7 +1134,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         datagram: &DatagramInfo,
         congestion_controller_endpoint: &mut Config::CongestionControllerEndpoint,
         path_migration: &mut Config::PathMigrationValidator,
-        mtu_config: mtu::CheckedConfig,
+        endpoint_mtu_config: mtu::Config,
+        mtu_provider: &mut Config::Mtu,
         subscriber: &mut Config::EventSubscriber,
     ) -> Result<path::Id, DatagramDropReason> {
         let mut publisher = self.event_context.publisher(datagram.timestamp, subscriber);
@@ -1158,7 +1159,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             handshake_confirmed,
             congestion_controller_endpoint,
             path_migration,
-            mtu_config,
+            endpoint_mtu_config,
+            mtu_provider,
             &self.limits,
             &mut publisher,
         )?;

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1134,8 +1134,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         datagram: &DatagramInfo,
         congestion_controller_endpoint: &mut Config::CongestionControllerEndpoint,
         path_migration: &mut Config::PathMigrationValidator,
-        endpoint_mtu_config: mtu::Config,
-        mtu_provider: &mut Config::Mtu,
+        mtu: &mut mtu::MtuManager<Config::Mtu>,
         subscriber: &mut Config::EventSubscriber,
     ) -> Result<path::Id, DatagramDropReason> {
         let mut publisher = self.event_context.publisher(datagram.timestamp, subscriber);
@@ -1159,8 +1158,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             handshake_confirmed,
             congestion_controller_endpoint,
             path_migration,
-            endpoint_mtu_config,
-            mtu_provider,
+            mtu,
             &self.limits,
             &mut publisher,
         )?;

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -209,7 +209,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         datagram: &DatagramInfo,
         congestion_controller_endpoint: &mut <Self::Config as endpoint::Config>::CongestionControllerEndpoint,
         migration_validator: &mut <Self::Config as endpoint::Config>::PathMigrationValidator,
-        mtu: &mut mtu::MtuManager<<Self::Config as endpoint::Config>::Mtu>,
+        mtu: &mut mtu::Manager<<Self::Config as endpoint::Config>::Mtu>,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) -> Result<path::Id, DatagramDropReason>;
 

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -209,7 +209,8 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         datagram: &DatagramInfo,
         congestion_controller_endpoint: &mut <Self::Config as endpoint::Config>::CongestionControllerEndpoint,
         migration_validator: &mut <Self::Config as endpoint::Config>::PathMigrationValidator,
-        mtu_config: mtu::CheckedConfig,
+        endpoint_mtu_config: mtu::Config,
+        mtu_provider: &mut <Self::Config as endpoint::Config>::Mtu,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) -> Result<path::Id, DatagramDropReason>;
 

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -209,7 +209,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         datagram: &DatagramInfo,
         congestion_controller_endpoint: &mut <Self::Config as endpoint::Config>::CongestionControllerEndpoint,
         migration_validator: &mut <Self::Config as endpoint::Config>::PathMigrationValidator,
-        mtu_config: mtu::Config,
+        mtu_config: mtu::CheckedConfig,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) -> Result<path::Id, DatagramDropReason>;
 

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -209,8 +209,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         datagram: &DatagramInfo,
         congestion_controller_endpoint: &mut <Self::Config as endpoint::Config>::CongestionControllerEndpoint,
         migration_validator: &mut <Self::Config as endpoint::Config>::PathMigrationValidator,
-        endpoint_mtu_config: mtu::Config,
-        mtu_provider: &mut <Self::Config as endpoint::Config>::Mtu,
+        mtu: &mut mtu::MtuManager<<Self::Config as endpoint::Config>::Mtu>,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) -> Result<path::Id, DatagramDropReason>;
 

--- a/quic/s2n-quic-transport/src/connection/mod.rs
+++ b/quic/s2n-quic-transport/src/connection/mod.rs
@@ -73,7 +73,7 @@ pub struct Parameters<'a, Cfg: endpoint::Config> {
     /// The limits that were advertised to the peer
     pub limits: connection::Limits,
     /// Configuration for the maximum transmission unit (MTU) that can be sent on a path
-    pub mtu_config: mtu::Config,
+    pub mtu_config: mtu::CheckedConfig,
     /// The context that should be passed to all related connection events
     pub event_context: <Cfg::EventSubscriber as event::Subscriber>::ConnectionContext,
     /// The context passed to the connection supervisor

--- a/quic/s2n-quic-transport/src/connection/mod.rs
+++ b/quic/s2n-quic-transport/src/connection/mod.rs
@@ -73,7 +73,7 @@ pub struct Parameters<'a, Cfg: endpoint::Config> {
     /// The limits that were advertised to the peer
     pub limits: connection::Limits,
     /// Configuration for the maximum transmission unit (MTU) that can be sent on a path
-    pub mtu_config: mtu::CheckedConfig,
+    pub mtu_config: mtu::Config,
     /// The context that should be passed to all related connection events
     pub event_context: <Cfg::EventSubscriber as event::Subscriber>::ConnectionContext,
     /// The context passed to the connection supervisor

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -30,7 +30,7 @@ pub trait Config: 'static + Send + Sized + core::fmt::Debug {
     type EndpointLimits: endpoint::Limiter;
     /// The connection limits
     type ConnectionLimits: connection::limits::Limiter;
-    /// The connection specific mtu config
+    /// The path specific mtu config
     type Mtu: s2n_quic_core::path::mtu::Endpoint;
     /// The type of stream
     type StreamManager: stream::Manager;
@@ -82,7 +82,7 @@ pub struct Context<'a, Cfg: Config> {
     /// The connection limits
     pub connection_limits: &'a mut Cfg::ConnectionLimits,
 
-    /// The connection specific mtu config
+    /// The path specific mtu config
     pub mtu: &'a mut Cfg::Mtu,
 
     pub connection_close_formatter: &'a mut Cfg::ConnectionCloseFormatter,

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -30,6 +30,8 @@ pub trait Config: 'static + Send + Sized + core::fmt::Debug {
     type EndpointLimits: endpoint::Limiter;
     /// The connection limits
     type ConnectionLimits: connection::limits::Limiter;
+    /// The connection specific mtu config
+    type MtuConfig: s2n_quic_core::path::mtu::Configurator;
     /// The type of stream
     type StreamManager: stream::Manager;
     /// The connection close formatter
@@ -79,6 +81,9 @@ pub struct Context<'a, Cfg: Config> {
 
     /// The connection limits
     pub connection_limits: &'a mut Cfg::ConnectionLimits,
+
+    /// The connection specific mtu config
+    pub mtu: &'a mut Cfg::MtuConfig,
 
     pub connection_close_formatter: &'a mut Cfg::ConnectionCloseFormatter,
 

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -5,7 +5,7 @@
 
 use crate::{connection, stream};
 use s2n_quic_core::{
-    crypto::tls, datagram, dc, endpoint, event, packet, path, random,
+    crypto::tls, datagram, dc, endpoint, event, packet, path, path::mtu, random,
     recovery::congestion_controller, stateless_reset,
 };
 
@@ -31,7 +31,7 @@ pub trait Config: 'static + Send + Sized + core::fmt::Debug {
     /// The connection limits
     type ConnectionLimits: connection::limits::Limiter;
     /// The path specific mtu config
-    type Mtu: s2n_quic_core::path::mtu::Endpoint;
+    type Mtu: mtu::Endpoint;
     /// The type of stream
     type StreamManager: stream::Manager;
     /// The connection close formatter
@@ -82,8 +82,9 @@ pub struct Context<'a, Cfg: Config> {
     /// The connection limits
     pub connection_limits: &'a mut Cfg::ConnectionLimits,
 
-    /// The path specific mtu config
-    pub mtu: &'a mut Cfg::Mtu,
+    /// Endpoint configuration for the maximum transmission unit (MTU) that can be sent
+    /// on a path
+    pub mtu: &'a mut mtu::MtuManager<Cfg::Mtu>,
 
     pub connection_close_formatter: &'a mut Cfg::ConnectionCloseFormatter,
 

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -31,7 +31,7 @@ pub trait Config: 'static + Send + Sized + core::fmt::Debug {
     /// The connection limits
     type ConnectionLimits: connection::limits::Limiter;
     /// The connection specific mtu config
-    type MtuConfig: s2n_quic_core::path::mtu::Configurator;
+    type Mtu: s2n_quic_core::path::mtu::Endpoint;
     /// The type of stream
     type StreamManager: stream::Manager;
     /// The connection close formatter
@@ -83,7 +83,7 @@ pub struct Context<'a, Cfg: Config> {
     pub connection_limits: &'a mut Cfg::ConnectionLimits,
 
     /// The connection specific mtu config
-    pub mtu: &'a mut Cfg::MtuConfig,
+    pub mtu: &'a mut Cfg::Mtu,
 
     pub connection_close_formatter: &'a mut Cfg::ConnectionCloseFormatter,
 

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -84,7 +84,7 @@ pub struct Context<'a, Cfg: Config> {
 
     /// Endpoint configuration for the maximum transmission unit (MTU) that can be sent
     /// on a path
-    pub mtu: &'a mut mtu::MtuManager<Cfg::Mtu>,
+    pub mtu: &'a mut mtu::Manager<Cfg::Mtu>,
 
     pub connection_close_formatter: &'a mut Cfg::ConnectionCloseFormatter,
 

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -324,8 +324,11 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                     datagram,
                     endpoint_context.congestion_controller,
                     endpoint_context.path_migration,
-                    endpoint_mtu_config,
-                    endpoint_context.mtu,
+                    // since this takes a &mut, we get borrow warning since we already have
+                    // a borrow in the endpoint_context
+                    //
+                    // &mut self.mtu,
+                    todo!(),
                     endpoint_context.event_subscriber,
                 );
 

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -17,10 +17,10 @@ use s2n_codec::DecoderBufferMut;
 use s2n_quic_core::{
     crypto::{tls, tls::Endpoint as TLSEndpoint, CryptoSuite, InitialKey},
     datagram::{Endpoint, PreConnectionInfo},
-    event::{self, supervisor, ConnectionPublisher, IntoEvent, Subscriber as _},
+    event::{self, supervisor, ConnectionPublisher, EndpointPublisher, IntoEvent, Subscriber as _},
     inet::{datagram, DatagramInfo},
     packet::initial::ProtectedInitial,
-    path::Handle as _,
+    path::{mtu, mtu::Configurator as _, CheckedConfig, Handle as _},
     stateless_reset::token::Generator as _,
     transport::{self, parameters::ServerTransportParameters},
 };
@@ -230,12 +230,6 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             .tls
             .new_server_session(&transport_parameters);
 
-        let path_info =
-            congestion_controller::PathInfo::new(self.mtu_config.initial_mtu, &remote_address);
-        let congestion_controller = endpoint_context
-            .congestion_controller
-            .new_congestion_controller(path_info);
-
         let quic_version = packet.version;
 
         let meta = event::builder::ConnectionMeta {
@@ -256,12 +250,40 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             &event::builder::ConnectionInfo {}.into_event(),
         );
 
+        let mut endpoint_publisher = event::EndpointPublisherSubscriber::new(
+            event::builder::EndpointMeta {
+                endpoint_type: Config::ENDPOINT_TYPE,
+                timestamp: datagram.timestamp,
+            },
+            Some(quic_version),
+            endpoint_context.event_subscriber,
+        );
+        let info = mtu::ConnectionInfo::new(&remote_address, self.endpoint_mtu_config);
+        let mtu_config = CheckedConfig::new(endpoint_context.mtu.on_connection(&info), &info)
+            .map_err(|_| {
+                endpoint_publisher.on_endpoint_datagram_dropped(
+                    event::builder::EndpointDatagramDropped {
+                        len: datagram.payload_len as u16,
+                        reason: event::builder::DatagramDropReason::MtuValidation {
+                            endpoint_mtu_config: self.endpoint_mtu_config.into_event(),
+                        },
+                    },
+                );
+                connection::Error::validation("failed to instantiate a valid MTU provider")
+            })?;
+
         let mut publisher = event::ConnectionPublisherSubscriber::new(
             meta,
             quic_version,
             endpoint_context.event_subscriber,
             &mut event_context,
         );
+
+        let path_info =
+            congestion_controller::PathInfo::new(mtu_config.initial_mtu(), &remote_address);
+        let congestion_controller = endpoint_context
+            .congestion_controller
+            .new_congestion_controller(path_info);
 
         let space_manager = PacketSpaceManager::new(
             original_destination_connection_id,
@@ -272,7 +294,6 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             &mut publisher,
         );
 
-        let mtu_config = self.mtu_config;
         let connection_parameters = connection::Parameters {
             internal_connection_id,
             local_id_registry,

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -259,7 +259,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             endpoint_context.event_subscriber,
         );
         let info = mtu::PathInfo::new(&remote_address);
-        let mtu_config = self.mtu.config(&info).map_err(|_err| {
+        let mtu_config = endpoint_context.mtu.config(&info).map_err(|_err| {
             let error = connection::Error::invalid_configuration(
                 "MTU provider produced an invalid MTU configuration",
             );
@@ -316,7 +316,6 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
 
         let mut connection = <Config as endpoint::Config>::Connection::new(connection_parameters)?;
 
-        let mtu = &mut self.mtu;
         let endpoint_context = self.config.context();
         let handle_first_packet =
             move |connection: &mut <Config as endpoint::Config>::Connection| {
@@ -325,7 +324,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                     datagram,
                     endpoint_context.congestion_controller,
                     endpoint_context.path_migration,
-                    mtu,
+                    endpoint_context.mtu,
                     endpoint_context.event_subscriber,
                 );
 

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -316,6 +316,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
 
         let mut connection = <Config as endpoint::Config>::Connection::new(connection_parameters)?;
 
+        let mtu = &mut self.mtu;
         let endpoint_context = self.config.context();
         let handle_first_packet =
             move |connection: &mut <Config as endpoint::Config>::Connection| {
@@ -324,11 +325,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                     datagram,
                     endpoint_context.congestion_controller,
                     endpoint_context.path_migration,
-                    // since this takes a &mut, we get borrow warning since we already have
-                    // a borrow in the endpoint_context
-                    //
-                    // &mut self.mtu,
-                    todo!(),
+                    mtu,
                     endpoint_context.event_subscriber,
                 );
 

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -259,8 +259,8 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             endpoint_context.event_subscriber,
         );
         let info = mtu::PathInfo::new(&remote_address, self.mtu_config);
-        let mtu_config = CheckedConfig::new(endpoint_context.mtu.on_path(&info), &info)
-            .map_err(|_| {
+        let mtu_config =
+            CheckedConfig::new(endpoint_context.mtu.on_path(&info), &info).map_err(|_| {
                 endpoint_publisher.on_endpoint_datagram_dropped(
                     event::builder::EndpointDatagramDropped {
                         len: datagram.payload_len as u16,

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -322,6 +322,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
         let mut connection = <Config as endpoint::Config>::Connection::new(connection_parameters)?;
 
         let endpoint_context = self.config.context();
+        let endpoint_mtu_config = self.mtu_config;
         let handle_first_packet =
             move |connection: &mut <Config as endpoint::Config>::Connection| {
                 let path_id = connection.on_datagram_received(
@@ -329,7 +330,8 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                     datagram,
                     endpoint_context.congestion_controller,
                     endpoint_context.path_migration,
-                    mtu_config,
+                    endpoint_mtu_config,
+                    endpoint_context.mtu,
                     endpoint_context.event_subscriber,
                 );
 

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -258,8 +258,8 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             Some(quic_version),
             endpoint_context.event_subscriber,
         );
-        let info = mtu::ConnectionInfo::new(&remote_address, self.mtu_config);
-        let mtu_config = CheckedConfig::new(endpoint_context.mtu.on_connection(&info), &info)
+        let info = mtu::PathInfo::new(&remote_address, self.mtu_config);
+        let mtu_config = CheckedConfig::new(endpoint_context.mtu.on_path(&info), &info)
             .map_err(|_| {
                 endpoint_publisher.on_endpoint_datagram_dropped(
                     event::builder::EndpointDatagramDropped {

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -1047,8 +1047,8 @@ impl<Cfg: Config> Endpoint<Cfg> {
             endpoint_context.event_subscriber,
         );
         let info = mtu::PathInfo::new(&remote_address, self.mtu_config);
-        let mtu_config = CheckedConfig::new(endpoint_context.mtu.on_path(&info), &info)
-            .map_err(|_err| {
+        let mtu_config =
+            CheckedConfig::new(endpoint_context.mtu.on_path(&info), &info).map_err(|_err| {
                 let error = connection::Error::invalid_configuration(
                     "MTU provider produced an invalid MTU configuration",
                 );

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -1042,16 +1042,18 @@ impl<Cfg: Config> Endpoint<Cfg> {
             endpoint_context.event_subscriber,
         );
 
-        let info = mtu::PathInfo::new(&remote_address);
-        let mtu_config = endpoint_context.mtu.config(&info).map_err(|_err| {
-            let error = connection::Error::invalid_configuration(
-                "MTU provider produced an invalid MTU configuration",
-            );
-            endpoint_publisher.on_endpoint_connection_attempt_failed(
-                event::builder::EndpointConnectionAttemptFailed { error },
-            );
-            error
-        })?;
+        let mtu_config = endpoint_context
+            .mtu
+            .config(&remote_address)
+            .map_err(|_err| {
+                let error = connection::Error::invalid_configuration(
+                    "MTU provider produced an invalid MTU configuration",
+                );
+                endpoint_publisher.on_endpoint_connection_attempt_failed(
+                    event::builder::EndpointConnectionAttemptFailed { error },
+                );
+                error
+            })?;
 
         let mut publisher = event::ConnectionPublisherSubscriber::new(
             meta,

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -324,8 +324,6 @@ impl<Cfg: Config> Endpoint<Cfg> {
         let connection_id_mapper =
             ConnectionIdMapper::new(config.context().random_generator, Cfg::ENDPOINT_TYPE);
 
-        let provider = config.context().mtu;
-        let mtu = mtu::MtuManager::new(provider, Default::default());
         let endpoint = Self {
             config,
             connections: ConnectionContainer::new(acceptor_sender, connector_receiver),
@@ -338,7 +336,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
             retry_dispatch: retry::Dispatch::default(),
             stateless_reset_dispatch: stateless_reset::Dispatch::default(),
             close_packet_buffer: Default::default(),
-            mtu,
+            mtu: mtu::MtuManager::default(),
         };
 
         (endpoint, handle)

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -1046,8 +1046,8 @@ impl<Cfg: Config> Endpoint<Cfg> {
             Some(quic_version),
             endpoint_context.event_subscriber,
         );
-        let info = mtu::ConnectionInfo::new(&remote_address, self.mtu_config);
-        let mtu_config = CheckedConfig::new(endpoint_context.mtu.on_connection(&info), &info)
+        let info = mtu::PathInfo::new(&remote_address, self.mtu_config);
+        let mtu_config = CheckedConfig::new(endpoint_context.mtu.on_path(&info), &info)
             .map_err(|_err| {
                 let error = connection::Error::invalid_configuration(
                     "MTU provider produced an invalid MTU configuration",

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -244,7 +244,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         handshake_confirmed: bool,
         congestion_controller_endpoint: &mut Config::CongestionControllerEndpoint,
         migration_validator: &mut Config::PathMigrationValidator,
-        mtu_config: mtu::Config,
+        mtu_config: mtu::CheckedConfig,
         limits: &Limits,
         publisher: &mut Pub,
     ) -> Result<(Id, AmplificationOutcome), DatagramDropReason> {
@@ -320,7 +320,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         datagram: &DatagramInfo,
         congestion_controller_endpoint: &mut Config::CongestionControllerEndpoint,
         migration_validator: &mut Config::PathMigrationValidator,
-        mtu_config: mtu::Config,
+        mtu_config: mtu::CheckedConfig,
         limits: &Limits,
         publisher: &mut Pub,
     ) -> Result<(Id, AmplificationOutcome), DatagramDropReason> {
@@ -419,7 +419,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             .rtt_estimator
             .for_new_path(limits.initial_round_trip_time());
         let path_info =
-            congestion_controller::PathInfo::new(mtu_config.initial_mtu, &remote_address);
+            congestion_controller::PathInfo::new(mtu_config.initial_mtu(), &remote_address);
         let cc = congestion_controller_endpoint.new_congestion_controller(path_info);
 
         let peer_connection_id = {

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -24,7 +24,7 @@ use s2n_quic_core::{
     packet::number::PacketNumberSpace,
     path::{
         migration::{self, Validator as _},
-        mtu, CheckedConfig, Endpoint as _, Handle as _, Id, MaxMtu,
+        mtu, CheckedConfig, Endpoint as _, Handle as _, Id,
     },
     random,
     recovery::congestion_controller::{self, Endpoint as _},
@@ -70,22 +70,16 @@ pub struct Manager<Config: endpoint::Config> {
     /// The `paths` data structure will need to be enhanced to include garbage collection
     /// of old paths to overcome this limitation.
     pending_packet_authentication: Option<u8>,
-    mtu_config: CheckedConfig,
 }
 
 impl<Config: endpoint::Config> Manager<Config> {
-    pub fn new(
-        initial_path: Path<Config>,
-        peer_id_registry: PeerIdRegistry,
-        mtu_config: CheckedConfig,
-    ) -> Self {
+    pub fn new(initial_path: Path<Config>, peer_id_registry: PeerIdRegistry) -> Self {
         let mut manager = Manager {
             paths: SmallVec::from_elem(initial_path, 1),
             peer_id_registry,
             active: 0,
             last_known_active_validated_path: None,
             pending_packet_authentication: None,
-            mtu_config,
         };
         manager.paths[0].activated = true;
         manager.paths[0].is_active = true;
@@ -857,12 +851,6 @@ impl<Config: endpoint::Config> Manager<Config> {
             .map(|path| path.transmission_constraint())
             .min()
             .unwrap_or(transmission::Constraint::None)
-    }
-
-    /// Returns the maximum size the UDP payload can reach for any probe packet.
-    #[inline]
-    pub fn max_mtu(&self) -> MaxMtu {
-        self.mtu_config.endpoint.max_mtu()
     }
 
     #[cfg(test)]

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -419,9 +419,8 @@ impl<Config: endpoint::Config> Manager<Config> {
             .rtt_estimator
             .for_new_path(limits.initial_round_trip_time());
 
-        let info = mtu::PathInfo::new(&remote_address);
-        let mtu_config = mtu.config(&info).map_err(|_err| {
-            event::builder::DatagramDropReason::MtuValidation {
+        let mtu_config = mtu.config(&remote_address).map_err(|_err| {
+            event::builder::DatagramDropReason::InvalidMtuConfiguration {
                 endpoint_mtu_config: mtu.endpoint_config().into_event(),
             }
         })?;

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -244,7 +244,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         handshake_confirmed: bool,
         congestion_controller_endpoint: &mut Config::CongestionControllerEndpoint,
         migration_validator: &mut Config::PathMigrationValidator,
-        mtu: &mut mtu::MtuManager<Config::Mtu>,
+        mtu: &mut mtu::Manager<Config::Mtu>,
         limits: &Limits,
         publisher: &mut Pub,
     ) -> Result<(Id, AmplificationOutcome), DatagramDropReason> {
@@ -320,7 +320,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         datagram: &DatagramInfo,
         congestion_controller_endpoint: &mut Config::CongestionControllerEndpoint,
         migration_validator: &mut Config::PathMigrationValidator,
-        mtu: &mut mtu::MtuManager<Config::Mtu>,
+        mtu: &mut mtu::Manager<Config::Mtu>,
         limits: &Limits,
         publisher: &mut Pub,
     ) -> Result<(Id, AmplificationOutcome), DatagramDropReason> {

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -418,8 +418,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             .active_path()
             .rtt_estimator
             .for_new_path(limits.initial_round_trip_time());
-        let path_info =
-            congestion_controller::PathInfo::new(mtu_config.initial_mtu(), &remote_address);
+        let path_info = congestion_controller::PathInfo::new(&mtu_config, &remote_address);
         let cc = congestion_controller_endpoint.new_congestion_controller(path_info);
 
         let peer_connection_id = {

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -422,9 +422,9 @@ impl<Config: endpoint::Config> Manager<Config> {
             .rtt_estimator
             .for_new_path(limits.initial_round_trip_time());
 
-        let info = mtu::ConnectionInfo::new(&remote_address, endpoint_mtu_config);
+        let info = mtu::PathInfo::new(&remote_address, endpoint_mtu_config);
         let mtu_config =
-            CheckedConfig::new(mtu_provider.on_connection(&info), &info).map_err(|_err| {
+            CheckedConfig::new(mtu_provider.on_path(&info), &info).map_err(|_err| {
                 event::builder::DatagramDropReason::MtuValidation {
                     endpoint_mtu_config: endpoint_mtu_config.into_event(),
                 }

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -70,14 +70,14 @@ pub struct Manager<Config: endpoint::Config> {
     /// The `paths` data structure will need to be enhanced to include garbage collection
     /// of old paths to overcome this limitation.
     pending_packet_authentication: Option<u8>,
-    endpoint_max_mtu: MaxMtu,
+    mtu_config: CheckedConfig,
 }
 
 impl<Config: endpoint::Config> Manager<Config> {
     pub fn new(
         initial_path: Path<Config>,
         peer_id_registry: PeerIdRegistry,
-        max_mtu: MaxMtu,
+        mtu_config: CheckedConfig,
     ) -> Self {
         let mut manager = Manager {
             paths: SmallVec::from_elem(initial_path, 1),
@@ -85,7 +85,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             active: 0,
             last_known_active_validated_path: None,
             pending_packet_authentication: None,
-            endpoint_max_mtu: max_mtu,
+            mtu_config,
         };
         manager.paths[0].activated = true;
         manager.paths[0].is_active = true;
@@ -862,7 +862,7 @@ impl<Config: endpoint::Config> Manager<Config> {
     /// Returns the maximum size the UDP payload can reach for any probe packet.
     #[inline]
     pub fn max_mtu(&self) -> MaxMtu {
-        self.endpoint_max_mtu
+        self.mtu_config.endpoint.max_mtu()
     }
 
     #[cfg(test)]

--- a/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
@@ -176,7 +176,7 @@ impl Model {
             true,
             &mut Default::default(),
             &mut migration_validator,
-            &mut mtu::MtuManager::new(mtu::Config::default()),
+            &mut mtu::Manager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         ) {

--- a/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
@@ -95,7 +95,7 @@ impl Model {
                         true,
                     );
 
-            Manager::new(zero_path, peer_id_registry, mtu::CheckedConfig::default())
+            Manager::new(zero_path, peer_id_registry)
         };
 
         let clock = Clock::default();

--- a/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
@@ -95,7 +95,7 @@ impl Model {
                         true,
                     );
 
-            Manager::new(zero_path, peer_id_registry)
+            Manager::new(zero_path, peer_id_registry, mtu::CheckedConfig::default())
         };
 
         let clock = Clock::default();
@@ -177,7 +177,7 @@ impl Model {
             &mut Default::default(),
             &mut migration_validator,
             mtu::Config::default().into(),
-            &mut Default::default(),
+            &mut mtu::Config::default(),
             &Limits::default(),
             &mut publisher,
         ) {

--- a/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
@@ -176,7 +176,7 @@ impl Model {
             true,
             &mut Default::default(),
             &mut migration_validator,
-            mtu::Config::default(),
+            mtu::Config::default().into(),
             &Limits::default(),
             &mut publisher,
         ) {

--- a/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
@@ -177,6 +177,7 @@ impl Model {
             &mut Default::default(),
             &mut migration_validator,
             mtu::Config::default().into(),
+            &mut Default::default(),
             &Limits::default(),
             &mut publisher,
         ) {

--- a/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
+++ b/quic/s2n-quic-transport/src/path/manager/fuzz_target.rs
@@ -176,8 +176,7 @@ impl Model {
             true,
             &mut Default::default(),
             &mut migration_validator,
-            mtu::Config::default().into(),
-            &mut mtu::Config::default(),
+            &mut mtu::MtuManager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         ) {

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -743,6 +743,7 @@ fn test_adding_new_path() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default().into(),
+            &mut mtu::Config::default(),
             &Limits::default(),
             &mut publisher,
         )
@@ -805,6 +806,7 @@ fn do_not_add_new_path_if_handshake_not_confirmed() {
         &mut Default::default(),
         &mut migration::allow_all::Validator,
         mtu::Config::default().into(),
+        &mut mtu::Config::default(),
         &Limits::default(),
         &mut publisher,
     );
@@ -868,6 +870,7 @@ fn do_not_add_new_path_if_client() {
         &mut Default::default(),
         &mut migration::allow_all::Validator,
         mtu::Config::default().into(),
+        &mut mtu::Config::default(),
         &Limits::default(),
         &mut publisher,
     );
@@ -961,6 +964,7 @@ fn limit_number_of_connection_migrations() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default().into(),
+            &mut mtu::Config::default(),
             &Limits::default(),
             &mut publisher,
         );
@@ -1032,6 +1036,7 @@ fn active_connection_migration_disabled() {
         &mut Default::default(),
         &mut migration::allow_all::Validator,
         mtu::Config::default().into(),
+        &mut mtu::Config::default(),
         // Active connection migration is disabled
         &Limits::default()
             .with_active_connection_migration(false)
@@ -1053,6 +1058,7 @@ fn active_connection_migration_disabled() {
         &mut Default::default(),
         &mut migration::allow_all::Validator,
         mtu::Config::default().into(),
+        &mut mtu::Config::default(),
         &Limits::default(),
         &mut publisher,
     );
@@ -1076,6 +1082,7 @@ fn active_connection_migration_disabled() {
         &mut Default::default(),
         &mut migration::allow_all::Validator,
         mtu::Config::default().into(),
+        &mut mtu::Config::default(),
         // Active connection migration is disabled
         &Limits::default()
             .with_active_connection_migration(false)
@@ -1128,6 +1135,7 @@ fn connection_migration_challenge_behavior() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default().into(),
+            &mut mtu::Config::default(),
             &Limits::default(),
             &mut publisher,
         )
@@ -1225,6 +1233,7 @@ fn connection_migration_use_max_ack_delay_from_active_path() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default().into(),
+            &mut mtu::Config::default(),
             &Limits::default(),
             &mut publisher,
         )
@@ -1305,6 +1314,7 @@ fn connection_migration_new_path_abandon_timer() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default().into(),
+            &mut mtu::Config::default(),
             &Limits::default(),
             &mut publisher,
         )
@@ -1584,6 +1594,7 @@ fn temporary_until_authenticated() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default().into(),
+            &mut mtu::Config::default(),
             &Limits::default(),
             &mut publisher,
         )
@@ -1607,6 +1618,7 @@ fn temporary_until_authenticated() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default().into(),
+            &mut mtu::Config::default(),
             &Limits::default(),
             &mut publisher,
         )
@@ -1645,6 +1657,7 @@ fn temporary_until_authenticated() {
             &mut Default::default(),
             &mut migration::allow_all::Validator,
             mtu::Config::default().into(),
+            &mut mtu::Config::default(),
             &Limits::default(),
             &mut publisher,
         )

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -743,8 +743,7 @@ fn test_adding_new_path() {
             true,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default().into(),
-            &mut mtu::Config::default(),
+            &mut mtu::MtuManager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         )
@@ -806,8 +805,7 @@ fn do_not_add_new_path_if_handshake_not_confirmed() {
         handshake_confirmed,
         &mut Default::default(),
         &mut migration::allow_all::Validator,
-        mtu::Config::default().into(),
-        &mut mtu::Config::default(),
+        &mut mtu::MtuManager::new(mtu::Config::default()),
         &Limits::default(),
         &mut publisher,
     );
@@ -870,8 +868,7 @@ fn do_not_add_new_path_if_client() {
         true,
         &mut Default::default(),
         &mut migration::allow_all::Validator,
-        mtu::Config::default().into(),
-        &mut mtu::Config::default(),
+        &mut mtu::MtuManager::new(mtu::Config::default()),
         &Limits::default(),
         &mut publisher,
     );
@@ -964,8 +961,7 @@ fn limit_number_of_connection_migrations() {
             &datagram,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default().into(),
-            &mut mtu::Config::default(),
+            &mut mtu::MtuManager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         );
@@ -1036,8 +1032,7 @@ fn active_connection_migration_disabled() {
         &datagram,
         &mut Default::default(),
         &mut migration::allow_all::Validator,
-        mtu::Config::default().into(),
-        &mut mtu::Config::default(),
+        &mut mtu::MtuManager::new(mtu::Config::default()),
         // Active connection migration is disabled
         &Limits::default()
             .with_active_connection_migration(false)
@@ -1058,8 +1053,7 @@ fn active_connection_migration_disabled() {
         &datagram,
         &mut Default::default(),
         &mut migration::allow_all::Validator,
-        mtu::Config::default().into(),
-        &mut mtu::Config::default(),
+        &mut mtu::MtuManager::new(mtu::Config::default()),
         &Limits::default(),
         &mut publisher,
     );
@@ -1082,8 +1076,7 @@ fn active_connection_migration_disabled() {
         &datagram,
         &mut Default::default(),
         &mut migration::allow_all::Validator,
-        mtu::Config::default().into(),
-        &mut mtu::Config::default(),
+        &mut mtu::MtuManager::new(mtu::Config::default()),
         // Active connection migration is disabled
         &Limits::default()
             .with_active_connection_migration(false)
@@ -1135,8 +1128,7 @@ fn connection_migration_challenge_behavior() {
             &datagram,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default().into(),
-            &mut mtu::Config::default(),
+            &mut mtu::MtuManager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         )
@@ -1233,8 +1225,7 @@ fn connection_migration_use_max_ack_delay_from_active_path() {
             &datagram,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default().into(),
-            &mut mtu::Config::default(),
+            &mut mtu::MtuManager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         )
@@ -1314,8 +1305,7 @@ fn connection_migration_new_path_abandon_timer() {
             &datagram,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default().into(),
-            &mut mtu::Config::default(),
+            &mut mtu::MtuManager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         )
@@ -1594,8 +1584,7 @@ fn temporary_until_authenticated() {
             true,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default().into(),
-            &mut mtu::Config::default(),
+            &mut mtu::MtuManager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         )
@@ -1618,8 +1607,7 @@ fn temporary_until_authenticated() {
             true,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default().into(),
-            &mut mtu::Config::default(),
+            &mut mtu::MtuManager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         )
@@ -1657,8 +1645,7 @@ fn temporary_until_authenticated() {
             true,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default().into(),
-            &mut mtu::Config::default(),
+            &mut mtu::MtuManager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         )

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -38,7 +38,7 @@ fn manager_server(first_path: ServerPath) -> ServerManager {
             first_path.peer_connection_id,
             true,
         );
-    ServerManager::new(first_path, peer_id_registry, mtu::CheckedConfig::default())
+    ServerManager::new(first_path, peer_id_registry)
 }
 
 // Helper function to easily create a PathManager as a Client
@@ -46,7 +46,7 @@ fn manager_client(first_path: ClientPath) -> ClientManager {
     let mut random_generator = random::testing::Generator(123);
     let peer_id_registry = ConnectionIdMapper::new(&mut random_generator, endpoint::Type::Client)
         .create_client_peer_id_registry(InternalConnectionIdGenerator::new().generate_id(), true);
-    ClientManager::new(first_path, peer_id_registry, mtu::CheckedConfig::default())
+    ClientManager::new(first_path, peer_id_registry)
 }
 
 #[test]
@@ -1736,7 +1736,7 @@ fn last_known_validated_path_should_update_on_path_response() {
         .on_new_connection_id(&second_conn_id, 2, 0, &TEST_TOKEN_2)
         .is_ok());
 
-    let mut manager = Manager::new(zero_path, peer_id_registry, mtu::CheckedConfig::default());
+    let mut manager = Manager::new(zero_path, peer_id_registry);
 
     assert!(!manager[zero_path_id].is_challenge_pending());
     assert!(manager[zero_path_id].is_validated());
@@ -1905,7 +1905,7 @@ pub fn helper_manager_with_paths_base(
             .is_ok());
     }
 
-    let mut manager = ServerManager::new(zero_path, peer_id_registry, CheckedConfig::default());
+    let mut manager = ServerManager::new(zero_path, peer_id_registry);
     assert!(manager.peer_id_registry.is_active(&first_conn_id));
     manager.paths.push(first_path);
     manager.paths.push(second_path);

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -60,7 +60,7 @@ fn get_path_by_address_test() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 
@@ -72,7 +72,7 @@ fn get_path_by_address_test() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 
@@ -104,7 +104,7 @@ fn test_invalid_path_fallback() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     // simulate receiving a handshake packet to force path validation
@@ -121,7 +121,7 @@ fn test_invalid_path_fallback() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     second_path.set_challenge(challenge);
@@ -505,7 +505,7 @@ fn silently_return_when_there_is_no_valid_path() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     first_path.set_challenge(challenge);
@@ -713,7 +713,7 @@ fn test_adding_new_path() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -742,7 +742,7 @@ fn test_adding_new_path() {
             true,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default(),
+            mtu::Config::default().into(),
             &Limits::default(),
             &mut publisher,
         )
@@ -777,7 +777,7 @@ fn do_not_add_new_path_if_handshake_not_confirmed() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -804,7 +804,7 @@ fn do_not_add_new_path_if_handshake_not_confirmed() {
         handshake_confirmed,
         &mut Default::default(),
         &mut migration::allow_all::Validator,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         &Limits::default(),
         &mut publisher,
     );
@@ -840,7 +840,7 @@ fn do_not_add_new_path_if_client() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_client(first_path);
@@ -867,7 +867,7 @@ fn do_not_add_new_path_if_client() {
         true,
         &mut Default::default(),
         &mut migration::allow_all::Validator,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         &Limits::default(),
         &mut publisher,
     );
@@ -896,7 +896,7 @@ fn switch_destination_connection_id_after_first_server_response() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_client(zero_path);
@@ -935,7 +935,7 @@ fn limit_number_of_connection_migrations() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -960,7 +960,7 @@ fn limit_number_of_connection_migrations() {
             &datagram,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default(),
+            mtu::Config::default().into(),
             &Limits::default(),
             &mut publisher,
         );
@@ -995,7 +995,7 @@ fn active_connection_migration_disabled() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -1031,7 +1031,7 @@ fn active_connection_migration_disabled() {
         &datagram,
         &mut Default::default(),
         &mut migration::allow_all::Validator,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         // Active connection migration is disabled
         &Limits::default()
             .with_active_connection_migration(false)
@@ -1052,7 +1052,7 @@ fn active_connection_migration_disabled() {
         &datagram,
         &mut Default::default(),
         &mut migration::allow_all::Validator,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         &Limits::default(),
         &mut publisher,
     );
@@ -1075,7 +1075,7 @@ fn active_connection_migration_disabled() {
         &datagram,
         &mut Default::default(),
         &mut migration::allow_all::Validator,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         // Active connection migration is disabled
         &Limits::default()
             .with_active_connection_migration(false)
@@ -1103,7 +1103,7 @@ fn connection_migration_challenge_behavior() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -1127,7 +1127,7 @@ fn connection_migration_challenge_behavior() {
             &datagram,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default(),
+            mtu::Config::default().into(),
             &Limits::default(),
             &mut publisher,
         )
@@ -1199,7 +1199,7 @@ fn connection_migration_use_max_ack_delay_from_active_path() {
         RttEstimator::new(Duration::from_millis(30)),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -1224,7 +1224,7 @@ fn connection_migration_use_max_ack_delay_from_active_path() {
             &datagram,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default(),
+            mtu::Config::default().into(),
             &Limits::default(),
             &mut publisher,
         )
@@ -1280,7 +1280,7 @@ fn connection_migration_new_path_abandon_timer() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -1304,7 +1304,7 @@ fn connection_migration_new_path_abandon_timer() {
             &datagram,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default(),
+            mtu::Config::default().into(),
             &Limits::default(),
             &mut publisher,
         )
@@ -1403,7 +1403,7 @@ fn stop_using_a_retired_connection_id() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -1500,7 +1500,7 @@ fn pending_paths_should_return_paths_pending_validation() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let expected_response_data = [0; 8];
@@ -1566,7 +1566,7 @@ fn temporary_until_authenticated() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -1583,7 +1583,7 @@ fn temporary_until_authenticated() {
             true,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default(),
+            mtu::Config::default().into(),
             &Limits::default(),
             &mut publisher,
         )
@@ -1606,7 +1606,7 @@ fn temporary_until_authenticated() {
             true,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default(),
+            mtu::Config::default().into(),
             &Limits::default(),
             &mut publisher,
         )
@@ -1644,7 +1644,7 @@ fn temporary_until_authenticated() {
             true,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            mtu::Config::default(),
+            mtu::Config::default().into(),
             &Limits::default(),
             &mut publisher,
         )
@@ -1952,7 +1952,7 @@ pub fn helper_path(peer_id: connection::PeerId) -> ServerPath {
         RttEstimator::new(Duration::from_millis(30)),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     )
 }

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -38,7 +38,7 @@ fn manager_server(first_path: ServerPath) -> ServerManager {
             first_path.peer_connection_id,
             true,
         );
-    ServerManager::new(first_path, peer_id_registry)
+    ServerManager::new(first_path, peer_id_registry, mtu::CheckedConfig::default())
 }
 
 // Helper function to easily create a PathManager as a Client
@@ -46,13 +46,14 @@ fn manager_client(first_path: ClientPath) -> ClientManager {
     let mut random_generator = random::testing::Generator(123);
     let peer_id_registry = ConnectionIdMapper::new(&mut random_generator, endpoint::Type::Client)
         .create_client_peer_id_registry(InternalConnectionIdGenerator::new().generate_id(), true);
-    ClientManager::new(first_path, peer_id_registry)
+    ClientManager::new(first_path, peer_id_registry, mtu::CheckedConfig::default())
 }
 
 #[test]
 fn get_path_by_address_test() {
     let first_conn_id = connection::PeerId::try_from_bytes(&[0, 1, 2, 3, 4, 5]).unwrap();
     let first_local_conn_id = connection::LocalId::TEST_ID;
+    let mtu_config = mtu::Config::default().into();
     let first_path = ServerPath::new(
         Default::default(),
         first_conn_id,
@@ -60,7 +61,7 @@ fn get_path_by_address_test() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu_config,
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 
@@ -72,7 +73,7 @@ fn get_path_by_address_test() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu_config,
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 
@@ -1735,7 +1736,7 @@ fn last_known_validated_path_should_update_on_path_response() {
         .on_new_connection_id(&second_conn_id, 2, 0, &TEST_TOKEN_2)
         .is_ok());
 
-    let mut manager = Manager::new(zero_path, peer_id_registry);
+    let mut manager = Manager::new(zero_path, peer_id_registry, mtu::CheckedConfig::default());
 
     assert!(!manager[zero_path_id].is_challenge_pending());
     assert!(manager[zero_path_id].is_validated());
@@ -1904,7 +1905,7 @@ pub fn helper_manager_with_paths_base(
             .is_ok());
     }
 
-    let mut manager = ServerManager::new(zero_path, peer_id_registry);
+    let mut manager = ServerManager::new(zero_path, peer_id_registry, CheckedConfig::default());
     assert!(manager.peer_id_registry.is_active(&first_conn_id));
     manager.paths.push(first_path);
     manager.paths.push(second_path);

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -743,7 +743,7 @@ fn test_adding_new_path() {
             true,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            &mut mtu::MtuManager::new(mtu::Config::default()),
+            &mut mtu::Manager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         )
@@ -805,7 +805,7 @@ fn do_not_add_new_path_if_handshake_not_confirmed() {
         handshake_confirmed,
         &mut Default::default(),
         &mut migration::allow_all::Validator,
-        &mut mtu::MtuManager::new(mtu::Config::default()),
+        &mut mtu::Manager::new(mtu::Config::default()),
         &Limits::default(),
         &mut publisher,
     );
@@ -868,7 +868,7 @@ fn do_not_add_new_path_if_client() {
         true,
         &mut Default::default(),
         &mut migration::allow_all::Validator,
-        &mut mtu::MtuManager::new(mtu::Config::default()),
+        &mut mtu::Manager::new(mtu::Config::default()),
         &Limits::default(),
         &mut publisher,
     );
@@ -961,7 +961,7 @@ fn limit_number_of_connection_migrations() {
             &datagram,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            &mut mtu::MtuManager::new(mtu::Config::default()),
+            &mut mtu::Manager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         );
@@ -1032,7 +1032,7 @@ fn active_connection_migration_disabled() {
         &datagram,
         &mut Default::default(),
         &mut migration::allow_all::Validator,
-        &mut mtu::MtuManager::new(mtu::Config::default()),
+        &mut mtu::Manager::new(mtu::Config::default()),
         // Active connection migration is disabled
         &Limits::default()
             .with_active_connection_migration(false)
@@ -1053,7 +1053,7 @@ fn active_connection_migration_disabled() {
         &datagram,
         &mut Default::default(),
         &mut migration::allow_all::Validator,
-        &mut mtu::MtuManager::new(mtu::Config::default()),
+        &mut mtu::Manager::new(mtu::Config::default()),
         &Limits::default(),
         &mut publisher,
     );
@@ -1076,7 +1076,7 @@ fn active_connection_migration_disabled() {
         &datagram,
         &mut Default::default(),
         &mut migration::allow_all::Validator,
-        &mut mtu::MtuManager::new(mtu::Config::default()),
+        &mut mtu::Manager::new(mtu::Config::default()),
         // Active connection migration is disabled
         &Limits::default()
             .with_active_connection_migration(false)
@@ -1128,7 +1128,7 @@ fn connection_migration_challenge_behavior() {
             &datagram,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            &mut mtu::MtuManager::new(mtu::Config::default()),
+            &mut mtu::Manager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         )
@@ -1225,7 +1225,7 @@ fn connection_migration_use_max_ack_delay_from_active_path() {
             &datagram,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            &mut mtu::MtuManager::new(mtu::Config::default()),
+            &mut mtu::Manager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         )
@@ -1305,7 +1305,7 @@ fn connection_migration_new_path_abandon_timer() {
             &datagram,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            &mut mtu::MtuManager::new(mtu::Config::default()),
+            &mut mtu::Manager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         )
@@ -1584,7 +1584,7 @@ fn temporary_until_authenticated() {
             true,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            &mut mtu::MtuManager::new(mtu::Config::default()),
+            &mut mtu::Manager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         )
@@ -1607,7 +1607,7 @@ fn temporary_until_authenticated() {
             true,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            &mut mtu::MtuManager::new(mtu::Config::default()),
+            &mut mtu::Manager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         )
@@ -1645,7 +1645,7 @@ fn temporary_until_authenticated() {
             true,
             &mut Default::default(),
             &mut migration::allow_all::Validator,
-            &mut mtu::MtuManager::new(mtu::Config::default()),
+            &mut mtu::Manager::new(mtu::Config::default()),
             &Limits::default(),
             &mut publisher,
         )

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -53,7 +53,7 @@ fn manager_client(first_path: ClientPath) -> ClientManager {
 fn get_path_by_address_test() {
     let first_conn_id = connection::PeerId::try_from_bytes(&[0, 1, 2, 3, 4, 5]).unwrap();
     let first_local_conn_id = connection::LocalId::TEST_ID;
-    let mtu_config = mtu::Config::default().into();
+    let mtu_config = mtu::Config::default();
     let first_path = ServerPath::new(
         Default::default(),
         first_conn_id,
@@ -105,7 +105,7 @@ fn test_invalid_path_fallback() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     // simulate receiving a handshake packet to force path validation
@@ -122,7 +122,7 @@ fn test_invalid_path_fallback() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     second_path.set_challenge(challenge);
@@ -506,7 +506,7 @@ fn silently_return_when_there_is_no_valid_path() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     first_path.set_challenge(challenge);
@@ -714,7 +714,7 @@ fn test_adding_new_path() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -778,7 +778,7 @@ fn do_not_add_new_path_if_handshake_not_confirmed() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -841,7 +841,7 @@ fn do_not_add_new_path_if_client() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_client(first_path);
@@ -897,7 +897,7 @@ fn switch_destination_connection_id_after_first_server_response() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_client(zero_path);
@@ -936,7 +936,7 @@ fn limit_number_of_connection_migrations() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -996,7 +996,7 @@ fn active_connection_migration_disabled() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -1104,7 +1104,7 @@ fn connection_migration_challenge_behavior() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -1200,7 +1200,7 @@ fn connection_migration_use_max_ack_delay_from_active_path() {
         RttEstimator::new(Duration::from_millis(30)),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -1281,7 +1281,7 @@ fn connection_migration_new_path_abandon_timer() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -1404,7 +1404,7 @@ fn stop_using_a_retired_connection_id() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -1501,7 +1501,7 @@ fn pending_paths_should_return_paths_pending_validation() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let expected_response_data = [0; 8];
@@ -1567,7 +1567,7 @@ fn temporary_until_authenticated() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     let mut manager = manager_server(first_path);
@@ -1953,7 +1953,7 @@ pub fn helper_path(peer_id: connection::PeerId) -> ServerPath {
         RttEstimator::new(Duration::from_millis(30)),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     )
 }

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -114,7 +114,7 @@ impl<Config: endpoint::Config> Path<Config> {
         rtt_estimator: RttEstimator,
         congestion_controller: <Config::CongestionControllerEndpoint as congestion_controller::Endpoint>::CongestionController,
         peer_validated: bool,
-        mtu_config: mtu::CheckedConfig,
+        mtu_config: mtu::Config,
         anti_amplification_multiplier: u8,
     ) -> Path<Config> {
         let state = match Config::ENDPOINT_TYPE {

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -114,7 +114,7 @@ impl<Config: endpoint::Config> Path<Config> {
         rtt_estimator: RttEstimator,
         congestion_controller: <Config::CongestionControllerEndpoint as congestion_controller::Endpoint>::CongestionController,
         peer_validated: bool,
-        mtu_config: mtu::Config,
+        mtu_config: mtu::CheckedConfig,
         anti_amplification_multiplier: u8,
     ) -> Path<Config> {
         let state = match Config::ENDPOINT_TYPE {
@@ -612,7 +612,7 @@ pub mod testing {
             RttEstimator::new(Duration::from_millis(30)),
             Default::default(),
             true,
-            mtu::Config::default(),
+            mtu::Config::default().into(),
             ANTI_AMPLIFICATION_MULTIPLIER,
         )
     }
@@ -625,7 +625,7 @@ pub mod testing {
             RttEstimator::new(Duration::from_millis(30)),
             Default::default(),
             false,
-            mtu::Config::default(),
+            mtu::Config::default().into(),
             ANTI_AMPLIFICATION_MULTIPLIER,
         )
     }
@@ -1159,7 +1159,7 @@ mod tests {
             RttEstimator::new(Duration::from_millis(30)),
             Default::default(),
             false,
-            mtu::Config::default(),
+            mtu::Config::default().into(),
             ANTI_AMPLIFICATION_MULTIPLIER,
         );
         let now = NoopClock.get_time();

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -612,7 +612,7 @@ pub mod testing {
             RttEstimator::new(Duration::from_millis(30)),
             Default::default(),
             true,
-            mtu::Config::default().into(),
+            mtu::Config::default(),
             ANTI_AMPLIFICATION_MULTIPLIER,
         )
     }
@@ -625,7 +625,7 @@ pub mod testing {
             RttEstimator::new(Duration::from_millis(30)),
             Default::default(),
             false,
-            mtu::Config::default().into(),
+            mtu::Config::default(),
             ANTI_AMPLIFICATION_MULTIPLIER,
         )
     }
@@ -1159,7 +1159,7 @@ mod tests {
             RttEstimator::new(Duration::from_millis(30)),
             Default::default(),
             false,
-            mtu::Config::default().into(),
+            mtu::Config::default(),
             ANTI_AMPLIFICATION_MULTIPLIER,
         );
         let now = NoopClock.get_time();

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -60,7 +60,7 @@ fn one_second_pto_when_no_previous_rtt_available() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 
@@ -439,7 +439,7 @@ fn on_ack_frame() {
         context.path().rtt_estimator,
         MockCongestionController::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     context.path_manager.activate_path_for_test(path_id);
@@ -2675,7 +2675,7 @@ fn update_pto_timer() {
         rtt_estimator,
         MockCongestionController::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     context.path_manager.activate_path_for_test(path_id);
@@ -2769,7 +2769,7 @@ fn pto_armed_if_handshake_not_confirmed() {
         RttEstimator::new(Duration::from_millis(10)),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     path_manager.activate_path_for_test(path_id);
@@ -2798,7 +2798,7 @@ fn pto_must_be_at_least_k_granularity() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default().into(),
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 
@@ -3426,7 +3426,6 @@ fn helper_generate_path_manager_with_first_addr(
     let mut rtt_estimator = RttEstimator::default();
     rtt_estimator.on_max_ack_delay(max_ack_delay.try_into().unwrap());
 
-    let mtu_config = mtu::Config::default().into();
     let path = Path::new(
         first_addr,
         connection::PeerId::TEST_ID,
@@ -3434,7 +3433,7 @@ fn helper_generate_path_manager_with_first_addr(
         rtt_estimator,
         MockCongestionController::new(first_addr),
         true,
-        mtu_config,
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 
@@ -3452,7 +3451,6 @@ fn helper_generate_client_path_manager(
     let mut rtt_estimator = RttEstimator::default();
     rtt_estimator.on_max_ack_delay(max_ack_delay.try_into().unwrap());
 
-    let mtu_config = mtu::Config::default().into();
     let path = super::Path::new(
         first_addr,
         connection::PeerId::TEST_ID,
@@ -3460,7 +3458,7 @@ fn helper_generate_client_path_manager(
         rtt_estimator,
         MockCongestionController::new(first_addr),
         false,
-        mtu_config,
+        mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -3367,6 +3367,7 @@ fn helper_generate_multi_path_manager(
                 &mut Endpoint::default(),
                 &mut migration::allow_all::Validator,
                 mtu::Config::default().into(),
+                &mut mtu::Config::default(),
                 &Limits::default(),
                 publisher,
             )

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -3366,8 +3366,7 @@ fn helper_generate_multi_path_manager(
                 true,
                 &mut Endpoint::default(),
                 &mut migration::allow_all::Validator,
-                mtu::Config::default().into(),
-                &mut mtu::Config::default(),
+                &mut mtu::MtuManager::new(mtu::Config::default()),
                 &Limits::default(),
                 publisher,
             )

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -3366,7 +3366,7 @@ fn helper_generate_multi_path_manager(
                 true,
                 &mut Endpoint::default(),
                 &mut migration::allow_all::Validator,
-                &mut mtu::MtuManager::new(mtu::Config::default()),
+                &mut mtu::Manager::new(mtu::Config::default()),
                 &Limits::default(),
                 publisher,
             )

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -3426,6 +3426,8 @@ fn helper_generate_path_manager_with_first_addr(
         );
     let mut rtt_estimator = RttEstimator::default();
     rtt_estimator.on_max_ack_delay(max_ack_delay.try_into().unwrap());
+
+    let mtu_config = mtu::Config::default().into();
     let path = Path::new(
         first_addr,
         connection::PeerId::TEST_ID,
@@ -3433,11 +3435,11 @@ fn helper_generate_path_manager_with_first_addr(
         rtt_estimator,
         MockCongestionController::new(first_addr),
         true,
-        mtu::Config::default().into(),
+        mtu_config,
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 
-    path::Manager::new(path, registry)
+    path::Manager::new(path, registry, mtu_config)
 }
 
 fn helper_generate_client_path_manager(
@@ -3450,6 +3452,8 @@ fn helper_generate_client_path_manager(
         .create_client_peer_id_registry(InternalConnectionIdGenerator::new().generate_id(), true);
     let mut rtt_estimator = RttEstimator::default();
     rtt_estimator.on_max_ack_delay(max_ack_delay.try_into().unwrap());
+
+    let mtu_config = mtu::Config::default().into();
     let path = super::Path::new(
         first_addr,
         connection::PeerId::TEST_ID,
@@ -3457,11 +3461,11 @@ fn helper_generate_client_path_manager(
         rtt_estimator,
         MockCongestionController::new(first_addr),
         false,
-        mtu::Config::default().into(),
+        mtu_config,
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 
-    path::Manager::new(path, registry)
+    path::Manager::new(path, registry, mtu_config)
 }
 
 struct MockContext<'a, Config: endpoint::Config> {

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -60,7 +60,7 @@ fn one_second_pto_when_no_previous_rtt_available() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 
@@ -439,7 +439,7 @@ fn on_ack_frame() {
         context.path().rtt_estimator,
         MockCongestionController::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     context.path_manager.activate_path_for_test(path_id);
@@ -2675,7 +2675,7 @@ fn update_pto_timer() {
         rtt_estimator,
         MockCongestionController::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     context.path_manager.activate_path_for_test(path_id);
@@ -2769,7 +2769,7 @@ fn pto_armed_if_handshake_not_confirmed() {
         RttEstimator::new(Duration::from_millis(10)),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
     path_manager.activate_path_for_test(path_id);
@@ -2798,7 +2798,7 @@ fn pto_must_be_at_least_k_granularity() {
         RttEstimator::default(),
         Default::default(),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 
@@ -3366,7 +3366,7 @@ fn helper_generate_multi_path_manager(
                 true,
                 &mut Endpoint::default(),
                 &mut migration::allow_all::Validator,
-                mtu::Config::default(),
+                mtu::Config::default().into(),
                 &Limits::default(),
                 publisher,
             )
@@ -3432,7 +3432,7 @@ fn helper_generate_path_manager_with_first_addr(
         rtt_estimator,
         MockCongestionController::new(first_addr),
         true,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 
@@ -3456,7 +3456,7 @@ fn helper_generate_client_path_manager(
         rtt_estimator,
         MockCongestionController::new(first_addr),
         false,
-        mtu::Config::default(),
+        mtu::Config::default().into(),
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -3439,7 +3439,7 @@ fn helper_generate_path_manager_with_first_addr(
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 
-    path::Manager::new(path, registry, mtu_config)
+    path::Manager::new(path, registry)
 }
 
 fn helper_generate_client_path_manager(
@@ -3465,7 +3465,7 @@ fn helper_generate_client_path_manager(
         ANTI_AMPLIFICATION_MULTIPLIER,
     );
 
-    path::Manager::new(path, registry, mtu_config)
+    path::Manager::new(path, registry)
 }
 
 struct MockContext<'a, Config: endpoint::Config> {

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -440,11 +440,9 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
             datagram_limits.max_datagram_payload,
         );
 
-        let max_mtu = self.path_manager.max_mtu();
-
         let dc_manager = if let Some(dc_version) = dc_version {
             let application_params =
-                dc::ApplicationParams::new(max_mtu, &peer_flow_control_limits, self.limits);
+                dc::ApplicationParams::new(&peer_flow_control_limits, self.limits);
             let remote_address = self.path_manager.active_path().remote_address().0;
             let conn_info = dc::ConnectionInfo::new(
                 &remote_address,
@@ -471,7 +469,6 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
             stream_manager,
             ack_manager,
             keep_alive,
-            max_mtu,
             datagram_manager,
             dc_manager,
         )));

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -441,8 +441,11 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
         );
 
         let dc_manager = if let Some(dc_version) = dc_version {
-            let application_params =
-                dc::ApplicationParams::new(&peer_flow_control_limits, self.limits);
+            let application_params = dc::ApplicationParams::new(
+                self.path_manager.active_path().max_mtu(),
+                &peer_flow_control_limits,
+                self.limits,
+            );
             let remote_address = self.path_manager.active_path().remote_address().0;
             let conn_info = dc::ConnectionInfo::new(
                 &remote_address,

--- a/quic/s2n-quic/src/client/builder.rs
+++ b/quic/s2n-quic/src/client/builder.rs
@@ -148,8 +148,8 @@ impl<Providers: ClientProviders> Builder<Providers> {
         ///         &mut self,
         ///         info: &mtu::PathInfo,
         ///         endpoint_mtu_config: mtu::Config,
-        ///     ) -> mtu::Config {
-        ///         self.0
+        ///     ) -> Option<mtu::Config> {
+        ///         Some(self.0)
         ///     }
         /// }
         /// let mtu = MyMtuProvider(mtu::Config::builder().build().unwrap());

--- a/quic/s2n-quic/src/client/builder.rs
+++ b/quic/s2n-quic/src/client/builder.rs
@@ -131,7 +131,7 @@ impl<Providers: ClientProviders> Builder<Providers> {
         ///
         /// # Examples
         ///
-        /// Set custom MTU values to use per connections, while inheriting the remaining default
+        /// Set custom MTU values to use per connection, while inheriting the remaining default
         /// config
         ///
         /// ```rust,no_run
@@ -143,7 +143,7 @@ impl<Providers: ClientProviders> Builder<Providers> {
         ///
         /// struct MyMtuProvider(mtu::Config);
         ///
-        /// impl mtu::Configurator for MyMtuProvider {
+        /// impl mtu::Endpoint for MyMtuProvider {
         ///     fn on_connection(
         ///         &mut self,
         ///         info: &mtu::ConnectionInfo,

--- a/quic/s2n-quic/src/client/builder.rs
+++ b/quic/s2n-quic/src/client/builder.rs
@@ -127,6 +127,45 @@ impl<Providers: ClientProviders> Builder<Providers> {
     );
 
     impl_provider_method!(
+        /// Sets the connection specific mtu config provider for the [`Client`]
+        ///
+        /// # Examples
+        ///
+        /// Set custom MTU values to use per connections, while inheriting the remaining default
+        /// config
+        ///
+        /// ```rust,no_run
+        /// # use std::{error::Error, time::Duration};
+        /// use s2n_quic::{Client, provider::mtu};
+        ///
+        /// # #[tokio::main]
+        /// # async fn main() -> Result<(), Box<dyn Error>> {
+        ///
+        /// struct MyMtuProvider(mtu::Config);
+        ///
+        /// impl mtu::Configurator for MyMtuProvider {
+        ///     fn on_connection(
+        ///         &mut self,
+        ///         info: &mtu::ConnectionInfo,
+        ///     ) -> mtu::Config {
+        ///         self.0
+        ///     }
+        /// }
+        /// let mtu = MyMtuProvider(mtu::Config::default());
+        ///
+        /// let client = Client::builder()
+        ///     .with_mtu(mtu)?
+        ///     .start()?;
+        /// #
+        /// #    Ok(())
+        /// # }
+        /// ```
+        with_mtu,
+        mtu,
+        ClientProviders
+    );
+
+    impl_provider_method!(
         /// Sets the event provider for the [`Client`]
         ///
         /// # Examples

--- a/quic/s2n-quic/src/client/builder.rs
+++ b/quic/s2n-quic/src/client/builder.rs
@@ -147,6 +147,7 @@ impl<Providers: ClientProviders> Builder<Providers> {
         ///     fn on_path(
         ///         &mut self,
         ///         info: &mtu::PathInfo,
+        ///         endpoint_mtu_config: mtu::Config,
         ///     ) -> mtu::Config {
         ///         self.0
         ///     }

--- a/quic/s2n-quic/src/client/builder.rs
+++ b/quic/s2n-quic/src/client/builder.rs
@@ -144,9 +144,9 @@ impl<Providers: ClientProviders> Builder<Providers> {
         /// struct MyMtuProvider(mtu::Config);
         ///
         /// impl mtu::Endpoint for MyMtuProvider {
-        ///     fn on_connection(
+        ///     fn on_path(
         ///         &mut self,
-        ///         info: &mtu::ConnectionInfo,
+        ///         info: &mtu::PathInfo,
         ///     ) -> mtu::Config {
         ///         self.0
         ///     }

--- a/quic/s2n-quic/src/client/builder.rs
+++ b/quic/s2n-quic/src/client/builder.rs
@@ -127,11 +127,11 @@ impl<Providers: ClientProviders> Builder<Providers> {
     );
 
     impl_provider_method!(
-        /// Sets the connection specific mtu config provider for the [`Client`]
+        /// Sets the path specific mtu config provider for the [`Client`]
         ///
         /// # Examples
         ///
-        /// Set custom MTU values to use per connection, while inheriting the remaining default
+        /// Set custom MTU values to use per path, while inheriting the remaining default
         /// config
         ///
         /// ```rust,no_run
@@ -151,7 +151,7 @@ impl<Providers: ClientProviders> Builder<Providers> {
         ///         self.0
         ///     }
         /// }
-        /// let mtu = MyMtuProvider(mtu::Config::default());
+        /// let mtu = MyMtuProvider(mtu::Config::builder().build().unwrap());
         ///
         /// let client = Client::builder()
         ///     .with_mtu(mtu)?

--- a/quic/s2n-quic/src/client/providers.rs
+++ b/quic/s2n-quic/src/client/providers.rs
@@ -17,7 +17,7 @@ impl_providers_state! {
         random: Random,
         event: Event,
         limits: Limits,
-        mtu: MtuConfig,
+        mtu: Mtu,
         io: IO,
         sync: Sync,
         tls: Tls,
@@ -38,7 +38,7 @@ impl<
         Random: random::Provider,
         Event: event::Provider,
         Limits: limits::Provider,
-        MtuConfig: mtu::Provider,
+        Mtu: mtu::Provider,
         IO: io::Provider,
         Sync: sync::Provider,
         Tls: tls::Provider,
@@ -54,7 +54,7 @@ impl<
         Random,
         Event,
         Limits,
-        MtuConfig,
+        Mtu,
         IO,
         Sync,
         Tls,
@@ -211,7 +211,7 @@ struct EndpointConfig<
     Random,
     Event,
     Limits,
-    MtuConfig,
+    Mtu,
     Sync,
     Tls,
     Datagram,
@@ -226,7 +226,7 @@ struct EndpointConfig<
     endpoint_limits: EndpointLimits,
     event: Event,
     limits: Limits,
-    mtu: MtuConfig,
+    mtu: Mtu,
     sync: Sync,
     tls: Tls,
     token: Token,
@@ -246,7 +246,7 @@ impl<
         Random: s2n_quic_core::random::Generator,
         Event: s2n_quic_core::event::Subscriber,
         Limits: s2n_quic_core::connection::limits::Limiter,
-        MtuConfig: s2n_quic_core::path::mtu::Configurator,
+        Mtu: s2n_quic_core::path::mtu::Endpoint,
         Sync,
         Tls: crypto::tls::Endpoint,
         Datagram: s2n_quic_core::datagram::Endpoint,
@@ -262,7 +262,7 @@ impl<
         Random,
         Event,
         Limits,
-        MtuConfig,
+        Mtu,
         Sync,
         Tls,
         Datagram,
@@ -284,7 +284,7 @@ impl<
         Random: s2n_quic_core::random::Generator,
         Event: s2n_quic_core::event::Subscriber,
         Limits: s2n_quic_core::connection::limits::Limiter,
-        MtuConfig: s2n_quic_core::path::mtu::Configurator,
+        Mtu: s2n_quic_core::path::mtu::Endpoint,
         Sync: 'static + Send,
         Tls: crypto::tls::Endpoint,
         Datagram: s2n_quic_core::datagram::Endpoint,
@@ -300,7 +300,7 @@ impl<
         Random,
         Event,
         Limits,
-        MtuConfig,
+        Mtu,
         Sync,
         Tls,
         Datagram,
@@ -321,7 +321,7 @@ impl<
     type TLSEndpoint = Tls;
     type TokenFormat = Token;
     type ConnectionLimits = Limits;
-    type MtuConfig = MtuConfig;
+    type Mtu = Mtu;
     type StreamManager = stream::DefaultStreamManager;
     type PathMigrationValidator = PathMigration;
     type PacketInterceptor = PacketInterceptor;

--- a/quic/s2n-quic/src/client/providers.rs
+++ b/quic/s2n-quic/src/client/providers.rs
@@ -17,6 +17,7 @@ impl_providers_state! {
         random: Random,
         event: Event,
         limits: Limits,
+        mtu: MtuConfig,
         io: IO,
         sync: Sync,
         tls: Tls,
@@ -37,6 +38,7 @@ impl<
         Random: random::Provider,
         Event: event::Provider,
         Limits: limits::Provider,
+        MtuConfig: mtu::Provider,
         IO: io::Provider,
         Sync: sync::Provider,
         Tls: tls::Provider,
@@ -52,6 +54,7 @@ impl<
         Random,
         Event,
         Limits,
+        MtuConfig,
         IO,
         Sync,
         Tls,
@@ -69,6 +72,7 @@ impl<
             random,
             event,
             limits,
+            mtu,
             io,
             sync,
             tls,
@@ -86,6 +90,7 @@ impl<
         let random = random.start().map_err(StartError::new)?;
         let endpoint_limits = EndpointLimits;
         let limits = limits.start().map_err(StartError::new)?;
+        let mtu = mtu.start().map_err(StartError::new)?;
         let event = event.start().map_err(StartError::new)?;
         let token = Token;
         let sync = sync.start().map_err(StartError::new)?;
@@ -116,6 +121,7 @@ impl<
             endpoint_limits,
             event,
             limits,
+            mtu,
             sync,
             tls,
             token,
@@ -205,6 +211,7 @@ struct EndpointConfig<
     Random,
     Event,
     Limits,
+    MtuConfig,
     Sync,
     Tls,
     Datagram,
@@ -219,6 +226,7 @@ struct EndpointConfig<
     endpoint_limits: EndpointLimits,
     event: Event,
     limits: Limits,
+    mtu: MtuConfig,
     sync: Sync,
     tls: Tls,
     token: Token,
@@ -238,6 +246,7 @@ impl<
         Random: s2n_quic_core::random::Generator,
         Event: s2n_quic_core::event::Subscriber,
         Limits: s2n_quic_core::connection::limits::Limiter,
+        MtuConfig: s2n_quic_core::path::mtu::Configurator,
         Sync,
         Tls: crypto::tls::Endpoint,
         Datagram: s2n_quic_core::datagram::Endpoint,
@@ -253,6 +262,7 @@ impl<
         Random,
         Event,
         Limits,
+        MtuConfig,
         Sync,
         Tls,
         Datagram,
@@ -274,6 +284,7 @@ impl<
         Random: s2n_quic_core::random::Generator,
         Event: s2n_quic_core::event::Subscriber,
         Limits: s2n_quic_core::connection::limits::Limiter,
+        MtuConfig: s2n_quic_core::path::mtu::Configurator,
         Sync: 'static + Send,
         Tls: crypto::tls::Endpoint,
         Datagram: s2n_quic_core::datagram::Endpoint,
@@ -289,6 +300,7 @@ impl<
         Random,
         Event,
         Limits,
+        MtuConfig,
         Sync,
         Tls,
         Datagram,
@@ -309,6 +321,7 @@ impl<
     type TLSEndpoint = Tls;
     type TokenFormat = Token;
     type ConnectionLimits = Limits;
+    type MtuConfig = MtuConfig;
     type StreamManager = stream::DefaultStreamManager;
     type PathMigrationValidator = PathMigration;
     type PacketInterceptor = PacketInterceptor;
@@ -329,6 +342,7 @@ impl<
             endpoint_limits: &mut self.endpoint_limits,
             token: &mut self.token,
             connection_limits: &mut self.limits,
+            mtu: &mut self.mtu,
             event_subscriber: &mut self.event,
             path_migration: &mut self.path_migration,
             datagram: &mut self.datagram,

--- a/quic/s2n-quic/src/client/providers.rs
+++ b/quic/s2n-quic/src/client/providers.rs
@@ -110,6 +110,7 @@ impl<
         {
             return Err(StartError::new(connection::id::Error::InvalidLifetime));
         };
+        let mtu = path::MtuManager::new(mtu);
 
         let endpoint_config = EndpointConfig {
             congestion_controller,
@@ -211,7 +212,7 @@ struct EndpointConfig<
     Random,
     Event,
     Limits,
-    Mtu,
+    Mtu: path::Endpoint,
     Sync,
     Tls,
     Datagram,
@@ -226,7 +227,7 @@ struct EndpointConfig<
     endpoint_limits: EndpointLimits,
     event: Event,
     limits: Limits,
-    mtu: Mtu,
+    mtu: path::mtu::MtuManager<Mtu>,
     sync: Sync,
     tls: Tls,
     token: Token,

--- a/quic/s2n-quic/src/client/providers.rs
+++ b/quic/s2n-quic/src/client/providers.rs
@@ -110,7 +110,7 @@ impl<
         {
             return Err(StartError::new(connection::id::Error::InvalidLifetime));
         };
-        let mtu = path::MtuManager::new(mtu);
+        let mtu = path::mtu::Manager::new(mtu);
 
         let endpoint_config = EndpointConfig {
             congestion_controller,
@@ -227,7 +227,7 @@ struct EndpointConfig<
     endpoint_limits: EndpointLimits,
     event: Event,
     limits: Limits,
-    mtu: path::mtu::MtuManager<Mtu>,
+    mtu: path::mtu::Manager<Mtu>,
     sync: Sync,
     tls: Tls,
     token: Token,

--- a/quic/s2n-quic/src/provider.rs
+++ b/quic/s2n-quic/src/provider.rs
@@ -14,6 +14,7 @@ pub mod endpoint_limits;
 pub mod event;
 pub mod io;
 pub mod limits;
+pub mod mtu;
 pub mod stateless_reset_token;
 pub mod tls;
 

--- a/quic/s2n-quic/src/provider/mtu.rs
+++ b/quic/s2n-quic/src/provider/mtu.rs
@@ -3,7 +3,7 @@
 
 //! Provides a path specific MTU configuration.
 
-pub use s2n_quic_core::path::mtu::{Builder, Config, PathInfo, Endpoint};
+pub use s2n_quic_core::path::mtu::{Builder, Config, Endpoint, PathInfo};
 
 pub trait Provider {
     type Config: 'static + Send + Endpoint;

--- a/quic/s2n-quic/src/provider/mtu.rs
+++ b/quic/s2n-quic/src/provider/mtu.rs
@@ -3,10 +3,10 @@
 
 //! Provides MTU configuration at the connection level.
 
-pub use s2n_quic_core::path::mtu::{Config, Configurator, ConnectionInfo};
+pub use s2n_quic_core::path::mtu::{Config, ConnectionInfo, Endpoint};
 
 pub trait Provider {
-    type Config: 'static + Send + Configurator;
+    type Config: 'static + Send + Endpoint;
     type Error: 'static + core::fmt::Display + Send + Sync;
 
     fn start(self) -> Result<Self::Config, Self::Error>;
@@ -16,7 +16,7 @@ pub use default::Provider as Default;
 
 impl_provider_utils!();
 
-impl<T: 'static + Send + Configurator> Provider for T {
+impl<T: 'static + Send + Endpoint> Provider for T {
     type Config = T;
     type Error = core::convert::Infallible;
 

--- a/quic/s2n-quic/src/provider/mtu.rs
+++ b/quic/s2n-quic/src/provider/mtu.rs
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Provides a path specific MTU configuration.
+//!
+//! By default paths inherit the endpoint configured MTU values. Applications
+//! should implement this provider to override the MTU configuration for
+//! specific paths.
 
-pub use s2n_quic_core::path::mtu::{Builder, Config, Endpoint, Noop, PathInfo};
+pub use s2n_quic_core::path::mtu::{Builder, Config, Endpoint, Inherit as Default, PathInfo};
 
 pub trait Provider {
     type Config: 'static + Send + Endpoint;
@@ -11,8 +15,6 @@ pub trait Provider {
 
     fn start(self) -> Result<Self::Config, Self::Error>;
 }
-
-pub use Noop as Default;
 
 impl_provider_utils!();
 

--- a/quic/s2n-quic/src/provider/mtu.rs
+++ b/quic/s2n-quic/src/provider/mtu.rs
@@ -3,7 +3,7 @@
 
 //! Provides a path specific MTU configuration.
 
-pub use s2n_quic_core::path::mtu::{Builder, Config, Endpoint, PathInfo};
+pub use s2n_quic_core::path::mtu::{Builder, Config, Endpoint, Noop, PathInfo};
 
 pub trait Provider {
     type Config: 'static + Send + Endpoint;
@@ -12,7 +12,7 @@ pub trait Provider {
     fn start(self) -> Result<Self::Config, Self::Error>;
 }
 
-pub use Config as Default;
+pub use Noop as Default;
 
 impl_provider_utils!();
 

--- a/quic/s2n-quic/src/provider/mtu.rs
+++ b/quic/s2n-quic/src/provider/mtu.rs
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Provides MTU configuration at the connection level.
+//! Provides a path specific MTU configuration.
 
-pub use s2n_quic_core::path::mtu::{Builder, Config, ConnectionInfo, Endpoint};
+pub use s2n_quic_core::path::mtu::{Builder, Config, PathInfo, Endpoint};
 
 pub trait Provider {
     type Config: 'static + Send + Endpoint;

--- a/quic/s2n-quic/src/provider/mtu.rs
+++ b/quic/s2n-quic/src/provider/mtu.rs
@@ -1,0 +1,42 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provides MTU configuration at the connection level.
+
+pub use s2n_quic_core::path::mtu::{Config, Configurator, ConnectionInfo};
+
+pub trait Provider {
+    type Config: 'static + Send + Configurator;
+    type Error: 'static + core::fmt::Display + Send + Sync;
+
+    fn start(self) -> Result<Self::Config, Self::Error>;
+}
+
+pub use default::Provider as Default;
+
+impl_provider_utils!();
+
+impl<T: 'static + Send + Configurator> Provider for T {
+    type Config = T;
+    type Error = core::convert::Infallible;
+
+    fn start(self) -> Result<Self::Config, Self::Error> {
+        Ok(self)
+    }
+}
+
+pub mod default {
+    pub use s2n_quic_core::path::mtu::Builder;
+
+    #[derive(Debug, Default)]
+    pub struct Provider(());
+
+    impl super::Provider for Provider {
+        type Config = super::Config;
+        type Error = core::convert::Infallible;
+
+        fn start(self) -> Result<Self::Config, Self::Error> {
+            Ok(Self::Config::default())
+        }
+    }
+}

--- a/quic/s2n-quic/src/provider/mtu.rs
+++ b/quic/s2n-quic/src/provider/mtu.rs
@@ -3,7 +3,7 @@
 
 //! Provides MTU configuration at the connection level.
 
-pub use s2n_quic_core::path::mtu::{Config, ConnectionInfo, Endpoint};
+pub use s2n_quic_core::path::mtu::{Builder, Config, ConnectionInfo, Endpoint};
 
 pub trait Provider {
     type Config: 'static + Send + Endpoint;
@@ -12,7 +12,7 @@ pub trait Provider {
     fn start(self) -> Result<Self::Config, Self::Error>;
 }
 
-pub use default::Provider as Default;
+pub use Config as Default;
 
 impl_provider_utils!();
 
@@ -22,21 +22,5 @@ impl<T: 'static + Send + Endpoint> Provider for T {
 
     fn start(self) -> Result<Self::Config, Self::Error> {
         Ok(self)
-    }
-}
-
-pub mod default {
-    pub use s2n_quic_core::path::mtu::Builder;
-
-    #[derive(Debug, Default)]
-    pub struct Provider(());
-
-    impl super::Provider for Provider {
-        type Config = super::Config;
-        type Error = core::convert::Infallible;
-
-        fn start(self) -> Result<Self::Config, Self::Error> {
-            Ok(Self::Config::default())
-        }
     }
 }

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -172,6 +172,7 @@ impl<Providers: ServerProviders> Builder<Providers> {
         ///     fn on_path(
         ///         &mut self,
         ///         info: &mtu::PathInfo,
+        ///         endpoint_mtu_config: mtu::Config,
         ///     ) -> mtu::Config {
         ///         self.0
         ///     }

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -169,9 +169,9 @@ impl<Providers: ServerProviders> Builder<Providers> {
         /// struct MyMtuProvider(mtu::Config);
         ///
         /// impl mtu::Endpoint for MyMtuProvider {
-        ///     fn on_connection(
+        ///     fn on_path(
         ///         &mut self,
-        ///         info: &mtu::ConnectionInfo,
+        ///         info: &mtu::PathInfo,
         ///     ) -> mtu::Config {
         ///         self.0
         ///     }

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -156,7 +156,7 @@ impl<Providers: ServerProviders> Builder<Providers> {
         ///
         /// # Examples
         ///
-        /// Set custom MTU values to use per connections, while inheriting the remaining default
+        /// Set custom MTU values to use per connection, while inheriting the remaining default
         /// config
         ///
         /// ```rust,no_run
@@ -168,7 +168,7 @@ impl<Providers: ServerProviders> Builder<Providers> {
         ///
         /// struct MyMtuProvider(mtu::Config);
         ///
-        /// impl mtu::Configurator for MyMtuProvider {
+        /// impl mtu::Endpoint for MyMtuProvider {
         ///     fn on_connection(
         ///         &mut self,
         ///         info: &mtu::ConnectionInfo,

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -152,6 +152,45 @@ impl<Providers: ServerProviders> Builder<Providers> {
     );
 
     impl_provider_method!(
+        /// Sets the connection specific mtu config provider for the [`Server`]
+        ///
+        /// # Examples
+        ///
+        /// Set custom MTU values to use per connections, while inheriting the remaining default
+        /// config
+        ///
+        /// ```rust,no_run
+        /// # use std::{error::Error, time::Duration};
+        /// use s2n_quic::{Server, provider::mtu};
+        ///
+        /// # #[tokio::main]
+        /// # async fn main() -> Result<(), Box<dyn Error>> {
+        ///
+        /// struct MyMtuProvider(mtu::Config);
+        ///
+        /// impl mtu::Configurator for MyMtuProvider {
+        ///     fn on_connection(
+        ///         &mut self,
+        ///         info: &mtu::ConnectionInfo,
+        ///     ) -> mtu::Config {
+        ///         self.0
+        ///     }
+        /// }
+        /// let mtu = MyMtuProvider(mtu::Config::default());
+        ///
+        /// let server = Server::builder()
+        ///     .with_mtu(mtu)?
+        ///     .start()?;
+        /// #
+        /// #    Ok(())
+        /// # }
+        /// ```
+        with_mtu,
+        mtu,
+        ServerProviders
+    );
+
+    impl_provider_method!(
         /// Sets the event provider for the [`Server`]
         ///
         /// # Examples

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -152,11 +152,11 @@ impl<Providers: ServerProviders> Builder<Providers> {
     );
 
     impl_provider_method!(
-        /// Sets the connection specific mtu config provider for the [`Server`]
+        /// Sets the path specific mtu config provider for the [`Server`]
         ///
         /// # Examples
         ///
-        /// Set custom MTU values to use per connection, while inheriting the remaining default
+        /// Set custom MTU values to use per path, while inheriting the remaining default
         /// config
         ///
         /// ```rust,no_run
@@ -176,7 +176,7 @@ impl<Providers: ServerProviders> Builder<Providers> {
         ///         self.0
         ///     }
         /// }
-        /// let mtu = MyMtuProvider(mtu::Config::default());
+        /// let mtu = MyMtuProvider(mtu::Config::builder().build().unwrap());
         ///
         /// let server = Server::builder()
         ///     .with_mtu(mtu)?

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -173,8 +173,8 @@ impl<Providers: ServerProviders> Builder<Providers> {
         ///         &mut self,
         ///         info: &mtu::PathInfo,
         ///         endpoint_mtu_config: mtu::Config,
-        ///     ) -> mtu::Config {
-        ///         self.0
+        ///     ) -> Option<mtu::Config> {
+        ///         Some(self.0)
         ///     }
         /// }
         /// let mtu = MyMtuProvider(mtu::Config::builder().build().unwrap());

--- a/quic/s2n-quic/src/server/providers.rs
+++ b/quic/s2n-quic/src/server/providers.rs
@@ -18,7 +18,7 @@ impl_providers_state! {
         endpoint_limits: EndpointLimits,
         event: Event,
         limits: Limits,
-        mtu: MtuConfig,
+        mtu: Mtu,
         io: IO,
         path_migration: PathMigration,
         sync: Sync,
@@ -42,7 +42,7 @@ impl<
         EndpointLimits: endpoint_limits::Provider,
         Event: event::Provider,
         Limits: limits::Provider,
-        MtuConfig: mtu::Provider,
+        Mtu: mtu::Provider,
         IO: io::Provider,
         PathMigration: path_migration::Provider,
         Sync: sync::Provider,
@@ -61,7 +61,7 @@ impl<
         EndpointLimits,
         Event,
         Limits,
-        MtuConfig,
+        Mtu,
         IO,
         PathMigration,
         Sync,
@@ -168,7 +168,7 @@ struct EndpointConfig<
     EndpointLimits,
     Event,
     Limits,
-    MtuConfig,
+    Mtu,
     Sync,
     Tls,
     AddressToken,
@@ -184,7 +184,7 @@ struct EndpointConfig<
     endpoint_limits: EndpointLimits,
     event: Event,
     limits: Limits,
-    mtu: MtuConfig,
+    mtu: Mtu,
     sync: Sync,
     tls: Tls,
     address_token: AddressToken,
@@ -206,7 +206,7 @@ impl<
         EndpointLimits: s2n_quic_core::endpoint::Limiter,
         Event: s2n_quic_core::event::Subscriber,
         Limits: s2n_quic_core::connection::limits::Limiter,
-        MtuConfig: s2n_quic_core::path::mtu::Configurator,
+        Mtu: s2n_quic_core::path::mtu::Endpoint,
         Sync,
         Tls: crypto::tls::Endpoint,
         AddressToken: address_token::Format,
@@ -225,7 +225,7 @@ impl<
         EndpointLimits,
         Event,
         Limits,
-        MtuConfig,
+        Mtu,
         Sync,
         Tls,
         AddressToken,
@@ -250,7 +250,7 @@ impl<
         EndpointLimits: s2n_quic_core::endpoint::Limiter,
         Event: s2n_quic_core::event::Subscriber,
         Limits: s2n_quic_core::connection::limits::Limiter,
-        MtuConfig: s2n_quic_core::path::mtu::Configurator,
+        Mtu: s2n_quic_core::path::mtu::Endpoint,
         Sync: 'static + Send,
         Tls: crypto::tls::Endpoint,
         AddressToken: address_token::Format,
@@ -269,7 +269,7 @@ impl<
         EndpointLimits,
         Event,
         Limits,
-        MtuConfig,
+        Mtu,
         Sync,
         Tls,
         AddressToken,
@@ -291,7 +291,7 @@ impl<
     type TLSEndpoint = Tls;
     type TokenFormat = AddressToken;
     type ConnectionLimits = Limits;
-    type MtuConfig = MtuConfig;
+    type Mtu = Mtu;
     type StreamManager = stream::DefaultStreamManager;
     type PathMigrationValidator = PathMigration;
     type PacketInterceptor = PacketInterceptor;

--- a/quic/s2n-quic/src/server/providers.rs
+++ b/quic/s2n-quic/src/server/providers.rs
@@ -18,6 +18,7 @@ impl_providers_state! {
         endpoint_limits: EndpointLimits,
         event: Event,
         limits: Limits,
+        mtu: MtuConfig,
         io: IO,
         path_migration: PathMigration,
         sync: Sync,
@@ -41,6 +42,7 @@ impl<
         EndpointLimits: endpoint_limits::Provider,
         Event: event::Provider,
         Limits: limits::Provider,
+        MtuConfig: mtu::Provider,
         IO: io::Provider,
         PathMigration: path_migration::Provider,
         Sync: sync::Provider,
@@ -59,6 +61,7 @@ impl<
         EndpointLimits,
         Event,
         Limits,
+        MtuConfig,
         IO,
         PathMigration,
         Sync,
@@ -79,6 +82,7 @@ impl<
             endpoint_limits,
             event,
             limits,
+            mtu,
             address_token,
             io,
             path_migration,
@@ -98,6 +102,7 @@ impl<
         let random = random.start().map_err(StartError::new)?;
         let endpoint_limits = endpoint_limits.start().map_err(StartError::new)?;
         let limits = limits.start().map_err(StartError::new)?;
+        let mtu = mtu.start().map_err(StartError::new)?;
         let event = event.start().map_err(StartError::new)?;
         let address_token = address_token.start().map_err(StartError::new)?;
         let sync = sync.start().map_err(StartError::new)?;
@@ -128,6 +133,7 @@ impl<
             endpoint_limits,
             event,
             limits,
+            mtu,
             sync,
             tls,
             address_token,
@@ -162,6 +168,7 @@ struct EndpointConfig<
     EndpointLimits,
     Event,
     Limits,
+    MtuConfig,
     Sync,
     Tls,
     AddressToken,
@@ -177,6 +184,7 @@ struct EndpointConfig<
     endpoint_limits: EndpointLimits,
     event: Event,
     limits: Limits,
+    mtu: MtuConfig,
     sync: Sync,
     tls: Tls,
     address_token: AddressToken,
@@ -198,6 +206,7 @@ impl<
         EndpointLimits: s2n_quic_core::endpoint::Limiter,
         Event: s2n_quic_core::event::Subscriber,
         Limits: s2n_quic_core::connection::limits::Limiter,
+        MtuConfig: s2n_quic_core::path::mtu::Configurator,
         Sync,
         Tls: crypto::tls::Endpoint,
         AddressToken: address_token::Format,
@@ -216,6 +225,7 @@ impl<
         EndpointLimits,
         Event,
         Limits,
+        MtuConfig,
         Sync,
         Tls,
         AddressToken,
@@ -240,6 +250,7 @@ impl<
         EndpointLimits: s2n_quic_core::endpoint::Limiter,
         Event: s2n_quic_core::event::Subscriber,
         Limits: s2n_quic_core::connection::limits::Limiter,
+        MtuConfig: s2n_quic_core::path::mtu::Configurator,
         Sync: 'static + Send,
         Tls: crypto::tls::Endpoint,
         AddressToken: address_token::Format,
@@ -258,6 +269,7 @@ impl<
         EndpointLimits,
         Event,
         Limits,
+        MtuConfig,
         Sync,
         Tls,
         AddressToken,
@@ -279,6 +291,7 @@ impl<
     type TLSEndpoint = Tls;
     type TokenFormat = AddressToken;
     type ConnectionLimits = Limits;
+    type MtuConfig = MtuConfig;
     type StreamManager = stream::DefaultStreamManager;
     type PathMigrationValidator = PathMigration;
     type PacketInterceptor = PacketInterceptor;
@@ -299,6 +312,7 @@ impl<
             endpoint_limits: &mut self.endpoint_limits,
             token: &mut self.address_token,
             connection_limits: &mut self.limits,
+            mtu: &mut self.mtu,
             event_subscriber: &mut self.event,
             path_migration: &mut self.path_migration,
             datagram: &mut self.datagram,

--- a/quic/s2n-quic/src/server/providers.rs
+++ b/quic/s2n-quic/src/server/providers.rs
@@ -122,7 +122,7 @@ impl<
         {
             return Err(StartError::new(connection::id::Error::InvalidLifetime));
         };
-        let mtu = path::MtuManager::new(mtu);
+        let mtu = path::mtu::Manager::new(mtu);
 
         let endpoint_config = EndpointConfig {
             congestion_controller,
@@ -185,7 +185,7 @@ struct EndpointConfig<
     endpoint_limits: EndpointLimits,
     event: Event,
     limits: Limits,
-    mtu: path::mtu::MtuManager<Mtu>,
+    mtu: path::mtu::Manager<Mtu>,
     sync: Sync,
     tls: Tls,
     address_token: AddressToken,

--- a/quic/s2n-quic/src/server/providers.rs
+++ b/quic/s2n-quic/src/server/providers.rs
@@ -122,6 +122,7 @@ impl<
         {
             return Err(StartError::new(connection::id::Error::InvalidLifetime));
         };
+        let mtu = path::MtuManager::new(mtu);
 
         let endpoint_config = EndpointConfig {
             congestion_controller,
@@ -168,7 +169,7 @@ struct EndpointConfig<
     EndpointLimits,
     Event,
     Limits,
-    Mtu,
+    Mtu: path::Endpoint,
     Sync,
     Tls,
     AddressToken,
@@ -184,7 +185,7 @@ struct EndpointConfig<
     endpoint_limits: EndpointLimits,
     event: Event,
     limits: Limits,
-    mtu: Mtu,
+    mtu: path::mtu::MtuManager<Mtu>,
     sync: Sync,
     tls: Tls,
     address_token: AddressToken,

--- a/quic/s2n-quic/src/tests/mtu.rs
+++ b/quic/s2n-quic/src/tests/mtu.rs
@@ -12,7 +12,7 @@ use s2n_quic_core::{
 struct CustomMtu(mtu::Config);
 
 impl mtu::Endpoint for CustomMtu {
-    fn on_connection(&mut self, _info: &mtu::PathInfo) -> mtu::Config {
+    fn on_path(&mut self, _info: &mtu::PathInfo) -> mtu::Config {
         self.0
     }
 }
@@ -21,7 +21,7 @@ impl mtu::Endpoint for CustomMtu {
 // back. The MtuUpdated events that the server experiences are recorded and
 // returns at the end of the simulation.
 fn mtu_updates(
-    conn_mtu_config: Option<mtu::Config>,
+    config_override: Option<mtu::Config>,
     initial_mtu: u16,
     base_mtu: u16,
     max_mtu: u16,
@@ -47,8 +47,8 @@ fn mtu_updates(
             .with_event((tracing_events(), subscriber))?
             .with_random(Random::with_seed(456))?;
 
-        let server = if let Some(conn_mtu_config) = conn_mtu_config {
-            server.with_mtu(CustomMtu(conn_mtu_config))?.start()?
+        let server = if let Some(config_override) = config_override {
+            server.with_mtu(CustomMtu(config_override))?.start()?
         } else {
             server.start()?
         };

--- a/quic/s2n-quic/src/tests/mtu.rs
+++ b/quic/s2n-quic/src/tests/mtu.rs
@@ -11,7 +11,7 @@ use s2n_quic_core::{
 
 struct CustomMtu(mtu::Config);
 
-impl mtu::Configurator for CustomMtu {
+impl mtu::Endpoint for CustomMtu {
     fn on_connection(&mut self, _info: &mtu::ConnectionInfo) -> mtu::Config {
         self.0
     }

--- a/quic/s2n-quic/src/tests/mtu.rs
+++ b/quic/s2n-quic/src/tests/mtu.rs
@@ -12,8 +12,12 @@ use s2n_quic_core::{
 struct CustomMtu(mtu::Config);
 
 impl mtu::Endpoint for CustomMtu {
-    fn on_path(&mut self, _info: &mtu::PathInfo, _endpoint_mtu_config: mtu::Config) -> mtu::Config {
-        self.0
+    fn on_path(
+        &mut self,
+        _info: &mtu::PathInfo,
+        _endpoint_mtu_config: mtu::Config,
+    ) -> Option<mtu::Config> {
+        Some(self.0)
     }
 }
 

--- a/quic/s2n-quic/src/tests/mtu.rs
+++ b/quic/s2n-quic/src/tests/mtu.rs
@@ -12,7 +12,7 @@ use s2n_quic_core::{
 struct CustomMtu(mtu::Config);
 
 impl mtu::Endpoint for CustomMtu {
-    fn on_connection(&mut self, _info: &mtu::ConnectionInfo) -> mtu::Config {
+    fn on_connection(&mut self, _info: &mtu::PathInfo) -> mtu::Config {
         self.0
     }
 }

--- a/quic/s2n-quic/src/tests/mtu.rs
+++ b/quic/s2n-quic/src/tests/mtu.rs
@@ -6,13 +6,22 @@ use s2n_codec::encoder::scatter;
 use s2n_quic_core::{
     event::api::Subject,
     packet::interceptor::{Interceptor, Packet},
-    path::{BaseMtu, InitialMtu},
+    path::{mtu, BaseMtu, InitialMtu},
 };
+
+struct CustomMtu(mtu::Config);
+
+impl mtu::Configurator for CustomMtu {
+    fn on_connection(&mut self, _info: &mtu::ConnectionInfo) -> mtu::Config {
+        self.0
+    }
+}
 
 // Construct a simulation where a client sends some data, which the server echos
 // back. The MtuUpdated events that the server experiences are recorded and
 // returns at the end of the simulation.
 fn mtu_updates(
+    conn_mtu_config: Option<mtu::Config>,
     initial_mtu: u16,
     base_mtu: u16,
     max_mtu: u16,
@@ -36,8 +45,14 @@ fn mtu_updates(
             )?
             .with_tls(SERVER_CERTS)?
             .with_event((tracing_events(), subscriber))?
-            .with_random(Random::with_seed(456))?
-            .start()?;
+            .with_random(Random::with_seed(456))?;
+
+        let server = if let Some(conn_mtu_config) = conn_mtu_config {
+            server.with_mtu(CustomMtu(conn_mtu_config))?.start()?
+        } else {
+            server.start()?
+        };
+
         let client = Client::builder()
             .with_io(
                 handle
@@ -68,6 +83,7 @@ fn mtu_updates(
 #[test]
 fn mtu_probe_jumbo_frame_test() {
     let events = mtu_updates(
+        None,
         InitialMtu::default().into(),
         BaseMtu::default().into(),
         9_001,
@@ -99,6 +115,7 @@ fn mtu_probe_jumbo_frame_test() {
 #[test]
 fn mtu_probe_jumbo_frame_unsupported_test() {
     let events = mtu_updates(
+        None,
         InitialMtu::default().into(),
         BaseMtu::default().into(),
         9_001,
@@ -112,7 +129,7 @@ fn mtu_probe_jumbo_frame_unsupported_test() {
 // The configured base mtu is the smallest MTU used
 #[test]
 fn base_mtu() {
-    let events = mtu_updates(1250, 1250, 9_001, 10_000);
+    let events = mtu_updates(None, 1250, 1250, 9_001, 10_000);
     let base_mtu = events
         .iter()
         .min_by_key(|&mtu_event| mtu_event.mtu)
@@ -124,17 +141,76 @@ fn base_mtu() {
 // The configured initial mtu is the first MTU used
 #[test]
 fn initial_mtu() {
-    let events = mtu_updates(2000, BaseMtu::default().into(), 9_001, 10_000);
+    let events = mtu_updates(None, 2000, BaseMtu::default().into(), 9_001, 10_000);
     let first_mtu = events.first().unwrap();
     // 2000 - UDP_HEADER_LEN - IPV4_HEADER_LEN
     assert_eq!(first_mtu.mtu, 1972);
+}
+
+// Connection specific initial MTU
+//
+// Override the initial (first) MTU we can use for the connection.
+#[test]
+fn conn_mtu_initial() {
+    let events = mtu_updates(None, 1228, BaseMtu::default().into(), 9_001, 10_000);
+    let first_mtu = events.first().unwrap();
+    // 1228 - UDP_HEADER_LEN - IPV4_HEADER_LEN
+    assert_eq!(first_mtu.mtu, 1200);
+
+    let config = mtu::Config::builder()
+        .with_initial_mtu(1328)
+        .unwrap()
+        .build()
+        .unwrap();
+    let events = mtu_updates(Some(config), 1228, BaseMtu::default().into(), 9_001, 10_000);
+    let first_mtu = events.first().unwrap();
+    // 1528 - UDP_HEADER_LEN - IPV4_HEADER_LEN
+    assert_eq!(first_mtu.mtu, 1300);
+}
+
+// Connection specific base MTU
+//
+// Override the base (lowest) MTU we can use for the connection.
+#[test]
+fn conn_mtu_base() {
+    let events = mtu_updates(None, 1228, BaseMtu::default().into(), 9_001, 10_000);
+    let first_mtu = events.first().unwrap();
+    assert_eq!(first_mtu.mtu, 1200);
+
+    let config = mtu::Config::builder()
+        .with_base_mtu(1328)
+        .unwrap()
+        .build()
+        .unwrap();
+    let events = mtu_updates(Some(config), 1228, BaseMtu::default().into(), 9_001, 10_000);
+    let first_mtu = events.first().unwrap();
+    assert_eq!(first_mtu.mtu, 1300);
+}
+
+// Connection specific max MTU
+//
+// Override the max MTU we can use for the connection.
+#[test]
+fn conn_mtu_max() {
+    let events = mtu_updates(None, 1228, BaseMtu::default().into(), 9_001, 10_000);
+    let last_mtu = events.last().unwrap();
+    assert_eq!(last_mtu.mtu, 8943);
+
+    let config = mtu::Config::builder()
+        .with_max_mtu(6_000)
+        .unwrap()
+        .build()
+        .unwrap();
+    let events = mtu_updates(Some(config), 1228, BaseMtu::default().into(), 9_001, 10_000);
+    let last_mtu = events.last().unwrap();
+    assert_eq!(last_mtu.mtu, 5_936);
 }
 
 // The configured initial mtu is the first MTU used. It is not supported by the network, so
 // the MTU drops to the base MTU, before increasing back to what the network supports.
 #[test]
 fn initial_mtu_not_supported() {
-    let events = mtu_updates(2000, BaseMtu::default().into(), 9_001, 1500);
+    let events = mtu_updates(None, 2000, BaseMtu::default().into(), 9_001, 1500);
     let first_mtu = events.first().unwrap();
     let second_mtu = events.get(1).unwrap();
     let last_mtu = events.last().unwrap();
@@ -149,7 +225,7 @@ fn initial_mtu_not_supported() {
 // The configured initial MTU is jumbo and the network supports it.
 #[test]
 fn initial_mtu_is_jumbo() {
-    let events = mtu_updates(9_001, BaseMtu::default().into(), 9_001, 10_000);
+    let events = mtu_updates(None, 9_001, BaseMtu::default().into(), 9_001, 10_000);
     let first_mtu = events.first().unwrap();
     let last_mtu = events.last().unwrap();
     // First try the initial MTU
@@ -162,7 +238,7 @@ fn initial_mtu_is_jumbo() {
 // MTU is used next.
 #[test]
 fn initial_mtu_is_jumbo_not_supported() {
-    let events = mtu_updates(9_001, 1_500, 9_001, 2_500);
+    let events = mtu_updates(None, 9_001, 1_500, 9_001, 2_500);
     let first_mtu = events.first().unwrap();
     let second_mtu = events.get(1).unwrap();
     let last_mtu = events.last().unwrap();
@@ -325,7 +401,7 @@ fn minimum_initial_packet() {
     );
 }
 
-/// Truncates paddings
+/// Erase client hello
 struct EraseClientHello;
 
 impl Interceptor for EraseClientHello {

--- a/quic/s2n-quic/src/tests/mtu.rs
+++ b/quic/s2n-quic/src/tests/mtu.rs
@@ -12,7 +12,7 @@ use s2n_quic_core::{
 struct CustomMtu(mtu::Config);
 
 impl mtu::Endpoint for CustomMtu {
-    fn on_path(&mut self, _info: &mtu::PathInfo) -> mtu::Config {
+    fn on_path(&mut self, _info: &mtu::PathInfo, _endpoint_mtu_config: mtu::Config) -> mtu::Config {
         self.0
     }
 }


### PR DESCRIPTION
### Description of changes: 
While it is currently possible to specify MTU setting on the [IO provider](https://docs.rs/s2n-quic/latest/s2n_quic/provider/io/tokio/struct.Builder.html#method.with_initial_mtu) (endpoint specific configuration), an application may want to specify these values per connection.

This PR exposes an MTU provider that allows Applications to provide MTU values at connection granularity. The MTU provider exposes `remote_address` and `endpoint_config`, which Applications can use to identify the connection.

### Usecases:
By default s2n-quic will attempt to set the DF (dont fragment) and do MTU probing on a path. The only way to disable MTU probing is to set the initial, base, and max MTU to the same values. With the inclusion of the MTU provider, Applications can disable MTU probing at the connection level rather than the entire endpoint.

MTU probing can lead to higher path MTUs and therefore lead to better transmission efficiency (25% = (1500-1200)/1200). However, probing for higher MTUs takes time and therefore doesn't benefit Initial and Handshake packets. Applications operating on predictable networks could set the MTU values for known paths and also benefit from efficiency gains during connection establishment.

### Testing:
- Unit tests to confirm that the MTU provider values propagate to the path.
- Unit test to confirm that validation is enforced.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

