### PR TITLE
build(deps): update bolero to 0.11.0

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -19,14 +19,14 @@ checked_range_unsafe = []
 generator = ["bolero-generator"]
 
 [dependencies]
-bolero-generator = { version = "0.10", default-features = false, optional = true }
+bolero-generator = { version = "0.11", default-features = false, optional = true }
 byteorder = { version = "1.1", default-features = false }
 bytes = { version = "1", default-features = false, optional = true }
 zerocopy = { version = "0.7", features = ["derive"] }
 
 [dev-dependencies]
-bolero = "0.10"
-bolero-generator = "0.10"
+bolero = "0.11"
+bolero-generator = "0.11"
 
 [package.metadata.kani]
 flags = { tests = true }

--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -30,7 +30,7 @@ tracing = "0.1"
 zerocopy = { version = "0.7", features = ["derive"] }
 
 [dev-dependencies]
-bolero = "0.10"
+bolero = "0.11"
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
 s2n-quic-core = { path = "../../quic/s2n-quic-core", features = ["testing"] }
 tokio = { version = "1", features = ["io-util"] }

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -27,7 +27,7 @@ usdt = ["dep:probe"]
 
 [dependencies]
 atomic-waker = { version = "1", optional = true }
-bolero-generator = { version = "0.10", optional = true }
+bolero-generator = { version = "0.11", optional = true }
 byteorder = { version = "1", default-features = false }
 bytes = { version = "1", optional = true, default-features = false }
 crossbeam-utils = { version = "0.8", optional = true }
@@ -47,8 +47,8 @@ futures-test = { version = "0.3", optional = true } # For testing Waker interact
 once_cell = { version = "1", optional = true }
 
 [dev-dependencies]
-bolero = "0.10"
-bolero-generator = "0.10"
+bolero = "0.11"
+bolero-generator = "0.11"
 insta = { version = "1", features = ["json"] }
 futures = "0.3"
 futures-test = "0.3"

--- a/quic/s2n-quic-core/src/inet/checksum.rs
+++ b/quic/s2n-quic-core/src/inet/checksum.rs
@@ -58,9 +58,9 @@ fn write_sized_generic<'a, const MAX_LEN: usize, const CHUNK_LEN: usize>(
     //# }
 
     while bytes.len() >= MAX_LEN {
-        let (chunks, remaining) = bytes.split_at(MAX_LEN);
-
-        bytes = remaining;
+        // use `get_unchecked` to make it easier for kani to analyze
+        let chunks = unsafe { bytes.get_unchecked(..MAX_LEN) };
+        bytes = unsafe { bytes.get_unchecked(MAX_LEN..) };
 
         let mut sum = 0;
         // for each pair of bytes, interpret them as integers and sum them up

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -21,7 +21,7 @@ xdp = ["s2n-quic-xdp"]
 
 [dependencies]
 bach = { version = "0.0.6", optional = true }
-bolero-generator = { version = "0.10", optional = true }
+bolero-generator = { version = "0.11", optional = true }
 cfg-if = "1"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 lazy_static = { version = "1", optional = true }
@@ -37,8 +37,8 @@ libc = "0.2"
 
 [dev-dependencies]
 bach = { version = "0.0.6" }
-bolero = "0.10"
-bolero-generator = "0.10"
+bolero = "0.11"
+bolero-generator = "0.11"
 futures = { version = "0.3", features = ["std"] }
 insta = { version = "1", features = ["json"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -28,7 +28,7 @@ siphasher = "1.0"
 smallvec = { version = "1", default-features = false }
 
 [dev-dependencies]
-bolero = "0.10"
+bolero = "0.11"
 futures-test = "0.3" # For testing Waker interactions
 insta = { version = "1", features = ["json"] }
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }

--- a/quic/s2n-quic-transport/src/ack/tests/generator.rs
+++ b/quic/s2n-quic-transport/src/ack/tests/generator.rs
@@ -3,7 +3,7 @@
 
 use bolero::generator::*;
 use core::time::Duration;
-use s2n_quic_core::{ack, inet::ExplicitCongestionNotification};
+use s2n_quic_core::ack;
 
 pub fn gen_ack_settings() -> impl ValueGenerator<Output = ack::Settings> {
     (gen_duration(), 0..20).map_gen(|(max_ack_delay, ack_delay_exponent)| ack::Settings {
@@ -13,20 +13,6 @@ pub fn gen_ack_settings() -> impl ValueGenerator<Output = ack::Settings> {
     })
 }
 
-pub fn gen_default<V: Default>() -> impl ValueGenerator<Output = V> {
-    gen::<()>().map_gen(|()| V::default())
-}
-
 pub fn gen_duration() -> impl ValueGenerator<Output = Duration> {
     (1u16..10_000).map_gen(|millis| Duration::from_millis(millis as u64))
-}
-
-pub fn gen_ecn() -> impl ValueGenerator<Output = ExplicitCongestionNotification> {
-    gen::<bool>().map_gen(|has_congestion| {
-        if has_congestion {
-            ExplicitCongestionNotification::Ce
-        } else {
-            ExplicitCongestionNotification::default()
-        }
-    })
 }

--- a/quic/s2n-quic-transport/src/ack/tests/network_event.rs
+++ b/quic/s2n-quic-transport/src/ack/tests/network_event.rs
@@ -1,10 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{
-    generator::{gen_duration, gen_ecn},
-    EndpointReport, Packet,
-};
+use super::{generator::gen_duration, EndpointReport, Packet};
 use bolero::generator::*;
 use core::time::Duration;
 use s2n_quic_core::inet::ExplicitCongestionNotification;
@@ -13,7 +10,7 @@ use s2n_quic_core::inet::ExplicitCongestionNotification;
 pub enum NetworkEvent {
     Pass,
     Drop,
-    Ecn(#[generator(gen_ecn())] ExplicitCongestionNotification),
+    Ecn(ExplicitCongestionNotification),
     Delay(#[generator(gen_duration())] Duration),
 }
 

--- a/quic/s2n-quic-transport/src/ack/tests/network_interface.rs
+++ b/quic/s2n-quic-transport/src/ack/tests/network_interface.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{generator::gen_default, Application, Packet};
+use super::{Application, Packet};
 use alloc::collections::BTreeMap;
 use bolero::generator::*;
 use s2n_quic_core::{endpoint, time::Timestamp};
@@ -9,7 +9,7 @@ use s2n_quic_core::{endpoint, time::Timestamp};
 #[derive(Clone, Debug, TypeGenerator)]
 pub struct NetworkInterface {
     pub application: Application,
-    #[generator(gen_default())]
+    #[generator(constant(Default::default()))]
     rx_queue: BTreeMap<Timestamp, Packet>,
 }
 

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -80,7 +80,7 @@ zerocopy = { version = "0.7", optional = true, features = ["derive"] }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-bolero = { version = "0.10" }
+bolero = { version = "0.11" }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "probe-tracing", "testing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }
 s2n-quic-transport = { version = "=0.37.0", path = "../s2n-quic-transport", features = ["unstable_resumption"] }

--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -23,7 +23,7 @@ s2n-quic-core = { version = "=0.37.0", path = "../../../quic/s2n-quic-core" }
 tokio = { version = "1", features = ["net"], optional = true }
 
 [dev-dependencies]
-bolero = "0.10"
+bolero = "0.11"
 futures = "0.3"
 pin-project-lite = "0.2"
 rand = "0.8"


### PR DESCRIPTION
### Description of changes: 

`bolero` `v0.11` was released. This updates our dependency.

### Callouts

I fixed the checksum tests with kani that slowed down after a change in the rustc version (see https://github.com/model-checking/kani/issues/3030). Using `get_unchecked` instead of `split_at` seems to have improved performance quite a bit - the job now completes in [10m](https://github.com/aws/s2n-quic/actions/runs/9453148563/job/26037892798) instead of [15m](https://github.com/aws/s2n-quic/actions/runs/9406675053/job/25910651328).

### Testing:

The CI tests should continue to pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

