### PR TITLE
feat(s2n-quic-dc): add socket constructor

### DIFF
--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -36,6 +36,7 @@ zerocopy = { version = "0.7", features = ["derive"] }
 [dev-dependencies]
 bolero = "0.11"
 bolero-generator = "0.11"
+insta = "1"
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
 s2n-quic-core = { path = "../../quic/s2n-quic-core", features = ["testing"] }
 tokio = { version = "1", features = ["io-util"] }

--- a/dc/s2n-quic-dc/src/lib.rs
+++ b/dc/s2n-quic-dc/src/lib.rs
@@ -11,4 +11,5 @@ pub mod packet;
 pub mod path;
 pub mod pool;
 pub mod recovery;
+pub mod socket;
 pub mod stream;

--- a/dc/s2n-quic-dc/src/socket.rs
+++ b/dc/s2n-quic-dc/src/socket.rs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(target_os = "linux")]
+mod bpf;
+// this module is used on platforms other than linux, but we still want to make
+// sure it compiles
+#[cfg_attr(target_os = "linux", allow(dead_code))]
+mod pair;
+
+#[cfg(target_os = "linux")]
+pub use bpf::Pair;
+#[cfg(not(target_os = "linux"))]
+pub use pair::Pair;
+
+pub use s2n_quic_platform::socket::options::{Options, ReusePort};

--- a/dc/s2n-quic-dc/src/socket/bpf.rs
+++ b/dc/s2n-quic-dc/src/socket/bpf.rs
@@ -1,0 +1,215 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Options;
+use crate::packet::stream;
+use s2n_quic_platform::bpf::cbpf::*;
+use std::{io, net::UdpSocket};
+
+/// Program for routing packets between two sockets based on the packet tag
+///
+/// High-level algorithm with asm is available here: https://godbolt.org/z/crxT4d53j
+pub static ROUTER: Program = Program::new(&[
+    // load the first byte of the packet
+    ldb(0),
+    // mask off the LSBs
+    and(!stream::Tag::MAX as _),
+    // IF:
+    // the control bit is set
+    jneq(stream::Tag::MAX as u32 + 1, 1, 0),
+    // THEN:
+    // return a 0 indicating we want to route to the writer socket
+    ret(0),
+    // ELSE:
+    // return a 1 indicating we want to route to the reader socket
+    ret(1),
+]);
+
+#[derive(Debug)]
+pub struct Pair {
+    pub writer: UdpSocket,
+    pub reader: UdpSocket,
+}
+
+impl Pair {
+    #[inline]
+    pub fn open(mut options: Options) -> io::Result<Self> {
+        // GRO is not compatible with this mode of operation
+        options.gro = false;
+        // set the reuse port option after binding to avoid port collisions
+        options.reuse_port = super::ReusePort::AfterBind;
+
+        let writer = options.build_udp()?;
+
+        // bind the sockets to the same address
+        options.addr = writer.local_addr()?;
+        // now that we have a concrete port from the OS, we set the option before the bind call
+        options.reuse_port = super::ReusePort::BeforeBind;
+
+        let reader = options.build_udp()?;
+
+        // attach the BPF program to the sockets
+        for socket in [&reader, &writer] {
+            ROUTER.attach(socket)?;
+        }
+
+        Ok(Self { writer, reader })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::packet::control;
+    use core::{
+        sync::atomic::{AtomicUsize, Ordering},
+        time::Duration,
+    };
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn snapshot_test() {
+        insta::assert_snapshot!(ROUTER);
+    }
+
+    #[derive(Debug, Default, PartialEq, Eq)]
+    struct Counts {
+        stream: usize,
+        control: usize,
+        garbage: usize,
+    }
+
+    impl Counts {
+        #[inline]
+        fn handle(&mut self, byte: u8) {
+            if byte <= stream::Tag::MAX {
+                self.stream += 1;
+            } else if byte >= 0b1000_0000 {
+                self.garbage += 1;
+            } else {
+                self.control += 1;
+            }
+        }
+
+        fn total(&self) -> usize {
+            self.stream + self.control + self.garbage
+        }
+    }
+
+    #[test]
+    fn routing_test() {
+        let mut options = Options::new("127.0.0.1:0".parse().unwrap());
+        options.blocking = true;
+
+        let Pair { writer, reader } = Pair::open(options).unwrap();
+
+        let timeout = Some(Duration::from_millis(100));
+        writer.set_read_timeout(timeout).unwrap();
+        reader.set_read_timeout(timeout).unwrap();
+
+        let addr = writer.local_addr().unwrap();
+
+        assert_eq!(addr, reader.local_addr().unwrap());
+
+        let mut reader_packets = Counts::default();
+        let mut writer_packets = Counts::default();
+        let sent_packets = AtomicUsize::new(0);
+
+        std::thread::scope(|s| {
+            s.spawn(|| {
+                let mut buffer = [0; 32];
+                while let Ok((_len, _src)) = reader.recv_from(&mut buffer) {
+                    reader_packets.handle(buffer[0]);
+                }
+            });
+
+            s.spawn(|| {
+                let mut buffer = [0; 32];
+                while let Ok((_len, _src)) = writer.recv_from(&mut buffer) {
+                    writer_packets.handle(buffer[0]);
+                }
+            });
+
+            for _ in 0..4 {
+                let client = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
+                // pace out senders to avoid drops on the receiver
+                std::thread::sleep(core::time::Duration::from_millis(1));
+                let sent_packets = &sent_packets;
+                s.spawn(move || {
+                    for idx in 0u32..300 {
+                        let mut packet = idx.to_le_bytes();
+                        packet[0] = if idx % 2 == 0 {
+                            // send a control packet
+                            control::Tag::MAX
+                        } else if idx / 2 % 2 == 0 {
+                            // send a stream packet
+                            stream::Tag::MAX
+                        } else {
+                            // send a garbage packet with the MSB set
+                            control::Tag::MAX | 0b1000_0000
+                        };
+
+                        client.send_to(&packet, addr).unwrap();
+
+                        sent_packets.fetch_add(1, Ordering::Relaxed);
+
+                        // pace out packets to avoid drops on the receiver
+                        if idx % 10 == 0 {
+                            std::thread::sleep(core::time::Duration::from_millis(5));
+                        }
+                    }
+
+                    dbg!();
+                });
+            }
+        });
+
+        dbg!(&reader_packets);
+        dbg!(&writer_packets);
+
+        // sometimes this test is a bit flaky in CI so we'll just log the failure for now
+        if reader_packets == Default::default() || writer_packets == Default::default() {
+            use std::io::{stderr, Write};
+
+            // we need to use stderr directly to bypass test harness capture
+            let _ = stderr()
+                .write_all(b"WARNING: no packets were received in cbpf test - skipping test\n");
+
+            return;
+        }
+
+        assert_eq!(writer_packets.stream, 0);
+        assert_eq!(writer_packets.garbage, 0);
+        assert_ne!(writer_packets.control, 0);
+
+        assert_ne!(reader_packets.stream, 0);
+        assert_ne!(reader_packets.garbage, 0);
+        assert_eq!(reader_packets.control, 0);
+
+        let reader_packets = reader_packets.total();
+        let writer_packets = writer_packets.total();
+
+        assert!(
+            reader_packets.abs_diff(writer_packets) < reader_packets.max(writer_packets) / 2,
+            "the difference should be less than half of the max received packets"
+        );
+    }
+
+    #[test]
+    fn routing_logic() {
+        let mut sockets = [Counts::default(), Counts::default()];
+
+        for byte in 0..=u8::MAX {
+            let index = match byte >> 6 {
+                // control bit is set - route to writer
+                0b01 => 0,
+                // otherwise route to reader
+                _ => 1,
+            };
+
+            sockets[index].handle(byte);
+        }
+
+        insta::assert_debug_snapshot!((&sockets[0], &sockets[1]));
+    }
+}

--- a/dc/s2n-quic-dc/src/socket/pair.rs
+++ b/dc/s2n-quic-dc/src/socket/pair.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::Options;
+use super::{Options, ReusePort};
 use std::{io, net::UdpSocket};
 
 pub struct Pair {
@@ -15,7 +15,7 @@ impl Pair {
         // have the OS select a random port for us
         options.addr.set_port(0);
         // don't reuse the ports since we don't have a consistent way to route packets
-        options.reuse_port = Default::default();
+        options.reuse_port = ReusePort::Disabled;
 
         let writer = options.build_udp()?;
         let reader = options.build_udp()?;

--- a/dc/s2n-quic-dc/src/socket/pair.rs
+++ b/dc/s2n-quic-dc/src/socket/pair.rs
@@ -1,0 +1,25 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Options;
+use std::{io, net::UdpSocket};
+
+pub struct Pair {
+    pub writer: UdpSocket,
+    pub reader: UdpSocket,
+}
+
+impl Pair {
+    #[inline]
+    pub fn open(mut options: Options) -> io::Result<Self> {
+        // have the OS select a random port for us
+        options.addr.set_port(0);
+        // don't reuse the ports since we don't have a consistent way to route packets
+        options.reuse_port = Default::default();
+
+        let writer = options.build_udp()?;
+        let reader = options.build_udp()?;
+
+        Ok(Self { writer, reader })
+    }
+}

--- a/dc/s2n-quic-dc/src/socket/snapshots/s2n_quic_dc__socket__bpf__tests__routing_logic.snap
+++ b/dc/s2n-quic-dc/src/socket/snapshots/s2n_quic_dc__socket__bpf__tests__routing_logic.snap
@@ -1,0 +1,16 @@
+---
+source: dc/s2n-quic-dc/src/socket/bpf.rs
+expression: "(&sockets[0], &sockets[1])"
+---
+(
+    Counts {
+        stream: 0,
+        control: 64,
+        garbage: 0,
+    },
+    Counts {
+        stream: 64,
+        control: 0,
+        garbage: 128,
+    },
+)

--- a/dc/s2n-quic-dc/src/socket/snapshots/s2n_quic_dc__socket__bpf__tests__snapshot_test.snap
+++ b/dc/s2n-quic-dc/src/socket/snapshots/s2n_quic_dc__socket__bpf__tests__snapshot_test.snap
@@ -1,0 +1,9 @@
+---
+source: dc/s2n-quic-dc/src/socket/bpf.rs
+expression: ROUTER
+---
+LDB [0]
+AND #192
+JEQ #64,0,1
+RET #0
+RET #1

--- a/quic/s2n-quic-platform/src/bpf.rs
+++ b/quic/s2n-quic-platform/src/bpf.rs
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[macro_use]
+pub mod instruction;
+#[macro_use]
+mod common;
+
+pub mod cbpf;
+pub mod ebpf;
+mod program;
+
+pub use cbpf::Cbpf;
+pub use ebpf::Ebpf;
+pub use instruction::Instruction;
+pub use program::Program;

--- a/quic/s2n-quic-platform/src/bpf/cbpf.rs
+++ b/quic/s2n-quic-platform/src/bpf/cbpf.rs
@@ -1,0 +1,230 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::fmt;
+
+pub use super::common::*;
+pub type Instruction = super::Instruction<Cbpf>;
+pub type Program<'a> = super::Program<'a, Cbpf>;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct Cbpf;
+
+impl super::instruction::Dialect for Cbpf {
+    // https://github.com/torvalds/linux/blob/b947cc5bf6d793101135265352e205aeb30b54f0/include/uapi/linux/bpf_common.h#L54
+    const MAX_INSTRUCTIONS: usize = 4096;
+    const SOCKOPT: libc::c_int = libc::SO_ATTACH_REUSEPORT_CBPF as _;
+
+    fn debug(i: &Instruction, f: &mut fmt::Formatter) -> fmt::Result {
+        let code = i.code;
+        let k = i.k;
+        let jt = i.jt;
+        let jf = i.jf;
+        let alt = f.alternate();
+
+        let mut f = f.debug_struct("Instruction");
+        let class = Class::decode(code);
+
+        if alt {
+            f.field("code", &code).field("jt", &jt).field("jf", &jf);
+        }
+
+        f.field("class", &class);
+
+        match class {
+            Class::ALU => {
+                f.field("op", &Alu::decode(code));
+            }
+            Class::JMP => {
+                f.field("op", &Jump::decode(code));
+            }
+            Class::LD | Class::LDX | Class::RET => {
+                f.field("size", &Size::decode(code))
+                    .field("mode", &Mode::decode(code));
+            }
+            _ => {}
+        }
+
+        if jt > 0 {
+            f.field("jt", &jt);
+        }
+
+        if jf > 0 {
+            f.field("jf", &jf);
+        }
+
+        f.field("k", &k).finish()
+    }
+
+    fn display(i: &Instruction, f: &mut fmt::Formatter) -> fmt::Result {
+        let code = i.code;
+        let k = i.k;
+        let jt = i.jt;
+        let jf = i.jf;
+
+        let class = Class::decode(code);
+
+        match class {
+            Class::LD | Class::LDX => {
+                let size = Size::decode(code).suffix();
+                let mode = Mode::decode(code);
+
+                match mode {
+                    Mode::IMM => return write!(f, "{class}{size} #{k}"),
+                    Mode::ABS => return write!(f, "{class}{size} [{k}]"),
+                    _ => {}
+                }
+            }
+            Class::ALU => {
+                let op = Alu::decode(code);
+                let source = Source::decode(code);
+
+                return match source {
+                    Source::K => write!(f, "{op} #{k}"),
+                    Source::X => write!(f, "{op} x"),
+                };
+            }
+            Class::JMP => {
+                let op = Jump::decode(code);
+                let source = Source::decode(code);
+
+                return match source {
+                    Source::K => write!(f, "{op} #{k},{jt},{jf}"),
+                    Source::X => write!(f, "{op} x,{jt},{jf}"),
+                };
+            }
+            Class::RET => {
+                let source = Source::decode(code);
+
+                return match source {
+                    Source::K => write!(f, "{class} #{k}"),
+                    Source::X => write!(f, "{class} x"),
+                };
+            }
+            _ => {}
+        }
+
+        write!(f, "<unknown instruction {i:?}>")
+    }
+}
+
+// https://github.com/torvalds/linux/blob/b947cc5bf6d793101135265352e205aeb30b54f0/include/uapi/linux/bpf_common.h#L6
+define!(
+    #[mask(0x07)]
+    pub enum Class {
+        LD = 0x00,
+        LDX = 0x01,
+        ST = 0x02,
+        STX = 0x03,
+        ALU = 0x04,
+        JMP = 0x05,
+        RET = 0x06,
+        MISC = 0x07,
+    }
+);
+
+// https://github.com/torvalds/linux/blob/b947cc5bf6d793101135265352e205aeb30b54f0/include/uapi/linux/bpf_common.h#L17
+define!(
+    #[mask(0x18)]
+    pub enum Size {
+        // word (4 bytes)
+        W = 0x00,
+        // half word (2 bytes)
+        H = 0x08,
+        // byte
+        B = 0x10,
+    }
+);
+
+impl Size {
+    #[inline]
+    pub const fn suffix(self) -> &'static str {
+        match self {
+            Self::W => "",
+            Self::H => "H",
+            Self::B => "B",
+        }
+    }
+}
+
+// https://github.com/torvalds/linux/blob/b947cc5bf6d793101135265352e205aeb30b54f0/include/uapi/linux/bpf_common.h#L22
+define!(
+    #[mask(0xe0)]
+    pub enum Mode {
+        IMM = 0x00,
+        ABS = 0x20,
+        IND = 0x40,
+        MEM = 0x60,
+        LEN = 0x80,
+        MSH = 0xa0,
+    }
+);
+
+// https://github.com/torvalds/linux/blob/b947cc5bf6d793101135265352e205aeb30b54f0/include/uapi/linux/bpf_common.h#L31
+define!(
+    #[mask(0xf0)]
+    pub enum Alu {
+        ADD = 0x00,
+        SUB = 0x10,
+        MUL = 0x20,
+        DIV = 0x30,
+        OR = 0x40,
+        AND = 0x50,
+        LSH = 0x60,
+        RSH = 0x70,
+        NEG = 0x80,
+        MOD = 0x90,
+        XOR = 0xa0,
+    }
+);
+
+// https://github.com/torvalds/linux/blob/b947cc5bf6d793101135265352e205aeb30b54f0/include/uapi/linux/bpf_common.h#L44
+define!(
+    #[mask(0xf0)]
+    pub enum Jump {
+        JA = 0x00,
+        JEQ = 0x10,
+        JGT = 0x20,
+        JSET = 0x40,
+    }
+);
+
+impl_ops!();
+impl_ret!();
+
+#[cfg(test)]
+mod tests {
+    use crate::bpf::cbpf::*;
+
+    static PROGRAM: Program = {
+        const MAX: u8 = 0b0011_1111;
+
+        Program::new(&[
+            // load the first byte of the packet
+            ldb(0),
+            // mask off the LSBs
+            and(!MAX as _),
+            // IF:
+            // the control bit is set
+            jneq(MAX as u32 + 1, 1, 0),
+            // THEN:
+            // return a 0 indicating we want to route to the writer socket
+            ret(0),
+            // ELSE:
+            // return a 1 indicating we want to route to the reader socket
+            ret(1),
+        ])
+    };
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn static_program_debug() {
+        insta::assert_debug_snapshot!(PROGRAM);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn static_program_display() {
+        insta::assert_snapshot!(PROGRAM);
+    }
+}

--- a/quic/s2n-quic-platform/src/bpf/common.rs
+++ b/quic/s2n-quic-platform/src/bpf/common.rs
@@ -1,0 +1,142 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// https://github.com/torvalds/linux/blob/b947cc5bf6d793101135265352e205aeb30b54f0/include/uapi/linux/bpf_common.h#L49
+define!(
+    #[mask(0x08)]
+    pub enum Source {
+        K = 0x00,
+        X = 0x08,
+    }
+);
+
+macro_rules! impl_ld {
+    () => {
+        impl_ld!(ld, ldk, W);
+        impl_ld!(ldb, ldbk, B);
+        impl_ld!(ldh, ldhk, H);
+    };
+    ($lower:ident, $k:ident, $size:ident) => {
+        pub const fn $lower(value: u32) -> Instruction {
+            Instruction::raw(
+                Mode::ABS as u16 | Class::LD as u16 | Size::$size as u16,
+                0,
+                0,
+                value,
+            )
+        }
+
+        pub const fn $k(value: u32) -> Instruction {
+            Instruction::raw(
+                Mode::IMM as u16 | Class::LD as u16 | Source::K as u16 | Size::$size as u16,
+                0,
+                0,
+                value,
+            )
+        }
+    };
+}
+
+macro_rules! impl_alu {
+    () => {
+        impl_alu!(add, addx, ADD);
+        impl_alu!(sub, subx, SUB);
+        impl_alu!(mul, mulx, MUL);
+        impl_alu!(div, divx, DIV);
+        impl_alu!(rem, remx, MOD);
+        impl_alu!(and, andx, AND);
+        impl_alu!(or, orx, OR);
+        impl_alu!(xor, xorx, XOR);
+        impl_alu!(lsh, lshx, LSH);
+        impl_alu!(rsh, rshx, RSH);
+    };
+    ($lower:ident, $x:ident, $upper:ident) => {
+        pub const fn $lower(value: u32) -> Instruction {
+            Instruction::raw(
+                Mode::IMM as u16 | Class::ALU as u16 | Source::K as u16 | Alu::$upper as u16,
+                0,
+                0,
+                value,
+            )
+        }
+
+        pub const fn $x() -> Instruction {
+            Instruction::raw(
+                Mode::IMM as u16 | Class::ALU as u16 | Source::X as u16 | Alu::$upper as u16,
+                0,
+                0,
+                0,
+            )
+        }
+    };
+}
+
+macro_rules! impl_jmp {
+    () => {
+        pub const fn ja(value: u32) -> Instruction {
+            Instruction::raw(
+                Class::JMP as u16 | Source::K as u16 | Jump::JA as u16,
+                0,
+                0,
+                value,
+            )
+        }
+
+        impl_jmp!(jgt, jgtx, JGT, false);
+        impl_jmp!(jle, jlex, JGT, true);
+        impl_jmp!(jeq, jeqx, JEQ, false);
+        impl_jmp!(jneq, jneqx, JEQ, true);
+        impl_jmp!(jset, jsetx, JSET, false);
+    };
+    ($lower:ident, $x:ident, $upper:ident, $invert:expr) => {
+        pub const fn $lower(value: u32, mut jt: u8, mut jf: u8) -> Instruction {
+            if $invert {
+                let tmp = jt;
+                jt = jf;
+                jf = tmp;
+            }
+
+            Instruction::raw(
+                Class::JMP as u16 | Source::K as u16 | Jump::$upper as u16,
+                jt,
+                jf,
+                value,
+            )
+        }
+
+        pub const fn $x(mut jt: u8, mut jf: u8) -> Instruction {
+            if $invert {
+                let tmp = jt;
+                jt = jf;
+                jf = tmp;
+            }
+
+            Instruction::raw(
+                Class::JMP as u16 | Source::X as u16 | Jump::$upper as u16,
+                jt,
+                jf,
+                0,
+            )
+        }
+    };
+}
+
+macro_rules! impl_ret {
+    () => {
+        pub const fn ret(value: u32) -> Instruction {
+            Instruction::raw(Class::RET as u16 | Source::K as u16, 0, 0, value)
+        }
+
+        pub const fn retx() -> Instruction {
+            Instruction::raw(Class::RET as u16 | Source::X as u16, 0, 0, 0)
+        }
+    };
+}
+
+macro_rules! impl_ops {
+    () => {
+        impl_ld!();
+        impl_alu!();
+        impl_jmp!();
+    };
+}

--- a/quic/s2n-quic-platform/src/bpf/ebpf.rs
+++ b/quic/s2n-quic-platform/src/bpf/ebpf.rs
@@ -1,0 +1,207 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::fmt;
+
+pub use super::common::*;
+pub type Instruction = super::Instruction<Ebpf>;
+pub type Program<'a> = super::Program<'a, Ebpf>;
+
+pub struct Ebpf;
+
+impl super::instruction::Dialect for Ebpf {
+    const MAX_INSTRUCTIONS: usize = u16::MAX as _;
+    const SOCKOPT: libc::c_int = libc::SO_ATTACH_REUSEPORT_EBPF as _;
+
+    fn debug(i: &Instruction, f: &mut fmt::Formatter) -> fmt::Result {
+        let code = i.code;
+        let k = i.k;
+        let jt = i.jt;
+        let jf = i.jf;
+        let alt = f.alternate();
+
+        let mut f = f.debug_struct("Instruction");
+        let class = Class::decode(code);
+
+        if alt {
+            f.field("code", &code).field("jt", &jt).field("jf", &jf);
+        }
+
+        f.field("class", &class);
+
+        match class {
+            Class::ALU => {
+                f.field("op", &Alu::decode(code));
+            }
+            Class::JMP | Class::JMP32 => {
+                f.field("op", &Jump::decode(code));
+            }
+            Class::LD | Class::LDX => {
+                f.field("size", &Size::decode(code))
+                    .field("mode", &Mode::decode(code));
+            }
+            // TODO other classes
+            _ => {}
+        }
+
+        if jt > 0 {
+            f.field("jt", &jt);
+        }
+
+        if jf > 0 {
+            f.field("jf", &jf);
+        }
+
+        f.field("k", &k).finish()
+    }
+
+    fn display(i: &Instruction, f: &mut fmt::Formatter) -> fmt::Result {
+        let code = i.code;
+        let k = i.k;
+        let jt = i.jt;
+        let jf = i.jf;
+
+        let class = Class::decode(code);
+
+        match class {
+            Class::LD | Class::LDX => {
+                let size = Size::decode(code).suffix();
+                let mode = Mode::decode(code);
+
+                match mode {
+                    Mode::IMM => return write!(f, "{class}{size} #{k}"),
+                    Mode::ABS => return write!(f, "{class}{size} [{k}]"),
+                    _ => {}
+                }
+            }
+            Class::ALU => {
+                let op = Alu::decode(code);
+                let source = Source::decode(code);
+
+                return match source {
+                    Source::K => write!(f, "{op} #{k}"),
+                    Source::X => write!(f, "{op} x"),
+                };
+            }
+            Class::JMP | Class::JMP32 => {
+                let op = Jump::decode(code);
+                let source = Source::decode(code);
+
+                return match source {
+                    Source::K => write!(f, "{op} #{k},{jt},{jf}"),
+                    Source::X => write!(f, "{op} x,{jt},{jf}"),
+                };
+            }
+            _ => {}
+        }
+
+        write!(f, "<unknown instruction {i:?}>")
+    }
+}
+
+// https://www.kernel.org/doc/html/next/bpf/instruction-set.html#instruction-classes
+define!(
+    #[mask(0x07)]
+    pub enum Class {
+        LD = 0x00,
+        LDX = 0x01,
+        ST = 0x02,
+        STX = 0x03,
+        ALU = 0x04,
+        JMP = 0x05,
+        JMP32 = 0x06,
+        ALU64 = 0x07,
+    }
+);
+
+// https://www.kernel.org/doc/html/next/bpf/instruction-set.html#load-and-store-instructions
+define!(
+    #[mask(0x18)]
+    pub enum Size {
+        // word (4 bytes)
+        W = 0x00,
+        // half word (2 bytes)
+        H = 0x08,
+        // byte
+        B = 0x10,
+        // double word (8 bytes)
+        DW = 0x18,
+    }
+);
+
+impl Size {
+    #[inline]
+    pub const fn suffix(self) -> &'static str {
+        match self {
+            Self::W => "",
+            Self::H => "H",
+            Self::B => "B",
+            Self::DW => "DW",
+        }
+    }
+}
+
+// https://www.kernel.org/doc/html/next/bpf/instruction-set.html#load-and-store-instructions
+define!(
+    #[mask(0xe0)]
+    pub enum Mode {
+        IMM = 0x00,
+        ABS = 0x20,
+        IND = 0x40,
+        MEM = 0x60,
+        ATOMIC = 0xc0,
+    }
+);
+
+// https://www.kernel.org/doc/html/next/bpf/instruction-set.html#arithmetic-instructions
+define!(
+    #[mask(0xf0)]
+    pub enum Alu {
+        ADD = 0x00,
+        SUB = 0x10,
+        MUL = 0x20,
+        DIV = 0x30,
+        OR = 0x40,
+        AND = 0x50,
+        LSH = 0x60,
+        RSH = 0x70,
+        NEG = 0x80,
+        MOD = 0x90,
+        XOR = 0xa0,
+        MOV = 0xb0,
+        ARSH = 0xc0,
+        END = 0xd0,
+    }
+);
+
+// https://www.kernel.org/doc/html/next/bpf/instruction-set.html#jump-instructions
+define!(
+    #[mask(0xf0)]
+    pub enum Jump {
+        JA = 0x00,
+        JEQ = 0x10,
+        JGT = 0x20,
+        JGE = 0x30,
+        JSET = 0x40,
+        JNE = 0x50,
+        JSGET = 0x60,
+        JSGE = 0x70,
+        CALL = 0x80,
+        EXIT = 0x90,
+        JLT = 0xa0,
+        JLE = 0xb0,
+        JSLT = 0xc0,
+        JSLE = 0xd0,
+    }
+);
+
+// https://www.kernel.org/doc/html/next/bpf/instruction-set.html#byte-swap-instructions
+define!(
+    #[mask(0x0f)]
+    pub enum Swap {
+        TO_LE = 0x00,
+        TO_BE = 0x08,
+    }
+);
+
+impl_ops!();

--- a/quic/s2n-quic-platform/src/bpf/instruction.rs
+++ b/quic/s2n-quic-platform/src/bpf/instruction.rs
@@ -1,0 +1,100 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use core::{fmt, marker::PhantomData, ops};
+use libc::sock_filter;
+
+pub trait Dialect: Sized {
+    const MAX_INSTRUCTIONS: usize;
+    const SOCKOPT: libc::c_int;
+
+    fn debug(instruction: &Instruction<Self>, f: &mut fmt::Formatter) -> fmt::Result;
+    fn display(instruction: &Instruction<Self>, f: &mut fmt::Formatter) -> fmt::Result;
+}
+
+#[derive(Clone, Copy)]
+#[repr(transparent)]
+pub struct Instruction<D: Dialect>(sock_filter, PhantomData<D>);
+
+impl<D: Dialect> ops::Deref for Instruction<D> {
+    type Target = sock_filter;
+
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl<D: Dialect> fmt::Debug for Instruction<D> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        D::debug(self, f)
+    }
+}
+
+impl<D: Dialect> fmt::Display for Instruction<D> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        if f.alternate() {
+            // write the C literal format if requested
+            write!(
+                f,
+                "{{ {}, {}, {}, {} }}",
+                self.code, self.jt, self.jf, self.k
+            )
+        } else {
+            D::display(self, f)
+        }
+    }
+}
+
+macro_rules! define {
+    (#[mask($mask:literal)]
+     pub enum $ty:ident {
+        $(
+            $OP:ident = $value:literal
+        ),*
+        $(,)?
+    }) => {
+        #[repr(u16)]
+        #[derive(Copy, Clone, Debug)]
+        #[allow(clippy::upper_case_acronyms, non_camel_case_types)]
+        pub enum $ty {
+            $(
+                $OP = $value,
+            )*
+        }
+
+        impl core::fmt::Display for $ty {
+            #[inline]
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+                self.to_str().fmt(f)
+            }
+        }
+
+        impl $ty {
+            #[inline]
+            pub fn decode(op: u16) -> Self {
+                match op & $mask {
+                    $(
+                        op if op == $value => Self::$OP,
+                    )*
+                    _ => unreachable!(),
+                }
+            }
+
+            #[inline]
+            pub const fn to_str(self) -> &'static str {
+                match self {
+                    $(
+                        Self::$OP => stringify!($OP),
+                    )*
+                }
+            }
+        }
+    }
+}
+
+impl<D: Dialect> Instruction<D> {
+    pub const fn raw(code: u16, jt: u8, jf: u8, k: u32) -> Self {
+        Instruction(libc::sock_filter { code, jt, jf, k }, PhantomData)
+    }
+}

--- a/quic/s2n-quic-platform/src/bpf/program.rs
+++ b/quic/s2n-quic-platform/src/bpf/program.rs
@@ -1,0 +1,62 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{instruction::Dialect, Instruction};
+use core::{fmt, mem::size_of};
+use libc::sock_fprog;
+use std::{io, os::fd::AsRawFd};
+
+pub struct Program<'a, D: Dialect> {
+    instructions: &'a [Instruction<D>],
+}
+
+impl<'a, D: Dialect> Program<'a, D> {
+    #[inline]
+    pub const fn new(instructions: &'a [Instruction<D>]) -> Self {
+        if instructions.len() > D::MAX_INSTRUCTIONS {
+            panic!("program too large");
+        }
+        Self { instructions }
+    }
+
+    #[inline]
+    pub fn attach<S: AsRawFd>(&self, socket: &S) -> io::Result<()> {
+        let prog = sock_fprog {
+            filter: self.instructions.as_ptr() as *const _ as *mut _,
+            len: self.instructions.len() as _,
+        };
+
+        let ret = unsafe {
+            libc::setsockopt(
+                socket.as_raw_fd(),
+                libc::SOL_SOCKET,
+                D::SOCKOPT as _,
+                &prog as *const _ as *const _,
+                size_of::<sock_fprog>() as _,
+            )
+        };
+
+        if ret < 0 {
+            Err(io::Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<'a, D: Dialect> fmt::Debug for Program<'a, D> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Program")
+            .field("instructions", &self.instructions)
+            .finish()
+    }
+}
+
+impl<'a, D: Dialect> fmt::Display for Program<'a, D> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        for inst in self.instructions {
+            writeln!(f, "{inst}")?;
+        }
+        Ok(())
+    }
+}

--- a/quic/s2n-quic-platform/src/bpf/snapshots/s2n_quic_platform__bpf__cbpf__tests__static_program_debug.snap
+++ b/quic/s2n-quic-platform/src/bpf/snapshots/s2n_quic_platform__bpf__cbpf__tests__static_program_debug.snap
@@ -1,0 +1,52 @@
+---
+source: quic/s2n-quic-platform/src/bpf/cbpf.rs
+expression: PROGRAM
+---
+Program {
+    instructions: [
+        Instruction {
+            code: 48,
+            jt: 0,
+            jf: 0,
+            class: LD,
+            size: B,
+            mode: ABS,
+            k: 0,
+        },
+        Instruction {
+            code: 84,
+            jt: 0,
+            jf: 0,
+            class: ALU,
+            op: AND,
+            k: 192,
+        },
+        Instruction {
+            code: 21,
+            jt: 0,
+            jf: 1,
+            class: JMP,
+            op: JEQ,
+            jf: 1,
+            k: 64,
+        },
+        Instruction {
+            code: 6,
+            jt: 0,
+            jf: 0,
+            class: RET,
+            size: W,
+            mode: IMM,
+            k: 0,
+        },
+        Instruction {
+            code: 6,
+            jt: 0,
+            jf: 0,
+            class: RET,
+            size: W,
+            mode: IMM,
+            k: 1,
+        },
+    ],
+}

--- a/quic/s2n-quic-platform/src/bpf/snapshots/s2n_quic_platform__bpf__cbpf__tests__static_program_display.snap
+++ b/quic/s2n-quic-platform/src/bpf/snapshots/s2n_quic_platform__bpf__cbpf__tests__static_program_display.snap
@@ -1,0 +1,9 @@
+---
+source: quic/s2n-quic-platform/src/bpf/cbpf.rs
+expression: PROGRAM
+---
+LDB [0]
+AND #192
+JEQ #64,0,1
+RET #0
+RET #1

--- a/quic/s2n-quic-platform/src/lib.rs
+++ b/quic/s2n-quic-platform/src/lib.rs
@@ -8,6 +8,8 @@
 
 extern crate alloc;
 
+#[cfg(target_os = "linux")]
+pub mod bpf;
 pub mod features;
 pub mod io;
 pub mod message;

--- a/quic/s2n-quic-platform/src/socket.rs
+++ b/quic/s2n-quic-platform/src/socket.rs
@@ -2,5 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub mod io;
+pub mod options;
 pub mod ring;
 pub mod task;

--- a/quic/s2n-quic-platform/src/socket/options.rs
+++ b/quic/s2n-quic-platform/src/socket/options.rs
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::syscall;
+use s2n_quic_core::inet::SocketAddress;
+use std::{
+    io,
+    net::{SocketAddr, TcpListener, UdpSocket},
+};
+
+#[derive(Clone, Copy, Debug, Default)]
+pub enum ReusePort {
+    #[default]
+    Disabled,
+    /// Enables reuse port before binding the socket
+    ///
+    /// NOTE: the provided `addr` must not be bound to a random port (`0`)
+    BeforeBind,
+    /// Enables reuse port after binding the socket
+    AfterBind,
+}
+
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct Options {
+    pub addr: SocketAddr,
+    pub reuse_address: bool,
+    pub reuse_port: ReusePort,
+    pub gro: bool,
+    pub blocking: bool,
+    pub delay: bool,
+    pub send_buffer: Option<usize>,
+    pub recv_buffer: Option<usize>,
+    pub backlog: usize,
+}
+
+impl Default for Options {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            addr: SocketAddress::default().into(),
+            reuse_address: false,
+            reuse_port: Default::default(),
+            gro: true,
+            blocking: false,
+            send_buffer: None,
+            recv_buffer: None,
+            delay: false,
+            backlog: 4096,
+        }
+    }
+}
+
+impl Options {
+    #[inline]
+    pub fn new(addr: SocketAddr) -> Self {
+        Self {
+            addr,
+            ..Default::default()
+        }
+    }
+
+    #[inline]
+    pub fn build_udp(&self) -> io::Result<UdpSocket> {
+        let socket = syscall::udp_socket(self.addr)?;
+
+        if self.gro {
+            let _ = syscall::configure_gro(&socket);
+        }
+
+        let _ = syscall::configure_tos(&socket);
+        let _ = syscall::configure_mtu_disc(&socket);
+
+        self.build_common(&socket)?;
+
+        let socket = socket.into();
+        Ok(socket)
+    }
+
+    #[inline]
+    pub fn build_tcp_listener(&self) -> io::Result<TcpListener> {
+        let domain = socket2::Domain::for_address(self.addr);
+        let ty = socket2::Type::STREAM;
+        let protocol = socket2::Protocol::TCP;
+
+        let socket = socket2::Socket::new(domain, ty, Some(protocol))?;
+
+        socket.set_nodelay(!self.delay)?;
+
+        self.build_common(&socket)?;
+
+        socket.listen(self.backlog.try_into().unwrap_or(core::ffi::c_int::MAX))?;
+
+        Ok(socket.into())
+    }
+
+    fn build_common(&self, socket: &socket2::Socket) -> io::Result<()> {
+        socket.set_reuse_address(self.reuse_address)?;
+        socket.set_nonblocking(!self.blocking)?;
+
+        if let Some(send_buffer) = self.send_buffer {
+            let _ = socket.set_send_buffer_size(send_buffer);
+        }
+
+        if let Some(recv_buffer) = self.recv_buffer {
+            let _ = socket.set_recv_buffer_size(recv_buffer);
+        }
+
+        if let ReusePort::BeforeBind = self.reuse_port {
+            assert_ne!(self.addr.port(), 0);
+            set_reuse_port(socket)?;
+        }
+
+        socket.bind(&self.addr.into())?;
+
+        if let ReusePort::AfterBind = self.reuse_port {
+            set_reuse_port(socket)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
+fn set_reuse_port(_socket: &socket2::Socket) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::InvalidInput,
+        "reuse port is not supported on windows",
+    ))
+}
+
+#[cfg(not(windows))]
+fn set_reuse_port(socket: &socket2::Socket) -> io::Result<()> {
+    socket.set_reuse_port(true)
+}


### PR DESCRIPTION
### Description of changes: 

This change adds a mechanism to easily construct UDP and TCP sockets with a `socket::Options` struct. I've also included an in-memory BPF assembler, which enables creating pairs of UDP sockets and route packets between them.

### Testing:

Several tests were added as part of these changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

