### PR TITLE
fix(s2n-quic-dc): replace generational-areana with slotmap

### DIFF
--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -21,13 +21,13 @@ bolero-generator = { version = "0.11", optional = true }
 bytes = "1"
 crossbeam-channel = "0.5"
 crossbeam-queue = { version = "0.3" }
-generational-arena = { version = "0.2" }
 libc = "0.2"
 num-rational = { version = "0.4", default-features = false }
 once_cell = "1"
 s2n-codec = { version = "=0.38.1", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.38.1", path = "../../quic/s2n-quic-core", default-features = false }
 s2n-quic-platform = { version = "=0.38.1", path = "../../quic/s2n-quic-platform" }
+slotmap = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["io-util"], optional = true }
 tracing = "0.1"


### PR DESCRIPTION
### Resolved issues:

resolves #2241

### Description of changes: 

`generational-arena` is unmaintained and needs to be replaced with `slotmap`

### Testing:

The interface/functionality is the same so the existing unit tests should suffice.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

