### PR TITLE
feat(s2n-quic-core): updates to dc provider

### DIFF
--- a/quic/s2n-quic-core/src/dc.rs
+++ b/quic/s2n-quic-core/src/dc.rs
@@ -3,7 +3,10 @@
 
 use crate::{
     connection::Limits,
-    event::{api::SocketAddress, IntoEvent as _},
+    event::{
+        api::{EndpointType, SocketAddress},
+        IntoEvent as _,
+    },
     inet,
     path::MaxMtu,
     transport::parameters::{DcSupportedVersions, InitialFlowControlLimits},
@@ -47,6 +50,8 @@ pub struct ConnectionInfo<'a> {
     pub dc_version: u32,
     /// Various settings relevant to the dc path
     pub application_params: ApplicationParams,
+    /// The local endpoint type (client or server)
+    pub endpoint_type: EndpointType,
 }
 
 impl<'a> ConnectionInfo<'a> {
@@ -56,11 +61,13 @@ impl<'a> ConnectionInfo<'a> {
         remote_address: &'a inet::SocketAddress,
         dc_version: Version,
         application_params: ApplicationParams,
+        endpoint_type: EndpointType,
     ) -> Self {
         Self {
             remote_address: remote_address.into_event(),
             dc_version,
             application_params,
+            endpoint_type,
         }
     }
 }

--- a/quic/s2n-quic-core/src/dc/disabled.rs
+++ b/quic/s2n-quic-core/src/dc/disabled.rs
@@ -4,7 +4,7 @@
 use crate::{
     crypto::tls::TlsSession,
     dc::{ConnectionInfo, Endpoint, Path},
-    stateless_reset,
+    stateless_reset, transport,
 };
 use alloc::vec::Vec;
 
@@ -23,7 +23,10 @@ impl Endpoint for Disabled {
 
 // The Disabled Endpoint returns `None`, so this is not used
 impl Path for () {
-    fn on_path_secrets_ready(&mut self, _session: &impl TlsSession) -> Vec<stateless_reset::Token> {
+    fn on_path_secrets_ready(
+        &mut self,
+        _session: &impl TlsSession,
+    ) -> Result<Vec<stateless_reset::Token>, transport::Error> {
         unimplemented!()
     }
 

--- a/quic/s2n-quic-core/src/dc/testing.rs
+++ b/quic/s2n-quic-core/src/dc/testing.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{crypto::tls::TlsSession, dc, dc::ConnectionInfo, stateless_reset};
+use crate::{crypto::tls::TlsSession, dc, dc::ConnectionInfo, stateless_reset, transport};
 
 pub struct MockDcEndpoint {
     stateless_reset_tokens: Vec<stateless_reset::Token>,
@@ -35,9 +35,12 @@ impl dc::Endpoint for MockDcEndpoint {
 }
 
 impl dc::Path for MockDcPath {
-    fn on_path_secrets_ready(&mut self, _session: &impl TlsSession) -> Vec<stateless_reset::Token> {
+    fn on_path_secrets_ready(
+        &mut self,
+        _session: &impl TlsSession,
+    ) -> Result<Vec<stateless_reset::Token>, transport::Error> {
         self.on_path_secrets_ready_count += 1;
-        self.stateless_reset_tokens.clone()
+        Ok(self.stateless_reset_tokens.clone())
     }
 
     fn on_peer_stateless_reset_tokens<'a>(

--- a/quic/s2n-quic-core/src/dc/traits.rs
+++ b/quic/s2n-quic-core/src/dc/traits.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{crypto::tls::TlsSession, dc, stateless_reset};
+use crate::{crypto::tls::TlsSession, dc, stateless_reset, transport};
 use alloc::vec::Vec;
 
 /// The `dc::Endpoint` trait provides a way to support dc functionality
@@ -25,7 +25,10 @@ pub trait Path: 'static + Send {
     ///
     /// Returns the stateless reset tokens to include in a `DC_STATELESS_RESET_TOKENS`
     /// frame sent to the peer.
-    fn on_path_secrets_ready(&mut self, session: &impl TlsSession) -> Vec<stateless_reset::Token>;
+    fn on_path_secrets_ready(
+        &mut self,
+        session: &impl TlsSession,
+    ) -> Result<Vec<stateless_reset::Token>, transport::Error>;
 
     /// Called when a `DC_STATELESS_RESET_TOKENS` frame has been received from the peer
     fn on_peer_stateless_reset_tokens<'a>(
@@ -36,11 +39,14 @@ pub trait Path: 'static + Send {
 
 impl<P: Path> Path for Option<P> {
     #[inline]
-    fn on_path_secrets_ready(&mut self, session: &impl TlsSession) -> Vec<stateless_reset::Token> {
+    fn on_path_secrets_ready(
+        &mut self,
+        session: &impl TlsSession,
+    ) -> Result<Vec<stateless_reset::Token>, transport::Error> {
         if let Some(path) = self {
             path.on_path_secrets_ready(session)
         } else {
-            Vec::default()
+            Ok(Vec::default())
         }
     }
 

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -446,8 +446,12 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
             let application_params =
                 dc::ApplicationParams::new(max_mtu, &peer_flow_control_limits, self.limits);
             let remote_address = self.path_manager.active_path().remote_address().0;
-            let conn_info =
-                dc::ConnectionInfo::new(&remote_address, dc_version, application_params);
+            let conn_info = dc::ConnectionInfo::new(
+                &remote_address,
+                dc_version,
+                application_params,
+                Config::ENDPOINT_TYPE.into_event(),
+            );
             let dc_path = self.dc.new_path(&conn_info);
             crate::dc::Manager::new(dc_path, dc_version, self.publisher)
         } else {
@@ -511,7 +515,7 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
             .as_mut()
             .expect("application keys should be ready before the tls exporter")
             .dc_manager
-            .on_path_secrets_ready(session, self.publisher);
+            .on_path_secrets_ready(session, self.publisher)?;
 
         self.publisher
             .on_tls_exporter_ready(event::builder::TlsExporterReady {


### PR DESCRIPTION
### Description of changes: 

dc provider implementations need to know if the local endpoint is a server or a client. This change adds that information to the `dc::ConnectionInfo` passed to the provider.

Also, the `on_path_secrets_ready` method may have reason to fail (such as if the given path secrets are using a cipher suite not supported by the provider implementation). This change makes that method fallible. 

### Testing:

Updated unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

