### PR TITLE
docs: make an actual policy recommendation for fips

### DIFF
--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -73,7 +73,7 @@
 //! use s2n_quic::provider::tls::s2n_tls::security::Policy;
 //!
 //! let mut tls = s2n_tls::Server::builder();
-//! let policy = Policy::from_version("select_a_fips_security_policy")?;
+//! let policy = Policy::from_version("20230317")?;
 //! tls.config_mut().set_security_policy(&policy)?;
 //! let tls = tls
 //!     .with_certificate(..)?

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -48,6 +48,8 @@ mod client_handshake_confirm;
 #[cfg(not(target_os = "windows"))]
 mod dc;
 #[cfg(not(target_os = "windows"))]
+mod fips;
+#[cfg(not(target_os = "windows"))]
 mod mtls;
 
 mod exporter;

--- a/quic/s2n-quic/src/tests/fips.rs
+++ b/quic/s2n-quic/src/tests/fips.rs
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::provider::tls::default::{self as tls, security};
+
+fn test_policy(policy: &security::Policy) {
+    let model = Model::default();
+
+    test(model, |handle| {
+        let server = tls::Server::from_loader({
+            let mut builder = tls::config::Config::builder();
+            builder
+                .enable_quic()?
+                .set_application_protocol_preference(["h3"])?
+                .set_security_policy(policy)?
+                .load_pem(
+                    certificates::CERT_PEM.as_bytes(),
+                    certificates::KEY_PEM.as_bytes(),
+                )?;
+
+            builder.build()?
+        });
+
+        let server = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(server)?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
+            .start()?;
+
+        let client = tls::Client::from_loader({
+            let mut builder = tls::config::Config::builder();
+            builder
+                .enable_quic()?
+                .set_application_protocol_preference(["h3"])?
+                .set_security_policy(policy)?
+                .trust_pem(certificates::CERT_PEM.as_bytes())?;
+
+            builder.build()?
+        });
+
+        let client = Client::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(client)?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
+            .start()?;
+
+        let addr = start_server(server)?;
+        start_client(client, addr, Data::new(1000))?;
+        Ok(addr)
+    })
+    .unwrap();
+}
+
+#[test]
+fn default_fips_test() {
+    // TODO switch this to `default_fips` when the policy support TLS 1.3
+    test_policy(&security::Policy::from_version("20230317").unwrap());
+}

--- a/quic/s2n-quic/src/tests/fips.rs
+++ b/quic/s2n-quic/src/tests/fips.rs
@@ -56,6 +56,7 @@ fn test_policy(policy: &security::Policy) {
 
 #[test]
 fn default_fips_test() {
-    // TODO switch this to `default_fips` when the policy support TLS 1.3
+    // TODO switch this to `default_fips` when the policy supports TLS 1.3
+    //      see https://github.com/aws/s2n-quic/issues/2247
     test_policy(&security::Policy::from_version("20230317").unwrap());
 }


### PR DESCRIPTION
### Description of changes: 

Our documentation should make an actual recommendation for a FIPS security policy, rather than rely on the customer reading the s2n-tls docs. Ideally it would be `default_fips`, but that doesn't support TLS 1.3 currently. When it does, we should update this documentation to refer to that instead.

### Testing:

I added a test to show the recommended policy working.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

