### PR TITLE
feat(s2n-quic-core): add waker contract helper

### DIFF
--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -58,7 +58,7 @@ pub trait Context<Crypto: crate::crypto::CryptoSuite> {
     /// Called when the client's application parameters are available, prior
     /// to completion of the handshake.
     ///
-    /// The `server_params` is provided as a mutable Vec<u8> of encoded
+    /// The `server_params` is provided as a mutable `Vec<u8>` of encoded
     /// server transport parameters to allow for additional parameters
     /// dependent on the `client_params` to be appended before transmitting
     /// them to the client.

--- a/quic/s2n-quic-core/src/inet/unspecified.rs
+++ b/quic/s2n-quic-core/src/inet/unspecified.rs
@@ -9,7 +9,7 @@ pub trait Unspecified: Sized {
     /// Returns true if the value is unspecified
     fn is_unspecified(&self) -> bool;
 
-    /// Coerce a potentially unspecified value into an Option<Self>
+    /// Coerce a potentially unspecified value into an `Option<Self>`
     fn filter_unspecified(self) -> Option<Self> {
         if self.is_unspecified() {
             None

--- a/quic/s2n-quic-core/src/task/waker.rs
+++ b/quic/s2n-quic-core/src/task/waker.rs
@@ -6,13 +6,18 @@ use core::{
     task::{RawWaker, RawWakerVTable, Waker},
 };
 
+#[cfg(feature = "alloc")]
+mod contract;
+#[cfg(feature = "alloc")]
+pub use contract::*;
+
 /// Creates a new `Waker` that does nothing when `wake` is called.
 ///
-/// This is mostly useful for writing tests that need a [`Context`] to poll
+/// This is mostly useful for writing tests that need a [`core::task::Context`] to poll
 /// some futures, but are not expecting those futures to wake the waker or
 /// do not need to do anything specific if it happens.
 ///
-/// Upstream Tracking issue: https://github.com/rust-lang/rust/issues/98286
+/// Upstream Tracking issue: <https://github.com/rust-lang/rust/issues/98286>
 #[inline]
 pub fn noop() -> Waker {
     const VTABLE: RawWakerVTable = RawWakerVTable::new(

--- a/quic/s2n-quic-core/src/task/waker/contract.rs
+++ b/quic/s2n-quic-core/src/task/waker/contract.rs
@@ -1,0 +1,144 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use alloc::{sync::Arc, task::Wake};
+use core::{
+    sync::atomic::{AtomicBool, Ordering},
+    task::{Context, Poll, Waker},
+};
+
+/// Checks that if a function returns [`Poll::Pending`], then the function called [`Waker::clone`],
+/// [`Waker::wake`], or [`Waker::wake_by_ref`] on the [`Context`]'s [`Waker`].
+pub struct Contract {
+    state: Arc<State>,
+    waker: Waker,
+}
+
+struct State {
+    inner: Waker,
+    wake_called: AtomicBool,
+}
+
+impl Wake for State {
+    #[inline]
+    fn wake(self: Arc<Self>) {
+        Wake::wake_by_ref(&self)
+    }
+
+    #[inline]
+    fn wake_by_ref(self: &Arc<Self>) {
+        self.wake_called.store(true, Ordering::Release);
+        self.inner.wake_by_ref();
+    }
+}
+
+impl Contract {
+    /// Wraps a [`Context`] in the contract checker
+    #[inline]
+    pub fn new(cx: &mut Context) -> Self {
+        let state = State {
+            inner: cx.waker().clone(),
+            wake_called: AtomicBool::new(false),
+        };
+        let state = Arc::new(state);
+        let waker = Waker::from(state.clone());
+        Self { state, waker }
+    }
+
+    /// Returns a new [`Context`] to be checked
+    #[inline]
+    pub fn context(&self) -> Context {
+        Context::from_waker(&self.waker)
+    }
+
+    /// Checks the state of the waker based on the provided `outcome`
+    #[inline]
+    #[track_caller]
+    pub fn check_outcome<T>(self, outcome: &Poll<T>) {
+        if outcome.is_ready() {
+            return;
+        }
+
+        let strong_count = Arc::strong_count(&self.state);
+        let is_cloned = strong_count > 2; // 1 for `state`, one for our owned `waker`
+        let wake_called = self.state.wake_called.load(Ordering::Acquire);
+
+        let is_ok = is_cloned || wake_called;
+
+        assert!(
+            is_ok,
+            "strong_count = {strong_count}; is_cloned = {is_cloned}; wake_called = {wake_called}"
+        );
+    }
+}
+
+/// Checks that if a function returns [`Poll::Pending`], then the function called [`Waker::clone`],
+/// [`Waker::wake`], or [`Waker::wake_by_ref`] on the [`Context`]'s [`Waker`].
+#[inline(always)]
+#[track_caller]
+pub fn contract<F: FnOnce(&mut Context) -> Poll<R>, R>(cx: &mut Context, f: F) -> Poll<R> {
+    let contract = Contract::new(cx);
+    let mut cx = contract.context();
+    let outcome = f(&mut cx);
+    contract.check_outcome(&outcome);
+    outcome
+}
+
+/// Checks that if a function returns [`Poll::Pending`], then the function called [`Waker::clone`],
+/// [`Waker::wake`], or [`Waker::wake_by_ref`] on the [`Context`]'s [`Waker`].
+///
+/// This is only enabled with `debug_assertions`.
+#[inline(always)]
+#[track_caller]
+pub fn contract_debug<F: FnOnce(&mut Context) -> Poll<R>, R>(cx: &mut Context, f: F) -> Poll<R> {
+    #[cfg(debug_assertions)]
+    return contract(cx, f);
+
+    #[cfg(not(debug_assertions))]
+    return f(cx);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::task::waker;
+
+    #[test]
+    fn correct_test() {
+        let waker = waker::noop();
+        let mut cx = Context::from_waker(&waker);
+
+        // the contract isn't violated when returning Ready
+        let _ = contract(&mut cx, |_cx| Poll::Ready(()));
+
+        // the contract isn't violated if the waker is immediately woken
+        let _ = contract(&mut cx, |cx| {
+            cx.waker().wake_by_ref();
+            Poll::<()>::Pending
+        });
+
+        // the contract isn't violated if the waker is cloned then immediately woken
+        let _ = contract(&mut cx, |cx| {
+            let waker = cx.waker().clone();
+            waker.wake();
+            Poll::<()>::Pending
+        });
+
+        // the contract isn't violated if the waker is cloned and stored for later
+        let mut stored = None;
+        let _ = contract(&mut cx, |cx| {
+            stored = Some(cx.waker().clone());
+            Poll::<()>::Pending
+        });
+    }
+
+    #[test]
+    #[should_panic]
+    fn incorrect_test() {
+        let waker = waker::noop();
+        let mut cx = Context::from_waker(&waker);
+
+        // the contract is violated if we return Pending without doing anything
+        let _ = contract(&mut cx, |_cx| Poll::<()>::Pending);
+    }
+}

--- a/quic/s2n-quic-platform/src/socket/io/rx.rs
+++ b/quic/s2n-quic-platform/src/socket/io/rx.rs
@@ -8,6 +8,7 @@ use s2n_quic_core::{
     inet::datagram,
     io::rx,
     path::{LocalAddress, MaxMtu},
+    task::waker,
 };
 
 /// Structure for receiving messages from consumer channels
@@ -35,33 +36,35 @@ impl<T: Message> rx::Rx for Rx<T> {
 
     #[inline]
     fn poll_ready(&mut self, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
-        let mut is_any_ready = false;
-        let mut is_all_closed = true;
+        waker::contract_debug(cx, |cx| {
+            let mut is_any_ready = false;
+            let mut is_all_closed = true;
 
-        // try to acquire any messages we can from the set of channels
-        for channel in &mut self.channels {
-            match channel.poll_acquire(u32::MAX, cx) {
-                Poll::Ready(_) => {
-                    is_all_closed = false;
-                    is_any_ready = true;
-                }
-                Poll::Pending => {
-                    is_all_closed &= !channel.is_open();
+            // try to acquire any messages we can from the set of channels
+            for channel in &mut self.channels {
+                match channel.poll_acquire(u32::MAX, cx) {
+                    Poll::Ready(_) => {
+                        is_all_closed = false;
+                        is_any_ready = true;
+                    }
+                    Poll::Pending => {
+                        is_all_closed &= !channel.is_open();
+                    }
                 }
             }
-        }
 
-        // if all of the channels are closed then shut down the task
-        if is_all_closed {
-            return Err(()).into();
-        }
+            // if all of the channels are closed then shut down the task
+            if is_all_closed {
+                return Err(()).into();
+            }
 
-        // if any have items to be consumed the wake the endpoint up
-        if is_any_ready {
-            Poll::Ready(Ok(()))
-        } else {
-            Poll::Pending
-        }
+            // if any have items to be consumed the wake the endpoint up
+            if is_any_ready {
+                Poll::Ready(Ok(()))
+            } else {
+                Poll::Pending
+            }
+        })
     }
 
     #[inline]

--- a/quic/s2n-quic-platform/src/socket/io/rx.rs
+++ b/quic/s2n-quic-platform/src/socket/io/rx.rs
@@ -36,7 +36,7 @@ impl<T: Message> rx::Rx for Rx<T> {
 
     #[inline]
     fn poll_ready(&mut self, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
-        waker::contract_debug(cx, |cx| {
+        waker::debug_assert_contract(cx, |cx| {
             let mut is_any_ready = false;
             let mut is_all_closed = true;
 

--- a/quic/s2n-quic-platform/src/socket/io/tx.rs
+++ b/quic/s2n-quic-platform/src/socket/io/tx.rs
@@ -8,6 +8,7 @@ use s2n_quic_core::{
     inet::ExplicitCongestionNotification,
     io::tx,
     path::{Handle as _, MaxMtu},
+    task::waker,
 };
 
 /// Structure for sending messages to producer channels
@@ -44,32 +45,36 @@ impl<T: Message> tx::Tx for Tx<T> {
             return Poll::Pending;
         }
 
-        let mut is_any_ready = false;
-        let mut is_all_closed = true;
+        // NOTE: we don't wrap the above check in the contract as we'd technically violate the
+        // contract since we're returning `Pending` without storing a waker
+        waker::contract_debug(cx, |cx| {
+            let mut is_any_ready = false;
+            let mut is_all_closed = true;
 
-        for channel in &mut self.channels {
-            match channel.poll_acquire(1, cx) {
-                Poll::Ready(_) => {
-                    is_all_closed = false;
-                    is_any_ready = true;
-                }
-                Poll::Pending => {
-                    is_all_closed &= !channel.is_open();
+            for channel in &mut self.channels {
+                match channel.poll_acquire(1, cx) {
+                    Poll::Ready(_) => {
+                        is_all_closed = false;
+                        is_any_ready = true;
+                    }
+                    Poll::Pending => {
+                        is_all_closed &= !channel.is_open();
+                    }
                 }
             }
-        }
 
-        // if all of the channels were closed then shut the task down
-        if is_all_closed {
-            return Err(()).into();
-        }
+            // if all of the channels were closed then shut the task down
+            if is_all_closed {
+                return Err(()).into();
+            }
 
-        // if any of the channels became ready then wake the endpoint up
-        if is_any_ready {
-            Poll::Ready(Ok(()))
-        } else {
-            Poll::Pending
-        }
+            // if any of the channels became ready then wake the endpoint up
+            if is_any_ready {
+                Poll::Ready(Ok(()))
+            } else {
+                Poll::Pending
+            }
+        })
     }
 
     #[inline]

--- a/quic/s2n-quic-platform/src/socket/io/tx.rs
+++ b/quic/s2n-quic-platform/src/socket/io/tx.rs
@@ -47,7 +47,7 @@ impl<T: Message> tx::Tx for Tx<T> {
 
         // NOTE: we don't wrap the above check in the contract as we'd technically violate the
         // contract since we're returning `Pending` without storing a waker
-        waker::contract_debug(cx, |cx| {
+        waker::debug_assert_contract(cx, |cx| {
             let mut is_any_ready = false;
             let mut is_all_closed = true;
 

--- a/quic/s2n-quic-transport/src/endpoint/connect.rs
+++ b/quic/s2n-quic-transport/src/endpoint/connect.rs
@@ -179,6 +179,6 @@ impl Future for Attempt {
     type Output = Result<Connection, connection::Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        s2n_quic_core::task::waker::contract_debug(cx, |cx| self.poll_state(cx))
+        s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| self.poll_state(cx))
     }
 }

--- a/quic/s2n-quic/src/connection/handle.rs
+++ b/quic/s2n-quic/src/connection/handle.rs
@@ -43,7 +43,7 @@ macro_rules! impl_handle_api {
             stream_type: $crate::stream::Type,
             cx: &mut core::task::Context,
         ) -> core::task::Poll<$crate::connection::Result<$crate::stream::LocalStream>> {
-            s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+            s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| {
                 use s2n_quic_core::stream::StreamType;
                 use $crate::stream::{BidirectionalStream, SendStream};
 
@@ -96,7 +96,7 @@ macro_rules! impl_handle_api {
             &mut self,
             cx: &mut core::task::Context,
         ) -> core::task::Poll<$crate::connection::Result<$crate::stream::BidirectionalStream>> {
-            s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+            s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| {
                 use s2n_quic_core::stream::StreamType;
                 use $crate::stream::BidirectionalStream;
 
@@ -134,7 +134,7 @@ macro_rules! impl_handle_api {
             &mut self,
             cx: &mut core::task::Context,
         ) -> core::task::Poll<$crate::connection::Result<$crate::stream::SendStream>> {
-            s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+            s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| {
                 use s2n_quic_core::stream::StreamType;
                 use $crate::stream::SendStream;
 

--- a/quic/s2n-quic/src/connection/handle.rs
+++ b/quic/s2n-quic/src/connection/handle.rs
@@ -43,18 +43,20 @@ macro_rules! impl_handle_api {
             stream_type: $crate::stream::Type,
             cx: &mut core::task::Context,
         ) -> core::task::Poll<$crate::connection::Result<$crate::stream::LocalStream>> {
-            use s2n_quic_core::stream::StreamType;
-            use $crate::stream::{BidirectionalStream, SendStream};
+            s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+                use s2n_quic_core::stream::StreamType;
+                use $crate::stream::{BidirectionalStream, SendStream};
 
-            Ok(
-                match core::task::ready!(self.0.poll_open_stream(stream_type, cx))? {
-                    stream if stream_type == StreamType::Unidirectional => {
-                        SendStream::new(stream.into()).into()
-                    }
-                    stream => BidirectionalStream::new(stream).into(),
-                },
-            )
-            .into()
+                Ok(
+                    match core::task::ready!(self.0.poll_open_stream(stream_type, cx))? {
+                        stream if stream_type == StreamType::Unidirectional => {
+                            SendStream::new(stream.into()).into()
+                        }
+                        stream => BidirectionalStream::new(stream).into(),
+                    },
+                )
+                .into()
+            })
         }
 
         /// Opens a new [`BidirectionalStream`](`crate::stream::BidirectionalStream`)
@@ -94,13 +96,15 @@ macro_rules! impl_handle_api {
             &mut self,
             cx: &mut core::task::Context,
         ) -> core::task::Poll<$crate::connection::Result<$crate::stream::BidirectionalStream>> {
-            use s2n_quic_core::stream::StreamType;
-            use $crate::stream::BidirectionalStream;
+            s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+                use s2n_quic_core::stream::StreamType;
+                use $crate::stream::BidirectionalStream;
 
-            let stream =
-                core::task::ready!(self.0.poll_open_stream(StreamType::Bidirectional, cx))?;
+                let stream =
+                    core::task::ready!(self.0.poll_open_stream(StreamType::Bidirectional, cx))?;
 
-            Ok(BidirectionalStream::new(stream)).into()
+                Ok(BidirectionalStream::new(stream)).into()
+            })
         }
 
         /// Opens a [`SendStream`](`crate::stream::SendStream`)
@@ -130,13 +134,15 @@ macro_rules! impl_handle_api {
             &mut self,
             cx: &mut core::task::Context,
         ) -> core::task::Poll<$crate::connection::Result<$crate::stream::SendStream>> {
-            use s2n_quic_core::stream::StreamType;
-            use $crate::stream::SendStream;
+            s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+                use s2n_quic_core::stream::StreamType;
+                use $crate::stream::SendStream;
 
-            let stream =
-                core::task::ready!(self.0.poll_open_stream(StreamType::Unidirectional, cx))?;
+                let stream =
+                    core::task::ready!(self.0.poll_open_stream(StreamType::Unidirectional, cx))?;
 
-            Ok(SendStream::new(stream.into())).into()
+                Ok(SendStream::new(stream.into())).into()
+            })
         }
 
         /// Returns the local address that this connection is bound to.

--- a/quic/s2n-quic/src/server.rs
+++ b/quic/s2n-quic/src/server.rs
@@ -90,15 +90,15 @@ impl Server {
     ///
     /// - `Poll::Pending` if no new connections have been established.
     /// - `Poll::Ready(Some(connection))` once a new connection has been established.
-    /// This function can be called again to try and accept new connections.
+    ///   This function can be called again to try and accept new connections.
     /// - `Poll::Ready(None)` the attempt failed because the server has closed. Once
-    /// None is returned, this function should not be called again.
+    ///   None is returned, this function should not be called again.
     pub fn poll_accept(&mut self, cx: &mut Context) -> Poll<Option<Connection>> {
-        match self.acceptor.poll_accept(cx) {
+        s2n_quic_core::task::waker::contract_debug(cx, |cx| match self.acceptor.poll_accept(cx) {
             Poll::Ready(Some(connection)) => Poll::Ready(Some(Connection::new(connection))),
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,
-        }
+        })
     }
 
     /// Returns the local address that this listener is bound to.

--- a/quic/s2n-quic/src/server.rs
+++ b/quic/s2n-quic/src/server.rs
@@ -94,7 +94,7 @@ impl Server {
     /// - `Poll::Ready(None)` the attempt failed because the server has closed. Once
     ///   None is returned, this function should not be called again.
     pub fn poll_accept(&mut self, cx: &mut Context) -> Poll<Option<Connection>> {
-        s2n_quic_core::task::waker::contract_debug(cx, |cx| match self.acceptor.poll_accept(cx) {
+        s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| match self.acceptor.poll_accept(cx) {
             Poll::Ready(Some(connection)) => Poll::Ready(Some(Connection::new(connection))),
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Pending => Poll::Pending,

--- a/quic/s2n-quic/src/server.rs
+++ b/quic/s2n-quic/src/server.rs
@@ -94,10 +94,12 @@ impl Server {
     /// - `Poll::Ready(None)` the attempt failed because the server has closed. Once
     ///   None is returned, this function should not be called again.
     pub fn poll_accept(&mut self, cx: &mut Context) -> Poll<Option<Connection>> {
-        s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| match self.acceptor.poll_accept(cx) {
-            Poll::Ready(Some(connection)) => Poll::Ready(Some(Connection::new(connection))),
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
+        s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| {
+            match self.acceptor.poll_accept(cx) {
+                Poll::Ready(Some(connection)) => Poll::Ready(Some(Connection::new(connection))),
+                Poll::Ready(None) => Poll::Ready(None),
+                Poll::Pending => Poll::Pending,
+            }
         })
     }
 

--- a/quic/s2n-quic/src/stream/receive.rs
+++ b/quic/s2n-quic/src/stream/receive.rs
@@ -61,7 +61,7 @@ macro_rules! impl_receive_stream_api {
                     Err($crate::stream::Error::non_readable()).into()
                 };
                 ($variant: expr) => {
-                    $variant.poll_receive(cx)
+                    s2n_quic_core::task::waker::contract_debug(cx, |cx| $variant.poll_receive(cx))
                 };
             }
 
@@ -145,7 +145,9 @@ macro_rules! impl_receive_stream_api {
                     Err($crate::stream::Error::non_readable()).into()
                 };
                 ($variant: expr) => {
-                    $variant.poll_receive_vectored(chunks, cx)
+                    s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+                        $variant.poll_receive_vectored(chunks, cx)
+                    })
                 };
             }
 
@@ -221,6 +223,27 @@ macro_rules! impl_receive_stream_api {
             let $stream = self;
             $dispatch_body
         }
+
+        #[inline]
+        pub(crate) fn receive_chunks(
+            &mut self,
+            cx: &mut core::task::Context,
+            chunks: &mut [bytes::Bytes],
+            high_watermark: usize,
+        ) -> core::task::Poll<$crate::stream::Result<s2n_quic_transport::stream::ops::rx::Response>>
+        {
+            s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+                let response = core::task::ready!(self
+                    .rx_request()?
+                    .receive(chunks)
+                    // don't receive more than we're capable of storing
+                    .with_high_watermark(high_watermark)
+                    .poll(Some(cx))?
+                    .into_poll());
+
+                core::task::Poll::Ready(Ok(response))
+            })
+        }
     };
 }
 
@@ -267,13 +290,8 @@ macro_rules! impl_receive_stream_trait {
 
                 let high_watermark = buf.len();
 
-                let response = core::task::ready!(self
-                    .rx_request()?
-                    .receive(&mut chunks)
-                    // don't receive more than we're capable of storing
-                    .with_high_watermark(high_watermark)
-                    .poll(Some(cx))?
-                    .into_poll());
+                let response =
+                    core::task::ready!(self.receive_chunks(cx, &mut chunks, high_watermark))?;
 
                 let chunks = &chunks[..response.chunks.consumed];
                 let mut bufs = [buf];
@@ -315,13 +333,8 @@ macro_rules! impl_receive_stream_trait {
 
                 let high_watermark = bufs.iter().map(|buf| buf.len()).sum();
 
-                let response = core::task::ready!(self
-                    .rx_request()?
-                    .receive(&mut chunks)
-                    // don't receive more than we're capable of storing
-                    .with_high_watermark(high_watermark)
-                    .poll(Some(cx))?
-                    .into_poll());
+                let response =
+                    core::task::ready!(self.receive_chunks(cx, &mut chunks, high_watermark))?;
 
                 let chunks = &chunks[..response.chunks.consumed];
                 let copied_len = s2n_quic_core::slice::vectored_copy(chunks, bufs);
@@ -359,13 +372,8 @@ macro_rules! impl_receive_stream_trait {
 
                 let high_watermark = buf.remaining();
 
-                let response = core::task::ready!(self
-                    .rx_request()?
-                    .receive(&mut chunks)
-                    // don't receive more than we're capable of storing
-                    .with_high_watermark(high_watermark)
-                    .poll(Some(cx))?
-                    .into_poll());
+                let response =
+                    core::task::ready!(self.receive_chunks(cx, &mut chunks, high_watermark))?;
 
                 for chunk in &chunks[..response.chunks.consumed] {
                     buf.put_slice(chunk);

--- a/quic/s2n-quic/src/stream/receive.rs
+++ b/quic/s2n-quic/src/stream/receive.rs
@@ -61,7 +61,7 @@ macro_rules! impl_receive_stream_api {
                     Err($crate::stream::Error::non_readable()).into()
                 };
                 ($variant: expr) => {
-                    s2n_quic_core::task::waker::contract_debug(cx, |cx| $variant.poll_receive(cx))
+                    s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| $variant.poll_receive(cx))
                 };
             }
 
@@ -145,7 +145,7 @@ macro_rules! impl_receive_stream_api {
                     Err($crate::stream::Error::non_readable()).into()
                 };
                 ($variant: expr) => {
-                    s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+                    s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| {
                         $variant.poll_receive_vectored(chunks, cx)
                     })
                 };
@@ -232,7 +232,7 @@ macro_rules! impl_receive_stream_api {
             high_watermark: usize,
         ) -> core::task::Poll<$crate::stream::Result<s2n_quic_transport::stream::ops::rx::Response>>
         {
-            s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+            s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| {
                 let response = core::task::ready!(self
                     .rx_request()?
                     .receive(chunks)

--- a/quic/s2n-quic/src/stream/receive.rs
+++ b/quic/s2n-quic/src/stream/receive.rs
@@ -61,7 +61,9 @@ macro_rules! impl_receive_stream_api {
                     Err($crate::stream::Error::non_readable()).into()
                 };
                 ($variant: expr) => {
-                    s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| $variant.poll_receive(cx))
+                    s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| {
+                        $variant.poll_receive(cx)
+                    })
                 };
             }
 

--- a/quic/s2n-quic/src/stream/send.rs
+++ b/quic/s2n-quic/src/stream/send.rs
@@ -254,7 +254,9 @@ macro_rules! impl_send_stream_api {
                     Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
-                    s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| $variant.poll_flush(cx))
+                    s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| {
+                        $variant.poll_flush(cx)
+                    })
                 };
             }
 
@@ -345,7 +347,9 @@ macro_rules! impl_send_stream_api {
                     Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
-                    s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| $variant.poll_close(cx))
+                    s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| {
+                        $variant.poll_close(cx)
+                    })
                 };
             }
 

--- a/quic/s2n-quic/src/stream/send.rs
+++ b/quic/s2n-quic/src/stream/send.rs
@@ -58,7 +58,7 @@ macro_rules! impl_send_stream_api {
                     Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
-                    s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+                    s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| {
                         $variant.poll_send(chunk, cx)
                     })
                 };
@@ -136,7 +136,7 @@ macro_rules! impl_send_stream_api {
                     Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
-                    s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+                    s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| {
                         $variant.poll_send_vectored(chunks, cx)
                     })
                 };
@@ -169,7 +169,7 @@ macro_rules! impl_send_stream_api {
                     Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
-                    s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+                    s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| {
                         $variant.poll_send_ready(cx)
                     })
                 };
@@ -254,7 +254,7 @@ macro_rules! impl_send_stream_api {
                     Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
-                    s2n_quic_core::task::waker::contract_debug(cx, |cx| $variant.poll_flush(cx))
+                    s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| $variant.poll_flush(cx))
                 };
             }
 
@@ -345,7 +345,7 @@ macro_rules! impl_send_stream_api {
                     Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
-                    s2n_quic_core::task::waker::contract_debug(cx, |cx| $variant.poll_close(cx))
+                    s2n_quic_core::task::waker::debug_assert_contract(cx, |cx| $variant.poll_close(cx))
                 };
             }
 

--- a/quic/s2n-quic/src/stream/send.rs
+++ b/quic/s2n-quic/src/stream/send.rs
@@ -58,7 +58,9 @@ macro_rules! impl_send_stream_api {
                     Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
-                    $variant.poll_send(chunk, cx)
+                    s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+                        $variant.poll_send(chunk, cx)
+                    })
                 };
             }
 
@@ -134,7 +136,9 @@ macro_rules! impl_send_stream_api {
                     Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
-                    $variant.poll_send_vectored(chunks, cx)
+                    s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+                        $variant.poll_send_vectored(chunks, cx)
+                    })
                 };
             }
 
@@ -165,7 +169,9 @@ macro_rules! impl_send_stream_api {
                     Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
-                    $variant.poll_send_ready(cx)
+                    s2n_quic_core::task::waker::contract_debug(cx, |cx| {
+                        $variant.poll_send_ready(cx)
+                    })
                 };
             }
 
@@ -248,7 +254,7 @@ macro_rules! impl_send_stream_api {
                     Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
-                    $variant.poll_flush(cx)
+                    s2n_quic_core::task::waker::contract_debug(cx, |cx| $variant.poll_flush(cx))
                 };
             }
 
@@ -339,7 +345,7 @@ macro_rules! impl_send_stream_api {
                     Err($crate::stream::Error::non_writable()).into()
                 };
                 ($variant: expr) => {
-                    $variant.poll_close(cx)
+                    s2n_quic_core::task::waker::contract_debug(cx, |cx| $variant.poll_close(cx))
                 };
             }
 


### PR DESCRIPTION
### Description of changes: 

This change adds a helper function to ensure `poll_*` methods adhere to the required contract of either storing the provided `Waker` for later or immediately waking the waker to reschedule the task to be polled again. If neither of these events happen, you end up with a zombie task that is never able to make any progress.

### Testing:

I've also wired up this helper to all of our top-level poll APIs to ensure this contract is preserved. Luckily, we don't have any issues there.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

