### PR TITLE
fix: clippy fixes for rustc 1.79

### DIFF
--- a/common/s2n-codec/src/encoder/value.rs
+++ b/common/s2n-codec/src/encoder/value.rs
@@ -21,7 +21,7 @@ pub trait EncoderValue: Sized {
     /// Returns the encoding size with no buffer constrains
     #[inline]
     fn encoding_size(&self) -> usize {
-        self.encoding_size_for_encoder(&EncoderLenEstimator::new(core::usize::MAX))
+        self.encoding_size_for_encoder(&EncoderLenEstimator::new(usize::MAX))
     }
 
     /// Returns the encoding size for the given encoder's capacity

--- a/common/s2n-codec/src/testing/mod.rs
+++ b/common/s2n-codec/src/testing/mod.rs
@@ -217,14 +217,14 @@ mod tests {
 
     #[test]
     fn u8_round_trip_value_test() {
-        for i in 0..=core::u8::MAX {
+        for i in 0..=u8::MAX {
             ensure_codec_round_trip_value!(u8, i).unwrap();
         }
     }
 
     #[test]
     fn u8_round_trip_bytes_test() {
-        let bytes = (0..=core::u8::MAX).collect::<Vec<_>>();
+        let bytes = (0..=u8::MAX).collect::<Vec<_>>();
         ensure_codec_round_trip_bytes!(u8, &bytes).unwrap();
     }
 

--- a/quic/s2n-quic-core/src/ack/ranges.rs
+++ b/quic/s2n-quic-core/src/ack/ranges.rs
@@ -95,7 +95,7 @@ impl Ranges {
             (Some(min), Some(max)) => {
                 let min = PacketNumber::as_varint(min);
                 let max = PacketNumber::as_varint(max);
-                (max - min).try_into().unwrap_or(core::usize::MAX)
+                (max - min).try_into().unwrap_or(usize::MAX)
             }
             _ => 0,
         }

--- a/quic/s2n-quic-core/src/crypto/label.rs
+++ b/quic/s2n-quic-core/src/crypto/label.rs
@@ -58,7 +58,7 @@ pub const QUIC_KU_48: [u8; 17] = hex!("00300d746c7331332071756963206b7500");
 pub fn compute_label<T: Extend<u8>>(len: usize, label: &[u8], out: &mut T) {
     const TLS_LABEL: &[u8] = b"tls13 ";
     let label_len = TLS_LABEL.len() + label.len();
-    debug_assert!(label_len <= core::u8::MAX as usize, "label is too long");
+    debug_assert!(label_len <= u8::MAX as usize, "label is too long");
 
     out.extend((len as u16).to_be_bytes().iter().cloned());
     out.extend(Some(label_len as u8));

--- a/quic/s2n-quic-core/src/frame/padding.rs
+++ b/quic/s2n-quic-core/src/frame/padding.rs
@@ -29,9 +29,7 @@ pub struct Padding {
 impl Padding {
     /// The maximum padding allowed. When placed at the end of the packet
     /// all of the remaining bytes will be consumed.
-    pub const MAX: Self = Self {
-        length: core::usize::MAX,
-    };
+    pub const MAX: Self = Self { length: usize::MAX };
 
     pub const fn tag(self) -> u8 {
         padding_tag!()

--- a/quic/s2n-quic-core/src/frame/tests.rs
+++ b/quic/s2n-quic-core/src/frame/tests.rs
@@ -14,7 +14,7 @@ fn round_trip() {
         for frame in frames {
             // make sure the frames encoding size matches what would actually
             // be written to an encoder
-            let mut estimator = EncoderLenEstimator::new(core::usize::MAX);
+            let mut estimator = EncoderLenEstimator::new(usize::MAX);
             frame.encode(&mut estimator);
             assert_eq!(frame.encoding_size(), estimator.len());
         }

--- a/quic/s2n-quic-core/src/interval_set/insert.rs
+++ b/quic/s2n-quic-core/src/interval_set/insert.rs
@@ -19,7 +19,7 @@ pub(crate) fn insert<T: IntervalBound + Ord>(
     // this range is intentionally invalid and will only be
     // valid if the `scan` method finds a match
     #[allow(clippy::reversed_empty_ranges)]
-    let replace_range = core::usize::MAX..0;
+    let replace_range = usize::MAX..0;
 
     let mut insertion = Insertion { replace_range };
 

--- a/quic/s2n-quic-core/src/interval_set/interval.rs
+++ b/quic/s2n-quic-core/src/interval_set/interval.rs
@@ -305,7 +305,7 @@ macro_rules! integer_bounds {
             #[inline]
             fn steps_between(&self, upper: &Self) -> usize {
                 use core::convert::TryInto;
-                (upper - self).try_into().unwrap_or(core::usize::MAX)
+                (upper - self).try_into().unwrap_or(usize::MAX)
             }
 
             #[inline]

--- a/quic/s2n-quic-core/src/interval_set/remove.rs
+++ b/quic/s2n-quic-core/src/interval_set/remove.rs
@@ -19,7 +19,7 @@ pub(crate) fn remove<T: IntervalBound + Ord>(
     // this range is intentionally invalid and will only be
     // valid if the `scan` method finds a match
     #[allow(clippy::reversed_empty_ranges)]
-    let replace_range = core::usize::MAX..0;
+    let replace_range = usize::MAX..0;
 
     let can_push_range = limit.map(|l| l.get() > ranges.len() + 1).unwrap_or(true);
 

--- a/quic/s2n-quic-core/src/io/rx/pair.rs
+++ b/quic/s2n-quic-core/src/io/rx/pair.rs
@@ -74,7 +74,10 @@ where
                     // See https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=9a32abe85c666f36fb2ec86496cc41b4
                     //
                     // Once https://github.com/aws/s2n-quic/issues/1742 is resolved this code can go away
-                    (core::mem::transmute(a), core::mem::transmute(b))
+                    (
+                        core::mem::transmute::<&mut <A as Rx>::Queue, &mut <A as Rx>::Queue>(a),
+                        core::mem::transmute::<&mut <B as Rx>::Queue, &mut <B as Rx>::Queue>(b),
+                    )
                 };
 
                 let mut queue = Queue { a, b };

--- a/quic/s2n-quic-core/src/io/tx/handle_map.rs
+++ b/quic/s2n-quic-core/src/io/tx/handle_map.rs
@@ -49,7 +49,12 @@ where
                 // See https://play.rust-lang.org/?version=stable&mode=debug&edition=2021&gist=9a32abe85c666f36fb2ec86496cc41b4
                 //
                 // Once https://github.com/aws/s2n-quic/issues/1742 is resolved this code can go away
-                (core::mem::transmute(map), core::mem::transmute(tx))
+                (
+                    core::mem::transmute::<&mut Map, &mut Map>(map),
+                    core::mem::transmute::<&mut <Tx as tx::Tx>::Queue, &mut <Tx as tx::Tx>::Queue>(
+                        tx,
+                    ),
+                )
             };
 
             let mut queue = Queue {

--- a/quic/s2n-quic-core/src/io/tx/router.rs
+++ b/quic/s2n-quic-core/src/io/tx/router.rs
@@ -88,9 +88,15 @@ where
                     //
                     // Once https://github.com/aws/s2n-quic/issues/1742 is resolved this code can go away
                     (
-                        core::mem::transmute(router),
-                        core::mem::transmute(a),
-                        core::mem::transmute(b),
+                        core::mem::transmute::<&mut R, &mut R>(router),
+                        core::mem::transmute::<
+                            &mut <A as tx::Tx>::Queue,
+                            &mut <A as tx::Tx>::Queue,
+                        >(a),
+                        core::mem::transmute::<
+                            &mut <B as tx::Tx>::Queue,
+                            &mut <B as tx::Tx>::Queue,
+                        >(b),
                     )
                 };
 

--- a/quic/s2n-quic-core/src/packet/number/packet_number.rs
+++ b/quic/s2n-quic-core/src/packet/number/packet_number.rs
@@ -22,7 +22,7 @@ use bolero_generator::*;
 
 const PACKET_SPACE_BITLEN: usize = 2;
 const PACKET_SPACE_SHIFT: usize = (size_of::<PacketNumber>() * 8) - PACKET_SPACE_BITLEN;
-const PACKET_NUMBER_MASK: u64 = core::u64::MAX >> PACKET_SPACE_BITLEN;
+const PACKET_NUMBER_MASK: u64 = u64::MAX >> PACKET_SPACE_BITLEN;
 
 /// Contains a fully-decoded packet number in a given space
 ///
@@ -208,15 +208,15 @@ mod tests {
             VarInt::from_u8(0),
             VarInt::from_u8(1),
             VarInt::from_u8(2),
-            VarInt::from_u8(core::u8::MAX / 2),
-            VarInt::from_u8(core::u8::MAX - 1),
-            VarInt::from_u8(core::u8::MAX),
-            VarInt::from_u16(core::u16::MAX / 2),
-            VarInt::from_u16(core::u16::MAX - 1),
-            VarInt::from_u16(core::u16::MAX),
-            VarInt::from_u32(core::u32::MAX / 2),
-            VarInt::from_u32(core::u32::MAX - 1),
-            VarInt::from_u32(core::u32::MAX),
+            VarInt::from_u8(u8::MAX / 2),
+            VarInt::from_u8(u8::MAX - 1),
+            VarInt::from_u8(u8::MAX),
+            VarInt::from_u16(u16::MAX / 2),
+            VarInt::from_u16(u16::MAX - 1),
+            VarInt::from_u16(u16::MAX),
+            VarInt::from_u32(u32::MAX / 2),
+            VarInt::from_u32(u32::MAX - 1),
+            VarInt::from_u32(u32::MAX),
             VarInt::MAX,
         ];
 

--- a/quic/s2n-quic-core/src/packet/number/packet_number_range.rs
+++ b/quic/s2n-quic-core/src/packet/number/packet_number_range.rs
@@ -177,9 +177,9 @@ mod test {
     #[test]
     fn end_is_max_packet_number() {
         let start = PacketNumberSpace::Handshake
-            .new_packet_number(VarInt::new((u64::max_value() >> 2) - 1).unwrap());
-        let end = PacketNumberSpace::Handshake
-            .new_packet_number(VarInt::new(u64::max_value() >> 2).unwrap());
+            .new_packet_number(VarInt::new((u64::MAX >> 2) - 1).unwrap());
+        let end =
+            PacketNumberSpace::Handshake.new_packet_number(VarInt::new(u64::MAX >> 2).unwrap());
 
         assert_eq!(2, PacketNumberRange::new(start, end).count());
     }

--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -44,7 +44,7 @@ pub mod testing {
 
     /// Creates a new mtu::Controller with the given mtu and probed size
     pub fn test_controller(mtu: u16, probed_size: u16) -> Controller {
-        let mut controller = new_controller(u16::max_value());
+        let mut controller = new_controller(u16::MAX);
         controller.plpmtu = mtu;
         controller.probed_size = probed_size;
         controller

--- a/quic/s2n-quic-core/src/random.rs
+++ b/quic/s2n-quic-core/src/random.rs
@@ -58,7 +58,7 @@ pub mod testing {
         }
 
         fn private_random_fill(&mut self, dest: &mut [u8]) {
-            let seed = u8::max_value() - self.0;
+            let seed = u8::MAX - self.0;
 
             for (i, elem) in dest.iter_mut().enumerate() {
                 *elem = seed ^ i as u8;

--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -300,7 +300,7 @@ pub mod testing {
             type PacketInfo = PacketInfo;
 
             fn congestion_window(&self) -> u32 {
-                u32::max_value()
+                u32::MAX
             }
 
             fn bytes_in_flight(&self) -> u32 {

--- a/quic/s2n-quic-core/src/stream/ops.rs
+++ b/quic/s2n-quic-core/src/stream/ops.rs
@@ -281,7 +281,7 @@ pub mod rx {
             Self {
                 chunks: None,
                 low_watermark: 0,
-                high_watermark: core::usize::MAX,
+                high_watermark: usize::MAX,
                 stop_sending: None,
                 detached: false,
             }

--- a/quic/s2n-quic-core/src/time/timestamp.rs
+++ b/quic/s2n-quic-core/src/time/timestamp.rs
@@ -108,7 +108,7 @@ impl Timestamp {
     #[inline]
     fn from_duration_impl(duration: Duration) -> Self {
         // 2^64 microseconds is ~580,000 years so casting from a u128 should be ok
-        debug_assert!(duration.as_micros() <= core::u64::MAX.into());
+        debug_assert!(duration.as_micros() <= u64::MAX.into());
         let micros = duration.as_micros() as u64;
         // if the value is 0 then round up to 1us after the epoch
         let micros = NonZeroU64::new(micros).unwrap_or(ONE_MICROSECOND);
@@ -225,13 +225,11 @@ mod tests {
         let ts2 = ts1 - Duration::from_millis(110);
         assert_eq!(Duration::from_millis(440), ts2 - initial);
         // Checked Sub
-        assert!(ts2
-            .checked_sub(Duration::from_secs(std::u64::MAX))
-            .is_none());
+        assert!(ts2.checked_sub(Duration::from_secs(u64::MAX)).is_none());
         assert_eq!(Some(initial), ts2.checked_sub(Duration::from_millis(440)));
         // Checked Add
         let max_duration =
-            Duration::from_secs(std::u64::MAX) + (Duration::from_secs(1) - Duration::from_nanos(1));
+            Duration::from_secs(u64::MAX) + (Duration::from_secs(1) - Duration::from_nanos(1));
         assert_eq!(None, ts2.checked_add(max_duration));
         assert!(ts2.checked_add(Duration::from_secs(24 * 60 * 60)).is_some());
 

--- a/quic/s2n-quic-core/src/transmission/writer/testing.rs
+++ b/quic/s2n-quic-core/src/transmission/writer/testing.rs
@@ -140,7 +140,7 @@ impl OutgoingFrameBuffer {
         if self.max_buffer_size.is_some() {
             self.remaining_packet_space
         } else {
-            core::usize::MAX
+            usize::MAX
         }
     }
 

--- a/quic/s2n-quic-core/src/transport/parameters/tests.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/tests.rs
@@ -13,7 +13,7 @@ fn round_trip() {
             return;
         }
 
-        if input[0] > core::u8::MAX / 2 {
+        if input[0] > u8::MAX / 2 {
             assert_codec_round_trip_bytes!(ClientTransportParameters, input[1..]);
         } else {
             assert_codec_round_trip_bytes!(ServerTransportParameters, input[1..]);

--- a/quic/s2n-quic-platform/src/io/testing/model.rs
+++ b/quic/s2n-quic-platform/src/io/testing/model.rs
@@ -183,7 +183,7 @@ impl Model {
 }
 
 fn rate_to_u64(rate: f64) -> u64 {
-    let value = rate.max(0.0).min(1.0);
+    let value = rate.clamp(0.0, 1.0);
     let value = value * u64::MAX as f64;
     value.round() as u64
 }

--- a/quic/s2n-quic-platform/src/message/mmsg.rs
+++ b/quic/s2n-quic-platform/src/message/mmsg.rs
@@ -28,13 +28,13 @@ impl MessageTrait for mmsghdr {
     #[inline]
     fn payload_len(&self) -> usize {
         let payload_len = self.msg_len as usize;
-        debug_assert!(payload_len <= core::u16::MAX as usize);
+        debug_assert!(payload_len <= u16::MAX as usize);
         payload_len
     }
 
     #[inline]
     unsafe fn set_payload_len(&mut self, len: usize) {
-        debug_assert!(len <= core::u16::MAX as usize);
+        debug_assert!(len <= u16::MAX as usize);
         self.msg_len = len as _;
         self.msg_hdr.set_payload_len(len);
     }
@@ -80,7 +80,7 @@ impl MessageTrait for mmsghdr {
     ) -> Result<usize, tx::Error> {
         let len = self.msg_hdr.tx_write(message)?;
         // We need to replicate the len with the `msg_len` field after delegating to `msg_hdr`
-        debug_assert!(len <= core::u16::MAX as usize);
+        debug_assert!(len <= u16::MAX as usize);
         self.msg_len = len as _;
         Ok(len)
     }

--- a/quic/s2n-quic-qns/src/io.rs
+++ b/quic/s2n-quic-qns/src/io.rs
@@ -39,6 +39,9 @@ impl Server {
         // GSO isn't currently supported for XDP so just read it to avoid a dead_code warning
         let _ = self.disable_gso;
         let _ = self.max_mtu;
+        let _ = self.initial_mtu;
+        let _ = self.queue_recv_buffer_size;
+        let _ = self.queue_send_buffer_size;
 
         let addr = (self.ip, self.port).into();
 
@@ -96,6 +99,9 @@ impl Client {
         // GSO isn't currently supported for XDP so just read it to avoid a dead_code warning
         let _ = self.disable_gso;
         let _ = self.max_mtu;
+        let _ = self.initial_mtu;
+        let _ = self.queue_recv_buffer_size;
+        let _ = self.queue_send_buffer_size;
 
         let addr = (self.local_ip, 0u16).into();
 

--- a/quic/s2n-quic-transport/src/ack/ack_manager.rs
+++ b/quic/s2n-quic-transport/src/ack/ack_manager.rs
@@ -619,13 +619,13 @@ mod tests {
             )
             .is_ok());
         manager.transmission_state = AckTransmissionState::Active { retransmissions: 0 };
-        manager.transmissions_since_elicitation = Counter::new(u8::max_value());
+        manager.transmissions_since_elicitation = Counter::new(u8::MAX);
 
         manager.on_transmit_complete(&mut write_context);
 
         assert_eq!(
             manager.transmissions_since_elicitation,
-            Counter::new(u8::max_value())
+            Counter::new(u8::MAX)
         );
     }
 

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -941,7 +941,7 @@ fn limit_number_of_connection_migrations() {
     let mut manager = manager_server(first_path);
     let mut total_paths = 1;
 
-    for i in 1..std::u8::MAX {
+    for i in 1..u8::MAX {
         let new_addr: SocketAddr = format!("127.0.0.2:{}", i).parse().unwrap();
         let new_addr = SocketAddress::from(new_addr);
         let new_addr = RemoteAddress::from(new_addr);
@@ -1934,7 +1934,6 @@ pub fn helper_manager_with_paths_base(
 
     Helper {
         now,
-        first_expected_data,
         second_expected_data,
         challenge_expiration,
         zero_path_id,
@@ -1964,7 +1963,6 @@ fn helper_manager_with_paths(publisher: &mut Publisher) -> Helper {
 
 pub struct Helper {
     pub now: Timestamp,
-    pub first_expected_data: challenge::Data,
     pub second_expected_data: challenge::Data,
     pub challenge_expiration: Duration,
     pub zero_path_id: Id,

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -383,10 +383,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
             config: PhantomData::<Config>,
             outcome: &mut outcome,
             packet_number,
-            payload: transmission::connection_close::Payload {
-                connection_close,
-                packet_number_space: PacketNumberSpace::ApplicationData,
-            },
+            payload: transmission::connection_close::Payload { connection_close },
             timestamp: context.timestamp,
             transmission_constraint: transmission::Constraint::None,
             transmission_mode: transmission::Mode::Normal,

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -136,7 +136,6 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
             payload: transmission::early::Payload {
                 ack_manager: &mut self.ack_manager,
                 crypto_stream: &mut self.crypto_stream,
-                packet_number_space: PacketNumberSpace::Handshake,
                 recovery_manager: &mut self.recovery_manager,
             },
             timestamp: context.timestamp,
@@ -221,10 +220,7 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
             config: PhantomData::<Config>,
             outcome: &mut outcome,
             packet_number,
-            payload: transmission::connection_close::Payload {
-                connection_close,
-                packet_number_space: PacketNumberSpace::Handshake,
-            },
+            payload: transmission::connection_close::Payload { connection_close },
             timestamp: context.timestamp,
             transmission_constraint: transmission::Constraint::None,
             transmission_mode: transmission::Mode::Normal,

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -184,7 +184,6 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
             payload: transmission::early::Payload {
                 ack_manager: &mut self.ack_manager,
                 crypto_stream: &mut self.crypto_stream,
-                packet_number_space: PacketNumberSpace::Initial,
                 recovery_manager: &mut self.recovery_manager,
             },
             timestamp: context.timestamp,
@@ -270,10 +269,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
             config: PhantomData::<Config>,
             outcome: &mut outcome,
             packet_number,
-            payload: transmission::connection_close::Payload {
-                connection_close,
-                packet_number_space: PacketNumberSpace::Initial,
-            },
+            payload: transmission::connection_close::Payload { connection_close },
             timestamp: context.timestamp,
             transmission_constraint: transmission::Constraint::None,
             transmission_mode: transmission::Mode::Normal,

--- a/quic/s2n-quic-transport/src/stream/manager.rs
+++ b/quic/s2n-quic-transport/src/stream/manager.rs
@@ -234,7 +234,7 @@ impl<S: StreamTrait> StreamManagerState<S> {
         // By representing the flow control value as a u32, we save space
         // on the connection state.
         assert!(
-            initial_receive_window <= VarInt::from_u32(core::u32::MAX),
+            initial_receive_window <= VarInt::from_u32(u32::MAX),
             "Receive window must not exceed 32bit range"
         );
 
@@ -573,7 +573,7 @@ impl<S: 'static + StreamTrait> stream::Manager for AbstractStreamManager<S> {
         // By representing the flow control value as a u32, we save space
         // on the connection state.
         assert!(
-            initial_local_limits.max_data <= VarInt::from_u32(core::u32::MAX),
+            initial_local_limits.max_data <= VarInt::from_u32(u32::MAX),
             "Receive window must not exceed 32bit range"
         );
 

--- a/quic/s2n-quic-transport/src/stream/receive_stream.rs
+++ b/quic/s2n-quic-transport/src/stream/receive_stream.rs
@@ -313,7 +313,7 @@ impl ReceiveStreamFlowController {
         // TODO possibly make this value configurable
         let watermark = self.desired_flow_control_window / 2;
 
-        usize::try_from(watermark).unwrap_or(core::usize::MAX)
+        usize::try_from(watermark).unwrap_or(usize::MAX)
     }
 
     /// Returns the MAX_STREAM_DATA window that is currently synchronized

--- a/quic/s2n-quic-transport/src/stream/receive_stream/tests.rs
+++ b/quic/s2n-quic-transport/src/stream/receive_stream/tests.rs
@@ -76,8 +76,8 @@ fn conn_flow_control_test_env_config() -> TestEnvironmentConfig {
         StreamType::Unidirectional,
     );
     // Increase the stream window to error on the connection window
-    test_env_config.initial_receive_window = core::u32::MAX.into();
-    test_env_config.desired_flow_control_window = core::u32::MAX;
+    test_env_config.initial_receive_window = u32::MAX.into();
+    test_env_config.desired_flow_control_window = u32::MAX;
     test_env_config.initial_connection_receive_window_size = 10 * 1024;
     test_env_config.desired_connection_flow_control_window = 10 * 1024;
     test_env_config

--- a/quic/s2n-quic-transport/src/sync/data_sender.rs
+++ b/quic/s2n-quic-transport/src/sync/data_sender.rs
@@ -254,7 +254,7 @@ impl<FlowController: OutgoingDataFlowController, Writer: FrameWriter>
             "Data transmission is not allowed after finish() was called"
         );
         debug_assert!(
-            data.len() <= core::u32::MAX as usize,
+            data.len() <= u32::MAX as usize,
             "Maximum data size exceeded"
         );
 

--- a/quic/s2n-quic-transport/src/transmission/connection_close.rs
+++ b/quic/s2n-quic-transport/src/transmission/connection_close.rs
@@ -4,11 +4,10 @@
 use crate::transmission::{self, WriteContext};
 use core::ops::RangeInclusive;
 use s2n_codec::EncoderValue;
-use s2n_quic_core::{frame, packet::number::PacketNumberSpace};
+use s2n_quic_core::frame;
 
 pub struct Payload<'a> {
     pub connection_close: &'a frame::ConnectionClose<'a>,
-    pub packet_number_space: PacketNumberSpace,
 }
 
 impl<'a> super::Payload for Payload<'a> {

--- a/quic/s2n-quic-transport/src/transmission/early.rs
+++ b/quic/s2n-quic-transport/src/transmission/early.rs
@@ -5,12 +5,10 @@ use crate::{
     ack::AckManager, contexts::WriteContext, endpoint, recovery, space::CryptoStream, transmission,
 };
 use core::ops::RangeInclusive;
-use s2n_quic_core::packet::number::PacketNumberSpace;
 
 pub struct Payload<'a, Config: endpoint::Config> {
     pub ack_manager: &'a mut AckManager,
     pub crypto_stream: &'a mut CryptoStream,
-    pub packet_number_space: PacketNumberSpace,
     pub recovery_manager: &'a mut recovery::Manager<Config>,
 }
 

--- a/tools/xdp/s2n-quic-xdp/src/io/tests.rs
+++ b/tools/xdp/s2n-quic-xdp/src/io/tests.rs
@@ -125,10 +125,8 @@ async fn send(count: u32, outputs: Vec<tx::Channel<atomic_waker::Handle>>, umem:
     let mut counter = 0;
     let mut needs_poll = false;
     while counter < count {
-        if core::mem::take(&mut needs_poll) {
-            if tx.ready().await.is_err() {
-                break;
-            }
+        if core::mem::take(&mut needs_poll) && tx.ready().await.is_err() {
+            break;
         }
 
         tx.queue(|queue| {


### PR DESCRIPTION
### Description of changes: 

This change fixes all of the new clippy lints released with  rustc 1.79

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

