### PR TITLE
chore: cleanup github issues and clippy warnings

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,1 +1,3 @@
 msrv = "1.71.0"
+# // https://github.com/aws/s2n-quic/pull/2251
+too-many-arguments-threshold = 100

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           #
           # manual_clamp will panic when min > max
           # See https://github.com/rust-lang/rust-clippy/pull/10101
-          cargo clippy --all-features --all-targets --workspace -- -A clippy::derive_partial_eq_without_eq -A clippy::manual_clamp -A clippy::too_many_arguments  ${{ matrix.args }}
+          cargo clippy --all-features --all-targets --workspace -- -A clippy::derive_partial_eq_without_eq -A clippy::manual_clamp ${{ matrix.args }}
 
   udeps:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
           #
           # manual_clamp will panic when min > max
           # See https://github.com/rust-lang/rust-clippy/pull/10101
-          cargo clippy --all-features --all-targets --workspace -- -A clippy::derive_partial_eq_without_eq -A clippy::manual_clamp ${{ matrix.args }}
+          cargo clippy --all-features --all-targets --workspace -- -A clippy::derive_partial_eq_without_eq -A clippy::manual_clamp -A clippy::too_many_arguments  ${{ matrix.args }}
 
   udeps:
     runs-on: ubuntu-latest

--- a/dc/s2n-quic-dc/src/packet/control/encoder.rs
+++ b/dc/s2n-quic-dc/src/packet/control/encoder.rs
@@ -12,7 +12,6 @@ use s2n_codec::{Encoder, EncoderBuffer, EncoderValue};
 use s2n_quic_core::{assume, buffer, varint::VarInt};
 
 #[inline(always)]
-#[allow(clippy::too_many_arguments)]
 pub fn encode<H, CD, C>(
     mut encoder: EncoderBuffer,
     source_control_port: u16,

--- a/dc/s2n-quic-dc/src/packet/datagram/encoder.rs
+++ b/dc/s2n-quic-dc/src/packet/datagram/encoder.rs
@@ -47,7 +47,6 @@ pub fn estimate_len(
 }
 
 #[inline(always)]
-#[allow(clippy::too_many_arguments)]
 pub fn encode<H, CD, P, C>(
     mut encoder: EncoderBuffer,
     source_control_port: u16,

--- a/dc/s2n-quic-dc/src/packet/stream/encoder.rs
+++ b/dc/s2n-quic-dc/src/packet/stream/encoder.rs
@@ -17,7 +17,6 @@ pub const MAX_RETRANSMISSION_HEADER_LEN: usize = MAX_HEADER_LEN + (32 / 8);
 pub const MAX_HEADER_LEN: usize = 64;
 
 #[inline(always)]
-#[allow(clippy::too_many_arguments)]
 pub fn encode<H, CD, P, C>(
     mut encoder: EncoderBuffer,
     source_control_port: u16,

--- a/dc/s2n-quic-dc/src/stream/send.rs
+++ b/dc/s2n-quic-dc/src/stream/send.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::too_many_arguments)]
-
 pub mod application;
 pub mod buffer;
 pub mod error;

--- a/dc/s2n-quic-dc/src/stream/send/probes.rs
+++ b/dc/s2n-quic-dc/src/stream/send/probes.rs
@@ -1,8 +1,6 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-#![allow(clippy::too_many_arguments)]
-
 use crate::{credentials, packet::stream};
 use core::time::Duration;
 use s2n_quic_core::{packet::number::PacketNumber, probe, varint::VarInt};

--- a/quic/s2n-quic-core/src/crypto/application/keyset.rs
+++ b/quic/s2n-quic-core/src/crypto/application/keyset.rs
@@ -144,7 +144,7 @@ impl<K: OneRttKey> KeySet<K> {
 
         let result = packet.decrypt(key.key_mut());
 
-        key.on_packet_decryption(&self.limits);
+        key.on_packet_decryption();
 
         match result {
             Ok(packet) => {
@@ -254,7 +254,7 @@ impl<K: OneRttKey> KeySet<K> {
         //= https://www.rfc-editor.org/rfc/rfc9001#section-6.6
         //# Endpoints MUST count the number of encrypted packets for each set of
         //# keys.
-        self.crypto[phase].on_packet_encryption(&self.limits);
+        self.crypto[phase].on_packet_encryption();
 
         Ok(r)
     }

--- a/quic/s2n-quic-core/src/crypto/application/limited.rs
+++ b/quic/s2n-quic-core/src/crypto/application/limited.rs
@@ -75,12 +75,12 @@ impl<K: OneRttKey> Key<K> {
     }
 
     #[inline]
-    pub fn on_packet_encryption(&mut self, _limits: &Limits) {
+    pub fn on_packet_encryption(&mut self) {
         self.encrypted_packets += 1;
     }
 
     #[inline]
-    pub fn on_packet_decryption(&mut self, _limits: &Limits) {
+    pub fn on_packet_decryption(&mut self) {
         self.decrypted_packets += 1;
     }
 

--- a/quic/s2n-quic-core/src/inet/macros.rs
+++ b/quic/s2n-quic-core/src/inet/macros.rs
@@ -36,7 +36,7 @@ macro_rules! define_inet_type {
         }
 
         impl $name {
-            #[allow(non_camel_case_types, clippy::too_many_arguments)]
+            #[allow(non_camel_case_types)]
             #[inline]
             pub fn new<$($field: Into<$field_ty>),*>($($field: $field),*) -> Self {
                 Self {

--- a/quic/s2n-quic-core/src/path/ecn.rs
+++ b/quic/s2n-quic-core/src/path/ecn.rs
@@ -211,7 +211,6 @@ impl Controller {
     /// * `baseline_ecn_counts` - the ECN counts present in the Ack frame the last time ECN counts were processed
     /// * `ack_frame_ecn_counts` - the ECN counts present in the current Ack frame (if any)
     /// * `now` - the time the Ack frame was received
-    #[allow(clippy::too_many_arguments)]
     #[inline]
     pub fn validate<Pub: event::ConnectionPublisher>(
         &mut self,

--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -637,7 +637,6 @@ impl Controller {
     //# robust in the case where probe packets are lost due to other
     //# reasons (including link transmission error, congestion).
     /// This method gets called when a packet loss is reported
-    #[allow(clippy::too_many_arguments)]
     #[inline]
     pub fn on_packet_loss<CC: CongestionController, Pub: event::ConnectionPublisher>(
         &mut self,

--- a/quic/s2n-quic-core/src/probe.rs
+++ b/quic/s2n-quic-core/src/probe.rs
@@ -18,7 +18,6 @@ macro_rules! __probe_define__ {
                 #[doc = $doc]
             )*
             #[inline(always)]
-            #[allow(clippy::too_many_arguments)]
             $vis fn $fun($($arg: $arg_t),*) {
                 $crate::probe::__trace!(
                     name: stringify!($fun),

--- a/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/congestion.rs
@@ -29,7 +29,6 @@ impl State {
     /// Updates the congestion state based on the latest delivery signals
     ///
     /// Called near the start of ACK processing
-    #[allow(clippy::too_many_arguments)]
     pub(super) fn update(
         &mut self,
         packet_info: PacketInfo,

--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -186,7 +186,6 @@ pub trait CongestionController: 'static + Clone + Send + Debug + private::Sealed
     /// it is possible this method may be called multiple times for one acknowledgement. In either
     /// case, `newest_acked_time_sent` and `newest_acked_packet_info` represent the newest acknowledged
     /// packet contributing to `bytes_acknowledged`.
-    #[allow(clippy::too_many_arguments)]
     fn on_ack<Pub: Publisher>(
         &mut self,
         newest_acked_time_sent: Timestamp,
@@ -203,7 +202,6 @@ pub trait CongestionController: 'static + Clone + Send + Debug + private::Sealed
     /// `new_loss_burst` is true if the lost packet is the first in a
     /// contiguous series of lost packets. This can be used for measuring or
     /// filtering out noise from burst losses.
-    #[allow(clippy::too_many_arguments)]
     fn on_packet_lost<Pub: Publisher>(
         &mut self,
         lost_bytes: u32,

--- a/quic/s2n-quic-core/src/recovery/pacing.rs
+++ b/quic/s2n-quic-core/src/recovery/pacing.rs
@@ -43,7 +43,6 @@ pub struct Pacer {
 
 impl Pacer {
     /// Called when each packet has been written
-    #[allow(clippy::too_many_arguments)]
     #[inline]
     pub fn on_packet_sent<Pub: Publisher>(
         &mut self,

--- a/quic/s2n-quic-core/src/recovery/sent_packets.rs
+++ b/quic/s2n-quic-core/src/recovery/sent_packets.rs
@@ -36,7 +36,6 @@ pub struct SentPacketInfo<PacketInfo> {
 }
 
 impl<PacketInfo> SentPacketInfo<PacketInfo> {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         congestion_controlled: bool,
         sent_bytes: usize,

--- a/quic/s2n-quic-tls/src/callback.rs
+++ b/quic/s2n-quic-tls/src/callback.rs
@@ -162,8 +162,6 @@ where
         match core::mem::replace(&mut self.state.secrets, Secrets::Waiting) {
             Secrets::Waiting => {
                 if id == s2n_secret_type_t::CLIENT_EARLY_TRAFFIC_SECRET {
-                    // TODO enable with 0rtt
-                    // I couldn't find a good citation but here's the issue: https://github.com/aws/s2n-quic/issues/301
                     return Ok(());
                 }
 

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1335,7 +1335,6 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
     }
 
     /// Is called when a handshake packet had been received
-    #[allow(clippy::too_many_arguments)]
     fn handle_handshake_packet(
         &mut self,
         datagram: &DatagramInfo,

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -116,7 +116,6 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     // Packet handling
 
     /// Is called when an initial packet had been received
-    #[allow(clippy::too_many_arguments)]
     fn handle_initial_packet(
         &mut self,
         datagram: &DatagramInfo,
@@ -130,7 +129,6 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     ) -> Result<(), ProcessingError>;
 
     /// Is called when an unprotected initial packet had been received
-    #[allow(clippy::too_many_arguments)]
     fn handle_cleartext_initial_packet(
         &mut self,
         datagram: &DatagramInfo,
@@ -144,7 +142,6 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     ) -> Result<(), ProcessingError>;
 
     /// Is called when a handshake packet had been received
-    #[allow(clippy::too_many_arguments)]
     fn handle_handshake_packet(
         &mut self,
         datagram: &DatagramInfo,
@@ -158,7 +155,6 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     ) -> Result<(), ProcessingError>;
 
     /// Is called when a short packet had been received
-    #[allow(clippy::too_many_arguments)]
     fn handle_short_packet(
         &mut self,
         datagram: &DatagramInfo,
@@ -202,7 +198,6 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     ) -> Result<(), ProcessingError>;
 
     /// Notifies a connection it has received a datagram from a peer
-    #[allow(clippy::too_many_arguments)]
     fn on_datagram_received(
         &mut self,
         path_handle: &<Self::Config as endpoint::Config>::PathHandle,
@@ -220,7 +215,6 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     fn quic_version(&self) -> u32;
 
     /// Handles reception of a single QUIC packet
-    #[allow(clippy::too_many_arguments)]
     fn handle_packet(
         &mut self,
         datagram: &DatagramInfo,
@@ -372,7 +366,6 @@ pub trait ConnectionTrait: 'static + Send + Sized {
 
     /// This is called to handle the remaining and yet undecoded packets inside
     /// a datagram.
-    #[allow(clippy::too_many_arguments)]
     fn handle_remaining_packets(
         &mut self,
         path_handle: &<Self::Config as endpoint::Config>::PathHandle,

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -236,7 +236,6 @@ impl<Config: endpoint::Config> Manager<Config> {
     /// This function is called prior to packet authentication. If possible add business
     /// logic to [`Self::on_processed_packet`], which is called after the packet has been
     /// authenticated.
-    #[allow(clippy::too_many_arguments)]
     pub fn on_datagram_received<Pub: event::ConnectionPublisher>(
         &mut self,
         path_handle: &Config::PathHandle,
@@ -313,7 +312,6 @@ impl<Config: endpoint::Config> Manager<Config> {
         )
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn handle_connection_migration<Pub: event::ConnectionPublisher>(
         &mut self,
         path_handle: &Config::PathHandle,

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -106,7 +106,6 @@ impl<Config: endpoint::Config> Clone for Path<Config> {
 /// A Path holds the local and peer socket addresses, connection ids, and state. It can be
 /// validated or pending validation.
 impl<Config: endpoint::Config> Path<Config> {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         handle: Config::PathHandle,
         peer_connection_id: connection::PeerId,

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -211,7 +211,6 @@ impl<Config: endpoint::Config> Manager<Config> {
 
     //= https://www.rfc-editor.org/rfc/rfc9002#appendix-A.5
     //# After a packet is sent, information about the packet is stored.
-    #[allow(clippy::too_many_arguments)]
     pub fn on_packet_sent<Ctx: Context<Config>, Pub: event::ConnectionPublisher>(
         &mut self,
         packet_number: PacketNumber,
@@ -412,7 +411,6 @@ impl<Config: endpoint::Config> Manager<Config> {
     }
 
     /// Generic interface for processing ACK ranges.
-    #[allow(clippy::too_many_arguments)]
     fn process_acks<Ctx: Context<Config>, Pub: event::ConnectionPublisher>(
         &mut self,
         timestamp: Timestamp,
@@ -559,7 +557,6 @@ impl<Config: endpoint::Config> Manager<Config> {
         Ok((largest_newly_acked, includes_ack_eliciting))
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn update_congestion_control<Ctx: Context<Config>, Pub: event::ConnectionPublisher>(
         &mut self,
         largest_newly_acked: PacketDetails<packet_info_type!()>,
@@ -617,7 +614,6 @@ impl<Config: endpoint::Config> Manager<Config> {
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     fn process_new_acked_packets<Ctx: Context<Config>, Pub: event::ConnectionPublisher>(
         &mut self,
         newly_acked_packets: &SmallVec<

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -96,7 +96,6 @@ impl<Config: endpoint::Config> fmt::Debug for ApplicationSpace<Config> {
 }
 
 impl<Config: endpoint::Config> ApplicationSpace<Config> {
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         key: <<Config::TLSEndpoint as tls::Endpoint>::Session as CryptoSuite>::OneRttKey,
         header_key: <<Config::TLSEndpoint as tls::Endpoint>::Session as CryptoSuite>::OneRttHeaderKey,
@@ -453,7 +452,6 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
     }
 
     /// Called when the connection timer expired
-    #[allow(clippy::too_many_arguments)]
     pub fn on_timeout<Pub: event::ConnectionPublisher>(
         &mut self,
         path_manager: &mut path::Manager<Config>,

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -260,7 +260,6 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
     }
 
     /// Called when the connection timer expired
-    #[allow(clippy::too_many_arguments)]
     pub fn on_timeout<Pub: event::ConnectionPublisher>(
         &mut self,
         handshake_status: &HandshakeStatus,

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -310,7 +310,6 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
     }
 
     /// Called when the connection timer expired
-    #[allow(clippy::too_many_arguments)]
     pub fn on_timeout<Pub: event::ConnectionPublisher>(
         &mut self,
         handshake_status: &HandshakeStatus,

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -238,7 +238,6 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         self.zero_rtt_crypto = None;
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn poll_crypto<Pub: event::ConnectionPublisher>(
         &mut self,
         path_manager: &mut path::Manager<Config>,
@@ -286,7 +285,6 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         Poll::Ready(Ok(()))
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn post_handshake_crypto<Pub: event::ConnectionPublisher>(
         &mut self,
         path_manager: &mut path::Manager<Config>,
@@ -686,7 +684,6 @@ pub trait PacketSpace<Config: endpoint::Config>: Sized {
         publisher: &mut Pub,
     ) -> Result<(), transport::Error>;
 
-    #[allow(clippy::too_many_arguments)]
     fn handle_ack_frame<A: AckRanges, Pub: event::ConnectionPublisher>(
         &mut self,
         frame: Ack<A>,
@@ -817,8 +814,6 @@ pub trait PacketSpace<Config: endpoint::Config>: Sized {
         publisher: &mut Pub,
     ) -> Result<(), transport::Error>;
 
-    // TODO: Reduce arguments, https://github.com/aws/s2n-quic/issues/312
-    #[allow(clippy::too_many_arguments)]
     fn handle_cleartext_payload<'a, Pub: event::ConnectionPublisher>(
         &mut self,
         packet_number: PacketNumber,

--- a/quic/s2n-quic-transport/src/transmission/application.rs
+++ b/quic/s2n-quic-transport/src/transmission/application.rs
@@ -25,7 +25,6 @@ pub enum Payload<'a, Config: endpoint::Config> {
 impl<'a, Config: endpoint::Config> Payload<'a, Config> {
     /// Constructs a transmission::application::Payload appropriate for the given
     /// `transmission::Mode` in the given `ConnectionTransmissionContext`
-    #[allow(clippy::too_many_arguments)]
     pub fn new(
         path_id: path::Id,
         path_manager: &'a mut path::Manager<Config>,

--- a/specs/todos/tls/4.6.2.toml
+++ b/specs/todos/tls/4.6.2.toml
@@ -6,7 +6,6 @@ When rejecting 0-RTT, a server MUST NOT
 process any 0-RTT packets, even if it could.
 '''
 feature = "0-RTT"
-tracking-issue = "301"
 
 [[TODO]]
 quote = '''
@@ -16,7 +15,6 @@ rejected, a client SHOULD treat receipt of an acknowledgement for a
 is able to detect the condition.
 '''
 feature = "0-RTT"
-tracking-issue = "301"
 
 [[TODO]]
 quote = '''
@@ -24,7 +22,6 @@ The client therefore MUST reset the state of all
 streams, including application state bound to those streams.
 '''
 feature = "0-RTT"
-tracking-issue = "301"
 
 [[TODO]]
 quote = '''
@@ -32,5 +29,4 @@ A client MAY reattempt 0-RTT if it receives a Retry or Version
 Negotiation packet.
 '''
 feature = "0-RTT"
-tracking-issue = "301"
 


### PR DESCRIPTION
https://github.com/aws/s2n-quic/issues/2204

### Description of changes: 
During grooming we identified a couple issues that don't have immediate next steps and no longer make sense to track.

- #301 This should be addressed once we add 0-RTT to s2n-quic. 
- #312 ignore `clippy::too_many_arguments` since our implementation needs all the args we pass to the functions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

