### PR TITLE
fix(dc-wireshark): parse all packet types in TCP

### DIFF
--- a/dc/wireshark/pcaps/secret-control-tcp.pcapng
+++ b/dc/wireshark/pcaps/secret-control-tcp.pcapng
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8299d0fb25435c05c52e827a554b791e163a38689602c0df9d7007dabe15c54b
+size 86040

--- a/dc/wireshark/pcaps/secret-control-udp.pcapng
+++ b/dc/wireshark/pcaps/secret-control-udp.pcapng
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fb9dd8afe64461da5b83ceba264db0c7f89109db7aa7b8ac50876d642f5c828
+size 87992

--- a/dc/wireshark/src/plugin.rs
+++ b/dc/wireshark/src/plugin.rs
@@ -99,9 +99,15 @@ unsafe extern "C" fn dissect_heur_udp(
             break;
         };
         let (mut tree, mut root) = register_root_node(proto, &buffer, fields);
-        let Some(()) =
-            dissect::udp_segment(&mut tree, &mut root, fields, tag, &mut buffer, &mut info)
-        else {
+        let Some(()) = dissect::segment(
+            &mut tree,
+            &mut root,
+            fields,
+            tag,
+            &mut buffer,
+            &mut info,
+            dissect::Protocol::Udp,
+        ) else {
             break;
         };
 
@@ -146,8 +152,15 @@ unsafe extern "C" fn dissect_heur_tcp(
         };
 
         let (mut tree, mut root) = register_root_node(proto, &buffer, fields);
-        root.append_text(c" Stream");
-        let parse_res = dissect::stream(&mut tree, fields, tag, &mut buffer, &mut info);
+        let parse_res = dissect::segment(
+            &mut tree,
+            &mut root,
+            fields,
+            tag,
+            &mut buffer,
+            &mut info,
+            dissect::Protocol::Tcp,
+        );
         wireshark_sys::proto_item_set_len(root, (buffer.offset - stream_frame_start) as i32);
         if parse_res.is_none() {
             // Start parsing again from the head of this stream...

--- a/dc/wireshark/src/test.rs
+++ b/dc/wireshark/src/test.rs
@@ -533,7 +533,7 @@ fn random_stream_packets() {
 }
 
 #[test]
-fn random_udp_packets() {
+fn random_segments() {
     // Initialize field IDs.
     let _ = crate::field::get();
 
@@ -545,7 +545,15 @@ fn random_udp_packets() {
             return;
         };
         // May fail to parse, but shouldn't panic.
-        let _ = dissect::udp_segment(&mut tracker, &mut (), fields, tag, &mut buffer, &mut ());
+        let _ = dissect::segment(
+            &mut tracker,
+            &mut (),
+            fields,
+            tag,
+            &mut buffer,
+            &mut (),
+            dissect::Protocol::Udp,
+        );
     });
 }
 

--- a/dc/wireshark/xtask/Cargo.toml
+++ b/dc/wireshark/xtask/Cargo.toml
@@ -6,4 +6,5 @@ publish = false
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
+homedir = "0.2"
 xshell = "0.2"

--- a/dc/wireshark/xtask/src/main.rs
+++ b/dc/wireshark/xtask/src/main.rs
@@ -192,7 +192,10 @@ impl Install {
         Build::default().run(sh)?;
 
         let dir = if cfg!(unix) {
-            format!("~/.local/lib/wireshark/{}", plugin_dir())
+            homedir::get_my_home()?
+                .expect("missing home dir")
+                .join(".local/lib/wireshark")
+                .join(plugin_dir())
         } else {
             todo!("OS is currently unsupported")
         };
@@ -202,7 +205,7 @@ impl Install {
         sh.copy_file(
             format!("target/release/libwireshark_dcquic.{so}"),
             // wireshark always looks for `.so`, regardless of platform
-            format!("{dir}/libdcquic.so"),
+            dir.join("libdcquic.so"),
         )?;
 
         Ok(())


### PR DESCRIPTION
### Description of changes: 

This change renamed the `dissect::udp_segment` function to `dissect::segment` and calls it from both UDP and TCP now. This ensures that all packet types are handled. It also can make it easier to diagnose issues if, for example, TCP is transmitting Control or Datagram packets.

### Testing:

I've added some sample pcaps to show it working for `UnknownPathSecret` packets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

