### PR TITLE
feat(s2n-quic-dc): set max_datagram_size in ApplicationParams

### DIFF
--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 exclude = ["corpus.tar.gz"]
 
 [features]
-testing = ["bolero-generator"]
+testing = ["bolero-generator", "s2n-quic-core/testing"]
 
 [dependencies]
 atomic-waker = "1"

--- a/quic/s2n-quic-core/src/dc.rs
+++ b/quic/s2n-quic-core/src/dc.rs
@@ -8,7 +8,6 @@ use crate::{
         IntoEvent as _,
     },
     inet,
-    path::MaxMtu,
     transport::parameters::{DcSupportedVersions, InitialFlowControlLimits},
     varint::VarInt,
 };
@@ -73,10 +72,10 @@ impl<'a> ConnectionInfo<'a> {
 }
 
 /// Various settings relevant to the dc path
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug)]
 #[non_exhaustive]
 pub struct ApplicationParams {
-    pub max_mtu: MaxMtu,
+    pub max_datagram_size: u16,
     pub remote_max_data: VarInt,
     pub local_send_max_data: VarInt,
     pub local_recv_max_data: VarInt,
@@ -86,12 +85,12 @@ pub struct ApplicationParams {
 
 impl ApplicationParams {
     pub fn new(
-        max_mtu: MaxMtu,
+        max_datagram_size: u16,
         peer_flow_control_limits: &InitialFlowControlLimits,
         limits: &Limits,
     ) -> Self {
         Self {
-            max_mtu,
+            max_datagram_size,
             remote_max_data: peer_flow_control_limits.max_data,
             local_send_max_data: limits.initial_stream_limits().max_data_bidi_local,
             local_recv_max_data: limits.initial_stream_limits().max_data_bidi_remote,

--- a/quic/s2n-quic-core/src/dc/testing.rs
+++ b/quic/s2n-quic-core/src/dc/testing.rs
@@ -1,7 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{crypto::tls::TlsSession, dc, dc::ConnectionInfo, stateless_reset, transport};
+use crate::{
+    crypto::tls::TlsSession,
+    dc,
+    dc::{ApplicationParams, ConnectionInfo},
+    stateless_reset, transport,
+    varint::VarInt,
+};
+use core::time::Duration;
 
 pub struct MockDcEndpoint {
     stateless_reset_tokens: Vec<stateless_reset::Token>,
@@ -52,3 +59,12 @@ impl dc::Path for MockDcPath {
             .extend(stateless_reset_tokens);
     }
 }
+
+pub const TEST_APPLICATION_PARAMS: ApplicationParams = ApplicationParams {
+    max_datagram_size: 1472,
+    remote_max_data: VarInt::from_u32(1u32 << 25),
+    local_send_max_data: VarInt::from_u32(1u32 << 25),
+    local_recv_max_data: VarInt::from_u32(1u32 << 25),
+    max_idle_timeout: Some(Duration::from_secs(30)),
+    max_ack_delay: Duration::from_millis(25),
+};

--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -470,8 +470,6 @@ pub struct Controller {
     //# The Packetization Layer PMTU is an estimate of the largest size
     //# of PL datagram that can be sent by a path, controlled by PLPMTUD
     plpmtu: u16,
-    /// The maximum size any packet can reach
-    max_mtu: MaxMtu,
     /// The maximum size the UDP payload can reach for any probe packet.
     max_udp_payload: u16,
     //= https://www.rfc-editor.org/rfc/rfc8899#section-5.1.3
@@ -543,7 +541,6 @@ impl Controller {
             base_plpmtu,
             plpmtu,
             probed_size: initial_probed_size,
-            max_mtu: config.max_mtu,
             max_udp_payload,
             max_probe_size: max_udp_payload,
             probe_count: 0,
@@ -712,12 +709,6 @@ impl Controller {
     #[inline]
     pub fn max_datagram_size(&self) -> usize {
         self.plpmtu as usize
-    }
-
-    /// Returns the maximum size any packet can reach, including IP and UDP headers
-    #[inline]
-    pub fn max_mtu(&self) -> MaxMtu {
-        self.max_mtu
     }
 
     /// Gets the max datagram size currently being probed for

--- a/quic/s2n-quic-core/src/path/mtu/tests.rs
+++ b/quic/s2n-quic-core/src/path/mtu/tests.rs
@@ -189,7 +189,6 @@ fn min_max_mtu() {
         &addr.into(),
     );
     assert_eq!(MINIMUM_MAX_DATAGRAM_SIZE, controller.plpmtu);
-    assert_eq!(MaxMtu::MIN, controller.max_mtu);
     assert_eq!(MINIMUM_MAX_DATAGRAM_SIZE, controller.base_plpmtu);
 }
 
@@ -199,7 +198,6 @@ fn new_max_mtu_smaller_than_common_mtu() {
 
     let mut controller = new_controller(max_mtu);
     assert_eq!(MINIMUM_MAX_DATAGRAM_SIZE + 1, controller.probed_size);
-    assert_eq!(max_mtu, u16::from(controller.max_mtu));
     assert_eq!(MINIMUM_MAX_DATAGRAM_SIZE, controller.base_plpmtu);
 
     controller.enable();
@@ -216,7 +214,6 @@ fn new_ipv4() {
         },
         &addr.into(),
     );
-    assert_eq!(1600_u16, u16::from(controller.max_mtu));
     assert_eq!(MINIMUM_MAX_DATAGRAM_SIZE, controller.base_plpmtu);
     assert_eq!(
         1600 - UDP_HEADER_LEN - IPV4_MIN_HEADER_LEN,
@@ -251,7 +248,6 @@ fn new_ipv6() {
         },
         &addr.into(),
     );
-    assert_eq!(2000_u16, u16::from(controller.max_mtu));
     assert_eq!(MINIMUM_MAX_DATAGRAM_SIZE, controller.base_plpmtu);
     assert_eq!(
         2000 - UDP_HEADER_LEN - IPV6_MIN_HEADER_LEN,
@@ -289,7 +285,6 @@ fn new_initial_and_base_mtu() {
         },
         &addr.into(),
     );
-    assert_eq!(2600_u16, u16::from(controller.max_mtu));
     assert_eq!(
         2600 - UDP_HEADER_LEN - IPV4_MIN_HEADER_LEN,
         controller.max_udp_payload

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -525,11 +525,6 @@ impl<Config: endpoint::Config> Path<Config> {
         self.pto_backoff = INITIAL_PTO_BACKOFF;
     }
 
-    #[inline]
-    pub fn max_mtu(&self) -> MaxMtu {
-        self.mtu_controller.max_mtu()
-    }
-
     /// Returns `true` if the congestion window does not have sufficient space for a packet of the maximum
     /// datagram size considering the current bytes in flight and the additional `bytes_sent` provided
     #[inline]

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -442,7 +442,10 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
 
         let dc_manager = if let Some(dc_version) = dc_version {
             let application_params = dc::ApplicationParams::new(
-                self.path_manager.active_path().max_mtu(),
+                self.path_manager
+                    .active_path()
+                    .mtu_controller
+                    .max_datagram_size() as u16,
                 &peer_flow_control_limits,
                 self.limits,
             );


### PR DESCRIPTION
### Description of changes: 

This change replaces the usage of `MaxMtu` in `dc::ApplicationParams` with the `max_datagram_size`, which is a value based on the actual confirmed MTU size, rather than a configured setting. This removes the last remaining usage of `MaxMtu` from the `mtu::Controller`, so I've cleaned that up a bit as well.

### Call-outs:

This requires setting the `InitialMtu` setting to quickly probe a given MTU size, as the `dc::ApplicationParams` are configured before any regular MTU probing occurs.

I've also derived `Copy` for `ApplicationParams` and added a `TEST_APPLICATION_PARAMS` const for convenience. 

### Testing:

Existing tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

