### PR TITLE
feat(s2n-quic-dc): Handle secret control packets in dc Endpoint

### DIFF
--- a/quic/s2n-quic-core/src/dc.rs
+++ b/quic/s2n-quic-core/src/dc.rs
@@ -83,9 +83,9 @@ pub struct DatagramInfo<'a> {
 impl<'a> DatagramInfo<'a> {
     #[inline]
     #[doc(hidden)]
-    pub fn new( remote_address: &'a inet::SocketAddress) -> Self {
+    pub fn new(remote_address: &'a inet::SocketAddress) -> Self {
         Self {
-            remote_address: remote_address.into_event()
+            remote_address: remote_address.into_event(),
         }
     }
 }

--- a/quic/s2n-quic-core/src/dc.rs
+++ b/quic/s2n-quic-core/src/dc.rs
@@ -71,6 +71,25 @@ impl<'a> ConnectionInfo<'a> {
     }
 }
 
+/// Information about a received datagram that may be used
+/// when parsing it for a secret control packet
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub struct DatagramInfo<'a> {
+    /// The address (IP + Port) of the remote peer
+    pub remote_address: SocketAddress<'a>,
+}
+
+impl<'a> DatagramInfo<'a> {
+    #[inline]
+    #[doc(hidden)]
+    pub fn new( remote_address: &'a inet::SocketAddress) -> Self {
+        Self {
+            remote_address: remote_address.into_event()
+        }
+    }
+}
+
 /// Various settings relevant to the dc path
 #[derive(Clone, Copy, Debug)]
 #[non_exhaustive]

--- a/quic/s2n-quic-core/src/dc/disabled.rs
+++ b/quic/s2n-quic-core/src/dc/disabled.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     crypto::tls::TlsSession,
-    dc::{ConnectionInfo, Endpoint, Path},
+    dc::{ConnectionInfo, DatagramInfo, Endpoint, Path},
     stateless_reset, transport,
 };
 use alloc::vec::Vec;
@@ -18,6 +18,14 @@ impl Endpoint for Disabled {
 
     fn new_path(&mut self, _connection_info: &ConnectionInfo) -> Option<Self::Path> {
         None
+    }
+
+    fn on_possible_secret_control_packet(
+        &mut self,
+        _datagram_info: &DatagramInfo,
+        _payload: &mut [u8],
+    ) -> bool {
+        unreachable!()
     }
 }
 

--- a/quic/s2n-quic-core/src/dc/testing.rs
+++ b/quic/s2n-quic-core/src/dc/testing.rs
@@ -4,7 +4,7 @@
 use crate::{
     crypto::tls::TlsSession,
     dc,
-    dc::{ApplicationParams, ConnectionInfo},
+    dc::{ApplicationParams, ConnectionInfo, DatagramInfo},
     stateless_reset, transport,
     varint::VarInt,
 };
@@ -38,6 +38,14 @@ impl dc::Endpoint for MockDcEndpoint {
             stateless_reset_tokens: self.stateless_reset_tokens.clone(),
             ..Default::default()
         })
+    }
+
+    fn on_possible_secret_control_packet(
+        &mut self,
+        _datagram_info: &DatagramInfo,
+        _payload: &mut [u8],
+    ) -> bool {
+        false
     }
 }
 

--- a/quic/s2n-quic-core/src/dc/traits.rs
+++ b/quic/s2n-quic-core/src/dc/traits.rs
@@ -17,6 +17,16 @@ pub trait Endpoint: 'static + Send {
     ///
     /// Return `None` if dc should not be used for this path
     fn new_path(&mut self, connection_info: &dc::ConnectionInfo) -> Option<Self::Path>;
+
+    /// Called when a datagram arrives that cannot be decoded as a non-DC QUIC packet, and
+    /// thus may contain a secret control packet
+    ///
+    /// Return `true` if a secret control packet was decoded from the datagram, `false` otherwise
+    fn on_possible_secret_control_packet(
+        &mut self,
+        datagram_info: &dc::DatagramInfo,
+        payload: &mut [u8],
+    ) -> bool;
 }
 
 /// A dc path

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -459,6 +459,17 @@ impl<Cfg: Config> Endpoint<Cfg> {
         ) {
             (packet, remaining)
         } else {
+            if Cfg::DcEndpoint::ENABLED
+                && endpoint_context.dc.on_possible_secret_control_packet(
+                    &dc::DatagramInfo::new(&remote_address),
+                    payload,
+                )
+            {
+                // This was a DC secret control packet, so we don't need to proceed
+                // with checking for a stateless reset
+                return;
+            }
+
             //= https://www.rfc-editor.org/rfc/rfc9000#section-5.2.2
             //# Servers MUST drop incoming packets under all other circumstances.
 


### PR DESCRIPTION
### Description of changes: 

This change adds a method to the `dc::Endpoint` trait that allows implementors of the trait to handle secret control packets. 

### Testing:

I didn't add new tests for this for now, but I think it should be possible to add an integration test as a follow up. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

