### PR TITLE
 fix(s2n-quic): implement Debug and Default for the disabled event Subscriber

### DIFF
--- a/quic/s2n-quic/src/provider/event/disabled.rs
+++ b/quic/s2n-quic/src/provider/event/disabled.rs
@@ -15,6 +15,7 @@ impl super::Provider for Provider {
     }
 }
 
+#[derive(Debug, Default)]
 pub struct Subscriber;
 
 impl super::Subscriber for Subscriber {


### PR DESCRIPTION
### Description of changes: 

This change implements `Default` (and `Debug`) for the disabled event Subscriber, so that one can call `s2n_quic::provider::event::default::Subscriber::default()` to get a default instance regardless if tracing is enabled or not

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

