### PR TITLE
feat(s2n-quic-transport): Support de-duplicating concurrent connections to the same peer

### DIFF
--- a/quic/s2n-quic-core/src/application/server_name.rs
+++ b/quic/s2n-quic-core/src/application/server_name.rs
@@ -23,7 +23,7 @@ use bytes::Bytes;
 /// - It can be converted into [`Bytes`] which supports zero-copy slicing and
 /// reference counting.
 /// - It can be accessed as `&str` so that applications can reason about the string value.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ServerName(Bytes);
 
 /// A static value for localhost

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -14,6 +14,7 @@ exclude = ["corpus.tar.gz"]
 default = ["std"]
 std = ["futures-channel/std"]
 unstable_resumption = []
+unstable-provider-dc = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }

--- a/quic/s2n-quic-transport/src/connection/mod.rs
+++ b/quic/s2n-quic-transport/src/connection/mod.rs
@@ -27,7 +27,7 @@ pub(crate) mod transmission;
 
 pub(crate) use api_provider::{ConnectionApi, ConnectionApiProvider};
 pub(crate) use connection_container::{ConnectionContainer, ConnectionContainerIterationResult};
-pub(crate) use connection_id_mapper::ConnectionIdMapper;
+pub(crate) use connection_id_mapper::{ConnectionIdMapper, OpenRegistry};
 pub(crate) use connection_interests::ConnectionInterests;
 pub(crate) use connection_timers::ConnectionTimers;
 pub(crate) use connection_trait::ConnectionTrait as Trait;
@@ -52,6 +52,9 @@ pub struct Parameters<'a, Cfg: endpoint::Config> {
     pub local_id_registry: LocalIdRegistry,
     /// The peer ID registry which should be utilized by the connection
     pub peer_id_registry: PeerIdRegistry,
+    /// The open connections registry which should be utilized by the connection
+    /// None for accepted/inbound connections.
+    pub open_registry: Option<OpenRegistry>,
     /// The last utilized remote Connection ID
     pub peer_connection_id: PeerId,
     /// The last utilized local Connection ID

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -314,6 +314,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             event_subscriber: endpoint_context.event_subscriber,
             datagram_endpoint: endpoint_context.datagram,
             dc_endpoint: endpoint_context.dc,
+            open_registry: None,
         };
 
         let mut connection = <Config as endpoint::Config>::Connection::new(connection_parameters)?;

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -54,7 +54,7 @@ unstable-provider-packet-interceptor = []
 # This feature enables the random provider
 unstable-provider-random = []
 # This feature enables the dc provider
-unstable-provider-dc = []
+unstable-provider-dc = ["s2n-quic-transport/unstable-provider-dc"]
 # This feature enables support for third party congestion controller implementations
 unstable-congestion-controller = ["s2n-quic-core/unstable-congestion-controller"]
 # This feature enables the use of unstable connection limits
@@ -85,7 +85,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 bolero = { version = "0.11" }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "probe-tracing", "testing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }
-s2n-quic-transport = { version = "=0.42.0", path = "../s2n-quic-transport", features = ["unstable_resumption"] }
+s2n-quic-transport = { version = "=0.42.0", path = "../s2n-quic-transport", features = ["unstable_resumption", "unstable-provider-dc"] }
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -30,6 +30,7 @@ use setup::*;
 
 mod blackhole;
 mod connection_migration;
+mod deduplicate;
 mod handshake_cid_rotation;
 mod interceptor;
 mod mtu;

--- a/quic/s2n-quic/src/tests/deduplicate.rs
+++ b/quic/s2n-quic/src/tests/deduplicate.rs
@@ -1,0 +1,129 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use s2n_quic_core::{dc::testing::MockDcEndpoint, stateless_reset::token::testing::TEST_TOKEN_1};
+
+const LEN: usize = 1_000_000;
+
+#[test]
+fn deduplicate_successfully() {
+    let model = Model::default();
+    model.set_delay(Duration::from_millis(50));
+
+    let server_subscriber = recorder::ConnectionStarted::new();
+    let server_events = server_subscriber.events();
+    let client_subscriber = recorder::ConnectionStarted::new();
+    let client_events = server_subscriber.events();
+    test(model, |handle| {
+        let mut server = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(SERVER_CERTS)?
+            .with_event((tracing_events(), server_subscriber.clone()))?
+            .with_random(Random::with_seed(456))?
+            .start()?;
+
+        let addr = server.local_addr()?;
+        spawn(async move {
+            let mut conn = server.accept().await.unwrap();
+            for _ in 0..2 {
+                let mut stream = conn.open_bidirectional_stream().await.unwrap();
+                stream.send(vec![42; LEN].into()).await.unwrap();
+                stream.flush().await.unwrap();
+            }
+            let mut conn = server.accept().await.unwrap();
+            let mut stream = conn.open_bidirectional_stream().await.unwrap();
+            stream.send(vec![42; LEN].into()).await.unwrap();
+            stream.flush().await.unwrap();
+        });
+
+        let mut server2 = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(SERVER_CERTS)?
+            .with_event((tracing_events(), server_subscriber))?
+            .with_random(Random::with_seed(456))?
+            .start()?;
+
+        let addr2 = server2.local_addr()?;
+        spawn(async move {
+            let mut conn = server2.accept().await.unwrap();
+            let mut stream = conn.open_bidirectional_stream().await.unwrap();
+            stream.send(vec![42; LEN].into()).await.unwrap();
+            stream.flush().await.unwrap();
+        });
+
+        let tokens = [TEST_TOKEN_1];
+        let client = Client::builder()
+            .with_io(handle.builder().build().unwrap())?
+            .with_tls(certificates::CERT_PEM)?
+            .with_event((tracing_events(), client_subscriber))?
+            .with_random(Random::with_seed(456))?
+            .with_dc(MockDcEndpoint::new(&tokens))?
+            .start()?;
+
+        primary::spawn(async move {
+            let connect = Connect::new(addr)
+                .with_server_name("localhost")
+                .with_deduplicate(true);
+            let mut conn = client.connect(connect.clone()).await.unwrap();
+            let id1 = conn.id();
+            confirm_conn_works(&mut conn).await;
+
+            // "Open" a second connection -- this should not actually open a new connection.
+            let mut conn2 = client.connect(connect.clone()).await.unwrap();
+            assert_eq!(conn2.id(), id1);
+            confirm_conn_works(&mut conn2).await;
+
+            // New address means new connection. (FIXME: Also test SNI differences, need to figure
+            // out certificates for that...)
+            let mut conn3 = client
+                .connect(
+                    Connect::new(addr2)
+                        .with_server_name("localhost")
+                        .with_deduplicate(true),
+                )
+                .await
+                .unwrap();
+            assert_ne!(conn3.id(), conn.id());
+            confirm_conn_works(&mut conn3).await;
+
+            drop(conn);
+            drop(conn2);
+
+            // "Open" a connection -- since the conn/conn2 handles have dropped, this should be a
+            // new connection.
+            let mut conn4 = client.connect(connect.clone()).await.unwrap();
+            assert_ne!(conn4.id(), id1);
+            confirm_conn_works(&mut conn4).await;
+        });
+
+        Ok(addr)
+    })
+    .unwrap();
+
+    let server_started_count = server_events.lock().unwrap().len();
+    let client_started_count = client_events.lock().unwrap().len();
+
+    assert_eq!(server_started_count, 3);
+    assert_eq!(client_started_count, 3);
+}
+
+#[track_caller]
+fn confirm_conn_works(
+    conn: &mut crate::connection::Connection,
+) -> impl std::future::Future<Output = ()> + '_ {
+    let caller = std::panic::Location::caller();
+    async move {
+        let mut stream = conn
+            .accept_bidirectional_stream()
+            .await
+            .unwrap()
+            .unwrap_or_else(|| panic!("from {:?}", caller));
+
+        let mut recv_len = 0;
+        while let Some(chunk) = stream.receive().await.unwrap() {
+            recv_len += chunk.len();
+        }
+        assert_eq!(LEN, recv_len);
+    }
+}

--- a/quic/s2n-quic/src/tests/recorder.rs
+++ b/quic/s2n-quic/src/tests/recorder.rs
@@ -154,3 +154,16 @@ event_recorder!(
         storage.push(event.reason.clone());
     }
 );
+
+event_recorder!(
+    ConnectionStarted,
+    ConnectionStarted,
+    on_connection_started,
+    SocketAddr,
+    |event: &events::ConnectionStarted, storage: &mut Vec<SocketAddr>| {
+        let addr: SocketAddr = event.path.local_addr.to_string().parse().unwrap();
+        if storage.last().map_or(true, |prev| *prev != addr) {
+            storage.push(addr);
+        }
+    }
+);

--- a/quic/s2n-quic/src/tests/skip_packets.rs
+++ b/quic/s2n-quic/src/tests/skip_packets.rs
@@ -88,6 +88,9 @@ fn optimistic_ack_mitigation() {
 
     // Verify that both client and server are skipping packets for Optimistic
     // Ack attack mitigation.
+    //
+    // The exact number of skipped packets depends on randomness, so this test may be changed by
+    // unrelated changes. The important thing is that both numbers are non-zero.
     assert_eq!(server_skip_count, 5);
     assert_eq!(client_skip_count, 5);
 }


### PR DESCRIPTION
### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2211

### Description of changes: 

This implements support for utilizing s2n-quic to track open (or pending open) connection handles, effectively de-duplicating requests to open a connection.

### Call-outs:

* Currently using a `HashMap<Connect, InternalId>`. It's possible this could be made intrusive and save memory, though I'm not sure if the SNI and initial open SocketAddr are actually tracked within the connection state. This is purely an optimization though and shouldn't affect public API if we choose to apply it.
* I'm not very confident that all of the structures/counters are updated in the right places. For example, I had to add a manual drop of the tracking state rather than relying on implicitly dropping it. There's nothing in that code that drops other maps though, so that makes me suspect it's the wrong approach.
* Locally I seem to have also managed to break the optimistic ack test (5 -> 4 skipped packets). However I don't see any of my code as doing anything without explicit enablement, so not sure yet what exactly is going on there. Opening for review regardless while I chase that down.

### Testing:

* Added a basic test that shows de-duplication works.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

