### PR TITLE
fix(s2n-quic-dc): reorder wire version to preserve wire invariants

### DIFF
--- a/dc/s2n-quic-dc/src/packet/control/decoder.rs
+++ b/dc/s2n-quic-dc/src/packet/control/decoder.rs
@@ -154,9 +154,8 @@ impl<'a> Packet<'a> {
             let (tag, buffer) = buffer.decode()?;
             validator.validate_tag(tag)?;
 
-            let (wire_version, buffer) = buffer.decode()?;
-
             let (credentials, buffer) = buffer.decode()?;
+            let (wire_version, buffer) = buffer.decode()?;
 
             let (source_control_port, buffer) = buffer.decode()?;
 

--- a/dc/s2n-quic-dc/src/packet/control/encoder.rs
+++ b/dc/s2n-quic-dc/src/packet/control/encoder.rs
@@ -36,13 +36,14 @@ where
     tag.set_has_application_header(*header_len > 0);
     encoder.encode(&tag);
 
-    // wire version - we only support `0` currently
-    encoder.encode(&WireVersion::ZERO);
-
     let nonce = *packet_number | NONCE_MASK;
 
     // encode the credentials being used
     encoder.encode(crypto.credentials());
+
+    // wire version - we only support `0` currently
+    encoder.encode(&WireVersion::ZERO);
+
     encoder.encode(&source_control_port);
 
     encoder.encode(&stream_id);

--- a/dc/s2n-quic-dc/src/packet/datagram/decoder.rs
+++ b/dc/s2n-quic-dc/src/packet/datagram/decoder.rs
@@ -178,9 +178,9 @@ impl<'a> Packet<'a> {
             let (tag, buffer) = buffer.decode()?;
             validator.validate_tag(tag)?;
 
-            let (wire_version, buffer) = buffer.decode()?;
-
             let (credentials, buffer) = buffer.decode()?;
+
+            let (wire_version, buffer) = buffer.decode()?;
 
             let (source_control_port, buffer) = buffer.decode()?;
 

--- a/dc/s2n-quic-dc/src/packet/datagram/encoder.rs
+++ b/dc/s2n-quic-dc/src/packet/datagram/encoder.rs
@@ -23,14 +23,14 @@ pub fn estimate_len(
     let mut encoder = s2n_codec::EncoderLenEstimator::new(usize::MAX);
 
     encoder.encode(&Tag::default());
-    // wire version
-    encoder.encode(&WireVersion::ZERO);
 
     // credentials
     {
         encoder.write_zerocopy::<credentials::Id, _>(|_| {});
         encoder.write_repeated(8, 0);
     }
+    // wire version
+    encoder.encode(&WireVersion::ZERO);
     encoder.encode(&0u16); // source control port
     encoder.write_repeated(8, 0); // packet number
     encoder.write_repeated(8, 0); // payload len
@@ -79,15 +79,16 @@ where
     tag.set_key_phase(crypto.key_phase());
     encoder.encode(&tag);
 
-    // wire version - we only support `0` currently
-    encoder.encode(&WireVersion::ZERO);
-
     let header_len_usize = *header_len as usize;
     let payload_len_usize = *payload_len as usize;
     let nonce = *packet_number.unwrap_or(super::PacketNumber::ZERO);
 
     // encode the credentials being used
     encoder.encode(crypto.credentials());
+
+    // wire version - we only support `0` currently
+    encoder.encode(&WireVersion::ZERO);
+
     encoder.encode(&source_control_port);
 
     if tag.is_connected() || tag.ack_eliciting() {

--- a/dc/s2n-quic-dc/src/packet/secret_control/replay_detected.rs
+++ b/dc/s2n-quic-dc/src/packet/secret_control/replay_detected.rs
@@ -21,8 +21,8 @@ impl ReplayDetected {
         C: encrypt::Key,
     {
         encoder.encode(&Tag::default());
-        encoder.encode(&self.wire_version);
         encoder.encode(&self.credential_id);
+        encoder.encode(&self.wire_version);
         encoder.encode(&self.rejected_key_id);
 
         encoder::finish(encoder, self.nonce(), crypto)
@@ -46,8 +46,8 @@ impl<'a> DecoderValue<'a> for ReplayDetected {
     fn decode(buffer: DecoderBuffer<'a>) -> R<'a, Self> {
         let (tag, buffer) = buffer.decode::<Tag>()?;
         decoder_invariant!(tag == Tag::default(), "invalid tag");
-        let (wire_version, buffer) = buffer.decode()?;
         let (credential_id, buffer) = buffer.decode()?;
+        let (wire_version, buffer) = buffer.decode()?;
         let (rejected_key_id, buffer) = buffer.decode()?;
         let value = Self {
             wire_version,

--- a/dc/s2n-quic-dc/src/packet/secret_control/stale_key.rs
+++ b/dc/s2n-quic-dc/src/packet/secret_control/stale_key.rs
@@ -21,8 +21,8 @@ impl StaleKey {
         C: encrypt::Key,
     {
         encoder.encode(&Tag::default());
-        encoder.encode(&self.wire_version);
         encoder.encode(&self.credential_id);
+        encoder.encode(&self.wire_version);
         encoder.encode(&self.min_key_id);
 
         encoder::finish(encoder, self.nonce(), crypto)
@@ -46,8 +46,8 @@ impl<'a> DecoderValue<'a> for StaleKey {
     fn decode(buffer: DecoderBuffer<'a>) -> R<'a, Self> {
         let (tag, buffer) = buffer.decode::<Tag>()?;
         decoder_invariant!(tag == Tag::default(), "invalid tag");
-        let (wire_version, buffer) = buffer.decode()?;
         let (credential_id, buffer) = buffer.decode()?;
+        let (wire_version, buffer) = buffer.decode()?;
         let (min_key_id, buffer) = buffer.decode()?;
         let value = Self {
             wire_version,

--- a/dc/s2n-quic-dc/src/packet/stream/decoder.rs
+++ b/dc/s2n-quic-dc/src/packet/stream/decoder.rs
@@ -404,9 +404,8 @@ impl<'a> Packet<'a> {
             tag
         };
 
-        let (_wire_version, buffer) = buffer.decode::<WireVersion>()?;
-
         let (credentials, buffer) = buffer.decode::<Credentials>()?;
+        let (_wire_version, buffer) = buffer.decode::<WireVersion>()?;
 
         debug_assert_eq!(&credentials, key.credentials());
 
@@ -520,9 +519,8 @@ impl<'a> Packet<'a> {
             let (tag, buffer) = buffer.decode()?;
             validator.validate_tag(tag)?;
 
-            let (wire_version, buffer) = buffer.decode::<WireVersion>()?;
-
             let (credentials, buffer) = buffer.decode()?;
+            let (wire_version, buffer) = buffer.decode()?;
 
             let (source_control_port, buffer) = buffer.decode()?;
 

--- a/dc/s2n-quic-dc/src/packet/stream/encoder.rs
+++ b/dc/s2n-quic-dc/src/packet/stream/encoder.rs
@@ -56,13 +56,14 @@ where
     tag.set_packet_space(packet_space);
     encoder.encode(&tag);
 
-    // wire version - we only support `0` currently
-    encoder.encode(&WireVersion::ZERO);
-
     let nonce = packet_space.packet_number_into_nonce(packet_number);
 
     // encode the credentials being used
     encoder.encode(crypto.credentials());
+
+    // wire version - we only support `0` currently
+    encoder.encode(&WireVersion::ZERO);
+
     encoder.encode(&source_control_port);
     encoder.encode(&source_stream_port);
 

--- a/dc/wireshark/src/dissect.rs
+++ b/dc/wireshark/src/dissect.rs
@@ -79,14 +79,14 @@ pub fn stream<T: Node>(
 
     let tag = tag.value;
 
-    let wire_version = buffer.consume::<WireVersion>()?;
-    wire_version.record(buffer, tree, fields.wire_version);
-
     let path_secret_id = buffer.consume_bytes(16)?;
     path_secret_id.record(buffer, tree, fields.path_secret_id);
 
     let key_id = buffer.consume::<VarInt>()?;
     key_id.record(buffer, tree, fields.key_id);
+
+    let wire_version = buffer.consume::<WireVersion>()?;
+    wire_version.record(buffer, tree, fields.wire_version);
 
     let source_control_port = buffer.consume::<u16>()?;
     source_control_port.record(buffer, tree, fields.source_control_port);
@@ -180,14 +180,14 @@ pub fn control<T: Node>(
 
     let tag = tag.value;
 
-    let wire_version = buffer.consume::<WireVersion>()?;
-    wire_version.record(buffer, tree, fields.wire_version);
-
     let path_secret_id = buffer.consume_bytes(16)?;
     path_secret_id.record(buffer, tree, fields.path_secret_id);
 
     let key_id = buffer.consume::<VarInt>()?;
     key_id.record(buffer, tree, fields.key_id);
+
+    let wire_version = buffer.consume::<WireVersion>()?;
+    wire_version.record(buffer, tree, fields.wire_version);
 
     let source_control_port = buffer.consume::<u16>()?;
     source_control_port.record(buffer, tree, fields.source_control_port);
@@ -419,14 +419,14 @@ pub fn datagram<T: Node>(
 
     let tag = tag.value;
 
-    let wire_version = buffer.consume::<WireVersion>()?;
-    wire_version.record(buffer, tree, fields.wire_version);
-
     let path_secret_id = buffer.consume_bytes(16)?;
     path_secret_id.record(buffer, tree, fields.path_secret_id);
 
     let key_id = buffer.consume::<VarInt>()?;
     key_id.record(buffer, tree, fields.key_id);
+
+    let wire_version = buffer.consume::<WireVersion>()?;
+    wire_version.record(buffer, tree, fields.wire_version);
 
     let source_control_port = buffer.consume::<u16>()?;
     source_control_port.record(buffer, tree, fields.source_control_port);
@@ -505,11 +505,11 @@ pub fn secret_control<T: Node>(
         packet::Tag::UnknownPathSecret(_) => {
             item.append_text(c" (UnknownPathSecret)");
 
-            let wire_version = buffer.consume::<WireVersion>()?;
-            wire_version.record(buffer, tree, fields.wire_version);
-
             let path_secret_id = buffer.consume_bytes(16)?;
             path_secret_id.record(buffer, tree, fields.path_secret_id);
+
+            let wire_version = buffer.consume::<WireVersion>()?;
+            wire_version.record(buffer, tree, fields.wire_version);
 
             let auth_tag = buffer.consume_bytes(16)?;
             auth_tag.record(buffer, tree, fields.auth_tag);
@@ -522,11 +522,11 @@ pub fn secret_control<T: Node>(
         packet::Tag::StaleKey(_) => {
             item.append_text(c" (StaleKey)");
 
-            let wire_version = buffer.consume::<WireVersion>()?;
-            wire_version.record(buffer, tree, fields.wire_version);
-
             let path_secret_id = buffer.consume_bytes(16)?;
             path_secret_id.record(buffer, tree, fields.path_secret_id);
+
+            let wire_version = buffer.consume::<WireVersion>()?;
+            wire_version.record(buffer, tree, fields.wire_version);
 
             let min_key_id = buffer.consume::<VarInt>()?;
             min_key_id.record(buffer, tree, fields.min_key_id);
@@ -542,11 +542,11 @@ pub fn secret_control<T: Node>(
         packet::Tag::ReplayDetected(_) => {
             item.append_text(c" (ReplayDetected)");
 
-            let wire_version = buffer.consume::<WireVersion>()?;
-            wire_version.record(buffer, tree, fields.wire_version);
-
             let path_secret_id = buffer.consume_bytes(16)?;
             path_secret_id.record(buffer, tree, fields.path_secret_id);
+
+            let wire_version = buffer.consume::<WireVersion>()?;
+            wire_version.record(buffer, tree, fields.wire_version);
 
             let rejected_key_id = buffer.consume::<VarInt>()?;
             rejected_key_id.record(buffer, tree, fields.rejected_key_id);


### PR DESCRIPTION
### Description of changes: 

This change reorders the wire_version and credential fields to better conform to the QUIC wire invariants.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

