### PR TITLE
feat(s2n-quic-dc): return from ConfirmComplete when no dc version negotiated

### DIFF
--- a/quic/s2n-quic-core/src/connection/error.rs
+++ b/quic/s2n-quic-core/src/connection/error.rs
@@ -224,6 +224,14 @@ impl PartialEq for Error {
                 a.eq(b)
             }
             (Error::EndpointClosing { .. }, Error::EndpointClosing { .. }) => true,
+            (
+                Error::InvalidConfiguration {
+                    reason: a_reason, ..
+                },
+                Error::InvalidConfiguration {
+                    reason: b_reason, ..
+                },
+            ) => a_reason.eq(b_reason),
             (Error::Unspecified { .. }, Error::Unspecified { .. }) => true,
             _ => false,
         }

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -606,6 +606,8 @@ pub mod api {
         #[non_exhaustive]
         VersionNegotiated { version: u32 },
         #[non_exhaustive]
+        NoVersionNegotiated {},
+        #[non_exhaustive]
         PathSecretsReady {},
         #[non_exhaustive]
         Complete {},
@@ -3560,6 +3562,7 @@ pub mod builder {
     #[derive(Clone, Debug)]
     pub enum DcState {
         VersionNegotiated { version: u32 },
+        NoVersionNegotiated,
         PathSecretsReady,
         Complete,
     }
@@ -3571,6 +3574,7 @@ pub mod builder {
                 Self::VersionNegotiated { version } => VersionNegotiated {
                     version: version.into_event(),
                 },
+                Self::NoVersionNegotiated => NoVersionNegotiated {},
                 Self::PathSecretsReady => PathSecretsReady {},
                 Self::Complete => Complete {},
             }

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -1002,6 +1002,7 @@ enum BbrState {
 
 enum DcState {
     VersionNegotiated { version: u32 },
+    NoVersionNegotiated,
     PathSecretsReady,
     Complete,
 }

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -25,7 +25,10 @@ use s2n_quic_core::{
     dc,
     dc::Endpoint as _,
     event,
-    event::IntoEvent,
+    event::{
+        builder::{DcState, DcStateChanged},
+        IntoEvent,
+    },
     packet::number::PacketNumberSpace,
     time::Timestamp,
     transport::{
@@ -459,6 +462,11 @@ impl<'a, Config: endpoint::Config, Pub: event::ConnectionPublisher>
             let dc_path = self.dc.new_path(&conn_info);
             crate::dc::Manager::new(dc_path, dc_version, self.publisher)
         } else {
+            if Config::DcEndpoint::ENABLED {
+                self.publisher.on_dc_state_changed(DcStateChanged {
+                    state: DcState::NoVersionNegotiated,
+                });
+            }
             crate::dc::Manager::disabled()
         };
 

--- a/quic/s2n-quic/src/tests/dc.rs
+++ b/quic/s2n-quic/src/tests/dc.rs
@@ -2,21 +2,37 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use crate::{client, client::ClientProviders, provider::dc, server, server::ServerProviders};
+use crate::{
+    client,
+    client::ClientProviders,
+    connection,
+    provider::{dc, io::testing::Result},
+    server,
+    server::ServerProviders,
+};
 use s2n_quic_core::{
+    crypto::tls,
     dc::testing::MockDcEndpoint,
     event::{api::DcState, Timestamp},
+    frame::ConnectionClose,
+    stateless_reset,
     stateless_reset::token::testing::{TEST_TOKEN_1, TEST_TOKEN_2},
+    transport,
+    varint::VarInt,
 };
-use std::io::ErrorKind;
+
+const SERVER_TOKENS: [stateless_reset::Token; 1] = [TEST_TOKEN_1];
+const CLIENT_TOKENS: [stateless_reset::Token; 1] = [TEST_TOKEN_2];
+const SERVER_CLOSE_ERROR_CODE: VarInt = VarInt::from_u8(111);
+const CLIENT_CLOSE_ERROR_CODE: VarInt = VarInt::from_u8(222);
 
 // Client                                                                    Server
 //
-// Initial[0]: CRYPTO[CH (DC_SUPPORTED_VERSIONS[3,2,1]] ->
+// Initial[0]: CRYPTO[CH (DC_SUPPORTED_VERSIONS[3,2,1])] ->
 //
 //                                      # dc_state_changed: state=VersionNegotiated
 //                                                    Initial[0]: CRYPTO[SH] ACK[0]
-//                Handshake[0]: CRYPTO[EE (DC_SUPPORTED_VERSIONS[3], CERT, CV, FIN]
+//               Handshake[0]: CRYPTO[EE (DC_SUPPORTED_VERSIONS[3]), CERT, CV, FIN]
 //
 // # dc_state_changed: state=VersionNegotiated
 // # handshake_status_updated: status=Complete
@@ -39,20 +55,24 @@ use std::io::ErrorKind;
 //                            # handshake_status_updated: status=HandshakeDoneAcked
 //                                               # dc_state_changed: state=Complete
 #[test]
-fn dc_handshake_self_test() {
-    let server = Server::builder().with_tls(SERVER_CERTS).unwrap();
-    let client = Client::builder().with_tls(certificates::CERT_PEM).unwrap();
+fn dc_handshake_self_test() -> Result<()> {
+    let server = Server::builder()
+        .with_tls(SERVER_CERTS)?
+        .with_dc(MockDcEndpoint::new(&SERVER_TOKENS))?;
+    let client = Client::builder()
+        .with_tls(certificates::CERT_PEM)?
+        .with_dc(MockDcEndpoint::new(&CLIENT_TOKENS))?;
 
-    self_test(server, client, None);
+    self_test(server, client, None, None)
 }
 
 // Client                                                                    Server
 //
-// Initial[0]: CRYPTO[CH (DC_SUPPORTED_VERSIONS[3,2,1]] ->
+// Initial[0]: CRYPTO[CH (DC_SUPPORTED_VERSIONS[3,2,1])] ->
 //
 //                                      # dc_state_changed: state=VersionNegotiated
 //                                                    Initial[0]: CRYPTO[SH] ACK[0]
-//                Handshake[0]: CRYPTO[EE (DC_SUPPORTED_VERSIONS[3], CERT, CV, FIN]
+//               Handshake[0]: CRYPTO[EE (DC_SUPPORTED_VERSIONS[3]), CERT, CV, FIN]
 //
 // # dc_state_changed: state=VersionNegotiated
 // # handshake_status_updated: status=Complete
@@ -75,32 +95,138 @@ fn dc_handshake_self_test() {
 //                            # handshake_status_updated: status=HandshakeDoneAcked
 //                                               # dc_state_changed: state=Complete
 #[test]
-fn dc_mtls_handshake_self_test() {
-    let server_tls = build_server_mtls_provider(certificates::MTLS_CA_CERT).unwrap();
-    let server = Server::builder().with_tls(server_tls).unwrap();
+fn dc_mtls_handshake_self_test() -> Result<()> {
+    let server_tls = build_server_mtls_provider(certificates::MTLS_CA_CERT)?;
+    let server = Server::builder()
+        .with_tls(server_tls)?
+        .with_dc(MockDcEndpoint::new(&SERVER_TOKENS))?;
 
-    let client_tls = build_client_mtls_provider(certificates::MTLS_CA_CERT).unwrap();
-    let client = Client::builder().with_tls(client_tls).unwrap();
+    let client_tls = build_client_mtls_provider(certificates::MTLS_CA_CERT)?;
+    let client = Client::builder()
+        .with_tls(client_tls)?
+        .with_dc(MockDcEndpoint::new(&SERVER_TOKENS))?;
 
-    self_test(server, client, None);
+    self_test(server, client, None, None)
 }
 
 #[test]
-fn dc_mtls_handshake_auth_failure_self_test() {
-    let server_tls = build_server_mtls_provider(certificates::UNTRUSTED_CERT_PEM).unwrap();
-    let server = Server::builder().with_tls(server_tls).unwrap();
+fn dc_mtls_handshake_auth_failure_self_test() -> Result<()> {
+    let server_tls = build_server_mtls_provider(certificates::UNTRUSTED_CERT_PEM)?;
+    let server = Server::builder()
+        .with_tls(server_tls)?
+        .with_dc(MockDcEndpoint::new(&CLIENT_TOKENS))?;
 
-    let client_tls = build_client_mtls_provider(certificates::MTLS_CA_CERT).unwrap();
-    let client = Client::builder().with_tls(client_tls).unwrap();
+    let client_tls = build_client_mtls_provider(certificates::MTLS_CA_CERT)?;
+    let client = Client::builder()
+        .with_tls(client_tls)?
+        .with_dc(MockDcEndpoint::new(&SERVER_TOKENS))?;
 
-    self_test(server, client, Some(ErrorKind::ConnectionReset));
+    // convert from a ConnectionClose frame so the initiator is `Remote`
+    let expected_client_error = ConnectionClose {
+        error_code: transport::Error::crypto_error(tls::Error::HANDSHAKE_FAILURE.code)
+            .code
+            .as_u64()
+            .try_into()
+            .unwrap(),
+        frame_type: Some(VarInt::ZERO),
+        reason: None,
+    }
+    .into();
+
+    self_test(server, client, Some(expected_client_error), None)
+}
+
+// Client                                                                    Server
+//
+// Initial[0]: CRYPTO[CH (DC_SUPPORTED_VERSIONS[3,2,1])] ->
+//
+//                                                    Initial[0]: CRYPTO[SH] ACK[0]
+//                                       <- Handshake[0]: CRYPTO[EE, CERT, CV, FIN]
+//
+// # dc_state_changed: state=NoVersionNegotiated
+// # handshake_status_updated: status=Complete
+// Initial[1]: ACK[0]
+// 1-RTT[0]: connection_closed: error=Application(222)
+#[test]
+fn dc_mtls_handshake_server_not_supported_self_test() -> Result<()> {
+    // No dc Provider configured on the server
+    let server_tls = build_server_mtls_provider(certificates::MTLS_CA_CERT)?;
+    let server = Server::builder().with_tls(server_tls)?;
+
+    let client_tls = build_client_mtls_provider(certificates::MTLS_CA_CERT)?;
+    let client = Client::builder()
+        .with_tls(client_tls)?
+        .with_dc(MockDcEndpoint::new(&SERVER_TOKENS))?;
+
+    // convert from a ConnectionClose frame so the initiator is `Remote`
+    let expected_server_error = ConnectionClose {
+        error_code: CLIENT_CLOSE_ERROR_CODE,
+        frame_type: None,
+        reason: None,
+    }
+    .into();
+
+    self_test(
+        server,
+        client,
+        Some(connection::Error::invalid_configuration(
+            "peer does not support specified dc versions",
+        )),
+        Some(expected_server_error),
+    )
+}
+
+// Client                                                                    Server
+//
+// Initial[0]: CRYPTO[CH] ->
+//
+//                                    # dc_state_changed: state=NoVersionNegotiated
+//                                                    Initial[0]: CRYPTO[SH] ACK[0]
+//                                          Handshake[0]: CRYPTO[EE, CERT, CV, FIN]
+//
+// # handshake_status_updated: status=Complete
+// Initial[1]: ACK[0]
+// Handshake[0]: CRYPTO[CERT, CV, FIN], ACK[0] ->
+//
+//                                      # handshake_status_updated: status=Complete
+//                                     # handshake_status_updated: status=Confirmed
+//                                           # key_space_discarded: space=Handshake
+//                           <- 1-RTT[0]: connection_closed: error=Application(111)
+#[test]
+fn dc_mtls_handshake_client_not_supported_self_test() -> Result<()> {
+    let server_tls = build_server_mtls_provider(certificates::MTLS_CA_CERT)?;
+    let server = Server::builder()
+        .with_tls(server_tls)?
+        .with_dc(MockDcEndpoint::new(&CLIENT_TOKENS))?;
+
+    // No dc Provider configured on the client
+    let client_tls = build_client_mtls_provider(certificates::MTLS_CA_CERT)?;
+    let client = Client::builder().with_tls(client_tls)?;
+
+    // convert from a ConnectionClose frame so the initiator is `Remote`
+    let expected_client_error = ConnectionClose {
+        error_code: SERVER_CLOSE_ERROR_CODE,
+        frame_type: None,
+        reason: None,
+    }
+    .into();
+
+    self_test(
+        server,
+        client,
+        Some(expected_client_error),
+        Some(connection::Error::invalid_configuration(
+            "peer does not support specified dc versions",
+        )),
+    )
 }
 
 fn self_test<S: ServerProviders, C: ClientProviders>(
     server: server::Builder<S>,
     client: client::Builder<C>,
-    expected_error: Option<ErrorKind>,
-) {
+    expected_client_error: Option<connection::Error>,
+    expected_server_error: Option<connection::Error>,
+) -> Result<()> {
     let model = Model::default();
     let rtt = Duration::from_millis(100);
     model.set_delay(rtt / 2);
@@ -109,26 +235,29 @@ fn self_test<S: ServerProviders, C: ClientProviders>(
     let server_events = server_subscriber.clone();
     let client_subscriber = DcStateChanged::new();
     let client_events = client_subscriber.clone();
-    let server_tokens = [TEST_TOKEN_1];
-    let client_tokens = [TEST_TOKEN_2];
 
     test(model, |handle| {
         let mut server = server
             .with_io(handle.builder().build()?)?
             .with_event((dc::ConfirmComplete, (tracing_events(), server_subscriber)))?
             .with_random(Random::with_seed(456))?
-            .with_dc(MockDcEndpoint::new(&server_tokens))?
             .start()?;
 
         let addr = server.local_addr()?;
+
         spawn(async move {
-            let conn = server.accept().await;
-            if expected_error.is_some() {
-                assert!(conn.is_none());
-            } else {
-                assert!(dc::ConfirmComplete::wait_ready(&mut conn.unwrap())
-                    .await
-                    .is_ok());
+            if let Some(mut conn) = server.accept().await {
+                let result = dc::ConfirmComplete::wait_ready(&mut conn).await;
+
+                if let Some(error) = expected_server_error {
+                    assert_eq!(error, convert_io_result(result).unwrap());
+
+                    if expected_client_error.is_some() {
+                        conn.close(SERVER_CLOSE_ERROR_CODE.into());
+                    }
+                } else {
+                    assert!(result.is_ok());
+                }
             }
         });
 
@@ -136,7 +265,6 @@ fn self_test<S: ServerProviders, C: ClientProviders>(
             .with_io(handle.builder().build().unwrap())?
             .with_event((dc::ConfirmComplete, (tracing_events(), client_subscriber)))?
             .with_random(Random::with_seed(456))?
-            .with_dc(MockDcEndpoint::new(&client_tokens))?
             .start()?;
 
         let client_events = client_events.clone();
@@ -146,8 +274,14 @@ fn self_test<S: ServerProviders, C: ClientProviders>(
             let mut conn = client.connect(connect).await.unwrap();
             let result = dc::ConfirmComplete::wait_ready(&mut conn).await;
 
-            if let Some(error) = expected_error {
-                assert_eq!(error, result.err().unwrap().kind());
+            if let Some(error) = expected_client_error {
+                assert_eq!(error, convert_io_result(result).unwrap());
+
+                if expected_server_error.is_some() {
+                    conn.close(CLIENT_CLOSE_ERROR_CODE.into());
+                    // wait for the server to assert the expected error before dropping
+                    delay(Duration::from_millis(100)).await;
+                }
             } else {
                 assert!(result.is_ok());
                 let client_events = client_events.events().lock().unwrap().clone();
@@ -163,8 +297,8 @@ fn self_test<S: ServerProviders, C: ClientProviders>(
     })
     .unwrap();
 
-    if expected_error.is_some() {
-        return;
+    if expected_client_error.is_some() || expected_server_error.is_some() {
+        return Ok(());
     }
 
     let server_events = server_events.events().lock().unwrap().clone();
@@ -172,10 +306,6 @@ fn self_test<S: ServerProviders, C: ClientProviders>(
 
     assert_dc_complete(&server_events);
     assert_dc_complete(&client_events);
-
-    // 3 state transitions (VersionNegotiated -> PathSecretsReady -> Complete)
-    assert_eq!(3, server_events.len());
-    assert_eq!(3, client_events.len());
 
     // Server path secrets are ready in 1.5 RTTs measured from the start of the test, since it takes
     // .5 RTT for the Initial from the client to reach the server
@@ -193,6 +323,8 @@ fn self_test<S: ServerProviders, C: ClientProviders>(
         server_events[2].timestamp.duration_since_start()
     );
     assert_eq!(rtt * 2, client_events[2].timestamp.duration_since_start());
+
+    Ok(())
 }
 
 fn assert_dc_complete(events: &[DcStateChangedEvent]) {
@@ -207,6 +339,16 @@ fn assert_dc_complete(events: &[DcStateChangedEvent]) {
 
     assert!(matches!(events[1].state, DcState::PathSecretsReady { .. }));
     assert!(matches!(events[2].state, DcState::Complete { .. }));
+}
+
+fn convert_io_result(io_result: std::io::Result<()>) -> Option<connection::Error> {
+    io_result
+        .err()?
+        .into_inner()?
+        .downcast::<connection::Error>()
+        .ok()
+        .as_deref()
+        .copied()
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
### Description of changes: 

The `ConfirmComplete` event subscriber is intended to allow a client or server using `dc` to wait for the `dc` handshake to complete before dropping the QUIC connection. In the case that the peer does not support `dc`, or does not support a `dc` version in common with the local endpoint, the current `ConfirmComplete` will not unblock the application. This change adds a new `NoVersionNegotiated` dc state changed event, and integrates it into the `ConfirmComplete` so that the application will be notified in such cases.

### Call-outs:

I'm not emitting the dc state changed event if the local endpoint has not configured a `dc` provider, so that these events wouldn't pollute logs for applications that are not using `dc`. This does mean that an application that has mistakenly not configured the `dc` provider would not see the `NoVersionNegotiated` message, but I don't think that is worth emitting this event for all applications. 

### Testing:

Added new integration tests to verify behavior when client or server have not enabled `dc`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

