### PR TITLE
chore: change further solvers in harnesses used with Kani

### DIFF
--- a/quic/s2n-quic-core/src/packet/number/tests.rs
+++ b/quic/s2n-quic-core/src/packet/number/tests.rs
@@ -10,7 +10,7 @@ use bolero::{check, generator::*};
 use s2n_codec::{testing::encode, DecoderBuffer};
 
 #[test]
-#[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(cadical))]
+#[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(minisat))]
 fn round_trip() {
     check!()
         .with_generator(

--- a/quic/s2n-quic-platform/src/message.rs
+++ b/quic/s2n-quic-platform/src/message.rs
@@ -160,7 +160,7 @@ mod tests {
     use bolero::check;
 
     #[test]
-    #[cfg_attr(kani, kani::proof, kani::unwind(17), kani::solver(cadical))]
+    #[cfg_attr(kani, kani::proof, kani::unwind(17), kani::solver(minisat))]
     fn rx_message_test() {
         let path = bolero::gen::<path::RemoteAddress>();
         let ecn = bolero::gen();


### PR DESCRIPTION
### Description of changes: 

CaDiCaL version 1.9.2 and later have a substantially worse performance on some instances produced by CBMC (via Kani). Use MiniSat to change overall verification time from over 800 seconds down to 20 (`rx_message_test`) and from over 80 seconds down to 15 (`round_trip`).

### Testing:

Tested in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

