### PR TITLE
  chore(s2n-quic): remove bytes pin and fix new clippy lints

### DIFF
--- a/common/s2n-codec/src/lib.rs
+++ b/common/s2n-codec/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(unexpected_cfgs)]
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 
 #[cfg(feature = "alloc")]

--- a/dc/s2n-quic-dc/src/lib.rs
+++ b/dc/s2n-quic-dc/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(unexpected_cfgs)]
+
 pub mod allocator;
 pub mod clock;
 pub mod congestion;

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -31,8 +31,7 @@ usdt = ["dep:probe"]
 atomic-waker = { version = "1", optional = true }
 bolero-generator = { version = "0.11", optional = true }
 byteorder = { version = "1", default-features = false }
-# TODO: Unpin when https://github.com/aws/s2n-quic/issues/2289 is resolved
-bytes = { version = "=1.6.1", optional = true, default-features = false }
+bytes = { version = "1", optional = true, default-features = false }
 crossbeam-utils = { version = "0.8", optional = true }
 cfg-if = "1"
 hex-literal = "0.4"

--- a/quic/s2n-quic-core/src/application/server_name.rs
+++ b/quic/s2n-quic-core/src/application/server_name.rs
@@ -21,7 +21,7 @@ use bytes::Bytes;
 ///
 /// `ServerName` serves a dual purpose:
 /// - It can be converted into [`Bytes`] which supports zero-copy slicing and
-/// reference counting.
+///   reference counting.
 /// - It can be accessed as `&str` so that applications can reason about the string value.
 #[derive(Clone, PartialEq, Eq, Hash)]
 pub struct ServerName(Bytes);

--- a/quic/s2n-quic-core/src/lib.rs
+++ b/quic/s2n-quic-core/src/lib.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(unexpected_cfgs)]
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 
 #[cfg(feature = "alloc")]

--- a/quic/s2n-quic-platform/src/lib.rs
+++ b/quic/s2n-quic-platform/src/lib.rs
@@ -4,6 +4,7 @@
 //! This module contains abstractions around the platform on which the
 //! stack is running
 
+#![allow(unexpected_cfgs)]
 #![cfg_attr(not(any(test, feature = "std")), no_std)]
 
 extern crate alloc;

--- a/quic/s2n-quic-qns/src/main.rs
+++ b/quic/s2n-quic-qns/src/main.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(unexpected_cfgs)]
+
 use structopt::StructOpt;
 
 pub type Error = Box<dyn 'static + std::error::Error + Send + Sync>;

--- a/quic/s2n-quic-tls/src/lib.rs
+++ b/quic/s2n-quic-tls/src/lib.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#![allow(unexpected_cfgs)]
+
 use s2n_quic_core::application::ServerName;
 
 /// Ensure memory is correctly managed in tests

--- a/quic/s2n-quic-transport/src/lib.rs
+++ b/quic/s2n-quic-transport/src/lib.rs
@@ -4,6 +4,7 @@
 //! This module contains all main runtime components for receiving and sending
 //! data via the QUIC protocol.
 
+#![allow(unexpected_cfgs)]
 #![deny(unused_must_use)]
 extern crate alloc;
 

--- a/quic/s2n-quic-transport/src/space/handshake_status.rs
+++ b/quic/s2n-quic-transport/src/space/handshake_status.rs
@@ -35,7 +35,7 @@ pub type Flag = flag::Flag<HandshakeDoneWriter>;
 /// - the handshake is complete and confirmed once the TLS-completes on the Server.
 /// - the Server is required to send a HANDSHAKE_DONE frame once the handshake completes.
 /// - the Client must wait for a HANDSHAKE_DONE (or an acked 1-rtt packet) to 'Confirm'
-/// the handshake.
+///   the handshake.
 ///
 /// Note: s2n-quic does not implement the optional 1-rtt acked requirement.
 #[derive(Debug, Default)]

--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -66,7 +66,7 @@
 //!```
 //!
 //! 2. Build a custom s2n-tls TLS provider configured with a FIPS approved
-//! [security policy](https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html):
+//!    [security policy](https://aws.github.io/s2n-tls/usage-guide/ch06-security-policies.html):
 //!
 //!```ignore
 //! use s2n_quic::provider::tls::s2n_tls;

--- a/quic/s2n-quic/src/provider/stateless_reset_token.rs
+++ b/quic/s2n-quic/src/provider/stateless_reset_token.rs
@@ -13,8 +13,8 @@
 /// generating stateless reset tokens. This is in accordance with the following requirement:
 ///
 /// > More generally, servers MUST NOT generate a stateless reset
-/// if a connection with the corresponding connection ID could
-/// be active on any endpoint using the same static key.
+/// > if a connection with the corresponding connection ID could
+/// > be active on any endpoint using the same static key.
 ///
 /// This may require coordination between endpoints and/or careful setup of load balancing and
 /// packet routing, as well as ensuring the connection IDs in use are difficult to guess.


### PR DESCRIPTION
### Resolved issues:

resolves #2289

### Description of changes: 

The latest bytes release corrects the issue with 1.7.0 so we can remove the pin on the old version, see https://github.com/tokio-rs/bytes/issues/725

I've also fixed some new Clippy lints.

### Call-outs:

I disabled the new `unexpected_cfgs` lint, as the MSRV we use does not support the recommended way to avoid this lint. This can be removed when the MSRV is 1.74.0, see https://github.com/aws/s2n-quic/issues/2292

### Testing:

Ran clippy +stable locally

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

