### PR TITLE
ci: remove static page rebuild on push to main

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,8 +1,6 @@
 name: Dashboard
 
 on:
-  push:
-    branches: ["main"]
   schedule:
     - cron: '0 0 * * 1-5'
 jobs:


### PR DESCRIPTION
### Description of changes: 

The static page generator from #2296 is having issues when pushing to gh-pages. It's possible there is a race with the other document generation action.  For now, go to a daily run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

