### PR TITLE
fix(s2n-quic-transport): wait until handshake is confirmed to start MTU probing

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -867,11 +867,12 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 let mut outcome = transmission::Outcome::default();
                 let path_id = self.path_manager.active_path_id();
 
-                // Send an MTU probe if necessary and the handshake has completed
+                // Send an MTU probe if necessary and the handshake has been confirmed
                 // MTU probes are prioritized over other data so they are not blocked by the
                 // congestion controller, as they are critical to achieving maximum throughput.
                 if self.state == ConnectionState::Active
                     && self.path_manager.active_path().can_transmit(timestamp)
+                    && self.space_manager.is_handshake_confirmed()
                     && self
                         .path_manager
                         .active_path()

--- a/quic/s2n-quic/src/tests/mtu.rs
+++ b/quic/s2n-quic/src/tests/mtu.rs
@@ -22,6 +22,7 @@ macro_rules! mtu_test {
                 $impl
             }
 
+            #[cfg(not(target_os = "windows"))]
             #[test]
             fn mutual_auth() {
                 let $client = build_client_mtls_provider(certificates::MTLS_CA_CERT).unwrap();

--- a/quic/s2n-quic/src/tests/mtu.rs
+++ b/quic/s2n-quic/src/tests/mtu.rs
@@ -2,12 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
+use crate::provider::tls;
 use s2n_codec::encoder::scatter;
 use s2n_quic_core::{
     event::api::Subject,
     packet::interceptor::{Interceptor, Packet},
     path::{mtu, BaseMtu, InitialMtu},
 };
+
+macro_rules! mtu_test {
+    (fn $name:ident($server:ident, $client:ident) $impl:block) => {
+        mod $name {
+            use super::*;
+
+            #[test]
+            fn one_way_auth() {
+                let $client = certificates::CERT_PEM;
+                let $server = SERVER_CERTS;
+                $impl
+            }
+
+            #[test]
+            fn mutual_auth() {
+                let $client = build_client_mtls_provider(certificates::MTLS_CA_CERT).unwrap();
+                let $server = build_server_mtls_provider(certificates::MTLS_CA_CERT).unwrap();
+                $impl
+            }
+        }
+    };
+}
 
 struct CustomMtu(mtu::Config);
 
@@ -24,7 +47,9 @@ impl mtu::Endpoint for CustomMtu {
 // Construct a simulation where a client sends some data, which the server echos
 // back. The MtuUpdated events that the server experiences are recorded and
 // returns at the end of the simulation.
-fn mtu_updates(
+fn mtu_updates<S: tls::Provider, C: tls::Provider>(
+    server: S,
+    client: C,
     config_override: Option<mtu::Config>,
     initial_mtu: u16,
     base_mtu: u16,
@@ -47,7 +72,7 @@ fn mtu_updates(
                     .with_base_mtu(base_mtu)
                     .build()?,
             )?
-            .with_tls(SERVER_CERTS)?
+            .with_tls(server)?
             .with_event((tracing_events(), subscriber))?
             .with_random(Random::with_seed(456))?;
 
@@ -67,9 +92,9 @@ fn mtu_updates(
                     .build()
                     .unwrap(),
             )?
-            .with_tls(certificates::CERT_PEM)?
             .with_event(tracing_events())?
             .with_random(Random::with_seed(456))?
+            .with_tls(client)?
             .start()?;
         let addr = start_server(server)?;
         // we need a large payload to allow for multiple rounds of MTU probing
@@ -84,175 +109,196 @@ fn mtu_updates(
 
 // if we specify jumbo frames on the endpoint and the network supports them,
 // then jumbo frames should be negotiated.
-#[test]
-fn mtu_probe_jumbo_frame_test() {
-    let events = mtu_updates(
-        None,
-        InitialMtu::default().into(),
-        BaseMtu::default().into(),
-        9_001,
-        10_000,
-    );
+mtu_test!(
+    fn mtu_probe_jumbo_frame_test(server, client) {
+        let events = mtu_updates(
+            server,
+            client,
+            None,
+            InitialMtu::default().into(),
+            BaseMtu::default().into(),
+            9_001,
+            10_000,
+        );
 
-    // handshake is padded to 1200, so we should immediately have an mtu of 1200
-    // since the handshake successfully completes
-    let handshake_mtu = events[0].clone();
-    assert_eq!(handshake_mtu.mtu, 1200);
-    assert!(matches!(
-        handshake_mtu.cause,
-        events::MtuUpdatedCause::NewPath { .. }
-    ));
+        // handshake is padded to 1200, so we should immediately have an mtu of 1200
+        // since the handshake successfully completes
+        let handshake_mtu = events[0].clone();
+        assert_eq!(handshake_mtu.mtu, 1200);
+        assert!(matches!(
+            handshake_mtu.cause,
+            events::MtuUpdatedCause::NewPath { .. }
+        ));
 
-    // we should then successfully probe for 1500 (minus headers = 1472)
-    let first_probe = events[1].clone();
-    assert_eq!(first_probe.mtu, 1472);
+        // we should then successfully probe for 1500 (minus headers = 1472)
+        let first_probe = events[1].clone();
+        assert_eq!(first_probe.mtu, 1472);
 
-    // we binary search upwards 9001
-    // this isn't the maximum mtu we'd find in practice, just the maximum mtu we
-    // find with a payload of 10_000_000 bytes.
-    let last_probe = events.last().unwrap();
-    assert_eq!(last_probe.mtu, 8943);
-}
+        // we binary search upwards 9001
+        // this isn't the maximum mtu we'd find in practice, just the maximum mtu we
+        // find with a payload of 10_000_000 bytes.
+        let last_probe = events.last().unwrap();
+        assert_eq!(last_probe.mtu, 8943);
+    }
+);
 
 // if we specify jumbo frames on the endpoint and the network does not support
 // them, the connection should gracefully complete with a smaller mtu
-#[test]
-fn mtu_probe_jumbo_frame_unsupported_test() {
-    let events = mtu_updates(
-        None,
-        InitialMtu::default().into(),
-        BaseMtu::default().into(),
-        9_001,
-        1472,
-    );
-    let last_mtu = events.last().unwrap();
-    // ETHERNET_MTU - UDP_HEADER_LEN - IPV4_HEADER_LEN
-    assert_eq!(last_mtu.mtu, 1472);
-}
+mtu_test!(
+    fn mtu_probe_jumbo_frame_unsupported_test(server, client) {
+        let events = mtu_updates(
+            server,
+            client,
+            None,
+            InitialMtu::default().into(),
+            BaseMtu::default().into(),
+            9_001,
+            1472,
+        );
+        let last_mtu = events.last().unwrap();
+        // ETHERNET_MTU - UDP_HEADER_LEN - IPV4_HEADER_LEN
+        assert_eq!(last_mtu.mtu, 1472);
+    }
+);
 
 // The configured base mtu is the smallest MTU used
-#[test]
-fn base_mtu() {
-    let events = mtu_updates(None, 1250, 1250, 9_001, 10_000);
-    let base_mtu = events
-        .iter()
-        .min_by_key(|&mtu_event| mtu_event.mtu)
-        .unwrap();
-    // 1250 - UDP_HEADER_LEN - IPV4_HEADER_LEN
-    assert_eq!(base_mtu.mtu, 1222);
-}
+mtu_test!(
+    fn base_mtu(server, client) {
+        let events = mtu_updates(server, client, None, 1250, 1250, 9_001, 10_000);
+        let base_mtu = events
+            .iter()
+            .min_by_key(|&mtu_event| mtu_event.mtu)
+            .unwrap();
+        // 1250 - UDP_HEADER_LEN - IPV4_HEADER_LEN
+        assert_eq!(base_mtu.mtu, 1222);
+    }
+);
 
 // The configured initial mtu is the first MTU used
-#[test]
-fn initial_mtu() {
-    let events = mtu_updates(None, 2000, BaseMtu::default().into(), 9_001, 10_000);
-    let first_mtu = events.first().unwrap();
-    // 2000 - UDP_HEADER_LEN - IPV4_HEADER_LEN
-    assert_eq!(first_mtu.mtu, 1972);
-}
+mtu_test!(
+    fn initial_mtu(server, client) {
+        let events = mtu_updates(server, client, None, 2000, BaseMtu::default().into(), 9_001, 10_000);
+        let first_mtu = events.first().unwrap();
+        // 2000 - UDP_HEADER_LEN - IPV4_HEADER_LEN
+        assert_eq!(first_mtu.mtu, 1972);
+    }
+);
+
+// No override config
+mtu_test!(
+    fn conn_mtu_no_override(server, client) {
+        let events = mtu_updates(server, client, None, 1228, BaseMtu::default().into(), 9_001, 10_000);
+        let first_mtu = events.first().unwrap();
+        // 1228 - UDP_HEADER_LEN - IPV4_HEADER_LEN
+        assert_eq!(first_mtu.mtu, 1200);
+        let last_mtu = events.last().unwrap();
+        assert_eq!(last_mtu.mtu, 8943);
+    }
+);
 
 // Connection specific initial MTU
 //
 // Override the initial (first) MTU we can use for the connection.
-#[test]
-fn conn_mtu_initial() {
-    let events = mtu_updates(None, 1228, BaseMtu::default().into(), 9_001, 10_000);
-    let first_mtu = events.first().unwrap();
-    // 1228 - UDP_HEADER_LEN - IPV4_HEADER_LEN
-    assert_eq!(first_mtu.mtu, 1200);
-
-    let config = mtu::Config::builder()
-        .with_initial_mtu(1328)
-        .unwrap()
-        .build()
-        .unwrap();
-    let events = mtu_updates(Some(config), 1228, BaseMtu::default().into(), 9_001, 10_000);
-    let first_mtu = events.first().unwrap();
-    // 1528 - UDP_HEADER_LEN - IPV4_HEADER_LEN
-    assert_eq!(first_mtu.mtu, 1300);
-}
+mtu_test!(
+    fn conn_mtu_initial_with_override(server, client) {
+        let config = mtu::Config::builder()
+            .with_initial_mtu(1328)
+            .unwrap()
+            .build()
+            .unwrap();
+        let events = mtu_updates(server, client, Some(config), 1228, BaseMtu::default().into(), 9_001, 10_000);
+        let first_mtu = events.first().unwrap();
+        // 1528 - UDP_HEADER_LEN - IPV4_HEADER_LEN
+        assert_eq!(first_mtu.mtu, 1300);
+    }
+);
 
 // Connection specific base MTU
 //
 // Override the base (lowest) MTU we can use for the connection.
-#[test]
-fn conn_mtu_base() {
-    let events = mtu_updates(None, 1228, BaseMtu::default().into(), 9_001, 10_000);
-    let first_mtu = events.first().unwrap();
-    assert_eq!(first_mtu.mtu, 1200);
-
-    let config = mtu::Config::builder()
-        .with_base_mtu(1328)
-        .unwrap()
-        .build()
-        .unwrap();
-    let events = mtu_updates(Some(config), 1228, BaseMtu::default().into(), 9_001, 10_000);
-    let first_mtu = events.first().unwrap();
-    assert_eq!(first_mtu.mtu, 1300);
-}
+mtu_test!(
+    fn conn_mtu_base(server, client) {
+        let config = mtu::Config::builder()
+            .with_base_mtu(1328)
+            .unwrap()
+            .build()
+            .unwrap();
+        let events = mtu_updates(
+            server,
+            client,
+            Some(config),
+            1228,
+            BaseMtu::default().into(),
+            9_001,
+            10_000,
+        );
+        let first_mtu = events.first().unwrap();
+        assert_eq!(first_mtu.mtu, 1300);
+    }
+);
 
 // Connection specific max MTU
 //
 // Override the max MTU we can use for the connection.
-#[test]
-fn conn_mtu_max() {
-    let events = mtu_updates(None, 1228, BaseMtu::default().into(), 9_001, 10_000);
-    let last_mtu = events.last().unwrap();
-    assert_eq!(last_mtu.mtu, 8943);
-
-    let config = mtu::Config::builder()
-        .with_max_mtu(6_000)
-        .unwrap()
-        .build()
-        .unwrap();
-    let events = mtu_updates(Some(config), 1228, BaseMtu::default().into(), 9_001, 10_000);
-    let last_mtu = events.last().unwrap();
-    assert_eq!(last_mtu.mtu, 5_936);
-}
+mtu_test!(
+    fn conn_mtu_max(server, client) {
+        let config = mtu::Config::builder()
+            .with_max_mtu(6_000)
+            .unwrap()
+            .build()
+            .unwrap();
+        let events = mtu_updates(server, client, Some(config), 1228, BaseMtu::default().into(), 9_001, 10_000);
+        let last_mtu = events.last().unwrap();
+        assert_eq!(last_mtu.mtu, 5_936);
+    }
+);
 
 // The configured initial mtu is the first MTU used. It is not supported by the network, so
 // the MTU drops to the base MTU, before increasing back to what the network supports.
-#[test]
-fn initial_mtu_not_supported() {
-    let events = mtu_updates(None, 2000, BaseMtu::default().into(), 9_001, 1500);
-    let first_mtu = events.first().unwrap();
-    let second_mtu = events.get(1).unwrap();
-    let last_mtu = events.last().unwrap();
-    // First try the initial MTU
-    assert_eq!(first_mtu.mtu, 1972);
-    // Next drop down to the base MTU
-    assert_eq!(second_mtu.mtu, 1200);
-    // Eventually reach the MTU the network supports
-    assert_eq!(last_mtu.mtu, 1500);
-}
+mtu_test!(
+    fn initial_mtu_not_supported(server, client) {
+        let events = mtu_updates(server, client, None, 2000, BaseMtu::default().into(), 9_001, 1500);
+        let first_mtu = events.first().unwrap();
+        let second_mtu = events.get(1).unwrap();
+        let last_mtu = events.last().unwrap();
+        // First try the initial MTU
+        assert_eq!(first_mtu.mtu, 1972);
+        // Next drop down to the base MTU
+        assert_eq!(second_mtu.mtu, 1200);
+        // Eventually reach the MTU the network supports
+        assert_eq!(last_mtu.mtu, 1500);
+    }
+);
 
 // The configured initial MTU is jumbo and the network supports it.
-#[test]
-fn initial_mtu_is_jumbo() {
-    let events = mtu_updates(None, 9_001, BaseMtu::default().into(), 9_001, 10_000);
-    let first_mtu = events.first().unwrap();
-    let last_mtu = events.last().unwrap();
-    // First try the initial MTU
-    assert_eq!(first_mtu.mtu, 8973);
-    // Stay on this MTU since the network supports it
-    assert_eq!(last_mtu.mtu, 8973);
-}
+mtu_test!(
+    fn initial_mtu_is_jumbo(server, client) {
+        let events = mtu_updates(server, client, None, 9_001, BaseMtu::default().into(), 9_001, 10_000);
+        let first_mtu = events.first().unwrap();
+        let last_mtu = events.last().unwrap();
+        // First try the initial MTU
+        assert_eq!(first_mtu.mtu, 8973);
+        // Stay on this MTU since the network supports it
+        assert_eq!(last_mtu.mtu, 8973);
+    }
+);
 
 // The configured initial MTU is jumbo and the network does not support it. The configured minimum
 // MTU is used next.
-#[test]
-fn initial_mtu_is_jumbo_not_supported() {
-    let events = mtu_updates(None, 9_001, 1_500, 9_001, 2_500);
-    let first_mtu = events.first().unwrap();
-    let second_mtu = events.get(1).unwrap();
-    let last_mtu = events.last().unwrap();
-    // First try the initial MTU
-    assert_eq!(first_mtu.mtu, 8_973);
-    // Next drop down to the base MTU
-    assert_eq!(second_mtu.mtu, 1472);
-    // Eventually reach the MTU the network supports
-    assert_eq!(last_mtu.mtu, 2_496);
-}
+mtu_test!(
+    fn initial_mtu_is_jumbo_not_supported(server, client) {
+        let events = mtu_updates(server, client, None, 9_001, 1_500, 9_001, 2_500);
+        let first_mtu = events.first().unwrap();
+        let second_mtu = events.get(1).unwrap();
+        let last_mtu = events.last().unwrap();
+        // First try the initial MTU
+        assert_eq!(first_mtu.mtu, 8_973);
+        // Next drop down to the base MTU
+        assert_eq!(second_mtu.mtu, 1472);
+        // Eventually reach the MTU the network supports
+        assert_eq!(last_mtu.mtu, 2_496);
+    }
+);
 
 // if we lose every packet during a round trip and then allow packets through,
 // this is not determined to be an MTU black hole


### PR DESCRIPTION
### Description of changes: 

MTU probing currently begins as soon as the handshake completes and the path has been validated. This is normally OK, but can cause issues when mutual TLS has been configured. 

When mTLS is used, MTU probes may be transmitted from the client prior to the handshake being confirmed (via receipt of `HANDSHAKE_DONE`). Prior to the handshake being confirmed, though, the client is not allowed to send PTO probes:

From [QUIC9002§6.2.1](https://www.rfc-editor.org/rfc/rfc9002.html#name-computing-pto):
> An endpoint MUST NOT set its PTO timer for the Application Data packet number space until the handshake is confirmed. 

The consequence of this is that MTU probes may be sent which are never detected as lost, as the client cannot send a PTO probe to trigger loss detection. This may result in a connection being blocked by the congestion controller, in cases where particular large MTU probes are configured.

This change will wait for the handshake to be confirmed before transmitting MTU probes to avoid this situation. 

### Call-outs:

This will slightly delay MTU probing on the client until a `HANDSHAKE_DONE` frame is received, but generally this would only be 0 to 1 more RTTs before probing begins. MTU probing on the server should not be impacted, as the handshake is confirmed on the server as soon as it completes:

> the TLS handshake is considered confirmed at the server when the handshake completes

I considered making this fix by only enabling the MTU controller when the handshake is confirmed (it is currently enabled when the path has been validated locally and by the peer). This ends up being more complicated, as new path created due to connection migration do not trigger the `on_handshake_confirmed` code paths, so we would need to wire through the handshake status to the path manager. It didn't seem worth it.

### Testing:

I've made the MTU integration tests parameterized over mTLS/one-way-auth to ensure coverage over both types of auth. I confirmed 2 of the tests fail without this fix in place.

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

