### PR TITLE
Fix ConfirmComplete with handshake de-duplication

### DIFF
--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -77,7 +77,7 @@ s2n-quic-rustls = { version = "=0.44.1", path = "../s2n-quic-rustls", optional =
 s2n-quic-tls = { version = "=0.44.1", path = "../s2n-quic-tls", optional = true }
 s2n-quic-tls-default = { version = "=0.44.1", path = "../s2n-quic-tls-default", optional = true }
 s2n-quic-transport = { version = "=0.44.1", path = "../s2n-quic-transport" }
-tokio = { version = "1", default-features = false }
+tokio = { version = "1", default-features = false, features = ["sync"] }
 zerocopy = { version = "0.7", optional = true, features = ["derive"] }
 zeroize = { version = "1", optional = true, default-features = false }
 


### PR DESCRIPTION
Previously, we only stored a single Waker, which meant that when the underlying s2n-quic connection/handle was returned to applications multiple times it ended up only waking one of the application tasks.

This modifies the ConfirmComplete logic such that we now store as many Wakers as needed (using Tokio's Semaphore) and wake all of them on final readiness.

### Resolved issues:

None.

### Call-outs:

This takes a new dependency on tokio's `sync` feature. This feature was previously not enabled in the s2n-quic dependency tree, but seems likely to be fine to enable. If needed, we can gate it behind the dc provider.

### Testing:

Confirmed locally that a concurrent handshake now successfully confirms from multiple connect with_dedupe handles. Also added a test 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

