### PR TITLE
docs(s2n-quic): fix link to compliance report in CI docs

### DIFF
--- a/docs/dev-guide/ci.md
+++ b/docs/dev-guide/ci.md
@@ -43,7 +43,7 @@ The [quic-interop-runner](https://github.com/marten-seemann/quic-interop-runner)
 
 ## Compliance
 
-`s2n-quic` annotates source code with inline references to requirements in [IETF RFC](https://www.ietf.org/process/rfcs/) specifications. [Duvet](https://github.com/awslabs/duvet) is used to generate [a report](https://dnglbrstg7yg.cloudfront.net/latest/interop/index.html), which makes it easy to track compliance with each requirement.
+`s2n-quic` annotates source code with inline references to requirements in [IETF RFC](https://www.ietf.org/process/rfcs/) specifications. [Duvet](https://github.com/awslabs/duvet) is used to generate [a report](https://dnglbrstg7yg.cloudfront.net/latest/compliance.html), which makes it easy to track compliance with each requirement.
 
 ## Simulations
 


### PR DESCRIPTION
### Description of changes: 

The link in the CI docs for compliance was pointing to the interop report. This fixes that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

