### PR TITLE
test(s2n-quic-core): revert to bigger length for Kani test

### DIFF
--- a/quic/s2n-quic-core/src/inet/checksum.rs
+++ b/quic/s2n-quic-core/src/inet/checksum.rs
@@ -401,15 +401,13 @@ mod tests {
         }
     }
 
-    // Reduce the length to 4 for Kani until
-    // https://github.com/model-checking/kani/issues/3030 is fixed
     #[cfg(any(kani, miri))]
-    const LEN: usize = if cfg!(kani) { 4 } else { 32 };
+    const LEN: usize = if cfg!(kani) { 16 } else { 32 };
 
     /// * Compares the implementation to a port of the C code defined in the RFC
     /// * Ensures partial writes are correctly handled, even if they're not at a 16 bit boundary
     #[test]
-    #[cfg_attr(kani, kani::proof, kani::unwind(9), kani::solver(cadical))]
+    #[cfg_attr(kani, kani::proof, kani::unwind(17), kani::solver(cadical))]
     fn differential() {
         #[cfg(any(kani, miri))]
         type Bytes = crate::testing::InlineVec<u8, LEN>;


### PR DESCRIPTION
### Resolved issues:

N/A

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.-->

In #2128, the length used in a Kani test was reduced from 16 to 4 because Kani was running out of memory (https://github.com/model-checking/kani/issues/3030). This issue is now resolved, so reverting to the previously used length of 16.

With Kani 0.54.0, memory usage for this harness does not exceed 1.5 GB.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

