### PR TITLE
feat(s2n-quic-events): add search_completed boolean to mtu updated event

### DIFF
--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -52,6 +52,10 @@ pub mod testing {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 enum State {
+    /// EARLY_SEARCH_REQUESTED indicates the initial MTU was configured higher
+    /// than the base MTU, to allow for quick confirmation or rejection of the
+    /// initial MTU
+    EarlySearchRequested,
     //= https://www.rfc-editor.org/rfc/rfc8899#section-5.2
     //# The DISABLED state is the initial state before probing has started.
     Disabled,
@@ -67,9 +71,19 @@ enum State {
 }
 
 impl State {
+    /// Returns true if the MTU controller is in the early search requested state
+    fn is_early_search_requested(&self) -> bool {
+        matches!(self, State::EarlySearchRequested)
+    }
+
     /// Returns true if the MTU controller is in the disabled state
     fn is_disabled(&self) -> bool {
         matches!(self, State::Disabled)
+    }
+
+    /// Returns true if the MTU controller is in the search complete state
+    fn is_search_complete(&self) -> bool {
+        matches!(self, State::SearchComplete)
     }
 }
 
@@ -536,8 +550,20 @@ impl Controller {
         }
         .min(max_udp_payload);
 
+        let state = if plpmtu > base_plpmtu {
+            // The initial MTU has been configured higher than the base MTU
+            State::EarlySearchRequested
+        } else if initial_probed_size - base_plpmtu < PROBE_THRESHOLD {
+            // The next probe size is within the probe threshold of the
+            // base MTU, so no probing will occur and the search is complete
+            State::SearchComplete
+        } else {
+            // Otherwise wait for regular MTU probing to be enabled
+            State::Disabled
+        };
+
         Self {
-            state: State::Disabled,
+            state,
             base_plpmtu,
             plpmtu,
             probed_size: initial_probed_size,
@@ -554,7 +580,7 @@ impl Controller {
     #[inline]
     pub fn enable(&mut self) {
         // ensure we haven't already enabled the controller
-        ensure!(self.state == State::Disabled);
+        ensure!(self.state.is_disabled() || self.state.is_early_search_requested());
 
         // TODO: Look up current MTU in a cache. If there is a cache hit
         //       move directly to SearchComplete and arm the PMTU raise timer.
@@ -583,6 +609,25 @@ impl Controller {
         path_id: path::Id,
         publisher: &mut Pub,
     ) {
+        if self.state.is_early_search_requested() && sent_bytes > self.base_plpmtu {
+            if self.is_next_probe_size_above_threshold() {
+                // Early probing has succeeded, but the max MTU is higher still so
+                // wait for regular MTU probing to be enabled to attempt higher MTUs
+                self.state = State::Disabled;
+            } else {
+                self.state = State::SearchComplete;
+            }
+
+            // Publish an `on_mtu_updated` event since the cause
+            // and possibly search_complete status have changed
+            publisher.on_mtu_updated(event::builder::MtuUpdated {
+                path_id: path_id.into_event(),
+                mtu: self.plpmtu,
+                cause: MtuUpdatedCause::InitialMtuPacketAcknowledged,
+                search_complete: self.state.is_search_complete(),
+            });
+        }
+
         // no need to process anything in the disabled state
         ensure!(self.state != State::Disabled);
 
@@ -609,12 +654,6 @@ impl Controller {
                     &mut congestion_controller::PathPublisher::new(publisher, path_id),
                 );
 
-                publisher.on_mtu_updated(event::builder::MtuUpdated {
-                    path_id: path_id.into_event(),
-                    mtu: self.plpmtu,
-                    cause: MtuUpdatedCause::ProbeAcknowledged,
-                });
-
                 self.update_probed_size();
 
                 //= https://www.rfc-editor.org/rfc/rfc8899#section-8
@@ -625,6 +664,13 @@ impl Controller {
                 // Subsequent probe packets are sent based on the round trip transmission and
                 // acknowledgement/loss of a packet, so the interval will be at least 1 RTT.
                 self.request_new_search(Some(transmit_time));
+
+                publisher.on_mtu_updated(event::builder::MtuUpdated {
+                    path_id: path_id.into_event(),
+                    mtu: self.plpmtu,
+                    cause: MtuUpdatedCause::ProbeAcknowledged,
+                    search_complete: self.state.is_search_complete(),
+                });
             }
         }
     }
@@ -647,28 +693,39 @@ impl Controller {
     ) {
         // MTU probes are only sent in the application data space, but since early packet
         // spaces will use the `InitialMtu` prior to MTU probing being enabled, we need
-        // to check for potentially MTU-related packet loss even when MTU probing is disabled
-        ensure!(self.state.is_disabled() || packet_number.space().is_application_data());
+        // to check for potentially MTU-related packet loss if an early search has been requested
+        ensure!(
+            self.state.is_early_search_requested() || packet_number.space().is_application_data()
+        );
 
         match &self.state {
-            State::Disabled => {
-                if lost_bytes > self.base_plpmtu && self.plpmtu > self.base_plpmtu {
-                    // MTU probing hasn't been enabled yet, but since the initial MTU was configured
-                    // higher than the base PLPMTU and this setting resulted in a lost packet
-                    // we drop back down to the base PLPMTU.
-                    self.plpmtu = self.base_plpmtu;
+            State::Disabled => {},
+            State::EarlySearchRequested => {
+                // MTU probing hasn't been enabled yet, but since the initial MTU was configured
+                // higher than the base PLPMTU and this setting resulted in a lost packet
+                // we drop back down to the base PLPMTU.
+                self.plpmtu = self.base_plpmtu;
 
-                    congestion_controller.on_mtu_update(
-                        self.plpmtu,
-                        &mut congestion_controller::PathPublisher::new(publisher, path_id),
-                    );
+                congestion_controller.on_mtu_update(
+                    self.plpmtu,
+                    &mut congestion_controller::PathPublisher::new(publisher, path_id),
+                );
 
-                    publisher.on_mtu_updated(event::builder::MtuUpdated {
-                        path_id: path_id.into_event(),
-                        mtu: self.plpmtu,
-                        cause: MtuUpdatedCause::InitialMtuPacketLost,
-                    })
+                if self.is_next_probe_size_above_threshold() {
+                    // Resume regular probing when the MTU controller is enabled
+                    self.state = State::Disabled;
+                } else {
+                    // The next probe is within the threshold, so move directly
+                    // to the SearchComplete state
+                    self.state = State::SearchComplete;
                 }
+
+                publisher.on_mtu_updated(event::builder::MtuUpdated {
+                    path_id: path_id.into_event(),
+                    mtu: self.plpmtu,
+                    cause: MtuUpdatedCause::InitialMtuPacketLost,
+                    search_complete: self.state.is_search_complete(),
+                })
             }
             State::Searching(probe_pn, _) if *probe_pn == packet_number => {
                 // The MTU probe was lost
@@ -678,6 +735,16 @@ impl Controller {
                     self.max_probe_size = self.probed_size;
                     self.update_probed_size();
                     self.request_new_search(None);
+
+                    if self.is_search_completed() {
+                        // Emit an on_mtu_updated event as the search has now completed
+                        publisher.on_mtu_updated(event::builder::MtuUpdated {
+                            path_id: path_id.into_event(),
+                            mtu: self.plpmtu,
+                            cause: MtuUpdatedCause::LargerProbesLost,
+                            search_complete: true,
+                        })
+                    }
                 } else {
                     // Try the same probe size again
                     self.state = State::SearchRequested
@@ -716,6 +783,11 @@ impl Controller {
         self.probed_size as usize
     }
 
+    /// Returns true if probing for the MTU has completed
+    pub fn is_search_completed(&self) -> bool {
+        self.state.is_search_complete()
+    }
+
     /// Sets `probed_size` to the next MTU size to probe for based on a binary search
     #[inline]
     fn update_probed_size(&mut self) {
@@ -731,6 +803,11 @@ impl Controller {
         current + ((max - current) / 2)
     }
 
+    #[inline]
+    fn is_next_probe_size_above_threshold(&self) -> bool {
+        self.probed_size - self.plpmtu >= PROBE_THRESHOLD
+    }
+
     /// Requests a new search to be initiated
     ///
     /// If `last_probe_time` is supplied, the PMTU Raise Timer will be armed as
@@ -738,7 +815,7 @@ impl Controller {
     /// of the current PLPMTU
     #[inline]
     fn request_new_search(&mut self, last_probe_time: Option<Timestamp>) {
-        if self.probed_size - self.plpmtu >= PROBE_THRESHOLD {
+        if self.is_next_probe_size_above_threshold() {
             self.probe_count = 0;
             self.state = State::SearchRequested;
         } else {
@@ -778,6 +855,7 @@ impl Controller {
             path_id: path_id.into_event(),
             mtu: self.plpmtu,
             cause: MtuUpdatedCause::Blackhole,
+            search_complete: self.state.is_search_complete(),
         })
     }
 
@@ -789,7 +867,7 @@ impl Controller {
         self.max_probe_size = self.max_udp_payload;
         self.update_probed_size();
 
-        if self.probed_size - self.plpmtu >= PROBE_THRESHOLD {
+        if self.is_next_probe_size_above_threshold() {
             // There is still some room to try a larger MTU again,
             // so arm the pmtu raise timer
             self.pmtu_raise_timer.set(timestamp);

--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -699,7 +699,7 @@ impl Controller {
         );
 
         match &self.state {
-            State::Disabled => {},
+            State::Disabled => {}
             State::EarlySearchRequested => {
                 // MTU probing hasn't been enabled yet, but since the initial MTU was configured
                 // higher than the base PLPMTU and this setting resulted in a lost packet

--- a/quic/s2n-quic-core/src/path/mtu/snapshots/quic__s2n-quic-core__src__path__mtu__tests__events__on_packet_ack_search_requested.snap
+++ b/quic/s2n-quic-core/src/path/mtu/snapshots/quic__s2n-quic-core__src__path__mtu__tests__events__on_packet_ack_search_requested.snap
@@ -2,4 +2,4 @@
 source: quic/s2n-quic-core/src/path/mtu/tests.rs
 expression: ""
 ---
-MtuUpdated { path_id: 0, mtu: 1472, cause: ProbeAcknowledged }
+MtuUpdated { path_id: 0, mtu: 1472, cause: ProbeAcknowledged, search_complete: false }

--- a/quic/s2n-quic-core/src/path/mtu/snapshots/quic__s2n-quic-core__src__path__mtu__tests__events__on_packet_ack_within_threshold.snap
+++ b/quic/s2n-quic-core/src/path/mtu/snapshots/quic__s2n-quic-core__src__path__mtu__tests__events__on_packet_ack_within_threshold.snap
@@ -2,4 +2,4 @@
 source: quic/s2n-quic-core/src/path/mtu/tests.rs
 expression: ""
 ---
-MtuUpdated { path_id: 0, mtu: 1200, cause: ProbeAcknowledged }
+MtuUpdated { path_id: 0, mtu: 1200, cause: ProbeAcknowledged, search_complete: true }

--- a/quic/s2n-quic-core/src/path/mtu/snapshots/quic__s2n-quic-core__src__path__mtu__tests__events__on_packet_ack_within_threshold_of_max_plpmtu.snap
+++ b/quic/s2n-quic-core/src/path/mtu/snapshots/quic__s2n-quic-core__src__path__mtu__tests__events__on_packet_ack_within_threshold_of_max_plpmtu.snap
@@ -2,4 +2,4 @@
 source: quic/s2n-quic-core/src/path/mtu/tests.rs
 expression: ""
 ---
-MtuUpdated { path_id: 0, mtu: 1472, cause: ProbeAcknowledged }
+MtuUpdated { path_id: 0, mtu: 1472, cause: ProbeAcknowledged, search_complete: true }

--- a/quic/s2n-quic-core/src/path/mtu/snapshots/quic__s2n-quic-core__src__path__mtu__tests__events__on_packet_loss_black_hole.snap
+++ b/quic/s2n-quic-core/src/path/mtu/snapshots/quic__s2n-quic-core__src__path__mtu__tests__events__on_packet_loss_black_hole.snap
@@ -2,4 +2,4 @@
 source: quic/s2n-quic-core/src/path/mtu/tests.rs
 expression: ""
 ---
-MtuUpdated { path_id: 0, mtu: 1200, cause: Blackhole }
+MtuUpdated { path_id: 0, mtu: 1200, cause: Blackhole, search_complete: true }

--- a/quic/s2n-quic-core/src/path/mtu/snapshots/quic__s2n-quic-core__src__path__mtu__tests__events__on_packet_loss_initial_mtu_configured.snap
+++ b/quic/s2n-quic-core/src/path/mtu/snapshots/quic__s2n-quic-core__src__path__mtu__tests__events__on_packet_loss_initial_mtu_configured.snap
@@ -2,94 +2,143 @@
 source: quic/s2n-quic-core/src/path/mtu/tests.rs
 expression: ""
 ---
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1492, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1492, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1492, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 1492, cause: InitialMtuPacketLost }
-MtuUpdated { path_id: 0, mtu: 3972, cause: InitialMtuPacketLost }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: true }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: true }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: true }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: true }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: true }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: true }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: true }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1492, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1492, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1492, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1200, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1210, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1272, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1422, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1472, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 1492, cause: InitialMtuPacketLost, search_complete: false }
+MtuUpdated { path_id: 0, mtu: 3972, cause: InitialMtuPacketLost, search_complete: false }

--- a/quic/s2n-quic-events/events/common.rs
+++ b/quic/s2n-quic-events/events/common.rs
@@ -963,6 +963,10 @@ enum MtuUpdatedCause {
     Blackhole,
     /// An early packet using the configured InitialMtu was lost
     InitialMtuPacketLost,
+    /// An early packet using the configured InitialMtu was acknowledged by the peer
+    InitialMtuPacketAcknowledged,
+    /// MTU probes larger than the current MTU were not acknowledged
+    LargerProbesLost,
 }
 
 /// A bandwidth delivery rate estimate with associated metadata

--- a/quic/s2n-quic-events/events/connection.rs
+++ b/quic/s2n-quic-events/events/connection.rs
@@ -297,12 +297,14 @@ pub struct KeepAliveTimerExpired {
 }
 
 #[event("connectivity:mtu_updated")]
-/// The maximum transmission unit (MTU) for the path has changed
+/// The maximum transmission unit (MTU) and/or MTU probing status for the path has changed
 struct MtuUpdated {
     path_id: u64,
     /// The maximum QUIC datagram size, not including UDP and IP headers
     mtu: u16,
     cause: MtuUpdatedCause,
+    /// The search for the maximum MTU has completed for now
+    search_complete: bool,
 }
 
 #[event("recovery:slow_start_exited")]

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -626,6 +626,10 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 .mtu_controller
                 .max_datagram_size() as u16,
             cause: MtuUpdatedCause::NewPath,
+            search_complete: path_manager
+                .active_path()
+                .mtu_controller
+                .is_search_completed(),
         });
 
         let wakeup_handle = Arc::from(parameters.wakeup_handle);

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -482,6 +482,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             path_id: new_path_id.into_event(),
             mtu: path.mtu_controller.max_datagram_size() as u16,
             cause: MtuUpdatedCause::NewPath,
+            search_complete: path.mtu_controller.is_search_completed(),
         });
 
         // create a new path

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__active_connection_migration_disabled.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__active_connection_migration_disabled.snap
@@ -4,6 +4,6 @@ expression: ""
 ---
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x01, current: 0x69643032 }
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:1, remote_cid: 0x69643032, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x69643032, remote_addr: 127.0.0.2:1, remote_cid: 0x69643033, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:1, remote_cid: 0x69643032, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.3:1, remote_cid: 0x69643032, id: 2, is_active: false } }
-MtuUpdated { path_id: 2, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 2, mtu: 1200, cause: NewPath, search_complete: false }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__adding_new_path.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__adding_new_path.snap
@@ -3,4 +3,4 @@ source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__connection_migration_challenge_behavior.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__connection_migration_challenge_behavior.snap
@@ -3,5 +3,5 @@ source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 1, is_active: true } }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__connection_migration_new_path_abandon_timer.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__connection_migration_new_path_abandon_timer.snap
@@ -3,6 +3,6 @@ source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 1, is_active: true } }
 PathChallengeUpdated { path_challenge_status: Abandoned, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 0, is_active: true }, challenge_data: [123, 122, 121, 120, 127, 126, 125, 124] }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__connection_migration_use_max_ack_delay_from_active_path.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__connection_migration_use_max_ack_delay_from_active_path.snap
@@ -3,4 +3,4 @@ source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__limit_number_of_connection_migrations.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__limit_number_of_connection_migrations.snap
@@ -3,14 +3,14 @@ source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:1, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:1, remote_cid: 0x01, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:1, remote_cid: 0x01, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:1, remote_cid: 0x01, id: 1, is_active: true } }
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:1, remote_cid: 0x01, id: 1, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:2, remote_cid: 0x01, id: 2, is_active: false } }
-MtuUpdated { path_id: 2, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 2, mtu: 1200, cause: NewPath, search_complete: false }
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:1, remote_cid: 0x01, id: 1, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:2, remote_cid: 0x01, id: 2, is_active: true } }
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:2, remote_cid: 0x01, id: 2, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:3, remote_cid: 0x01, id: 3, is_active: false } }
-MtuUpdated { path_id: 3, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 3, mtu: 1200, cause: NewPath, search_complete: false }
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:2, remote_cid: 0x01, id: 2, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:3, remote_cid: 0x01, id: 3, is_active: true } }
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:3, remote_cid: 0x01, id: 3, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:4, remote_cid: 0x01, id: 4, is_active: false } }
-MtuUpdated { path_id: 4, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 4, mtu: 1200, cause: NewPath, search_complete: false }
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:3, remote_cid: 0x01, id: 3, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:4, remote_cid: 0x01, id: 4, is_active: true } }

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__temporary_until_authenticated.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/quic__s2n-quic-transport__src__path__manager__tests__events__temporary_until_authenticated.snap
@@ -3,9 +3,9 @@ source: quic/s2n-quic-transport/src/path/manager/tests.rs
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.3:8001, remote_cid: 0x01, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }
 ActivePathUpdated { previous: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:8001, remote_cid: 0x01, id: 0, is_active: false }, active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.3:8001, remote_cid: 0x01, id: 1, is_active: true } }
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.3:8001, remote_cid: 0x01, id: 1, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:8001, remote_cid: 0x01, id: 2, is_active: false } }
-MtuUpdated { path_id: 2, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 2, mtu: 1200, cause: NewPath, search_complete: false }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__detect_lost_packets_persistent_congestion_path_aware.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__detect_lost_packets_persistent_congestion_path_aware.snap
@@ -3,4 +3,4 @@ source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__no_rtt_update_when_receiving_packet_on_different_path.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__no_rtt_update_when_receiving_packet_on_different_path.snap
@@ -3,7 +3,7 @@ source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }
 AckRangeReceived { packet_header: OneRtt { number: 0 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false }, ack_range: 0..=0 }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false }, min_rtt: 333ms, smoothed_rtt: 333ms, latest_rtt: 333ms, rtt_variance: 166.5ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 0, congestion_limited: false }
 AckRangeReceived { packet_header: OneRtt { number: 1 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, ack_range: 1..=1 }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__on_packet_sent.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__on_packet_sent.snap
@@ -3,5 +3,5 @@ source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }
 EcnStateChanged { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, state: Unknown }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__on_packet_sent_across_multiple_paths.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__on_packet_sent_across_multiple_paths.snap
@@ -3,4 +3,4 @@ source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_congestion_controller.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_congestion_controller.snap
@@ -3,6 +3,6 @@ source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }
 AckRangeReceived { packet_header: OneRtt { number: 1 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, ack_range: 1..=2 }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 333ms, smoothed_rtt: 333ms, latest_rtt: 333ms, rtt_variance: 166.5ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 128, congestion_limited: false }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_pto_timer.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_pto_timer.snap
@@ -3,7 +3,7 @@ source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }
 AckRangeReceived { packet_header: OneRtt { number: 1 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, ack_range: 1..=1 }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 500ms, smoothed_rtt: 500ms, latest_rtt: 500ms, rtt_variance: 250ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 128, congestion_limited: false }
 AckRangeReceived { packet_header: OneRtt { number: 2 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false }, ack_range: 2..=2 }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_update_pto_timer.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__process_new_acked_packets_update_pto_timer.snap
@@ -3,7 +3,7 @@ source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }
 AckRangeReceived { packet_header: OneRtt { number: 1 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, ack_range: 1..=1 }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 500ms, smoothed_rtt: 500ms, latest_rtt: 500ms, rtt_variance: 250ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 128, congestion_limited: false }
 AckRangeReceived { packet_header: OneRtt { number: 2 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, ack_range: 2..=2 }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__remove_lost_packets_persistent_congestion_path_aware.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__remove_lost_packets_persistent_congestion_path_aware.snap
@@ -3,7 +3,7 @@ source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }
 PacketLost { packet_header: OneRtt { number: 9 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: true }, bytes_lost: 1, is_mtu_probe: false }
 PacketLost { packet_header: OneRtt { number: 10 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false }, bytes_lost: 1, is_mtu_probe: false }
 Congestion { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false }, source: PacketLoss }

--- a/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__rtt_update_when_receiving_ack_from_multiple_paths.snap
+++ b/quic/s2n-quic-transport/src/recovery/manager/snapshots/quic__s2n-quic-transport__src__recovery__manager__tests__events__rtt_update_when_receiving_ack_from_multiple_paths.snap
@@ -3,6 +3,6 @@ source: quic/s2n-quic-transport/src/recovery/manager/tests.rs
 expression: ""
 ---
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.2:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 1, is_active: false } }
-MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath }
+MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }
 AckRangeReceived { packet_header: OneRtt { number: 0 }, path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, ack_range: 0..=1 }
 RecoveryMetrics { path: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:80, remote_cid: 0x5065657249640000000000000000506565724964, id: 0, is_active: true }, min_rtt: 700ms, smoothed_rtt: 700ms, latest_rtt: 700ms, rtt_variance: 350ms, max_ack_delay: 100ms, pto_count: 0, congestion_window: 15000, bytes_in_flight: 128, congestion_limited: false }


### PR DESCRIPTION
### Description of changes: 

This change adds a `search_completed` boolean field to the `mtu_updated` event, to indicate when MTU probing has completed 

### Call-outs:

At the time the MTU is changed (after a probe is acked for example), we often don't know if that MTU value is going to be the final MTU, so the search_completed flag will be false. It some cases, the MTU may not change again, but we this PR will emit an additional `mtu_updated` event in these cases to update the `search_completed` flag.

### Testing:

Added tests and integration tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

