### PR TITLE
refactor(s2n-quic-h3): remove s2n-quic-core dependency

### DIFF
--- a/quic/s2n-quic-h3/Cargo.toml
+++ b/quic/s2n-quic-h3/Cargo.toml
@@ -14,7 +14,6 @@ bytes = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false }
 h3 = "0.0.6"
 s2n-quic = { path = "../s2n-quic" }
-s2n-quic-core = { path = "../s2n-quic-core" }
 tracing = { version = "0.1", optional = true }
 
 [features]

--- a/quic/s2n-quic-h3/src/s2n_quic.rs
+++ b/quic/s2n-quic-h3/src/s2n_quic.rs
@@ -4,8 +4,10 @@
 use bytes::{Buf, Bytes};
 use core::task::ready;
 use h3::quic::{self, Error, StreamId, WriteBuf};
-use s2n_quic::stream::{BidirectionalStream, ReceiveStream};
-use s2n_quic_core::varint::VarInt;
+use s2n_quic::{
+    application,
+    stream::{BidirectionalStream, ReceiveStream},
+};
 use std::{
     convert::TryInto,
     fmt::{self, Display},
@@ -178,7 +180,7 @@ where
         self.conn.close(
             code.value()
                 .try_into()
-                .unwrap_or_else(|_| VarInt::MAX.into()),
+                .unwrap_or(application::Error::UNKNOWN),
         );
     }
 }
@@ -461,7 +463,7 @@ where
     fn reset(&mut self, reset_code: u64) {
         let _ = self
             .stream
-            .reset(reset_code.try_into().unwrap_or_else(|_| VarInt::MAX.into()));
+            .reset(reset_code.try_into().unwrap_or(application::Error::UNKNOWN));
     }
 
     #[cfg_attr(feature = "tracing", instrument(skip_all, level = "trace"))]


### PR DESCRIPTION
### Description of changes: 

`s2n-quic-core` is an internal crate that is not guaranteed to be stable, and thus it should not be used directly. `s2n-quic-h3` is a proof of concept of an HTTP3 integration of s2n-quic, so it should follow this recommendation as well. This change removes the `s2n-quic-core` dependency from `s2n-quic-h3`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

