### PR TITLE
Optimize path secret Entry size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,7 +220,7 @@ jobs:
           - rust: stable
             os: ubuntu-latest
             target: native
-            env: S2N_QUIC_PLATFORM_FEATURES_OVERRIDE="mtu_disc,pktinfo,tos,socket_msg"
+            env: S2N_QUIC_PLATFORM_FEATURES_OVERRIDE="mtu_disc,pktinfo,tos,socket_msg" >> $GITHUB_ENV; echo S2N_QUIC_RUN_VERSION_SPECIFIC_TESTS=1
     steps:
       - uses: ilammy/setup-nasm@v1
       - uses: actions/checkout@v4

--- a/dc/s2n-quic-dc/benches/src/crypto.rs
+++ b/dc/s2n-quic-dc/benches/src/crypto.rs
@@ -5,8 +5,10 @@ use criterion::Criterion;
 
 pub mod encrypt;
 pub mod hkdf;
+pub mod hmac;
 
 pub fn benchmarks(c: &mut Criterion) {
     encrypt::benchmarks(c);
     hkdf::benchmarks(c);
+    hmac::benchmarks(c);
 }

--- a/dc/s2n-quic-dc/benches/src/crypto/hmac.rs
+++ b/dc/s2n-quic-dc/benches/src/crypto/hmac.rs
@@ -1,0 +1,32 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use criterion::{black_box, Criterion, Throughput};
+
+pub fn benchmarks(c: &mut Criterion) {
+    init(c);
+}
+
+fn init(c: &mut Criterion) {
+    let mut group = c.benchmark_group("crypto/hmac/init");
+
+    group.throughput(Throughput::Elements(1));
+
+    let algs = [
+        ("sha256", aws_lc_rs::hmac::HMAC_SHA256),
+        ("sha384", aws_lc_rs::hmac::HMAC_SHA384),
+        ("sha512", aws_lc_rs::hmac::HMAC_SHA512),
+    ];
+
+    for (alg_name, alg) in algs {
+        group.bench_function(format!("{alg_name}_init"), |b| {
+            let key_len = aws_lc_rs::hkdf::KeyType::len(&alg);
+            let mut key = vec![0u8; key_len];
+            aws_lc_rs::rand::fill(&mut key).unwrap();
+            let key = black_box(&key);
+            b.iter(move || {
+                let _ = black_box(aws_lc_rs::hmac::Key::new(alg, &key));
+            });
+        });
+    }
+}

--- a/dc/s2n-quic-dc/src/path/secret/map.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map.rs
@@ -437,7 +437,7 @@ impl Map {
 
         match packet {
             control::Packet::StaleKey(packet) => {
-                let Some(packet) = packet.authenticate(key) else {
+                let Some(packet) = packet.authenticate(&key) else {
                     return;
                 };
                 state.mark_live(self.state.cleaner.epoch());
@@ -447,7 +447,7 @@ impl Map {
                     .fetch_add(1, Ordering::Relaxed);
             }
             control::Packet::ReplayDetected(packet) => {
-                let Some(_packet) = packet.authenticate(key) else {
+                let Some(_packet) = packet.authenticate(&key) else {
                     return;
                 };
                 self.state

--- a/dc/s2n-quic-dc/src/path/secret/map/test.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/test.rs
@@ -308,3 +308,11 @@ fn check_invariants_no_overflow() {
             }
         })
 }
+
+#[test]
+fn entry_size() {
+    // This gates to running only on specific GHA to reduce false positives.
+    if std::env::var("S2N_QUIC_RUN_VERSION_SPECIFIC_TESTS").is_ok() {
+        assert_eq!(fake_entry(0).size(), 1000);
+    }
+}

--- a/dc/s2n-quic-dc/src/path/secret/map/test.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/test.rs
@@ -310,9 +310,10 @@ fn check_invariants_no_overflow() {
 }
 
 #[test]
+#[cfg(all(target_pointer_width = "64", target_os = "linux"))]
 fn entry_size() {
     // This gates to running only on specific GHA to reduce false positives.
     if std::env::var("S2N_QUIC_RUN_VERSION_SPECIFIC_TESTS").is_ok() {
-        assert_eq!(fake_entry(0).size(), 1000);
+        assert_eq!(fake_entry(0).size(), 350);
     }
 }

--- a/dc/s2n-quic-dc/src/path/secret/schedule.rs
+++ b/dc/s2n-quic-dc/src/path/secret/schedule.rs
@@ -109,6 +109,30 @@ pub struct Secret {
     ciphersuite: Ciphersuite,
 }
 
+impl super::map::SizeOf for Id {}
+impl super::map::SizeOf for Prk {
+    fn size(&self) -> usize {
+        // FIXME: maybe don't use this type since it has overhead and needs this weird assert to
+        // check the mode?
+        assert!(format!("{:?}", self).contains("mode: Expand"));
+        std::mem::size_of::<Self>()
+    }
+}
+impl super::map::SizeOf for endpoint::Type {}
+impl super::map::SizeOf for Ciphersuite {}
+
+impl super::map::SizeOf for Secret {
+    fn size(&self) -> usize {
+        let Secret {
+            id,
+            prk,
+            endpoint,
+            ciphersuite,
+        } = self;
+        id.size() + prk.size() + endpoint.size() + ciphersuite.size()
+    }
+}
+
 impl Secret {
     #[inline]
     pub fn new(

--- a/dc/s2n-quic-dc/src/path/secret/sender.rs
+++ b/dc/s2n-quic-dc/src/path/secret/sender.rs
@@ -3,7 +3,6 @@
 
 use super::schedule;
 use crate::{crypto::awslc::open, packet::secret_control};
-use once_cell::sync::OnceCell;
 use s2n_quic_core::varint::VarInt;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -13,16 +12,6 @@ type StatelessReset = [u8; secret_control::TAG_LEN];
 pub struct State {
     current_id: AtomicU64,
     pub(super) stateless_reset: StatelessReset,
-    control_secret: OnceCell<open::control::Secret>,
-}
-
-impl super::map::SizeOf for OnceCell<open::control::Secret> {
-    fn size(&self) -> usize {
-        // FIXME: OnceCell stores the value inline, but it also has a AtomicPtr to a list of
-        // waiters. That should be ~empty after init finishes. We should probably just initialize
-        // this eagerly when creating the secret rather than adding extra mutable state.
-        std::mem::size_of::<Self>()
-    }
 }
 
 impl super::map::SizeOf for StatelessReset {}
@@ -32,9 +21,8 @@ impl super::map::SizeOf for State {
         let State {
             current_id,
             stateless_reset,
-            control_secret,
         } = self;
-        current_id.size() + stateless_reset.size() + control_secret.size()
+        current_id.size() + stateless_reset.size()
     }
 }
 
@@ -43,7 +31,6 @@ impl State {
         Self {
             current_id: AtomicU64::new(0),
             stateless_reset,
-            control_secret: Default::default(),
         }
     }
 
@@ -69,8 +56,10 @@ impl State {
     }
 
     #[inline]
-    pub fn control_secret(&self, secret: &schedule::Secret) -> &open::control::Secret {
-        self.control_secret.get_or_init(|| secret.control_opener())
+    pub fn control_secret(&self, secret: &schedule::Secret) -> open::control::Secret {
+        // We don't try to cache this, hmac init is cheap (~200-600ns depending on algorithm) and
+        // the space requirement is huge (700+ bytes)
+        secret.control_opener()
     }
 
     /// Update the sender for a received stale key packet.

--- a/dc/s2n-quic-dc/src/path/secret/sender.rs
+++ b/dc/s2n-quic-dc/src/path/secret/sender.rs
@@ -16,6 +16,28 @@ pub struct State {
     control_secret: OnceCell<open::control::Secret>,
 }
 
+impl super::map::SizeOf for OnceCell<open::control::Secret> {
+    fn size(&self) -> usize {
+        // FIXME: OnceCell stores the value inline, but it also has a AtomicPtr to a list of
+        // waiters. That should be ~empty after init finishes. We should probably just initialize
+        // this eagerly when creating the secret rather than adding extra mutable state.
+        std::mem::size_of::<Self>()
+    }
+}
+
+impl super::map::SizeOf for StatelessReset {}
+
+impl super::map::SizeOf for State {
+    fn size(&self) -> usize {
+        let State {
+            current_id,
+            stateless_reset,
+            control_secret,
+        } = self;
+        current_id.size() + stateless_reset.size() + control_secret.size()
+    }
+}
+
 impl State {
     pub fn new(stateless_reset: StatelessReset) -> Self {
         Self {


### PR DESCRIPTION
### Description of changes: 

This adds a custom SizeOf trait and implements it for the types contained in a given Entry, and adds a GHA CI-only test that checks the size of the entry is as we expect. It's likely that we will want to change this but this is an initial proposal of how to do that without breaking downstream consumers.

We also add a benchmark for hmac init (locally I get 200-600ns depending on key type) and removes the OnceCell cache as part of Entry, bringing us down to ~300 bytes.

### Testing:

See added test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

