### PR TITLE
chore(s2n-quic-crypto): remove ring

### DIFF
--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -17,17 +17,12 @@ fips = ["aws-lc-rs/fips"]
 testing = []
 
 [dependencies]
+aws-lc-rs = { version = "1.9", features = ["prebuilt-nasm"] }
 cfg-if = "1"
 lazy_static = "1"
 s2n-codec = { version = "=0.46.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.46.0", path = "../s2n-quic-core", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["derive"] }
-
-[target.'cfg(not(target_os = "windows"))'.dependencies]
-aws-lc-rs = { version = "1.6" }
-
-[target.'cfg(target_os = "windows")'.dependencies]
-ring = { version = "0.17", default-features = false }
 
 [dev-dependencies]
 hex-literal = "0.4"

--- a/quic/s2n-quic-crypto/src/aead/default.rs
+++ b/quic/s2n-quic-crypto/src/aead/default.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     aead::{Aead, Result},
-    ring_aead::{Aad, LessSafeKey, Nonce, MAX_TAG_LEN, NONCE_LEN},
+    aws_lc_aead::{Aad, LessSafeKey, Nonce, MAX_TAG_LEN, NONCE_LEN},
 };
 use s2n_quic_core::crypto::{packet_protection::Error, scatter};
 

--- a/quic/s2n-quic-crypto/src/aead/fips.rs
+++ b/quic/s2n-quic-crypto/src/aead/fips.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     aead::{Aead, Result},
-    ring_aead::{
+    aws_lc_aead::{
         self, Aad, Nonce, TlsProtocolId, TlsRecordOpeningKey, TlsRecordSealingKey, MAX_TAG_LEN,
         NONCE_LEN,
     },
@@ -21,7 +21,7 @@ pub struct FipsKey {
 
 impl FipsKey {
     #[inline]
-    pub fn new(algorithm: &'static ring_aead::Algorithm, key_bytes: &[u8]) -> Result<Self> {
+    pub fn new(algorithm: &'static aws_lc_aead::Algorithm, key_bytes: &[u8]) -> Result<Self> {
         let opener = TlsRecordOpeningKey::new(algorithm, TlsProtocolId::TLS13, key_bytes)
             .expect("key size verified");
         let sealer = TlsRecordSealingKey::new(algorithm, TlsProtocolId::TLS13, key_bytes)

--- a/quic/s2n-quic-crypto/src/cipher_suite.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{aead::Aead, header_key::HeaderKey, hkdf, iv, ring_aead as aead};
+use crate::{aead::Aead, aws_lc_aead as aead, header_key::HeaderKey, hkdf, iv};
 use core::fmt;
 use s2n_quic_core::{
     assume,
@@ -36,7 +36,7 @@ macro_rules! impl_cipher_suite {
 
             pub const KEY_LEN: usize = $cipher_key_len;
             pub const TAG_LEN: usize = 16;
-            pub const NONCE_LEN: usize = crate::ring_aead::NONCE_LEN;
+            pub const NONCE_LEN: usize = crate::aws_lc_aead::NONCE_LEN;
 
             type Key = platform::$lower::Key;
 

--- a/quic/s2n-quic-crypto/src/cipher_suite/negotiated.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite/negotiated.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    aws_lc_aead as aead,
     cipher_suite::{TLS_AES_128_GCM_SHA256, TLS_AES_256_GCM_SHA384, TLS_CHACHA20_POLY1305_SHA256},
     header_key::HeaderKey,
-    hkdf, ring_aead as aead,
+    hkdf,
 };
 use core::fmt;
 use s2n_quic_core::crypto::{self, packet_protection, scatter};

--- a/quic/s2n-quic-crypto/src/cipher_suite/ring.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite/ring.rs
@@ -6,7 +6,7 @@ macro_rules! key {
     ($name:ident, $ring_cipher:path, $key_size:expr, $tag_len:expr) => {
         pub mod $name {
             use super::super::$name::{KEY_LEN, NONCE_LEN, TAG_LEN};
-            use crate::ring_aead::{self as aead};
+            use crate::aws_lc_aead::{self as aead};
             use s2n_quic_core::crypto::scatter;
             use zeroize::Zeroize;
 
@@ -43,7 +43,7 @@ macro_rules! key_no_fips_support {
     ($name:ident, $ring_cipher:path, $key_size:expr, $tag_len:expr) => {
         pub mod $name {
             use super::super::$name::{KEY_LEN, NONCE_LEN, TAG_LEN};
-            use crate::ring_aead::{self as aead};
+            use crate::aws_lc_aead::{self as aead};
             use s2n_quic_core::crypto::scatter;
             use zeroize::Zeroize;
 

--- a/quic/s2n-quic-crypto/src/header_key.rs
+++ b/quic/s2n-quic-crypto/src/header_key.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{hkdf, aws_lc_aead as aead};
+use crate::{aws_lc_aead as aead, hkdf};
 use core::fmt;
 use s2n_quic_core::crypto::{self, HeaderProtectionMask};
 

--- a/quic/s2n-quic-crypto/src/header_key.rs
+++ b/quic/s2n-quic-crypto/src/header_key.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{hkdf, ring_aead as aead};
+use crate::{hkdf, aws_lc_aead as aead};
 use core::fmt;
 use s2n_quic_core::crypto::{self, HeaderProtectionMask};
 

--- a/quic/s2n-quic-crypto/src/iv.rs
+++ b/quic/s2n-quic-crypto/src/iv.rs
@@ -5,7 +5,7 @@ use crate::hkdf;
 use s2n_codec::{Encoder, EncoderBuffer};
 use zeroize::Zeroize;
 
-pub use crate::ring_aead::NONCE_LEN;
+pub use crate::aws_lc_aead::NONCE_LEN;
 
 pub struct Iv([u8; NONCE_LEN]);
 

--- a/quic/s2n-quic-crypto/src/lib.rs
+++ b/quic/s2n-quic-crypto/src/lib.rs
@@ -13,12 +13,9 @@ mod aead;
 mod cipher_suite;
 mod iv;
 
-#[cfg(not(target_os = "windows"))]
-use aws_lc_rs as ring;
-
 #[doc(hidden)]
-pub use ring::{
-    aead as ring_aead, aead::MAX_TAG_LEN, constant_time, digest, hkdf, hkdf::Prk, hmac,
+pub use aws_lc_rs::{
+    aead as aws_lc_aead, aead::MAX_TAG_LEN, constant_time, digest, hkdf, hkdf::Prk, hmac,
 };
 
 #[derive(Clone)]

--- a/quic/s2n-quic-crypto/src/negotiated.rs
+++ b/quic/s2n-quic-crypto/src/negotiated.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cipher_suite::NegotiatedCipherSuite as CipherSuite, header_key::HeaderKeyPair,
-    ring_aead::Algorithm, SecretPair,
+    aws_lc_aead::Algorithm, cipher_suite::NegotiatedCipherSuite as CipherSuite,
+    header_key::HeaderKeyPair, SecretPair,
 };
 use s2n_quic_core::{
     crypto::{packet_protection, scatter, Key},
@@ -100,7 +100,7 @@ macro_rules! negotiated_crypto {
         impl $name {
             /// Create a server cipher suite with a given negotiated algorithm and secret
             pub fn new_server(
-                algorithm: &$crate::ring_aead::Algorithm,
+                algorithm: &$crate::aws_lc_aead::Algorithm,
                 secrets: $crate::SecretPair,
             ) -> Option<(Self, $header_key)> {
                 Self::new(s2n_quic_core::endpoint::Type::Server, algorithm, secrets)
@@ -108,7 +108,7 @@ macro_rules! negotiated_crypto {
 
             /// Create a client cipher suite with a given negotiated algorithm and secret
             pub fn new_client(
-                algorithm: &$crate::ring_aead::Algorithm,
+                algorithm: &$crate::aws_lc_aead::Algorithm,
                 secrets: $crate::SecretPair,
             ) -> Option<(Self, $header_key)> {
                 Self::new(s2n_quic_core::endpoint::Type::Client, algorithm, secrets)
@@ -117,7 +117,7 @@ macro_rules! negotiated_crypto {
             /// Create a cipher_suite for an endpoint type with a given negotiated algorithm and secret
             pub fn new(
                 endpoint: s2n_quic_core::endpoint::Type,
-                algorithm: &$crate::ring_aead::Algorithm,
+                algorithm: &$crate::aws_lc_aead::Algorithm,
                 secrets: $crate::SecretPair,
             ) -> Option<(Self, $header_key)> {
                 let (key, header_key) =

--- a/quic/s2n-quic-crypto/src/retry.rs
+++ b/quic/s2n-quic-crypto/src/retry.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{constant_time, ring_aead as aead};
+use crate::{aws_lc_aead as aead, constant_time};
 use s2n_quic_core::crypto::{
     self, packet_protection,
     retry::{IntegrityTag, NONCE_BYTES, SECRET_KEY_BYTES},

--- a/quic/s2n-quic-tls/src/callback.rs
+++ b/quic/s2n-quic-tls/src/callback.rs
@@ -9,7 +9,7 @@ use s2n_quic_core::{
     endpoint, transport,
 };
 use s2n_quic_crypto::{
-    handshake::HandshakeKey, hkdf, one_rtt::OneRttKey, ring_aead as aead, Prk, SecretPair, Suite,
+    handshake::HandshakeKey, hkdf, one_rtt::OneRttKey, aws_lc_aead as aead, Prk, SecretPair, Suite,
 };
 use s2n_tls::{connection::Connection, error::Fallible, ffi::*};
 

--- a/quic/s2n-quic-tls/src/callback.rs
+++ b/quic/s2n-quic-tls/src/callback.rs
@@ -9,7 +9,7 @@ use s2n_quic_core::{
     endpoint, transport,
 };
 use s2n_quic_crypto::{
-    handshake::HandshakeKey, hkdf, one_rtt::OneRttKey, aws_lc_aead as aead, Prk, SecretPair, Suite,
+    aws_lc_aead as aead, handshake::HandshakeKey, hkdf, one_rtt::OneRttKey, Prk, SecretPair, Suite,
 };
 use s2n_tls::{connection::Connection, error::Fallible, ffi::*};
 


### PR DESCRIPTION
### Description of changes: 

Since https://github.com/aws/aws-lc/issues/1477 was addressed, `aws-lc-rs` can now build on Windows without requiring NASM to be installed. This was the last hurdle before removing our dependency on `ring`, so this PR does that.

### Call-outs:

Including `prebuilt-nasm` as a feature makes it difficult to opt out of this functionality, so we may want to bump it up to an `s2n-quic` level feature in the future

### Testing:

Builds in CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

