### PR TITLE
feat(dc): Further shrink path secret entry

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map/test.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/test.rs
@@ -327,6 +327,6 @@ fn no_memory_growth() {
 fn entry_size() {
     // This gates to running only on specific GHA to reduce false positives.
     if std::env::var("S2N_QUIC_RUN_VERSION_SPECIFIC_TESTS").is_ok() {
-        assert_eq!(fake_entry(0).size(), 350);
+        assert_eq!(fake_entry(0).size(), 270);
     }
 }


### PR DESCRIPTION
### Description of changes: 

See individual commits. This cuts out a bit more from the path secret entries, bringing the size to 270 bytes (our current goal is 250).

### Testing:

See edited test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

