### PR TITLE
fix(dc): support updated wireshark definitions

### DIFF
--- a/dc/wireshark/build.rs
+++ b/dc/wireshark/build.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fn main() {
-    let plugin_name = option_env("PLUGIN_NAME").unwrap_or_else(|| "dcQUIC".to_string());
-    println!("cargo:rustc-env=PLUGIN_NAME={plugin_name}");
+    let plugin_name = fwd("PLUGIN_NAME", "dcQUIC");
+    let _ = fwd("PLUGIN_MAJOR_VERSION", "4");
+    let _ = fwd("PLUGIN_MINOR_VERSION", "2");
     println!(
         "cargo:rustc-env=PLUGIN_NAME_LOWER={}",
         plugin_name.to_lowercase()
@@ -16,6 +17,13 @@ fn main() {
         println!("cargo:rustc-link-arg=-U");
         println!("cargo:rustc-link-arg=-shared");
     }
+}
+
+fn fwd<N: AsRef<str>, D: AsRef<str>>(name: N, default: D) -> String {
+    let name = name.as_ref();
+    let value = option_env(name).unwrap_or_else(|| default.as_ref().to_string());
+    println!("cargo:rustc-env={name}={value}");
+    value
 }
 
 fn env<N: AsRef<str>>(name: N) -> String {

--- a/dc/wireshark/src/wireshark.rs
+++ b/dc/wireshark/src/wireshark.rs
@@ -168,7 +168,7 @@ mod wireshark_sys_impl {
                     buffer.tvb,
                     parsed.offset as _,
                     parsed.len as _,
-                    parsed.value as u32,
+                    parsed.value as _,
                 )
             }
         }
@@ -186,7 +186,7 @@ mod wireshark_sys_impl {
                     buffer.tvb,
                     parsed.offset as _,
                     parsed.len as _,
-                    parsed.value.into() as u32,
+                    parsed.value.into() as _,
                 )
             }
         }
@@ -237,8 +237,8 @@ mod wireshark_sys_impl {
             parsed: Parsed<Duration>,
         ) -> Self::AddedItem {
             let time = wireshark_sys::nstime_t {
-                secs: parsed.value.as_secs() as i64,
-                nsecs: parsed.value.subsec_nanos() as i32,
+                secs: parsed.value.as_secs() as _,
+                nsecs: parsed.value.subsec_nanos() as _,
             };
             unsafe {
                 wireshark_sys::proto_tree_add_time(


### PR DESCRIPTION
### Description of changes: 

This change makes the dc wireshark plugin compatible with wireshark 4.4. Previously it only worked with 4.2.

### Testing:

The tests are now passing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

