### PR TITLE
build(deps): update aya to 0.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-04-16
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-10-09
   CDN: https://dnglbrstg7yg.cloudfront.net
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100
@@ -424,9 +424,8 @@ jobs:
       - name: Install rust toolchain
         id: toolchain
         run: |
-          rustup toolchain install ${{ needs.env.outputs.msrv }} --profile minimal
-          rustup override set ${{ needs.env.outputs.msrv }}
-
+          rustup toolchain install stable --profile minimal
+          rustup override set stable
 
       - name: Run cargo build
         run: cargo build --manifest-path ${{ matrix.crate }}

--- a/common/s2n-codec/src/decoder/value.rs
+++ b/common/s2n-codec/src/decoder/value.rs
@@ -16,7 +16,7 @@ pub trait DecoderValue<'a>: Sized {
 }
 
 pub trait DecoderValueMut<'a>: Sized {
-    fn decode_mut(bytes: DecoderBufferMut<'a>) -> DecoderBufferMutResult<Self>;
+    fn decode_mut(bytes: DecoderBufferMut<'a>) -> DecoderBufferMutResult<'a, Self>;
 }
 
 #[macro_export]

--- a/common/s2n-codec/src/zerocopy.rs
+++ b/common/s2n-codec/src/zerocopy.rs
@@ -21,7 +21,7 @@ macro_rules! zerocopy_value_codec {
             $name: $crate::zerocopy::FromBytes,
         {
             #[inline]
-            fn decode(buffer: $crate::DecoderBuffer<'a>) -> $crate::DecoderBufferResult<Self> {
+            fn decode(buffer: $crate::DecoderBuffer<'a>) -> $crate::DecoderBufferResult<'a, Self> {
                 let (value, buffer) = <&'a $name as $crate::DecoderValue>::decode(buffer)?;
                 Ok((*value, buffer))
             }
@@ -32,7 +32,7 @@ macro_rules! zerocopy_value_codec {
             $name: $crate::zerocopy::FromBytes,
         {
             #[inline]
-            fn decode(buffer: $crate::DecoderBuffer<'a>) -> $crate::DecoderBufferResult<Self> {
+            fn decode(buffer: $crate::DecoderBuffer<'a>) -> $crate::DecoderBufferResult<'a, Self> {
                 let (value, buffer) = buffer.decode_slice(core::mem::size_of::<$name>())?;
                 let value = value.into_less_safe_slice();
                 let value = unsafe {
@@ -50,7 +50,7 @@ macro_rules! zerocopy_value_codec {
             #[inline]
             fn decode_mut(
                 buffer: $crate::DecoderBufferMut<'a>,
-            ) -> $crate::DecoderBufferMutResult<Self> {
+            ) -> $crate::DecoderBufferMutResult<'a, Self> {
                 let (value, buffer) = <&'a $name as $crate::DecoderValueMut>::decode_mut(buffer)?;
                 Ok((*value, buffer))
             }

--- a/quic/s2n-quic-core/src/frame/ack.rs
+++ b/quic/s2n-quic-core/src/frame/ack.rs
@@ -282,7 +282,7 @@ impl<'a> core::fmt::Debug for AckRangesDecoder<'a> {
 
 decoder_parameterized_value!(
     impl<'a> AckRangesDecoder<'a> {
-        fn decode(largest_acknowledged: VarInt, buffer: Buffer) -> Result<AckRangesDecoder> {
+        fn decode(largest_acknowledged: VarInt, buffer: Buffer) -> Result<AckRangesDecoder<'a>> {
             let (mut ack_range_count, buffer) = buffer.decode::<VarInt>()?;
 
             // add one to the total, which includes the first ack range

--- a/quic/s2n-quic-core/src/recovery/congestion_controller.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller.rs
@@ -71,7 +71,7 @@ pub struct PathPublisher<'a, Pub: event::ConnectionPublisher> {
 
 impl<'a, Pub: event::ConnectionPublisher> PathPublisher<'a, Pub> {
     /// Constructs a new `Publisher` around the given `event::ConnectionPublisher` and `path_id`
-    pub fn new(publisher: &'a mut Pub, path_id: path::Id) -> PathPublisher<Pub> {
+    pub fn new(publisher: &'a mut Pub, path_id: path::Id) -> PathPublisher<'a, Pub> {
         Self { publisher, path_id }
     }
 }

--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -12,8 +12,7 @@ use crate::{
 use core::{mem::size_of, time::Duration};
 use s2n_codec::{
     decoder_invariant, decoder_value, DecoderBuffer, DecoderBufferMut, DecoderBufferMutResult,
-    DecoderBufferResult, DecoderError, DecoderValue, DecoderValueMut, Encoder, EncoderBuffer,
-    EncoderValue,
+    DecoderBufferResult, DecoderError, DecoderValue, DecoderValueMut, Encoder, EncoderValue,
 };
 
 #[cfg(test)]
@@ -48,7 +47,7 @@ pub trait TransportParameter: Sized {
         let original_size = buffer.len();
         let new_parameter_size = TransportParameterCodec(self).encoding_size();
         buffer.resize(original_size + new_parameter_size, 0);
-        let mut buffer = EncoderBuffer::new(buffer);
+        let mut buffer = s2n_codec::EncoderBuffer::new(buffer);
         buffer.set_position(original_size);
         buffer.encode(&TransportParameterCodec(self));
     }

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -14,8 +14,8 @@ trace = ["s2n-quic-core/branch-tracing", "s2n-quic-core/probe-tracing", "s2n-qui
 xdp = ["s2n-quic/unstable-provider-io-xdp", "aya", "aya-log"]
 
 [dependencies]
-aya = { version = "0.12", optional = true }
-aya-log = { version = "0.2", optional = true }
+aya = { version = "0.13", optional = true }
+aya-log = { version = "0.2.1", optional = true }
 bytes = { version = "1", default-features = false }
 cfg-if = "1"
 futures = "0.3"

--- a/quic/s2n-quic-qns/src/xdp.rs
+++ b/quic/s2n-quic-qns/src/xdp.rs
@@ -4,7 +4,7 @@
 use crate::Result;
 use aya::{
     maps::{HashMap, MapData, XskMap},
-    programs, Bpf,
+    programs, Ebpf,
 };
 use s2n_quic::provider::io::{
     self,
@@ -203,15 +203,15 @@ impl Xdp {
     fn bpf_task(&self, port: u16, rx_fds: Vec<(u32, socket::Fd)>) -> Result<()> {
         // load the default BPF program from s2n-quic-xdp
         let mut bpf = if self.bpf_trace {
-            let mut bpf = Bpf::load(bpf::DEFAULT_PROGRAM_TRACE)?;
+            let mut bpf = Ebpf::load(bpf::DEFAULT_PROGRAM_TRACE)?;
 
-            if let Err(err) = aya_log::BpfLogger::init(&mut bpf) {
+            if let Err(err) = aya_log::EbpfLogger::init(&mut bpf) {
                 eprint!("error initializing BPF trace: {err:?}");
             }
 
             bpf
         } else {
-            Bpf::load(bpf::DEFAULT_PROGRAM)?
+            Ebpf::load(bpf::DEFAULT_PROGRAM)?
         };
 
         let interface = self.interface.clone();

--- a/tools/xdp/ebpf/Cargo.toml
+++ b/tools/xdp/ebpf/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 # These crates are not published so use a git dependency for now. See https://github.com/aya-rs/aya/issues/464
-aya-bpf = { git = "https://github.com/aya-rs/aya", tag = "aya-v0.12.0" }
-aya-log-ebpf = { git = "https://github.com/aya-rs/aya", tag = "aya-v0.12.0" }
+aya-ebpf = { git = "https://github.com/aya-rs/aya", tag = "aya-v0.13.0" }
+aya-log-ebpf = { git = "https://github.com/aya-rs/aya", tag = "aya-v0.13.0" }
 s2n-quic-core = { path = "../../../quic/s2n-quic-core", default-features = false }
 
 [features]

--- a/tools/xdp/ebpf/rust-toolchain.toml
+++ b/tools/xdp/ebpf/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # pin the version to prevent random breakage
-channel = "nightly-2024-04-16"
+channel = "nightly-2024-10-09"
 # The source code of rustc, provided by the rust-src component, is needed for
 # building eBPF programs.
 components = [ "rustc", "cargo", "rust-src" ]

--- a/tools/xdp/ebpf/src/main.rs
+++ b/tools/xdp/ebpf/src/main.rs
@@ -4,7 +4,7 @@
 #![no_std]
 #![no_main]
 
-use aya_bpf::{
+use aya_ebpf::{
     bindings::xdp_action,
     macros::{map, xdp},
     maps::{HashMap, XskMap},

--- a/tools/xdp/rust-toolchain
+++ b/tools/xdp/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.74.1"
+channel = "1.80.0"
 components = [ "rustc", "clippy", "rustfmt" ]

--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["corpus.tar.gz"]
 default = ["tokio"]
 
 [dependencies]
-aya = { version = "0.12", default-features = false }
+aya = { version = "0.13", default-features = false }
 bitflags = "2"
 errno = "0.3"
 libc = "0.2"
@@ -29,3 +29,9 @@ pin-project-lite = "0.2"
 rand = "0.8"
 s2n-quic-core = { path = "../../../quic/s2n-quic-core", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(s2n_quic_xdp_trace)',
+]

--- a/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfeb-trace.ebpf
+++ b/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfeb-trace.ebpf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fba47c364fb19e71609e40466441fc29af5e511a8396e6e4bb32d06b4391f4c7
-size 9040
+oid sha256:e7e1a2f7505be3f3e70c0db90fc558c45b5e2b33d9037dd7d35b003d2c730bd3
+size 8728

--- a/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfeb.ebpf
+++ b/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfeb.ebpf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9e09f4d5daf0c71f144778deff4983187c543d2cc1e65df37cd7f17e54a96e62
-size 2568
+oid sha256:4bdb72572f52ad23f797ec7937fd0c56638b2fc1aa35147b8720588d6dbe4680
+size 2456

--- a/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfel-trace.ebpf
+++ b/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfel-trace.ebpf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:09e64ffe8cf1e6fef0ecab3addff835faec61784e3e887fa3977c1ba703eba63
-size 9072
+oid sha256:e7cd328e2c2686812c079b8e3a276255f351966fe119da24b17b89c50b0343cc
+size 8760

--- a/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfel.ebpf
+++ b/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfel.ebpf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:742fc28f3d94b579a18ae4f466c7577565e4eaaf88693c221fd670d2b2f51b4e
-size 2600
+oid sha256:0837e02ce8fa913832d6cfafefd6bd58901d8e2a018639e7fb127edd05eb1d2b
+size 2488

--- a/tools/xdp/tester/Cargo.toml
+++ b/tools/xdp/tester/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aya = { version = "0.12", features = ["async_tokio"] }
-aya-log = "0.2"
+aya = { version = "0.13", features = ["async_tokio"] }
+aya-log = "0.2.1"
 clap = { version = "4.1", features = ["derive"] }
 anyhow = "1.0.68"
 env_logger = "0.11"

--- a/tools/xdp/tester/src/main.rs
+++ b/tools/xdp/tester/src/main.rs
@@ -4,9 +4,9 @@
 use anyhow::Context;
 use aya::{
     programs::{Xdp, XdpFlags},
-    Bpf,
+    Ebpf,
 };
-use aya_log::BpfLogger;
+use aya_log::EbpfLogger;
 use clap::Parser;
 use log::{info, warn};
 use tokio::signal;
@@ -40,10 +40,10 @@ async fn main() -> Result<(), anyhow::Error> {
         s2n_quic_xdp::bpf::DEFAULT_PROGRAM
     };
 
-    let mut bpf = Bpf::load(bpf)?;
+    let mut bpf = Ebpf::load(bpf)?;
 
     if opt.trace {
-        if let Err(e) = BpfLogger::init(&mut bpf) {
+        if let Err(e) = EbpfLogger::init(&mut bpf) {
             warn!("failed to initialize eBPF logger: {}", e);
         }
     }


### PR DESCRIPTION
### Description of changes: 

This change updates our `aya` dependency, which started failing after they published a new version.

### Call-outs:

I've also updated our nightly version, since it was pretty out of date and the BPF build depends on it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

