### PR TITLE
chore(GHA): allow OIDC aws credentials

### DIFF
--- a/.github/actions/duvet/README.md
+++ b/.github/actions/duvet/README.md
@@ -16,11 +16,19 @@ Path to the output report generated in `report-script`. Defaults to `report.html
 
 ### `aws-access-key-id: ''`
 
-An AWS access key. The corresponding user must have S3 write permissions.
+Deprecated.  This was previously used to authenticate with long lived IAM credentials. See [Configuring OpenID Connect](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers)
 
 ### `aws-secret-access-key: ''`
 
-The AWS secret key.
+Deprecated.  This was previously used to authenticate with long lived IAM credentials. See [Configuring OpenID Connect](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-cloud-providers)
+
+### `role-to-assume: ''`
+
+For Open ID Connect, the role attached to the IdP, in the form of an ARN. Intended for use with [AWS](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
+
+### `role-session-name: ''`
+
+For Open ID Connect, an arbitrary session name. Intended for use with [AWS](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
 
 ### `aws-s3-bucket-name: ''`
 
@@ -52,8 +60,8 @@ jobs:
         with:
           s2n-quic-dir: ./s2n-quic
           report-script: compliance/generate_report.sh
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::123456789:role/GitHubOIDCRole
+          role-session-name: GithubActionSession
           aws-s3-bucket-name: s2n-tls-ci-artifacts
           aws-s3-region: us-west-2
           cdn: https://d3fqnyekunr9xg.cloudfront.net

--- a/.github/actions/duvet/action.yml
+++ b/.github/actions/duvet/action.yml
@@ -7,11 +7,11 @@ inputs:
   report-path:
     description: 'Path to generated Duvet report output'
     required: false
-  aws-access-key-id:
-    description: 'AWS access key ID with S3 permissions'
+  role-to-assume:
+    description: 'Role to assume for OpenID Connect'
     required: true
-  aws-secret-access-key:
-    description: 'AWS secret key'
+  role-session-name:
+    description: 'Role session name for OpenID Connect'
     required: true
   aws-s3-bucket-name:
     description: 'Destination S3 bucket name for duvet reports'
@@ -46,11 +46,11 @@ runs:
       shell: bash
       run: ${{ inputs.report-script }} ${{ github.sha }}
 
-    - uses: aws-actions/configure-aws-credentials@v1.6.1
+    - uses: aws-actions/configure-aws-credentials@v4.0.2
       if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
       with:
-        aws-access-key-id: ${{ inputs.aws-access-key-id }}
-        aws-secret-access-key: ${{ inputs.aws-secret-access-key}}
+        role-to-assume: ${{ inputs.role-to-assume}}
+        role-session-name: ${{ inputs.role-session-name}}
         aws-region: ${{ inputs.aws-s3-region }}
 
     - name: Upload to S3

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -50,7 +50,7 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2nQuicGHABookSession
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -19,6 +19,7 @@ env:
 permissions:
   contents: write
   statuses: write
+  id-token: write # This is required for requesting the JWT/OIDC
 
 jobs:
   build-deploy:
@@ -48,9 +49,9 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHABookSession
+          aws-region: us-west-2
 
       - name: Upload to S3
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2nQuicGHADocSession
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
@@ -352,7 +352,7 @@ jobs:
           report-script: ./scripts/compliance
           report-path: ./target/compliance/report.html
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2nQuicGHAComplianceSession
+          role-session-name: S2nQuicGHAS3Session
           aws-s3-region: us-west-2
           aws-s3-bucket-name: s2n-quic-ci-artifacts
           cdn: $CDN
@@ -387,7 +387,7 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2nQuicGHACoverageSession
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload results
@@ -499,7 +499,7 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2nQuicGHARecoverySession
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
@@ -544,7 +544,7 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2nQuicGHASimsSession
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
@@ -651,7 +651,7 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2nQuicGHATimingSession
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
 
@@ -747,7 +747,7 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2nQuicGHADhatSession
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,7 @@ env:
 # should we taken before adding more permissions.
 permissions:
   statuses: write
+  id-token: write # This is required for requesting the JWT/OIDC
 
 jobs:
   env:
@@ -164,9 +165,9 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHADocSession
+          aws-region: us-west-2
 
       - name: Upload to S3
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -350,10 +351,10 @@ jobs:
         with:
           report-script: ./scripts/compliance
           report-path: ./target/compliance/report.html
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHAComplianceSession
+          aws-s3-region: us-west-2
           aws-s3-bucket-name: s2n-quic-ci-artifacts
-          aws-s3-region: us-west-1
           cdn: $CDN
 
   coverage:
@@ -385,9 +386,9 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHACoverageSession
+          aws-region: us-west-2
 
       - name: Upload results
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -497,9 +498,9 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHARecoverySession
+          aws-region: us-west-2
 
       - name: Upload to S3
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -542,9 +543,9 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHASimsSession
+          aws-region: us-west-2
 
       - name: Upload to S3
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -649,9 +650,10 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHATimingSession
+          aws-region: us-west-2
+
 
       - name: Upload to S3
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -744,9 +746,9 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHADhatSession
+          aws-region: us-west-2
 
       - name: Upload to S3
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -215,7 +215,7 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2nQuicGHAInteropSession
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
@@ -307,7 +307,7 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2nQuicGHAInteropReportSession
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
@@ -410,7 +410,7 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2nQuicGHABenchSession
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload results
@@ -558,7 +558,7 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2nQuicGHAPerfReportSession
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload results

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -30,6 +30,7 @@ env:
 # should we taken before adding more permissions.
 permissions:
   statuses: write
+  id-token: write # This is required for requesting the JWT/OIDC
 
 jobs:
   env:
@@ -213,9 +214,9 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHAInteropSession
+          aws-region: us-west-2
 
       - name: Upload to S3
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -305,9 +306,9 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHAInteropReportSession
+          aws-region: us-west-2
 
       - name: Upload to S3
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -408,9 +409,9 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHABenchSession
+          aws-region: us-west-2
 
       - name: Upload results
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -556,9 +557,9 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHAPerfReportSession
+          aws-region: us-west-2
 
       - name: Upload results
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name

--- a/.github/workflows/tshark.yml
+++ b/.github/workflows/tshark.yml
@@ -26,6 +26,13 @@ on:
         default: '3.7.1'
         type: string
 
+# Updating status is relatively safe (doesnt modify source code) and caution
+# should we taken before adding more permissions.
+permissions:
+  statuses: write
+  id-token: write # This is required for requesting the JWT/OIDC
+
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -48,9 +55,9 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'schedule' || github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHADocSession
+          aws-region: us-west-2
 
       - name: Upload to S3
         if: github.event_name == 'schedule' || github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name

--- a/.github/workflows/tshark.yml
+++ b/.github/workflows/tshark.yml
@@ -27,7 +27,7 @@ on:
         type: string
 
 # Updating status is relatively safe (doesnt modify source code) and caution
-# should we taken before adding more permissions.
+# should be taken before adding more permissions.
 permissions:
   statuses: write
   id-token: write # This is required for requesting the JWT/OIDC

--- a/.github/workflows/tshark.yml
+++ b/.github/workflows/tshark.yml
@@ -56,7 +56,7 @@ jobs:
         if: github.event_name == 'schedule' || github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2nQuicGHADocSession
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3


### PR DESCRIPTION
### Resolved issues:

n/a

### Description of changes: 

Similar to the change for [s2n-tls](https://github.com/aws/s2n-tls/pull/4839), update the use of AWS credentials from GitHub secrets to OpenID Connect.

### Call-outs:

This also includes a change to the Duvet action that will need to be merged in coordinated with an update to the s2n-tls workflow https://github.com/aws/s2n-tls/pull/4850

The [publish to public ECR](https://github.com/aws/s2n-quic/blob/main/.github/workflows/qns.yml#L367) needs more work and will be in a future PR.

### Testing:

How was this change tested ? in the s2n-netbench repo.  Changes based on [this doc](https://docs.github.com/en/actions/security-for-github-actions/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)

In this PR, you can see a successful use of the OIDC auth in the `book/deploy` action, on the aws auth step of the workflow, note the `Assuming role with OIDC` success message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

