### PR TITLE
chore: update qns actions for OIDC

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -218,7 +218,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2ntlsGHAS3Session
-          aws-region: us-west-1
+          aws-region: us-west-2
 
       - name: Upload to S3
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -369,7 +369,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCEcrRole
           role-session-name: S2ntlsGHAECRSession
-          aws-region: us-east-1
+          aws-region: us-east-1   # Required for ECR
 
       # authenticate pull to avoid hitting pull quota
       - name: Login to Amazon ECR Public
@@ -417,9 +417,9 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2ntlsGHAS3Session
+          aws-region: us-west-2
 
       - name: Upload results
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -565,9 +565,9 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2ntlsGHAS3Session
+          aws-region: us-west-2
 
       - name: Upload results
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -30,6 +30,9 @@ env:
 # should we taken before adding more permissions.
 permissions:
   statuses: write
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 
 jobs:
   env:
@@ -213,8 +216,8 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2ntlsGHAS3Session
           aws-region: us-west-1
 
       - name: Upload to S3
@@ -305,9 +308,9 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-session-name: S2ntlsGHAS3Session
+          aws-region: us-west-2
 
       - name: Upload to S3
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -361,14 +364,20 @@ jobs:
           sudo apt-get -o Acquire::Retries=3 update
           sudo apt-get -o Acquire::Retries=3 install -y gnuplot
 
-      # authenticate pull to avoid hitting pull quota
-      - name: Login to Amazon Elastic Container Registry Public
+      - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.repository == github.event.pull_request.head.repo.full_name
-        uses: docker/login-action@v3.3.0
         with:
-          registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCEcrRole
+          role-session-name: S2ntlsGHAECRSession
+          aws-region: us-west-2
+
+      # authenticate pull to avoid hitting pull quota
+      - name: Login to Amazon ECR Public
+        if: github.repository == github.event.pull_request.head.repo.full_name
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: Pull s2n-quic-qns:main
         if: github.event.pull_request

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -369,7 +369,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCEcrRole
           role-session-name: S2ntlsGHAECRSession
-          aws-region: us-west-2
+          aws-region: us-east-1
 
       # authenticate pull to avoid hitting pull quota
       - name: Login to Amazon ECR Public

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -217,7 +217,7 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2ntlsGHAS3Session
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
@@ -309,7 +309,7 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2ntlsGHAS3Session
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
@@ -368,7 +368,7 @@ jobs:
         if: github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCEcrRole
-          role-session-name: S2ntlsGHAECRSession
+          role-session-name: S2nQuicGHAECRSession
           aws-region: us-east-1   # Required for ECR
 
       # authenticate pull to avoid hitting pull quota
@@ -418,7 +418,7 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2ntlsGHAS3Session
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload results
@@ -566,7 +566,7 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
-          role-session-name: S2ntlsGHAS3Session
+          role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload results

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,10 @@ on:
 
 name: release
 
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read  # This is required for actions/checkout
+
 jobs:
   qns:
     runs-on: ubuntu-latest
@@ -41,13 +45,18 @@ jobs:
           fi
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 
-      - name: Login to Amazon Elastic Container Registry Public
-        uses: docker/login-action@v3.3.0
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+      - uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
-          registry: public.ecr.aws
-          username: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          password: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCEcrRole
+          role-session-name: S2ntlsGHAECRSession
+          aws-region: us-east-1   # Required for ECR
+
+      - name: Login to Amazon ECR Public
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        id: login-ecr-public
+        uses: aws-actions/amazon-ecr-login@v2
+        with:
+          registry-type: public
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3.3.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCEcrRole
-          role-session-name: S2ntlsGHAECRSession
+          role-session-name: S2nQuicGHAECRSession
           aws-region: us-east-1   # Required for ECR
 
       - name: Login to Amazon ECR Public


### PR DESCRIPTION
### Description of changes: 

Rework the qns and release actions to use short term credentials.

### Call-outs:

There are now separate roles for S3 access vs Public ECR.

### Testing:

Is this a refactor change? Relying on CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

