### PR TITLE
fix(s2n-quic-dc): wait to insert in peer map until handshake completes

### DIFF
--- a/quic/s2n-quic-core/src/dc/disabled.rs
+++ b/quic/s2n-quic-core/src/dc/disabled.rs
@@ -45,6 +45,10 @@ impl Path for () {
         unimplemented!()
     }
 
+    fn on_dc_handshake_complete(&mut self) {
+        unimplemented!()
+    }
+
     fn on_mtu_updated(&mut self, _mtu: u16) {
         unimplemented!()
     }

--- a/quic/s2n-quic-core/src/dc/testing.rs
+++ b/quic/s2n-quic-core/src/dc/testing.rs
@@ -34,6 +34,7 @@ impl MockDcEndpoint {
 pub struct MockDcPath {
     pub on_path_secrets_ready_count: u8,
     pub on_peer_stateless_reset_tokens_count: u8,
+    pub on_dc_handshake_complete: u8,
     pub stateless_reset_tokens: Vec<stateless_reset::Token>,
     pub peer_stateless_reset_tokens: Vec<stateless_reset::Token>,
     pub mtu: u16,
@@ -69,6 +70,7 @@ impl dc::Path for MockDcPath {
         &mut self,
         _session: &impl TlsSession,
     ) -> Result<Vec<stateless_reset::Token>, transport::Error> {
+        debug_assert_eq!(0, self.on_path_secrets_ready_count);
         self.on_path_secrets_ready_count += 1;
         Ok(self.stateless_reset_tokens.clone())
     }
@@ -77,9 +79,15 @@ impl dc::Path for MockDcPath {
         &mut self,
         stateless_reset_tokens: impl Iterator<Item = &'a stateless_reset::Token>,
     ) {
+        debug_assert_eq!(0, self.on_peer_stateless_reset_tokens_count);
         self.on_peer_stateless_reset_tokens_count += 1;
         self.peer_stateless_reset_tokens
             .extend(stateless_reset_tokens);
+    }
+
+    fn on_dc_handshake_complete(&mut self) {
+        debug_assert_eq!(0, self.on_dc_handshake_complete);
+        self.on_dc_handshake_complete += 1;
     }
 
     fn on_mtu_updated(&mut self, mtu: u16) {

--- a/quic/s2n-quic-core/src/dc/traits.rs
+++ b/quic/s2n-quic-core/src/dc/traits.rs
@@ -46,6 +46,11 @@ pub trait Path: 'static + Send {
         stateless_reset_tokens: impl Iterator<Item = &'a stateless_reset::Token>,
     );
 
+    /// Called when the peer has confirmed receipt of `DC_STATELESS_RESET_TOKENS`, either
+    /// by the server sending back its own `DC_STATELESS_RESET_TOKENS` or by the client
+    /// acknowledging the `DC_STATELESS_RESET_TOKENS` frame was received.
+    fn on_dc_handshake_complete(&mut self);
+
     /// Called when the MTU has been updated for the path
     fn on_mtu_updated(&mut self, mtu: u16);
 }
@@ -70,6 +75,13 @@ impl<P: Path> Path for Option<P> {
     ) {
         if let Some(path) = self {
             path.on_peer_stateless_reset_tokens(stateless_reset_tokens)
+        }
+    }
+
+    #[inline]
+    fn on_dc_handshake_complete(&mut self) {
+        if let Some(path) = self {
+            path.on_dc_handshake_complete()
         }
     }
 

--- a/quic/s2n-quic-transport/src/dc/manager.rs
+++ b/quic/s2n-quic-transport/src/dc/manager.rs
@@ -160,6 +160,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         if Config::ENDPOINT_TYPE.is_server() {
             self.stateless_reset_token_sync.send();
         } else {
+            self.path.on_dc_handshake_complete();
             publisher.on_dc_state_changed(DcStateChanged {
                 state: DcState::Complete,
             });
@@ -176,6 +177,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         ensure!(self.state.on_stateless_reset_tokens_acked().is_ok());
 
         debug_assert!(Config::ENDPOINT_TYPE.is_server());
+        self.path.on_dc_handshake_complete();
         publisher.on_dc_state_changed(DcStateChanged {
             state: DcState::Complete,
         });

--- a/quic/s2n-quic-transport/src/dc/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/dc/manager/tests.rs
@@ -149,7 +149,9 @@ fn on_peer_dc_stateless_reset_tokens<Config, Endpoint>(
 
     if Config::ENDPOINT_TYPE.is_server() {
         assert!(manager.state.is_server_tokens_sent());
+        assert_eq!(0, manager.path().on_dc_handshake_complete);
     } else {
+        assert_eq!(1, manager.path().on_dc_handshake_complete);
         assert!(manager.state.is_complete());
     }
 
@@ -169,6 +171,7 @@ fn on_packet_ack_client() {
 
     // Client completes when it has received stateless reset tokens from the peer
     assert!(!manager.state.is_complete());
+    assert_eq!(0, manager.path().on_dc_handshake_complete);
 }
 
 #[test]
@@ -182,6 +185,7 @@ fn on_packet_ack_server() {
 
     // Server completes when its stateless reset tokens are acked
     assert!(manager.state.is_complete());
+    assert_eq!(1, manager.path().on_dc_handshake_complete);
 }
 
 fn on_packet_ack<Config, Endpoint>(


### PR DESCRIPTION
### Resolved issues:

resolves #2314

### Description of changes: 

Currently, a dc path secret entry is inserted into both the `Secret ID -> Entry` map and the `Socket Address -> Entry` map at the same time (when dc stateless reset tokens are received). Since the dc handshake hasn't completed yet when this occurs, it is possible that the server may start encrypting with path secrets that the client is not yet aware of (as highlighted in #2314). This change splits the insertion of entries into the two maps into two operations, with the insertion into the `Socket Address -> Entry` map only occurring once the dc handshake has completed

### Testing:

Updated existing testing

Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

