### PR TITLE
feat(s2n-quic-dc): add map events

### DIFF
--- a/dc/s2n-quic-dc/events/common.rs
+++ b/dc/s2n-quic-dc/events/common.rs
@@ -1,0 +1,10 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+struct ConnectionMeta {
+    id: u64,
+}
+
+struct EndpointMeta {}
+
+struct ConnectionInfo {}

--- a/dc/s2n-quic-dc/events/connection.rs
+++ b/dc/s2n-quic-dc/events/connection.rs
@@ -4,11 +4,17 @@
 #[event("application:write")]
 pub struct ApplicationWrite {
     /// The number of bytes that the application tried to write
-    len: usize,
+    total_len: usize,
+
+    /// The amount that was written
+    write_len: usize,
 }
 
-#[event("application:write")]
+#[event("application:read")]
 pub struct ApplicationRead {
     /// The number of bytes that the application tried to read
-    len: usize,
+    capacity: usize,
+
+    /// The amount that was read
+    read_len: usize,
 }

--- a/dc/s2n-quic-dc/events/map.rs
+++ b/dc/s2n-quic-dc/events/map.rs
@@ -1,0 +1,176 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[event("path_secret_map:initialized")]
+#[subject(endpoint)]
+struct PathSecretMapInitialized {
+    /// The capacity of the path secret map
+    capacity: usize,
+
+    /// The port that the path secret is listening on
+    control_socket_port: u16,
+}
+
+#[event("path_secret_map:uninitialized")]
+#[subject(endpoint)]
+struct PathSecretMapUninitialized {
+    /// The capacity of the path secret map
+    capacity: usize,
+
+    /// The port that the path secret is listening on
+    control_socket_port: u16,
+
+    /// The number of entries in the map
+    entries: usize,
+}
+
+#[event("path_secret_map:background_handshake_requested")]
+#[subject(endpoint)]
+/// Emitted when a background handshake is requested
+struct PathSecretMapBackgroundHandshakeRequested<'a> {
+    peer_address: SocketAddress<'a>,
+}
+
+#[event("path_secret_map:entry_replaced")]
+#[subject(endpoint)]
+/// Emitted when the entry is inserted into the path secret map
+struct PathSecretMapEntryInserted<'a> {
+    peer_address: SocketAddress<'a>,
+
+    credential_id: &'a [u8],
+}
+
+#[event("path_secret_map:entry_replaced")]
+#[subject(endpoint)]
+/// Emitted when the entry is considered ready for use
+struct PathSecretMapEntryReady<'a> {
+    peer_address: SocketAddress<'a>,
+
+    credential_id: &'a [u8],
+}
+
+#[event("path_secret_map:entry_replaced")]
+#[subject(endpoint)]
+/// Emitted when an entry is replaced by a new one for the same `peer_address`
+struct PathSecretMapEntryReplaced<'a> {
+    peer_address: SocketAddress<'a>,
+
+    new_credential_id: &'a [u8],
+
+    previous_credential_id: &'a [u8],
+}
+
+#[event("path_secret_map:unknown_path_secret_packet_sent")]
+#[subject(endpoint)]
+/// Emitted when an UnknownPathSecret packet was sent
+struct UnknownPathSecretPacketSent<'a> {
+    peer_address: SocketAddress<'a>,
+    credential_id: &'a [u8],
+}
+
+#[event("path_secret_map:unknown_path_secret_packet_received")]
+#[subject(endpoint)]
+/// Emitted when an UnknownPathSecret packet was received
+struct UnknownPathSecretPacketReceived<'a> {
+    peer_address: SocketAddress<'a>,
+    credential_id: &'a [u8],
+}
+
+#[event("path_secret_map:unknown_path_secret_packet_accepted")]
+#[subject(endpoint)]
+/// Emitted when an UnknownPathSecret packet was authentic and processed
+struct UnknownPathSecretPacketAccepted<'a> {
+    peer_address: SocketAddress<'a>,
+    credential_id: &'a [u8],
+}
+
+#[event("path_secret_map:unknown_path_secret_packet_rejected")]
+#[subject(endpoint)]
+/// Emitted when an UnknownPathSecret packet was rejected as invalid
+struct UnknownPathSecretPacketRejected<'a> {
+    peer_address: SocketAddress<'a>,
+    credential_id: &'a [u8],
+}
+
+#[event("path_secret_map:replay_definitely_detected")]
+#[subject(endpoint)]
+/// Emitted when credential replay was definitely detected
+struct ReplayDefinitelyDetected<'a> {
+    credential_id: &'a [u8],
+    key_id: u64,
+}
+
+#[event("path_secret_map:replay_potentially_detected")]
+#[subject(endpoint)]
+/// Emitted when credential replay was potentially detected, but could not be verified
+/// due to a limiting tracking window
+struct ReplayPotentiallyDetected<'a> {
+    credential_id: &'a [u8],
+    key_id: u64,
+    gap: u64,
+}
+
+#[event("path_secret_map:replay_detected_packet_sent")]
+#[subject(endpoint)]
+/// Emitted when an ReplayDetected packet was sent
+struct ReplayDetectedPacketSent<'a> {
+    peer_address: SocketAddress<'a>,
+    credential_id: &'a [u8],
+}
+
+#[event("path_secret_map:replay_detected_packet_received")]
+#[subject(endpoint)]
+/// Emitted when an ReplayDetected packet was received
+struct ReplayDetectedPacketReceived<'a> {
+    peer_address: SocketAddress<'a>,
+    credential_id: &'a [u8],
+}
+
+#[event("path_secret_map:replay_detected_packet_accepted")]
+#[subject(endpoint)]
+/// Emitted when an StaleKey packet was authentic and processed
+struct ReplayDetectedPacketAccepted<'a> {
+    peer_address: SocketAddress<'a>,
+    credential_id: &'a [u8],
+    key_id: u64,
+}
+
+#[event("path_secret_map:replay_detected_packet_rejected")]
+#[subject(endpoint)]
+/// Emitted when an ReplayDetected packet was rejected as invalid
+struct ReplayDetectedPacketRejected<'a> {
+    peer_address: SocketAddress<'a>,
+    credential_id: &'a [u8],
+}
+
+#[event("path_secret_map:stale_key_packet_sent")]
+#[subject(endpoint)]
+/// Emitted when an StaleKey packet was sent
+struct StaleKeyPacketSent<'a> {
+    peer_address: SocketAddress<'a>,
+    credential_id: &'a [u8],
+}
+
+#[event("path_secret_map:stale_key_packet_received")]
+#[subject(endpoint)]
+/// Emitted when an StaleKey packet was received
+struct StaleKeyPacketReceived<'a> {
+    peer_address: SocketAddress<'a>,
+    credential_id: &'a [u8],
+}
+
+#[event("path_secret_map:stale_key_packet_accepted")]
+#[subject(endpoint)]
+/// Emitted when an StaleKey packet was authentic and processed
+struct StaleKeyPacketAccepted<'a> {
+    peer_address: SocketAddress<'a>,
+    credential_id: &'a [u8],
+}
+
+#[event("path_secret_map:stale_key_packet_rejected")]
+#[subject(endpoint)]
+/// Emitted when an StaleKey packet was rejected as invalid
+struct StaleKeyPacketRejected<'a> {
+    peer_address: SocketAddress<'a>,
+    credential_id: &'a [u8],
+}

--- a/dc/s2n-quic-dc/events/map.rs
+++ b/dc/s2n-quic-dc/events/map.rs
@@ -6,9 +6,6 @@
 struct PathSecretMapInitialized {
     /// The capacity of the path secret map
     capacity: usize,
-
-    /// The port that the path secret is listening on
-    control_socket_port: u16,
 }
 
 #[event("path_secret_map:uninitialized")]
@@ -16,9 +13,6 @@ struct PathSecretMapInitialized {
 struct PathSecretMapUninitialized {
     /// The capacity of the path secret map
     capacity: usize,
-
-    /// The port that the path secret is listening on
-    control_socket_port: u16,
 
     /// The number of entries in the map
     entries: usize,
@@ -92,6 +86,14 @@ struct UnknownPathSecretPacketRejected<'a> {
     credential_id: &'a [u8],
 }
 
+#[event("path_secret_map:unknown_path_secret_packet_dropped")]
+#[subject(endpoint)]
+/// Emitted when an UnknownPathSecret packet was dropped due to a missing entry
+struct UnknownPathSecretPacketDropped<'a> {
+    peer_address: SocketAddress<'a>,
+    credential_id: &'a [u8],
+}
+
 #[event("path_secret_map:replay_definitely_detected")]
 #[subject(endpoint)]
 /// Emitted when credential replay was definitely detected
@@ -143,6 +145,14 @@ struct ReplayDetectedPacketRejected<'a> {
     credential_id: &'a [u8],
 }
 
+#[event("path_secret_map:replay_detected_packet_dropped")]
+#[subject(endpoint)]
+/// Emitted when an ReplayDetected packet was dropped due to a missing entry
+struct ReplayDetectedPacketDropped<'a> {
+    peer_address: SocketAddress<'a>,
+    credential_id: &'a [u8],
+}
+
 #[event("path_secret_map:stale_key_packet_sent")]
 #[subject(endpoint)]
 /// Emitted when an StaleKey packet was sent
@@ -171,6 +181,14 @@ struct StaleKeyPacketAccepted<'a> {
 #[subject(endpoint)]
 /// Emitted when an StaleKey packet was rejected as invalid
 struct StaleKeyPacketRejected<'a> {
+    peer_address: SocketAddress<'a>,
+    credential_id: &'a [u8],
+}
+
+#[event("path_secret_map:stale_key_packet_dropped")]
+#[subject(endpoint)]
+/// Emitted when an StaleKey packet was dropped due to a missing entry
+struct StaleKeyPacketDropped<'a> {
     peer_address: SocketAddress<'a>,
     credential_id: &'a [u8],
 }

--- a/dc/s2n-quic-dc/src/event.rs
+++ b/dc/s2n-quic-dc/src/event.rs
@@ -4,7 +4,27 @@
 #[cfg(any(test, feature = "testing"))]
 use s2n_quic_core::event::snapshot;
 
-pub use s2n_quic_core::event::{Event, IntoEvent, Timestamp};
+pub use s2n_quic_core::event::{Event, IntoEvent};
+
+/// Provides metadata related to an event
+pub trait Meta: core::fmt::Debug {
+    /// A context from which the event is being emitted
+    ///
+    /// An event can occur in the context of an Endpoint or Connection
+    fn subject(&self) -> api::Subject;
+}
+
+impl Meta for api::ConnectionMeta {
+    fn subject(&self) -> api::Subject {
+        builder::Subject::Connection { id: self.id }.into_event()
+    }
+}
+
+impl Meta for api::EndpointMeta {
+    fn subject(&self) -> api::Subject {
+        builder::Subject::Endpoint {}.into_event()
+    }
+}
 
 mod generated;
 pub use generated::*;

--- a/dc/s2n-quic-dc/src/event/generated.rs
+++ b/dc/s2n-quic-dc/src/event/generated.rs
@@ -9,10 +9,19 @@ use super::*;
 pub mod api {
     #![doc = r" This module contains events that are emitted to the [`Subscriber`](crate::event::Subscriber)"]
     use super::*;
-    pub use s2n_quic_core::event::api::{
-        ConnectionInfo, ConnectionMeta, EndpointMeta, EndpointType, SocketAddress, Subject,
-    };
+    pub use s2n_quic_core::event::api::{EndpointType, SocketAddress, Subject};
     pub use traits::Subscriber;
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub struct ConnectionMeta {
+        pub id: u64,
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub struct EndpointMeta {}
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub struct ConnectionInfo {}
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct ApplicationWrite {
@@ -42,6 +51,213 @@ pub mod api {
     impl<'a> Event for EndpointInitialized<'a> {
         const NAME: &'static str = "endpoint:initialized";
     }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub struct PathSecretMapInitialized {
+        #[doc = " The capacity of the path secret map"]
+        pub capacity: usize,
+        #[doc = " The port that the path secret is listening on"]
+        pub control_socket_port: u16,
+    }
+    impl Event for PathSecretMapInitialized {
+        const NAME: &'static str = "path_secret_map:initialized";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub struct PathSecretMapUninitialized {
+        #[doc = " The capacity of the path secret map"]
+        pub capacity: usize,
+        #[doc = " The port that the path secret is listening on"]
+        pub control_socket_port: u16,
+        #[doc = " The number of entries in the map"]
+        pub entries: usize,
+    }
+    impl Event for PathSecretMapUninitialized {
+        const NAME: &'static str = "path_secret_map:uninitialized";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when a background handshake is requested"]
+    pub struct PathSecretMapBackgroundHandshakeRequested<'a> {
+        pub peer_address: SocketAddress<'a>,
+    }
+    impl<'a> Event for PathSecretMapBackgroundHandshakeRequested<'a> {
+        const NAME: &'static str = "path_secret_map:background_handshake_requested";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when the entry is inserted into the path secret map"]
+    pub struct PathSecretMapEntryInserted<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> Event for PathSecretMapEntryInserted<'a> {
+        const NAME: &'static str = "path_secret_map:entry_replaced";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when the entry is considered ready for use"]
+    pub struct PathSecretMapEntryReady<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> Event for PathSecretMapEntryReady<'a> {
+        const NAME: &'static str = "path_secret_map:entry_replaced";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when an entry is replaced by a new one for the same `peer_address`"]
+    pub struct PathSecretMapEntryReplaced<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub new_credential_id: &'a [u8],
+        pub previous_credential_id: &'a [u8],
+    }
+    impl<'a> Event for PathSecretMapEntryReplaced<'a> {
+        const NAME: &'static str = "path_secret_map:entry_replaced";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when an UnknownPathSecret packet was sent"]
+    pub struct UnknownPathSecretPacketSent<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> Event for UnknownPathSecretPacketSent<'a> {
+        const NAME: &'static str = "path_secret_map:unknown_path_secret_packet_sent";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when an UnknownPathSecret packet was received"]
+    pub struct UnknownPathSecretPacketReceived<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> Event for UnknownPathSecretPacketReceived<'a> {
+        const NAME: &'static str = "path_secret_map:unknown_path_secret_packet_received";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when an UnknownPathSecret packet was authentic and processed"]
+    pub struct UnknownPathSecretPacketAccepted<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> Event for UnknownPathSecretPacketAccepted<'a> {
+        const NAME: &'static str = "path_secret_map:unknown_path_secret_packet_accepted";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when an UnknownPathSecret packet was rejected as invalid"]
+    pub struct UnknownPathSecretPacketRejected<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> Event for UnknownPathSecretPacketRejected<'a> {
+        const NAME: &'static str = "path_secret_map:unknown_path_secret_packet_rejected";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when credential replay was definitely detected"]
+    pub struct ReplayDefinitelyDetected<'a> {
+        pub credential_id: &'a [u8],
+        pub key_id: u64,
+    }
+    impl<'a> Event for ReplayDefinitelyDetected<'a> {
+        const NAME: &'static str = "path_secret_map:replay_definitely_detected";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when credential replay was potentially detected, but could not be verified"]
+    #[doc = " due to a limiting tracking window"]
+    pub struct ReplayPotentiallyDetected<'a> {
+        pub credential_id: &'a [u8],
+        pub key_id: u64,
+        pub gap: u64,
+    }
+    impl<'a> Event for ReplayPotentiallyDetected<'a> {
+        const NAME: &'static str = "path_secret_map:replay_potentially_detected";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when an ReplayDetected packet was sent"]
+    pub struct ReplayDetectedPacketSent<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> Event for ReplayDetectedPacketSent<'a> {
+        const NAME: &'static str = "path_secret_map:replay_detected_packet_sent";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when an ReplayDetected packet was received"]
+    pub struct ReplayDetectedPacketReceived<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> Event for ReplayDetectedPacketReceived<'a> {
+        const NAME: &'static str = "path_secret_map:replay_detected_packet_received";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when an StaleKey packet was authentic and processed"]
+    pub struct ReplayDetectedPacketAccepted<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+        pub key_id: u64,
+    }
+    impl<'a> Event for ReplayDetectedPacketAccepted<'a> {
+        const NAME: &'static str = "path_secret_map:replay_detected_packet_accepted";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when an ReplayDetected packet was rejected as invalid"]
+    pub struct ReplayDetectedPacketRejected<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> Event for ReplayDetectedPacketRejected<'a> {
+        const NAME: &'static str = "path_secret_map:replay_detected_packet_rejected";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when an StaleKey packet was sent"]
+    pub struct StaleKeyPacketSent<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> Event for StaleKeyPacketSent<'a> {
+        const NAME: &'static str = "path_secret_map:stale_key_packet_sent";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when an StaleKey packet was received"]
+    pub struct StaleKeyPacketReceived<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> Event for StaleKeyPacketReceived<'a> {
+        const NAME: &'static str = "path_secret_map:stale_key_packet_received";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when an StaleKey packet was authentic and processed"]
+    pub struct StaleKeyPacketAccepted<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> Event for StaleKeyPacketAccepted<'a> {
+        const NAME: &'static str = "path_secret_map:stale_key_packet_accepted";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when an StaleKey packet was rejected as invalid"]
+    pub struct StaleKeyPacketRejected<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> Event for StaleKeyPacketRejected<'a> {
+        const NAME: &'static str = "path_secret_map:stale_key_packet_rejected";
+    }
 }
 pub mod tracing {
     #![doc = r" This module contains event integration with [`tracing`](https://docs.rs/tracing)"]
@@ -49,17 +265,17 @@ pub mod tracing {
     #[doc = r" Emits events with [`tracing`](https://docs.rs/tracing)"]
     #[derive(Clone, Debug)]
     pub struct Subscriber {
-        client: tracing::Span,
-        server: tracing::Span,
+        root: tracing::Span,
     }
     impl Default for Subscriber {
         fn default() -> Self {
             let root = tracing :: span ! (target : "s2n_quic_dc" , tracing :: Level :: DEBUG , "s2n_quic_dc");
-            let client =
-                tracing :: span ! (parent : root . id () , tracing :: Level :: DEBUG , "client");
-            let server =
-                tracing :: span ! (parent : root . id () , tracing :: Level :: DEBUG , "server");
-            Self { client, server }
+            Self { root }
+        }
+    }
+    impl Subscriber {
+        fn parent<M: crate::event::Meta>(&self, _meta: &M) -> Option<tracing::Id> {
+            self.root.id()
         }
     }
     impl super::Subscriber for Subscriber {
@@ -69,10 +285,7 @@ pub mod tracing {
             meta: &api::ConnectionMeta,
             _info: &api::ConnectionInfo,
         ) -> Self::ConnectionContext {
-            let parent = match meta.endpoint_type {
-                api::EndpointType::Client { .. } => self.client.id(),
-                api::EndpointType::Server { .. } => self.server.id(),
-            };
+            let parent = self.parent(meta);
             tracing :: span ! (target : "s2n_quic_dc" , parent : parent , tracing :: Level :: DEBUG , "conn" , id = meta . id)
         }
         #[inline]
@@ -103,10 +316,7 @@ pub mod tracing {
             meta: &api::EndpointMeta,
             event: &api::EndpointInitialized,
         ) {
-            let parent = match meta.endpoint_type {
-                api::EndpointType::Client { .. } => self.client.id(),
-                api::EndpointType::Server { .. } => self.server.id(),
-            };
+            let parent = self.parent(meta);
             let api::EndpointInitialized {
                 acceptor_addr,
                 handshake_addr,
@@ -115,13 +325,303 @@ pub mod tracing {
             } = event;
             tracing :: event ! (target : "endpoint_initialized" , parent : parent , tracing :: Level :: DEBUG , acceptor_addr = tracing :: field :: debug (acceptor_addr) , handshake_addr = tracing :: field :: debug (handshake_addr) , tcp = tracing :: field :: debug (tcp) , udp = tracing :: field :: debug (udp));
         }
+        #[inline]
+        fn on_path_secret_map_initialized(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapInitialized,
+        ) {
+            let parent = self.parent(meta);
+            let api::PathSecretMapInitialized {
+                capacity,
+                control_socket_port,
+            } = event;
+            tracing :: event ! (target : "path_secret_map_initialized" , parent : parent , tracing :: Level :: DEBUG , capacity = tracing :: field :: debug (capacity) , control_socket_port = tracing :: field :: debug (control_socket_port));
+        }
+        #[inline]
+        fn on_path_secret_map_uninitialized(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapUninitialized,
+        ) {
+            let parent = self.parent(meta);
+            let api::PathSecretMapUninitialized {
+                capacity,
+                control_socket_port,
+                entries,
+            } = event;
+            tracing :: event ! (target : "path_secret_map_uninitialized" , parent : parent , tracing :: Level :: DEBUG , capacity = tracing :: field :: debug (capacity) , control_socket_port = tracing :: field :: debug (control_socket_port) , entries = tracing :: field :: debug (entries));
+        }
+        #[inline]
+        fn on_path_secret_map_background_handshake_requested(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapBackgroundHandshakeRequested,
+        ) {
+            let parent = self.parent(meta);
+            let api::PathSecretMapBackgroundHandshakeRequested { peer_address } = event;
+            tracing :: event ! (target : "path_secret_map_background_handshake_requested" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address));
+        }
+        #[inline]
+        fn on_path_secret_map_entry_inserted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapEntryInserted,
+        ) {
+            let parent = self.parent(meta);
+            let api::PathSecretMapEntryInserted {
+                peer_address,
+                credential_id,
+            } = event;
+            tracing :: event ! (target : "path_secret_map_entry_inserted" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+        }
+        #[inline]
+        fn on_path_secret_map_entry_ready(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapEntryReady,
+        ) {
+            let parent = self.parent(meta);
+            let api::PathSecretMapEntryReady {
+                peer_address,
+                credential_id,
+            } = event;
+            tracing :: event ! (target : "path_secret_map_entry_ready" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+        }
+        #[inline]
+        fn on_path_secret_map_entry_replaced(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapEntryReplaced,
+        ) {
+            let parent = self.parent(meta);
+            let api::PathSecretMapEntryReplaced {
+                peer_address,
+                new_credential_id,
+                previous_credential_id,
+            } = event;
+            tracing :: event ! (target : "path_secret_map_entry_replaced" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , new_credential_id = tracing :: field :: debug (new_credential_id) , previous_credential_id = tracing :: field :: debug (previous_credential_id));
+        }
+        #[inline]
+        fn on_unknown_path_secret_packet_sent(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketSent,
+        ) {
+            let parent = self.parent(meta);
+            let api::UnknownPathSecretPacketSent {
+                peer_address,
+                credential_id,
+            } = event;
+            tracing :: event ! (target : "unknown_path_secret_packet_sent" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+        }
+        #[inline]
+        fn on_unknown_path_secret_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketReceived,
+        ) {
+            let parent = self.parent(meta);
+            let api::UnknownPathSecretPacketReceived {
+                peer_address,
+                credential_id,
+            } = event;
+            tracing :: event ! (target : "unknown_path_secret_packet_received" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+        }
+        #[inline]
+        fn on_unknown_path_secret_packet_accepted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketAccepted,
+        ) {
+            let parent = self.parent(meta);
+            let api::UnknownPathSecretPacketAccepted {
+                peer_address,
+                credential_id,
+            } = event;
+            tracing :: event ! (target : "unknown_path_secret_packet_accepted" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+        }
+        #[inline]
+        fn on_unknown_path_secret_packet_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketRejected,
+        ) {
+            let parent = self.parent(meta);
+            let api::UnknownPathSecretPacketRejected {
+                peer_address,
+                credential_id,
+            } = event;
+            tracing :: event ! (target : "unknown_path_secret_packet_rejected" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+        }
+        #[inline]
+        fn on_replay_definitely_detected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDefinitelyDetected,
+        ) {
+            let parent = self.parent(meta);
+            let api::ReplayDefinitelyDetected {
+                credential_id,
+                key_id,
+            } = event;
+            tracing :: event ! (target : "replay_definitely_detected" , parent : parent , tracing :: Level :: DEBUG , credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id));
+        }
+        #[inline]
+        fn on_replay_potentially_detected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayPotentiallyDetected,
+        ) {
+            let parent = self.parent(meta);
+            let api::ReplayPotentiallyDetected {
+                credential_id,
+                key_id,
+                gap,
+            } = event;
+            tracing :: event ! (target : "replay_potentially_detected" , parent : parent , tracing :: Level :: DEBUG , credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id) , gap = tracing :: field :: debug (gap));
+        }
+        #[inline]
+        fn on_replay_detected_packet_sent(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketSent,
+        ) {
+            let parent = self.parent(meta);
+            let api::ReplayDetectedPacketSent {
+                peer_address,
+                credential_id,
+            } = event;
+            tracing :: event ! (target : "replay_detected_packet_sent" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+        }
+        #[inline]
+        fn on_replay_detected_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketReceived,
+        ) {
+            let parent = self.parent(meta);
+            let api::ReplayDetectedPacketReceived {
+                peer_address,
+                credential_id,
+            } = event;
+            tracing :: event ! (target : "replay_detected_packet_received" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+        }
+        #[inline]
+        fn on_replay_detected_packet_accepted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketAccepted,
+        ) {
+            let parent = self.parent(meta);
+            let api::ReplayDetectedPacketAccepted {
+                peer_address,
+                credential_id,
+                key_id,
+            } = event;
+            tracing :: event ! (target : "replay_detected_packet_accepted" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id));
+        }
+        #[inline]
+        fn on_replay_detected_packet_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketRejected,
+        ) {
+            let parent = self.parent(meta);
+            let api::ReplayDetectedPacketRejected {
+                peer_address,
+                credential_id,
+            } = event;
+            tracing :: event ! (target : "replay_detected_packet_rejected" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+        }
+        #[inline]
+        fn on_stale_key_packet_sent(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketSent,
+        ) {
+            let parent = self.parent(meta);
+            let api::StaleKeyPacketSent {
+                peer_address,
+                credential_id,
+            } = event;
+            tracing :: event ! (target : "stale_key_packet_sent" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+        }
+        #[inline]
+        fn on_stale_key_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketReceived,
+        ) {
+            let parent = self.parent(meta);
+            let api::StaleKeyPacketReceived {
+                peer_address,
+                credential_id,
+            } = event;
+            tracing :: event ! (target : "stale_key_packet_received" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+        }
+        #[inline]
+        fn on_stale_key_packet_accepted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketAccepted,
+        ) {
+            let parent = self.parent(meta);
+            let api::StaleKeyPacketAccepted {
+                peer_address,
+                credential_id,
+            } = event;
+            tracing :: event ! (target : "stale_key_packet_accepted" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+        }
+        #[inline]
+        fn on_stale_key_packet_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketRejected,
+        ) {
+            let parent = self.parent(meta);
+            let api::StaleKeyPacketRejected {
+                peer_address,
+                credential_id,
+            } = event;
+            tracing :: event ! (target : "stale_key_packet_rejected" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+        }
     }
 }
 pub mod builder {
     use super::*;
-    pub use s2n_quic_core::event::builder::{
-        ConnectionInfo, ConnectionMeta, EndpointMeta, EndpointType, SocketAddress, Subject,
-    };
+    pub use s2n_quic_core::event::builder::{EndpointType, SocketAddress, Subject};
+    #[derive(Clone, Debug)]
+    pub struct ConnectionMeta {
+        pub id: u64,
+    }
+    impl IntoEvent<api::ConnectionMeta> for ConnectionMeta {
+        #[inline]
+        fn into_event(self) -> api::ConnectionMeta {
+            let ConnectionMeta { id } = self;
+            api::ConnectionMeta {
+                id: id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct EndpointMeta {}
+    impl IntoEvent<api::EndpointMeta> for EndpointMeta {
+        #[inline]
+        fn into_event(self) -> api::EndpointMeta {
+            let EndpointMeta {} = self;
+            api::EndpointMeta {}
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct ConnectionInfo {}
+    impl IntoEvent<api::ConnectionInfo> for ConnectionInfo {
+        #[inline]
+        fn into_event(self) -> api::ConnectionInfo {
+            let ConnectionInfo {} = self;
+            api::ConnectionInfo {}
+        }
+    }
     #[derive(Clone, Debug)]
     pub struct ApplicationWrite {
         #[doc = " The number of bytes that the application tried to write"]
@@ -174,14 +674,414 @@ pub mod builder {
             }
         }
     }
+    #[derive(Clone, Debug)]
+    pub struct PathSecretMapInitialized {
+        #[doc = " The capacity of the path secret map"]
+        pub capacity: usize,
+        #[doc = " The port that the path secret is listening on"]
+        pub control_socket_port: u16,
+    }
+    impl IntoEvent<api::PathSecretMapInitialized> for PathSecretMapInitialized {
+        #[inline]
+        fn into_event(self) -> api::PathSecretMapInitialized {
+            let PathSecretMapInitialized {
+                capacity,
+                control_socket_port,
+            } = self;
+            api::PathSecretMapInitialized {
+                capacity: capacity.into_event(),
+                control_socket_port: control_socket_port.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct PathSecretMapUninitialized {
+        #[doc = " The capacity of the path secret map"]
+        pub capacity: usize,
+        #[doc = " The port that the path secret is listening on"]
+        pub control_socket_port: u16,
+        #[doc = " The number of entries in the map"]
+        pub entries: usize,
+    }
+    impl IntoEvent<api::PathSecretMapUninitialized> for PathSecretMapUninitialized {
+        #[inline]
+        fn into_event(self) -> api::PathSecretMapUninitialized {
+            let PathSecretMapUninitialized {
+                capacity,
+                control_socket_port,
+                entries,
+            } = self;
+            api::PathSecretMapUninitialized {
+                capacity: capacity.into_event(),
+                control_socket_port: control_socket_port.into_event(),
+                entries: entries.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when a background handshake is requested"]
+    pub struct PathSecretMapBackgroundHandshakeRequested<'a> {
+        pub peer_address: SocketAddress<'a>,
+    }
+    impl<'a> IntoEvent<api::PathSecretMapBackgroundHandshakeRequested<'a>>
+        for PathSecretMapBackgroundHandshakeRequested<'a>
+    {
+        #[inline]
+        fn into_event(self) -> api::PathSecretMapBackgroundHandshakeRequested<'a> {
+            let PathSecretMapBackgroundHandshakeRequested { peer_address } = self;
+            api::PathSecretMapBackgroundHandshakeRequested {
+                peer_address: peer_address.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when the entry is inserted into the path secret map"]
+    pub struct PathSecretMapEntryInserted<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> IntoEvent<api::PathSecretMapEntryInserted<'a>> for PathSecretMapEntryInserted<'a> {
+        #[inline]
+        fn into_event(self) -> api::PathSecretMapEntryInserted<'a> {
+            let PathSecretMapEntryInserted {
+                peer_address,
+                credential_id,
+            } = self;
+            api::PathSecretMapEntryInserted {
+                peer_address: peer_address.into_event(),
+                credential_id: credential_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when the entry is considered ready for use"]
+    pub struct PathSecretMapEntryReady<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> IntoEvent<api::PathSecretMapEntryReady<'a>> for PathSecretMapEntryReady<'a> {
+        #[inline]
+        fn into_event(self) -> api::PathSecretMapEntryReady<'a> {
+            let PathSecretMapEntryReady {
+                peer_address,
+                credential_id,
+            } = self;
+            api::PathSecretMapEntryReady {
+                peer_address: peer_address.into_event(),
+                credential_id: credential_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when an entry is replaced by a new one for the same `peer_address`"]
+    pub struct PathSecretMapEntryReplaced<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub new_credential_id: &'a [u8],
+        pub previous_credential_id: &'a [u8],
+    }
+    impl<'a> IntoEvent<api::PathSecretMapEntryReplaced<'a>> for PathSecretMapEntryReplaced<'a> {
+        #[inline]
+        fn into_event(self) -> api::PathSecretMapEntryReplaced<'a> {
+            let PathSecretMapEntryReplaced {
+                peer_address,
+                new_credential_id,
+                previous_credential_id,
+            } = self;
+            api::PathSecretMapEntryReplaced {
+                peer_address: peer_address.into_event(),
+                new_credential_id: new_credential_id.into_event(),
+                previous_credential_id: previous_credential_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when an UnknownPathSecret packet was sent"]
+    pub struct UnknownPathSecretPacketSent<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> IntoEvent<api::UnknownPathSecretPacketSent<'a>> for UnknownPathSecretPacketSent<'a> {
+        #[inline]
+        fn into_event(self) -> api::UnknownPathSecretPacketSent<'a> {
+            let UnknownPathSecretPacketSent {
+                peer_address,
+                credential_id,
+            } = self;
+            api::UnknownPathSecretPacketSent {
+                peer_address: peer_address.into_event(),
+                credential_id: credential_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when an UnknownPathSecret packet was received"]
+    pub struct UnknownPathSecretPacketReceived<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> IntoEvent<api::UnknownPathSecretPacketReceived<'a>>
+        for UnknownPathSecretPacketReceived<'a>
+    {
+        #[inline]
+        fn into_event(self) -> api::UnknownPathSecretPacketReceived<'a> {
+            let UnknownPathSecretPacketReceived {
+                peer_address,
+                credential_id,
+            } = self;
+            api::UnknownPathSecretPacketReceived {
+                peer_address: peer_address.into_event(),
+                credential_id: credential_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when an UnknownPathSecret packet was authentic and processed"]
+    pub struct UnknownPathSecretPacketAccepted<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> IntoEvent<api::UnknownPathSecretPacketAccepted<'a>>
+        for UnknownPathSecretPacketAccepted<'a>
+    {
+        #[inline]
+        fn into_event(self) -> api::UnknownPathSecretPacketAccepted<'a> {
+            let UnknownPathSecretPacketAccepted {
+                peer_address,
+                credential_id,
+            } = self;
+            api::UnknownPathSecretPacketAccepted {
+                peer_address: peer_address.into_event(),
+                credential_id: credential_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when an UnknownPathSecret packet was rejected as invalid"]
+    pub struct UnknownPathSecretPacketRejected<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> IntoEvent<api::UnknownPathSecretPacketRejected<'a>>
+        for UnknownPathSecretPacketRejected<'a>
+    {
+        #[inline]
+        fn into_event(self) -> api::UnknownPathSecretPacketRejected<'a> {
+            let UnknownPathSecretPacketRejected {
+                peer_address,
+                credential_id,
+            } = self;
+            api::UnknownPathSecretPacketRejected {
+                peer_address: peer_address.into_event(),
+                credential_id: credential_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when credential replay was definitely detected"]
+    pub struct ReplayDefinitelyDetected<'a> {
+        pub credential_id: &'a [u8],
+        pub key_id: u64,
+    }
+    impl<'a> IntoEvent<api::ReplayDefinitelyDetected<'a>> for ReplayDefinitelyDetected<'a> {
+        #[inline]
+        fn into_event(self) -> api::ReplayDefinitelyDetected<'a> {
+            let ReplayDefinitelyDetected {
+                credential_id,
+                key_id,
+            } = self;
+            api::ReplayDefinitelyDetected {
+                credential_id: credential_id.into_event(),
+                key_id: key_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when credential replay was potentially detected, but could not be verified"]
+    #[doc = " due to a limiting tracking window"]
+    pub struct ReplayPotentiallyDetected<'a> {
+        pub credential_id: &'a [u8],
+        pub key_id: u64,
+        pub gap: u64,
+    }
+    impl<'a> IntoEvent<api::ReplayPotentiallyDetected<'a>> for ReplayPotentiallyDetected<'a> {
+        #[inline]
+        fn into_event(self) -> api::ReplayPotentiallyDetected<'a> {
+            let ReplayPotentiallyDetected {
+                credential_id,
+                key_id,
+                gap,
+            } = self;
+            api::ReplayPotentiallyDetected {
+                credential_id: credential_id.into_event(),
+                key_id: key_id.into_event(),
+                gap: gap.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when an ReplayDetected packet was sent"]
+    pub struct ReplayDetectedPacketSent<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> IntoEvent<api::ReplayDetectedPacketSent<'a>> for ReplayDetectedPacketSent<'a> {
+        #[inline]
+        fn into_event(self) -> api::ReplayDetectedPacketSent<'a> {
+            let ReplayDetectedPacketSent {
+                peer_address,
+                credential_id,
+            } = self;
+            api::ReplayDetectedPacketSent {
+                peer_address: peer_address.into_event(),
+                credential_id: credential_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when an ReplayDetected packet was received"]
+    pub struct ReplayDetectedPacketReceived<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> IntoEvent<api::ReplayDetectedPacketReceived<'a>> for ReplayDetectedPacketReceived<'a> {
+        #[inline]
+        fn into_event(self) -> api::ReplayDetectedPacketReceived<'a> {
+            let ReplayDetectedPacketReceived {
+                peer_address,
+                credential_id,
+            } = self;
+            api::ReplayDetectedPacketReceived {
+                peer_address: peer_address.into_event(),
+                credential_id: credential_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when an StaleKey packet was authentic and processed"]
+    pub struct ReplayDetectedPacketAccepted<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+        pub key_id: u64,
+    }
+    impl<'a> IntoEvent<api::ReplayDetectedPacketAccepted<'a>> for ReplayDetectedPacketAccepted<'a> {
+        #[inline]
+        fn into_event(self) -> api::ReplayDetectedPacketAccepted<'a> {
+            let ReplayDetectedPacketAccepted {
+                peer_address,
+                credential_id,
+                key_id,
+            } = self;
+            api::ReplayDetectedPacketAccepted {
+                peer_address: peer_address.into_event(),
+                credential_id: credential_id.into_event(),
+                key_id: key_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when an ReplayDetected packet was rejected as invalid"]
+    pub struct ReplayDetectedPacketRejected<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> IntoEvent<api::ReplayDetectedPacketRejected<'a>> for ReplayDetectedPacketRejected<'a> {
+        #[inline]
+        fn into_event(self) -> api::ReplayDetectedPacketRejected<'a> {
+            let ReplayDetectedPacketRejected {
+                peer_address,
+                credential_id,
+            } = self;
+            api::ReplayDetectedPacketRejected {
+                peer_address: peer_address.into_event(),
+                credential_id: credential_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when an StaleKey packet was sent"]
+    pub struct StaleKeyPacketSent<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> IntoEvent<api::StaleKeyPacketSent<'a>> for StaleKeyPacketSent<'a> {
+        #[inline]
+        fn into_event(self) -> api::StaleKeyPacketSent<'a> {
+            let StaleKeyPacketSent {
+                peer_address,
+                credential_id,
+            } = self;
+            api::StaleKeyPacketSent {
+                peer_address: peer_address.into_event(),
+                credential_id: credential_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when an StaleKey packet was received"]
+    pub struct StaleKeyPacketReceived<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> IntoEvent<api::StaleKeyPacketReceived<'a>> for StaleKeyPacketReceived<'a> {
+        #[inline]
+        fn into_event(self) -> api::StaleKeyPacketReceived<'a> {
+            let StaleKeyPacketReceived {
+                peer_address,
+                credential_id,
+            } = self;
+            api::StaleKeyPacketReceived {
+                peer_address: peer_address.into_event(),
+                credential_id: credential_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when an StaleKey packet was authentic and processed"]
+    pub struct StaleKeyPacketAccepted<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> IntoEvent<api::StaleKeyPacketAccepted<'a>> for StaleKeyPacketAccepted<'a> {
+        #[inline]
+        fn into_event(self) -> api::StaleKeyPacketAccepted<'a> {
+            let StaleKeyPacketAccepted {
+                peer_address,
+                credential_id,
+            } = self;
+            api::StaleKeyPacketAccepted {
+                peer_address: peer_address.into_event(),
+                credential_id: credential_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when an StaleKey packet was rejected as invalid"]
+    pub struct StaleKeyPacketRejected<'a> {
+        pub peer_address: SocketAddress<'a>,
+        pub credential_id: &'a [u8],
+    }
+    impl<'a> IntoEvent<api::StaleKeyPacketRejected<'a>> for StaleKeyPacketRejected<'a> {
+        #[inline]
+        fn into_event(self) -> api::StaleKeyPacketRejected<'a> {
+            let StaleKeyPacketRejected {
+                peer_address,
+                credential_id,
+            } = self;
+            api::StaleKeyPacketRejected {
+                peer_address: peer_address.into_event(),
+                credential_id: credential_id.into_event(),
+            }
+        }
+    }
 }
 pub use traits::*;
 mod traits {
     use super::*;
+    use crate::event::Meta;
     use core::fmt;
-    use s2n_quic_core::{event::Meta, query};
+    use s2n_quic_core::query;
     #[doc = r" Allows for events to be subscribed to"]
-    pub trait Subscriber: 'static + Send {
+    pub trait Subscriber: 'static + Send + Sync {
         #[doc = r" An application provided type associated with each connection."]
         #[doc = r""]
         #[doc = r" The context provides a mechanism for applications to provide a custom type"]
@@ -265,6 +1165,206 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
+        #[doc = "Called when the `PathSecretMapInitialized` event is triggered"]
+        #[inline]
+        fn on_path_secret_map_initialized(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapInitialized,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `PathSecretMapUninitialized` event is triggered"]
+        #[inline]
+        fn on_path_secret_map_uninitialized(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapUninitialized,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `PathSecretMapBackgroundHandshakeRequested` event is triggered"]
+        #[inline]
+        fn on_path_secret_map_background_handshake_requested(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapBackgroundHandshakeRequested,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `PathSecretMapEntryInserted` event is triggered"]
+        #[inline]
+        fn on_path_secret_map_entry_inserted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapEntryInserted,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `PathSecretMapEntryReady` event is triggered"]
+        #[inline]
+        fn on_path_secret_map_entry_ready(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapEntryReady,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `PathSecretMapEntryReplaced` event is triggered"]
+        #[inline]
+        fn on_path_secret_map_entry_replaced(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapEntryReplaced,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `UnknownPathSecretPacketSent` event is triggered"]
+        #[inline]
+        fn on_unknown_path_secret_packet_sent(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketSent,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `UnknownPathSecretPacketReceived` event is triggered"]
+        #[inline]
+        fn on_unknown_path_secret_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketReceived,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `UnknownPathSecretPacketAccepted` event is triggered"]
+        #[inline]
+        fn on_unknown_path_secret_packet_accepted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketAccepted,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `UnknownPathSecretPacketRejected` event is triggered"]
+        #[inline]
+        fn on_unknown_path_secret_packet_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketRejected,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `ReplayDefinitelyDetected` event is triggered"]
+        #[inline]
+        fn on_replay_definitely_detected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDefinitelyDetected,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `ReplayPotentiallyDetected` event is triggered"]
+        #[inline]
+        fn on_replay_potentially_detected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayPotentiallyDetected,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `ReplayDetectedPacketSent` event is triggered"]
+        #[inline]
+        fn on_replay_detected_packet_sent(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketSent,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `ReplayDetectedPacketReceived` event is triggered"]
+        #[inline]
+        fn on_replay_detected_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketReceived,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `ReplayDetectedPacketAccepted` event is triggered"]
+        #[inline]
+        fn on_replay_detected_packet_accepted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketAccepted,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `ReplayDetectedPacketRejected` event is triggered"]
+        #[inline]
+        fn on_replay_detected_packet_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketRejected,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `StaleKeyPacketSent` event is triggered"]
+        #[inline]
+        fn on_stale_key_packet_sent(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketSent,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `StaleKeyPacketReceived` event is triggered"]
+        #[inline]
+        fn on_stale_key_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketReceived,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `StaleKeyPacketAccepted` event is triggered"]
+        #[inline]
+        fn on_stale_key_packet_accepted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketAccepted,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `StaleKeyPacketRejected` event is triggered"]
+        #[inline]
+        fn on_stale_key_packet_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketRejected,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
         #[doc = r" Called for each event that relates to the endpoint and all connections"]
         #[inline]
         fn on_event<M: Meta, E: Event>(&self, meta: &M, event: &E) {
@@ -341,6 +1441,186 @@ mod traits {
             (self.1).on_endpoint_initialized(meta, event);
         }
         #[inline]
+        fn on_path_secret_map_initialized(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapInitialized,
+        ) {
+            (self.0).on_path_secret_map_initialized(meta, event);
+            (self.1).on_path_secret_map_initialized(meta, event);
+        }
+        #[inline]
+        fn on_path_secret_map_uninitialized(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapUninitialized,
+        ) {
+            (self.0).on_path_secret_map_uninitialized(meta, event);
+            (self.1).on_path_secret_map_uninitialized(meta, event);
+        }
+        #[inline]
+        fn on_path_secret_map_background_handshake_requested(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapBackgroundHandshakeRequested,
+        ) {
+            (self.0).on_path_secret_map_background_handshake_requested(meta, event);
+            (self.1).on_path_secret_map_background_handshake_requested(meta, event);
+        }
+        #[inline]
+        fn on_path_secret_map_entry_inserted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapEntryInserted,
+        ) {
+            (self.0).on_path_secret_map_entry_inserted(meta, event);
+            (self.1).on_path_secret_map_entry_inserted(meta, event);
+        }
+        #[inline]
+        fn on_path_secret_map_entry_ready(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapEntryReady,
+        ) {
+            (self.0).on_path_secret_map_entry_ready(meta, event);
+            (self.1).on_path_secret_map_entry_ready(meta, event);
+        }
+        #[inline]
+        fn on_path_secret_map_entry_replaced(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapEntryReplaced,
+        ) {
+            (self.0).on_path_secret_map_entry_replaced(meta, event);
+            (self.1).on_path_secret_map_entry_replaced(meta, event);
+        }
+        #[inline]
+        fn on_unknown_path_secret_packet_sent(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketSent,
+        ) {
+            (self.0).on_unknown_path_secret_packet_sent(meta, event);
+            (self.1).on_unknown_path_secret_packet_sent(meta, event);
+        }
+        #[inline]
+        fn on_unknown_path_secret_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketReceived,
+        ) {
+            (self.0).on_unknown_path_secret_packet_received(meta, event);
+            (self.1).on_unknown_path_secret_packet_received(meta, event);
+        }
+        #[inline]
+        fn on_unknown_path_secret_packet_accepted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketAccepted,
+        ) {
+            (self.0).on_unknown_path_secret_packet_accepted(meta, event);
+            (self.1).on_unknown_path_secret_packet_accepted(meta, event);
+        }
+        #[inline]
+        fn on_unknown_path_secret_packet_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketRejected,
+        ) {
+            (self.0).on_unknown_path_secret_packet_rejected(meta, event);
+            (self.1).on_unknown_path_secret_packet_rejected(meta, event);
+        }
+        #[inline]
+        fn on_replay_definitely_detected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDefinitelyDetected,
+        ) {
+            (self.0).on_replay_definitely_detected(meta, event);
+            (self.1).on_replay_definitely_detected(meta, event);
+        }
+        #[inline]
+        fn on_replay_potentially_detected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayPotentiallyDetected,
+        ) {
+            (self.0).on_replay_potentially_detected(meta, event);
+            (self.1).on_replay_potentially_detected(meta, event);
+        }
+        #[inline]
+        fn on_replay_detected_packet_sent(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketSent,
+        ) {
+            (self.0).on_replay_detected_packet_sent(meta, event);
+            (self.1).on_replay_detected_packet_sent(meta, event);
+        }
+        #[inline]
+        fn on_replay_detected_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketReceived,
+        ) {
+            (self.0).on_replay_detected_packet_received(meta, event);
+            (self.1).on_replay_detected_packet_received(meta, event);
+        }
+        #[inline]
+        fn on_replay_detected_packet_accepted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketAccepted,
+        ) {
+            (self.0).on_replay_detected_packet_accepted(meta, event);
+            (self.1).on_replay_detected_packet_accepted(meta, event);
+        }
+        #[inline]
+        fn on_replay_detected_packet_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketRejected,
+        ) {
+            (self.0).on_replay_detected_packet_rejected(meta, event);
+            (self.1).on_replay_detected_packet_rejected(meta, event);
+        }
+        #[inline]
+        fn on_stale_key_packet_sent(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketSent,
+        ) {
+            (self.0).on_stale_key_packet_sent(meta, event);
+            (self.1).on_stale_key_packet_sent(meta, event);
+        }
+        #[inline]
+        fn on_stale_key_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketReceived,
+        ) {
+            (self.0).on_stale_key_packet_received(meta, event);
+            (self.1).on_stale_key_packet_received(meta, event);
+        }
+        #[inline]
+        fn on_stale_key_packet_accepted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketAccepted,
+        ) {
+            (self.0).on_stale_key_packet_accepted(meta, event);
+            (self.1).on_stale_key_packet_accepted(meta, event);
+        }
+        #[inline]
+        fn on_stale_key_packet_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketRejected,
+        ) {
+            (self.0).on_stale_key_packet_rejected(meta, event);
+            (self.1).on_stale_key_packet_rejected(meta, event);
+        }
+        #[inline]
         fn on_event<M: Meta, E: Event>(&self, meta: &M, event: &E) {
             self.0.on_event(meta, event);
             self.1.on_event(meta, event);
@@ -369,6 +1649,58 @@ mod traits {
     pub trait EndpointPublisher {
         #[doc = "Publishes a `EndpointInitialized` event to the publisher's subscriber"]
         fn on_endpoint_initialized(&self, event: builder::EndpointInitialized);
+        #[doc = "Publishes a `PathSecretMapInitialized` event to the publisher's subscriber"]
+        fn on_path_secret_map_initialized(&self, event: builder::PathSecretMapInitialized);
+        #[doc = "Publishes a `PathSecretMapUninitialized` event to the publisher's subscriber"]
+        fn on_path_secret_map_uninitialized(&self, event: builder::PathSecretMapUninitialized);
+        #[doc = "Publishes a `PathSecretMapBackgroundHandshakeRequested` event to the publisher's subscriber"]
+        fn on_path_secret_map_background_handshake_requested(
+            &self,
+            event: builder::PathSecretMapBackgroundHandshakeRequested,
+        );
+        #[doc = "Publishes a `PathSecretMapEntryInserted` event to the publisher's subscriber"]
+        fn on_path_secret_map_entry_inserted(&self, event: builder::PathSecretMapEntryInserted);
+        #[doc = "Publishes a `PathSecretMapEntryReady` event to the publisher's subscriber"]
+        fn on_path_secret_map_entry_ready(&self, event: builder::PathSecretMapEntryReady);
+        #[doc = "Publishes a `PathSecretMapEntryReplaced` event to the publisher's subscriber"]
+        fn on_path_secret_map_entry_replaced(&self, event: builder::PathSecretMapEntryReplaced);
+        #[doc = "Publishes a `UnknownPathSecretPacketSent` event to the publisher's subscriber"]
+        fn on_unknown_path_secret_packet_sent(&self, event: builder::UnknownPathSecretPacketSent);
+        #[doc = "Publishes a `UnknownPathSecretPacketReceived` event to the publisher's subscriber"]
+        fn on_unknown_path_secret_packet_received(
+            &self,
+            event: builder::UnknownPathSecretPacketReceived,
+        );
+        #[doc = "Publishes a `UnknownPathSecretPacketAccepted` event to the publisher's subscriber"]
+        fn on_unknown_path_secret_packet_accepted(
+            &self,
+            event: builder::UnknownPathSecretPacketAccepted,
+        );
+        #[doc = "Publishes a `UnknownPathSecretPacketRejected` event to the publisher's subscriber"]
+        fn on_unknown_path_secret_packet_rejected(
+            &self,
+            event: builder::UnknownPathSecretPacketRejected,
+        );
+        #[doc = "Publishes a `ReplayDefinitelyDetected` event to the publisher's subscriber"]
+        fn on_replay_definitely_detected(&self, event: builder::ReplayDefinitelyDetected);
+        #[doc = "Publishes a `ReplayPotentiallyDetected` event to the publisher's subscriber"]
+        fn on_replay_potentially_detected(&self, event: builder::ReplayPotentiallyDetected);
+        #[doc = "Publishes a `ReplayDetectedPacketSent` event to the publisher's subscriber"]
+        fn on_replay_detected_packet_sent(&self, event: builder::ReplayDetectedPacketSent);
+        #[doc = "Publishes a `ReplayDetectedPacketReceived` event to the publisher's subscriber"]
+        fn on_replay_detected_packet_received(&self, event: builder::ReplayDetectedPacketReceived);
+        #[doc = "Publishes a `ReplayDetectedPacketAccepted` event to the publisher's subscriber"]
+        fn on_replay_detected_packet_accepted(&self, event: builder::ReplayDetectedPacketAccepted);
+        #[doc = "Publishes a `ReplayDetectedPacketRejected` event to the publisher's subscriber"]
+        fn on_replay_detected_packet_rejected(&self, event: builder::ReplayDetectedPacketRejected);
+        #[doc = "Publishes a `StaleKeyPacketSent` event to the publisher's subscriber"]
+        fn on_stale_key_packet_sent(&self, event: builder::StaleKeyPacketSent);
+        #[doc = "Publishes a `StaleKeyPacketReceived` event to the publisher's subscriber"]
+        fn on_stale_key_packet_received(&self, event: builder::StaleKeyPacketReceived);
+        #[doc = "Publishes a `StaleKeyPacketAccepted` event to the publisher's subscriber"]
+        fn on_stale_key_packet_accepted(&self, event: builder::StaleKeyPacketAccepted);
+        #[doc = "Publishes a `StaleKeyPacketRejected` event to the publisher's subscriber"]
+        fn on_stale_key_packet_rejected(&self, event: builder::StaleKeyPacketRejected);
         #[doc = r" Returns the QUIC version, if any"]
         fn quic_version(&self) -> Option<u32>;
     }
@@ -404,6 +1736,157 @@ mod traits {
         fn on_endpoint_initialized(&self, event: builder::EndpointInitialized) {
             let event = event.into_event();
             self.subscriber.on_endpoint_initialized(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_path_secret_map_initialized(&self, event: builder::PathSecretMapInitialized) {
+            let event = event.into_event();
+            self.subscriber
+                .on_path_secret_map_initialized(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_path_secret_map_uninitialized(&self, event: builder::PathSecretMapUninitialized) {
+            let event = event.into_event();
+            self.subscriber
+                .on_path_secret_map_uninitialized(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_path_secret_map_background_handshake_requested(
+            &self,
+            event: builder::PathSecretMapBackgroundHandshakeRequested,
+        ) {
+            let event = event.into_event();
+            self.subscriber
+                .on_path_secret_map_background_handshake_requested(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_path_secret_map_entry_inserted(&self, event: builder::PathSecretMapEntryInserted) {
+            let event = event.into_event();
+            self.subscriber
+                .on_path_secret_map_entry_inserted(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_path_secret_map_entry_ready(&self, event: builder::PathSecretMapEntryReady) {
+            let event = event.into_event();
+            self.subscriber
+                .on_path_secret_map_entry_ready(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_path_secret_map_entry_replaced(&self, event: builder::PathSecretMapEntryReplaced) {
+            let event = event.into_event();
+            self.subscriber
+                .on_path_secret_map_entry_replaced(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_unknown_path_secret_packet_sent(&self, event: builder::UnknownPathSecretPacketSent) {
+            let event = event.into_event();
+            self.subscriber
+                .on_unknown_path_secret_packet_sent(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_unknown_path_secret_packet_received(
+            &self,
+            event: builder::UnknownPathSecretPacketReceived,
+        ) {
+            let event = event.into_event();
+            self.subscriber
+                .on_unknown_path_secret_packet_received(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_unknown_path_secret_packet_accepted(
+            &self,
+            event: builder::UnknownPathSecretPacketAccepted,
+        ) {
+            let event = event.into_event();
+            self.subscriber
+                .on_unknown_path_secret_packet_accepted(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_unknown_path_secret_packet_rejected(
+            &self,
+            event: builder::UnknownPathSecretPacketRejected,
+        ) {
+            let event = event.into_event();
+            self.subscriber
+                .on_unknown_path_secret_packet_rejected(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_replay_definitely_detected(&self, event: builder::ReplayDefinitelyDetected) {
+            let event = event.into_event();
+            self.subscriber
+                .on_replay_definitely_detected(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_replay_potentially_detected(&self, event: builder::ReplayPotentiallyDetected) {
+            let event = event.into_event();
+            self.subscriber
+                .on_replay_potentially_detected(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_replay_detected_packet_sent(&self, event: builder::ReplayDetectedPacketSent) {
+            let event = event.into_event();
+            self.subscriber
+                .on_replay_detected_packet_sent(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_replay_detected_packet_received(&self, event: builder::ReplayDetectedPacketReceived) {
+            let event = event.into_event();
+            self.subscriber
+                .on_replay_detected_packet_received(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_replay_detected_packet_accepted(&self, event: builder::ReplayDetectedPacketAccepted) {
+            let event = event.into_event();
+            self.subscriber
+                .on_replay_detected_packet_accepted(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_replay_detected_packet_rejected(&self, event: builder::ReplayDetectedPacketRejected) {
+            let event = event.into_event();
+            self.subscriber
+                .on_replay_detected_packet_rejected(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_stale_key_packet_sent(&self, event: builder::StaleKeyPacketSent) {
+            let event = event.into_event();
+            self.subscriber.on_stale_key_packet_sent(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_stale_key_packet_received(&self, event: builder::StaleKeyPacketReceived) {
+            let event = event.into_event();
+            self.subscriber
+                .on_stale_key_packet_received(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_stale_key_packet_accepted(&self, event: builder::StaleKeyPacketAccepted) {
+            let event = event.into_event();
+            self.subscriber
+                .on_stale_key_packet_accepted(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_stale_key_packet_rejected(&self, event: builder::StaleKeyPacketRejected) {
+            let event = event.into_event();
+            self.subscriber
+                .on_stale_key_packet_rejected(&self.meta, &event);
             self.subscriber.on_event(&self.meta, &event);
         }
         #[inline]
@@ -568,6 +2051,26 @@ pub mod testing {
             location: Option<Location>,
             output: Mutex<Vec<String>>,
             pub endpoint_initialized: AtomicU32,
+            pub path_secret_map_initialized: AtomicU32,
+            pub path_secret_map_uninitialized: AtomicU32,
+            pub path_secret_map_background_handshake_requested: AtomicU32,
+            pub path_secret_map_entry_inserted: AtomicU32,
+            pub path_secret_map_entry_ready: AtomicU32,
+            pub path_secret_map_entry_replaced: AtomicU32,
+            pub unknown_path_secret_packet_sent: AtomicU32,
+            pub unknown_path_secret_packet_received: AtomicU32,
+            pub unknown_path_secret_packet_accepted: AtomicU32,
+            pub unknown_path_secret_packet_rejected: AtomicU32,
+            pub replay_definitely_detected: AtomicU32,
+            pub replay_potentially_detected: AtomicU32,
+            pub replay_detected_packet_sent: AtomicU32,
+            pub replay_detected_packet_received: AtomicU32,
+            pub replay_detected_packet_accepted: AtomicU32,
+            pub replay_detected_packet_rejected: AtomicU32,
+            pub stale_key_packet_sent: AtomicU32,
+            pub stale_key_packet_received: AtomicU32,
+            pub stale_key_packet_accepted: AtomicU32,
+            pub stale_key_packet_rejected: AtomicU32,
         }
         impl Drop for Subscriber {
             fn drop(&mut self) {
@@ -600,6 +2103,26 @@ pub mod testing {
                     location: None,
                     output: Default::default(),
                     endpoint_initialized: AtomicU32::new(0),
+                    path_secret_map_initialized: AtomicU32::new(0),
+                    path_secret_map_uninitialized: AtomicU32::new(0),
+                    path_secret_map_background_handshake_requested: AtomicU32::new(0),
+                    path_secret_map_entry_inserted: AtomicU32::new(0),
+                    path_secret_map_entry_ready: AtomicU32::new(0),
+                    path_secret_map_entry_replaced: AtomicU32::new(0),
+                    unknown_path_secret_packet_sent: AtomicU32::new(0),
+                    unknown_path_secret_packet_received: AtomicU32::new(0),
+                    unknown_path_secret_packet_accepted: AtomicU32::new(0),
+                    unknown_path_secret_packet_rejected: AtomicU32::new(0),
+                    replay_definitely_detected: AtomicU32::new(0),
+                    replay_potentially_detected: AtomicU32::new(0),
+                    replay_detected_packet_sent: AtomicU32::new(0),
+                    replay_detected_packet_received: AtomicU32::new(0),
+                    replay_detected_packet_accepted: AtomicU32::new(0),
+                    replay_detected_packet_rejected: AtomicU32::new(0),
+                    stale_key_packet_sent: AtomicU32::new(0),
+                    stale_key_packet_received: AtomicU32::new(0),
+                    stale_key_packet_accepted: AtomicU32::new(0),
+                    stale_key_packet_rejected: AtomicU32::new(0),
                 }
             }
         }
@@ -622,6 +2145,245 @@ pub mod testing {
                     .unwrap()
                     .push(format!("{meta:?} {event:?}"));
             }
+            fn on_path_secret_map_initialized(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::PathSecretMapInitialized,
+            ) {
+                self.path_secret_map_initialized
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_path_secret_map_uninitialized(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::PathSecretMapUninitialized,
+            ) {
+                self.path_secret_map_uninitialized
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_path_secret_map_background_handshake_requested(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::PathSecretMapBackgroundHandshakeRequested,
+            ) {
+                self.path_secret_map_background_handshake_requested
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_path_secret_map_entry_inserted(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::PathSecretMapEntryInserted,
+            ) {
+                self.path_secret_map_entry_inserted
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_path_secret_map_entry_ready(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::PathSecretMapEntryReady,
+            ) {
+                self.path_secret_map_entry_ready
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_path_secret_map_entry_replaced(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::PathSecretMapEntryReplaced,
+            ) {
+                self.path_secret_map_entry_replaced
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_unknown_path_secret_packet_sent(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::UnknownPathSecretPacketSent,
+            ) {
+                self.unknown_path_secret_packet_sent
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_unknown_path_secret_packet_received(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::UnknownPathSecretPacketReceived,
+            ) {
+                self.unknown_path_secret_packet_received
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_unknown_path_secret_packet_accepted(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::UnknownPathSecretPacketAccepted,
+            ) {
+                self.unknown_path_secret_packet_accepted
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_unknown_path_secret_packet_rejected(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::UnknownPathSecretPacketRejected,
+            ) {
+                self.unknown_path_secret_packet_rejected
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_replay_definitely_detected(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::ReplayDefinitelyDetected,
+            ) {
+                self.replay_definitely_detected
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_replay_potentially_detected(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::ReplayPotentiallyDetected,
+            ) {
+                self.replay_potentially_detected
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_replay_detected_packet_sent(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::ReplayDetectedPacketSent,
+            ) {
+                self.replay_detected_packet_sent
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_replay_detected_packet_received(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::ReplayDetectedPacketReceived,
+            ) {
+                self.replay_detected_packet_received
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_replay_detected_packet_accepted(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::ReplayDetectedPacketAccepted,
+            ) {
+                self.replay_detected_packet_accepted
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_replay_detected_packet_rejected(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::ReplayDetectedPacketRejected,
+            ) {
+                self.replay_detected_packet_rejected
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_stale_key_packet_sent(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::StaleKeyPacketSent,
+            ) {
+                self.stale_key_packet_sent.fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_stale_key_packet_received(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::StaleKeyPacketReceived,
+            ) {
+                self.stale_key_packet_received
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_stale_key_packet_accepted(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::StaleKeyPacketAccepted,
+            ) {
+                self.stale_key_packet_accepted
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
+            fn on_stale_key_packet_rejected(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::StaleKeyPacketRejected,
+            ) {
+                self.stale_key_packet_rejected
+                    .fetch_add(1, Ordering::Relaxed);
+                self.output
+                    .lock()
+                    .unwrap()
+                    .push(format!("{meta:?} {event:?}"));
+            }
         }
     }
     #[derive(Debug)]
@@ -631,6 +2393,26 @@ pub mod testing {
         pub application_write: AtomicU32,
         pub application_read: AtomicU32,
         pub endpoint_initialized: AtomicU32,
+        pub path_secret_map_initialized: AtomicU32,
+        pub path_secret_map_uninitialized: AtomicU32,
+        pub path_secret_map_background_handshake_requested: AtomicU32,
+        pub path_secret_map_entry_inserted: AtomicU32,
+        pub path_secret_map_entry_ready: AtomicU32,
+        pub path_secret_map_entry_replaced: AtomicU32,
+        pub unknown_path_secret_packet_sent: AtomicU32,
+        pub unknown_path_secret_packet_received: AtomicU32,
+        pub unknown_path_secret_packet_accepted: AtomicU32,
+        pub unknown_path_secret_packet_rejected: AtomicU32,
+        pub replay_definitely_detected: AtomicU32,
+        pub replay_potentially_detected: AtomicU32,
+        pub replay_detected_packet_sent: AtomicU32,
+        pub replay_detected_packet_received: AtomicU32,
+        pub replay_detected_packet_accepted: AtomicU32,
+        pub replay_detected_packet_rejected: AtomicU32,
+        pub stale_key_packet_sent: AtomicU32,
+        pub stale_key_packet_received: AtomicU32,
+        pub stale_key_packet_accepted: AtomicU32,
+        pub stale_key_packet_rejected: AtomicU32,
     }
     impl Drop for Subscriber {
         fn drop(&mut self) {
@@ -665,6 +2447,26 @@ pub mod testing {
                 application_write: AtomicU32::new(0),
                 application_read: AtomicU32::new(0),
                 endpoint_initialized: AtomicU32::new(0),
+                path_secret_map_initialized: AtomicU32::new(0),
+                path_secret_map_uninitialized: AtomicU32::new(0),
+                path_secret_map_background_handshake_requested: AtomicU32::new(0),
+                path_secret_map_entry_inserted: AtomicU32::new(0),
+                path_secret_map_entry_ready: AtomicU32::new(0),
+                path_secret_map_entry_replaced: AtomicU32::new(0),
+                unknown_path_secret_packet_sent: AtomicU32::new(0),
+                unknown_path_secret_packet_received: AtomicU32::new(0),
+                unknown_path_secret_packet_accepted: AtomicU32::new(0),
+                unknown_path_secret_packet_rejected: AtomicU32::new(0),
+                replay_definitely_detected: AtomicU32::new(0),
+                replay_potentially_detected: AtomicU32::new(0),
+                replay_detected_packet_sent: AtomicU32::new(0),
+                replay_detected_packet_received: AtomicU32::new(0),
+                replay_detected_packet_accepted: AtomicU32::new(0),
+                replay_detected_packet_rejected: AtomicU32::new(0),
+                stale_key_packet_sent: AtomicU32::new(0),
+                stale_key_packet_received: AtomicU32::new(0),
+                stale_key_packet_accepted: AtomicU32::new(0),
+                stale_key_packet_rejected: AtomicU32::new(0),
             }
         }
     }
@@ -715,6 +2517,245 @@ pub mod testing {
                 .unwrap()
                 .push(format!("{meta:?} {event:?}"));
         }
+        fn on_path_secret_map_initialized(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapInitialized,
+        ) {
+            self.path_secret_map_initialized
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_path_secret_map_uninitialized(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapUninitialized,
+        ) {
+            self.path_secret_map_uninitialized
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_path_secret_map_background_handshake_requested(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapBackgroundHandshakeRequested,
+        ) {
+            self.path_secret_map_background_handshake_requested
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_path_secret_map_entry_inserted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapEntryInserted,
+        ) {
+            self.path_secret_map_entry_inserted
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_path_secret_map_entry_ready(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapEntryReady,
+        ) {
+            self.path_secret_map_entry_ready
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_path_secret_map_entry_replaced(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapEntryReplaced,
+        ) {
+            self.path_secret_map_entry_replaced
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_unknown_path_secret_packet_sent(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketSent,
+        ) {
+            self.unknown_path_secret_packet_sent
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_unknown_path_secret_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketReceived,
+        ) {
+            self.unknown_path_secret_packet_received
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_unknown_path_secret_packet_accepted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketAccepted,
+        ) {
+            self.unknown_path_secret_packet_accepted
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_unknown_path_secret_packet_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::UnknownPathSecretPacketRejected,
+        ) {
+            self.unknown_path_secret_packet_rejected
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_replay_definitely_detected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDefinitelyDetected,
+        ) {
+            self.replay_definitely_detected
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_replay_potentially_detected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayPotentiallyDetected,
+        ) {
+            self.replay_potentially_detected
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_replay_detected_packet_sent(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketSent,
+        ) {
+            self.replay_detected_packet_sent
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_replay_detected_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketReceived,
+        ) {
+            self.replay_detected_packet_received
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_replay_detected_packet_accepted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketAccepted,
+        ) {
+            self.replay_detected_packet_accepted
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_replay_detected_packet_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::ReplayDetectedPacketRejected,
+        ) {
+            self.replay_detected_packet_rejected
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_stale_key_packet_sent(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketSent,
+        ) {
+            self.stale_key_packet_sent.fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_stale_key_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketReceived,
+        ) {
+            self.stale_key_packet_received
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_stale_key_packet_accepted(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketAccepted,
+        ) {
+            self.stale_key_packet_accepted
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
+        fn on_stale_key_packet_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::StaleKeyPacketRejected,
+        ) {
+            self.stale_key_packet_rejected
+                .fetch_add(1, Ordering::Relaxed);
+            self.output
+                .lock()
+                .unwrap()
+                .push(format!("{meta:?} {event:?}"));
+        }
     }
     #[derive(Debug)]
     pub struct Publisher {
@@ -723,6 +2764,26 @@ pub mod testing {
         pub application_write: AtomicU32,
         pub application_read: AtomicU32,
         pub endpoint_initialized: AtomicU32,
+        pub path_secret_map_initialized: AtomicU32,
+        pub path_secret_map_uninitialized: AtomicU32,
+        pub path_secret_map_background_handshake_requested: AtomicU32,
+        pub path_secret_map_entry_inserted: AtomicU32,
+        pub path_secret_map_entry_ready: AtomicU32,
+        pub path_secret_map_entry_replaced: AtomicU32,
+        pub unknown_path_secret_packet_sent: AtomicU32,
+        pub unknown_path_secret_packet_received: AtomicU32,
+        pub unknown_path_secret_packet_accepted: AtomicU32,
+        pub unknown_path_secret_packet_rejected: AtomicU32,
+        pub replay_definitely_detected: AtomicU32,
+        pub replay_potentially_detected: AtomicU32,
+        pub replay_detected_packet_sent: AtomicU32,
+        pub replay_detected_packet_received: AtomicU32,
+        pub replay_detected_packet_accepted: AtomicU32,
+        pub replay_detected_packet_rejected: AtomicU32,
+        pub stale_key_packet_sent: AtomicU32,
+        pub stale_key_packet_received: AtomicU32,
+        pub stale_key_packet_accepted: AtomicU32,
+        pub stale_key_packet_rejected: AtomicU32,
     }
     impl Publisher {
         #[doc = r" Creates a publisher with snapshot assertions enabled"]
@@ -747,12 +2808,163 @@ pub mod testing {
                 application_write: AtomicU32::new(0),
                 application_read: AtomicU32::new(0),
                 endpoint_initialized: AtomicU32::new(0),
+                path_secret_map_initialized: AtomicU32::new(0),
+                path_secret_map_uninitialized: AtomicU32::new(0),
+                path_secret_map_background_handshake_requested: AtomicU32::new(0),
+                path_secret_map_entry_inserted: AtomicU32::new(0),
+                path_secret_map_entry_ready: AtomicU32::new(0),
+                path_secret_map_entry_replaced: AtomicU32::new(0),
+                unknown_path_secret_packet_sent: AtomicU32::new(0),
+                unknown_path_secret_packet_received: AtomicU32::new(0),
+                unknown_path_secret_packet_accepted: AtomicU32::new(0),
+                unknown_path_secret_packet_rejected: AtomicU32::new(0),
+                replay_definitely_detected: AtomicU32::new(0),
+                replay_potentially_detected: AtomicU32::new(0),
+                replay_detected_packet_sent: AtomicU32::new(0),
+                replay_detected_packet_received: AtomicU32::new(0),
+                replay_detected_packet_accepted: AtomicU32::new(0),
+                replay_detected_packet_rejected: AtomicU32::new(0),
+                stale_key_packet_sent: AtomicU32::new(0),
+                stale_key_packet_received: AtomicU32::new(0),
+                stale_key_packet_accepted: AtomicU32::new(0),
+                stale_key_packet_rejected: AtomicU32::new(0),
             }
         }
     }
     impl super::EndpointPublisher for Publisher {
         fn on_endpoint_initialized(&self, event: builder::EndpointInitialized) {
             self.endpoint_initialized.fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_path_secret_map_initialized(&self, event: builder::PathSecretMapInitialized) {
+            self.path_secret_map_initialized
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_path_secret_map_uninitialized(&self, event: builder::PathSecretMapUninitialized) {
+            self.path_secret_map_uninitialized
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_path_secret_map_background_handshake_requested(
+            &self,
+            event: builder::PathSecretMapBackgroundHandshakeRequested,
+        ) {
+            self.path_secret_map_background_handshake_requested
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_path_secret_map_entry_inserted(&self, event: builder::PathSecretMapEntryInserted) {
+            self.path_secret_map_entry_inserted
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_path_secret_map_entry_ready(&self, event: builder::PathSecretMapEntryReady) {
+            self.path_secret_map_entry_ready
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_path_secret_map_entry_replaced(&self, event: builder::PathSecretMapEntryReplaced) {
+            self.path_secret_map_entry_replaced
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_unknown_path_secret_packet_sent(&self, event: builder::UnknownPathSecretPacketSent) {
+            self.unknown_path_secret_packet_sent
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_unknown_path_secret_packet_received(
+            &self,
+            event: builder::UnknownPathSecretPacketReceived,
+        ) {
+            self.unknown_path_secret_packet_received
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_unknown_path_secret_packet_accepted(
+            &self,
+            event: builder::UnknownPathSecretPacketAccepted,
+        ) {
+            self.unknown_path_secret_packet_accepted
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_unknown_path_secret_packet_rejected(
+            &self,
+            event: builder::UnknownPathSecretPacketRejected,
+        ) {
+            self.unknown_path_secret_packet_rejected
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_replay_definitely_detected(&self, event: builder::ReplayDefinitelyDetected) {
+            self.replay_definitely_detected
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_replay_potentially_detected(&self, event: builder::ReplayPotentiallyDetected) {
+            self.replay_potentially_detected
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_replay_detected_packet_sent(&self, event: builder::ReplayDetectedPacketSent) {
+            self.replay_detected_packet_sent
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_replay_detected_packet_received(&self, event: builder::ReplayDetectedPacketReceived) {
+            self.replay_detected_packet_received
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_replay_detected_packet_accepted(&self, event: builder::ReplayDetectedPacketAccepted) {
+            self.replay_detected_packet_accepted
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_replay_detected_packet_rejected(&self, event: builder::ReplayDetectedPacketRejected) {
+            self.replay_detected_packet_rejected
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_stale_key_packet_sent(&self, event: builder::StaleKeyPacketSent) {
+            self.stale_key_packet_sent.fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_stale_key_packet_received(&self, event: builder::StaleKeyPacketReceived) {
+            self.stale_key_packet_received
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_stale_key_packet_accepted(&self, event: builder::StaleKeyPacketAccepted) {
+            self.stale_key_packet_accepted
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            self.output.lock().unwrap().push(format!("{event:?}"));
+        }
+        fn on_stale_key_packet_rejected(&self, event: builder::StaleKeyPacketRejected) {
+            self.stale_key_packet_rejected
+                .fetch_add(1, Ordering::Relaxed);
             let event = event.into_event();
             self.output.lock().unwrap().push(format!("{event:?}"));
         }

--- a/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::state::State;
+use crate::event;
 use rand::Rng as _;
 use std::{
     sync::{
@@ -50,7 +51,7 @@ impl Cleaner {
         }
     }
 
-    pub fn spawn_thread(&self, state: Arc<State>) {
+    pub fn spawn_thread<S: event::Subscriber>(&self, state: Arc<State<S>>) {
         let state = Arc::downgrade(&state);
         let handle = std::thread::spawn(move || loop {
             let Some(state) = state.upgrade() else {
@@ -68,7 +69,7 @@ impl Cleaner {
     }
 
     /// Periodic maintenance for various maps.
-    pub fn clean(&self, state: &State, eviction_cycles: u64) {
+    pub fn clean<S: event::Subscriber>(&self, state: &State<S>, eviction_cycles: u64) {
         let current_epoch = self.epoch.fetch_add(1, Ordering::Relaxed);
         let now = Instant::now();
 

--- a/dc/s2n-quic-dc/src/path/secret/map/handshake.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/handshake.rs
@@ -57,7 +57,7 @@ impl dc::Endpoint for Map {
         &mut self,
         // TODO: Maybe we should confirm that the sender IP at least matches the IP for the
         //       corresponding control secret?
-        _datagram_info: &DatagramInfo,
+        datagram_info: &DatagramInfo,
         payload: &mut [u8],
     ) -> bool {
         let payload = s2n_codec::DecoderBufferMut::new(payload);
@@ -68,7 +68,7 @@ impl dc::Endpoint for Map {
                 ensure!(tail.is_empty(), false);
 
                 // If we successfully decoded a control packet, pass it into our map to handle.
-                self.handle_control_packet(&packet);
+                self.handle_control_packet(&packet, &datagram_info.remote_address.clone().into());
 
                 true
             }

--- a/dc/s2n-quic-dc/src/path/secret/map/state/snapshots/path__secret__map__state__tests__thread_shutdown__events.snap
+++ b/dc/s2n-quic-dc/src/path/secret/map/state/snapshots/path__secret__map__state__tests__thread_shutdown__events.snap
@@ -1,0 +1,6 @@
+---
+source: quic/s2n-quic-core/src/event/snapshot.rs
+input_file: dc/s2n-quic-dc/src/path/secret/map/state/tests.rs
+---
+EndpointMeta PathSecretMapInitialized { capacity: 10 }
+EndpointMeta PathSecretMapUninitialized { capacity: 10, entries: 0 }

--- a/dc/s2n-quic-dc/src/stream/recv/shared.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/shared.rs
@@ -492,7 +492,10 @@ impl Inner {
                 }
                 other => {
                     let kind = other.kind();
-                    shared.crypto.map().handle_unexpected_packet(other);
+                    shared
+                        .crypto
+                        .map()
+                        .handle_unexpected_packet(other, &shared.read_remote_addr().into());
 
                     // if we get a packet we don't expect then it's fatal for streams
                     msg.clear();
@@ -586,7 +589,10 @@ impl Inner {
                         });
                     }
                     other => {
-                        shared.crypto.map().handle_unexpected_packet(&other);
+                        shared
+                            .crypto
+                            .map()
+                            .handle_unexpected_packet(&other, &shared.read_remote_addr().into());
 
                         // TODO if the packet was authentic then close the receiver with an error
                     }

--- a/dc/s2n-quic-dc/src/stream/send/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/send/worker.rs
@@ -335,7 +335,11 @@ where
                             any_valid_packets = true;
                         }
                     }
-                    other => self.shared.crypto.map().handle_unexpected_packet(&other),
+                    other => self
+                        .shared
+                        .crypto
+                        .map()
+                        .handle_unexpected_packet(&other, &self.shared.write_remote_addr().into()),
                 }
             }
         }

--- a/quic/s2n-quic-events/src/parser.rs
+++ b/quic/s2n-quic-events/src/parser.rs
@@ -190,14 +190,7 @@ impl Struct {
                         #[inline]
                         #allow_deprecated
                         fn #function(&#receiver self, meta: &api::EndpointMeta, event: &api::#ident) {
-                            let parent = match meta.endpoint_type {
-                                api::EndpointType::Client { .. } => {
-                                    self.client.id()
-                                }
-                                api::EndpointType::Server { .. } => {
-                                    self.server.id()
-                                }
-                            };
+                            let parent = self.parent(meta);
                             let api::#ident { #(#destructure_fields),* } = event;
                             tracing::event!(target: #snake, parent: parent, tracing::Level::DEBUG, #(#destructure_fields = tracing::field::debug(#destructure_fields)),*);
                         }


### PR DESCRIPTION
### Description of changes: 

This change adds a bunch of new events to the dc map implementation. These events should provide the following:

* Knowing when a map was initialized/destroyed
* Knowing when an entry was requested to perform another handshake
* Providing insights into secret control packet metrics
* Knowing when replay protection is being applied and what the current gap is

### Call-outs:

There's a few more things I still need to include in a follow-up:

* Ages of secrets - this can be emitted by the cleaner
* Cache hit ratios for `contains` calls

### Testing:

I've currently only manually tested that the events are being emitted. As a follow-up PR (since this one is already quite large), I will add several event snapshot tests to show it all working and prevent regressions in events.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

