### PR TITLE
chore: update cargo audit

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,0 +1,7 @@
+[advisories]
+ignore = [
+  # `atty` is a dependency of structopt and only used in s2n-quic-qns and s2n-quic-sim
+  "RUSTSEC-2021-0145",
+  # `atty` is a dependency of structopt and only used in s2n-quic-qns and s2n-quic-sim
+  "RUSTSEC-2024-0375"
+]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,7 +1,11 @@
 [advisories]
 ignore = [
-  # `atty` is a dependency of structopt and only used in s2n-quic-qns and s2n-quic-sim
+  # `atty` is a dependency of `structopt` and only used in s2n-quic-qns and s2n-quic-sim
   "RUSTSEC-2021-0145",
-  # `atty` is a dependency of structopt and only used in s2n-quic-qns and s2n-quic-sim
-  "RUSTSEC-2024-0375"
+  # `atty` is a dependency of `structopt` and only used in s2n-quic-qns and s2n-quic-sim
+  "RUSTSEC-2024-0375",
+  # ` proc-macro-error` is a dependency of `structopt` and only used in s2n-quic-qns and s2n-quic-sim
+  "RUSTSEC-2024-0370",
+  # `ansi_term` is a dependency of `structopt` and only used in s2n-quic-qns and s2n-quic-sim
+  "RUSTSEC-2021-0139"
 ]

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,11 +1,15 @@
 [advisories]
 ignore = [
   # `atty` is a dependency of `structopt` and only used in s2n-quic-qns and s2n-quic-sim
+  # https://github.com/aws/s2n-quic/issues/2324
   "RUSTSEC-2021-0145",
   # `atty` is a dependency of `structopt` and only used in s2n-quic-qns and s2n-quic-sim
+  # https://github.com/aws/s2n-quic/issues/2324
   "RUSTSEC-2024-0375",
   # ` proc-macro-error` is a dependency of `structopt` and only used in s2n-quic-qns and s2n-quic-sim
+  # https://github.com/aws/s2n-quic/issues/2324
   "RUSTSEC-2024-0370",
   # `ansi_term` is a dependency of `structopt` and only used in s2n-quic-qns and s2n-quic-sim
+  # https://github.com/aws/s2n-quic/issues/2324
   "RUSTSEC-2021-0139"
 ]

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -28,7 +28,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: rustsec/audit-check@v1.4.1
+        with:
+          submodules: true
+
+      - name: Install rust toolchain
+        id: toolchain
+        run: |
+          rustup toolchain install stable --profile minimal
+          rustup override set stable
+
+      - uses: camshaft/rust-cache@v1
+
+      - name: Run cargo build
+        run: cargo build
+
+      - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### Resolved issues:
Will also resolve https://github.com/aws/s2n-quic/pull/2330

### Description of changes: 
This updates the cargo audit version in our CI.

### Call-outs:
I added a few advisories to our allow list since they are dependencies of structopt and only used in s2n-quic-qns and s2n-quic-sim. These can be removed as part of completing https://github.com/aws/s2n-quic/issues/2324


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

