### PR TITLE
chore: grant more permissions to the qns release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,9 @@ on:
 name: release
 
 permissions:
-  id-token: write # This is required for requesting the JWT
+  id-token: write # This is required for requesting the JWT (used for docker push to AWS ECR)
   contents: read  # This is required for actions/checkout
+  packages: write # This is required for docker push to ghcr
 
 jobs:
   qns:


### PR DESCRIPTION
### Resolved issues:

none

### Description of changes: 

In https://github.com/aws/s2n-quic/pull/2352, we switched to short term credentials for actions use with AWS. This added a [permissions stanza to the workflow](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#how-the-permissions-are-calculated-for-a-workflow-job), but missed a permission needed to publish docker to GitHub container registry.

### Call-outs:

Authentication is succeeding, but permissions are insufficient to publish, e.g. https://github.com/aws/s2n-quic/actions/runs/11724796171/job/32659577102

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

