### PR TITLE
core: update github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,13 @@
+### Release Summary:
+<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->
+
 ### Resolved issues:
 
 resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.
 
 ### Description of changes: 
 
-<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary.-->
+<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary. If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff. -->
 
 ### Call-outs:
 
@@ -13,8 +16,9 @@ resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.
 ### Testing:
 
 <!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
-
+How can you convince your reviewers that this PR is safe and effective?
 Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->
+
 
 By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ### Release Summary:
-<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is future customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->
+<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->
 
 ### Resolved issues:
 


### PR DESCRIPTION
### Description of changes: 

s2n-quic version of https://github.com/aws/s2n-tls/pull/4885

### Call-outs:

I wasn't sure what testing I could list under "Testing" the way I listed testing requirements for s2n-tls. The unit tests requirement hold true, but I'm not sure about the others. Suggestions? That could also just be a separate PR from someone more familiar with s2n-quic tests.

### Testing:
documentation change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

