### PR TITLE
feat(s2n-quic-dc): add acceptor events

### DIFF
--- a/dc/s2n-quic-dc/events/acceptor.rs
+++ b/dc/s2n-quic-dc/events/acceptor.rs
@@ -1,0 +1,343 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+/// Emitted when a TCP acceptor is started
+#[event("acceptor:tcp:started")]
+#[subject(endpoint)]
+struct AcceptorTcpStarted<'a> {
+    /// The id of the acceptor worker
+    id: usize,
+
+    /// The local address of the acceptor
+    #[builder(&'a s2n_quic_core::inet::SocketAddress)]
+    local_address: SocketAddress<'a>,
+
+    /// The backlog size
+    backlog: usize,
+}
+
+/// Emitted when a TCP acceptor completes a single iteration of the event loop
+#[event("acceptor:tcp:started")]
+#[subject(endpoint)]
+struct AcceptorTcpLoopIterationCompleted {
+    /// The number of streams that are waiting on initial packets
+    #[measure("pending_streams")]
+    pending_streams: usize,
+
+    /// The amount of time it took to complete the iteration
+    #[timer("processing_duration")]
+    processing_duration: core::time::Duration,
+
+    /// The computed max sojourn time that is allowed for streams
+    ///
+    /// If streams consume more time than this value to initialize, they
+    /// may potentially be replaced by more recent streams.
+    #[measure("max_sojourn_time", Duration)]
+    max_sojourn_time: core::time::Duration,
+}
+
+/// Emitted when a fresh TCP stream is enqueued for processing
+#[event("acceptor:tcp:fresh:enqueued")]
+#[subject(endpoint)]
+struct AcceptorTcpFreshEnqueued<'a> {
+    /// The remote address of the TCP stream
+    #[builder(&'a s2n_quic_core::inet::SocketAddress)]
+    remote_address: SocketAddress<'a>,
+}
+
+/// Emitted when a the TCP acceptor has completed a batch of stream enqueues
+#[event("acceptor:tcp:fresh:batch_completed")]
+#[subject(endpoint)]
+struct AcceptorTcpFreshBatchCompleted {
+    /// The number of fresh TCP streams enqueued in this batch
+    #[measure("enqueued")]
+    enqueued: usize,
+
+    /// The number of fresh TCP streams dropped in this batch due to capacity limits
+    #[measure("dropped")]
+    dropped: usize,
+
+    /// The number of TCP streams that errored in this batch
+    #[measure("errored")]
+    errored: usize,
+}
+
+/// Emitted when a TCP stream has been dropped
+#[event("acceptor:tcp:stream_dropped")]
+#[subject(endpoint)]
+struct AcceptorTcpStreamDropped<'a> {
+    /// The remote address of the TCP stream
+    #[builder(&'a s2n_quic_core::inet::SocketAddress)]
+    remote_address: SocketAddress<'a>,
+
+    #[nominal_counter("reason")]
+    reason: AcceptorTcpStreamDropReason,
+}
+
+enum AcceptorTcpStreamDropReason {
+    /// There were more streams in the TCP backlog than the userspace queue can store
+    FreshQueueAtCapacity,
+
+    /// There are no available slots for processing
+    SlotsAtCapacity,
+}
+
+/// Emitted when a TCP stream has been replaced by another stream
+#[event("acceptor:tcp:stream_replaced")]
+#[subject(endpoint)]
+struct AcceptorTcpStreamReplaced<'a> {
+    /// The remote address of the stream being replaced
+    #[builder(&'a s2n_quic_core::inet::SocketAddress)]
+    remote_address: SocketAddress<'a>,
+
+    /// The amount of time that the stream spent in the accept queue before
+    /// being replaced with another
+    #[timer("sojourn_time")]
+    sojourn_time: core::time::Duration,
+
+    /// The amount of bytes buffered on the stream
+    #[measure("buffer_len", Bytes)]
+    buffer_len: usize,
+}
+
+/// Emitted when a full packet has been received on the TCP stream
+#[event("acceptor:tcp:packet_received")]
+#[subject(endpoint)]
+struct AcceptorTcpPacketReceived<'a> {
+    /// The address of the packet's sender
+    #[builder(&'a s2n_quic_core::inet::SocketAddress)]
+    remote_address: SocketAddress<'a>,
+
+    /// The credential ID of the packet
+    #[snapshot("[HIDDEN]")]
+    credential_id: &'a [u8],
+
+    /// The stream ID of the packet
+    stream_id: u64,
+
+    /// The payload length of the packet
+    #[measure("payload_len", Bytes)]
+    payload_len: usize,
+
+    /// If the packet includes the final bytes of the stream
+    #[bool_counter("is_fin")]
+    is_fin: bool,
+
+    /// The amount of time the TCP stream spent in the queue before receiving
+    /// the initial packet
+    #[timer("sojourn_time")]
+    sojourn_time: core::time::Duration,
+}
+
+/// Emitted when the TCP acceptor received an invalid initial packet
+#[event("acceptor:tcp:packet_dropped")]
+#[subject(endpoint)]
+struct AcceptorTcpPacketDropped<'a> {
+    /// The address of the packet's sender
+    #[builder(&'a s2n_quic_core::inet::SocketAddress)]
+    remote_address: SocketAddress<'a>,
+
+    /// The reason the packet was dropped
+    reason: AcceptorPacketDropReason,
+
+    /// The amount of time the TCP stream spent in the queue before receiving
+    /// an error
+    #[timer("sojourn_time")]
+    sojourn_time: core::time::Duration,
+}
+
+/// Emitted when the TCP stream has been enqueued for the application
+#[event("acceptor:tcp:stream_enqueued")]
+#[subject(endpoint)]
+struct AcceptorTcpStreamEnqueued<'a> {
+    /// The address of the stream's peer
+    #[builder(&'a s2n_quic_core::inet::SocketAddress)]
+    remote_address: SocketAddress<'a>,
+
+    /// The credential ID of the stream
+    #[snapshot("[HIDDEN]")]
+    credential_id: &'a [u8],
+
+    /// The ID of the stream
+    stream_id: u64,
+
+    /// The amount of time the TCP stream spent in the queue before being enqueued
+    #[timer("sojourn_time")]
+    sojourn_time: core::time::Duration,
+
+    /// The number of times the stream was blocked on receiving more data
+    #[measure("blocked_count")]
+    blocked_count: usize,
+}
+
+/// Emitted when the TCP acceptor encounters an IO error
+#[event("acceptor:tcp:io_error")]
+#[subject(endpoint)]
+struct AcceptorTcpIoError<'a> {
+    /// The error encountered
+    #[builder(&'a std::io::Error)]
+    error: &'a std::io::Error,
+}
+
+/// Emitted when a UDP acceptor is started
+#[event("acceptor:udp:started")]
+#[subject(endpoint)]
+struct AcceptorUdpStarted<'a> {
+    /// The id of the acceptor worker
+    id: usize,
+
+    /// The local address of the acceptor
+    local_address: SocketAddress<'a>,
+}
+
+/// Emitted when a UDP datagram is received by the acceptor
+#[event("acceptor:udp:datagram_received")]
+#[subject(endpoint)]
+struct AcceptorUdpDatagramReceived<'a> {
+    /// The address of the datagram's sender
+    #[builder(&'a s2n_quic_core::inet::SocketAddress)]
+    remote_address: SocketAddress<'a>,
+
+    /// The len of the datagram
+    #[measure("len", Bytes)]
+    len: usize,
+}
+
+/// Emitted when the UDP acceptor parsed a packet contained in a datagram
+#[event("acceptor:udp:packet_received")]
+#[subject(endpoint)]
+struct AcceptorUdpPacketReceived<'a> {
+    /// The address of the packet's sender
+    #[builder(&'a s2n_quic_core::inet::SocketAddress)]
+    remote_address: SocketAddress<'a>,
+
+    /// The credential ID of the packet
+    #[snapshot("[HIDDEN]")]
+    credential_id: &'a [u8],
+
+    /// The stream ID of the packet
+    stream_id: u64,
+
+    /// The payload length of the packet
+    #[measure("payload_len", Bytes)]
+    payload_len: usize,
+
+    /// If the packets is a zero offset in the stream
+    #[bool_counter("is_zero_offset")]
+    is_zero_offset: bool,
+
+    /// If the packet is a retransmission
+    #[bool_counter("is_retransmisson")]
+    is_retransmission: bool,
+
+    /// If the packet includes the final bytes of the stream
+    #[bool_counter("is_fin")]
+    is_fin: bool,
+}
+
+/// Emitted when the UDP acceptor received an invalid initial packet
+#[event("acceptor:udp:packet_dropped")]
+#[subject(endpoint)]
+struct AcceptorUdpPacketDropped<'a> {
+    /// The address of the packet's sender
+    #[builder(&'a s2n_quic_core::inet::SocketAddress)]
+    remote_address: SocketAddress<'a>,
+
+    /// The reason the packet was dropped
+    reason: AcceptorPacketDropReason,
+}
+
+/// Emitted when the UDP stream has been enqueued for the application
+#[event("acceptor:udp:stream_enqueued")]
+#[subject(endpoint)]
+struct AcceptorUdpStreamEnqueued<'a> {
+    /// The address of the stream's peer
+    #[builder(&'a s2n_quic_core::inet::SocketAddress)]
+    remote_address: SocketAddress<'a>,
+
+    /// The credential ID of the stream
+    #[snapshot("[HIDDEN]")]
+    credential_id: &'a [u8],
+
+    /// The ID of the stream
+    stream_id: u64,
+}
+
+/// Emitted when the UDP acceptor encounters an IO error
+#[event("acceptor:udp:io_error")]
+#[subject(endpoint)]
+struct AcceptorUdpIoError<'a> {
+    /// The error encountered
+    #[builder(&'a std::io::Error)]
+    error: &'a std::io::Error,
+}
+
+/// Emitted when a stream has been pruned
+#[event("acceptor:stream_pruned")]
+#[subject(endpoint)]
+struct AcceptorStreamPruned<'a> {
+    /// The remote address of the stream
+    #[builder(&'a s2n_quic_core::inet::SocketAddress)]
+    remote_address: SocketAddress<'a>,
+
+    /// The credential ID of the stream
+    #[snapshot("[HIDDEN]")]
+    credential_id: &'a [u8],
+
+    /// The ID of the stream
+    stream_id: u64,
+
+    /// The amount of time that the stream spent in the accept queue before
+    /// being pruned
+    #[timer("sojourn_time")]
+    sojourn_time: core::time::Duration,
+
+    #[nominal_counter("reason")]
+    reason: AcceptorStreamPruneReason,
+}
+
+enum AcceptorStreamPruneReason {
+    MaxSojournTimeExceeded,
+    AcceptQueueCapacityExceeded,
+}
+
+/// Emitted when a stream has been dequeued by the application
+#[event("acceptor:stream_dequeued")]
+#[subject(endpoint)]
+struct AcceptorStreamDequeued<'a> {
+    /// The remote address of the stream
+    #[builder(&'a s2n_quic_core::inet::SocketAddress)]
+    remote_address: SocketAddress<'a>,
+
+    /// The credential ID of the stream
+    #[snapshot("[HIDDEN]")]
+    credential_id: &'a [u8],
+
+    /// The ID of the stream
+    stream_id: u64,
+
+    /// The amount of time that the stream spent in the accept queue before
+    /// being dequeued
+    #[timer("sojourn_time")]
+    sojourn_time: core::time::Duration,
+}
+
+enum AcceptorPacketDropReason {
+    UnexpectedEof,
+    UnexpectedBytes,
+    LengthCapacityExceeded,
+    InvariantViolation { message: &'static str },
+}
+
+impl IntoEvent<builder::AcceptorPacketDropReason> for s2n_codec::DecoderError {
+    fn into_event(self) -> builder::AcceptorPacketDropReason {
+        use builder::AcceptorPacketDropReason as Reason;
+        use s2n_codec::DecoderError;
+        match self {
+            DecoderError::UnexpectedEof(_) => Reason::UnexpectedEof {},
+            DecoderError::UnexpectedBytes(_) => Reason::UnexpectedBytes {},
+            DecoderError::LengthCapacityExceeded => Reason::LengthCapacityExceeded {},
+            DecoderError::InvariantViolation(message) => Reason::InvariantViolation { message },
+        }
+    }
+}

--- a/dc/s2n-quic-dc/events/acceptor.rs
+++ b/dc/s2n-quic-dc/events/acceptor.rs
@@ -17,12 +17,20 @@ struct AcceptorTcpStarted<'a> {
 }
 
 /// Emitted when a TCP acceptor completes a single iteration of the event loop
-#[event("acceptor:tcp:started")]
+#[event("acceptor:tcp:loop_iteration_completed")]
 #[subject(endpoint)]
 struct AcceptorTcpLoopIterationCompleted {
     /// The number of streams that are waiting on initial packets
     #[measure("pending_streams")]
     pending_streams: usize,
+
+    /// The number of slots that are not currently processing a stream
+    #[measure("slots_idle")]
+    slots_idle: usize,
+
+    /// The percentage of slots currently processing streams
+    #[measure("slot_utilization", Percent)]
+    slot_utilization: f32,
 
     /// The amount of time it took to complete the iteration
     #[timer("processing_duration")]
@@ -123,6 +131,10 @@ struct AcceptorTcpPacketReceived<'a> {
     #[bool_counter("is_fin")]
     is_fin: bool,
 
+    /// If the packet includes the final offset of the stream
+    #[bool_counter("is_fin_known")]
+    is_fin_known: bool,
+
     /// The amount of time the TCP stream spent in the queue before receiving
     /// the initial packet
     #[timer("sojourn_time")]
@@ -138,6 +150,7 @@ struct AcceptorTcpPacketDropped<'a> {
     remote_address: SocketAddress<'a>,
 
     /// The reason the packet was dropped
+    #[nominal_counter("reason")]
     reason: AcceptorPacketDropReason,
 
     /// The amount of time the TCP stream spent in the queue before receiving
@@ -233,6 +246,10 @@ struct AcceptorUdpPacketReceived<'a> {
     /// If the packet includes the final bytes of the stream
     #[bool_counter("is_fin")]
     is_fin: bool,
+
+    /// If the packet includes the final offset of the stream
+    #[bool_counter("is_fin_known")]
+    is_fin_known: bool,
 }
 
 /// Emitted when the UDP acceptor received an invalid initial packet
@@ -244,6 +261,7 @@ struct AcceptorUdpPacketDropped<'a> {
     remote_address: SocketAddress<'a>,
 
     /// The reason the packet was dropped
+    #[nominal_counter("reason")]
     reason: AcceptorPacketDropReason,
 }
 

--- a/dc/s2n-quic-dc/events/map.rs
+++ b/dc/s2n-quic-dc/events/map.rs
@@ -32,7 +32,7 @@ struct PathSecretMapBackgroundHandshakeRequested<'a> {
     peer_address: SocketAddress<'a>,
 }
 
-#[event("path_secret_map:entry_replaced")]
+#[event("path_secret_map:entry_inserted")]
 #[subject(endpoint)]
 /// Emitted when the entry is inserted into the path secret map
 struct PathSecretMapEntryInserted<'a> {
@@ -43,7 +43,7 @@ struct PathSecretMapEntryInserted<'a> {
     credential_id: &'a [u8],
 }
 
-#[event("path_secret_map:entry_replaced")]
+#[event("path_secret_map:entry_ready")]
 #[subject(endpoint)]
 /// Emitted when the entry is considered ready for use
 struct PathSecretMapEntryReady<'a> {

--- a/dc/s2n-quic-dc/src/event.rs
+++ b/dc/s2n-quic-dc/src/event.rs
@@ -45,3 +45,20 @@ pub mod metrics {
         }
     }
 }
+
+pub mod disabled {
+    #[derive(Debug, Default)]
+    pub struct Subscriber(());
+
+    impl super::Subscriber for Subscriber {
+        type ConnectionContext = ();
+
+        #[inline]
+        fn create_connection_context(
+            &self,
+            _meta: &super::api::ConnectionMeta,
+            _info: &super::api::ConnectionInfo,
+        ) -> Self::ConnectionContext {
+        }
+    }
+}

--- a/dc/s2n-quic-dc/src/event/generated.rs
+++ b/dc/s2n-quic-dc/src/event/generated.rs
@@ -16,6 +16,555 @@ pub mod api {
     pub use traits::Subscriber;
     #[derive(Clone, Debug)]
     #[non_exhaustive]
+    #[doc = " Emitted when a TCP acceptor is started"]
+    pub struct AcceptorTcpStarted<'a> {
+        #[doc = " The id of the acceptor worker"]
+        pub id: usize,
+        #[doc = " The local address of the acceptor"]
+        pub local_address: SocketAddress<'a>,
+        #[doc = " The backlog size"]
+        pub backlog: usize,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorTcpStarted<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorTcpStarted");
+            fmt.field("id", &self.id);
+            fmt.field("local_address", &self.local_address);
+            fmt.field("backlog", &self.backlog);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorTcpStarted<'a> {
+        const NAME: &'static str = "acceptor:tcp:started";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when a TCP acceptor completes a single iteration of the event loop"]
+    pub struct AcceptorTcpLoopIterationCompleted {
+        #[doc = " The number of streams that are waiting on initial packets"]
+        pub pending_streams: usize,
+        #[doc = " The amount of time it took to complete the iteration"]
+        pub processing_duration: core::time::Duration,
+        #[doc = " The computed max sojourn time that is allowed for streams"]
+        #[doc = ""]
+        #[doc = " If streams consume more time than this value to initialize, they"]
+        #[doc = " may potentially be replaced by more recent streams."]
+        pub max_sojourn_time: core::time::Duration,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl crate::event::snapshot::Fmt for AcceptorTcpLoopIterationCompleted {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorTcpLoopIterationCompleted");
+            fmt.field("pending_streams", &self.pending_streams);
+            fmt.field("processing_duration", &self.processing_duration);
+            fmt.field("max_sojourn_time", &self.max_sojourn_time);
+            fmt.finish()
+        }
+    }
+    impl Event for AcceptorTcpLoopIterationCompleted {
+        const NAME: &'static str = "acceptor:tcp:started";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when a fresh TCP stream is enqueued for processing"]
+    pub struct AcceptorTcpFreshEnqueued<'a> {
+        #[doc = " The remote address of the TCP stream"]
+        pub remote_address: SocketAddress<'a>,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorTcpFreshEnqueued<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorTcpFreshEnqueued");
+            fmt.field("remote_address", &self.remote_address);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorTcpFreshEnqueued<'a> {
+        const NAME: &'static str = "acceptor:tcp:fresh:enqueued";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when a the TCP acceptor has completed a batch of stream enqueues"]
+    pub struct AcceptorTcpFreshBatchCompleted {
+        #[doc = " The number of fresh TCP streams enqueued in this batch"]
+        pub enqueued: usize,
+        #[doc = " The number of fresh TCP streams dropped in this batch due to capacity limits"]
+        pub dropped: usize,
+        #[doc = " The number of TCP streams that errored in this batch"]
+        pub errored: usize,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl crate::event::snapshot::Fmt for AcceptorTcpFreshBatchCompleted {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorTcpFreshBatchCompleted");
+            fmt.field("enqueued", &self.enqueued);
+            fmt.field("dropped", &self.dropped);
+            fmt.field("errored", &self.errored);
+            fmt.finish()
+        }
+    }
+    impl Event for AcceptorTcpFreshBatchCompleted {
+        const NAME: &'static str = "acceptor:tcp:fresh:batch_completed";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when a TCP stream has been dropped"]
+    pub struct AcceptorTcpStreamDropped<'a> {
+        #[doc = " The remote address of the TCP stream"]
+        pub remote_address: SocketAddress<'a>,
+        pub reason: AcceptorTcpStreamDropReason,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorTcpStreamDropped<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorTcpStreamDropped");
+            fmt.field("remote_address", &self.remote_address);
+            fmt.field("reason", &self.reason);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorTcpStreamDropped<'a> {
+        const NAME: &'static str = "acceptor:tcp:stream_dropped";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when a TCP stream has been replaced by another stream"]
+    pub struct AcceptorTcpStreamReplaced<'a> {
+        #[doc = " The remote address of the stream being replaced"]
+        pub remote_address: SocketAddress<'a>,
+        #[doc = " The amount of time that the stream spent in the accept queue before"]
+        #[doc = " being replaced with another"]
+        pub sojourn_time: core::time::Duration,
+        #[doc = " The amount of bytes buffered on the stream"]
+        pub buffer_len: usize,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorTcpStreamReplaced<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorTcpStreamReplaced");
+            fmt.field("remote_address", &self.remote_address);
+            fmt.field("sojourn_time", &self.sojourn_time);
+            fmt.field("buffer_len", &self.buffer_len);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorTcpStreamReplaced<'a> {
+        const NAME: &'static str = "acceptor:tcp:stream_replaced";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when a full packet has been received on the TCP stream"]
+    pub struct AcceptorTcpPacketReceived<'a> {
+        #[doc = " The address of the packet's sender"]
+        pub remote_address: SocketAddress<'a>,
+        #[doc = " The credential ID of the packet"]
+        pub credential_id: &'a [u8],
+        #[doc = " The stream ID of the packet"]
+        pub stream_id: u64,
+        #[doc = " The payload length of the packet"]
+        pub payload_len: usize,
+        #[doc = " If the packet includes the final bytes of the stream"]
+        pub is_fin: bool,
+        #[doc = " The amount of time the TCP stream spent in the queue before receiving"]
+        #[doc = " the initial packet"]
+        pub sojourn_time: core::time::Duration,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorTcpPacketReceived<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorTcpPacketReceived");
+            fmt.field("remote_address", &self.remote_address);
+            fmt.field("credential_id", &"[HIDDEN]");
+            fmt.field("stream_id", &self.stream_id);
+            fmt.field("payload_len", &self.payload_len);
+            fmt.field("is_fin", &self.is_fin);
+            fmt.field("sojourn_time", &self.sojourn_time);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorTcpPacketReceived<'a> {
+        const NAME: &'static str = "acceptor:tcp:packet_received";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when the TCP acceptor received an invalid initial packet"]
+    pub struct AcceptorTcpPacketDropped<'a> {
+        #[doc = " The address of the packet's sender"]
+        pub remote_address: SocketAddress<'a>,
+        #[doc = " The reason the packet was dropped"]
+        pub reason: AcceptorPacketDropReason,
+        #[doc = " The amount of time the TCP stream spent in the queue before receiving"]
+        #[doc = " an error"]
+        pub sojourn_time: core::time::Duration,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorTcpPacketDropped<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorTcpPacketDropped");
+            fmt.field("remote_address", &self.remote_address);
+            fmt.field("reason", &self.reason);
+            fmt.field("sojourn_time", &self.sojourn_time);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorTcpPacketDropped<'a> {
+        const NAME: &'static str = "acceptor:tcp:packet_dropped";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when the TCP stream has been enqueued for the application"]
+    pub struct AcceptorTcpStreamEnqueued<'a> {
+        #[doc = " The address of the stream's peer"]
+        pub remote_address: SocketAddress<'a>,
+        #[doc = " The credential ID of the stream"]
+        pub credential_id: &'a [u8],
+        #[doc = " The ID of the stream"]
+        pub stream_id: u64,
+        #[doc = " The amount of time the TCP stream spent in the queue before being enqueued"]
+        pub sojourn_time: core::time::Duration,
+        #[doc = " The number of times the stream was blocked on receiving more data"]
+        pub blocked_count: usize,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorTcpStreamEnqueued<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorTcpStreamEnqueued");
+            fmt.field("remote_address", &self.remote_address);
+            fmt.field("credential_id", &"[HIDDEN]");
+            fmt.field("stream_id", &self.stream_id);
+            fmt.field("sojourn_time", &self.sojourn_time);
+            fmt.field("blocked_count", &self.blocked_count);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorTcpStreamEnqueued<'a> {
+        const NAME: &'static str = "acceptor:tcp:stream_enqueued";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when the TCP acceptor encounters an IO error"]
+    pub struct AcceptorTcpIoError<'a> {
+        #[doc = " The error encountered"]
+        pub error: &'a std::io::Error,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorTcpIoError<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorTcpIoError");
+            fmt.field("error", &self.error);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorTcpIoError<'a> {
+        const NAME: &'static str = "acceptor:tcp:io_error";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when a UDP acceptor is started"]
+    pub struct AcceptorUdpStarted<'a> {
+        #[doc = " The id of the acceptor worker"]
+        pub id: usize,
+        #[doc = " The local address of the acceptor"]
+        pub local_address: SocketAddress<'a>,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorUdpStarted<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorUdpStarted");
+            fmt.field("id", &self.id);
+            fmt.field("local_address", &self.local_address);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorUdpStarted<'a> {
+        const NAME: &'static str = "acceptor:udp:started";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when a UDP datagram is received by the acceptor"]
+    pub struct AcceptorUdpDatagramReceived<'a> {
+        #[doc = " The address of the datagram's sender"]
+        pub remote_address: SocketAddress<'a>,
+        #[doc = " The len of the datagram"]
+        pub len: usize,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorUdpDatagramReceived<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorUdpDatagramReceived");
+            fmt.field("remote_address", &self.remote_address);
+            fmt.field("len", &self.len);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorUdpDatagramReceived<'a> {
+        const NAME: &'static str = "acceptor:udp:datagram_received";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when the UDP acceptor parsed a packet contained in a datagram"]
+    pub struct AcceptorUdpPacketReceived<'a> {
+        #[doc = " The address of the packet's sender"]
+        pub remote_address: SocketAddress<'a>,
+        #[doc = " The credential ID of the packet"]
+        pub credential_id: &'a [u8],
+        #[doc = " The stream ID of the packet"]
+        pub stream_id: u64,
+        #[doc = " The payload length of the packet"]
+        pub payload_len: usize,
+        #[doc = " If the packets is a zero offset in the stream"]
+        pub is_zero_offset: bool,
+        #[doc = " If the packet is a retransmission"]
+        pub is_retransmission: bool,
+        #[doc = " If the packet includes the final bytes of the stream"]
+        pub is_fin: bool,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorUdpPacketReceived<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorUdpPacketReceived");
+            fmt.field("remote_address", &self.remote_address);
+            fmt.field("credential_id", &"[HIDDEN]");
+            fmt.field("stream_id", &self.stream_id);
+            fmt.field("payload_len", &self.payload_len);
+            fmt.field("is_zero_offset", &self.is_zero_offset);
+            fmt.field("is_retransmission", &self.is_retransmission);
+            fmt.field("is_fin", &self.is_fin);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorUdpPacketReceived<'a> {
+        const NAME: &'static str = "acceptor:udp:packet_received";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when the UDP acceptor received an invalid initial packet"]
+    pub struct AcceptorUdpPacketDropped<'a> {
+        #[doc = " The address of the packet's sender"]
+        pub remote_address: SocketAddress<'a>,
+        #[doc = " The reason the packet was dropped"]
+        pub reason: AcceptorPacketDropReason,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorUdpPacketDropped<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorUdpPacketDropped");
+            fmt.field("remote_address", &self.remote_address);
+            fmt.field("reason", &self.reason);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorUdpPacketDropped<'a> {
+        const NAME: &'static str = "acceptor:udp:packet_dropped";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when the UDP stream has been enqueued for the application"]
+    pub struct AcceptorUdpStreamEnqueued<'a> {
+        #[doc = " The address of the stream's peer"]
+        pub remote_address: SocketAddress<'a>,
+        #[doc = " The credential ID of the stream"]
+        pub credential_id: &'a [u8],
+        #[doc = " The ID of the stream"]
+        pub stream_id: u64,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorUdpStreamEnqueued<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorUdpStreamEnqueued");
+            fmt.field("remote_address", &self.remote_address);
+            fmt.field("credential_id", &"[HIDDEN]");
+            fmt.field("stream_id", &self.stream_id);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorUdpStreamEnqueued<'a> {
+        const NAME: &'static str = "acceptor:udp:stream_enqueued";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when the UDP acceptor encounters an IO error"]
+    pub struct AcceptorUdpIoError<'a> {
+        #[doc = " The error encountered"]
+        pub error: &'a std::io::Error,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorUdpIoError<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorUdpIoError");
+            fmt.field("error", &self.error);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorUdpIoError<'a> {
+        const NAME: &'static str = "acceptor:udp:io_error";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when a stream has been pruned"]
+    pub struct AcceptorStreamPruned<'a> {
+        #[doc = " The remote address of the stream"]
+        pub remote_address: SocketAddress<'a>,
+        #[doc = " The credential ID of the stream"]
+        pub credential_id: &'a [u8],
+        #[doc = " The ID of the stream"]
+        pub stream_id: u64,
+        #[doc = " The amount of time that the stream spent in the accept queue before"]
+        #[doc = " being pruned"]
+        pub sojourn_time: core::time::Duration,
+        pub reason: AcceptorStreamPruneReason,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorStreamPruned<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorStreamPruned");
+            fmt.field("remote_address", &self.remote_address);
+            fmt.field("credential_id", &"[HIDDEN]");
+            fmt.field("stream_id", &self.stream_id);
+            fmt.field("sojourn_time", &self.sojourn_time);
+            fmt.field("reason", &self.reason);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorStreamPruned<'a> {
+        const NAME: &'static str = "acceptor:stream_pruned";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Emitted when a stream has been dequeued by the application"]
+    pub struct AcceptorStreamDequeued<'a> {
+        #[doc = " The remote address of the stream"]
+        pub remote_address: SocketAddress<'a>,
+        #[doc = " The credential ID of the stream"]
+        pub credential_id: &'a [u8],
+        #[doc = " The ID of the stream"]
+        pub stream_id: u64,
+        #[doc = " The amount of time that the stream spent in the accept queue before"]
+        #[doc = " being dequeued"]
+        pub sojourn_time: core::time::Duration,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorStreamDequeued<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorStreamDequeued");
+            fmt.field("remote_address", &self.remote_address);
+            fmt.field("credential_id", &"[HIDDEN]");
+            fmt.field("stream_id", &self.stream_id);
+            fmt.field("sojourn_time", &self.sojourn_time);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorStreamDequeued<'a> {
+        const NAME: &'static str = "acceptor:stream_dequeued";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub enum AcceptorTcpStreamDropReason {
+        #[non_exhaustive]
+        #[doc = " There were more streams in the TCP backlog than the userspace queue can store"]
+        FreshQueueAtCapacity {},
+        #[non_exhaustive]
+        #[doc = " There are no available slots for processing"]
+        SlotsAtCapacity {},
+    }
+    impl aggregate::AsVariant for AcceptorTcpStreamDropReason {
+        const VARIANTS: &'static [aggregate::info::Variant] = &[
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("FRESH_QUEUE_AT_CAPACITY\0"),
+                id: 0usize,
+            }
+            .build(),
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("SLOTS_AT_CAPACITY\0"),
+                id: 1usize,
+            }
+            .build(),
+        ];
+        #[inline]
+        fn variant_idx(&self) -> usize {
+            match self {
+                Self::FreshQueueAtCapacity { .. } => 0usize,
+                Self::SlotsAtCapacity { .. } => 1usize,
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub enum AcceptorStreamPruneReason {
+        #[non_exhaustive]
+        MaxSojournTimeExceeded {},
+        #[non_exhaustive]
+        AcceptQueueCapacityExceeded {},
+    }
+    impl aggregate::AsVariant for AcceptorStreamPruneReason {
+        const VARIANTS: &'static [aggregate::info::Variant] = &[
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("MAX_SOJOURN_TIME_EXCEEDED\0"),
+                id: 0usize,
+            }
+            .build(),
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("ACCEPT_QUEUE_CAPACITY_EXCEEDED\0"),
+                id: 1usize,
+            }
+            .build(),
+        ];
+        #[inline]
+        fn variant_idx(&self) -> usize {
+            match self {
+                Self::MaxSojournTimeExceeded { .. } => 0usize,
+                Self::AcceptQueueCapacityExceeded { .. } => 1usize,
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub enum AcceptorPacketDropReason {
+        #[non_exhaustive]
+        UnexpectedEof {},
+        #[non_exhaustive]
+        UnexpectedBytes {},
+        #[non_exhaustive]
+        LengthCapacityExceeded {},
+        #[non_exhaustive]
+        InvariantViolation { message: &'static str },
+    }
+    impl aggregate::AsVariant for AcceptorPacketDropReason {
+        const VARIANTS: &'static [aggregate::info::Variant] = &[
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("UNEXPECTED_EOF\0"),
+                id: 0usize,
+            }
+            .build(),
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("UNEXPECTED_BYTES\0"),
+                id: 1usize,
+            }
+            .build(),
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("LENGTH_CAPACITY_EXCEEDED\0"),
+                id: 2usize,
+            }
+            .build(),
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("INVARIANT_VIOLATION\0"),
+                id: 3usize,
+            }
+            .build(),
+        ];
+        #[inline]
+        fn variant_idx(&self) -> usize {
+            match self {
+                Self::UnexpectedEof { .. } => 0usize,
+                Self::UnexpectedBytes { .. } => 1usize,
+                Self::LengthCapacityExceeded { .. } => 2usize,
+                Self::InvariantViolation { .. } => 3usize,
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
     pub struct ConnectionMeta {
         pub id: u64,
         pub timestamp: Timestamp,
@@ -557,6 +1106,18 @@ pub mod api {
     impl<'a> Event for StaleKeyPacketDropped<'a> {
         const NAME: &'static str = "path_secret_map:stale_key_packet_dropped";
     }
+    impl IntoEvent<builder::AcceptorPacketDropReason> for s2n_codec::DecoderError {
+        fn into_event(self) -> builder::AcceptorPacketDropReason {
+            use builder::AcceptorPacketDropReason as Reason;
+            use s2n_codec::DecoderError;
+            match self {
+                DecoderError::UnexpectedEof(_) => Reason::UnexpectedEof {},
+                DecoderError::UnexpectedBytes(_) => Reason::UnexpectedBytes {},
+                DecoderError::LengthCapacityExceeded => Reason::LengthCapacityExceeded {},
+                DecoderError::InvariantViolation(message) => Reason::InvariantViolation { message },
+            }
+        }
+    }
 }
 pub mod tracing {
     #![doc = r" This module contains event integration with [`tracing`](https://docs.rs/tracing)"]
@@ -586,6 +1147,251 @@ pub mod tracing {
         ) -> Self::ConnectionContext {
             let parent = self.parent(meta);
             tracing :: span ! (target : "s2n_quic_dc" , parent : parent , tracing :: Level :: DEBUG , "conn" , id = meta . id)
+        }
+        #[inline]
+        fn on_acceptor_tcp_started(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStarted,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorTcpStarted {
+                id,
+                local_address,
+                backlog,
+            } = event;
+            tracing :: event ! (target : "acceptor_tcp_started" , parent : parent , tracing :: Level :: DEBUG , id = tracing :: field :: debug (id) , local_address = tracing :: field :: debug (local_address) , backlog = tracing :: field :: debug (backlog));
+        }
+        #[inline]
+        fn on_acceptor_tcp_loop_iteration_completed(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpLoopIterationCompleted,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorTcpLoopIterationCompleted {
+                pending_streams,
+                processing_duration,
+                max_sojourn_time,
+            } = event;
+            tracing :: event ! (target : "acceptor_tcp_loop_iteration_completed" , parent : parent , tracing :: Level :: DEBUG , pending_streams = tracing :: field :: debug (pending_streams) , processing_duration = tracing :: field :: debug (processing_duration) , max_sojourn_time = tracing :: field :: debug (max_sojourn_time));
+        }
+        #[inline]
+        fn on_acceptor_tcp_fresh_enqueued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpFreshEnqueued,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorTcpFreshEnqueued { remote_address } = event;
+            tracing :: event ! (target : "acceptor_tcp_fresh_enqueued" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address));
+        }
+        #[inline]
+        fn on_acceptor_tcp_fresh_batch_completed(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpFreshBatchCompleted,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorTcpFreshBatchCompleted {
+                enqueued,
+                dropped,
+                errored,
+            } = event;
+            tracing :: event ! (target : "acceptor_tcp_fresh_batch_completed" , parent : parent , tracing :: Level :: DEBUG , enqueued = tracing :: field :: debug (enqueued) , dropped = tracing :: field :: debug (dropped) , errored = tracing :: field :: debug (errored));
+        }
+        #[inline]
+        fn on_acceptor_tcp_stream_dropped(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStreamDropped,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorTcpStreamDropped {
+                remote_address,
+                reason,
+            } = event;
+            tracing :: event ! (target : "acceptor_tcp_stream_dropped" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , reason = tracing :: field :: debug (reason));
+        }
+        #[inline]
+        fn on_acceptor_tcp_stream_replaced(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStreamReplaced,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorTcpStreamReplaced {
+                remote_address,
+                sojourn_time,
+                buffer_len,
+            } = event;
+            tracing :: event ! (target : "acceptor_tcp_stream_replaced" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , sojourn_time = tracing :: field :: debug (sojourn_time) , buffer_len = tracing :: field :: debug (buffer_len));
+        }
+        #[inline]
+        fn on_acceptor_tcp_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpPacketReceived,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorTcpPacketReceived {
+                remote_address,
+                credential_id,
+                stream_id,
+                payload_len,
+                is_fin,
+                sojourn_time,
+            } = event;
+            tracing :: event ! (target : "acceptor_tcp_packet_received" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , payload_len = tracing :: field :: debug (payload_len) , is_fin = tracing :: field :: debug (is_fin) , sojourn_time = tracing :: field :: debug (sojourn_time));
+        }
+        #[inline]
+        fn on_acceptor_tcp_packet_dropped(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpPacketDropped,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorTcpPacketDropped {
+                remote_address,
+                reason,
+                sojourn_time,
+            } = event;
+            tracing :: event ! (target : "acceptor_tcp_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , reason = tracing :: field :: debug (reason) , sojourn_time = tracing :: field :: debug (sojourn_time));
+        }
+        #[inline]
+        fn on_acceptor_tcp_stream_enqueued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStreamEnqueued,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorTcpStreamEnqueued {
+                remote_address,
+                credential_id,
+                stream_id,
+                sojourn_time,
+                blocked_count,
+            } = event;
+            tracing :: event ! (target : "acceptor_tcp_stream_enqueued" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , sojourn_time = tracing :: field :: debug (sojourn_time) , blocked_count = tracing :: field :: debug (blocked_count));
+        }
+        #[inline]
+        fn on_acceptor_tcp_io_error(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpIoError,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorTcpIoError { error } = event;
+            tracing :: event ! (target : "acceptor_tcp_io_error" , parent : parent , tracing :: Level :: DEBUG , error = tracing :: field :: debug (error));
+        }
+        #[inline]
+        fn on_acceptor_udp_started(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpStarted,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorUdpStarted { id, local_address } = event;
+            tracing :: event ! (target : "acceptor_udp_started" , parent : parent , tracing :: Level :: DEBUG , id = tracing :: field :: debug (id) , local_address = tracing :: field :: debug (local_address));
+        }
+        #[inline]
+        fn on_acceptor_udp_datagram_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpDatagramReceived,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorUdpDatagramReceived {
+                remote_address,
+                len,
+            } = event;
+            tracing :: event ! (target : "acceptor_udp_datagram_received" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , len = tracing :: field :: debug (len));
+        }
+        #[inline]
+        fn on_acceptor_udp_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpPacketReceived,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorUdpPacketReceived {
+                remote_address,
+                credential_id,
+                stream_id,
+                payload_len,
+                is_zero_offset,
+                is_retransmission,
+                is_fin,
+            } = event;
+            tracing :: event ! (target : "acceptor_udp_packet_received" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , payload_len = tracing :: field :: debug (payload_len) , is_zero_offset = tracing :: field :: debug (is_zero_offset) , is_retransmission = tracing :: field :: debug (is_retransmission) , is_fin = tracing :: field :: debug (is_fin));
+        }
+        #[inline]
+        fn on_acceptor_udp_packet_dropped(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpPacketDropped,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorUdpPacketDropped {
+                remote_address,
+                reason,
+            } = event;
+            tracing :: event ! (target : "acceptor_udp_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , reason = tracing :: field :: debug (reason));
+        }
+        #[inline]
+        fn on_acceptor_udp_stream_enqueued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpStreamEnqueued,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorUdpStreamEnqueued {
+                remote_address,
+                credential_id,
+                stream_id,
+            } = event;
+            tracing :: event ! (target : "acceptor_udp_stream_enqueued" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id));
+        }
+        #[inline]
+        fn on_acceptor_udp_io_error(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpIoError,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorUdpIoError { error } = event;
+            tracing :: event ! (target : "acceptor_udp_io_error" , parent : parent , tracing :: Level :: DEBUG , error = tracing :: field :: debug (error));
+        }
+        #[inline]
+        fn on_acceptor_stream_pruned(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorStreamPruned,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorStreamPruned {
+                remote_address,
+                credential_id,
+                stream_id,
+                sojourn_time,
+                reason,
+            } = event;
+            tracing :: event ! (target : "acceptor_stream_pruned" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , sojourn_time = tracing :: field :: debug (sojourn_time) , reason = tracing :: field :: debug (reason));
+        }
+        #[inline]
+        fn on_acceptor_stream_dequeued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorStreamDequeued,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorStreamDequeued {
+                remote_address,
+                credential_id,
+                stream_id,
+                sojourn_time,
+            } = event;
+            tracing :: event ! (target : "acceptor_stream_dequeued" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , sojourn_time = tracing :: field :: debug (sojourn_time));
         }
         #[inline]
         fn on_application_write(
@@ -929,6 +1735,514 @@ pub mod tracing {
 pub mod builder {
     use super::*;
     pub use s2n_quic_core::event::builder::{EndpointType, SocketAddress, Subject};
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when a TCP acceptor is started"]
+    pub struct AcceptorTcpStarted<'a> {
+        #[doc = " The id of the acceptor worker"]
+        pub id: usize,
+        #[doc = " The local address of the acceptor"]
+        pub local_address: &'a s2n_quic_core::inet::SocketAddress,
+        #[doc = " The backlog size"]
+        pub backlog: usize,
+    }
+    impl<'a> IntoEvent<api::AcceptorTcpStarted<'a>> for AcceptorTcpStarted<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorTcpStarted<'a> {
+            let AcceptorTcpStarted {
+                id,
+                local_address,
+                backlog,
+            } = self;
+            api::AcceptorTcpStarted {
+                id: id.into_event(),
+                local_address: local_address.into_event(),
+                backlog: backlog.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when a TCP acceptor completes a single iteration of the event loop"]
+    pub struct AcceptorTcpLoopIterationCompleted {
+        #[doc = " The number of streams that are waiting on initial packets"]
+        pub pending_streams: usize,
+        #[doc = " The amount of time it took to complete the iteration"]
+        pub processing_duration: core::time::Duration,
+        #[doc = " The computed max sojourn time that is allowed for streams"]
+        #[doc = ""]
+        #[doc = " If streams consume more time than this value to initialize, they"]
+        #[doc = " may potentially be replaced by more recent streams."]
+        pub max_sojourn_time: core::time::Duration,
+    }
+    impl IntoEvent<api::AcceptorTcpLoopIterationCompleted> for AcceptorTcpLoopIterationCompleted {
+        #[inline]
+        fn into_event(self) -> api::AcceptorTcpLoopIterationCompleted {
+            let AcceptorTcpLoopIterationCompleted {
+                pending_streams,
+                processing_duration,
+                max_sojourn_time,
+            } = self;
+            api::AcceptorTcpLoopIterationCompleted {
+                pending_streams: pending_streams.into_event(),
+                processing_duration: processing_duration.into_event(),
+                max_sojourn_time: max_sojourn_time.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when a fresh TCP stream is enqueued for processing"]
+    pub struct AcceptorTcpFreshEnqueued<'a> {
+        #[doc = " The remote address of the TCP stream"]
+        pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
+    }
+    impl<'a> IntoEvent<api::AcceptorTcpFreshEnqueued<'a>> for AcceptorTcpFreshEnqueued<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorTcpFreshEnqueued<'a> {
+            let AcceptorTcpFreshEnqueued { remote_address } = self;
+            api::AcceptorTcpFreshEnqueued {
+                remote_address: remote_address.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when a the TCP acceptor has completed a batch of stream enqueues"]
+    pub struct AcceptorTcpFreshBatchCompleted {
+        #[doc = " The number of fresh TCP streams enqueued in this batch"]
+        pub enqueued: usize,
+        #[doc = " The number of fresh TCP streams dropped in this batch due to capacity limits"]
+        pub dropped: usize,
+        #[doc = " The number of TCP streams that errored in this batch"]
+        pub errored: usize,
+    }
+    impl IntoEvent<api::AcceptorTcpFreshBatchCompleted> for AcceptorTcpFreshBatchCompleted {
+        #[inline]
+        fn into_event(self) -> api::AcceptorTcpFreshBatchCompleted {
+            let AcceptorTcpFreshBatchCompleted {
+                enqueued,
+                dropped,
+                errored,
+            } = self;
+            api::AcceptorTcpFreshBatchCompleted {
+                enqueued: enqueued.into_event(),
+                dropped: dropped.into_event(),
+                errored: errored.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when a TCP stream has been dropped"]
+    pub struct AcceptorTcpStreamDropped<'a> {
+        #[doc = " The remote address of the TCP stream"]
+        pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
+        pub reason: AcceptorTcpStreamDropReason,
+    }
+    impl<'a> IntoEvent<api::AcceptorTcpStreamDropped<'a>> for AcceptorTcpStreamDropped<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorTcpStreamDropped<'a> {
+            let AcceptorTcpStreamDropped {
+                remote_address,
+                reason,
+            } = self;
+            api::AcceptorTcpStreamDropped {
+                remote_address: remote_address.into_event(),
+                reason: reason.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when a TCP stream has been replaced by another stream"]
+    pub struct AcceptorTcpStreamReplaced<'a> {
+        #[doc = " The remote address of the stream being replaced"]
+        pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
+        #[doc = " The amount of time that the stream spent in the accept queue before"]
+        #[doc = " being replaced with another"]
+        pub sojourn_time: core::time::Duration,
+        #[doc = " The amount of bytes buffered on the stream"]
+        pub buffer_len: usize,
+    }
+    impl<'a> IntoEvent<api::AcceptorTcpStreamReplaced<'a>> for AcceptorTcpStreamReplaced<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorTcpStreamReplaced<'a> {
+            let AcceptorTcpStreamReplaced {
+                remote_address,
+                sojourn_time,
+                buffer_len,
+            } = self;
+            api::AcceptorTcpStreamReplaced {
+                remote_address: remote_address.into_event(),
+                sojourn_time: sojourn_time.into_event(),
+                buffer_len: buffer_len.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when a full packet has been received on the TCP stream"]
+    pub struct AcceptorTcpPacketReceived<'a> {
+        #[doc = " The address of the packet's sender"]
+        pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
+        #[doc = " The credential ID of the packet"]
+        pub credential_id: &'a [u8],
+        #[doc = " The stream ID of the packet"]
+        pub stream_id: u64,
+        #[doc = " The payload length of the packet"]
+        pub payload_len: usize,
+        #[doc = " If the packet includes the final bytes of the stream"]
+        pub is_fin: bool,
+        #[doc = " The amount of time the TCP stream spent in the queue before receiving"]
+        #[doc = " the initial packet"]
+        pub sojourn_time: core::time::Duration,
+    }
+    impl<'a> IntoEvent<api::AcceptorTcpPacketReceived<'a>> for AcceptorTcpPacketReceived<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorTcpPacketReceived<'a> {
+            let AcceptorTcpPacketReceived {
+                remote_address,
+                credential_id,
+                stream_id,
+                payload_len,
+                is_fin,
+                sojourn_time,
+            } = self;
+            api::AcceptorTcpPacketReceived {
+                remote_address: remote_address.into_event(),
+                credential_id: credential_id.into_event(),
+                stream_id: stream_id.into_event(),
+                payload_len: payload_len.into_event(),
+                is_fin: is_fin.into_event(),
+                sojourn_time: sojourn_time.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when the TCP acceptor received an invalid initial packet"]
+    pub struct AcceptorTcpPacketDropped<'a> {
+        #[doc = " The address of the packet's sender"]
+        pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
+        #[doc = " The reason the packet was dropped"]
+        pub reason: AcceptorPacketDropReason,
+        #[doc = " The amount of time the TCP stream spent in the queue before receiving"]
+        #[doc = " an error"]
+        pub sojourn_time: core::time::Duration,
+    }
+    impl<'a> IntoEvent<api::AcceptorTcpPacketDropped<'a>> for AcceptorTcpPacketDropped<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorTcpPacketDropped<'a> {
+            let AcceptorTcpPacketDropped {
+                remote_address,
+                reason,
+                sojourn_time,
+            } = self;
+            api::AcceptorTcpPacketDropped {
+                remote_address: remote_address.into_event(),
+                reason: reason.into_event(),
+                sojourn_time: sojourn_time.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when the TCP stream has been enqueued for the application"]
+    pub struct AcceptorTcpStreamEnqueued<'a> {
+        #[doc = " The address of the stream's peer"]
+        pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
+        #[doc = " The credential ID of the stream"]
+        pub credential_id: &'a [u8],
+        #[doc = " The ID of the stream"]
+        pub stream_id: u64,
+        #[doc = " The amount of time the TCP stream spent in the queue before being enqueued"]
+        pub sojourn_time: core::time::Duration,
+        #[doc = " The number of times the stream was blocked on receiving more data"]
+        pub blocked_count: usize,
+    }
+    impl<'a> IntoEvent<api::AcceptorTcpStreamEnqueued<'a>> for AcceptorTcpStreamEnqueued<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorTcpStreamEnqueued<'a> {
+            let AcceptorTcpStreamEnqueued {
+                remote_address,
+                credential_id,
+                stream_id,
+                sojourn_time,
+                blocked_count,
+            } = self;
+            api::AcceptorTcpStreamEnqueued {
+                remote_address: remote_address.into_event(),
+                credential_id: credential_id.into_event(),
+                stream_id: stream_id.into_event(),
+                sojourn_time: sojourn_time.into_event(),
+                blocked_count: blocked_count.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when the TCP acceptor encounters an IO error"]
+    pub struct AcceptorTcpIoError<'a> {
+        #[doc = " The error encountered"]
+        pub error: &'a std::io::Error,
+    }
+    impl<'a> IntoEvent<api::AcceptorTcpIoError<'a>> for AcceptorTcpIoError<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorTcpIoError<'a> {
+            let AcceptorTcpIoError { error } = self;
+            api::AcceptorTcpIoError {
+                error: error.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when a UDP acceptor is started"]
+    pub struct AcceptorUdpStarted<'a> {
+        #[doc = " The id of the acceptor worker"]
+        pub id: usize,
+        #[doc = " The local address of the acceptor"]
+        pub local_address: SocketAddress<'a>,
+    }
+    impl<'a> IntoEvent<api::AcceptorUdpStarted<'a>> for AcceptorUdpStarted<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorUdpStarted<'a> {
+            let AcceptorUdpStarted { id, local_address } = self;
+            api::AcceptorUdpStarted {
+                id: id.into_event(),
+                local_address: local_address.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when a UDP datagram is received by the acceptor"]
+    pub struct AcceptorUdpDatagramReceived<'a> {
+        #[doc = " The address of the datagram's sender"]
+        pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
+        #[doc = " The len of the datagram"]
+        pub len: usize,
+    }
+    impl<'a> IntoEvent<api::AcceptorUdpDatagramReceived<'a>> for AcceptorUdpDatagramReceived<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorUdpDatagramReceived<'a> {
+            let AcceptorUdpDatagramReceived {
+                remote_address,
+                len,
+            } = self;
+            api::AcceptorUdpDatagramReceived {
+                remote_address: remote_address.into_event(),
+                len: len.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when the UDP acceptor parsed a packet contained in a datagram"]
+    pub struct AcceptorUdpPacketReceived<'a> {
+        #[doc = " The address of the packet's sender"]
+        pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
+        #[doc = " The credential ID of the packet"]
+        pub credential_id: &'a [u8],
+        #[doc = " The stream ID of the packet"]
+        pub stream_id: u64,
+        #[doc = " The payload length of the packet"]
+        pub payload_len: usize,
+        #[doc = " If the packets is a zero offset in the stream"]
+        pub is_zero_offset: bool,
+        #[doc = " If the packet is a retransmission"]
+        pub is_retransmission: bool,
+        #[doc = " If the packet includes the final bytes of the stream"]
+        pub is_fin: bool,
+    }
+    impl<'a> IntoEvent<api::AcceptorUdpPacketReceived<'a>> for AcceptorUdpPacketReceived<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorUdpPacketReceived<'a> {
+            let AcceptorUdpPacketReceived {
+                remote_address,
+                credential_id,
+                stream_id,
+                payload_len,
+                is_zero_offset,
+                is_retransmission,
+                is_fin,
+            } = self;
+            api::AcceptorUdpPacketReceived {
+                remote_address: remote_address.into_event(),
+                credential_id: credential_id.into_event(),
+                stream_id: stream_id.into_event(),
+                payload_len: payload_len.into_event(),
+                is_zero_offset: is_zero_offset.into_event(),
+                is_retransmission: is_retransmission.into_event(),
+                is_fin: is_fin.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when the UDP acceptor received an invalid initial packet"]
+    pub struct AcceptorUdpPacketDropped<'a> {
+        #[doc = " The address of the packet's sender"]
+        pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
+        #[doc = " The reason the packet was dropped"]
+        pub reason: AcceptorPacketDropReason,
+    }
+    impl<'a> IntoEvent<api::AcceptorUdpPacketDropped<'a>> for AcceptorUdpPacketDropped<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorUdpPacketDropped<'a> {
+            let AcceptorUdpPacketDropped {
+                remote_address,
+                reason,
+            } = self;
+            api::AcceptorUdpPacketDropped {
+                remote_address: remote_address.into_event(),
+                reason: reason.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when the UDP stream has been enqueued for the application"]
+    pub struct AcceptorUdpStreamEnqueued<'a> {
+        #[doc = " The address of the stream's peer"]
+        pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
+        #[doc = " The credential ID of the stream"]
+        pub credential_id: &'a [u8],
+        #[doc = " The ID of the stream"]
+        pub stream_id: u64,
+    }
+    impl<'a> IntoEvent<api::AcceptorUdpStreamEnqueued<'a>> for AcceptorUdpStreamEnqueued<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorUdpStreamEnqueued<'a> {
+            let AcceptorUdpStreamEnqueued {
+                remote_address,
+                credential_id,
+                stream_id,
+            } = self;
+            api::AcceptorUdpStreamEnqueued {
+                remote_address: remote_address.into_event(),
+                credential_id: credential_id.into_event(),
+                stream_id: stream_id.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when the UDP acceptor encounters an IO error"]
+    pub struct AcceptorUdpIoError<'a> {
+        #[doc = " The error encountered"]
+        pub error: &'a std::io::Error,
+    }
+    impl<'a> IntoEvent<api::AcceptorUdpIoError<'a>> for AcceptorUdpIoError<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorUdpIoError<'a> {
+            let AcceptorUdpIoError { error } = self;
+            api::AcceptorUdpIoError {
+                error: error.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when a stream has been pruned"]
+    pub struct AcceptorStreamPruned<'a> {
+        #[doc = " The remote address of the stream"]
+        pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
+        #[doc = " The credential ID of the stream"]
+        pub credential_id: &'a [u8],
+        #[doc = " The ID of the stream"]
+        pub stream_id: u64,
+        #[doc = " The amount of time that the stream spent in the accept queue before"]
+        #[doc = " being pruned"]
+        pub sojourn_time: core::time::Duration,
+        pub reason: AcceptorStreamPruneReason,
+    }
+    impl<'a> IntoEvent<api::AcceptorStreamPruned<'a>> for AcceptorStreamPruned<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorStreamPruned<'a> {
+            let AcceptorStreamPruned {
+                remote_address,
+                credential_id,
+                stream_id,
+                sojourn_time,
+                reason,
+            } = self;
+            api::AcceptorStreamPruned {
+                remote_address: remote_address.into_event(),
+                credential_id: credential_id.into_event(),
+                stream_id: stream_id.into_event(),
+                sojourn_time: sojourn_time.into_event(),
+                reason: reason.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Emitted when a stream has been dequeued by the application"]
+    pub struct AcceptorStreamDequeued<'a> {
+        #[doc = " The remote address of the stream"]
+        pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
+        #[doc = " The credential ID of the stream"]
+        pub credential_id: &'a [u8],
+        #[doc = " The ID of the stream"]
+        pub stream_id: u64,
+        #[doc = " The amount of time that the stream spent in the accept queue before"]
+        #[doc = " being dequeued"]
+        pub sojourn_time: core::time::Duration,
+    }
+    impl<'a> IntoEvent<api::AcceptorStreamDequeued<'a>> for AcceptorStreamDequeued<'a> {
+        #[inline]
+        fn into_event(self) -> api::AcceptorStreamDequeued<'a> {
+            let AcceptorStreamDequeued {
+                remote_address,
+                credential_id,
+                stream_id,
+                sojourn_time,
+            } = self;
+            api::AcceptorStreamDequeued {
+                remote_address: remote_address.into_event(),
+                credential_id: credential_id.into_event(),
+                stream_id: stream_id.into_event(),
+                sojourn_time: sojourn_time.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub enum AcceptorTcpStreamDropReason {
+        #[doc = " There were more streams in the TCP backlog than the userspace queue can store"]
+        FreshQueueAtCapacity,
+        #[doc = " There are no available slots for processing"]
+        SlotsAtCapacity,
+    }
+    impl IntoEvent<api::AcceptorTcpStreamDropReason> for AcceptorTcpStreamDropReason {
+        #[inline]
+        fn into_event(self) -> api::AcceptorTcpStreamDropReason {
+            use api::AcceptorTcpStreamDropReason::*;
+            match self {
+                Self::FreshQueueAtCapacity => FreshQueueAtCapacity {},
+                Self::SlotsAtCapacity => SlotsAtCapacity {},
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub enum AcceptorStreamPruneReason {
+        MaxSojournTimeExceeded,
+        AcceptQueueCapacityExceeded,
+    }
+    impl IntoEvent<api::AcceptorStreamPruneReason> for AcceptorStreamPruneReason {
+        #[inline]
+        fn into_event(self) -> api::AcceptorStreamPruneReason {
+            use api::AcceptorStreamPruneReason::*;
+            match self {
+                Self::MaxSojournTimeExceeded => MaxSojournTimeExceeded {},
+                Self::AcceptQueueCapacityExceeded => AcceptQueueCapacityExceeded {},
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub enum AcceptorPacketDropReason {
+        UnexpectedEof,
+        UnexpectedBytes,
+        LengthCapacityExceeded,
+        InvariantViolation { message: &'static str },
+    }
+    impl IntoEvent<api::AcceptorPacketDropReason> for AcceptorPacketDropReason {
+        #[inline]
+        fn into_event(self) -> api::AcceptorPacketDropReason {
+            use api::AcceptorPacketDropReason::*;
+            match self {
+                Self::UnexpectedEof => UnexpectedEof {},
+                Self::UnexpectedBytes => UnexpectedBytes {},
+                Self::LengthCapacityExceeded => LengthCapacityExceeded {},
+                Self::InvariantViolation { message } => InvariantViolation {
+                    message: message.into_event(),
+                },
+            }
+        }
+    }
     #[derive(Clone, Debug)]
     pub struct ConnectionMeta {
         pub id: u64,
@@ -1534,6 +2848,186 @@ mod traits {
             meta: &api::ConnectionMeta,
             info: &api::ConnectionInfo,
         ) -> Self::ConnectionContext;
+        #[doc = "Called when the `AcceptorTcpStarted` event is triggered"]
+        #[inline]
+        fn on_acceptor_tcp_started(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStarted,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorTcpLoopIterationCompleted` event is triggered"]
+        #[inline]
+        fn on_acceptor_tcp_loop_iteration_completed(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpLoopIterationCompleted,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorTcpFreshEnqueued` event is triggered"]
+        #[inline]
+        fn on_acceptor_tcp_fresh_enqueued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpFreshEnqueued,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorTcpFreshBatchCompleted` event is triggered"]
+        #[inline]
+        fn on_acceptor_tcp_fresh_batch_completed(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpFreshBatchCompleted,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorTcpStreamDropped` event is triggered"]
+        #[inline]
+        fn on_acceptor_tcp_stream_dropped(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStreamDropped,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorTcpStreamReplaced` event is triggered"]
+        #[inline]
+        fn on_acceptor_tcp_stream_replaced(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStreamReplaced,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorTcpPacketReceived` event is triggered"]
+        #[inline]
+        fn on_acceptor_tcp_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpPacketReceived,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorTcpPacketDropped` event is triggered"]
+        #[inline]
+        fn on_acceptor_tcp_packet_dropped(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpPacketDropped,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorTcpStreamEnqueued` event is triggered"]
+        #[inline]
+        fn on_acceptor_tcp_stream_enqueued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStreamEnqueued,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorTcpIoError` event is triggered"]
+        #[inline]
+        fn on_acceptor_tcp_io_error(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpIoError,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorUdpStarted` event is triggered"]
+        #[inline]
+        fn on_acceptor_udp_started(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpStarted,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorUdpDatagramReceived` event is triggered"]
+        #[inline]
+        fn on_acceptor_udp_datagram_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpDatagramReceived,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorUdpPacketReceived` event is triggered"]
+        #[inline]
+        fn on_acceptor_udp_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpPacketReceived,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorUdpPacketDropped` event is triggered"]
+        #[inline]
+        fn on_acceptor_udp_packet_dropped(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpPacketDropped,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorUdpStreamEnqueued` event is triggered"]
+        #[inline]
+        fn on_acceptor_udp_stream_enqueued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpStreamEnqueued,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorUdpIoError` event is triggered"]
+        #[inline]
+        fn on_acceptor_udp_io_error(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpIoError,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorStreamPruned` event is triggered"]
+        #[inline]
+        fn on_acceptor_stream_pruned(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorStreamPruned,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `AcceptorStreamDequeued` event is triggered"]
+        #[inline]
+        fn on_acceptor_stream_dequeued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorStreamDequeued,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
         #[doc = "Called when the `ApplicationWrite` event is triggered"]
         #[inline]
         fn on_application_write(
@@ -1836,6 +3330,152 @@ mod traits {
             self.as_ref().create_connection_context(meta, info)
         }
         #[inline]
+        fn on_acceptor_tcp_started(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStarted,
+        ) {
+            self.as_ref().on_acceptor_tcp_started(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_loop_iteration_completed(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpLoopIterationCompleted,
+        ) {
+            self.as_ref()
+                .on_acceptor_tcp_loop_iteration_completed(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_fresh_enqueued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpFreshEnqueued,
+        ) {
+            self.as_ref().on_acceptor_tcp_fresh_enqueued(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_fresh_batch_completed(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpFreshBatchCompleted,
+        ) {
+            self.as_ref()
+                .on_acceptor_tcp_fresh_batch_completed(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_stream_dropped(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStreamDropped,
+        ) {
+            self.as_ref().on_acceptor_tcp_stream_dropped(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_stream_replaced(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStreamReplaced,
+        ) {
+            self.as_ref().on_acceptor_tcp_stream_replaced(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpPacketReceived,
+        ) {
+            self.as_ref().on_acceptor_tcp_packet_received(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_packet_dropped(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpPacketDropped,
+        ) {
+            self.as_ref().on_acceptor_tcp_packet_dropped(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_stream_enqueued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStreamEnqueued,
+        ) {
+            self.as_ref().on_acceptor_tcp_stream_enqueued(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_io_error(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpIoError,
+        ) {
+            self.as_ref().on_acceptor_tcp_io_error(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_udp_started(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpStarted,
+        ) {
+            self.as_ref().on_acceptor_udp_started(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_udp_datagram_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpDatagramReceived,
+        ) {
+            self.as_ref().on_acceptor_udp_datagram_received(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_udp_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpPacketReceived,
+        ) {
+            self.as_ref().on_acceptor_udp_packet_received(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_udp_packet_dropped(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpPacketDropped,
+        ) {
+            self.as_ref().on_acceptor_udp_packet_dropped(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_udp_stream_enqueued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpStreamEnqueued,
+        ) {
+            self.as_ref().on_acceptor_udp_stream_enqueued(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_udp_io_error(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpIoError,
+        ) {
+            self.as_ref().on_acceptor_udp_io_error(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_stream_pruned(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorStreamPruned,
+        ) {
+            self.as_ref().on_acceptor_stream_pruned(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_stream_dequeued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorStreamDequeued,
+        ) {
+            self.as_ref().on_acceptor_stream_dequeued(meta, event);
+        }
+        #[inline]
         fn on_application_write(
             &self,
             context: &Self::ConnectionContext,
@@ -2086,6 +3726,168 @@ mod traits {
                 self.0.create_connection_context(meta, info),
                 self.1.create_connection_context(meta, info),
             )
+        }
+        #[inline]
+        fn on_acceptor_tcp_started(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStarted,
+        ) {
+            (self.0).on_acceptor_tcp_started(meta, event);
+            (self.1).on_acceptor_tcp_started(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_loop_iteration_completed(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpLoopIterationCompleted,
+        ) {
+            (self.0).on_acceptor_tcp_loop_iteration_completed(meta, event);
+            (self.1).on_acceptor_tcp_loop_iteration_completed(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_fresh_enqueued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpFreshEnqueued,
+        ) {
+            (self.0).on_acceptor_tcp_fresh_enqueued(meta, event);
+            (self.1).on_acceptor_tcp_fresh_enqueued(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_fresh_batch_completed(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpFreshBatchCompleted,
+        ) {
+            (self.0).on_acceptor_tcp_fresh_batch_completed(meta, event);
+            (self.1).on_acceptor_tcp_fresh_batch_completed(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_stream_dropped(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStreamDropped,
+        ) {
+            (self.0).on_acceptor_tcp_stream_dropped(meta, event);
+            (self.1).on_acceptor_tcp_stream_dropped(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_stream_replaced(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStreamReplaced,
+        ) {
+            (self.0).on_acceptor_tcp_stream_replaced(meta, event);
+            (self.1).on_acceptor_tcp_stream_replaced(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpPacketReceived,
+        ) {
+            (self.0).on_acceptor_tcp_packet_received(meta, event);
+            (self.1).on_acceptor_tcp_packet_received(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_packet_dropped(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpPacketDropped,
+        ) {
+            (self.0).on_acceptor_tcp_packet_dropped(meta, event);
+            (self.1).on_acceptor_tcp_packet_dropped(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_stream_enqueued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStreamEnqueued,
+        ) {
+            (self.0).on_acceptor_tcp_stream_enqueued(meta, event);
+            (self.1).on_acceptor_tcp_stream_enqueued(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_io_error(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpIoError,
+        ) {
+            (self.0).on_acceptor_tcp_io_error(meta, event);
+            (self.1).on_acceptor_tcp_io_error(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_udp_started(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpStarted,
+        ) {
+            (self.0).on_acceptor_udp_started(meta, event);
+            (self.1).on_acceptor_udp_started(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_udp_datagram_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpDatagramReceived,
+        ) {
+            (self.0).on_acceptor_udp_datagram_received(meta, event);
+            (self.1).on_acceptor_udp_datagram_received(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_udp_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpPacketReceived,
+        ) {
+            (self.0).on_acceptor_udp_packet_received(meta, event);
+            (self.1).on_acceptor_udp_packet_received(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_udp_packet_dropped(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpPacketDropped,
+        ) {
+            (self.0).on_acceptor_udp_packet_dropped(meta, event);
+            (self.1).on_acceptor_udp_packet_dropped(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_udp_stream_enqueued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpStreamEnqueued,
+        ) {
+            (self.0).on_acceptor_udp_stream_enqueued(meta, event);
+            (self.1).on_acceptor_udp_stream_enqueued(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_udp_io_error(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpIoError,
+        ) {
+            (self.0).on_acceptor_udp_io_error(meta, event);
+            (self.1).on_acceptor_udp_io_error(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_stream_pruned(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorStreamPruned,
+        ) {
+            (self.0).on_acceptor_stream_pruned(meta, event);
+            (self.1).on_acceptor_stream_pruned(meta, event);
+        }
+        #[inline]
+        fn on_acceptor_stream_dequeued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorStreamDequeued,
+        ) {
+            (self.0).on_acceptor_stream_dequeued(meta, event);
+            (self.1).on_acceptor_stream_dequeued(meta, event);
         }
         #[inline]
         fn on_application_write(
@@ -2350,6 +4152,48 @@ mod traits {
         }
     }
     pub trait EndpointPublisher {
+        #[doc = "Publishes a `AcceptorTcpStarted` event to the publisher's subscriber"]
+        fn on_acceptor_tcp_started(&self, event: builder::AcceptorTcpStarted);
+        #[doc = "Publishes a `AcceptorTcpLoopIterationCompleted` event to the publisher's subscriber"]
+        fn on_acceptor_tcp_loop_iteration_completed(
+            &self,
+            event: builder::AcceptorTcpLoopIterationCompleted,
+        );
+        #[doc = "Publishes a `AcceptorTcpFreshEnqueued` event to the publisher's subscriber"]
+        fn on_acceptor_tcp_fresh_enqueued(&self, event: builder::AcceptorTcpFreshEnqueued);
+        #[doc = "Publishes a `AcceptorTcpFreshBatchCompleted` event to the publisher's subscriber"]
+        fn on_acceptor_tcp_fresh_batch_completed(
+            &self,
+            event: builder::AcceptorTcpFreshBatchCompleted,
+        );
+        #[doc = "Publishes a `AcceptorTcpStreamDropped` event to the publisher's subscriber"]
+        fn on_acceptor_tcp_stream_dropped(&self, event: builder::AcceptorTcpStreamDropped);
+        #[doc = "Publishes a `AcceptorTcpStreamReplaced` event to the publisher's subscriber"]
+        fn on_acceptor_tcp_stream_replaced(&self, event: builder::AcceptorTcpStreamReplaced);
+        #[doc = "Publishes a `AcceptorTcpPacketReceived` event to the publisher's subscriber"]
+        fn on_acceptor_tcp_packet_received(&self, event: builder::AcceptorTcpPacketReceived);
+        #[doc = "Publishes a `AcceptorTcpPacketDropped` event to the publisher's subscriber"]
+        fn on_acceptor_tcp_packet_dropped(&self, event: builder::AcceptorTcpPacketDropped);
+        #[doc = "Publishes a `AcceptorTcpStreamEnqueued` event to the publisher's subscriber"]
+        fn on_acceptor_tcp_stream_enqueued(&self, event: builder::AcceptorTcpStreamEnqueued);
+        #[doc = "Publishes a `AcceptorTcpIoError` event to the publisher's subscriber"]
+        fn on_acceptor_tcp_io_error(&self, event: builder::AcceptorTcpIoError);
+        #[doc = "Publishes a `AcceptorUdpStarted` event to the publisher's subscriber"]
+        fn on_acceptor_udp_started(&self, event: builder::AcceptorUdpStarted);
+        #[doc = "Publishes a `AcceptorUdpDatagramReceived` event to the publisher's subscriber"]
+        fn on_acceptor_udp_datagram_received(&self, event: builder::AcceptorUdpDatagramReceived);
+        #[doc = "Publishes a `AcceptorUdpPacketReceived` event to the publisher's subscriber"]
+        fn on_acceptor_udp_packet_received(&self, event: builder::AcceptorUdpPacketReceived);
+        #[doc = "Publishes a `AcceptorUdpPacketDropped` event to the publisher's subscriber"]
+        fn on_acceptor_udp_packet_dropped(&self, event: builder::AcceptorUdpPacketDropped);
+        #[doc = "Publishes a `AcceptorUdpStreamEnqueued` event to the publisher's subscriber"]
+        fn on_acceptor_udp_stream_enqueued(&self, event: builder::AcceptorUdpStreamEnqueued);
+        #[doc = "Publishes a `AcceptorUdpIoError` event to the publisher's subscriber"]
+        fn on_acceptor_udp_io_error(&self, event: builder::AcceptorUdpIoError);
+        #[doc = "Publishes a `AcceptorStreamPruned` event to the publisher's subscriber"]
+        fn on_acceptor_stream_pruned(&self, event: builder::AcceptorStreamPruned);
+        #[doc = "Publishes a `AcceptorStreamDequeued` event to the publisher's subscriber"]
+        fn on_acceptor_stream_dequeued(&self, event: builder::AcceptorStreamDequeued);
         #[doc = "Publishes a `EndpointInitialized` event to the publisher's subscriber"]
         fn on_endpoint_initialized(&self, event: builder::EndpointInitialized);
         #[doc = "Publishes a `PathSecretMapInitialized` event to the publisher's subscriber"]
@@ -2444,6 +4288,134 @@ mod traits {
         }
     }
     impl<'a, Sub: Subscriber> EndpointPublisher for EndpointPublisherSubscriber<'a, Sub> {
+        #[inline]
+        fn on_acceptor_tcp_started(&self, event: builder::AcceptorTcpStarted) {
+            let event = event.into_event();
+            self.subscriber.on_acceptor_tcp_started(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_loop_iteration_completed(
+            &self,
+            event: builder::AcceptorTcpLoopIterationCompleted,
+        ) {
+            let event = event.into_event();
+            self.subscriber
+                .on_acceptor_tcp_loop_iteration_completed(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_fresh_enqueued(&self, event: builder::AcceptorTcpFreshEnqueued) {
+            let event = event.into_event();
+            self.subscriber
+                .on_acceptor_tcp_fresh_enqueued(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_fresh_batch_completed(
+            &self,
+            event: builder::AcceptorTcpFreshBatchCompleted,
+        ) {
+            let event = event.into_event();
+            self.subscriber
+                .on_acceptor_tcp_fresh_batch_completed(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_stream_dropped(&self, event: builder::AcceptorTcpStreamDropped) {
+            let event = event.into_event();
+            self.subscriber
+                .on_acceptor_tcp_stream_dropped(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_stream_replaced(&self, event: builder::AcceptorTcpStreamReplaced) {
+            let event = event.into_event();
+            self.subscriber
+                .on_acceptor_tcp_stream_replaced(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_packet_received(&self, event: builder::AcceptorTcpPacketReceived) {
+            let event = event.into_event();
+            self.subscriber
+                .on_acceptor_tcp_packet_received(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_packet_dropped(&self, event: builder::AcceptorTcpPacketDropped) {
+            let event = event.into_event();
+            self.subscriber
+                .on_acceptor_tcp_packet_dropped(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_stream_enqueued(&self, event: builder::AcceptorTcpStreamEnqueued) {
+            let event = event.into_event();
+            self.subscriber
+                .on_acceptor_tcp_stream_enqueued(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_io_error(&self, event: builder::AcceptorTcpIoError) {
+            let event = event.into_event();
+            self.subscriber.on_acceptor_tcp_io_error(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_udp_started(&self, event: builder::AcceptorUdpStarted) {
+            let event = event.into_event();
+            self.subscriber.on_acceptor_udp_started(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_udp_datagram_received(&self, event: builder::AcceptorUdpDatagramReceived) {
+            let event = event.into_event();
+            self.subscriber
+                .on_acceptor_udp_datagram_received(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_udp_packet_received(&self, event: builder::AcceptorUdpPacketReceived) {
+            let event = event.into_event();
+            self.subscriber
+                .on_acceptor_udp_packet_received(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_udp_packet_dropped(&self, event: builder::AcceptorUdpPacketDropped) {
+            let event = event.into_event();
+            self.subscriber
+                .on_acceptor_udp_packet_dropped(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_udp_stream_enqueued(&self, event: builder::AcceptorUdpStreamEnqueued) {
+            let event = event.into_event();
+            self.subscriber
+                .on_acceptor_udp_stream_enqueued(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_udp_io_error(&self, event: builder::AcceptorUdpIoError) {
+            let event = event.into_event();
+            self.subscriber.on_acceptor_udp_io_error(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_stream_pruned(&self, event: builder::AcceptorStreamPruned) {
+            let event = event.into_event();
+            self.subscriber
+                .on_acceptor_stream_pruned(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_stream_dequeued(&self, event: builder::AcceptorStreamDequeued) {
+            let event = event.into_event();
+            self.subscriber
+                .on_acceptor_stream_dequeued(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
         #[inline]
         fn on_endpoint_initialized(&self, event: builder::EndpointInitialized) {
             let event = event.into_event();
@@ -2710,6 +4682,24 @@ pub mod testing {
         pub struct Subscriber {
             location: Option<Location>,
             output: Mutex<Vec<String>>,
+            pub acceptor_tcp_started: AtomicU32,
+            pub acceptor_tcp_loop_iteration_completed: AtomicU32,
+            pub acceptor_tcp_fresh_enqueued: AtomicU32,
+            pub acceptor_tcp_fresh_batch_completed: AtomicU32,
+            pub acceptor_tcp_stream_dropped: AtomicU32,
+            pub acceptor_tcp_stream_replaced: AtomicU32,
+            pub acceptor_tcp_packet_received: AtomicU32,
+            pub acceptor_tcp_packet_dropped: AtomicU32,
+            pub acceptor_tcp_stream_enqueued: AtomicU32,
+            pub acceptor_tcp_io_error: AtomicU32,
+            pub acceptor_udp_started: AtomicU32,
+            pub acceptor_udp_datagram_received: AtomicU32,
+            pub acceptor_udp_packet_received: AtomicU32,
+            pub acceptor_udp_packet_dropped: AtomicU32,
+            pub acceptor_udp_stream_enqueued: AtomicU32,
+            pub acceptor_udp_io_error: AtomicU32,
+            pub acceptor_stream_pruned: AtomicU32,
+            pub acceptor_stream_dequeued: AtomicU32,
             pub endpoint_initialized: AtomicU32,
             pub path_secret_map_initialized: AtomicU32,
             pub path_secret_map_uninitialized: AtomicU32,
@@ -2765,6 +4755,24 @@ pub mod testing {
                 Self {
                     location: None,
                     output: Default::default(),
+                    acceptor_tcp_started: AtomicU32::new(0),
+                    acceptor_tcp_loop_iteration_completed: AtomicU32::new(0),
+                    acceptor_tcp_fresh_enqueued: AtomicU32::new(0),
+                    acceptor_tcp_fresh_batch_completed: AtomicU32::new(0),
+                    acceptor_tcp_stream_dropped: AtomicU32::new(0),
+                    acceptor_tcp_stream_replaced: AtomicU32::new(0),
+                    acceptor_tcp_packet_received: AtomicU32::new(0),
+                    acceptor_tcp_packet_dropped: AtomicU32::new(0),
+                    acceptor_tcp_stream_enqueued: AtomicU32::new(0),
+                    acceptor_tcp_io_error: AtomicU32::new(0),
+                    acceptor_udp_started: AtomicU32::new(0),
+                    acceptor_udp_datagram_received: AtomicU32::new(0),
+                    acceptor_udp_packet_received: AtomicU32::new(0),
+                    acceptor_udp_packet_dropped: AtomicU32::new(0),
+                    acceptor_udp_stream_enqueued: AtomicU32::new(0),
+                    acceptor_udp_io_error: AtomicU32::new(0),
+                    acceptor_stream_pruned: AtomicU32::new(0),
+                    acceptor_stream_dequeued: AtomicU32::new(0),
                     endpoint_initialized: AtomicU32::new(0),
                     path_secret_map_initialized: AtomicU32::new(0),
                     path_secret_map_uninitialized: AtomicU32::new(0),
@@ -2799,6 +4807,217 @@ pub mod testing {
                 _meta: &api::ConnectionMeta,
                 _info: &api::ConnectionInfo,
             ) -> Self::ConnectionContext {
+            }
+            fn on_acceptor_tcp_started(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorTcpStarted,
+            ) {
+                self.acceptor_tcp_started.fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_tcp_loop_iteration_completed(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorTcpLoopIterationCompleted,
+            ) {
+                self.acceptor_tcp_loop_iteration_completed
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_tcp_fresh_enqueued(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorTcpFreshEnqueued,
+            ) {
+                self.acceptor_tcp_fresh_enqueued
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_tcp_fresh_batch_completed(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorTcpFreshBatchCompleted,
+            ) {
+                self.acceptor_tcp_fresh_batch_completed
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_tcp_stream_dropped(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorTcpStreamDropped,
+            ) {
+                self.acceptor_tcp_stream_dropped
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_tcp_stream_replaced(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorTcpStreamReplaced,
+            ) {
+                self.acceptor_tcp_stream_replaced
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_tcp_packet_received(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorTcpPacketReceived,
+            ) {
+                self.acceptor_tcp_packet_received
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_tcp_packet_dropped(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorTcpPacketDropped,
+            ) {
+                self.acceptor_tcp_packet_dropped
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_tcp_stream_enqueued(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorTcpStreamEnqueued,
+            ) {
+                self.acceptor_tcp_stream_enqueued
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_tcp_io_error(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorTcpIoError,
+            ) {
+                self.acceptor_tcp_io_error.fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_udp_started(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorUdpStarted,
+            ) {
+                self.acceptor_udp_started.fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_udp_datagram_received(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorUdpDatagramReceived,
+            ) {
+                self.acceptor_udp_datagram_received
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_udp_packet_received(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorUdpPacketReceived,
+            ) {
+                self.acceptor_udp_packet_received
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_udp_packet_dropped(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorUdpPacketDropped,
+            ) {
+                self.acceptor_udp_packet_dropped
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_udp_stream_enqueued(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorUdpStreamEnqueued,
+            ) {
+                self.acceptor_udp_stream_enqueued
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_udp_io_error(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorUdpIoError,
+            ) {
+                self.acceptor_udp_io_error.fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_stream_pruned(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorStreamPruned,
+            ) {
+                self.acceptor_stream_pruned.fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_stream_dequeued(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorStreamDequeued,
+            ) {
+                self.acceptor_stream_dequeued
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
             }
             fn on_endpoint_initialized(
                 &self,
@@ -3092,6 +5311,24 @@ pub mod testing {
     pub struct Subscriber {
         location: Option<Location>,
         output: Mutex<Vec<String>>,
+        pub acceptor_tcp_started: AtomicU32,
+        pub acceptor_tcp_loop_iteration_completed: AtomicU32,
+        pub acceptor_tcp_fresh_enqueued: AtomicU32,
+        pub acceptor_tcp_fresh_batch_completed: AtomicU32,
+        pub acceptor_tcp_stream_dropped: AtomicU32,
+        pub acceptor_tcp_stream_replaced: AtomicU32,
+        pub acceptor_tcp_packet_received: AtomicU32,
+        pub acceptor_tcp_packet_dropped: AtomicU32,
+        pub acceptor_tcp_stream_enqueued: AtomicU32,
+        pub acceptor_tcp_io_error: AtomicU32,
+        pub acceptor_udp_started: AtomicU32,
+        pub acceptor_udp_datagram_received: AtomicU32,
+        pub acceptor_udp_packet_received: AtomicU32,
+        pub acceptor_udp_packet_dropped: AtomicU32,
+        pub acceptor_udp_stream_enqueued: AtomicU32,
+        pub acceptor_udp_io_error: AtomicU32,
+        pub acceptor_stream_pruned: AtomicU32,
+        pub acceptor_stream_dequeued: AtomicU32,
         pub application_write: AtomicU32,
         pub application_read: AtomicU32,
         pub endpoint_initialized: AtomicU32,
@@ -3149,6 +5386,24 @@ pub mod testing {
             Self {
                 location: None,
                 output: Default::default(),
+                acceptor_tcp_started: AtomicU32::new(0),
+                acceptor_tcp_loop_iteration_completed: AtomicU32::new(0),
+                acceptor_tcp_fresh_enqueued: AtomicU32::new(0),
+                acceptor_tcp_fresh_batch_completed: AtomicU32::new(0),
+                acceptor_tcp_stream_dropped: AtomicU32::new(0),
+                acceptor_tcp_stream_replaced: AtomicU32::new(0),
+                acceptor_tcp_packet_received: AtomicU32::new(0),
+                acceptor_tcp_packet_dropped: AtomicU32::new(0),
+                acceptor_tcp_stream_enqueued: AtomicU32::new(0),
+                acceptor_tcp_io_error: AtomicU32::new(0),
+                acceptor_udp_started: AtomicU32::new(0),
+                acceptor_udp_datagram_received: AtomicU32::new(0),
+                acceptor_udp_packet_received: AtomicU32::new(0),
+                acceptor_udp_packet_dropped: AtomicU32::new(0),
+                acceptor_udp_stream_enqueued: AtomicU32::new(0),
+                acceptor_udp_io_error: AtomicU32::new(0),
+                acceptor_stream_pruned: AtomicU32::new(0),
+                acceptor_stream_dequeued: AtomicU32::new(0),
                 application_write: AtomicU32::new(0),
                 application_read: AtomicU32::new(0),
                 endpoint_initialized: AtomicU32::new(0),
@@ -3185,6 +5440,217 @@ pub mod testing {
             _meta: &api::ConnectionMeta,
             _info: &api::ConnectionInfo,
         ) -> Self::ConnectionContext {
+        }
+        fn on_acceptor_tcp_started(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStarted,
+        ) {
+            self.acceptor_tcp_started.fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_loop_iteration_completed(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpLoopIterationCompleted,
+        ) {
+            self.acceptor_tcp_loop_iteration_completed
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_fresh_enqueued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpFreshEnqueued,
+        ) {
+            self.acceptor_tcp_fresh_enqueued
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_fresh_batch_completed(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpFreshBatchCompleted,
+        ) {
+            self.acceptor_tcp_fresh_batch_completed
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_stream_dropped(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStreamDropped,
+        ) {
+            self.acceptor_tcp_stream_dropped
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_stream_replaced(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStreamReplaced,
+        ) {
+            self.acceptor_tcp_stream_replaced
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpPacketReceived,
+        ) {
+            self.acceptor_tcp_packet_received
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_packet_dropped(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpPacketDropped,
+        ) {
+            self.acceptor_tcp_packet_dropped
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_stream_enqueued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpStreamEnqueued,
+        ) {
+            self.acceptor_tcp_stream_enqueued
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_io_error(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpIoError,
+        ) {
+            self.acceptor_tcp_io_error.fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_udp_started(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpStarted,
+        ) {
+            self.acceptor_udp_started.fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_udp_datagram_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpDatagramReceived,
+        ) {
+            self.acceptor_udp_datagram_received
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_udp_packet_received(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpPacketReceived,
+        ) {
+            self.acceptor_udp_packet_received
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_udp_packet_dropped(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpPacketDropped,
+        ) {
+            self.acceptor_udp_packet_dropped
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_udp_stream_enqueued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpStreamEnqueued,
+        ) {
+            self.acceptor_udp_stream_enqueued
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_udp_io_error(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorUdpIoError,
+        ) {
+            self.acceptor_udp_io_error.fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_stream_pruned(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorStreamPruned,
+        ) {
+            self.acceptor_stream_pruned.fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_stream_dequeued(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorStreamDequeued,
+        ) {
+            self.acceptor_stream_dequeued
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
         }
         fn on_application_write(
             &self,
@@ -3505,6 +5971,24 @@ pub mod testing {
     pub struct Publisher {
         location: Option<Location>,
         output: Mutex<Vec<String>>,
+        pub acceptor_tcp_started: AtomicU32,
+        pub acceptor_tcp_loop_iteration_completed: AtomicU32,
+        pub acceptor_tcp_fresh_enqueued: AtomicU32,
+        pub acceptor_tcp_fresh_batch_completed: AtomicU32,
+        pub acceptor_tcp_stream_dropped: AtomicU32,
+        pub acceptor_tcp_stream_replaced: AtomicU32,
+        pub acceptor_tcp_packet_received: AtomicU32,
+        pub acceptor_tcp_packet_dropped: AtomicU32,
+        pub acceptor_tcp_stream_enqueued: AtomicU32,
+        pub acceptor_tcp_io_error: AtomicU32,
+        pub acceptor_udp_started: AtomicU32,
+        pub acceptor_udp_datagram_received: AtomicU32,
+        pub acceptor_udp_packet_received: AtomicU32,
+        pub acceptor_udp_packet_dropped: AtomicU32,
+        pub acceptor_udp_stream_enqueued: AtomicU32,
+        pub acceptor_udp_io_error: AtomicU32,
+        pub acceptor_stream_pruned: AtomicU32,
+        pub acceptor_stream_dequeued: AtomicU32,
         pub application_write: AtomicU32,
         pub application_read: AtomicU32,
         pub endpoint_initialized: AtomicU32,
@@ -3552,6 +6036,24 @@ pub mod testing {
             Self {
                 location: None,
                 output: Default::default(),
+                acceptor_tcp_started: AtomicU32::new(0),
+                acceptor_tcp_loop_iteration_completed: AtomicU32::new(0),
+                acceptor_tcp_fresh_enqueued: AtomicU32::new(0),
+                acceptor_tcp_fresh_batch_completed: AtomicU32::new(0),
+                acceptor_tcp_stream_dropped: AtomicU32::new(0),
+                acceptor_tcp_stream_replaced: AtomicU32::new(0),
+                acceptor_tcp_packet_received: AtomicU32::new(0),
+                acceptor_tcp_packet_dropped: AtomicU32::new(0),
+                acceptor_tcp_stream_enqueued: AtomicU32::new(0),
+                acceptor_tcp_io_error: AtomicU32::new(0),
+                acceptor_udp_started: AtomicU32::new(0),
+                acceptor_udp_datagram_received: AtomicU32::new(0),
+                acceptor_udp_packet_received: AtomicU32::new(0),
+                acceptor_udp_packet_dropped: AtomicU32::new(0),
+                acceptor_udp_stream_enqueued: AtomicU32::new(0),
+                acceptor_udp_io_error: AtomicU32::new(0),
+                acceptor_stream_pruned: AtomicU32::new(0),
+                acceptor_stream_dequeued: AtomicU32::new(0),
                 application_write: AtomicU32::new(0),
                 application_read: AtomicU32::new(0),
                 endpoint_initialized: AtomicU32::new(0),
@@ -3582,6 +6084,151 @@ pub mod testing {
         }
     }
     impl super::EndpointPublisher for Publisher {
+        fn on_acceptor_tcp_started(&self, event: builder::AcceptorTcpStarted) {
+            self.acceptor_tcp_started.fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_loop_iteration_completed(
+            &self,
+            event: builder::AcceptorTcpLoopIterationCompleted,
+        ) {
+            self.acceptor_tcp_loop_iteration_completed
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_fresh_enqueued(&self, event: builder::AcceptorTcpFreshEnqueued) {
+            self.acceptor_tcp_fresh_enqueued
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_fresh_batch_completed(
+            &self,
+            event: builder::AcceptorTcpFreshBatchCompleted,
+        ) {
+            self.acceptor_tcp_fresh_batch_completed
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_stream_dropped(&self, event: builder::AcceptorTcpStreamDropped) {
+            self.acceptor_tcp_stream_dropped
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_stream_replaced(&self, event: builder::AcceptorTcpStreamReplaced) {
+            self.acceptor_tcp_stream_replaced
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_packet_received(&self, event: builder::AcceptorTcpPacketReceived) {
+            self.acceptor_tcp_packet_received
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_packet_dropped(&self, event: builder::AcceptorTcpPacketDropped) {
+            self.acceptor_tcp_packet_dropped
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_stream_enqueued(&self, event: builder::AcceptorTcpStreamEnqueued) {
+            self.acceptor_tcp_stream_enqueued
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_io_error(&self, event: builder::AcceptorTcpIoError) {
+            self.acceptor_tcp_io_error.fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_udp_started(&self, event: builder::AcceptorUdpStarted) {
+            self.acceptor_udp_started.fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_udp_datagram_received(&self, event: builder::AcceptorUdpDatagramReceived) {
+            self.acceptor_udp_datagram_received
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_udp_packet_received(&self, event: builder::AcceptorUdpPacketReceived) {
+            self.acceptor_udp_packet_received
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_udp_packet_dropped(&self, event: builder::AcceptorUdpPacketDropped) {
+            self.acceptor_udp_packet_dropped
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_udp_stream_enqueued(&self, event: builder::AcceptorUdpStreamEnqueued) {
+            self.acceptor_udp_stream_enqueued
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_udp_io_error(&self, event: builder::AcceptorUdpIoError) {
+            self.acceptor_udp_io_error.fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_stream_pruned(&self, event: builder::AcceptorStreamPruned) {
+            self.acceptor_stream_pruned.fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_stream_dequeued(&self, event: builder::AcceptorStreamDequeued) {
+            self.acceptor_stream_dequeued
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
         fn on_endpoint_initialized(&self, event: builder::EndpointInitialized) {
             self.endpoint_initialized.fetch_add(1, Ordering::Relaxed);
             let event = event.into_event();

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -12,363 +12,609 @@ use crate::event::{
         AsVariant, BoolRecorder, Info, Metric, NominalRecorder, Recorder, Registry, Units,
     },
 };
-static INFO: &[Info; 60usize] = &[
+static INFO: &[Info; 101usize] = &[
     info::Builder {
         id: 0usize,
-        name: Str::new("application_write\0"),
+        name: Str::new("acceptor_tcp_started\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 1usize,
-        name: Str::new("application_write.provided\0"),
-        units: Units::Bytes,
-    }
-    .build(),
-    info::Builder {
-        id: 2usize,
-        name: Str::new("application_write.committed.total\0"),
-        units: Units::Bytes,
-    }
-    .build(),
-    info::Builder {
-        id: 3usize,
-        name: Str::new("application_write.committed\0"),
-        units: Units::Bytes,
-    }
-    .build(),
-    info::Builder {
-        id: 4usize,
-        name: Str::new("application_read\0"),
+        name: Str::new("acceptor_tcp_loop_iteration_completed\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
+        id: 2usize,
+        name: Str::new("acceptor_tcp_loop_iteration_completed.pending_streams\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 3usize,
+        name: Str::new("acceptor_tcp_loop_iteration_completed.processing_duration\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
+        id: 4usize,
+        name: Str::new("acceptor_tcp_loop_iteration_completed.max_sojourn_time\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
         id: 5usize,
-        name: Str::new("application_read.capacity\0"),
-        units: Units::Bytes,
+        name: Str::new("acceptor_tcp_fresh_enqueued\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 6usize,
-        name: Str::new("application_read.committed.total\0"),
-        units: Units::Bytes,
+        name: Str::new("acceptor_tcp_fresh_batch_completed\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 7usize,
-        name: Str::new("application_read.committed\0"),
-        units: Units::Bytes,
+        name: Str::new("acceptor_tcp_fresh_batch_completed.enqueued\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 8usize,
-        name: Str::new("endpoint_initialized\0"),
+        name: Str::new("acceptor_tcp_fresh_batch_completed.dropped\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 9usize,
-        name: Str::new("endpoint_initialized.acceptor.protocol\0"),
+        name: Str::new("acceptor_tcp_fresh_batch_completed.errored\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 10usize,
-        name: Str::new("endpoint_initialized.handshake.protocol\0"),
+        name: Str::new("acceptor_tcp_stream_dropped\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 11usize,
-        name: Str::new("endpoint_initialized.tcp\0"),
+        name: Str::new("acceptor_tcp_stream_dropped.reason\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 12usize,
-        name: Str::new("endpoint_initialized.udp\0"),
+        name: Str::new("acceptor_tcp_stream_replaced\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 13usize,
-        name: Str::new("path_secret_map_initialized\0"),
-        units: Units::None,
+        name: Str::new("acceptor_tcp_stream_replaced.sojourn_time\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 14usize,
-        name: Str::new("path_secret_map_initialized.capacity\0"),
-        units: Units::None,
+        name: Str::new("acceptor_tcp_stream_replaced.buffer_len\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 15usize,
-        name: Str::new("path_secret_map_uninitialized\0"),
+        name: Str::new("acceptor_tcp_packet_received\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 16usize,
-        name: Str::new("path_secret_map_uninitialized.capacity\0"),
-        units: Units::None,
+        name: Str::new("acceptor_tcp_packet_received.payload_len\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 17usize,
-        name: Str::new("path_secret_map_uninitialized.entries\0"),
+        name: Str::new("acceptor_tcp_packet_received.is_fin\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 18usize,
-        name: Str::new("path_secret_map_uninitialized.lifetime\0"),
+        name: Str::new("acceptor_tcp_packet_received.sojourn_time\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 19usize,
-        name: Str::new("path_secret_map_background_handshake_requested\0"),
+        name: Str::new("acceptor_tcp_packet_dropped\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 20usize,
-        name: Str::new("path_secret_map_background_handshake_requested.peer_address.protocol\0"),
-        units: Units::None,
+        name: Str::new("acceptor_tcp_packet_dropped.sojourn_time\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 21usize,
-        name: Str::new("path_secret_map_entry_inserted\0"),
+        name: Str::new("acceptor_tcp_stream_enqueued\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 22usize,
-        name: Str::new("path_secret_map_entry_inserted.peer_address.protocol\0"),
-        units: Units::None,
+        name: Str::new("acceptor_tcp_stream_enqueued.sojourn_time\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 23usize,
-        name: Str::new("path_secret_map_entry_ready\0"),
+        name: Str::new("acceptor_tcp_stream_enqueued.blocked_count\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 24usize,
-        name: Str::new("path_secret_map_entry_ready.peer_address.protocol\0"),
+        name: Str::new("acceptor_tcp_io_error\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 25usize,
-        name: Str::new("path_secret_map_entry_replaced\0"),
+        name: Str::new("acceptor_udp_started\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 26usize,
-        name: Str::new("path_secret_map_entry_replaced.peer_address.protocol\0"),
+        name: Str::new("acceptor_udp_datagram_received\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 27usize,
-        name: Str::new("unknown_path_secret_packet_sent\0"),
-        units: Units::None,
+        name: Str::new("acceptor_udp_datagram_received.len\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 28usize,
-        name: Str::new("unknown_path_secret_packet_sent.peer_address.protocol\0"),
+        name: Str::new("acceptor_udp_packet_received\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 29usize,
-        name: Str::new("unknown_path_secret_packet_received\0"),
-        units: Units::None,
+        name: Str::new("acceptor_udp_packet_received.payload_len\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 30usize,
-        name: Str::new("unknown_path_secret_packet_received.peer_address.protocol\0"),
+        name: Str::new("acceptor_udp_packet_received.is_zero_offset\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 31usize,
-        name: Str::new("unknown_path_secret_packet_accepted\0"),
+        name: Str::new("acceptor_udp_packet_received.is_retransmisson\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 32usize,
-        name: Str::new("unknown_path_secret_packet_accepted.peer_address.protocol\0"),
+        name: Str::new("acceptor_udp_packet_received.is_fin\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 33usize,
-        name: Str::new("unknown_path_secret_packet_rejected\0"),
+        name: Str::new("acceptor_udp_packet_dropped\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 34usize,
-        name: Str::new("unknown_path_secret_packet_rejected.peer_address.protocol\0"),
+        name: Str::new("acceptor_udp_stream_enqueued\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 35usize,
-        name: Str::new("unknown_path_secret_packet_dropped\0"),
+        name: Str::new("acceptor_udp_io_error\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 36usize,
-        name: Str::new("unknown_path_secret_packet_dropped.peer_address.protocol\0"),
+        name: Str::new("acceptor_stream_pruned\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 37usize,
-        name: Str::new("replay_definitely_detected\0"),
-        units: Units::None,
+        name: Str::new("acceptor_stream_pruned.sojourn_time\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 38usize,
-        name: Str::new("replay_potentially_detected\0"),
+        name: Str::new("acceptor_stream_pruned.reason\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 39usize,
-        name: Str::new("replay_potentially_detected.gap\0"),
+        name: Str::new("acceptor_stream_dequeued\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 40usize,
-        name: Str::new("replay_detected_packet_sent\0"),
-        units: Units::None,
+        name: Str::new("acceptor_stream_dequeued.sojourn_time\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 41usize,
-        name: Str::new("replay_detected_packet_sent.peer_address.protocol\0"),
+        name: Str::new("application_write\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 42usize,
-        name: Str::new("replay_detected_packet_received\0"),
-        units: Units::None,
+        name: Str::new("application_write.provided\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 43usize,
-        name: Str::new("replay_detected_packet_received.peer_address.protocol\0"),
-        units: Units::None,
+        name: Str::new("application_write.committed.total\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 44usize,
-        name: Str::new("replay_detected_packet_accepted\0"),
-        units: Units::None,
+        name: Str::new("application_write.committed\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 45usize,
-        name: Str::new("replay_detected_packet_accepted.peer_address.protocol\0"),
+        name: Str::new("application_read\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 46usize,
-        name: Str::new("replay_detected_packet_rejected\0"),
-        units: Units::None,
+        name: Str::new("application_read.capacity\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 47usize,
-        name: Str::new("replay_detected_packet_rejected.peer_address.protocol\0"),
-        units: Units::None,
+        name: Str::new("application_read.committed.total\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 48usize,
-        name: Str::new("replay_detected_packet_dropped\0"),
-        units: Units::None,
+        name: Str::new("application_read.committed\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 49usize,
-        name: Str::new("replay_detected_packet_dropped.peer_address.protocol\0"),
+        name: Str::new("endpoint_initialized\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 50usize,
-        name: Str::new("stale_key_packet_sent\0"),
+        name: Str::new("endpoint_initialized.acceptor.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 51usize,
-        name: Str::new("stale_key_packet_sent.peer_address.protocol\0"),
+        name: Str::new("endpoint_initialized.handshake.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 52usize,
-        name: Str::new("stale_key_packet_received\0"),
+        name: Str::new("endpoint_initialized.tcp\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 53usize,
-        name: Str::new("stale_key_packet_received.peer_address.protocol\0"),
+        name: Str::new("endpoint_initialized.udp\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 54usize,
-        name: Str::new("stale_key_packet_accepted\0"),
+        name: Str::new("path_secret_map_initialized\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 55usize,
-        name: Str::new("stale_key_packet_accepted.peer_address.protocol\0"),
+        name: Str::new("path_secret_map_initialized.capacity\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 56usize,
-        name: Str::new("stale_key_packet_rejected\0"),
+        name: Str::new("path_secret_map_uninitialized\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 57usize,
-        name: Str::new("stale_key_packet_rejected.peer_address.protocol\0"),
+        name: Str::new("path_secret_map_uninitialized.capacity\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 58usize,
-        name: Str::new("stale_key_packet_dropped\0"),
+        name: Str::new("path_secret_map_uninitialized.entries\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 59usize,
+        name: Str::new("path_secret_map_uninitialized.lifetime\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
+        id: 60usize,
+        name: Str::new("path_secret_map_background_handshake_requested\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 61usize,
+        name: Str::new("path_secret_map_background_handshake_requested.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 62usize,
+        name: Str::new("path_secret_map_entry_inserted\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 63usize,
+        name: Str::new("path_secret_map_entry_inserted.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 64usize,
+        name: Str::new("path_secret_map_entry_ready\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 65usize,
+        name: Str::new("path_secret_map_entry_ready.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 66usize,
+        name: Str::new("path_secret_map_entry_replaced\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 67usize,
+        name: Str::new("path_secret_map_entry_replaced.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 68usize,
+        name: Str::new("unknown_path_secret_packet_sent\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 69usize,
+        name: Str::new("unknown_path_secret_packet_sent.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 70usize,
+        name: Str::new("unknown_path_secret_packet_received\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 71usize,
+        name: Str::new("unknown_path_secret_packet_received.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 72usize,
+        name: Str::new("unknown_path_secret_packet_accepted\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 73usize,
+        name: Str::new("unknown_path_secret_packet_accepted.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 74usize,
+        name: Str::new("unknown_path_secret_packet_rejected\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 75usize,
+        name: Str::new("unknown_path_secret_packet_rejected.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 76usize,
+        name: Str::new("unknown_path_secret_packet_dropped\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 77usize,
+        name: Str::new("unknown_path_secret_packet_dropped.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 78usize,
+        name: Str::new("replay_definitely_detected\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 79usize,
+        name: Str::new("replay_potentially_detected\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 80usize,
+        name: Str::new("replay_potentially_detected.gap\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 81usize,
+        name: Str::new("replay_detected_packet_sent\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 82usize,
+        name: Str::new("replay_detected_packet_sent.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 83usize,
+        name: Str::new("replay_detected_packet_received\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 84usize,
+        name: Str::new("replay_detected_packet_received.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 85usize,
+        name: Str::new("replay_detected_packet_accepted\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 86usize,
+        name: Str::new("replay_detected_packet_accepted.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 87usize,
+        name: Str::new("replay_detected_packet_rejected\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 88usize,
+        name: Str::new("replay_detected_packet_rejected.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 89usize,
+        name: Str::new("replay_detected_packet_dropped\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 90usize,
+        name: Str::new("replay_detected_packet_dropped.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 91usize,
+        name: Str::new("stale_key_packet_sent\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 92usize,
+        name: Str::new("stale_key_packet_sent.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 93usize,
+        name: Str::new("stale_key_packet_received\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 94usize,
+        name: Str::new("stale_key_packet_received.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 95usize,
+        name: Str::new("stale_key_packet_accepted\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 96usize,
+        name: Str::new("stale_key_packet_accepted.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 97usize,
+        name: Str::new("stale_key_packet_rejected\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 98usize,
+        name: Str::new("stale_key_packet_rejected.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 99usize,
+        name: Str::new("stale_key_packet_dropped\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 100usize,
         name: Str::new("stale_key_packet_dropped.peer_address.protocol\0"),
         units: Units::None,
     }
@@ -381,19 +627,19 @@ pub struct ConnectionContext {
 }
 pub struct Subscriber<R: Registry> {
     #[allow(dead_code)]
-    counters: Box<[R::Counter; 28usize]>,
+    counters: Box<[R::Counter; 46usize]>,
     #[allow(dead_code)]
-    bool_counters: Box<[R::BoolCounter; 2usize]>,
+    bool_counters: Box<[R::BoolCounter; 6usize]>,
     #[allow(dead_code)]
     nominal_counters: Box<[R::NominalCounter]>,
     #[allow(dead_code)]
-    nominal_counter_offsets: Box<[usize; 21usize]>,
+    nominal_counter_offsets: Box<[usize; 23usize]>,
     #[allow(dead_code)]
-    measures: Box<[R::Measure; 9usize]>,
+    measures: Box<[R::Measure; 19usize]>,
     #[allow(dead_code)]
     gauges: Box<[R::Gauge; 0usize]>,
     #[allow(dead_code)]
-    timers: Box<[R::Timer; 0usize]>,
+    timers: Box<[R::Timer; 7usize]>,
     #[allow(dead_code)]
     nominal_timers: Box<[R::NominalTimer]>,
     #[allow(dead_code)]
@@ -416,54 +662,87 @@ impl<R: Registry> Subscriber<R> {
     #[allow(unused_mut)]
     #[inline]
     pub fn new(registry: R) -> Self {
-        let mut counters = Vec::with_capacity(28usize);
-        let mut bool_counters = Vec::with_capacity(2usize);
-        let mut nominal_counters = Vec::with_capacity(21usize);
-        let mut nominal_counter_offsets = Vec::with_capacity(21usize);
-        let mut measures = Vec::with_capacity(9usize);
+        let mut counters = Vec::with_capacity(46usize);
+        let mut bool_counters = Vec::with_capacity(6usize);
+        let mut nominal_counters = Vec::with_capacity(23usize);
+        let mut nominal_counter_offsets = Vec::with_capacity(23usize);
+        let mut measures = Vec::with_capacity(19usize);
         let mut gauges = Vec::with_capacity(0usize);
-        let mut timers = Vec::with_capacity(0usize);
+        let mut timers = Vec::with_capacity(7usize);
         let mut nominal_timers = Vec::with_capacity(0usize);
         let mut nominal_timer_offsets = Vec::with_capacity(0usize);
         counters.push(registry.register_counter(&INFO[0usize]));
-        counters.push(registry.register_counter(&INFO[2usize]));
-        counters.push(registry.register_counter(&INFO[4usize]));
+        counters.push(registry.register_counter(&INFO[1usize]));
+        counters.push(registry.register_counter(&INFO[5usize]));
         counters.push(registry.register_counter(&INFO[6usize]));
-        counters.push(registry.register_counter(&INFO[8usize]));
-        counters.push(registry.register_counter(&INFO[13usize]));
+        counters.push(registry.register_counter(&INFO[10usize]));
+        counters.push(registry.register_counter(&INFO[12usize]));
         counters.push(registry.register_counter(&INFO[15usize]));
         counters.push(registry.register_counter(&INFO[19usize]));
         counters.push(registry.register_counter(&INFO[21usize]));
-        counters.push(registry.register_counter(&INFO[23usize]));
+        counters.push(registry.register_counter(&INFO[24usize]));
         counters.push(registry.register_counter(&INFO[25usize]));
-        counters.push(registry.register_counter(&INFO[27usize]));
-        counters.push(registry.register_counter(&INFO[29usize]));
-        counters.push(registry.register_counter(&INFO[31usize]));
+        counters.push(registry.register_counter(&INFO[26usize]));
+        counters.push(registry.register_counter(&INFO[28usize]));
         counters.push(registry.register_counter(&INFO[33usize]));
+        counters.push(registry.register_counter(&INFO[34usize]));
         counters.push(registry.register_counter(&INFO[35usize]));
-        counters.push(registry.register_counter(&INFO[37usize]));
-        counters.push(registry.register_counter(&INFO[38usize]));
-        counters.push(registry.register_counter(&INFO[40usize]));
-        counters.push(registry.register_counter(&INFO[42usize]));
-        counters.push(registry.register_counter(&INFO[44usize]));
-        counters.push(registry.register_counter(&INFO[46usize]));
-        counters.push(registry.register_counter(&INFO[48usize]));
-        counters.push(registry.register_counter(&INFO[50usize]));
-        counters.push(registry.register_counter(&INFO[52usize]));
+        counters.push(registry.register_counter(&INFO[36usize]));
+        counters.push(registry.register_counter(&INFO[39usize]));
+        counters.push(registry.register_counter(&INFO[41usize]));
+        counters.push(registry.register_counter(&INFO[43usize]));
+        counters.push(registry.register_counter(&INFO[45usize]));
+        counters.push(registry.register_counter(&INFO[47usize]));
+        counters.push(registry.register_counter(&INFO[49usize]));
         counters.push(registry.register_counter(&INFO[54usize]));
         counters.push(registry.register_counter(&INFO[56usize]));
-        counters.push(registry.register_counter(&INFO[58usize]));
-        bool_counters.push(registry.register_bool_counter(&INFO[11usize]));
-        bool_counters.push(registry.register_bool_counter(&INFO[12usize]));
+        counters.push(registry.register_counter(&INFO[60usize]));
+        counters.push(registry.register_counter(&INFO[62usize]));
+        counters.push(registry.register_counter(&INFO[64usize]));
+        counters.push(registry.register_counter(&INFO[66usize]));
+        counters.push(registry.register_counter(&INFO[68usize]));
+        counters.push(registry.register_counter(&INFO[70usize]));
+        counters.push(registry.register_counter(&INFO[72usize]));
+        counters.push(registry.register_counter(&INFO[74usize]));
+        counters.push(registry.register_counter(&INFO[76usize]));
+        counters.push(registry.register_counter(&INFO[78usize]));
+        counters.push(registry.register_counter(&INFO[79usize]));
+        counters.push(registry.register_counter(&INFO[81usize]));
+        counters.push(registry.register_counter(&INFO[83usize]));
+        counters.push(registry.register_counter(&INFO[85usize]));
+        counters.push(registry.register_counter(&INFO[87usize]));
+        counters.push(registry.register_counter(&INFO[89usize]));
+        counters.push(registry.register_counter(&INFO[91usize]));
+        counters.push(registry.register_counter(&INFO[93usize]));
+        counters.push(registry.register_counter(&INFO[95usize]));
+        counters.push(registry.register_counter(&INFO[97usize]));
+        counters.push(registry.register_counter(&INFO[99usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[17usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[30usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[31usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[32usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[52usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[53usize]));
         {
             #[allow(unused_imports)]
             use api::*;
             {
                 let offset = nominal_counters.len();
                 let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                for variant in <AcceptorTcpStreamDropReason as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[9usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[11usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <AcceptorStreamPruneReason as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[38usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -474,161 +753,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[10usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[20usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[22usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[24usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[26usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[28usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[30usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[32usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[34usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[36usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[41usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[43usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[45usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[47usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[49usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[50usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -650,7 +775,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[53usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[61usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -661,7 +786,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[55usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[63usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -672,7 +797,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[57usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[65usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -683,22 +808,204 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[59usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[67usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[69usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[71usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[73usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[75usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[77usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[82usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[84usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[86usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[88usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[90usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[92usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[94usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[96usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[98usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[100usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
                 nominal_counter_offsets.push(offset);
             }
         }
-        measures.push(registry.register_measure(&INFO[1usize]));
-        measures.push(registry.register_measure(&INFO[3usize]));
-        measures.push(registry.register_measure(&INFO[5usize]));
+        measures.push(registry.register_measure(&INFO[2usize]));
+        measures.push(registry.register_measure(&INFO[4usize]));
         measures.push(registry.register_measure(&INFO[7usize]));
+        measures.push(registry.register_measure(&INFO[8usize]));
+        measures.push(registry.register_measure(&INFO[9usize]));
         measures.push(registry.register_measure(&INFO[14usize]));
         measures.push(registry.register_measure(&INFO[16usize]));
-        measures.push(registry.register_measure(&INFO[17usize]));
-        measures.push(registry.register_measure(&INFO[18usize]));
-        measures.push(registry.register_measure(&INFO[39usize]));
+        measures.push(registry.register_measure(&INFO[23usize]));
+        measures.push(registry.register_measure(&INFO[27usize]));
+        measures.push(registry.register_measure(&INFO[29usize]));
+        measures.push(registry.register_measure(&INFO[42usize]));
+        measures.push(registry.register_measure(&INFO[44usize]));
+        measures.push(registry.register_measure(&INFO[46usize]));
+        measures.push(registry.register_measure(&INFO[48usize]));
+        measures.push(registry.register_measure(&INFO[55usize]));
+        measures.push(registry.register_measure(&INFO[57usize]));
+        measures.push(registry.register_measure(&INFO[58usize]));
+        measures.push(registry.register_measure(&INFO[59usize]));
+        measures.push(registry.register_measure(&INFO[80usize]));
+        timers.push(registry.register_timer(&INFO[3usize]));
+        timers.push(registry.register_timer(&INFO[13usize]));
+        timers.push(registry.register_timer(&INFO[18usize]));
+        timers.push(registry.register_timer(&INFO[20usize]));
+        timers.push(registry.register_timer(&INFO[22usize]));
+        timers.push(registry.register_timer(&INFO[37usize]));
+        timers.push(registry.register_timer(&INFO[40usize]));
         {
             #[allow(unused_imports)]
             use api::*;
@@ -734,33 +1041,51 @@ impl<R: Registry> Subscriber<R> {
             .enumerate()
             .map(|(idx, entry)| match idx {
                 0usize => (&INFO[0usize], entry),
-                1usize => (&INFO[2usize], entry),
-                2usize => (&INFO[4usize], entry),
+                1usize => (&INFO[1usize], entry),
+                2usize => (&INFO[5usize], entry),
                 3usize => (&INFO[6usize], entry),
-                4usize => (&INFO[8usize], entry),
-                5usize => (&INFO[13usize], entry),
+                4usize => (&INFO[10usize], entry),
+                5usize => (&INFO[12usize], entry),
                 6usize => (&INFO[15usize], entry),
                 7usize => (&INFO[19usize], entry),
                 8usize => (&INFO[21usize], entry),
-                9usize => (&INFO[23usize], entry),
+                9usize => (&INFO[24usize], entry),
                 10usize => (&INFO[25usize], entry),
-                11usize => (&INFO[27usize], entry),
-                12usize => (&INFO[29usize], entry),
-                13usize => (&INFO[31usize], entry),
-                14usize => (&INFO[33usize], entry),
+                11usize => (&INFO[26usize], entry),
+                12usize => (&INFO[28usize], entry),
+                13usize => (&INFO[33usize], entry),
+                14usize => (&INFO[34usize], entry),
                 15usize => (&INFO[35usize], entry),
-                16usize => (&INFO[37usize], entry),
-                17usize => (&INFO[38usize], entry),
-                18usize => (&INFO[40usize], entry),
-                19usize => (&INFO[42usize], entry),
-                20usize => (&INFO[44usize], entry),
-                21usize => (&INFO[46usize], entry),
-                22usize => (&INFO[48usize], entry),
-                23usize => (&INFO[50usize], entry),
-                24usize => (&INFO[52usize], entry),
-                25usize => (&INFO[54usize], entry),
-                26usize => (&INFO[56usize], entry),
-                27usize => (&INFO[58usize], entry),
+                16usize => (&INFO[36usize], entry),
+                17usize => (&INFO[39usize], entry),
+                18usize => (&INFO[41usize], entry),
+                19usize => (&INFO[43usize], entry),
+                20usize => (&INFO[45usize], entry),
+                21usize => (&INFO[47usize], entry),
+                22usize => (&INFO[49usize], entry),
+                23usize => (&INFO[54usize], entry),
+                24usize => (&INFO[56usize], entry),
+                25usize => (&INFO[60usize], entry),
+                26usize => (&INFO[62usize], entry),
+                27usize => (&INFO[64usize], entry),
+                28usize => (&INFO[66usize], entry),
+                29usize => (&INFO[68usize], entry),
+                30usize => (&INFO[70usize], entry),
+                31usize => (&INFO[72usize], entry),
+                32usize => (&INFO[74usize], entry),
+                33usize => (&INFO[76usize], entry),
+                34usize => (&INFO[78usize], entry),
+                35usize => (&INFO[79usize], entry),
+                36usize => (&INFO[81usize], entry),
+                37usize => (&INFO[83usize], entry),
+                38usize => (&INFO[85usize], entry),
+                39usize => (&INFO[87usize], entry),
+                40usize => (&INFO[89usize], entry),
+                41usize => (&INFO[91usize], entry),
+                42usize => (&INFO[93usize], entry),
+                43usize => (&INFO[95usize], entry),
+                44usize => (&INFO[97usize], entry),
+                45usize => (&INFO[99usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -778,8 +1103,12 @@ impl<R: Registry> Subscriber<R> {
             .iter()
             .enumerate()
             .map(|(idx, entry)| match idx {
-                0usize => (&INFO[11usize], entry),
-                1usize => (&INFO[12usize], entry),
+                0usize => (&INFO[17usize], entry),
+                1usize => (&INFO[30usize], entry),
+                2usize => (&INFO[31usize], entry),
+                3usize => (&INFO[32usize], entry),
+                4usize => (&INFO[52usize], entry),
+                5usize => (&INFO[53usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -802,129 +1131,141 @@ impl<R: Registry> Subscriber<R> {
             .map(|(idx, entry)| match idx {
                 0usize => {
                     let offset = *entry;
-                    let variants = <SocketAddress as AsVariant>::VARIANTS;
+                    let variants = <AcceptorTcpStreamDropReason as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[9usize], entries, variants)
+                    (&INFO[11usize], entries, variants)
                 }
                 1usize => {
                     let offset = *entry;
-                    let variants = <SocketAddress as AsVariant>::VARIANTS;
+                    let variants = <AcceptorStreamPruneReason as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[10usize], entries, variants)
+                    (&INFO[38usize], entries, variants)
                 }
                 2usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[20usize], entries, variants)
+                    (&INFO[50usize], entries, variants)
                 }
                 3usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[22usize], entries, variants)
+                    (&INFO[51usize], entries, variants)
                 }
                 4usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[24usize], entries, variants)
+                    (&INFO[61usize], entries, variants)
                 }
                 5usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[26usize], entries, variants)
+                    (&INFO[63usize], entries, variants)
                 }
                 6usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[28usize], entries, variants)
+                    (&INFO[65usize], entries, variants)
                 }
                 7usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[30usize], entries, variants)
+                    (&INFO[67usize], entries, variants)
                 }
                 8usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[32usize], entries, variants)
+                    (&INFO[69usize], entries, variants)
                 }
                 9usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[34usize], entries, variants)
+                    (&INFO[71usize], entries, variants)
                 }
                 10usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[36usize], entries, variants)
+                    (&INFO[73usize], entries, variants)
                 }
                 11usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[41usize], entries, variants)
+                    (&INFO[75usize], entries, variants)
                 }
                 12usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[43usize], entries, variants)
+                    (&INFO[77usize], entries, variants)
                 }
                 13usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[45usize], entries, variants)
+                    (&INFO[82usize], entries, variants)
                 }
                 14usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[47usize], entries, variants)
+                    (&INFO[84usize], entries, variants)
                 }
                 15usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[49usize], entries, variants)
+                    (&INFO[86usize], entries, variants)
                 }
                 16usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[51usize], entries, variants)
+                    (&INFO[88usize], entries, variants)
                 }
                 17usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[53usize], entries, variants)
+                    (&INFO[90usize], entries, variants)
                 }
                 18usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[55usize], entries, variants)
+                    (&INFO[92usize], entries, variants)
                 }
                 19usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[57usize], entries, variants)
+                    (&INFO[94usize], entries, variants)
                 }
                 20usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[59usize], entries, variants)
+                    (&INFO[96usize], entries, variants)
+                }
+                21usize => {
+                    let offset = *entry;
+                    let variants = <SocketAddress as AsVariant>::VARIANTS;
+                    let entries = &self.nominal_counters[offset..offset + variants.len()];
+                    (&INFO[98usize], entries, variants)
+                }
+                22usize => {
+                    let offset = *entry;
+                    let variants = <SocketAddress as AsVariant>::VARIANTS;
+                    let entries = &self.nominal_counters[offset..offset + variants.len()];
+                    (&INFO[100usize], entries, variants)
                 }
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
@@ -944,15 +1285,25 @@ impl<R: Registry> Subscriber<R> {
             .iter()
             .enumerate()
             .map(|(idx, entry)| match idx {
-                0usize => (&INFO[1usize], entry),
-                1usize => (&INFO[3usize], entry),
-                2usize => (&INFO[5usize], entry),
-                3usize => (&INFO[7usize], entry),
-                4usize => (&INFO[14usize], entry),
-                5usize => (&INFO[16usize], entry),
-                6usize => (&INFO[17usize], entry),
-                7usize => (&INFO[18usize], entry),
-                8usize => (&INFO[39usize], entry),
+                0usize => (&INFO[2usize], entry),
+                1usize => (&INFO[4usize], entry),
+                2usize => (&INFO[7usize], entry),
+                3usize => (&INFO[8usize], entry),
+                4usize => (&INFO[9usize], entry),
+                5usize => (&INFO[14usize], entry),
+                6usize => (&INFO[16usize], entry),
+                7usize => (&INFO[23usize], entry),
+                8usize => (&INFO[27usize], entry),
+                9usize => (&INFO[29usize], entry),
+                10usize => (&INFO[42usize], entry),
+                11usize => (&INFO[44usize], entry),
+                12usize => (&INFO[46usize], entry),
+                13usize => (&INFO[48usize], entry),
+                14usize => (&INFO[55usize], entry),
+                15usize => (&INFO[57usize], entry),
+                16usize => (&INFO[58usize], entry),
+                17usize => (&INFO[59usize], entry),
+                18usize => (&INFO[80usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -978,7 +1329,19 @@ impl<R: Registry> Subscriber<R> {
     #[doc = r" Returns all of the registered timers"]
     #[inline]
     pub fn timers(&self) -> impl Iterator<Item = (&'static Info, &R::Timer)> + '_ {
-        core::iter::empty()
+        self.timers
+            .iter()
+            .enumerate()
+            .map(|(idx, entry)| match idx {
+                0usize => (&INFO[3usize], entry),
+                1usize => (&INFO[13usize], entry),
+                2usize => (&INFO[18usize], entry),
+                3usize => (&INFO[20usize], entry),
+                4usize => (&INFO[22usize], entry),
+                5usize => (&INFO[37usize], entry),
+                6usize => (&INFO[40usize], entry),
+                _ => unsafe { core::hint::unreachable_unchecked() },
+            })
     }
     #[allow(dead_code)]
     #[inline(always)]
@@ -1014,6 +1377,229 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
         }
     }
     #[inline]
+    fn on_acceptor_tcp_started(&self, meta: &api::EndpointMeta, event: &api::AcceptorTcpStarted) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(0usize, 0usize, 1usize);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_tcp_loop_iteration_completed(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::AcceptorTcpLoopIterationCompleted,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(1usize, 1usize, 1usize);
+        self.measure(2usize, 0usize, event.pending_streams);
+        self.time(3usize, 0usize, event.processing_duration);
+        self.measure(4usize, 1usize, event.max_sojourn_time);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_tcp_fresh_enqueued(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::AcceptorTcpFreshEnqueued,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(5usize, 2usize, 1usize);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_tcp_fresh_batch_completed(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::AcceptorTcpFreshBatchCompleted,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(6usize, 3usize, 1usize);
+        self.measure(7usize, 2usize, event.enqueued);
+        self.measure(8usize, 3usize, event.dropped);
+        self.measure(9usize, 4usize, event.errored);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_tcp_stream_dropped(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::AcceptorTcpStreamDropped,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(10usize, 4usize, 1usize);
+        self.count_nominal(11usize, 0usize, &event.reason);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_tcp_stream_replaced(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::AcceptorTcpStreamReplaced,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(12usize, 5usize, 1usize);
+        self.time(13usize, 1usize, event.sojourn_time);
+        self.measure(14usize, 5usize, event.buffer_len);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_tcp_packet_received(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::AcceptorTcpPacketReceived,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(15usize, 6usize, 1usize);
+        self.measure(16usize, 6usize, event.payload_len);
+        self.count_bool(17usize, 0usize, event.is_fin);
+        self.time(18usize, 2usize, event.sojourn_time);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_tcp_packet_dropped(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::AcceptorTcpPacketDropped,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(19usize, 7usize, 1usize);
+        self.time(20usize, 3usize, event.sojourn_time);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_tcp_stream_enqueued(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::AcceptorTcpStreamEnqueued,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(21usize, 8usize, 1usize);
+        self.time(22usize, 4usize, event.sojourn_time);
+        self.measure(23usize, 7usize, event.blocked_count);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_tcp_io_error(&self, meta: &api::EndpointMeta, event: &api::AcceptorTcpIoError) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(24usize, 9usize, 1usize);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_udp_started(&self, meta: &api::EndpointMeta, event: &api::AcceptorUdpStarted) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(25usize, 10usize, 1usize);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_udp_datagram_received(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::AcceptorUdpDatagramReceived,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(26usize, 11usize, 1usize);
+        self.measure(27usize, 8usize, event.len);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_udp_packet_received(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::AcceptorUdpPacketReceived,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(28usize, 12usize, 1usize);
+        self.measure(29usize, 9usize, event.payload_len);
+        self.count_bool(30usize, 1usize, event.is_zero_offset);
+        self.count_bool(31usize, 2usize, event.is_retransmission);
+        self.count_bool(32usize, 3usize, event.is_fin);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_udp_packet_dropped(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::AcceptorUdpPacketDropped,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(33usize, 13usize, 1usize);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_udp_stream_enqueued(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::AcceptorUdpStreamEnqueued,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(34usize, 14usize, 1usize);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_udp_io_error(&self, meta: &api::EndpointMeta, event: &api::AcceptorUdpIoError) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(35usize, 15usize, 1usize);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_stream_pruned(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::AcceptorStreamPruned,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(36usize, 16usize, 1usize);
+        self.time(37usize, 5usize, event.sojourn_time);
+        self.count_nominal(38usize, 1usize, &event.reason);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_stream_dequeued(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::AcceptorStreamDequeued,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(39usize, 17usize, 1usize);
+        self.time(40usize, 6usize, event.sojourn_time);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
     fn on_application_write(
         &self,
         context: &Self::ConnectionContext,
@@ -1022,10 +1608,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(0usize, 0usize, 1usize);
-        self.measure(1usize, 0usize, event.total_len);
-        self.count(2usize, 1usize, event.write_len);
-        self.measure(3usize, 1usize, event.write_len);
+        self.count(41usize, 18usize, 1usize);
+        self.measure(42usize, 10usize, event.total_len);
+        self.count(43usize, 19usize, event.write_len);
+        self.measure(44usize, 11usize, event.write_len);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -1039,10 +1625,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(4usize, 2usize, 1usize);
-        self.measure(5usize, 2usize, event.capacity);
-        self.count(6usize, 3usize, event.read_len);
-        self.measure(7usize, 3usize, event.read_len);
+        self.count(45usize, 20usize, 1usize);
+        self.measure(46usize, 12usize, event.capacity);
+        self.count(47usize, 21usize, event.read_len);
+        self.measure(48usize, 13usize, event.read_len);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -1051,11 +1637,11 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     fn on_endpoint_initialized(&self, meta: &api::EndpointMeta, event: &api::EndpointInitialized) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(8usize, 4usize, 1usize);
-        self.count_nominal(9usize, 0usize, &event.acceptor_addr);
-        self.count_nominal(10usize, 1usize, &event.handshake_addr);
-        self.count_bool(11usize, 0usize, event.tcp);
-        self.count_bool(12usize, 1usize, event.udp);
+        self.count(49usize, 22usize, 1usize);
+        self.count_nominal(50usize, 2usize, &event.acceptor_addr);
+        self.count_nominal(51usize, 3usize, &event.handshake_addr);
+        self.count_bool(52usize, 4usize, event.tcp);
+        self.count_bool(53usize, 5usize, event.udp);
         let _ = event;
         let _ = meta;
     }
@@ -1067,8 +1653,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(13usize, 5usize, 1usize);
-        self.measure(14usize, 4usize, event.capacity);
+        self.count(54usize, 23usize, 1usize);
+        self.measure(55usize, 14usize, event.capacity);
         let _ = event;
         let _ = meta;
     }
@@ -1080,10 +1666,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(15usize, 6usize, 1usize);
-        self.measure(16usize, 5usize, event.capacity);
-        self.measure(17usize, 6usize, event.entries);
-        self.measure(18usize, 7usize, event.lifetime);
+        self.count(56usize, 24usize, 1usize);
+        self.measure(57usize, 15usize, event.capacity);
+        self.measure(58usize, 16usize, event.entries);
+        self.measure(59usize, 17usize, event.lifetime);
         let _ = event;
         let _ = meta;
     }
@@ -1095,8 +1681,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(19usize, 7usize, 1usize);
-        self.count_nominal(20usize, 2usize, &event.peer_address);
+        self.count(60usize, 25usize, 1usize);
+        self.count_nominal(61usize, 4usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1108,8 +1694,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(21usize, 8usize, 1usize);
-        self.count_nominal(22usize, 3usize, &event.peer_address);
+        self.count(62usize, 26usize, 1usize);
+        self.count_nominal(63usize, 5usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1121,8 +1707,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(23usize, 9usize, 1usize);
-        self.count_nominal(24usize, 4usize, &event.peer_address);
+        self.count(64usize, 27usize, 1usize);
+        self.count_nominal(65usize, 6usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1134,8 +1720,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(25usize, 10usize, 1usize);
-        self.count_nominal(26usize, 5usize, &event.peer_address);
+        self.count(66usize, 28usize, 1usize);
+        self.count_nominal(67usize, 7usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1147,8 +1733,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(27usize, 11usize, 1usize);
-        self.count_nominal(28usize, 6usize, &event.peer_address);
+        self.count(68usize, 29usize, 1usize);
+        self.count_nominal(69usize, 8usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1160,8 +1746,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(29usize, 12usize, 1usize);
-        self.count_nominal(30usize, 7usize, &event.peer_address);
+        self.count(70usize, 30usize, 1usize);
+        self.count_nominal(71usize, 9usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1173,8 +1759,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(31usize, 13usize, 1usize);
-        self.count_nominal(32usize, 8usize, &event.peer_address);
+        self.count(72usize, 31usize, 1usize);
+        self.count_nominal(73usize, 10usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1186,8 +1772,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(33usize, 14usize, 1usize);
-        self.count_nominal(34usize, 9usize, &event.peer_address);
+        self.count(74usize, 32usize, 1usize);
+        self.count_nominal(75usize, 11usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1199,8 +1785,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(35usize, 15usize, 1usize);
-        self.count_nominal(36usize, 10usize, &event.peer_address);
+        self.count(76usize, 33usize, 1usize);
+        self.count_nominal(77usize, 12usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1212,7 +1798,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(37usize, 16usize, 1usize);
+        self.count(78usize, 34usize, 1usize);
         let _ = event;
         let _ = meta;
     }
@@ -1224,8 +1810,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(38usize, 17usize, 1usize);
-        self.measure(39usize, 8usize, event.gap);
+        self.count(79usize, 35usize, 1usize);
+        self.measure(80usize, 18usize, event.gap);
         let _ = event;
         let _ = meta;
     }
@@ -1237,8 +1823,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(40usize, 18usize, 1usize);
-        self.count_nominal(41usize, 11usize, &event.peer_address);
+        self.count(81usize, 36usize, 1usize);
+        self.count_nominal(82usize, 13usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1250,8 +1836,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(42usize, 19usize, 1usize);
-        self.count_nominal(43usize, 12usize, &event.peer_address);
+        self.count(83usize, 37usize, 1usize);
+        self.count_nominal(84usize, 14usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1263,8 +1849,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(44usize, 20usize, 1usize);
-        self.count_nominal(45usize, 13usize, &event.peer_address);
+        self.count(85usize, 38usize, 1usize);
+        self.count_nominal(86usize, 15usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1276,8 +1862,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(46usize, 21usize, 1usize);
-        self.count_nominal(47usize, 14usize, &event.peer_address);
+        self.count(87usize, 39usize, 1usize);
+        self.count_nominal(88usize, 16usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1289,8 +1875,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(48usize, 22usize, 1usize);
-        self.count_nominal(49usize, 15usize, &event.peer_address);
+        self.count(89usize, 40usize, 1usize);
+        self.count_nominal(90usize, 17usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1298,8 +1884,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     fn on_stale_key_packet_sent(&self, meta: &api::EndpointMeta, event: &api::StaleKeyPacketSent) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(50usize, 23usize, 1usize);
-        self.count_nominal(51usize, 16usize, &event.peer_address);
+        self.count(91usize, 41usize, 1usize);
+        self.count_nominal(92usize, 18usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1311,8 +1897,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(52usize, 24usize, 1usize);
-        self.count_nominal(53usize, 17usize, &event.peer_address);
+        self.count(93usize, 42usize, 1usize);
+        self.count_nominal(94usize, 19usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1324,8 +1910,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(54usize, 25usize, 1usize);
-        self.count_nominal(55usize, 18usize, &event.peer_address);
+        self.count(95usize, 43usize, 1usize);
+        self.count_nominal(96usize, 20usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1337,8 +1923,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(56usize, 26usize, 1usize);
-        self.count_nominal(57usize, 19usize, &event.peer_address);
+        self.count(97usize, 44usize, 1usize);
+        self.count_nominal(98usize, 21usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1350,8 +1936,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(58usize, 27usize, 1usize);
-        self.count_nominal(59usize, 20usize, &event.peer_address);
+        self.count(99usize, 45usize, 1usize);
+        self.count_nominal(100usize, 22usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -12,7 +12,7 @@ use crate::event::{
         AsVariant, BoolRecorder, Info, Metric, NominalRecorder, Recorder, Registry, Units,
     },
 };
-static INFO: &[Info; 101usize] = &[
+static INFO: &[Info; 107usize] = &[
     info::Builder {
         id: 0usize,
         name: Str::new("acceptor_tcp_started\0"),
@@ -33,588 +33,624 @@ static INFO: &[Info; 101usize] = &[
     .build(),
     info::Builder {
         id: 3usize,
+        name: Str::new("acceptor_tcp_loop_iteration_completed.slots_idle\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 4usize,
+        name: Str::new("acceptor_tcp_loop_iteration_completed.slot_utilization\0"),
+        units: Units::Percent,
+    }
+    .build(),
+    info::Builder {
+        id: 5usize,
         name: Str::new("acceptor_tcp_loop_iteration_completed.processing_duration\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 4usize,
+        id: 6usize,
         name: Str::new("acceptor_tcp_loop_iteration_completed.max_sojourn_time\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 5usize,
+        id: 7usize,
         name: Str::new("acceptor_tcp_fresh_enqueued\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 6usize,
+        id: 8usize,
         name: Str::new("acceptor_tcp_fresh_batch_completed\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 7usize,
+        id: 9usize,
         name: Str::new("acceptor_tcp_fresh_batch_completed.enqueued\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 8usize,
+        id: 10usize,
         name: Str::new("acceptor_tcp_fresh_batch_completed.dropped\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 9usize,
+        id: 11usize,
         name: Str::new("acceptor_tcp_fresh_batch_completed.errored\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 10usize,
+        id: 12usize,
         name: Str::new("acceptor_tcp_stream_dropped\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 11usize,
+        id: 13usize,
         name: Str::new("acceptor_tcp_stream_dropped.reason\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 12usize,
+        id: 14usize,
         name: Str::new("acceptor_tcp_stream_replaced\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 13usize,
+        id: 15usize,
         name: Str::new("acceptor_tcp_stream_replaced.sojourn_time\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 14usize,
+        id: 16usize,
         name: Str::new("acceptor_tcp_stream_replaced.buffer_len\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 15usize,
+        id: 17usize,
         name: Str::new("acceptor_tcp_packet_received\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 16usize,
+        id: 18usize,
         name: Str::new("acceptor_tcp_packet_received.payload_len\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 17usize,
+        id: 19usize,
         name: Str::new("acceptor_tcp_packet_received.is_fin\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 18usize,
+        id: 20usize,
+        name: Str::new("acceptor_tcp_packet_received.is_fin_known\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 21usize,
         name: Str::new("acceptor_tcp_packet_received.sojourn_time\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 19usize,
+        id: 22usize,
         name: Str::new("acceptor_tcp_packet_dropped\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 20usize,
-        name: Str::new("acceptor_tcp_packet_dropped.sojourn_time\0"),
-        units: Units::Duration,
-    }
-    .build(),
-    info::Builder {
-        id: 21usize,
-        name: Str::new("acceptor_tcp_stream_enqueued\0"),
-        units: Units::None,
-    }
-    .build(),
-    info::Builder {
-        id: 22usize,
-        name: Str::new("acceptor_tcp_stream_enqueued.sojourn_time\0"),
-        units: Units::Duration,
-    }
-    .build(),
-    info::Builder {
         id: 23usize,
-        name: Str::new("acceptor_tcp_stream_enqueued.blocked_count\0"),
+        name: Str::new("acceptor_tcp_packet_dropped.reason\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 24usize,
-        name: Str::new("acceptor_tcp_io_error\0"),
-        units: Units::None,
+        name: Str::new("acceptor_tcp_packet_dropped.sojourn_time\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 25usize,
-        name: Str::new("acceptor_udp_started\0"),
+        name: Str::new("acceptor_tcp_stream_enqueued\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 26usize,
-        name: Str::new("acceptor_udp_datagram_received\0"),
-        units: Units::None,
+        name: Str::new("acceptor_tcp_stream_enqueued.sojourn_time\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 27usize,
-        name: Str::new("acceptor_udp_datagram_received.len\0"),
-        units: Units::Bytes,
+        name: Str::new("acceptor_tcp_stream_enqueued.blocked_count\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 28usize,
-        name: Str::new("acceptor_udp_packet_received\0"),
+        name: Str::new("acceptor_tcp_io_error\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 29usize,
-        name: Str::new("acceptor_udp_packet_received.payload_len\0"),
-        units: Units::Bytes,
+        name: Str::new("acceptor_udp_started\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 30usize,
-        name: Str::new("acceptor_udp_packet_received.is_zero_offset\0"),
+        name: Str::new("acceptor_udp_datagram_received\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 31usize,
-        name: Str::new("acceptor_udp_packet_received.is_retransmisson\0"),
-        units: Units::None,
+        name: Str::new("acceptor_udp_datagram_received.len\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 32usize,
-        name: Str::new("acceptor_udp_packet_received.is_fin\0"),
+        name: Str::new("acceptor_udp_packet_received\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 33usize,
-        name: Str::new("acceptor_udp_packet_dropped\0"),
-        units: Units::None,
+        name: Str::new("acceptor_udp_packet_received.payload_len\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 34usize,
-        name: Str::new("acceptor_udp_stream_enqueued\0"),
+        name: Str::new("acceptor_udp_packet_received.is_zero_offset\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 35usize,
-        name: Str::new("acceptor_udp_io_error\0"),
+        name: Str::new("acceptor_udp_packet_received.is_retransmisson\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 36usize,
-        name: Str::new("acceptor_stream_pruned\0"),
+        name: Str::new("acceptor_udp_packet_received.is_fin\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 37usize,
-        name: Str::new("acceptor_stream_pruned.sojourn_time\0"),
-        units: Units::Duration,
+        name: Str::new("acceptor_udp_packet_received.is_fin_known\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 38usize,
-        name: Str::new("acceptor_stream_pruned.reason\0"),
+        name: Str::new("acceptor_udp_packet_dropped\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 39usize,
-        name: Str::new("acceptor_stream_dequeued\0"),
+        name: Str::new("acceptor_udp_packet_dropped.reason\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 40usize,
-        name: Str::new("acceptor_stream_dequeued.sojourn_time\0"),
-        units: Units::Duration,
+        name: Str::new("acceptor_udp_stream_enqueued\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 41usize,
-        name: Str::new("application_write\0"),
+        name: Str::new("acceptor_udp_io_error\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 42usize,
-        name: Str::new("application_write.provided\0"),
-        units: Units::Bytes,
+        name: Str::new("acceptor_stream_pruned\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 43usize,
-        name: Str::new("application_write.committed.total\0"),
-        units: Units::Bytes,
+        name: Str::new("acceptor_stream_pruned.sojourn_time\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 44usize,
-        name: Str::new("application_write.committed\0"),
-        units: Units::Bytes,
+        name: Str::new("acceptor_stream_pruned.reason\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 45usize,
-        name: Str::new("application_read\0"),
+        name: Str::new("acceptor_stream_dequeued\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 46usize,
-        name: Str::new("application_read.capacity\0"),
-        units: Units::Bytes,
+        name: Str::new("acceptor_stream_dequeued.sojourn_time\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 47usize,
-        name: Str::new("application_read.committed.total\0"),
-        units: Units::Bytes,
+        name: Str::new("application_write\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 48usize,
-        name: Str::new("application_read.committed\0"),
+        name: Str::new("application_write.provided\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 49usize,
-        name: Str::new("endpoint_initialized\0"),
-        units: Units::None,
+        name: Str::new("application_write.committed.total\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 50usize,
-        name: Str::new("endpoint_initialized.acceptor.protocol\0"),
-        units: Units::None,
+        name: Str::new("application_write.committed\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 51usize,
-        name: Str::new("endpoint_initialized.handshake.protocol\0"),
+        name: Str::new("application_read\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 52usize,
-        name: Str::new("endpoint_initialized.tcp\0"),
-        units: Units::None,
+        name: Str::new("application_read.capacity\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 53usize,
-        name: Str::new("endpoint_initialized.udp\0"),
-        units: Units::None,
+        name: Str::new("application_read.committed.total\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 54usize,
-        name: Str::new("path_secret_map_initialized\0"),
-        units: Units::None,
+        name: Str::new("application_read.committed\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 55usize,
-        name: Str::new("path_secret_map_initialized.capacity\0"),
+        name: Str::new("endpoint_initialized\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 56usize,
-        name: Str::new("path_secret_map_uninitialized\0"),
+        name: Str::new("endpoint_initialized.acceptor.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 57usize,
-        name: Str::new("path_secret_map_uninitialized.capacity\0"),
+        name: Str::new("endpoint_initialized.handshake.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 58usize,
-        name: Str::new("path_secret_map_uninitialized.entries\0"),
+        name: Str::new("endpoint_initialized.tcp\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 59usize,
-        name: Str::new("path_secret_map_uninitialized.lifetime\0"),
-        units: Units::Duration,
+        name: Str::new("endpoint_initialized.udp\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 60usize,
-        name: Str::new("path_secret_map_background_handshake_requested\0"),
+        name: Str::new("path_secret_map_initialized\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 61usize,
-        name: Str::new("path_secret_map_background_handshake_requested.peer_address.protocol\0"),
+        name: Str::new("path_secret_map_initialized.capacity\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 62usize,
-        name: Str::new("path_secret_map_entry_inserted\0"),
+        name: Str::new("path_secret_map_uninitialized\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 63usize,
-        name: Str::new("path_secret_map_entry_inserted.peer_address.protocol\0"),
+        name: Str::new("path_secret_map_uninitialized.capacity\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 64usize,
-        name: Str::new("path_secret_map_entry_ready\0"),
+        name: Str::new("path_secret_map_uninitialized.entries\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 65usize,
-        name: Str::new("path_secret_map_entry_ready.peer_address.protocol\0"),
-        units: Units::None,
+        name: Str::new("path_secret_map_uninitialized.lifetime\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 66usize,
-        name: Str::new("path_secret_map_entry_replaced\0"),
+        name: Str::new("path_secret_map_background_handshake_requested\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 67usize,
-        name: Str::new("path_secret_map_entry_replaced.peer_address.protocol\0"),
+        name: Str::new("path_secret_map_background_handshake_requested.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 68usize,
-        name: Str::new("unknown_path_secret_packet_sent\0"),
+        name: Str::new("path_secret_map_entry_inserted\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 69usize,
-        name: Str::new("unknown_path_secret_packet_sent.peer_address.protocol\0"),
+        name: Str::new("path_secret_map_entry_inserted.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 70usize,
-        name: Str::new("unknown_path_secret_packet_received\0"),
+        name: Str::new("path_secret_map_entry_ready\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 71usize,
-        name: Str::new("unknown_path_secret_packet_received.peer_address.protocol\0"),
+        name: Str::new("path_secret_map_entry_ready.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 72usize,
-        name: Str::new("unknown_path_secret_packet_accepted\0"),
+        name: Str::new("path_secret_map_entry_replaced\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 73usize,
-        name: Str::new("unknown_path_secret_packet_accepted.peer_address.protocol\0"),
+        name: Str::new("path_secret_map_entry_replaced.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 74usize,
-        name: Str::new("unknown_path_secret_packet_rejected\0"),
+        name: Str::new("unknown_path_secret_packet_sent\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 75usize,
-        name: Str::new("unknown_path_secret_packet_rejected.peer_address.protocol\0"),
+        name: Str::new("unknown_path_secret_packet_sent.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 76usize,
-        name: Str::new("unknown_path_secret_packet_dropped\0"),
+        name: Str::new("unknown_path_secret_packet_received\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 77usize,
-        name: Str::new("unknown_path_secret_packet_dropped.peer_address.protocol\0"),
+        name: Str::new("unknown_path_secret_packet_received.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 78usize,
-        name: Str::new("replay_definitely_detected\0"),
+        name: Str::new("unknown_path_secret_packet_accepted\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 79usize,
-        name: Str::new("replay_potentially_detected\0"),
+        name: Str::new("unknown_path_secret_packet_accepted.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 80usize,
-        name: Str::new("replay_potentially_detected.gap\0"),
+        name: Str::new("unknown_path_secret_packet_rejected\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 81usize,
-        name: Str::new("replay_detected_packet_sent\0"),
+        name: Str::new("unknown_path_secret_packet_rejected.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 82usize,
-        name: Str::new("replay_detected_packet_sent.peer_address.protocol\0"),
+        name: Str::new("unknown_path_secret_packet_dropped\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 83usize,
-        name: Str::new("replay_detected_packet_received\0"),
+        name: Str::new("unknown_path_secret_packet_dropped.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 84usize,
-        name: Str::new("replay_detected_packet_received.peer_address.protocol\0"),
+        name: Str::new("replay_definitely_detected\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 85usize,
-        name: Str::new("replay_detected_packet_accepted\0"),
+        name: Str::new("replay_potentially_detected\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 86usize,
-        name: Str::new("replay_detected_packet_accepted.peer_address.protocol\0"),
+        name: Str::new("replay_potentially_detected.gap\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 87usize,
-        name: Str::new("replay_detected_packet_rejected\0"),
+        name: Str::new("replay_detected_packet_sent\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 88usize,
-        name: Str::new("replay_detected_packet_rejected.peer_address.protocol\0"),
+        name: Str::new("replay_detected_packet_sent.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 89usize,
-        name: Str::new("replay_detected_packet_dropped\0"),
+        name: Str::new("replay_detected_packet_received\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 90usize,
-        name: Str::new("replay_detected_packet_dropped.peer_address.protocol\0"),
+        name: Str::new("replay_detected_packet_received.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 91usize,
-        name: Str::new("stale_key_packet_sent\0"),
+        name: Str::new("replay_detected_packet_accepted\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 92usize,
-        name: Str::new("stale_key_packet_sent.peer_address.protocol\0"),
+        name: Str::new("replay_detected_packet_accepted.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 93usize,
-        name: Str::new("stale_key_packet_received\0"),
+        name: Str::new("replay_detected_packet_rejected\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 94usize,
-        name: Str::new("stale_key_packet_received.peer_address.protocol\0"),
+        name: Str::new("replay_detected_packet_rejected.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 95usize,
-        name: Str::new("stale_key_packet_accepted\0"),
+        name: Str::new("replay_detected_packet_dropped\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 96usize,
-        name: Str::new("stale_key_packet_accepted.peer_address.protocol\0"),
+        name: Str::new("replay_detected_packet_dropped.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 97usize,
-        name: Str::new("stale_key_packet_rejected\0"),
+        name: Str::new("stale_key_packet_sent\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 98usize,
-        name: Str::new("stale_key_packet_rejected.peer_address.protocol\0"),
+        name: Str::new("stale_key_packet_sent.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 99usize,
-        name: Str::new("stale_key_packet_dropped\0"),
+        name: Str::new("stale_key_packet_received\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 100usize,
+        name: Str::new("stale_key_packet_received.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 101usize,
+        name: Str::new("stale_key_packet_accepted\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 102usize,
+        name: Str::new("stale_key_packet_accepted.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 103usize,
+        name: Str::new("stale_key_packet_rejected\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 104usize,
+        name: Str::new("stale_key_packet_rejected.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 105usize,
+        name: Str::new("stale_key_packet_dropped\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 106usize,
         name: Str::new("stale_key_packet_dropped.peer_address.protocol\0"),
         units: Units::None,
     }
@@ -629,13 +665,13 @@ pub struct Subscriber<R: Registry> {
     #[allow(dead_code)]
     counters: Box<[R::Counter; 46usize]>,
     #[allow(dead_code)]
-    bool_counters: Box<[R::BoolCounter; 6usize]>,
+    bool_counters: Box<[R::BoolCounter; 8usize]>,
     #[allow(dead_code)]
     nominal_counters: Box<[R::NominalCounter]>,
     #[allow(dead_code)]
-    nominal_counter_offsets: Box<[usize; 23usize]>,
+    nominal_counter_offsets: Box<[usize; 25usize]>,
     #[allow(dead_code)]
-    measures: Box<[R::Measure; 19usize]>,
+    measures: Box<[R::Measure; 21usize]>,
     #[allow(dead_code)]
     gauges: Box<[R::Gauge; 0usize]>,
     #[allow(dead_code)]
@@ -663,42 +699,39 @@ impl<R: Registry> Subscriber<R> {
     #[inline]
     pub fn new(registry: R) -> Self {
         let mut counters = Vec::with_capacity(46usize);
-        let mut bool_counters = Vec::with_capacity(6usize);
-        let mut nominal_counters = Vec::with_capacity(23usize);
-        let mut nominal_counter_offsets = Vec::with_capacity(23usize);
-        let mut measures = Vec::with_capacity(19usize);
+        let mut bool_counters = Vec::with_capacity(8usize);
+        let mut nominal_counters = Vec::with_capacity(25usize);
+        let mut nominal_counter_offsets = Vec::with_capacity(25usize);
+        let mut measures = Vec::with_capacity(21usize);
         let mut gauges = Vec::with_capacity(0usize);
         let mut timers = Vec::with_capacity(7usize);
         let mut nominal_timers = Vec::with_capacity(0usize);
         let mut nominal_timer_offsets = Vec::with_capacity(0usize);
         counters.push(registry.register_counter(&INFO[0usize]));
         counters.push(registry.register_counter(&INFO[1usize]));
-        counters.push(registry.register_counter(&INFO[5usize]));
-        counters.push(registry.register_counter(&INFO[6usize]));
-        counters.push(registry.register_counter(&INFO[10usize]));
+        counters.push(registry.register_counter(&INFO[7usize]));
+        counters.push(registry.register_counter(&INFO[8usize]));
         counters.push(registry.register_counter(&INFO[12usize]));
-        counters.push(registry.register_counter(&INFO[15usize]));
-        counters.push(registry.register_counter(&INFO[19usize]));
-        counters.push(registry.register_counter(&INFO[21usize]));
-        counters.push(registry.register_counter(&INFO[24usize]));
+        counters.push(registry.register_counter(&INFO[14usize]));
+        counters.push(registry.register_counter(&INFO[17usize]));
+        counters.push(registry.register_counter(&INFO[22usize]));
         counters.push(registry.register_counter(&INFO[25usize]));
-        counters.push(registry.register_counter(&INFO[26usize]));
         counters.push(registry.register_counter(&INFO[28usize]));
-        counters.push(registry.register_counter(&INFO[33usize]));
-        counters.push(registry.register_counter(&INFO[34usize]));
-        counters.push(registry.register_counter(&INFO[35usize]));
-        counters.push(registry.register_counter(&INFO[36usize]));
-        counters.push(registry.register_counter(&INFO[39usize]));
+        counters.push(registry.register_counter(&INFO[29usize]));
+        counters.push(registry.register_counter(&INFO[30usize]));
+        counters.push(registry.register_counter(&INFO[32usize]));
+        counters.push(registry.register_counter(&INFO[38usize]));
+        counters.push(registry.register_counter(&INFO[40usize]));
         counters.push(registry.register_counter(&INFO[41usize]));
-        counters.push(registry.register_counter(&INFO[43usize]));
+        counters.push(registry.register_counter(&INFO[42usize]));
         counters.push(registry.register_counter(&INFO[45usize]));
         counters.push(registry.register_counter(&INFO[47usize]));
         counters.push(registry.register_counter(&INFO[49usize]));
-        counters.push(registry.register_counter(&INFO[54usize]));
-        counters.push(registry.register_counter(&INFO[56usize]));
+        counters.push(registry.register_counter(&INFO[51usize]));
+        counters.push(registry.register_counter(&INFO[53usize]));
+        counters.push(registry.register_counter(&INFO[55usize]));
         counters.push(registry.register_counter(&INFO[60usize]));
         counters.push(registry.register_counter(&INFO[62usize]));
-        counters.push(registry.register_counter(&INFO[64usize]));
         counters.push(registry.register_counter(&INFO[66usize]));
         counters.push(registry.register_counter(&INFO[68usize]));
         counters.push(registry.register_counter(&INFO[70usize]));
@@ -706,9 +739,9 @@ impl<R: Registry> Subscriber<R> {
         counters.push(registry.register_counter(&INFO[74usize]));
         counters.push(registry.register_counter(&INFO[76usize]));
         counters.push(registry.register_counter(&INFO[78usize]));
-        counters.push(registry.register_counter(&INFO[79usize]));
-        counters.push(registry.register_counter(&INFO[81usize]));
-        counters.push(registry.register_counter(&INFO[83usize]));
+        counters.push(registry.register_counter(&INFO[80usize]));
+        counters.push(registry.register_counter(&INFO[82usize]));
+        counters.push(registry.register_counter(&INFO[84usize]));
         counters.push(registry.register_counter(&INFO[85usize]));
         counters.push(registry.register_counter(&INFO[87usize]));
         counters.push(registry.register_counter(&INFO[89usize]));
@@ -717,12 +750,17 @@ impl<R: Registry> Subscriber<R> {
         counters.push(registry.register_counter(&INFO[95usize]));
         counters.push(registry.register_counter(&INFO[97usize]));
         counters.push(registry.register_counter(&INFO[99usize]));
-        bool_counters.push(registry.register_bool_counter(&INFO[17usize]));
-        bool_counters.push(registry.register_bool_counter(&INFO[30usize]));
-        bool_counters.push(registry.register_bool_counter(&INFO[31usize]));
-        bool_counters.push(registry.register_bool_counter(&INFO[32usize]));
-        bool_counters.push(registry.register_bool_counter(&INFO[52usize]));
-        bool_counters.push(registry.register_bool_counter(&INFO[53usize]));
+        counters.push(registry.register_counter(&INFO[101usize]));
+        counters.push(registry.register_counter(&INFO[103usize]));
+        counters.push(registry.register_counter(&INFO[105usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[19usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[20usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[34usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[35usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[36usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[37usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[58usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[59usize]));
         {
             #[allow(unused_imports)]
             use api::*;
@@ -731,7 +769,29 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <AcceptorTcpStreamDropReason as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[11usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[13usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <AcceptorPacketDropReason as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[23usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <AcceptorPacketDropReason as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[39usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -742,7 +802,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <AcceptorStreamPruneReason as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[38usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[44usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -753,7 +813,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[50usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[56usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -764,40 +824,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[51usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[61usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[63usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[65usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[57usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -874,7 +901,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[82usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[79usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -885,7 +912,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[84usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[81usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -896,7 +923,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[86usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[83usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -979,33 +1006,68 @@ impl<R: Registry> Subscriber<R> {
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
                 nominal_counter_offsets.push(offset);
             }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[102usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[104usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[106usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
         }
         measures.push(registry.register_measure(&INFO[2usize]));
+        measures.push(registry.register_measure(&INFO[3usize]));
         measures.push(registry.register_measure(&INFO[4usize]));
-        measures.push(registry.register_measure(&INFO[7usize]));
-        measures.push(registry.register_measure(&INFO[8usize]));
+        measures.push(registry.register_measure(&INFO[6usize]));
         measures.push(registry.register_measure(&INFO[9usize]));
-        measures.push(registry.register_measure(&INFO[14usize]));
+        measures.push(registry.register_measure(&INFO[10usize]));
+        measures.push(registry.register_measure(&INFO[11usize]));
         measures.push(registry.register_measure(&INFO[16usize]));
-        measures.push(registry.register_measure(&INFO[23usize]));
+        measures.push(registry.register_measure(&INFO[18usize]));
         measures.push(registry.register_measure(&INFO[27usize]));
-        measures.push(registry.register_measure(&INFO[29usize]));
-        measures.push(registry.register_measure(&INFO[42usize]));
-        measures.push(registry.register_measure(&INFO[44usize]));
-        measures.push(registry.register_measure(&INFO[46usize]));
+        measures.push(registry.register_measure(&INFO[31usize]));
+        measures.push(registry.register_measure(&INFO[33usize]));
         measures.push(registry.register_measure(&INFO[48usize]));
-        measures.push(registry.register_measure(&INFO[55usize]));
-        measures.push(registry.register_measure(&INFO[57usize]));
-        measures.push(registry.register_measure(&INFO[58usize]));
-        measures.push(registry.register_measure(&INFO[59usize]));
-        measures.push(registry.register_measure(&INFO[80usize]));
-        timers.push(registry.register_timer(&INFO[3usize]));
-        timers.push(registry.register_timer(&INFO[13usize]));
-        timers.push(registry.register_timer(&INFO[18usize]));
-        timers.push(registry.register_timer(&INFO[20usize]));
-        timers.push(registry.register_timer(&INFO[22usize]));
-        timers.push(registry.register_timer(&INFO[37usize]));
-        timers.push(registry.register_timer(&INFO[40usize]));
+        measures.push(registry.register_measure(&INFO[50usize]));
+        measures.push(registry.register_measure(&INFO[52usize]));
+        measures.push(registry.register_measure(&INFO[54usize]));
+        measures.push(registry.register_measure(&INFO[61usize]));
+        measures.push(registry.register_measure(&INFO[63usize]));
+        measures.push(registry.register_measure(&INFO[64usize]));
+        measures.push(registry.register_measure(&INFO[65usize]));
+        measures.push(registry.register_measure(&INFO[86usize]));
+        timers.push(registry.register_timer(&INFO[5usize]));
+        timers.push(registry.register_timer(&INFO[15usize]));
+        timers.push(registry.register_timer(&INFO[21usize]));
+        timers.push(registry.register_timer(&INFO[24usize]));
+        timers.push(registry.register_timer(&INFO[26usize]));
+        timers.push(registry.register_timer(&INFO[43usize]));
+        timers.push(registry.register_timer(&INFO[46usize]));
         {
             #[allow(unused_imports)]
             use api::*;
@@ -1042,50 +1104,50 @@ impl<R: Registry> Subscriber<R> {
             .map(|(idx, entry)| match idx {
                 0usize => (&INFO[0usize], entry),
                 1usize => (&INFO[1usize], entry),
-                2usize => (&INFO[5usize], entry),
-                3usize => (&INFO[6usize], entry),
-                4usize => (&INFO[10usize], entry),
-                5usize => (&INFO[12usize], entry),
-                6usize => (&INFO[15usize], entry),
-                7usize => (&INFO[19usize], entry),
-                8usize => (&INFO[21usize], entry),
-                9usize => (&INFO[24usize], entry),
-                10usize => (&INFO[25usize], entry),
-                11usize => (&INFO[26usize], entry),
-                12usize => (&INFO[28usize], entry),
-                13usize => (&INFO[33usize], entry),
-                14usize => (&INFO[34usize], entry),
-                15usize => (&INFO[35usize], entry),
-                16usize => (&INFO[36usize], entry),
-                17usize => (&INFO[39usize], entry),
-                18usize => (&INFO[41usize], entry),
-                19usize => (&INFO[43usize], entry),
-                20usize => (&INFO[45usize], entry),
-                21usize => (&INFO[47usize], entry),
-                22usize => (&INFO[49usize], entry),
-                23usize => (&INFO[54usize], entry),
-                24usize => (&INFO[56usize], entry),
-                25usize => (&INFO[60usize], entry),
-                26usize => (&INFO[62usize], entry),
-                27usize => (&INFO[64usize], entry),
-                28usize => (&INFO[66usize], entry),
-                29usize => (&INFO[68usize], entry),
-                30usize => (&INFO[70usize], entry),
-                31usize => (&INFO[72usize], entry),
-                32usize => (&INFO[74usize], entry),
-                33usize => (&INFO[76usize], entry),
-                34usize => (&INFO[78usize], entry),
-                35usize => (&INFO[79usize], entry),
-                36usize => (&INFO[81usize], entry),
-                37usize => (&INFO[83usize], entry),
-                38usize => (&INFO[85usize], entry),
-                39usize => (&INFO[87usize], entry),
-                40usize => (&INFO[89usize], entry),
-                41usize => (&INFO[91usize], entry),
-                42usize => (&INFO[93usize], entry),
-                43usize => (&INFO[95usize], entry),
-                44usize => (&INFO[97usize], entry),
-                45usize => (&INFO[99usize], entry),
+                2usize => (&INFO[7usize], entry),
+                3usize => (&INFO[8usize], entry),
+                4usize => (&INFO[12usize], entry),
+                5usize => (&INFO[14usize], entry),
+                6usize => (&INFO[17usize], entry),
+                7usize => (&INFO[22usize], entry),
+                8usize => (&INFO[25usize], entry),
+                9usize => (&INFO[28usize], entry),
+                10usize => (&INFO[29usize], entry),
+                11usize => (&INFO[30usize], entry),
+                12usize => (&INFO[32usize], entry),
+                13usize => (&INFO[38usize], entry),
+                14usize => (&INFO[40usize], entry),
+                15usize => (&INFO[41usize], entry),
+                16usize => (&INFO[42usize], entry),
+                17usize => (&INFO[45usize], entry),
+                18usize => (&INFO[47usize], entry),
+                19usize => (&INFO[49usize], entry),
+                20usize => (&INFO[51usize], entry),
+                21usize => (&INFO[53usize], entry),
+                22usize => (&INFO[55usize], entry),
+                23usize => (&INFO[60usize], entry),
+                24usize => (&INFO[62usize], entry),
+                25usize => (&INFO[66usize], entry),
+                26usize => (&INFO[68usize], entry),
+                27usize => (&INFO[70usize], entry),
+                28usize => (&INFO[72usize], entry),
+                29usize => (&INFO[74usize], entry),
+                30usize => (&INFO[76usize], entry),
+                31usize => (&INFO[78usize], entry),
+                32usize => (&INFO[80usize], entry),
+                33usize => (&INFO[82usize], entry),
+                34usize => (&INFO[84usize], entry),
+                35usize => (&INFO[85usize], entry),
+                36usize => (&INFO[87usize], entry),
+                37usize => (&INFO[89usize], entry),
+                38usize => (&INFO[91usize], entry),
+                39usize => (&INFO[93usize], entry),
+                40usize => (&INFO[95usize], entry),
+                41usize => (&INFO[97usize], entry),
+                42usize => (&INFO[99usize], entry),
+                43usize => (&INFO[101usize], entry),
+                44usize => (&INFO[103usize], entry),
+                45usize => (&INFO[105usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -1103,12 +1165,14 @@ impl<R: Registry> Subscriber<R> {
             .iter()
             .enumerate()
             .map(|(idx, entry)| match idx {
-                0usize => (&INFO[17usize], entry),
-                1usize => (&INFO[30usize], entry),
-                2usize => (&INFO[31usize], entry),
-                3usize => (&INFO[32usize], entry),
-                4usize => (&INFO[52usize], entry),
-                5usize => (&INFO[53usize], entry),
+                0usize => (&INFO[19usize], entry),
+                1usize => (&INFO[20usize], entry),
+                2usize => (&INFO[34usize], entry),
+                3usize => (&INFO[35usize], entry),
+                4usize => (&INFO[36usize], entry),
+                5usize => (&INFO[37usize], entry),
+                6usize => (&INFO[58usize], entry),
+                7usize => (&INFO[59usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -1133,139 +1197,151 @@ impl<R: Registry> Subscriber<R> {
                     let offset = *entry;
                     let variants = <AcceptorTcpStreamDropReason as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[11usize], entries, variants)
+                    (&INFO[13usize], entries, variants)
                 }
                 1usize => {
                     let offset = *entry;
-                    let variants = <AcceptorStreamPruneReason as AsVariant>::VARIANTS;
+                    let variants = <AcceptorPacketDropReason as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[38usize], entries, variants)
+                    (&INFO[23usize], entries, variants)
                 }
                 2usize => {
                     let offset = *entry;
-                    let variants = <SocketAddress as AsVariant>::VARIANTS;
+                    let variants = <AcceptorPacketDropReason as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[50usize], entries, variants)
+                    (&INFO[39usize], entries, variants)
                 }
                 3usize => {
                     let offset = *entry;
-                    let variants = <SocketAddress as AsVariant>::VARIANTS;
+                    let variants = <AcceptorStreamPruneReason as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[51usize], entries, variants)
+                    (&INFO[44usize], entries, variants)
                 }
                 4usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[61usize], entries, variants)
+                    (&INFO[56usize], entries, variants)
                 }
                 5usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[63usize], entries, variants)
+                    (&INFO[57usize], entries, variants)
                 }
                 6usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[65usize], entries, variants)
+                    (&INFO[67usize], entries, variants)
                 }
                 7usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[67usize], entries, variants)
+                    (&INFO[69usize], entries, variants)
                 }
                 8usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[69usize], entries, variants)
+                    (&INFO[71usize], entries, variants)
                 }
                 9usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[71usize], entries, variants)
+                    (&INFO[73usize], entries, variants)
                 }
                 10usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[73usize], entries, variants)
+                    (&INFO[75usize], entries, variants)
                 }
                 11usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[75usize], entries, variants)
+                    (&INFO[77usize], entries, variants)
                 }
                 12usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[77usize], entries, variants)
+                    (&INFO[79usize], entries, variants)
                 }
                 13usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[82usize], entries, variants)
+                    (&INFO[81usize], entries, variants)
                 }
                 14usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[84usize], entries, variants)
+                    (&INFO[83usize], entries, variants)
                 }
                 15usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[86usize], entries, variants)
+                    (&INFO[88usize], entries, variants)
                 }
                 16usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[88usize], entries, variants)
+                    (&INFO[90usize], entries, variants)
                 }
                 17usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[90usize], entries, variants)
+                    (&INFO[92usize], entries, variants)
                 }
                 18usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[92usize], entries, variants)
+                    (&INFO[94usize], entries, variants)
                 }
                 19usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[94usize], entries, variants)
+                    (&INFO[96usize], entries, variants)
                 }
                 20usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[96usize], entries, variants)
+                    (&INFO[98usize], entries, variants)
                 }
                 21usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[98usize], entries, variants)
+                    (&INFO[100usize], entries, variants)
                 }
                 22usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[100usize], entries, variants)
+                    (&INFO[102usize], entries, variants)
+                }
+                23usize => {
+                    let offset = *entry;
+                    let variants = <SocketAddress as AsVariant>::VARIANTS;
+                    let entries = &self.nominal_counters[offset..offset + variants.len()];
+                    (&INFO[104usize], entries, variants)
+                }
+                24usize => {
+                    let offset = *entry;
+                    let variants = <SocketAddress as AsVariant>::VARIANTS;
+                    let entries = &self.nominal_counters[offset..offset + variants.len()];
+                    (&INFO[106usize], entries, variants)
                 }
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
@@ -1286,24 +1362,26 @@ impl<R: Registry> Subscriber<R> {
             .enumerate()
             .map(|(idx, entry)| match idx {
                 0usize => (&INFO[2usize], entry),
-                1usize => (&INFO[4usize], entry),
-                2usize => (&INFO[7usize], entry),
-                3usize => (&INFO[8usize], entry),
+                1usize => (&INFO[3usize], entry),
+                2usize => (&INFO[4usize], entry),
+                3usize => (&INFO[6usize], entry),
                 4usize => (&INFO[9usize], entry),
-                5usize => (&INFO[14usize], entry),
-                6usize => (&INFO[16usize], entry),
-                7usize => (&INFO[23usize], entry),
-                8usize => (&INFO[27usize], entry),
-                9usize => (&INFO[29usize], entry),
-                10usize => (&INFO[42usize], entry),
-                11usize => (&INFO[44usize], entry),
-                12usize => (&INFO[46usize], entry),
-                13usize => (&INFO[48usize], entry),
-                14usize => (&INFO[55usize], entry),
-                15usize => (&INFO[57usize], entry),
-                16usize => (&INFO[58usize], entry),
-                17usize => (&INFO[59usize], entry),
-                18usize => (&INFO[80usize], entry),
+                5usize => (&INFO[10usize], entry),
+                6usize => (&INFO[11usize], entry),
+                7usize => (&INFO[16usize], entry),
+                8usize => (&INFO[18usize], entry),
+                9usize => (&INFO[27usize], entry),
+                10usize => (&INFO[31usize], entry),
+                11usize => (&INFO[33usize], entry),
+                12usize => (&INFO[48usize], entry),
+                13usize => (&INFO[50usize], entry),
+                14usize => (&INFO[52usize], entry),
+                15usize => (&INFO[54usize], entry),
+                16usize => (&INFO[61usize], entry),
+                17usize => (&INFO[63usize], entry),
+                18usize => (&INFO[64usize], entry),
+                19usize => (&INFO[65usize], entry),
+                20usize => (&INFO[86usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -1333,13 +1411,13 @@ impl<R: Registry> Subscriber<R> {
             .iter()
             .enumerate()
             .map(|(idx, entry)| match idx {
-                0usize => (&INFO[3usize], entry),
-                1usize => (&INFO[13usize], entry),
-                2usize => (&INFO[18usize], entry),
-                3usize => (&INFO[20usize], entry),
-                4usize => (&INFO[22usize], entry),
-                5usize => (&INFO[37usize], entry),
-                6usize => (&INFO[40usize], entry),
+                0usize => (&INFO[5usize], entry),
+                1usize => (&INFO[15usize], entry),
+                2usize => (&INFO[21usize], entry),
+                3usize => (&INFO[24usize], entry),
+                4usize => (&INFO[26usize], entry),
+                5usize => (&INFO[43usize], entry),
+                6usize => (&INFO[46usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -1394,8 +1472,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
         use api::*;
         self.count(1usize, 1usize, 1usize);
         self.measure(2usize, 0usize, event.pending_streams);
-        self.time(3usize, 0usize, event.processing_duration);
-        self.measure(4usize, 1usize, event.max_sojourn_time);
+        self.measure(3usize, 1usize, event.slots_idle);
+        self.measure(4usize, 2usize, event.slot_utilization);
+        self.time(5usize, 0usize, event.processing_duration);
+        self.measure(6usize, 3usize, event.max_sojourn_time);
         let _ = event;
         let _ = meta;
     }
@@ -1407,7 +1487,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(5usize, 2usize, 1usize);
+        self.count(7usize, 2usize, 1usize);
         let _ = event;
         let _ = meta;
     }
@@ -1419,10 +1499,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(6usize, 3usize, 1usize);
-        self.measure(7usize, 2usize, event.enqueued);
-        self.measure(8usize, 3usize, event.dropped);
-        self.measure(9usize, 4usize, event.errored);
+        self.count(8usize, 3usize, 1usize);
+        self.measure(9usize, 4usize, event.enqueued);
+        self.measure(10usize, 5usize, event.dropped);
+        self.measure(11usize, 6usize, event.errored);
         let _ = event;
         let _ = meta;
     }
@@ -1434,8 +1514,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(10usize, 4usize, 1usize);
-        self.count_nominal(11usize, 0usize, &event.reason);
+        self.count(12usize, 4usize, 1usize);
+        self.count_nominal(13usize, 0usize, &event.reason);
         let _ = event;
         let _ = meta;
     }
@@ -1447,9 +1527,9 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(12usize, 5usize, 1usize);
-        self.time(13usize, 1usize, event.sojourn_time);
-        self.measure(14usize, 5usize, event.buffer_len);
+        self.count(14usize, 5usize, 1usize);
+        self.time(15usize, 1usize, event.sojourn_time);
+        self.measure(16usize, 7usize, event.buffer_len);
         let _ = event;
         let _ = meta;
     }
@@ -1461,10 +1541,11 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(15usize, 6usize, 1usize);
-        self.measure(16usize, 6usize, event.payload_len);
-        self.count_bool(17usize, 0usize, event.is_fin);
-        self.time(18usize, 2usize, event.sojourn_time);
+        self.count(17usize, 6usize, 1usize);
+        self.measure(18usize, 8usize, event.payload_len);
+        self.count_bool(19usize, 0usize, event.is_fin);
+        self.count_bool(20usize, 1usize, event.is_fin_known);
+        self.time(21usize, 2usize, event.sojourn_time);
         let _ = event;
         let _ = meta;
     }
@@ -1476,8 +1557,9 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(19usize, 7usize, 1usize);
-        self.time(20usize, 3usize, event.sojourn_time);
+        self.count(22usize, 7usize, 1usize);
+        self.count_nominal(23usize, 1usize, &event.reason);
+        self.time(24usize, 3usize, event.sojourn_time);
         let _ = event;
         let _ = meta;
     }
@@ -1489,9 +1571,9 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(21usize, 8usize, 1usize);
-        self.time(22usize, 4usize, event.sojourn_time);
-        self.measure(23usize, 7usize, event.blocked_count);
+        self.count(25usize, 8usize, 1usize);
+        self.time(26usize, 4usize, event.sojourn_time);
+        self.measure(27usize, 9usize, event.blocked_count);
         let _ = event;
         let _ = meta;
     }
@@ -1499,7 +1581,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     fn on_acceptor_tcp_io_error(&self, meta: &api::EndpointMeta, event: &api::AcceptorTcpIoError) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(24usize, 9usize, 1usize);
+        self.count(28usize, 9usize, 1usize);
         let _ = event;
         let _ = meta;
     }
@@ -1507,7 +1589,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     fn on_acceptor_udp_started(&self, meta: &api::EndpointMeta, event: &api::AcceptorUdpStarted) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(25usize, 10usize, 1usize);
+        self.count(29usize, 10usize, 1usize);
         let _ = event;
         let _ = meta;
     }
@@ -1519,8 +1601,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(26usize, 11usize, 1usize);
-        self.measure(27usize, 8usize, event.len);
+        self.count(30usize, 11usize, 1usize);
+        self.measure(31usize, 10usize, event.len);
         let _ = event;
         let _ = meta;
     }
@@ -1532,11 +1614,12 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(28usize, 12usize, 1usize);
-        self.measure(29usize, 9usize, event.payload_len);
-        self.count_bool(30usize, 1usize, event.is_zero_offset);
-        self.count_bool(31usize, 2usize, event.is_retransmission);
-        self.count_bool(32usize, 3usize, event.is_fin);
+        self.count(32usize, 12usize, 1usize);
+        self.measure(33usize, 11usize, event.payload_len);
+        self.count_bool(34usize, 2usize, event.is_zero_offset);
+        self.count_bool(35usize, 3usize, event.is_retransmission);
+        self.count_bool(36usize, 4usize, event.is_fin);
+        self.count_bool(37usize, 5usize, event.is_fin_known);
         let _ = event;
         let _ = meta;
     }
@@ -1548,7 +1631,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(33usize, 13usize, 1usize);
+        self.count(38usize, 13usize, 1usize);
+        self.count_nominal(39usize, 2usize, &event.reason);
         let _ = event;
         let _ = meta;
     }
@@ -1560,7 +1644,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(34usize, 14usize, 1usize);
+        self.count(40usize, 14usize, 1usize);
         let _ = event;
         let _ = meta;
     }
@@ -1568,7 +1652,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     fn on_acceptor_udp_io_error(&self, meta: &api::EndpointMeta, event: &api::AcceptorUdpIoError) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(35usize, 15usize, 1usize);
+        self.count(41usize, 15usize, 1usize);
         let _ = event;
         let _ = meta;
     }
@@ -1580,9 +1664,9 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(36usize, 16usize, 1usize);
-        self.time(37usize, 5usize, event.sojourn_time);
-        self.count_nominal(38usize, 1usize, &event.reason);
+        self.count(42usize, 16usize, 1usize);
+        self.time(43usize, 5usize, event.sojourn_time);
+        self.count_nominal(44usize, 3usize, &event.reason);
         let _ = event;
         let _ = meta;
     }
@@ -1594,8 +1678,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(39usize, 17usize, 1usize);
-        self.time(40usize, 6usize, event.sojourn_time);
+        self.count(45usize, 17usize, 1usize);
+        self.time(46usize, 6usize, event.sojourn_time);
         let _ = event;
         let _ = meta;
     }
@@ -1608,10 +1692,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(41usize, 18usize, 1usize);
-        self.measure(42usize, 10usize, event.total_len);
-        self.count(43usize, 19usize, event.write_len);
-        self.measure(44usize, 11usize, event.write_len);
+        self.count(47usize, 18usize, 1usize);
+        self.measure(48usize, 12usize, event.total_len);
+        self.count(49usize, 19usize, event.write_len);
+        self.measure(50usize, 13usize, event.write_len);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -1625,10 +1709,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(45usize, 20usize, 1usize);
-        self.measure(46usize, 12usize, event.capacity);
-        self.count(47usize, 21usize, event.read_len);
-        self.measure(48usize, 13usize, event.read_len);
+        self.count(51usize, 20usize, 1usize);
+        self.measure(52usize, 14usize, event.capacity);
+        self.count(53usize, 21usize, event.read_len);
+        self.measure(54usize, 15usize, event.read_len);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -1637,11 +1721,11 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     fn on_endpoint_initialized(&self, meta: &api::EndpointMeta, event: &api::EndpointInitialized) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(49usize, 22usize, 1usize);
-        self.count_nominal(50usize, 2usize, &event.acceptor_addr);
-        self.count_nominal(51usize, 3usize, &event.handshake_addr);
-        self.count_bool(52usize, 4usize, event.tcp);
-        self.count_bool(53usize, 5usize, event.udp);
+        self.count(55usize, 22usize, 1usize);
+        self.count_nominal(56usize, 4usize, &event.acceptor_addr);
+        self.count_nominal(57usize, 5usize, &event.handshake_addr);
+        self.count_bool(58usize, 6usize, event.tcp);
+        self.count_bool(59usize, 7usize, event.udp);
         let _ = event;
         let _ = meta;
     }
@@ -1653,8 +1737,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(54usize, 23usize, 1usize);
-        self.measure(55usize, 14usize, event.capacity);
+        self.count(60usize, 23usize, 1usize);
+        self.measure(61usize, 16usize, event.capacity);
         let _ = event;
         let _ = meta;
     }
@@ -1666,10 +1750,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(56usize, 24usize, 1usize);
-        self.measure(57usize, 15usize, event.capacity);
-        self.measure(58usize, 16usize, event.entries);
-        self.measure(59usize, 17usize, event.lifetime);
+        self.count(62usize, 24usize, 1usize);
+        self.measure(63usize, 17usize, event.capacity);
+        self.measure(64usize, 18usize, event.entries);
+        self.measure(65usize, 19usize, event.lifetime);
         let _ = event;
         let _ = meta;
     }
@@ -1681,8 +1765,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(60usize, 25usize, 1usize);
-        self.count_nominal(61usize, 4usize, &event.peer_address);
+        self.count(66usize, 25usize, 1usize);
+        self.count_nominal(67usize, 6usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1694,8 +1778,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(62usize, 26usize, 1usize);
-        self.count_nominal(63usize, 5usize, &event.peer_address);
+        self.count(68usize, 26usize, 1usize);
+        self.count_nominal(69usize, 7usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1707,8 +1791,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(64usize, 27usize, 1usize);
-        self.count_nominal(65usize, 6usize, &event.peer_address);
+        self.count(70usize, 27usize, 1usize);
+        self.count_nominal(71usize, 8usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1720,8 +1804,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(66usize, 28usize, 1usize);
-        self.count_nominal(67usize, 7usize, &event.peer_address);
+        self.count(72usize, 28usize, 1usize);
+        self.count_nominal(73usize, 9usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1733,8 +1817,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(68usize, 29usize, 1usize);
-        self.count_nominal(69usize, 8usize, &event.peer_address);
+        self.count(74usize, 29usize, 1usize);
+        self.count_nominal(75usize, 10usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1746,8 +1830,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(70usize, 30usize, 1usize);
-        self.count_nominal(71usize, 9usize, &event.peer_address);
+        self.count(76usize, 30usize, 1usize);
+        self.count_nominal(77usize, 11usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1759,8 +1843,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(72usize, 31usize, 1usize);
-        self.count_nominal(73usize, 10usize, &event.peer_address);
+        self.count(78usize, 31usize, 1usize);
+        self.count_nominal(79usize, 12usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1772,8 +1856,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(74usize, 32usize, 1usize);
-        self.count_nominal(75usize, 11usize, &event.peer_address);
+        self.count(80usize, 32usize, 1usize);
+        self.count_nominal(81usize, 13usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1785,8 +1869,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(76usize, 33usize, 1usize);
-        self.count_nominal(77usize, 12usize, &event.peer_address);
+        self.count(82usize, 33usize, 1usize);
+        self.count_nominal(83usize, 14usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1798,7 +1882,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(78usize, 34usize, 1usize);
+        self.count(84usize, 34usize, 1usize);
         let _ = event;
         let _ = meta;
     }
@@ -1810,8 +1894,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(79usize, 35usize, 1usize);
-        self.measure(80usize, 18usize, event.gap);
+        self.count(85usize, 35usize, 1usize);
+        self.measure(86usize, 20usize, event.gap);
         let _ = event;
         let _ = meta;
     }
@@ -1823,8 +1907,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(81usize, 36usize, 1usize);
-        self.count_nominal(82usize, 13usize, &event.peer_address);
+        self.count(87usize, 36usize, 1usize);
+        self.count_nominal(88usize, 15usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1836,8 +1920,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(83usize, 37usize, 1usize);
-        self.count_nominal(84usize, 14usize, &event.peer_address);
+        self.count(89usize, 37usize, 1usize);
+        self.count_nominal(90usize, 16usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1849,8 +1933,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(85usize, 38usize, 1usize);
-        self.count_nominal(86usize, 15usize, &event.peer_address);
+        self.count(91usize, 38usize, 1usize);
+        self.count_nominal(92usize, 17usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1862,8 +1946,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(87usize, 39usize, 1usize);
-        self.count_nominal(88usize, 16usize, &event.peer_address);
+        self.count(93usize, 39usize, 1usize);
+        self.count_nominal(94usize, 18usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1875,8 +1959,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(89usize, 40usize, 1usize);
-        self.count_nominal(90usize, 17usize, &event.peer_address);
+        self.count(95usize, 40usize, 1usize);
+        self.count_nominal(96usize, 19usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1884,8 +1968,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     fn on_stale_key_packet_sent(&self, meta: &api::EndpointMeta, event: &api::StaleKeyPacketSent) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(91usize, 41usize, 1usize);
-        self.count_nominal(92usize, 18usize, &event.peer_address);
+        self.count(97usize, 41usize, 1usize);
+        self.count_nominal(98usize, 20usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1897,8 +1981,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(93usize, 42usize, 1usize);
-        self.count_nominal(94usize, 19usize, &event.peer_address);
+        self.count(99usize, 42usize, 1usize);
+        self.count_nominal(100usize, 21usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1910,8 +1994,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(95usize, 43usize, 1usize);
-        self.count_nominal(96usize, 20usize, &event.peer_address);
+        self.count(101usize, 43usize, 1usize);
+        self.count_nominal(102usize, 22usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1923,8 +2007,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(97usize, 44usize, 1usize);
-        self.count_nominal(98usize, 21usize, &event.peer_address);
+        self.count(103usize, 44usize, 1usize);
+        self.count_nominal(104usize, 23usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1936,8 +2020,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(99usize, 45usize, 1usize);
-        self.count_nominal(100usize, 22usize, &event.peer_address);
+        self.count(105usize, 45usize, 1usize);
+        self.count_nominal(106usize, 24usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -19,50 +19,50 @@ mod counter {
             match info.id {
                 0usize => Self(acceptor_tcp_started),
                 1usize => Self(acceptor_tcp_loop_iteration_completed),
-                5usize => Self(acceptor_tcp_fresh_enqueued),
-                6usize => Self(acceptor_tcp_fresh_batch_completed),
-                10usize => Self(acceptor_tcp_stream_dropped),
-                12usize => Self(acceptor_tcp_stream_replaced),
-                15usize => Self(acceptor_tcp_packet_received),
-                19usize => Self(acceptor_tcp_packet_dropped),
-                21usize => Self(acceptor_tcp_stream_enqueued),
-                24usize => Self(acceptor_tcp_io_error),
-                25usize => Self(acceptor_udp_started),
-                26usize => Self(acceptor_udp_datagram_received),
-                28usize => Self(acceptor_udp_packet_received),
-                33usize => Self(acceptor_udp_packet_dropped),
-                34usize => Self(acceptor_udp_stream_enqueued),
-                35usize => Self(acceptor_udp_io_error),
-                36usize => Self(acceptor_stream_pruned),
-                39usize => Self(acceptor_stream_dequeued),
-                41usize => Self(application_write),
-                43usize => Self(application_write__committed__total),
-                45usize => Self(application_read),
-                47usize => Self(application_read__committed__total),
-                49usize => Self(endpoint_initialized),
-                54usize => Self(path_secret_map_initialized),
-                56usize => Self(path_secret_map_uninitialized),
-                60usize => Self(path_secret_map_background_handshake_requested),
-                62usize => Self(path_secret_map_entry_inserted),
-                64usize => Self(path_secret_map_entry_ready),
-                66usize => Self(path_secret_map_entry_replaced),
-                68usize => Self(unknown_path_secret_packet_sent),
-                70usize => Self(unknown_path_secret_packet_received),
-                72usize => Self(unknown_path_secret_packet_accepted),
-                74usize => Self(unknown_path_secret_packet_rejected),
-                76usize => Self(unknown_path_secret_packet_dropped),
-                78usize => Self(replay_definitely_detected),
-                79usize => Self(replay_potentially_detected),
-                81usize => Self(replay_detected_packet_sent),
-                83usize => Self(replay_detected_packet_received),
-                85usize => Self(replay_detected_packet_accepted),
-                87usize => Self(replay_detected_packet_rejected),
-                89usize => Self(replay_detected_packet_dropped),
-                91usize => Self(stale_key_packet_sent),
-                93usize => Self(stale_key_packet_received),
-                95usize => Self(stale_key_packet_accepted),
-                97usize => Self(stale_key_packet_rejected),
-                99usize => Self(stale_key_packet_dropped),
+                7usize => Self(acceptor_tcp_fresh_enqueued),
+                8usize => Self(acceptor_tcp_fresh_batch_completed),
+                12usize => Self(acceptor_tcp_stream_dropped),
+                14usize => Self(acceptor_tcp_stream_replaced),
+                17usize => Self(acceptor_tcp_packet_received),
+                22usize => Self(acceptor_tcp_packet_dropped),
+                25usize => Self(acceptor_tcp_stream_enqueued),
+                28usize => Self(acceptor_tcp_io_error),
+                29usize => Self(acceptor_udp_started),
+                30usize => Self(acceptor_udp_datagram_received),
+                32usize => Self(acceptor_udp_packet_received),
+                38usize => Self(acceptor_udp_packet_dropped),
+                40usize => Self(acceptor_udp_stream_enqueued),
+                41usize => Self(acceptor_udp_io_error),
+                42usize => Self(acceptor_stream_pruned),
+                45usize => Self(acceptor_stream_dequeued),
+                47usize => Self(application_write),
+                49usize => Self(application_write__committed__total),
+                51usize => Self(application_read),
+                53usize => Self(application_read__committed__total),
+                55usize => Self(endpoint_initialized),
+                60usize => Self(path_secret_map_initialized),
+                62usize => Self(path_secret_map_uninitialized),
+                66usize => Self(path_secret_map_background_handshake_requested),
+                68usize => Self(path_secret_map_entry_inserted),
+                70usize => Self(path_secret_map_entry_ready),
+                72usize => Self(path_secret_map_entry_replaced),
+                74usize => Self(unknown_path_secret_packet_sent),
+                76usize => Self(unknown_path_secret_packet_received),
+                78usize => Self(unknown_path_secret_packet_accepted),
+                80usize => Self(unknown_path_secret_packet_rejected),
+                82usize => Self(unknown_path_secret_packet_dropped),
+                84usize => Self(replay_definitely_detected),
+                85usize => Self(replay_potentially_detected),
+                87usize => Self(replay_detected_packet_sent),
+                89usize => Self(replay_detected_packet_received),
+                91usize => Self(replay_detected_packet_accepted),
+                93usize => Self(replay_detected_packet_rejected),
+                95usize => Self(replay_detected_packet_dropped),
+                97usize => Self(stale_key_packet_sent),
+                99usize => Self(stale_key_packet_received),
+                101usize => Self(stale_key_packet_accepted),
+                103usize => Self(stale_key_packet_rejected),
+                105usize => Self(stale_key_packet_dropped),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }
@@ -175,12 +175,14 @@ mod counter {
         impl Recorder {
             pub(crate) fn new(info: &'static Info) -> Self {
                 match info.id {
-                    17usize => Self(acceptor_tcp_packet_received__is_fin),
-                    30usize => Self(acceptor_udp_packet_received__is_zero_offset),
-                    31usize => Self(acceptor_udp_packet_received__is_retransmisson),
-                    32usize => Self(acceptor_udp_packet_received__is_fin),
-                    52usize => Self(endpoint_initialized__tcp),
-                    53usize => Self(endpoint_initialized__udp),
+                    19usize => Self(acceptor_tcp_packet_received__is_fin),
+                    20usize => Self(acceptor_tcp_packet_received__is_fin_known),
+                    34usize => Self(acceptor_udp_packet_received__is_zero_offset),
+                    35usize => Self(acceptor_udp_packet_received__is_retransmisson),
+                    36usize => Self(acceptor_udp_packet_received__is_fin),
+                    37usize => Self(acceptor_udp_packet_received__is_fin_known),
+                    58usize => Self(endpoint_initialized__tcp),
+                    59usize => Self(endpoint_initialized__udp),
                     _ => unreachable!("invalid info: {info:?}"),
                 }
             }
@@ -194,12 +196,16 @@ mod counter {
             extern "probe" {
                 # [link_name = s2n_quic_dc__event__counter__bool__acceptor_tcp_packet_received__is_fin]
                 fn acceptor_tcp_packet_received__is_fin(value: bool);
+                # [link_name = s2n_quic_dc__event__counter__bool__acceptor_tcp_packet_received__is_fin_known]
+                fn acceptor_tcp_packet_received__is_fin_known(value: bool);
                 # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_zero_offset]
                 fn acceptor_udp_packet_received__is_zero_offset(value: bool);
                 # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_retransmisson]
                 fn acceptor_udp_packet_received__is_retransmisson(value: bool);
                 # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_fin]
                 fn acceptor_udp_packet_received__is_fin(value: bool);
+                # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_fin_known]
+                fn acceptor_udp_packet_received__is_fin_known(value: bool);
                 # [link_name = s2n_quic_dc__event__counter__bool__endpoint_initialized__tcp]
                 fn endpoint_initialized__tcp(value: bool);
                 # [link_name = s2n_quic_dc__event__counter__bool__endpoint_initialized__udp]
@@ -215,31 +221,33 @@ mod counter {
         impl Recorder {
             pub(crate) fn new(info: &'static Info, _variant: &'static info::Variant) -> Self {
                 match info.id {
-                    11usize => Self(acceptor_tcp_stream_dropped__reason),
-                    38usize => Self(acceptor_stream_pruned__reason),
-                    50usize => Self(endpoint_initialized__acceptor__protocol),
-                    51usize => Self(endpoint_initialized__handshake__protocol),
-                    61usize => {
+                    13usize => Self(acceptor_tcp_stream_dropped__reason),
+                    23usize => Self(acceptor_tcp_packet_dropped__reason),
+                    39usize => Self(acceptor_udp_packet_dropped__reason),
+                    44usize => Self(acceptor_stream_pruned__reason),
+                    56usize => Self(endpoint_initialized__acceptor__protocol),
+                    57usize => Self(endpoint_initialized__handshake__protocol),
+                    67usize => {
                         Self(path_secret_map_background_handshake_requested__peer_address__protocol)
                     }
-                    63usize => Self(path_secret_map_entry_inserted__peer_address__protocol),
-                    65usize => Self(path_secret_map_entry_ready__peer_address__protocol),
-                    67usize => Self(path_secret_map_entry_replaced__peer_address__protocol),
-                    69usize => Self(unknown_path_secret_packet_sent__peer_address__protocol),
-                    71usize => Self(unknown_path_secret_packet_received__peer_address__protocol),
-                    73usize => Self(unknown_path_secret_packet_accepted__peer_address__protocol),
-                    75usize => Self(unknown_path_secret_packet_rejected__peer_address__protocol),
-                    77usize => Self(unknown_path_secret_packet_dropped__peer_address__protocol),
-                    82usize => Self(replay_detected_packet_sent__peer_address__protocol),
-                    84usize => Self(replay_detected_packet_received__peer_address__protocol),
-                    86usize => Self(replay_detected_packet_accepted__peer_address__protocol),
-                    88usize => Self(replay_detected_packet_rejected__peer_address__protocol),
-                    90usize => Self(replay_detected_packet_dropped__peer_address__protocol),
-                    92usize => Self(stale_key_packet_sent__peer_address__protocol),
-                    94usize => Self(stale_key_packet_received__peer_address__protocol),
-                    96usize => Self(stale_key_packet_accepted__peer_address__protocol),
-                    98usize => Self(stale_key_packet_rejected__peer_address__protocol),
-                    100usize => Self(stale_key_packet_dropped__peer_address__protocol),
+                    69usize => Self(path_secret_map_entry_inserted__peer_address__protocol),
+                    71usize => Self(path_secret_map_entry_ready__peer_address__protocol),
+                    73usize => Self(path_secret_map_entry_replaced__peer_address__protocol),
+                    75usize => Self(unknown_path_secret_packet_sent__peer_address__protocol),
+                    77usize => Self(unknown_path_secret_packet_received__peer_address__protocol),
+                    79usize => Self(unknown_path_secret_packet_accepted__peer_address__protocol),
+                    81usize => Self(unknown_path_secret_packet_rejected__peer_address__protocol),
+                    83usize => Self(unknown_path_secret_packet_dropped__peer_address__protocol),
+                    88usize => Self(replay_detected_packet_sent__peer_address__protocol),
+                    90usize => Self(replay_detected_packet_received__peer_address__protocol),
+                    92usize => Self(replay_detected_packet_accepted__peer_address__protocol),
+                    94usize => Self(replay_detected_packet_rejected__peer_address__protocol),
+                    96usize => Self(replay_detected_packet_dropped__peer_address__protocol),
+                    98usize => Self(stale_key_packet_sent__peer_address__protocol),
+                    100usize => Self(stale_key_packet_received__peer_address__protocol),
+                    102usize => Self(stale_key_packet_accepted__peer_address__protocol),
+                    104usize => Self(stale_key_packet_rejected__peer_address__protocol),
+                    106usize => Self(stale_key_packet_dropped__peer_address__protocol),
                     _ => unreachable!("invalid info: {info:?}"),
                 }
             }
@@ -258,6 +266,18 @@ mod counter {
             extern "probe" {
                 # [link_name = s2n_quic_dc__event__counter__nominal__acceptor_tcp_stream_dropped__reason]
                 fn acceptor_tcp_stream_dropped__reason(
+                    value: u64,
+                    variant: u64,
+                    variant_name: &info::Str,
+                );
+                # [link_name = s2n_quic_dc__event__counter__nominal__acceptor_tcp_packet_dropped__reason]
+                fn acceptor_tcp_packet_dropped__reason(
+                    value: u64,
+                    variant: u64,
+                    variant_name: &info::Str,
+                );
+                # [link_name = s2n_quic_dc__event__counter__nominal__acceptor_udp_packet_dropped__reason]
+                fn acceptor_udp_packet_dropped__reason(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
@@ -407,24 +427,26 @@ mod measure {
         pub(crate) fn new(info: &'static Info) -> Self {
             match info.id {
                 2usize => Self(acceptor_tcp_loop_iteration_completed__pending_streams),
-                4usize => Self(acceptor_tcp_loop_iteration_completed__max_sojourn_time),
-                7usize => Self(acceptor_tcp_fresh_batch_completed__enqueued),
-                8usize => Self(acceptor_tcp_fresh_batch_completed__dropped),
-                9usize => Self(acceptor_tcp_fresh_batch_completed__errored),
-                14usize => Self(acceptor_tcp_stream_replaced__buffer_len),
-                16usize => Self(acceptor_tcp_packet_received__payload_len),
-                23usize => Self(acceptor_tcp_stream_enqueued__blocked_count),
-                27usize => Self(acceptor_udp_datagram_received__len),
-                29usize => Self(acceptor_udp_packet_received__payload_len),
-                42usize => Self(application_write__provided),
-                44usize => Self(application_write__committed),
-                46usize => Self(application_read__capacity),
-                48usize => Self(application_read__committed),
-                55usize => Self(path_secret_map_initialized__capacity),
-                57usize => Self(path_secret_map_uninitialized__capacity),
-                58usize => Self(path_secret_map_uninitialized__entries),
-                59usize => Self(path_secret_map_uninitialized__lifetime),
-                80usize => Self(replay_potentially_detected__gap),
+                3usize => Self(acceptor_tcp_loop_iteration_completed__slots_idle),
+                4usize => Self(acceptor_tcp_loop_iteration_completed__slot_utilization),
+                6usize => Self(acceptor_tcp_loop_iteration_completed__max_sojourn_time),
+                9usize => Self(acceptor_tcp_fresh_batch_completed__enqueued),
+                10usize => Self(acceptor_tcp_fresh_batch_completed__dropped),
+                11usize => Self(acceptor_tcp_fresh_batch_completed__errored),
+                16usize => Self(acceptor_tcp_stream_replaced__buffer_len),
+                18usize => Self(acceptor_tcp_packet_received__payload_len),
+                27usize => Self(acceptor_tcp_stream_enqueued__blocked_count),
+                31usize => Self(acceptor_udp_datagram_received__len),
+                33usize => Self(acceptor_udp_packet_received__payload_len),
+                48usize => Self(application_write__provided),
+                50usize => Self(application_write__committed),
+                52usize => Self(application_read__capacity),
+                54usize => Self(application_read__committed),
+                61usize => Self(path_secret_map_initialized__capacity),
+                63usize => Self(path_secret_map_uninitialized__capacity),
+                64usize => Self(path_secret_map_uninitialized__entries),
+                65usize => Self(path_secret_map_uninitialized__lifetime),
+                86usize => Self(replay_potentially_detected__gap),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }
@@ -438,6 +460,10 @@ mod measure {
         extern "probe" {
             # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_loop_iteration_completed__pending_streams]
             fn acceptor_tcp_loop_iteration_completed__pending_streams(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_loop_iteration_completed__slots_idle]
+            fn acceptor_tcp_loop_iteration_completed__slots_idle(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_loop_iteration_completed__slot_utilization]
+            fn acceptor_tcp_loop_iteration_completed__slot_utilization(value: u64);
             # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_loop_iteration_completed__max_sojourn_time]
             fn acceptor_tcp_loop_iteration_completed__max_sojourn_time(value: u64);
             # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_fresh_batch_completed__enqueued]
@@ -501,13 +527,13 @@ mod timer {
     impl Recorder {
         pub(crate) fn new(info: &'static Info) -> Self {
             match info.id {
-                3usize => Self(acceptor_tcp_loop_iteration_completed__processing_duration),
-                13usize => Self(acceptor_tcp_stream_replaced__sojourn_time),
-                18usize => Self(acceptor_tcp_packet_received__sojourn_time),
-                20usize => Self(acceptor_tcp_packet_dropped__sojourn_time),
-                22usize => Self(acceptor_tcp_stream_enqueued__sojourn_time),
-                37usize => Self(acceptor_stream_pruned__sojourn_time),
-                40usize => Self(acceptor_stream_dequeued__sojourn_time),
+                5usize => Self(acceptor_tcp_loop_iteration_completed__processing_duration),
+                15usize => Self(acceptor_tcp_stream_replaced__sojourn_time),
+                21usize => Self(acceptor_tcp_packet_received__sojourn_time),
+                24usize => Self(acceptor_tcp_packet_dropped__sojourn_time),
+                26usize => Self(acceptor_tcp_stream_enqueued__sojourn_time),
+                43usize => Self(acceptor_stream_pruned__sojourn_time),
+                46usize => Self(acceptor_stream_dequeued__sojourn_time),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -17,34 +17,52 @@ mod counter {
     impl Recorder {
         pub(crate) fn new(info: &'static Info) -> Self {
             match info.id {
-                0usize => Self(application_write),
-                2usize => Self(application_write__committed__total),
-                4usize => Self(application_read),
-                6usize => Self(application_read__committed__total),
-                8usize => Self(endpoint_initialized),
-                13usize => Self(path_secret_map_initialized),
-                15usize => Self(path_secret_map_uninitialized),
-                19usize => Self(path_secret_map_background_handshake_requested),
-                21usize => Self(path_secret_map_entry_inserted),
-                23usize => Self(path_secret_map_entry_ready),
-                25usize => Self(path_secret_map_entry_replaced),
-                27usize => Self(unknown_path_secret_packet_sent),
-                29usize => Self(unknown_path_secret_packet_received),
-                31usize => Self(unknown_path_secret_packet_accepted),
-                33usize => Self(unknown_path_secret_packet_rejected),
-                35usize => Self(unknown_path_secret_packet_dropped),
-                37usize => Self(replay_definitely_detected),
-                38usize => Self(replay_potentially_detected),
-                40usize => Self(replay_detected_packet_sent),
-                42usize => Self(replay_detected_packet_received),
-                44usize => Self(replay_detected_packet_accepted),
-                46usize => Self(replay_detected_packet_rejected),
-                48usize => Self(replay_detected_packet_dropped),
-                50usize => Self(stale_key_packet_sent),
-                52usize => Self(stale_key_packet_received),
-                54usize => Self(stale_key_packet_accepted),
-                56usize => Self(stale_key_packet_rejected),
-                58usize => Self(stale_key_packet_dropped),
+                0usize => Self(acceptor_tcp_started),
+                1usize => Self(acceptor_tcp_loop_iteration_completed),
+                5usize => Self(acceptor_tcp_fresh_enqueued),
+                6usize => Self(acceptor_tcp_fresh_batch_completed),
+                10usize => Self(acceptor_tcp_stream_dropped),
+                12usize => Self(acceptor_tcp_stream_replaced),
+                15usize => Self(acceptor_tcp_packet_received),
+                19usize => Self(acceptor_tcp_packet_dropped),
+                21usize => Self(acceptor_tcp_stream_enqueued),
+                24usize => Self(acceptor_tcp_io_error),
+                25usize => Self(acceptor_udp_started),
+                26usize => Self(acceptor_udp_datagram_received),
+                28usize => Self(acceptor_udp_packet_received),
+                33usize => Self(acceptor_udp_packet_dropped),
+                34usize => Self(acceptor_udp_stream_enqueued),
+                35usize => Self(acceptor_udp_io_error),
+                36usize => Self(acceptor_stream_pruned),
+                39usize => Self(acceptor_stream_dequeued),
+                41usize => Self(application_write),
+                43usize => Self(application_write__committed__total),
+                45usize => Self(application_read),
+                47usize => Self(application_read__committed__total),
+                49usize => Self(endpoint_initialized),
+                54usize => Self(path_secret_map_initialized),
+                56usize => Self(path_secret_map_uninitialized),
+                60usize => Self(path_secret_map_background_handshake_requested),
+                62usize => Self(path_secret_map_entry_inserted),
+                64usize => Self(path_secret_map_entry_ready),
+                66usize => Self(path_secret_map_entry_replaced),
+                68usize => Self(unknown_path_secret_packet_sent),
+                70usize => Self(unknown_path_secret_packet_received),
+                72usize => Self(unknown_path_secret_packet_accepted),
+                74usize => Self(unknown_path_secret_packet_rejected),
+                76usize => Self(unknown_path_secret_packet_dropped),
+                78usize => Self(replay_definitely_detected),
+                79usize => Self(replay_potentially_detected),
+                81usize => Self(replay_detected_packet_sent),
+                83usize => Self(replay_detected_packet_received),
+                85usize => Self(replay_detected_packet_accepted),
+                87usize => Self(replay_detected_packet_rejected),
+                89usize => Self(replay_detected_packet_dropped),
+                91usize => Self(stale_key_packet_sent),
+                93usize => Self(stale_key_packet_received),
+                95usize => Self(stale_key_packet_accepted),
+                97usize => Self(stale_key_packet_rejected),
+                99usize => Self(stale_key_packet_dropped),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }
@@ -56,6 +74,42 @@ mod counter {
     }
     define!(
         extern "probe" {
+            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_started]
+            fn acceptor_tcp_started(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_loop_iteration_completed]
+            fn acceptor_tcp_loop_iteration_completed(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_fresh_enqueued]
+            fn acceptor_tcp_fresh_enqueued(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_fresh_batch_completed]
+            fn acceptor_tcp_fresh_batch_completed(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_stream_dropped]
+            fn acceptor_tcp_stream_dropped(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_stream_replaced]
+            fn acceptor_tcp_stream_replaced(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_packet_received]
+            fn acceptor_tcp_packet_received(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_packet_dropped]
+            fn acceptor_tcp_packet_dropped(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_stream_enqueued]
+            fn acceptor_tcp_stream_enqueued(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_io_error]
+            fn acceptor_tcp_io_error(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_udp_started]
+            fn acceptor_udp_started(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_udp_datagram_received]
+            fn acceptor_udp_datagram_received(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_udp_packet_received]
+            fn acceptor_udp_packet_received(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_udp_packet_dropped]
+            fn acceptor_udp_packet_dropped(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_udp_stream_enqueued]
+            fn acceptor_udp_stream_enqueued(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_udp_io_error]
+            fn acceptor_udp_io_error(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_stream_pruned]
+            fn acceptor_stream_pruned(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__acceptor_stream_dequeued]
+            fn acceptor_stream_dequeued(value: u64);
             # [link_name = s2n_quic_dc__event__counter__application_write]
             fn application_write(value: u64);
             # [link_name = s2n_quic_dc__event__counter__application_write__committed__total]
@@ -121,8 +175,12 @@ mod counter {
         impl Recorder {
             pub(crate) fn new(info: &'static Info) -> Self {
                 match info.id {
-                    11usize => Self(endpoint_initialized__tcp),
-                    12usize => Self(endpoint_initialized__udp),
+                    17usize => Self(acceptor_tcp_packet_received__is_fin),
+                    30usize => Self(acceptor_udp_packet_received__is_zero_offset),
+                    31usize => Self(acceptor_udp_packet_received__is_retransmisson),
+                    32usize => Self(acceptor_udp_packet_received__is_fin),
+                    52usize => Self(endpoint_initialized__tcp),
+                    53usize => Self(endpoint_initialized__udp),
                     _ => unreachable!("invalid info: {info:?}"),
                 }
             }
@@ -134,6 +192,14 @@ mod counter {
         }
         define!(
             extern "probe" {
+                # [link_name = s2n_quic_dc__event__counter__bool__acceptor_tcp_packet_received__is_fin]
+                fn acceptor_tcp_packet_received__is_fin(value: bool);
+                # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_zero_offset]
+                fn acceptor_udp_packet_received__is_zero_offset(value: bool);
+                # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_retransmisson]
+                fn acceptor_udp_packet_received__is_retransmisson(value: bool);
+                # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_fin]
+                fn acceptor_udp_packet_received__is_fin(value: bool);
                 # [link_name = s2n_quic_dc__event__counter__bool__endpoint_initialized__tcp]
                 fn endpoint_initialized__tcp(value: bool);
                 # [link_name = s2n_quic_dc__event__counter__bool__endpoint_initialized__udp]
@@ -149,29 +215,31 @@ mod counter {
         impl Recorder {
             pub(crate) fn new(info: &'static Info, _variant: &'static info::Variant) -> Self {
                 match info.id {
-                    9usize => Self(endpoint_initialized__acceptor__protocol),
-                    10usize => Self(endpoint_initialized__handshake__protocol),
-                    20usize => {
+                    11usize => Self(acceptor_tcp_stream_dropped__reason),
+                    38usize => Self(acceptor_stream_pruned__reason),
+                    50usize => Self(endpoint_initialized__acceptor__protocol),
+                    51usize => Self(endpoint_initialized__handshake__protocol),
+                    61usize => {
                         Self(path_secret_map_background_handshake_requested__peer_address__protocol)
                     }
-                    22usize => Self(path_secret_map_entry_inserted__peer_address__protocol),
-                    24usize => Self(path_secret_map_entry_ready__peer_address__protocol),
-                    26usize => Self(path_secret_map_entry_replaced__peer_address__protocol),
-                    28usize => Self(unknown_path_secret_packet_sent__peer_address__protocol),
-                    30usize => Self(unknown_path_secret_packet_received__peer_address__protocol),
-                    32usize => Self(unknown_path_secret_packet_accepted__peer_address__protocol),
-                    34usize => Self(unknown_path_secret_packet_rejected__peer_address__protocol),
-                    36usize => Self(unknown_path_secret_packet_dropped__peer_address__protocol),
-                    41usize => Self(replay_detected_packet_sent__peer_address__protocol),
-                    43usize => Self(replay_detected_packet_received__peer_address__protocol),
-                    45usize => Self(replay_detected_packet_accepted__peer_address__protocol),
-                    47usize => Self(replay_detected_packet_rejected__peer_address__protocol),
-                    49usize => Self(replay_detected_packet_dropped__peer_address__protocol),
-                    51usize => Self(stale_key_packet_sent__peer_address__protocol),
-                    53usize => Self(stale_key_packet_received__peer_address__protocol),
-                    55usize => Self(stale_key_packet_accepted__peer_address__protocol),
-                    57usize => Self(stale_key_packet_rejected__peer_address__protocol),
-                    59usize => Self(stale_key_packet_dropped__peer_address__protocol),
+                    63usize => Self(path_secret_map_entry_inserted__peer_address__protocol),
+                    65usize => Self(path_secret_map_entry_ready__peer_address__protocol),
+                    67usize => Self(path_secret_map_entry_replaced__peer_address__protocol),
+                    69usize => Self(unknown_path_secret_packet_sent__peer_address__protocol),
+                    71usize => Self(unknown_path_secret_packet_received__peer_address__protocol),
+                    73usize => Self(unknown_path_secret_packet_accepted__peer_address__protocol),
+                    75usize => Self(unknown_path_secret_packet_rejected__peer_address__protocol),
+                    77usize => Self(unknown_path_secret_packet_dropped__peer_address__protocol),
+                    82usize => Self(replay_detected_packet_sent__peer_address__protocol),
+                    84usize => Self(replay_detected_packet_received__peer_address__protocol),
+                    86usize => Self(replay_detected_packet_accepted__peer_address__protocol),
+                    88usize => Self(replay_detected_packet_rejected__peer_address__protocol),
+                    90usize => Self(replay_detected_packet_dropped__peer_address__protocol),
+                    92usize => Self(stale_key_packet_sent__peer_address__protocol),
+                    94usize => Self(stale_key_packet_received__peer_address__protocol),
+                    96usize => Self(stale_key_packet_accepted__peer_address__protocol),
+                    98usize => Self(stale_key_packet_rejected__peer_address__protocol),
+                    100usize => Self(stale_key_packet_dropped__peer_address__protocol),
                     _ => unreachable!("invalid info: {info:?}"),
                 }
             }
@@ -188,6 +256,18 @@ mod counter {
         }
         define!(
             extern "probe" {
+                # [link_name = s2n_quic_dc__event__counter__nominal__acceptor_tcp_stream_dropped__reason]
+                fn acceptor_tcp_stream_dropped__reason(
+                    value: u64,
+                    variant: u64,
+                    variant_name: &info::Str,
+                );
+                # [link_name = s2n_quic_dc__event__counter__nominal__acceptor_stream_pruned__reason]
+                fn acceptor_stream_pruned__reason(
+                    value: u64,
+                    variant: u64,
+                    variant_name: &info::Str,
+                );
                 # [link_name = s2n_quic_dc__event__counter__nominal__endpoint_initialized__acceptor__protocol]
                 fn endpoint_initialized__acceptor__protocol(
                     value: u64,
@@ -326,15 +406,25 @@ mod measure {
     impl Recorder {
         pub(crate) fn new(info: &'static Info) -> Self {
             match info.id {
-                1usize => Self(application_write__provided),
-                3usize => Self(application_write__committed),
-                5usize => Self(application_read__capacity),
-                7usize => Self(application_read__committed),
-                14usize => Self(path_secret_map_initialized__capacity),
-                16usize => Self(path_secret_map_uninitialized__capacity),
-                17usize => Self(path_secret_map_uninitialized__entries),
-                18usize => Self(path_secret_map_uninitialized__lifetime),
-                39usize => Self(replay_potentially_detected__gap),
+                2usize => Self(acceptor_tcp_loop_iteration_completed__pending_streams),
+                4usize => Self(acceptor_tcp_loop_iteration_completed__max_sojourn_time),
+                7usize => Self(acceptor_tcp_fresh_batch_completed__enqueued),
+                8usize => Self(acceptor_tcp_fresh_batch_completed__dropped),
+                9usize => Self(acceptor_tcp_fresh_batch_completed__errored),
+                14usize => Self(acceptor_tcp_stream_replaced__buffer_len),
+                16usize => Self(acceptor_tcp_packet_received__payload_len),
+                23usize => Self(acceptor_tcp_stream_enqueued__blocked_count),
+                27usize => Self(acceptor_udp_datagram_received__len),
+                29usize => Self(acceptor_udp_packet_received__payload_len),
+                42usize => Self(application_write__provided),
+                44usize => Self(application_write__committed),
+                46usize => Self(application_read__capacity),
+                48usize => Self(application_read__committed),
+                55usize => Self(path_secret_map_initialized__capacity),
+                57usize => Self(path_secret_map_uninitialized__capacity),
+                58usize => Self(path_secret_map_uninitialized__entries),
+                59usize => Self(path_secret_map_uninitialized__lifetime),
+                80usize => Self(replay_potentially_detected__gap),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }
@@ -346,6 +436,26 @@ mod measure {
     }
     define!(
         extern "probe" {
+            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_loop_iteration_completed__pending_streams]
+            fn acceptor_tcp_loop_iteration_completed__pending_streams(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_loop_iteration_completed__max_sojourn_time]
+            fn acceptor_tcp_loop_iteration_completed__max_sojourn_time(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_fresh_batch_completed__enqueued]
+            fn acceptor_tcp_fresh_batch_completed__enqueued(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_fresh_batch_completed__dropped]
+            fn acceptor_tcp_fresh_batch_completed__dropped(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_fresh_batch_completed__errored]
+            fn acceptor_tcp_fresh_batch_completed__errored(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_stream_replaced__buffer_len]
+            fn acceptor_tcp_stream_replaced__buffer_len(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_packet_received__payload_len]
+            fn acceptor_tcp_packet_received__payload_len(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_stream_enqueued__blocked_count]
+            fn acceptor_tcp_stream_enqueued__blocked_count(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__acceptor_udp_datagram_received__len]
+            fn acceptor_udp_datagram_received__len(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__acceptor_udp_packet_received__payload_len]
+            fn acceptor_udp_packet_received__payload_len(value: u64);
             # [link_name = s2n_quic_dc__event__measure__application_write__provided]
             fn application_write__provided(value: u64);
             # [link_name = s2n_quic_dc__event__measure__application_write__committed]
@@ -390,7 +500,16 @@ mod timer {
     pub struct Recorder(fn(core::time::Duration));
     impl Recorder {
         pub(crate) fn new(info: &'static Info) -> Self {
-            unreachable!("invalid info: {info:?}")
+            match info.id {
+                3usize => Self(acceptor_tcp_loop_iteration_completed__processing_duration),
+                13usize => Self(acceptor_tcp_stream_replaced__sojourn_time),
+                18usize => Self(acceptor_tcp_packet_received__sojourn_time),
+                20usize => Self(acceptor_tcp_packet_dropped__sojourn_time),
+                22usize => Self(acceptor_tcp_stream_enqueued__sojourn_time),
+                37usize => Self(acceptor_stream_pruned__sojourn_time),
+                40usize => Self(acceptor_stream_dequeued__sojourn_time),
+                _ => unreachable!("invalid info: {info:?}"),
+            }
         }
     }
     impl MetricRecorder for Recorder {
@@ -398,6 +517,26 @@ mod timer {
             (self.0)(value.as_duration());
         }
     }
+    define!(
+        extern "probe" {
+            # [link_name = s2n_quic_dc__event__timer__acceptor_tcp_loop_iteration_completed__processing_duration]
+            fn acceptor_tcp_loop_iteration_completed__processing_duration(
+                value: core::time::Duration,
+            );
+            # [link_name = s2n_quic_dc__event__timer__acceptor_tcp_stream_replaced__sojourn_time]
+            fn acceptor_tcp_stream_replaced__sojourn_time(value: core::time::Duration);
+            # [link_name = s2n_quic_dc__event__timer__acceptor_tcp_packet_received__sojourn_time]
+            fn acceptor_tcp_packet_received__sojourn_time(value: core::time::Duration);
+            # [link_name = s2n_quic_dc__event__timer__acceptor_tcp_packet_dropped__sojourn_time]
+            fn acceptor_tcp_packet_dropped__sojourn_time(value: core::time::Duration);
+            # [link_name = s2n_quic_dc__event__timer__acceptor_tcp_stream_enqueued__sojourn_time]
+            fn acceptor_tcp_stream_enqueued__sojourn_time(value: core::time::Duration);
+            # [link_name = s2n_quic_dc__event__timer__acceptor_stream_pruned__sojourn_time]
+            fn acceptor_stream_pruned__sojourn_time(value: core::time::Duration);
+            # [link_name = s2n_quic_dc__event__timer__acceptor_stream_dequeued__sojourn_time]
+            fn acceptor_stream_dequeued__sojourn_time(value: core::time::Duration);
+        }
+    );
     pub mod nominal {
         #![allow(non_snake_case)]
         use super::*;

--- a/dc/s2n-quic-dc/src/stream/client/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/client/tokio.rs
@@ -37,7 +37,7 @@ where
     )?;
 
     // build the stream inside the application context
-    let mut stream = stream.build()?;
+    let mut stream = stream.build_without_event()?;
 
     debug_assert_eq!(stream.protocol(), Protocol::Udp);
 
@@ -70,7 +70,7 @@ where
     )?;
 
     // build the stream inside the application context
-    let mut stream = stream.build()?;
+    let mut stream = stream.build_without_event()?;
 
     debug_assert_eq!(stream.protocol(), Protocol::Tcp);
 
@@ -100,7 +100,7 @@ pub async fn connect_tcp_with(
     )?;
 
     // build the stream inside the application context
-    let mut stream = stream.build()?;
+    let mut stream = stream.build_without_event()?;
 
     debug_assert_eq!(stream.protocol(), Protocol::Tcp);
 

--- a/dc/s2n-quic-dc/src/stream/endpoint.rs
+++ b/dc/s2n-quic-dc/src/stream/endpoint.rs
@@ -17,6 +17,7 @@ use core::cell::UnsafeCell;
 use s2n_quic_core::{
     dc, endpoint,
     inet::{ExplicitCongestionNotification, SocketAddress},
+    time::Clock as _,
     varint::VarInt,
 };
 use std::{io, sync::Arc};
@@ -158,6 +159,8 @@ where
     Env: Environment,
     P: Peer<Env>,
 {
+    let now = env.clock().get_time();
+
     let features = peer.features();
 
     let sockets = peer.setup(env)?;
@@ -328,6 +331,7 @@ where
         write,
         shared,
         sockets: sockets.application,
+        queue_time: now,
     };
 
     Ok(stream)

--- a/dc/s2n-quic-dc/src/stream/server.rs
+++ b/dc/s2n-quic-dc/src/stream/server.rs
@@ -19,6 +19,7 @@ pub struct InitialPacket {
     pub is_zero_offset: bool,
     pub is_retransmission: bool,
     pub is_fin: bool,
+    pub is_fin_known: bool,
 }
 
 impl InitialPacket {
@@ -55,6 +56,7 @@ impl<'a> From<packet::stream::decoder::Packet<'a>> for InitialPacket {
         let is_zero_offset = packet.stream_offset().as_u64() == 0;
         let is_retransmission = packet.is_retransmission();
         let is_fin = packet.is_fin();
+        let is_fin_known = packet.final_offset().is_some();
         Self {
             credentials,
             stream_id,
@@ -64,6 +66,7 @@ impl<'a> From<packet::stream::decoder::Packet<'a>> for InitialPacket {
             payload_len,
             is_retransmission,
             is_fin,
+            is_fin_known,
         }
     }
 }

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp.rs
@@ -112,7 +112,8 @@ where
                 event::builder::AcceptorTcpLoopIterationCompleted {
                     pending_streams: workers.working.len(),
                     slots_idle: workers.free.len(),
-                    slot_utilization: workers.working.len() as f32 / workers.workers.len() as f32,
+                    slot_utilization: (workers.working.len() as f32 / workers.workers.len() as f32)
+                        * 100.0,
                     processing_duration: self.env.clock().get_time().saturating_duration_since(now),
                     max_sojourn_time: workers.max_sojourn_time(),
                 },

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp.rs
@@ -3,6 +3,7 @@
 
 use super::accept;
 use crate::{
+    event::{self, EndpointPublisher, IntoEvent, Subscriber},
     msg,
     path::secret,
     stream::{
@@ -22,8 +23,9 @@ use core::{
     task::{Context, Poll},
     time::Duration,
 };
+use s2n_codec::DecoderError;
 use s2n_quic_core::{
-    ensure,
+    inet::SocketAddress,
     packet::number::PacketNumberSpace,
     ready,
     recovery::RttEstimator,
@@ -34,35 +36,58 @@ use tokio::{
     io::AsyncWrite as _,
     net::{TcpListener, TcpStream},
 };
-use tracing::{debug, error, trace};
+use tracing::{debug, trace};
 
-pub struct Acceptor {
+pub struct Acceptor<Sub>
+where
+    Sub: Subscriber,
+{
     sender: accept::Sender,
     socket: TcpListener,
     env: Environment,
     secrets: secret::Map,
     backlog: usize,
     accept_flavor: accept::Flavor,
+    subscriber: Sub,
 }
 
-impl Acceptor {
+impl<Sub> Acceptor<Sub>
+where
+    Sub: Subscriber,
+{
     #[inline]
     pub fn new(
+        id: usize,
         socket: TcpListener,
         sender: &accept::Sender,
         env: &Environment,
         secrets: &secret::Map,
         backlog: usize,
         accept_flavor: accept::Flavor,
+        subscriber: Sub,
     ) -> Self {
-        Self {
+        let acceptor = Self {
             sender: sender.clone(),
             socket,
             env: env.clone(),
             secrets: secrets.clone(),
             backlog,
             accept_flavor,
+            subscriber,
+        };
+
+        if let Ok(addr) = acceptor.socket.local_addr() {
+            let local_address: SocketAddress = addr.into();
+            acceptor
+                .publisher()
+                .on_acceptor_tcp_started(event::builder::AcceptorTcpStarted {
+                    id,
+                    local_address: &local_address,
+                    backlog,
+                });
         }
+
+        acceptor
     }
 
     pub async fn run(self) {
@@ -73,17 +98,23 @@ impl Acceptor {
 
         poll_fn(move |cx| {
             let now = self.env.clock().get_time();
+            let publisher = publisher(&self.subscriber, &now);
 
-            fresh.fill(cx, &self.socket);
-            trace!(accepted_backlog = fresh.len());
+            fresh.fill(cx, &self.socket, &publisher);
 
             for socket in fresh.drain() {
-                workers.push(socket, now);
+                workers.push(socket, now, &publisher);
             }
 
-            trace!(pre_worker_count = workers.working.len());
-            let res = workers.poll(cx, &mut context, now);
-            trace!(post_worker_count = workers.working.len());
+            let res = workers.poll(cx, &mut context, now, &publisher);
+
+            publisher.on_acceptor_tcp_loop_iteration_completed(
+                event::builder::AcceptorTcpLoopIterationCompleted {
+                    pending_streams: workers.working.len(),
+                    processing_duration: self.env.clock().get_time().saturating_duration_since(now),
+                    max_sojourn_time: workers.max_sojourn_time(),
+                },
+            );
 
             workers.invariants();
 
@@ -97,6 +128,23 @@ impl Acceptor {
 
         drop(drop_guard);
     }
+
+    fn publisher(&self) -> event::EndpointPublisherSubscriber<Sub> {
+        publisher(&self.subscriber, self.env.clock())
+    }
+}
+
+fn publisher<'a, Sub: Subscriber, C: Clock>(
+    subscriber: &'a Sub,
+    clock: &C,
+) -> event::EndpointPublisherSubscriber<'a, Sub> {
+    let timestamp = clock.get_time().into_event();
+
+    event::EndpointPublisherSubscriber::new(
+        event::builder::EndpointMeta { timestamp },
+        None,
+        subscriber,
+    )
 }
 
 /// Converts the kernel's TCP FIFO accept queue to LIFO
@@ -107,13 +155,19 @@ struct FreshQueue {
 }
 
 impl FreshQueue {
-    fn new(acceptor: &Acceptor) -> Self {
+    fn new<Sub>(acceptor: &Acceptor<Sub>) -> Self
+    where
+        Sub: Subscriber,
+    {
         Self {
             queue: VecDeque::with_capacity(acceptor.backlog),
         }
     }
 
-    fn fill(&mut self, cx: &mut Context, listener: &TcpListener) {
+    fn fill<Pub>(&mut self, cx: &mut Context, listener: &TcpListener, publisher: &Pub)
+    where
+        Pub: EndpointPublisher,
+    {
         // Allow draining the queue twice the capacity
         //
         // The idea here is to try and reduce the number of connections in the kernel's queue while
@@ -123,34 +177,63 @@ impl FreshQueue {
         // than pop/push with the userspace queue
         let mut remaining = self.queue.capacity() * 2;
 
+        let mut enqueued = 0;
+        let mut dropped = 0;
+        let mut errored = 0;
+
         while let Poll::Ready(res) = listener.poll_accept(cx) {
             match res {
-                Ok((socket, _remote_addr)) => {
+                Ok((socket, remote_addr)) => {
                     if self.queue.len() == self.queue.capacity() {
-                        let _ = self.queue.pop_back();
-                        trace!("fresh backlog too full; dropping stream");
+                        if let Some(remote_addr) = self
+                            .queue
+                            .pop_back()
+                            .and_then(|socket| socket.peer_addr().ok())
+                        {
+                            let remote_address: SocketAddress = remote_addr.into();
+                            let remote_address = &remote_address;
+                            publisher.on_acceptor_tcp_stream_dropped(
+                                event::builder::AcceptorTcpStreamDropped { remote_address, reason: event::builder::AcceptorTcpStreamDropReason::FreshQueueAtCapacity },
+                            );
+                            dropped += 1;
+                        }
                     }
+
+                    let remote_address: SocketAddress = remote_addr.into();
+                    let remote_address = &remote_address;
+                    publisher.on_acceptor_tcp_fresh_enqueued(
+                        event::builder::AcceptorTcpFreshEnqueued { remote_address },
+                    );
+                    enqueued += 1;
+
                     // most recent streams go to the front of the line, since they're the most
                     // likely to be successfully processed
                     self.queue.push_front(socket);
                 }
-                Err(err) => {
+                Err(error) => {
                     // TODO submit to a separate error channel that the application can subscribe
                     // to
-                    error!(listener_error = %err);
+                    publisher.on_acceptor_tcp_io_error(event::builder::AcceptorTcpIoError {
+                        error: &error,
+                    });
+                    errored += 1;
                 }
             }
 
             remaining -= 1;
 
             if remaining == 0 {
-                return;
+                break;
             }
         }
-    }
 
-    fn len(&self) -> usize {
-        self.queue.len()
+        publisher.on_acceptor_tcp_fresh_batch_completed(
+            event::builder::AcceptorTcpFreshBatchCompleted {
+                enqueued,
+                dropped,
+                errored,
+            },
+        )
     }
 
     fn drain(&mut self) -> impl Iterator<Item = TcpStream> + '_ {
@@ -178,7 +261,10 @@ struct WorkerSet {
 
 impl WorkerSet {
     #[inline]
-    pub fn new(acceptor: &Acceptor) -> Self {
+    pub fn new<Sub>(acceptor: &Acceptor<Sub>) -> Self
+    where
+        Sub: Subscriber,
+    {
         let backlog = acceptor.backlog;
         let mut workers = Vec::with_capacity(backlog);
         let mut free = VecDeque::with_capacity(backlog);
@@ -197,36 +283,49 @@ impl WorkerSet {
     }
 
     #[inline]
-    pub fn push(&mut self, stream: TcpStream, now: Timestamp) {
+    pub fn push<Pub>(&mut self, stream: TcpStream, now: Timestamp, publisher: &Pub)
+    where
+        Pub: EndpointPublisher,
+    {
         let Some(idx) = self.next_worker(now) else {
             // NOTE: we do not apply back pressure on the listener's `accept` since the aim is to
             // keep that queue as short as possible so we can control the behavior in userspace.
             //
             // TODO: we need to investigate how this interacts with SYN cookies/retries and fast
             // failure modes in kernel space.
-            trace!(
-                "could not find an available worker; dropping stream {:?}",
-                stream
-            );
+            if let Ok(remote_addr) = stream.peer_addr() {
+                let remote_address: SocketAddress = remote_addr.into();
+                let remote_address = &remote_address;
+                publisher.on_acceptor_tcp_stream_dropped(
+                    event::builder::AcceptorTcpStreamDropped {
+                        remote_address,
+                        reason: event::builder::AcceptorTcpStreamDropReason::SlotsAtCapacity,
+                    },
+                );
+            }
             drop(stream);
             return;
         };
-        self.workers[idx].push(stream, now);
+        self.workers[idx].push(stream, now, publisher);
         self.working.push_back(idx);
     }
 
     #[inline]
-    pub fn poll(
+    pub fn poll<Pub>(
         &mut self,
         cx: &mut Context,
         worker_cx: &mut WorkerContext,
         now: Timestamp,
-    ) -> ControlFlow<()> {
+        publisher: &Pub,
+    ) -> ControlFlow<()>
+    where
+        Pub: EndpointPublisher,
+    {
         let mut cf = ControlFlow::Continue(());
 
         self.working.retain(|&idx| {
             let worker = &mut self.workers[idx];
-            let Poll::Ready(res) = worker.poll(cx, worker_cx, now) else {
+            let Poll::Ready(res) = worker.poll(cx, worker_cx, now, publisher) else {
                 // keep processing it
                 return true;
             };
@@ -234,9 +333,6 @@ impl WorkerSet {
             match res {
                 Ok(ControlFlow::Continue(())) => {
                     // update the accept_time estimate
-                    let sample = worker.sojourn(now);
-                    trace!(sojourn_sample = ?sample);
-
                     self.sojourn_time.update_rtt(
                         Duration::ZERO,
                         worker.sojourn(now),
@@ -248,9 +344,9 @@ impl WorkerSet {
                 Ok(ControlFlow::Break(())) => {
                     cf = ControlFlow::Break(());
                 }
-                Err(err) => {
-                    debug!(accept_stream_error = %err);
-                }
+                Err(Some(err)) => publisher
+                    .on_acceptor_tcp_io_error(event::builder::AcceptorTcpIoError { error: &err }),
+                Err(None) => {}
             }
 
             // the worker is done so remove it from the working queue
@@ -342,7 +438,10 @@ struct WorkerContext {
 }
 
 impl WorkerContext {
-    fn new(acceptor: &Acceptor) -> Self {
+    fn new<Sub>(acceptor: &Acceptor<Sub>) -> Self
+    where
+        Sub: Subscriber,
+    {
         Self {
             recv_buffer: msg::recv::Message::new(u16::MAX),
             sender: acceptor.sender.clone(),
@@ -369,23 +468,42 @@ impl Worker {
     }
 
     #[inline]
-    pub fn push(&mut self, stream: TcpStream, now: Timestamp) {
-        self.queue_time = now;
+    pub fn push<Pub>(&mut self, stream: TcpStream, now: Timestamp, publisher: &Pub)
+    where
+        Pub: EndpointPublisher,
+    {
+        let prev_queue_time = core::mem::replace(&mut self.queue_time, now);
         let prev_state = core::mem::replace(&mut self.state, WorkerState::Init);
         let prev = core::mem::replace(&mut self.stream, Some(stream));
 
-        if prev.is_some() {
-            trace!(worker_prev_state = ?prev_state);
+        if let Some(remote_addr) = prev.and_then(|socket| socket.peer_addr().ok()) {
+            let remote_address: SocketAddress = remote_addr.into();
+            let remote_address = &remote_address;
+            let sojourn_time = now.saturating_duration_since(prev_queue_time);
+            let buffer_len = match prev_state {
+                WorkerState::Init => 0,
+                WorkerState::Buffering { buffer, .. } => buffer.payload_len(),
+                WorkerState::Erroring { .. } => 0,
+            };
+            publisher.on_acceptor_tcp_stream_replaced(event::builder::AcceptorTcpStreamReplaced {
+                remote_address,
+                sojourn_time,
+                buffer_len,
+            });
         }
     }
 
     #[inline]
-    pub fn poll(
+    pub fn poll<Pub>(
         &mut self,
         cx: &mut Context,
         context: &mut WorkerContext,
         now: Timestamp,
-    ) -> Poll<io::Result<ControlFlow<()>>> {
+        publisher: &Pub,
+    ) -> Poll<Result<ControlFlow<()>, Option<io::Error>>>
+    where
+        Pub: EndpointPublisher,
+    {
         // if we don't have a stream then it's a bug in the worker impl - in production just return
         // `Ready`, which will correct the state
         if self.stream.is_none() {
@@ -399,9 +517,14 @@ impl Worker {
         // make sure another worker didn't leave around a buffer
         context.recv_buffer.clear();
 
-        let res = ready!(self
-            .state
-            .poll(cx, context, &mut self.stream, self.queue_time, now));
+        let res = ready!(self.state.poll(
+            cx,
+            context,
+            &mut self.stream,
+            self.queue_time,
+            now,
+            publisher
+        ));
 
         // if we're ready then reset the worker
         self.state = WorkerState::Init;
@@ -422,7 +545,11 @@ enum WorkerState {
     /// Worker is waiting for a packet
     Init,
     /// Worker received a partial packet and is waiting on more data
-    Buffering(msg::recv::Message),
+    Buffering {
+        buffer: msg::recv::Message,
+        /// The number of times we got Pending from the `recv` call
+        blocked_count: usize,
+    },
     /// Worker encountered an error and is trying to send a response
     Erroring {
         offset: usize,
@@ -432,21 +559,30 @@ enum WorkerState {
 }
 
 impl WorkerState {
-    fn poll(
+    fn poll<Pub>(
         &mut self,
         cx: &mut Context,
         context: &mut WorkerContext,
         stream: &mut Option<TcpStream>,
         queue_time: Timestamp,
         now: Timestamp,
-    ) -> Poll<io::Result<ControlFlow<()>>> {
+        publisher: &Pub,
+    ) -> Poll<Result<ControlFlow<()>, Option<io::Error>>>
+    where
+        Pub: EndpointPublisher,
+    {
+        let sojourn_time = now.saturating_duration_since(queue_time);
+
         loop {
             // figure out where to put the received bytes
-            let (recv_buffer, recv_buffer_owned) = match self {
+            let (recv_buffer, blocked_count) = match self {
                 // borrow the context's recv buffer initially
-                WorkerState::Init => (&mut context.recv_buffer, false),
+                WorkerState::Init => (&mut context.recv_buffer, 0),
                 // we have our own recv buffer to use
-                WorkerState::Buffering(recv_buffer) => (recv_buffer, true),
+                WorkerState::Buffering {
+                    buffer,
+                    blocked_count,
+                } => (buffer, *blocked_count),
                 // we encountered an error so try and send it back
                 WorkerState::Erroring { offset, buffer, .. } => {
                     let stream = Pin::new(stream.as_mut().unwrap());
@@ -465,26 +601,38 @@ impl WorkerState {
                         unreachable!()
                     };
 
-                    return Err(error).into();
+                    return Err(Some(error)).into();
                 }
             };
 
             // try to read an initial packet from the socket
-            let res = Self::poll_initial_packet(cx, stream.as_mut().unwrap(), recv_buffer);
+            let res = Self::poll_initial_packet(
+                cx,
+                stream.as_mut().unwrap(),
+                recv_buffer,
+                sojourn_time,
+                publisher,
+            );
 
             let Poll::Ready(res) = res else {
                 // if we got `Pending` but we don't own the recv buffer then we need to copy it
                 // into the worker so we can resume where we left off last time
-                if !recv_buffer_owned {
-                    *self = WorkerState::Buffering(recv_buffer.take());
-                };
+                if blocked_count == 0 {
+                    let buffer = recv_buffer.take();
+                    *self = Self::Buffering {
+                        buffer,
+                        blocked_count,
+                    };
+                }
+
+                if let Self::Buffering { blocked_count, .. } = self {
+                    *blocked_count += 1;
+                }
 
                 return Poll::Pending;
             };
 
             let initial_packet = res?;
-
-            debug!(?initial_packet);
 
             let stream_builder = match endpoint::accept_stream(
                 &context.env,
@@ -510,28 +658,42 @@ impl WorkerState {
                             continue;
                         }
                     }
-                    return Err(error.error).into();
+                    return Err(Some(error.error)).into();
                 }
             };
 
-            trace!(
-                enqueue_stream = ?stream_builder.shared.remote_ip(),
-                sojourn_time = ?now.saturating_duration_since(queue_time),
-            );
+            {
+                let remote_address: SocketAddress = stream_builder.shared.read_remote_addr();
+                let remote_address = &remote_address;
+                let credential_id = &*stream_builder.shared.credentials().id;
+                let stream_id = stream_builder
+                    .shared
+                    .application()
+                    .stream_id
+                    .into_varint()
+                    .as_u64();
+                publisher.on_acceptor_tcp_stream_enqueued(
+                    event::builder::AcceptorTcpStreamEnqueued {
+                        remote_address,
+                        credential_id,
+                        stream_id,
+                        sojourn_time,
+                        blocked_count,
+                    },
+                );
+            }
 
-            let item = (stream_builder, queue_time);
             let res = match context.accept_flavor {
-                accept::Flavor::Fifo => context.sender.send_back(item),
-                accept::Flavor::Lifo => context.sender.send_front(item),
+                accept::Flavor::Fifo => context.sender.send_back(stream_builder),
+                accept::Flavor::Lifo => context.sender.send_front(stream_builder),
             };
 
             return Poll::Ready(Ok(match res {
                 Ok(prev) => {
-                    if let Some((stream, queue_time)) = prev {
-                        debug!(
-                            event = "accept::prune",
-                            credentials = ?stream.shared.credentials(),
-                            queue_duration = ?now.saturating_duration_since(queue_time),
+                    if let Some(stream) = prev {
+                        stream.prune(
+                            event::builder::AcceptorStreamPruneReason::AcceptQueueCapacityExceeded,
+                            publisher,
                         );
                     }
                     ControlFlow::Continue(())
@@ -545,41 +707,78 @@ impl WorkerState {
     }
 
     #[inline]
-    fn poll_initial_packet(
+    fn poll_initial_packet<Pub>(
         cx: &mut Context,
         stream: &mut TcpStream,
         recv_buffer: &mut msg::recv::Message,
-    ) -> Poll<io::Result<server::InitialPacket>> {
+        sojourn_time: Duration,
+        publisher: &Pub,
+    ) -> Poll<Result<server::InitialPacket, Option<io::Error>>>
+    where
+        Pub: EndpointPublisher,
+    {
         loop {
-            ensure!(
-                recv_buffer.payload_len() < 10_000,
-                Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "prelude did not come in the first 10k bytes"
-                ))
-                .into()
-            );
+            if recv_buffer.payload_len() > 10_000 {
+                let remote_address = stream
+                    .peer_addr()
+                    .ok()
+                    .map(SocketAddress::from)
+                    .unwrap_or_default();
 
-            let res = ready!(stream.poll_recv_buffer(cx, recv_buffer))?;
+                publisher.on_acceptor_tcp_packet_dropped(
+                    event::builder::AcceptorTcpPacketDropped {
+                        remote_address: &remote_address,
+                        reason: DecoderError::UnexpectedBytes(recv_buffer.payload_len())
+                            .into_event(),
+                        sojourn_time,
+                    },
+                );
+                return Err(None).into();
+            }
+
+            let res = ready!(stream.poll_recv_buffer(cx, recv_buffer)).map_err(Some)?;
 
             match server::InitialPacket::peek(recv_buffer, 16) {
                 Ok(packet) => {
+                    let remote_address = stream
+                        .peer_addr()
+                        .ok()
+                        .map(SocketAddress::from)
+                        .unwrap_or_default();
+
+                    publisher.on_acceptor_tcp_packet_received(
+                        event::builder::AcceptorTcpPacketReceived {
+                            remote_address: &remote_address,
+                            credential_id: &*packet.credentials.id,
+                            stream_id: packet.stream_id.into_varint().as_u64(),
+                            payload_len: packet.payload_len,
+                            is_fin: packet.is_fin,
+                            sojourn_time,
+                        },
+                    );
                     return Ok(packet).into();
                 }
-                Err(s2n_codec::DecoderError::UnexpectedEof(_)) => {
-                    // If at end of the stream, we're not going to succeed. End early.
-                    if res == 0 {
-                        return Err(io::Error::new(
-                            io::ErrorKind::InvalidData,
-                            "insufficient data in prelude before EOF",
-                        ))
-                        .into();
-                    }
-                    // we don't have enough bytes buffered so try reading more
-                    continue;
-                }
                 Err(err) => {
-                    return Err(io::Error::new(io::ErrorKind::InvalidData, err.to_string())).into();
+                    if matches!(err, DecoderError::UnexpectedEof(_)) && res > 0 {
+                        // we don't have enough bytes buffered so try reading more
+                        continue;
+                    }
+
+                    let remote_address = stream
+                        .peer_addr()
+                        .ok()
+                        .map(SocketAddress::from)
+                        .unwrap_or_default();
+
+                    publisher.on_acceptor_tcp_packet_dropped(
+                        event::builder::AcceptorTcpPacketDropped {
+                            remote_address: &remote_address,
+                            reason: err.into_event(),
+                            sojourn_time,
+                        },
+                    );
+
+                    return Err(None).into();
                 }
             }
         }

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp.rs
@@ -111,6 +111,8 @@ where
             publisher.on_acceptor_tcp_loop_iteration_completed(
                 event::builder::AcceptorTcpLoopIterationCompleted {
                     pending_streams: workers.working.len(),
+                    slots_idle: workers.free.len(),
+                    slot_utilization: workers.working.len() as f32 / workers.workers.len() as f32,
                     processing_duration: self.env.clock().get_time().saturating_duration_since(now),
                     max_sojourn_time: workers.max_sojourn_time(),
                 },
@@ -753,6 +755,7 @@ impl WorkerState {
                             stream_id: packet.stream_id.into_varint().as_u64(),
                             payload_len: packet.payload_len,
                             is_fin: packet.is_fin,
+                            is_fin_known: packet.is_fin_known,
                             sojourn_time,
                         },
                     );

--- a/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
@@ -3,6 +3,7 @@
 
 use super::accept;
 use crate::{
+    event::{self, EndpointPublisher, IntoEvent, Subscriber},
     msg,
     path::secret,
     stream::{
@@ -16,11 +17,15 @@ use crate::{
     },
 };
 use core::ops::ControlFlow;
-use s2n_quic_core::time::Clock as _;
+use s2n_quic_core::{inet::SocketAddress, time::Clock};
 use std::io;
 use tracing::debug;
 
-pub struct Acceptor<S: Socket> {
+pub struct Acceptor<S, Sub>
+where
+    S: Socket,
+    Sub: Subscriber,
+{
     sender: accept::Sender,
     socket: S,
     recv_buffer: msg::recv::Message,
@@ -28,18 +33,25 @@ pub struct Acceptor<S: Socket> {
     env: Environment,
     secrets: secret::Map,
     accept_flavor: accept::Flavor,
+    subscriber: Sub,
 }
 
-impl<S: Socket> Acceptor<S> {
+impl<S, Sub> Acceptor<S, Sub>
+where
+    S: Socket,
+    Sub: Subscriber,
+{
     #[inline]
     pub fn new(
+        id: usize,
         socket: S,
         sender: &accept::Sender,
         env: &Environment,
         secrets: &secret::Map,
         accept_flavor: accept::Flavor,
+        subscriber: Sub,
     ) -> Self {
-        Self {
+        let acceptor = Self {
             sender: sender.clone(),
             socket,
             recv_buffer: msg::recv::Message::new(9000.try_into().unwrap()),
@@ -47,7 +59,18 @@ impl<S: Socket> Acceptor<S> {
             env: env.clone(),
             secrets: secrets.clone(),
             accept_flavor,
+            subscriber,
+        };
+
+        if let Ok(addr) = acceptor.socket.local_addr() {
+            let addr: SocketAddress = addr.into();
+            let local_address = addr.into_event();
+            acceptor
+                .publisher()
+                .on_acceptor_udp_started(event::builder::AcceptorUdpStarted { id, local_address });
         }
+
+        acceptor
     }
 
     pub async fn run(mut self) {
@@ -55,8 +78,11 @@ impl<S: Socket> Acceptor<S> {
             match self.accept_one().await {
                 Ok(ControlFlow::Continue(())) => continue,
                 Ok(ControlFlow::Break(())) => break,
-                Err(err) => {
-                    tracing::error!(acceptor_error = %err);
+                Err(error) => {
+                    self.publisher()
+                        .on_acceptor_udp_io_error(event::builder::AcceptorUdpIoError {
+                            error: &error,
+                        });
                 }
             }
         }
@@ -66,6 +92,7 @@ impl<S: Socket> Acceptor<S> {
         let packet = self.recv_packet().await?;
 
         let now = self.env.clock().get_time();
+        let publisher = publisher(&self.subscriber, &now);
 
         let server::handshake::Outcome::Created {
             receiver: handshake,
@@ -100,19 +127,29 @@ impl<S: Socket> Acceptor<S> {
             }
         };
 
-        let item = (stream, now);
+        {
+            let remote_address: SocketAddress = stream.shared.read_remote_addr();
+            let remote_address = &remote_address;
+            let credential_id = &*stream.shared.credentials().id;
+            let stream_id = stream.shared.application().stream_id.into_varint().as_u64();
+            publisher.on_acceptor_udp_stream_enqueued(event::builder::AcceptorUdpStreamEnqueued {
+                remote_address,
+                credential_id,
+                stream_id,
+            });
+        }
+
         let res = match self.accept_flavor {
-            accept::Flavor::Fifo => self.sender.send_back(item),
-            accept::Flavor::Lifo => self.sender.send_front(item),
+            accept::Flavor::Fifo => self.sender.send_back(stream),
+            accept::Flavor::Lifo => self.sender.send_front(stream),
         };
 
         match res {
             Ok(prev) => {
-                if let Some((stream, queue_time)) = prev {
-                    debug!(
-                        event = "accept::prune",
-                        credentials = ?stream.shared.credentials(),
-                        queue_duration = ?now.saturating_duration_since(queue_time),
+                if let Some(stream) = prev {
+                    stream.prune(
+                        event::builder::AcceptorStreamPruneReason::AcceptQueueCapacityExceeded,
+                        &publisher,
                     );
                 }
 
@@ -129,20 +166,64 @@ impl<S: Socket> Acceptor<S> {
         loop {
             // discard any pending packets
             self.recv_buffer.clear();
-            tracing::trace!("recv_start");
             self.socket.recv_buffer(&mut self.recv_buffer).await?;
-            tracing::trace!("recv_finish");
 
-            match server::InitialPacket::peek(&mut self.recv_buffer, 16) {
-                Ok(initial_packet) => {
-                    tracing::debug!(?initial_packet);
-                    return Ok(initial_packet);
+            let remote_address = self.recv_buffer.remote_address();
+            let remote_address = &remote_address;
+            let packet = server::InitialPacket::peek(&mut self.recv_buffer, 16);
+
+            let publisher = self.publisher();
+            publisher.on_acceptor_udp_datagram_received(
+                event::builder::AcceptorUdpDatagramReceived {
+                    remote_address,
+                    len: self.recv_buffer.payload_len(),
+                },
+            );
+
+            match packet {
+                Ok(packet) => {
+                    publisher.on_acceptor_udp_packet_received(
+                        event::builder::AcceptorUdpPacketReceived {
+                            remote_address,
+                            credential_id: &*packet.credentials.id,
+                            stream_id: packet.stream_id.into_varint().as_u64(),
+                            payload_len: packet.payload_len,
+                            is_zero_offset: packet.is_zero_offset,
+                            is_retransmission: packet.is_retransmission,
+                            is_fin: packet.is_fin,
+                        },
+                    );
+
+                    return Ok(packet);
                 }
-                Err(initial_packet_error) => {
-                    tracing::debug!(?initial_packet_error);
+                Err(error) => {
+                    publisher.on_acceptor_udp_packet_dropped(
+                        event::builder::AcceptorUdpPacketDropped {
+                            remote_address,
+                            reason: error.into_event(),
+                        },
+                    );
+
                     continue;
                 }
             }
         }
     }
+
+    fn publisher(&self) -> event::EndpointPublisherSubscriber<Sub> {
+        publisher(&self.subscriber, self.env.clock())
+    }
+}
+
+fn publisher<'a, Sub: Subscriber, C: Clock>(
+    subscriber: &'a Sub,
+    clock: &C,
+) -> event::EndpointPublisherSubscriber<'a, Sub> {
+    let timestamp = clock.get_time().into_event();
+
+    event::EndpointPublisherSubscriber::new(
+        event::builder::EndpointMeta { timestamp },
+        None,
+        subscriber,
+    )
 }

--- a/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
@@ -191,6 +191,7 @@ where
                             is_zero_offset: packet.is_zero_offset,
                             is_retransmission: packet.is_retransmission,
                             is_fin: packet.is_fin,
+                            is_fin_known: packet.is_fin_known,
                         },
                     );
 

--- a/quic/s2n-quic-core/src/event.rs
+++ b/quic/s2n-quic-core/src/event.rs
@@ -199,6 +199,14 @@ impl core::fmt::Debug for TlsSession<'_> {
     }
 }
 
+#[cfg(feature = "std")]
+impl<'a> IntoEvent<&'a std::io::Error> for &'a std::io::Error {
+    #[inline]
+    fn into_event(self) -> &'a std::io::Error {
+        self
+    }
+}
+
 /// Provides metadata related to an event
 pub trait Meta: core::fmt::Debug {
     /// Returns whether the local endpoint is a Client or Server

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -273,14 +273,16 @@ pub mod api {
     }
     impl<'a> aggregate::AsVariant for SocketAddress<'a> {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("IP_V4\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("IP_V6\0"),
                 id: 1usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -307,14 +309,16 @@ pub mod api {
     }
     impl aggregate::AsVariant for DuplicatePacketError {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("DUPLICATE\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("TOO_OLD\0"),
                 id: 1usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -400,94 +404,116 @@ pub mod api {
     }
     impl aggregate::AsVariant for Frame {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PADDING\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PING\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("ACK\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("RESET_STREAM\0"),
                 id: 3usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("STOP_SENDING\0"),
                 id: 4usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("CRYPTO\0"),
                 id: 5usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("NEW_TOKEN\0"),
                 id: 6usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("STREAM\0"),
                 id: 7usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("MAX_DATA\0"),
                 id: 8usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("MAX_STREAM_DATA\0"),
                 id: 9usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("MAX_STREAMS\0"),
                 id: 10usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("DATA_BLOCKED\0"),
                 id: 11usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("STREAM_DATA_BLOCKED\0"),
                 id: 12usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("STREAMS_BLOCKED\0"),
                 id: 13usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("NEW_CONNECTION_ID\0"),
                 id: 14usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("RETIRE_CONNECTION_ID\0"),
                 id: 15usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PATH_CHALLENGE\0"),
                 id: 16usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PATH_RESPONSE\0"),
                 id: 17usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("CONNECTION_CLOSE\0"),
                 id: 18usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("HANDSHAKE_DONE\0"),
                 id: 19usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("DATAGRAM\0"),
                 id: 20usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("DC_STATELESS_RESET_TOKENS\0"),
                 id: 21usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -527,14 +553,16 @@ pub mod api {
     }
     impl aggregate::AsVariant for StreamType {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("BIDIRECTIONAL\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("UNIDIRECTIONAL\0"),
                 id: 1usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -564,34 +592,41 @@ pub mod api {
     }
     impl aggregate::AsVariant for PacketHeader {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("INITIAL\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("HANDSHAKE\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("ZERO_RTT\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("ONE_RTT\0"),
                 id: 3usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("RETRY\0"),
                 id: 4usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("VERSION_NEGOTIATION\0"),
                 id: 5usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("STATELESS_RESET\0"),
                 id: 6usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -626,34 +661,41 @@ pub mod api {
     }
     impl aggregate::AsVariant for PacketType {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("INITIAL\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("HANDSHAKE\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("ZERO_RTT\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("ONE_RTT\0"),
                 id: 3usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("RETRY\0"),
                 id: 4usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("VERSION_NEGOTIATION\0"),
                 id: 5usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("STATELESS_RESET\0"),
                 id: 6usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -682,22 +724,26 @@ pub mod api {
     }
     impl aggregate::AsVariant for KeyType {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("INITIAL\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("HANDSHAKE\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("ZERO_RTT\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("ONE_RTT\0"),
                 id: 3usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -723,14 +769,16 @@ pub mod api {
     }
     impl aggregate::AsVariant for Subject {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("ENDPOINT\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("CONNECTION\0"),
                 id: 1usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -750,14 +798,16 @@ pub mod api {
     }
     impl aggregate::AsVariant for EndpointType {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("SERVER\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("CLIENT\0"),
                 id: 1usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -820,58 +870,71 @@ pub mod api {
     }
     impl aggregate::AsVariant for DatagramDropReason {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("DECODING_FAILED\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("INVALID_RETRY_TOKEN\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("UNSUPPORTED_VERSION\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("INVALID_DESTINATION_CONNECTION_ID\0"),
                 id: 3usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("INVALID_SOURCE_CONNECTION_ID\0"),
                 id: 4usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("INVALID_MTU_CONFIGURATION\0"),
                 id: 5usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("UNKNOWN_DESTINATION_CONNECTION_ID\0"),
                 id: 6usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("REJECTED_CONNECTION_ATTEMPT\0"),
                 id: 7usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("UNKNOWN_SERVER_ADDRESS\0"),
                 id: 8usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("CONNECTION_MIGRATION_DURING_HANDSHAKE\0"),
                 id: 9usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("REJECTED_CONNECTION_MIGRATION\0"),
                 id: 10usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PATH_LIMIT_EXCEEDED\0"),
                 id: 11usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("INSUFFICIENT_CONNECTION_IDS\0"),
                 id: 12usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -906,22 +969,26 @@ pub mod api {
     }
     impl aggregate::AsVariant for KeySpace {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("INITIAL\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("HANDSHAKE\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("ZERO_RTT\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("ONE_RTT\0"),
                 id: 3usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -945,14 +1012,16 @@ pub mod api {
     }
     impl aggregate::AsVariant for PacketSkipReason {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PTO_PROBE\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("OPTIMISTIC_ACK_MITIGATION\0"),
                 id: 1usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -1022,50 +1091,61 @@ pub mod api {
     }
     impl<'a> aggregate::AsVariant for PacketDropReason<'a> {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("CONNECTION_ERROR\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("HANDSHAKE_NOT_COMPLETE\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("VERSION_MISMATCH\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("CONNECTION_ID_MISMATCH\0"),
                 id: 3usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("UNPROTECT_FAILED\0"),
                 id: 4usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("DECRYPTION_FAILED\0"),
                 id: 5usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("DECODING_FAILED\0"),
                 id: 6usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("NON_EMPTY_RETRY_TOKEN\0"),
                 id: 7usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("RETRY_DISCARDED\0"),
                 id: 8usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("UNDERSIZED_INITIAL_PACKET\0"),
                 id: 9usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("INITIAL_CONNECTION_ID_INVALID_SPACE\0"),
                 id: 10usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -1108,10 +1188,12 @@ pub mod api {
     }
     #[allow(deprecated)]
     impl aggregate::AsVariant for AckAction {
-        const VARIANTS: &'static [aggregate::info::Variant] = &[aggregate::info::Variant {
-            name: aggregate::info::Str::new("RX_ACK_RANGE_DROPPED\0"),
-            id: 0usize,
-        }];
+        const VARIANTS: &'static [aggregate::info::Variant] =
+            &[aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("RX_ACK_RANGE_DROPPED\0"),
+                id: 0usize,
+            }
+            .build()];
         #[inline]
         fn variant_idx(&self) -> usize {
             match self {
@@ -1138,22 +1220,26 @@ pub mod api {
     }
     impl<'a> aggregate::AsVariant for RetryDiscardReason<'a> {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("SCID_EQUALS_DCID\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("RETRY_ALREADY_PROCESSED\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("INITIAL_ALREADY_PROCESSED\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("INVALID_INTEGRITY_TAG\0"),
                 id: 3usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -1179,22 +1265,26 @@ pub mod api {
     }
     impl aggregate::AsVariant for MigrationDenyReason {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("BLOCKED_PORT\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PORT_SCOPE_CHANGED\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("IP_SCOPE_CHANGE\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("CONNECTION_MIGRATION_DISABLED\0"),
                 id: 3usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -1225,22 +1315,26 @@ pub mod api {
     }
     impl aggregate::AsVariant for EcnState {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("TESTING\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("UNKNOWN\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("FAILED\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("CAPABLE\0"),
                 id: 3usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -1278,22 +1372,26 @@ pub mod api {
     }
     impl aggregate::AsVariant for HandshakeStatus {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("COMPLETE\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("CONFIRMED\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("HANDSHAKE_DONE_ACKED\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("HANDSHAKE_DONE_LOST\0"),
                 id: 3usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -1318,14 +1416,16 @@ pub mod api {
     }
     impl aggregate::AsVariant for CongestionSource {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("ECN\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PACKET_LOSS\0"),
                 id: 1usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -1350,22 +1450,26 @@ pub mod api {
     }
     impl aggregate::AsVariant for CipherSuite {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("TLS_AES_128_GCM_SHA256\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("TLS_AES_256_GCM_SHA384\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("TLS_CHACHA20_POLY1305_SHA256\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("UNKNOWN\0"),
                 id: 3usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -1387,14 +1491,16 @@ pub mod api {
     }
     impl aggregate::AsVariant for PathChallengeStatus {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("VALIDATED\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("ABANDONED\0"),
                 id: 1usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -1427,22 +1533,26 @@ pub mod api {
     }
     impl aggregate::AsVariant for SlowStartExitCause {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PACKET_LOSS\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("ECN\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("RTT\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("OTHER\0"),
                 id: 3usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -1479,30 +1589,36 @@ pub mod api {
     }
     impl aggregate::AsVariant for MtuUpdatedCause {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("NEW_PATH\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PROBE_ACKNOWLEDGED\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("BLACKHOLE\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("INITIAL_MTU_PACKET_LOST\0"),
                 id: 3usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("INITIAL_MTU_PACKET_ACKNOWLEDGED\0"),
                 id: 4usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("LARGER_PROBES_LOST\0"),
                 id: 5usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -1536,34 +1652,41 @@ pub mod api {
     }
     impl aggregate::AsVariant for BbrState {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("STARTUP\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("DRAIN\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PROBE_BW_DOWN\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PROBE_BW_CRUISE\0"),
                 id: 3usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PROBE_BW_REFILL\0"),
                 id: 4usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PROBE_BW_UP\0"),
                 id: 5usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PROBE_RTT\0"),
                 id: 6usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -1592,22 +1715,26 @@ pub mod api {
     }
     impl aggregate::AsVariant for DcState {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("VERSION_NEGOTIATED\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("NO_VERSION_NEGOTIATED\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("PATH_SECRETS_READY\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("COMPLETE\0"),
                 id: 3usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {
@@ -2807,30 +2934,36 @@ pub mod api {
     }
     impl aggregate::AsVariant for PlatformFeatureConfiguration {
         const VARIANTS: &'static [aggregate::info::Variant] = &[
-            aggregate::info::Variant {
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("GSO\0"),
                 id: 0usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("GRO\0"),
                 id: 1usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("ECN\0"),
                 id: 2usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("BASE_MTU\0"),
                 id: 3usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("INITIAL_MTU\0"),
                 id: 4usize,
-            },
-            aggregate::info::Variant {
+            }
+            .build(),
+            aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new("MAX_MTU\0"),
                 id: 5usize,
-            },
+            }
+            .build(),
         ];
         #[inline]
         fn variant_idx(&self) -> usize {

--- a/quic/s2n-quic-core/src/event/metrics/aggregate/info.rs
+++ b/quic/s2n-quic-core/src/event/metrics/aggregate/info.rs
@@ -13,13 +13,6 @@ pub struct Info {
     pub units: Units,
 }
 
-#[derive(Copy, Clone, Debug)]
-#[non_exhaustive]
-pub struct Variant {
-    pub id: usize,
-    pub name: &'static Str,
-}
-
 #[doc(hidden)]
 pub struct Builder {
     pub id: usize,
@@ -34,6 +27,32 @@ impl Builder {
             id: self.id,
             name: self.name,
             units: self.units,
+        }
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+#[non_exhaustive]
+pub struct Variant {
+    pub id: usize,
+    pub name: &'static Str,
+}
+
+#[doc(hidden)]
+pub mod variant {
+    use super::*;
+
+    pub struct Builder {
+        pub id: usize,
+        pub name: &'static Str,
+    }
+
+    impl Builder {
+        pub const fn build(self) -> Variant {
+            Variant {
+                id: self.id,
+                name: self.name,
+            }
         }
     }
 }

--- a/quic/s2n-quic-core/src/event/metrics/aggregate/metric.rs
+++ b/quic/s2n-quic-core/src/event/metrics/aggregate/metric.rs
@@ -10,6 +10,7 @@ pub enum Units {
     None,
     Bytes,
     Duration,
+    Percent,
 }
 
 impl Units {
@@ -18,6 +19,7 @@ impl Units {
             Units::None => Str::new("\0"),
             Units::Bytes => Str::new("bytes\0"),
             Units::Duration => Str::new("duration\0"),
+            Units::Percent => Str::new("percent\0"),
         }
     }
 }

--- a/quic/s2n-quic-events/src/main.rs
+++ b/quic/s2n-quic-events/src/main.rs
@@ -10,6 +10,7 @@ type Result<T, E = Error> = core::result::Result<T, E>;
 mod output;
 mod output_mode;
 mod parser;
+mod validation;
 
 use output::Output;
 use output_mode::OutputMode;
@@ -154,6 +155,9 @@ fn main() -> Result<()> {
 
         // make sure events are in a deterministic order
         files.sort_by(|a, b| a.path.as_os_str().cmp(b.path.as_os_str()));
+
+        // validate the events
+        validation::validate(&files);
 
         let root = std::path::Path::new(event_info.output_path);
         let _ = std::fs::create_dir_all(root);

--- a/quic/s2n-quic-events/src/parser.rs
+++ b/quic/s2n-quic-events/src/parser.rs
@@ -496,10 +496,10 @@ impl Enum {
             let mut name = name.to_shouty_snake_case();
             name.push('\0');
 
-            variant_defs.extend(quote!(aggregate::info::Variant {
+            variant_defs.extend(quote!(aggregate::info::variant::Builder {
                 name: aggregate::info::Str::new(#name),
                 id: #idx,
-            },));
+            }.build(),));
 
             variant_matches.extend(quote!(
                 Self::#ident { .. } => #idx,

--- a/quic/s2n-quic-events/src/validation.rs
+++ b/quic/s2n-quic-events/src/validation.rs
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::parser::File;
+use std::collections::HashSet;
+
+pub fn validate(files: &[File]) {
+    let mut endpoint_names = HashSet::new();
+    let mut connection_names = HashSet::new();
+    let mut errored = false;
+
+    for file in files {
+        for (subject, name) in file
+            .structs
+            .iter()
+            .map(|v| (&v.attrs.subject, v.attrs.event_name.as_ref()))
+        {
+            let Some(name) = name else {
+                continue;
+            };
+
+            let set = if subject.is_connection() {
+                &mut connection_names
+            } else {
+                &mut endpoint_names
+            };
+
+            if !set.insert(name.value()) {
+                let path = file.path.canonicalize().unwrap();
+                let path = path.strip_prefix(std::env::current_dir().unwrap()).unwrap();
+                eprintln!(
+                    "[{}]: Duplicate event name: {:?}, subject = {subject:?}",
+                    path.display(),
+                    name.value()
+                );
+                errored = true;
+            }
+        }
+    }
+
+    if errored {
+        panic!("Validation errors");
+    }
+}


### PR DESCRIPTION
### Description of changes: 

This change adds several acceptor events for the s2n-quic-dc crate. This will provide a lot better insight into the decisions being made by the workers.

### Call-outs:

The `info::Variant` struct is marked as `#[non_exhaustive]` and can't be constructed outside of s2n-quic-core. I needed to modify the event generator script to use a `info::variant::Builder` instead.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

