### PR TITLE
Metric for forward gaps in key ID tracking

### DIFF
--- a/dc/s2n-quic-dc/events/map.rs
+++ b/dc/s2n-quic-dc/events/map.rs
@@ -133,9 +133,17 @@ struct KeyAccepted<'a> {
 
     key_id: u64,
 
-    /// How far away this credential is from the leading edge of key IDs.
+    /// How far away this credential is from the leading edge of key IDs (after updating the edge).
+    ///
+    /// Zero if this shifted us forward.
     #[measure("gap")]
     gap: u64,
+
+    /// How far away this credential is from the leading edge of key IDs (before updating the edge).
+    ///
+    /// Zero if this didn't change the leading edge.
+    #[measure("forward_shift")]
+    forward_shift: u64,
 }
 
 #[event("path_secret_map:replay_definitely_detected")]

--- a/dc/s2n-quic-dc/src/event/generated.rs
+++ b/dc/s2n-quic-dc/src/event/generated.rs
@@ -892,8 +892,14 @@ pub mod api {
     pub struct KeyAccepted<'a> {
         pub credential_id: &'a [u8],
         pub key_id: u64,
-        #[doc = " How far away this credential is from the leading edge of key IDs."]
+        #[doc = " How far away this credential is from the leading edge of key IDs (after updating the edge)."]
+        #[doc = ""]
+        #[doc = " Zero if this shifted us forward."]
         pub gap: u64,
+        #[doc = " How far away this credential is from the leading edge of key IDs (before updating the edge)."]
+        #[doc = ""]
+        #[doc = " Zero if this didn't change the leading edge."]
+        pub forward_shift: u64,
     }
     #[cfg(any(test, feature = "testing"))]
     impl<'a> crate::event::snapshot::Fmt for KeyAccepted<'a> {
@@ -902,6 +908,7 @@ pub mod api {
             fmt.field("credential_id", &"[HIDDEN]");
             fmt.field("key_id", &self.key_id);
             fmt.field("gap", &self.gap);
+            fmt.field("forward_shift", &self.forward_shift);
             fmt.finish()
         }
     }
@@ -1618,8 +1625,9 @@ pub mod tracing {
                 credential_id,
                 key_id,
                 gap,
+                forward_shift,
             } = event;
-            tracing :: event ! (target : "key_accepted" , parent : parent , tracing :: Level :: DEBUG , credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id) , gap = tracing :: field :: debug (gap));
+            tracing :: event ! (target : "key_accepted" , parent : parent , tracing :: Level :: DEBUG , credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id) , gap = tracing :: field :: debug (gap) , forward_shift = tracing :: field :: debug (forward_shift));
         }
         #[inline]
         fn on_replay_definitely_detected(
@@ -2626,8 +2634,14 @@ pub mod builder {
     pub struct KeyAccepted<'a> {
         pub credential_id: &'a [u8],
         pub key_id: u64,
-        #[doc = " How far away this credential is from the leading edge of key IDs."]
+        #[doc = " How far away this credential is from the leading edge of key IDs (after updating the edge)."]
+        #[doc = ""]
+        #[doc = " Zero if this shifted us forward."]
         pub gap: u64,
+        #[doc = " How far away this credential is from the leading edge of key IDs (before updating the edge)."]
+        #[doc = ""]
+        #[doc = " Zero if this didn't change the leading edge."]
+        pub forward_shift: u64,
     }
     impl<'a> IntoEvent<api::KeyAccepted<'a>> for KeyAccepted<'a> {
         #[inline]
@@ -2636,11 +2650,13 @@ pub mod builder {
                 credential_id,
                 key_id,
                 gap,
+                forward_shift,
             } = self;
             api::KeyAccepted {
                 credential_id: credential_id.into_event(),
                 key_id: key_id.into_event(),
                 gap: gap.into_event(),
+                forward_shift: forward_shift.into_event(),
             }
         }
     }

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -12,7 +12,7 @@ use crate::event::{
         AsVariant, BoolRecorder, Info, Metric, NominalRecorder, Recorder, Registry, Units,
     },
 };
-static INFO: &[Info; 109usize] = &[
+static INFO: &[Info; 110usize] = &[
     info::Builder {
         id: 0usize,
         name: Str::new("acceptor_tcp_started\0"),
@@ -531,138 +531,144 @@ static INFO: &[Info; 109usize] = &[
     .build(),
     info::Builder {
         id: 86usize,
-        name: Str::new("replay_definitely_detected\0"),
+        name: Str::new("key_accepted.forward_shift\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 87usize,
-        name: Str::new("replay_potentially_detected\0"),
+        name: Str::new("replay_definitely_detected\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 88usize,
-        name: Str::new("replay_potentially_detected.gap\0"),
+        name: Str::new("replay_potentially_detected\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 89usize,
-        name: Str::new("replay_detected_packet_sent\0"),
+        name: Str::new("replay_potentially_detected.gap\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 90usize,
-        name: Str::new("replay_detected_packet_sent.peer_address.protocol\0"),
+        name: Str::new("replay_detected_packet_sent\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 91usize,
-        name: Str::new("replay_detected_packet_received\0"),
+        name: Str::new("replay_detected_packet_sent.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 92usize,
-        name: Str::new("replay_detected_packet_received.peer_address.protocol\0"),
+        name: Str::new("replay_detected_packet_received\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 93usize,
-        name: Str::new("replay_detected_packet_accepted\0"),
+        name: Str::new("replay_detected_packet_received.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 94usize,
-        name: Str::new("replay_detected_packet_accepted.peer_address.protocol\0"),
+        name: Str::new("replay_detected_packet_accepted\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 95usize,
-        name: Str::new("replay_detected_packet_rejected\0"),
+        name: Str::new("replay_detected_packet_accepted.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 96usize,
-        name: Str::new("replay_detected_packet_rejected.peer_address.protocol\0"),
+        name: Str::new("replay_detected_packet_rejected\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 97usize,
-        name: Str::new("replay_detected_packet_dropped\0"),
+        name: Str::new("replay_detected_packet_rejected.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 98usize,
-        name: Str::new("replay_detected_packet_dropped.peer_address.protocol\0"),
+        name: Str::new("replay_detected_packet_dropped\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 99usize,
-        name: Str::new("stale_key_packet_sent\0"),
+        name: Str::new("replay_detected_packet_dropped.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 100usize,
-        name: Str::new("stale_key_packet_sent.peer_address.protocol\0"),
+        name: Str::new("stale_key_packet_sent\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 101usize,
-        name: Str::new("stale_key_packet_received\0"),
+        name: Str::new("stale_key_packet_sent.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 102usize,
-        name: Str::new("stale_key_packet_received.peer_address.protocol\0"),
+        name: Str::new("stale_key_packet_received\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 103usize,
-        name: Str::new("stale_key_packet_accepted\0"),
+        name: Str::new("stale_key_packet_received.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 104usize,
-        name: Str::new("stale_key_packet_accepted.peer_address.protocol\0"),
+        name: Str::new("stale_key_packet_accepted\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 105usize,
-        name: Str::new("stale_key_packet_rejected\0"),
+        name: Str::new("stale_key_packet_accepted.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 106usize,
-        name: Str::new("stale_key_packet_rejected.peer_address.protocol\0"),
+        name: Str::new("stale_key_packet_rejected\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 107usize,
-        name: Str::new("stale_key_packet_dropped\0"),
+        name: Str::new("stale_key_packet_rejected.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 108usize,
+        name: Str::new("stale_key_packet_dropped\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 109usize,
         name: Str::new("stale_key_packet_dropped.peer_address.protocol\0"),
         units: Units::None,
     }
@@ -683,7 +689,7 @@ pub struct Subscriber<R: Registry> {
     #[allow(dead_code)]
     nominal_counter_offsets: Box<[usize; 25usize]>,
     #[allow(dead_code)]
-    measures: Box<[R::Measure; 22usize]>,
+    measures: Box<[R::Measure; 23usize]>,
     #[allow(dead_code)]
     gauges: Box<[R::Gauge; 0usize]>,
     #[allow(dead_code)]
@@ -714,7 +720,7 @@ impl<R: Registry> Subscriber<R> {
         let mut bool_counters = Vec::with_capacity(8usize);
         let mut nominal_counters = Vec::with_capacity(25usize);
         let mut nominal_counter_offsets = Vec::with_capacity(25usize);
-        let mut measures = Vec::with_capacity(22usize);
+        let mut measures = Vec::with_capacity(23usize);
         let mut gauges = Vec::with_capacity(0usize);
         let mut timers = Vec::with_capacity(7usize);
         let mut nominal_timers = Vec::with_capacity(0usize);
@@ -754,18 +760,18 @@ impl<R: Registry> Subscriber<R> {
         counters.push(registry.register_counter(&INFO[80usize]));
         counters.push(registry.register_counter(&INFO[82usize]));
         counters.push(registry.register_counter(&INFO[84usize]));
-        counters.push(registry.register_counter(&INFO[86usize]));
         counters.push(registry.register_counter(&INFO[87usize]));
-        counters.push(registry.register_counter(&INFO[89usize]));
-        counters.push(registry.register_counter(&INFO[91usize]));
-        counters.push(registry.register_counter(&INFO[93usize]));
-        counters.push(registry.register_counter(&INFO[95usize]));
-        counters.push(registry.register_counter(&INFO[97usize]));
-        counters.push(registry.register_counter(&INFO[99usize]));
-        counters.push(registry.register_counter(&INFO[101usize]));
-        counters.push(registry.register_counter(&INFO[103usize]));
-        counters.push(registry.register_counter(&INFO[105usize]));
-        counters.push(registry.register_counter(&INFO[107usize]));
+        counters.push(registry.register_counter(&INFO[88usize]));
+        counters.push(registry.register_counter(&INFO[90usize]));
+        counters.push(registry.register_counter(&INFO[92usize]));
+        counters.push(registry.register_counter(&INFO[94usize]));
+        counters.push(registry.register_counter(&INFO[96usize]));
+        counters.push(registry.register_counter(&INFO[98usize]));
+        counters.push(registry.register_counter(&INFO[100usize]));
+        counters.push(registry.register_counter(&INFO[102usize]));
+        counters.push(registry.register_counter(&INFO[104usize]));
+        counters.push(registry.register_counter(&INFO[106usize]));
+        counters.push(registry.register_counter(&INFO[108usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[19usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[20usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[34usize]));
@@ -947,7 +953,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[90usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[91usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -958,7 +964,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[92usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[93usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -969,7 +975,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[94usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[95usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -980,7 +986,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[96usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[97usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -991,7 +997,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[98usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[99usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1002,7 +1008,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[100usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[101usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1013,7 +1019,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[102usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[103usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1024,7 +1030,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[104usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[105usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1035,7 +1041,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[106usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[107usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1046,7 +1052,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[108usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[109usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1074,7 +1080,8 @@ impl<R: Registry> Subscriber<R> {
         measures.push(registry.register_measure(&INFO[64usize]));
         measures.push(registry.register_measure(&INFO[65usize]));
         measures.push(registry.register_measure(&INFO[85usize]));
-        measures.push(registry.register_measure(&INFO[88usize]));
+        measures.push(registry.register_measure(&INFO[86usize]));
+        measures.push(registry.register_measure(&INFO[89usize]));
         timers.push(registry.register_timer(&INFO[5usize]));
         timers.push(registry.register_timer(&INFO[15usize]));
         timers.push(registry.register_timer(&INFO[21usize]));
@@ -1151,18 +1158,18 @@ impl<R: Registry> Subscriber<R> {
                 32usize => (&INFO[80usize], entry),
                 33usize => (&INFO[82usize], entry),
                 34usize => (&INFO[84usize], entry),
-                35usize => (&INFO[86usize], entry),
-                36usize => (&INFO[87usize], entry),
-                37usize => (&INFO[89usize], entry),
-                38usize => (&INFO[91usize], entry),
-                39usize => (&INFO[93usize], entry),
-                40usize => (&INFO[95usize], entry),
-                41usize => (&INFO[97usize], entry),
-                42usize => (&INFO[99usize], entry),
-                43usize => (&INFO[101usize], entry),
-                44usize => (&INFO[103usize], entry),
-                45usize => (&INFO[105usize], entry),
-                46usize => (&INFO[107usize], entry),
+                35usize => (&INFO[87usize], entry),
+                36usize => (&INFO[88usize], entry),
+                37usize => (&INFO[90usize], entry),
+                38usize => (&INFO[92usize], entry),
+                39usize => (&INFO[94usize], entry),
+                40usize => (&INFO[96usize], entry),
+                41usize => (&INFO[98usize], entry),
+                42usize => (&INFO[100usize], entry),
+                43usize => (&INFO[102usize], entry),
+                44usize => (&INFO[104usize], entry),
+                45usize => (&INFO[106usize], entry),
+                46usize => (&INFO[108usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -1302,61 +1309,61 @@ impl<R: Registry> Subscriber<R> {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[90usize], entries, variants)
+                    (&INFO[91usize], entries, variants)
                 }
                 16usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[92usize], entries, variants)
+                    (&INFO[93usize], entries, variants)
                 }
                 17usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[94usize], entries, variants)
+                    (&INFO[95usize], entries, variants)
                 }
                 18usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[96usize], entries, variants)
+                    (&INFO[97usize], entries, variants)
                 }
                 19usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[98usize], entries, variants)
+                    (&INFO[99usize], entries, variants)
                 }
                 20usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[100usize], entries, variants)
+                    (&INFO[101usize], entries, variants)
                 }
                 21usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[102usize], entries, variants)
+                    (&INFO[103usize], entries, variants)
                 }
                 22usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[104usize], entries, variants)
+                    (&INFO[105usize], entries, variants)
                 }
                 23usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[106usize], entries, variants)
+                    (&INFO[107usize], entries, variants)
                 }
                 24usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[108usize], entries, variants)
+                    (&INFO[109usize], entries, variants)
                 }
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
@@ -1397,7 +1404,8 @@ impl<R: Registry> Subscriber<R> {
                 18usize => (&INFO[64usize], entry),
                 19usize => (&INFO[65usize], entry),
                 20usize => (&INFO[85usize], entry),
-                21usize => (&INFO[88usize], entry),
+                21usize => (&INFO[86usize], entry),
+                22usize => (&INFO[89usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -1896,6 +1904,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
         use api::*;
         self.count(84usize, 34usize, 1usize);
         self.measure(85usize, 20usize, event.gap);
+        self.measure(86usize, 21usize, event.forward_shift);
         let _ = event;
         let _ = meta;
     }
@@ -1907,7 +1916,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(86usize, 35usize, 1usize);
+        self.count(87usize, 35usize, 1usize);
         let _ = event;
         let _ = meta;
     }
@@ -1919,8 +1928,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(87usize, 36usize, 1usize);
-        self.measure(88usize, 21usize, event.gap);
+        self.count(88usize, 36usize, 1usize);
+        self.measure(89usize, 22usize, event.gap);
         let _ = event;
         let _ = meta;
     }
@@ -1932,8 +1941,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(89usize, 37usize, 1usize);
-        self.count_nominal(90usize, 15usize, &event.peer_address);
+        self.count(90usize, 37usize, 1usize);
+        self.count_nominal(91usize, 15usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1945,8 +1954,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(91usize, 38usize, 1usize);
-        self.count_nominal(92usize, 16usize, &event.peer_address);
+        self.count(92usize, 38usize, 1usize);
+        self.count_nominal(93usize, 16usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1958,8 +1967,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(93usize, 39usize, 1usize);
-        self.count_nominal(94usize, 17usize, &event.peer_address);
+        self.count(94usize, 39usize, 1usize);
+        self.count_nominal(95usize, 17usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1971,8 +1980,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(95usize, 40usize, 1usize);
-        self.count_nominal(96usize, 18usize, &event.peer_address);
+        self.count(96usize, 40usize, 1usize);
+        self.count_nominal(97usize, 18usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1984,8 +1993,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(97usize, 41usize, 1usize);
-        self.count_nominal(98usize, 19usize, &event.peer_address);
+        self.count(98usize, 41usize, 1usize);
+        self.count_nominal(99usize, 19usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -1993,8 +2002,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     fn on_stale_key_packet_sent(&self, meta: &api::EndpointMeta, event: &api::StaleKeyPacketSent) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(99usize, 42usize, 1usize);
-        self.count_nominal(100usize, 20usize, &event.peer_address);
+        self.count(100usize, 42usize, 1usize);
+        self.count_nominal(101usize, 20usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2006,8 +2015,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(101usize, 43usize, 1usize);
-        self.count_nominal(102usize, 21usize, &event.peer_address);
+        self.count(102usize, 43usize, 1usize);
+        self.count_nominal(103usize, 21usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2019,8 +2028,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(103usize, 44usize, 1usize);
-        self.count_nominal(104usize, 22usize, &event.peer_address);
+        self.count(104usize, 44usize, 1usize);
+        self.count_nominal(105usize, 22usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2032,8 +2041,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(105usize, 45usize, 1usize);
-        self.count_nominal(106usize, 23usize, &event.peer_address);
+        self.count(106usize, 45usize, 1usize);
+        self.count_nominal(107usize, 23usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2045,8 +2054,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(107usize, 46usize, 1usize);
-        self.count_nominal(108usize, 24usize, &event.peer_address);
+        self.count(108usize, 46usize, 1usize);
+        self.count_nominal(109usize, 24usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -52,18 +52,18 @@ mod counter {
                 80usize => Self(unknown_path_secret_packet_rejected),
                 82usize => Self(unknown_path_secret_packet_dropped),
                 84usize => Self(key_accepted),
-                86usize => Self(replay_definitely_detected),
-                87usize => Self(replay_potentially_detected),
-                89usize => Self(replay_detected_packet_sent),
-                91usize => Self(replay_detected_packet_received),
-                93usize => Self(replay_detected_packet_accepted),
-                95usize => Self(replay_detected_packet_rejected),
-                97usize => Self(replay_detected_packet_dropped),
-                99usize => Self(stale_key_packet_sent),
-                101usize => Self(stale_key_packet_received),
-                103usize => Self(stale_key_packet_accepted),
-                105usize => Self(stale_key_packet_rejected),
-                107usize => Self(stale_key_packet_dropped),
+                87usize => Self(replay_definitely_detected),
+                88usize => Self(replay_potentially_detected),
+                90usize => Self(replay_detected_packet_sent),
+                92usize => Self(replay_detected_packet_received),
+                94usize => Self(replay_detected_packet_accepted),
+                96usize => Self(replay_detected_packet_rejected),
+                98usize => Self(replay_detected_packet_dropped),
+                100usize => Self(stale_key_packet_sent),
+                102usize => Self(stale_key_packet_received),
+                104usize => Self(stale_key_packet_accepted),
+                106usize => Self(stale_key_packet_rejected),
+                108usize => Self(stale_key_packet_dropped),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }
@@ -241,16 +241,16 @@ mod counter {
                     79usize => Self(unknown_path_secret_packet_accepted__peer_address__protocol),
                     81usize => Self(unknown_path_secret_packet_rejected__peer_address__protocol),
                     83usize => Self(unknown_path_secret_packet_dropped__peer_address__protocol),
-                    90usize => Self(replay_detected_packet_sent__peer_address__protocol),
-                    92usize => Self(replay_detected_packet_received__peer_address__protocol),
-                    94usize => Self(replay_detected_packet_accepted__peer_address__protocol),
-                    96usize => Self(replay_detected_packet_rejected__peer_address__protocol),
-                    98usize => Self(replay_detected_packet_dropped__peer_address__protocol),
-                    100usize => Self(stale_key_packet_sent__peer_address__protocol),
-                    102usize => Self(stale_key_packet_received__peer_address__protocol),
-                    104usize => Self(stale_key_packet_accepted__peer_address__protocol),
-                    106usize => Self(stale_key_packet_rejected__peer_address__protocol),
-                    108usize => Self(stale_key_packet_dropped__peer_address__protocol),
+                    91usize => Self(replay_detected_packet_sent__peer_address__protocol),
+                    93usize => Self(replay_detected_packet_received__peer_address__protocol),
+                    95usize => Self(replay_detected_packet_accepted__peer_address__protocol),
+                    97usize => Self(replay_detected_packet_rejected__peer_address__protocol),
+                    99usize => Self(replay_detected_packet_dropped__peer_address__protocol),
+                    101usize => Self(stale_key_packet_sent__peer_address__protocol),
+                    103usize => Self(stale_key_packet_received__peer_address__protocol),
+                    105usize => Self(stale_key_packet_accepted__peer_address__protocol),
+                    107usize => Self(stale_key_packet_rejected__peer_address__protocol),
+                    109usize => Self(stale_key_packet_dropped__peer_address__protocol),
                     _ => unreachable!("invalid info: {info:?}"),
                 }
             }
@@ -450,7 +450,8 @@ mod measure {
                 64usize => Self(path_secret_map_uninitialized__entries),
                 65usize => Self(path_secret_map_uninitialized__lifetime),
                 85usize => Self(key_accepted__gap),
-                88usize => Self(replay_potentially_detected__gap),
+                86usize => Self(key_accepted__forward_shift),
+                89usize => Self(replay_potentially_detected__gap),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }
@@ -504,6 +505,8 @@ mod measure {
             fn path_secret_map_uninitialized__lifetime(value: u64);
             # [link_name = s2n_quic_dc__event__measure__key_accepted__gap]
             fn key_accepted__gap(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__key_accepted__forward_shift]
+            fn key_accepted__forward_shift(value: u64);
             # [link_name = s2n_quic_dc__event__measure__replay_potentially_detected__gap]
             fn replay_potentially_detected__gap(value: u64);
         }

--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -510,6 +510,7 @@ where
             id: *entry.id(),
             key_id,
         };
+        let starting = *entry.receiver().minimum_unseen_key_id();
         match entry.receiver().post_authentication(creds) {
             Ok(()) => {
                 let gap = (*entry.receiver().minimum_unseen_key_id())
@@ -522,6 +523,7 @@ where
                         credential_id: creds.id.into_event(),
                         key_id: key_id.into_event(),
                         gap,
+                        forward_shift: (*creds.key_id).saturating_sub(starting),
                     });
                 Ok(())
             }


### PR DESCRIPTION
### Resolved issues:

None

### Description of changes: 

Goal is to have essentially a +/- tracker so we get a better sense of both positive and negative reordering.

### Call-outs:

I'm not sure if we should be using a consistent pre-auth baseline or the setup here. Naming is also... suboptimal, but I don't have better ideas.

### Testing:

None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

