### PR TITLE
feat(s2n-quic): improve local handshake failure visibility

### DIFF
--- a/quic/s2n-quic-tls/src/session.rs
+++ b/quic/s2n-quic-tls/src/session.rs
@@ -161,6 +161,7 @@ impl tls::Session for Session {
                 .alert()
                 .map(tls::Error::new)
                 .unwrap_or(tls::Error::HANDSHAKE_FAILURE)
+                .with_reason(e.message())
                 .into())),
             Poll::Pending => Poll::Pending,
         }

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -286,7 +286,9 @@ impl<Config: endpoint::Config> ConnectionImpl<Config> {
             datagram,
             dc,
         ) {
-            Poll::Ready(res) => res?,
+            Poll::Ready(Ok(())) => {}
+            // use `from` instead of `into` so the location is correctly captured
+            Poll::Ready(Err(err)) => return Err(connection::Error::from(err)),
             Poll::Pending => return Ok(()),
         }
 

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -948,7 +948,9 @@ pub trait PacketSpace<Config: endpoint::Config>: Sized {
                     .map_err(on_error)?;
 
                     // skip processing any other frames and return an error
-                    return Err(frame.into());
+
+                    // use `from` instead of `into` so the location is correctly captured
+                    return Err(connection::Error::from(frame));
                 }
                 Frame::Stream(frame) => {
                     let on_error = on_frame_processed!(frame);

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -59,6 +59,8 @@ unstable-provider-dc = ["s2n-quic-transport/unstable-provider-dc"]
 unstable-congestion-controller = ["s2n-quic-core/unstable-congestion-controller"]
 # This feature enables the use of unstable connection limits
 unstable-limits = ["s2n-quic-core/unstable-limits"]
+# The feature enables the close formatter provider
+unstable-provider-connection-close-formatter = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }

--- a/quic/s2n-quic/src/provider.rs
+++ b/quic/s2n-quic/src/provider.rs
@@ -20,11 +20,18 @@ pub mod tls;
 
 // These providers are not currently exposed to applications
 #[allow(dead_code)]
-pub(crate) mod connection_close_formatter;
-#[allow(dead_code)]
 pub(crate) mod path_migration;
 #[allow(dead_code)]
 pub(crate) mod sync;
+
+cfg_if!(
+    if #[cfg(any(test, feature = "unstable-provider-connection-close-formatter"))] {
+        pub mod connection_close_formatter;
+    } else {
+        #[allow(dead_code)]
+        pub(crate) mod connection_close_formatter;
+    }
+);
 
 cfg_if!(
     if #[cfg(any(test, feature = "unstable-provider-packet-interceptor"))] {


### PR DESCRIPTION
### Description of changes: 

This change includes a few additions that will better assist in debugging handshake failures:

* For the `s2n-tls` provider, it includes the `error.message()` as the `reason`, which is much more descriptive than a generic `HANDSHAKE_FAILURE`
* It uses `connection::Error::from` instead of `Into::into` which has issues with passing on the `#[track_caller]` information
* Finally, it exposes the `CONNECTION_CLOSE` formatter provider as an unstable feature, which allows for more descriptive errors to be sent over the wire, if desired. This option comes with the warning outlined in the docs: https://docs.rs/s2n-quic-core/latest/s2n_quic_core/connection/close/struct.Development.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

