### PR TITLE
feat(s2n-quic-dc): implement cache events

### DIFF
--- a/dc/s2n-quic-dc/events/map.rs
+++ b/dc/s2n-quic-dc/events/map.rs
@@ -281,3 +281,16 @@ struct StaleKeyPacketDropped<'a> {
     #[snapshot("[HIDDEN]")]
     credential_id: &'a [u8],
 }
+
+#[event("path_secret_map:cache_accessed")]
+#[subject(endpoint)]
+/// Emitted when the cache is accessed for connection attempts
+///
+/// This can be used to track cache hit ratios
+struct PathSecretMapCacheAccessed<'a> {
+    #[nominal_counter("peer_address.protocol")]
+    peer_address: SocketAddress<'a>,
+
+    #[bool_counter("hit")]
+    hit: bool,
+}

--- a/dc/s2n-quic-dc/events/map.rs
+++ b/dc/s2n-quic-dc/events/map.rs
@@ -282,14 +282,27 @@ struct StaleKeyPacketDropped<'a> {
     credential_id: &'a [u8],
 }
 
-#[event("path_secret_map:cache_accessed")]
+#[event("path_secret_map:address_cache_accessed")]
 #[subject(endpoint)]
-/// Emitted when the cache is accessed for connection attempts
+/// Emitted when the cache is accessed by peer address
 ///
 /// This can be used to track cache hit ratios
-struct PathSecretMapCacheAccessed<'a> {
+struct PathSecretMapAddressCacheAccessed<'a> {
     #[nominal_counter("peer_address.protocol")]
     peer_address: SocketAddress<'a>,
+
+    #[bool_counter("hit")]
+    hit: bool,
+}
+
+#[event("path_secret_map:id_cache_accessed")]
+#[subject(endpoint)]
+/// Emitted when the cache is accessed by path secret ID
+///
+/// This can be used to track cache hit ratios
+struct PathSecretMapIdCacheAccessed<'a> {
+    #[snapshot("[HIDDEN]")]
+    credential_id: &'a [u8],
 
     #[bool_counter("hit")]
     hit: bool,

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -12,7 +12,7 @@ use crate::event::{
         AsVariant, BoolRecorder, Info, Metric, NominalRecorder, Recorder, Registry, Units,
     },
 };
-static INFO: &[Info; 113usize] = &[
+static INFO: &[Info; 115usize] = &[
     info::Builder {
         id: 0usize,
         name: Str::new("acceptor_tcp_started\0"),
@@ -675,19 +675,31 @@ static INFO: &[Info; 113usize] = &[
     .build(),
     info::Builder {
         id: 110usize,
-        name: Str::new("path_secret_map_cache_accessed\0"),
+        name: Str::new("path_secret_map_address_cache_accessed\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 111usize,
-        name: Str::new("path_secret_map_cache_accessed.peer_address.protocol\0"),
+        name: Str::new("path_secret_map_address_cache_accessed.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 112usize,
-        name: Str::new("path_secret_map_cache_accessed.hit\0"),
+        name: Str::new("path_secret_map_address_cache_accessed.hit\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 113usize,
+        name: Str::new("path_secret_map_id_cache_accessed\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 114usize,
+        name: Str::new("path_secret_map_id_cache_accessed.hit\0"),
         units: Units::None,
     }
     .build(),
@@ -699,9 +711,9 @@ pub struct ConnectionContext {
 }
 pub struct Subscriber<R: Registry> {
     #[allow(dead_code)]
-    counters: Box<[R::Counter; 48usize]>,
+    counters: Box<[R::Counter; 49usize]>,
     #[allow(dead_code)]
-    bool_counters: Box<[R::BoolCounter; 9usize]>,
+    bool_counters: Box<[R::BoolCounter; 10usize]>,
     #[allow(dead_code)]
     nominal_counters: Box<[R::NominalCounter]>,
     #[allow(dead_code)]
@@ -734,8 +746,8 @@ impl<R: Registry> Subscriber<R> {
     #[allow(unused_mut)]
     #[inline]
     pub fn new(registry: R) -> Self {
-        let mut counters = Vec::with_capacity(48usize);
-        let mut bool_counters = Vec::with_capacity(9usize);
+        let mut counters = Vec::with_capacity(49usize);
+        let mut bool_counters = Vec::with_capacity(10usize);
         let mut nominal_counters = Vec::with_capacity(26usize);
         let mut nominal_counter_offsets = Vec::with_capacity(26usize);
         let mut measures = Vec::with_capacity(23usize);
@@ -791,6 +803,7 @@ impl<R: Registry> Subscriber<R> {
         counters.push(registry.register_counter(&INFO[106usize]));
         counters.push(registry.register_counter(&INFO[108usize]));
         counters.push(registry.register_counter(&INFO[110usize]));
+        counters.push(registry.register_counter(&INFO[113usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[19usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[20usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[34usize]));
@@ -800,6 +813,7 @@ impl<R: Registry> Subscriber<R> {
         bool_counters.push(registry.register_bool_counter(&INFO[58usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[59usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[112usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[114usize]));
         {
             #[allow(unused_imports)]
             use api::*;
@@ -1202,6 +1216,7 @@ impl<R: Registry> Subscriber<R> {
                 45usize => (&INFO[106usize], entry),
                 46usize => (&INFO[108usize], entry),
                 47usize => (&INFO[110usize], entry),
+                48usize => (&INFO[113usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -1228,6 +1243,7 @@ impl<R: Registry> Subscriber<R> {
                 6usize => (&INFO[58usize], entry),
                 7usize => (&INFO[59usize], entry),
                 8usize => (&INFO[112usize], entry),
+                9usize => (&INFO[114usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -2099,16 +2115,29 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
         let _ = meta;
     }
     #[inline]
-    fn on_path_secret_map_cache_accessed(
+    fn on_path_secret_map_address_cache_accessed(
         &self,
         meta: &api::EndpointMeta,
-        event: &api::PathSecretMapCacheAccessed,
+        event: &api::PathSecretMapAddressCacheAccessed,
     ) {
         #[allow(unused_imports)]
         use api::*;
         self.count(110usize, 47usize, 1usize);
         self.count_nominal(111usize, 25usize, &event.peer_address);
         self.count_bool(112usize, 8usize, event.hit);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_path_secret_map_id_cache_accessed(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::PathSecretMapIdCacheAccessed,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(113usize, 48usize, 1usize);
+        self.count_bool(114usize, 9usize, event.hit);
         let _ = event;
         let _ = meta;
     }

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -64,7 +64,8 @@ mod counter {
                 104usize => Self(stale_key_packet_accepted),
                 106usize => Self(stale_key_packet_rejected),
                 108usize => Self(stale_key_packet_dropped),
-                110usize => Self(path_secret_map_cache_accessed),
+                110usize => Self(path_secret_map_address_cache_accessed),
+                113usize => Self(path_secret_map_id_cache_accessed),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }
@@ -170,8 +171,10 @@ mod counter {
             fn stale_key_packet_rejected(value: u64);
             # [link_name = s2n_quic_dc__event__counter__stale_key_packet_dropped]
             fn stale_key_packet_dropped(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_cache_accessed]
-            fn path_secret_map_cache_accessed(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__path_secret_map_address_cache_accessed]
+            fn path_secret_map_address_cache_accessed(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__path_secret_map_id_cache_accessed]
+            fn path_secret_map_id_cache_accessed(value: u64);
         }
     );
     pub mod bool {
@@ -189,7 +192,8 @@ mod counter {
                     37usize => Self(acceptor_udp_packet_received__is_fin_known),
                     58usize => Self(endpoint_initialized__tcp),
                     59usize => Self(endpoint_initialized__udp),
-                    112usize => Self(path_secret_map_cache_accessed__hit),
+                    112usize => Self(path_secret_map_address_cache_accessed__hit),
+                    114usize => Self(path_secret_map_id_cache_accessed__hit),
                     _ => unreachable!("invalid info: {info:?}"),
                 }
             }
@@ -217,8 +221,10 @@ mod counter {
                 fn endpoint_initialized__tcp(value: bool);
                 # [link_name = s2n_quic_dc__event__counter__bool__endpoint_initialized__udp]
                 fn endpoint_initialized__udp(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__path_secret_map_cache_accessed__hit]
-                fn path_secret_map_cache_accessed__hit(value: bool);
+                # [link_name = s2n_quic_dc__event__counter__bool__path_secret_map_address_cache_accessed__hit]
+                fn path_secret_map_address_cache_accessed__hit(value: bool);
+                # [link_name = s2n_quic_dc__event__counter__bool__path_secret_map_id_cache_accessed__hit]
+                fn path_secret_map_id_cache_accessed__hit(value: bool);
             }
         );
     }
@@ -257,7 +263,9 @@ mod counter {
                     105usize => Self(stale_key_packet_accepted__peer_address__protocol),
                     107usize => Self(stale_key_packet_rejected__peer_address__protocol),
                     109usize => Self(stale_key_packet_dropped__peer_address__protocol),
-                    111usize => Self(path_secret_map_cache_accessed__peer_address__protocol),
+                    111usize => {
+                        Self(path_secret_map_address_cache_accessed__peer_address__protocol)
+                    }
                     _ => unreachable!("invalid info: {info:?}"),
                 }
             }
@@ -424,8 +432,8 @@ mod counter {
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__path_secret_map_cache_accessed__peer_address__protocol]
-                fn path_secret_map_cache_accessed__peer_address__protocol(
+                # [link_name = s2n_quic_dc__event__counter__nominal__path_secret_map_address_cache_accessed__peer_address__protocol]
+                fn path_secret_map_address_cache_accessed__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -64,6 +64,7 @@ mod counter {
                 104usize => Self(stale_key_packet_accepted),
                 106usize => Self(stale_key_packet_rejected),
                 108usize => Self(stale_key_packet_dropped),
+                110usize => Self(path_secret_map_cache_accessed),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }
@@ -169,6 +170,8 @@ mod counter {
             fn stale_key_packet_rejected(value: u64);
             # [link_name = s2n_quic_dc__event__counter__stale_key_packet_dropped]
             fn stale_key_packet_dropped(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__path_secret_map_cache_accessed]
+            fn path_secret_map_cache_accessed(value: u64);
         }
     );
     pub mod bool {
@@ -186,6 +189,7 @@ mod counter {
                     37usize => Self(acceptor_udp_packet_received__is_fin_known),
                     58usize => Self(endpoint_initialized__tcp),
                     59usize => Self(endpoint_initialized__udp),
+                    112usize => Self(path_secret_map_cache_accessed__hit),
                     _ => unreachable!("invalid info: {info:?}"),
                 }
             }
@@ -213,6 +217,8 @@ mod counter {
                 fn endpoint_initialized__tcp(value: bool);
                 # [link_name = s2n_quic_dc__event__counter__bool__endpoint_initialized__udp]
                 fn endpoint_initialized__udp(value: bool);
+                # [link_name = s2n_quic_dc__event__counter__bool__path_secret_map_cache_accessed__hit]
+                fn path_secret_map_cache_accessed__hit(value: bool);
             }
         );
     }
@@ -251,6 +257,7 @@ mod counter {
                     105usize => Self(stale_key_packet_accepted__peer_address__protocol),
                     107usize => Self(stale_key_packet_rejected__peer_address__protocol),
                     109usize => Self(stale_key_packet_dropped__peer_address__protocol),
+                    111usize => Self(path_secret_map_cache_accessed__peer_address__protocol),
                     _ => unreachable!("invalid info: {info:?}"),
                 }
             }
@@ -413,6 +420,12 @@ mod counter {
                 );
                 # [link_name = s2n_quic_dc__event__counter__nominal__stale_key_packet_dropped__peer_address__protocol]
                 fn stale_key_packet_dropped__peer_address__protocol(
+                    value: u64,
+                    variant: u64,
+                    variant_name: &info::Str,
+                );
+                # [link_name = s2n_quic_dc__event__counter__nominal__path_secret_map_cache_accessed__peer_address__protocol]
+                fn path_secret_map_cache_accessed__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,

--- a/dc/s2n-quic-dc/src/path/secret/map.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map.rs
@@ -107,7 +107,7 @@ impl Map {
     /// Note that unlike by-IP lookup this should typically not be done significantly after the
     /// original secret was used for decryption.
     pub fn seal_once_id(&self, id: Id) -> Option<(seal::Once, Credentials, dc::ApplicationParams)> {
-        let entry = self.store.get_by_id(&id)?;
+        let entry = self.store.get_by_id_tracked(&id)?;
         let (sealer, credentials) = entry.uni_sealer();
         Some((sealer, credentials, entry.parameters()))
     }

--- a/dc/s2n-quic-dc/src/path/secret/map.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map.rs
@@ -5,7 +5,7 @@ use crate::{
     credentials::{Credentials, Id},
     event,
     packet::{secret_control as control, Packet},
-    path::secret::{open, seal, stateless_reset},
+    path::secret::{open, seal, stateless_reset, HandshakeKind},
     stream::TransportFeatures,
 };
 use s2n_quic_core::{dc, time};
@@ -14,6 +14,7 @@ use std::{net::SocketAddr, sync::Arc};
 mod cleaner;
 mod entry;
 mod handshake;
+mod peer;
 mod size_of;
 mod state;
 mod status;
@@ -29,6 +30,7 @@ use entry::Entry;
 use store::Store;
 
 pub use entry::{ApplicationPair, Bidirectional, ControlPair};
+pub use peer::Peer;
 
 pub(crate) use size_of::SizeOf;
 pub(crate) use status::Dedup;
@@ -88,13 +90,13 @@ impl Map {
         self.store.contains(peer)
     }
 
-    pub fn seal_once(
-        &self,
-        peer: SocketAddr,
-    ) -> Option<(seal::Once, Credentials, dc::ApplicationParams)> {
-        let entry = self.store.get_by_addr(&peer)?;
-        let (sealer, credentials) = entry.uni_sealer();
-        Some((sealer, credentials, entry.parameters()))
+    /// Gets the [`Peer`] entry for the given address
+    ///
+    /// NOTE: This function is used to track cache hit ratios so it
+    ///       should only be used for connection attempts.
+    pub fn get_tracked(&self, peer: SocketAddr, handshake: HandshakeKind) -> Option<Peer> {
+        let entry = self.store.get_by_addr_tracked(&peer, handshake)?;
+        Some(Peer::new(&entry, self))
     }
 
     /// Retrieve a sealer by path secret ID.
@@ -118,17 +120,6 @@ impl Map {
         let entry = self.store.pre_authentication(credentials, control_out)?;
         let opener = entry.uni_opener(self.clone(), credentials);
         Some(opener)
-    }
-
-    pub fn pair_for_peer(
-        &self,
-        peer: SocketAddr,
-        features: &TransportFeatures,
-    ) -> Option<(entry::Bidirectional, dc::ApplicationParams)> {
-        let entry = self.store.get_by_addr(&peer)?;
-        let keys = entry.bidi_local(features);
-
-        Some((keys, entry.parameters()))
     }
 
     pub fn pair_for_credentials(

--- a/dc/s2n-quic-dc/src/path/secret/map/event_tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/event_tests.rs
@@ -70,8 +70,8 @@ fn control_packets() {
         };
     }
 
-    let server_entry = server.store.get_by_id(&id).unwrap().clone();
-    let client_entry = client.store.get_by_id(&id).unwrap().clone();
+    let server_entry = server.store.get_by_id_untracked(&id).unwrap().clone();
+    let client_entry = client.store.get_by_id_untracked(&id).unwrap().clone();
 
     let fake_secret =
         crate::path::secret::seal::control::Secret::new(&[0; 32], &aws_lc_rs::hmac::HMAC_SHA256);

--- a/dc/s2n-quic-dc/src/path/secret/map/peer.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/peer.rs
@@ -1,0 +1,37 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{dc, seal, Bidirectional, Credentials, Entry, Map, TransportFeatures};
+use std::sync::Arc;
+
+pub struct Peer {
+    entry: Arc<Entry>,
+    map: Map,
+}
+
+impl Peer {
+    pub(super) fn new(entry: &Arc<Entry>, map: &Map) -> Self {
+        Self {
+            entry: entry.clone(),
+            map: map.clone(),
+        }
+    }
+
+    #[inline]
+    pub fn seal_once(&self) -> (seal::Once, Credentials, dc::ApplicationParams) {
+        let (sealer, credentials) = self.entry.uni_sealer();
+        (sealer, credentials, self.entry.parameters())
+    }
+
+    #[inline]
+    pub fn pair(&self, features: &TransportFeatures) -> (Bidirectional, dc::ApplicationParams) {
+        let keys = self.entry.bidi_local(features);
+
+        (keys, self.entry.parameters())
+    }
+
+    #[inline]
+    pub fn map(&self) -> &Map {
+        &self.map
+    }
+}

--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -408,13 +408,6 @@ where
             });
     }
 
-    fn get_by_addr_untracked(&self, peer: &SocketAddr) -> Option<ReadGuard<Arc<Entry>>> {
-        self.peers.get_by_key(peer).filter(|_| {
-            // ensure this entry isn't requested to rehandshake
-            !self.requested_handshakes.pin().contains(peer)
-        })
-    }
-
     fn get_by_addr_tracked(
         &self,
         peer: &SocketAddr,

--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -169,7 +169,7 @@ where
         );
 
         // don't track access patterns here since it's not initiated by the local application
-        let Some(entry) = self.get_by_id(packet.credential_id()) else {
+        let Some(entry) = self.get_by_id_untracked(packet.credential_id()) else {
             self.subscriber().on_unknown_path_secret_packet_dropped(
                 event::builder::UnknownPathSecretPacketDropped {
                     credential_id: packet.credential_id().into_event(),
@@ -408,7 +408,7 @@ where
             });
     }
 
-    fn get_by_addr(&self, peer: &SocketAddr) -> Option<ReadGuard<Arc<Entry>>> {
+    fn get_by_addr_untracked(&self, peer: &SocketAddr) -> Option<ReadGuard<Arc<Entry>>> {
         self.peers.get_by_key(peer).filter(|_| {
             // ensure this entry isn't requested to rehandshake
             !self.requested_handshakes.pin().contains(peer)
@@ -440,12 +440,12 @@ where
         Some(result)
     }
 
-    fn get_by_id(&self, id: &Id) -> Option<ReadGuard<Arc<Entry>>> {
+    fn get_by_id_untracked(&self, id: &Id) -> Option<ReadGuard<Arc<Entry>>> {
         self.ids.get_by_key(id)
     }
 
     fn get_by_id_tracked(&self, id: &Id) -> Option<ReadGuard<Arc<Entry>>> {
-        let result = self.get_by_id(id);
+        let result = self.ids.get_by_key(id);
 
         self.subscriber().on_path_secret_map_id_cache_accessed(
             event::builder::PathSecretMapIdCacheAccessed {

--- a/dc/s2n-quic-dc/src/path/secret/map/state/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state/tests.rs
@@ -149,7 +149,7 @@ impl Model {
                 self.invariants.retain(|invariant| {
                     if let Invariant::ContainsId(id) = invariant {
                         if state
-                            .get_by_id(id)
+                            .get_by_id_untracked(id)
                             .map_or(true, |v| v.retired_at().is_some())
                         {
                             invalidated.push(*id);

--- a/dc/s2n-quic-dc/src/path/secret/map/store.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/store.rs
@@ -33,7 +33,7 @@ pub trait Store: 'static + Send + Sync {
         self.on_handshake_complete(entry);
     }
 
-    fn get_by_addr(&self, peer: &SocketAddr) -> Option<ReadGuard<Arc<Entry>>>;
+    fn get_by_addr_untracked(&self, peer: &SocketAddr) -> Option<ReadGuard<Arc<Entry>>>;
 
     fn get_by_addr_tracked(
         &self,
@@ -41,7 +41,7 @@ pub trait Store: 'static + Send + Sync {
         handshake: HandshakeKind,
     ) -> Option<ReadGuard<Arc<Entry>>>;
 
-    fn get_by_id(&self, id: &Id) -> Option<ReadGuard<Arc<Entry>>>;
+    fn get_by_id_untracked(&self, id: &Id) -> Option<ReadGuard<Arc<Entry>>>;
 
     fn get_by_id_tracked(&self, id: &Id) -> Option<ReadGuard<Arc<Entry>>>;
 

--- a/dc/s2n-quic-dc/src/path/secret/map/store.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/store.rs
@@ -6,7 +6,7 @@ use crate::{
     credentials::{Credentials, Id},
     fixed_map::ReadGuard,
     packet::{secret_control as control, Packet, WireVersion},
-    path::secret::{receiver, stateless_reset},
+    path::secret::{receiver, stateless_reset, HandshakeKind},
 };
 use core::time::Duration;
 use s2n_codec::EncoderBuffer;
@@ -34,6 +34,12 @@ pub trait Store: 'static + Send + Sync {
     }
 
     fn get_by_addr(&self, peer: &SocketAddr) -> Option<ReadGuard<Arc<Entry>>>;
+
+    fn get_by_addr_tracked(
+        &self,
+        peer: &SocketAddr,
+        handshake: HandshakeKind,
+    ) -> Option<ReadGuard<Arc<Entry>>>;
 
     fn get_by_id(&self, id: &Id) -> Option<ReadGuard<Arc<Entry>>>;
 

--- a/dc/s2n-quic-dc/src/path/secret/map/store.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/store.rs
@@ -43,6 +43,8 @@ pub trait Store: 'static + Send + Sync {
 
     fn get_by_id(&self, id: &Id) -> Option<ReadGuard<Arc<Entry>>>;
 
+    fn get_by_id_tracked(&self, id: &Id) -> Option<ReadGuard<Arc<Entry>>>;
+
     fn handle_unexpected_packet(&self, packet: &Packet, peer: &SocketAddr);
 
     fn handle_control_packet(&self, packet: &control::Packet, peer: &SocketAddr);
@@ -76,7 +78,7 @@ pub trait Store: 'static + Send + Sync {
         identity: &Credentials,
         control_out: &mut Vec<u8>,
     ) -> Option<Arc<Entry>> {
-        let Some(state) = self.get_by_id(&identity.id) else {
+        let Some(state) = self.get_by_id_tracked(&identity.id) else {
             let packet = control::UnknownPathSecret {
                 wire_version: WireVersion::ZERO,
                 credential_id: identity.id,

--- a/dc/s2n-quic-dc/src/path/secret/map/store.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/store.rs
@@ -33,8 +33,6 @@ pub trait Store: 'static + Send + Sync {
         self.on_handshake_complete(entry);
     }
 
-    fn get_by_addr_untracked(&self, peer: &SocketAddr) -> Option<ReadGuard<Arc<Entry>>>;
-
     fn get_by_addr_tracked(
         &self,
         peer: &SocketAddr,


### PR DESCRIPTION
### Description of changes: 

This change adds events around cache hits for path secrets. This should give a good idea of how often flows are needing to wait for handshakes to complete before continuing.

In adding these, I've also included a TOCTOU issue I've been wanting to address for awhile. Now, we return the path secret entry atomically when checking if we have an entry or not.

### Call-outs:

The `get_by_addr` method were missing the same checks that the `contains` method has around `requested_handshakes.contains(peer)`, so I've added that.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

