### PR TITLE
refactor(s2n-quic-dc): thread event::Subscriber through streams

### DIFF
--- a/dc/s2n-quic-dc/src/event/generated.rs
+++ b/dc/s2n-quic-dc/src/event/generated.rs
@@ -3046,7 +3046,7 @@ mod traits {
         #[doc = r"     }"]
         #[doc = r" }"]
         #[doc = r"  ```"]
-        type ConnectionContext: 'static + Send;
+        type ConnectionContext: 'static + Send + Sync;
         #[doc = r" Creates a context to be passed to each connection-related event"]
         fn create_connection_context(
             &self,

--- a/dc/s2n-quic-dc/src/stream/application.rs
+++ b/dc/s2n-quic-dc/src/stream/application.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    event,
+    event::{self, EndpointPublisher as _},
     stream::{
         recv::application::{self as recv, Reader},
         send::application::{self as send, Writer},
@@ -14,21 +14,21 @@ use core::{fmt, time::Duration};
 use s2n_quic_core::{buffer, time::Timestamp};
 use std::{io, net::SocketAddr};
 
-pub struct Builder {
-    pub read: recv::Builder,
-    pub write: send::Builder,
-    pub shared: ArcShared,
+pub struct Builder<Sub: event::Subscriber> {
+    pub read: recv::Builder<Sub>,
+    pub write: send::Builder<Sub>,
+    pub shared: ArcShared<Sub>,
     pub sockets: Box<dyn socket::application::Builder>,
     pub queue_time: Timestamp,
 }
 
-impl Builder {
+impl<Sub> Builder<Sub>
+where
+    Sub: event::Subscriber,
+{
     /// Builds the stream and emits an event indicating that the stream was built
     #[inline]
-    pub(crate) fn build<Pub>(self, publisher: &Pub) -> io::Result<(Stream, Duration)>
-    where
-        Pub: event::EndpointPublisher,
-    {
+    pub(crate) fn accept(self) -> io::Result<(Stream<Sub>, Duration)> {
         let sojourn_time = {
             let remote_address = self.shared.read_remote_addr();
             let remote_address = &remote_address;
@@ -37,22 +37,30 @@ impl Builder {
             let now = self.shared.common.clock.get_time();
             let sojourn_time = now.saturating_duration_since(self.queue_time);
 
-            publisher.on_acceptor_stream_dequeued(event::builder::AcceptorStreamDequeued {
-                remote_address,
-                credential_id,
-                stream_id,
-                sojourn_time,
-            });
+            self.shared
+                .endpoint_publisher(now)
+                .on_acceptor_stream_dequeued(event::builder::AcceptorStreamDequeued {
+                    remote_address,
+                    credential_id,
+                    stream_id,
+                    sojourn_time,
+                });
+
+            // TODO emit event
 
             sojourn_time
         };
 
-        self.build_without_event()
-            .map(|stream| (stream, sojourn_time))
+        self.build().map(|stream| (stream, sojourn_time))
     }
 
     #[inline]
-    pub(crate) fn build_without_event(self) -> io::Result<Stream> {
+    pub(crate) fn connect(self) -> io::Result<Stream<Sub>> {
+        self.build()
+    }
+
+    #[inline]
+    pub(crate) fn build(self) -> io::Result<Stream<Sub>> {
         let Self {
             read,
             write,
@@ -60,6 +68,8 @@ impl Builder {
             sockets,
             queue_time: _,
         } = self;
+
+        // TODO emit event
 
         let sockets = sockets.build()?;
         let read = read.build(shared.clone(), sockets.clone());
@@ -69,35 +79,40 @@ impl Builder {
 
     /// Emits an event indicating that the stream was pruned
     #[inline]
-    pub(crate) fn prune<Pub>(
-        self,
-        reason: event::builder::AcceptorStreamPruneReason,
-        publisher: &Pub,
-    ) where
-        Pub: event::EndpointPublisher,
-    {
+    pub(crate) fn prune(self, reason: event::builder::AcceptorStreamPruneReason) {
         let now = self.shared.clock.get_time();
         let remote_address = self.shared.read_remote_addr();
         let remote_address = &remote_address;
         let credential_id = &*self.shared.credentials().id;
         let stream_id = self.shared.application().stream_id.into_varint().as_u64();
         let sojourn_time = now.saturating_duration_since(self.queue_time);
-        publisher.on_acceptor_stream_pruned(event::builder::AcceptorStreamPruned {
-            remote_address,
-            credential_id,
-            stream_id,
-            sojourn_time,
-            reason,
-        });
+
+        self.shared
+            .endpoint_publisher(now)
+            .on_acceptor_stream_pruned(event::builder::AcceptorStreamPruned {
+                remote_address,
+                credential_id,
+                stream_id,
+                sojourn_time,
+                reason,
+            });
+
+        // TODO emit event
     }
 }
 
-pub struct Stream {
-    read: Reader,
-    write: Writer,
+pub struct Stream<Sub>
+where
+    Sub: event::Subscriber,
+{
+    read: Reader<Sub>,
+    write: Writer<Sub>,
 }
 
-impl fmt::Debug for Stream {
+impl<Sub> fmt::Debug for Stream<Sub>
+where
+    Sub: event::Subscriber,
+{
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("Stream")
             .field("peer_addr", &self.peer_addr().unwrap())
@@ -106,7 +121,10 @@ impl fmt::Debug for Stream {
     }
 }
 
-impl Stream {
+impl<Sub> Stream<Sub>
+where
+    Sub: event::Subscriber,
+{
     #[inline]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         self.read.peer_addr()
@@ -139,26 +157,29 @@ impl Stream {
     }
 
     #[inline]
-    pub fn split(&mut self) -> (&mut Reader, &mut Writer) {
+    pub fn split(&mut self) -> (&mut Reader<Sub>, &mut Writer<Sub>) {
         (&mut self.read, &mut self.write)
     }
 
     #[inline]
-    pub fn into_split(self) -> (Reader, Writer) {
+    pub fn into_split(self) -> (Reader<Sub>, Writer<Sub>) {
         (self.read, self.write)
     }
 }
 
 #[cfg(feature = "tokio")]
 mod tokio_impl {
-    use super::Stream;
+    use super::{event, Stream};
     use core::{
         pin::Pin,
         task::{Context, Poll},
     };
     use tokio::io::{self, AsyncRead, AsyncWrite, ReadBuf};
 
-    impl AsyncRead for Stream {
+    impl<Sub> AsyncRead for Stream<Sub>
+    where
+        Sub: event::Subscriber,
+    {
         #[inline]
         fn poll_read(
             mut self: Pin<&mut Self>,
@@ -169,7 +190,10 @@ mod tokio_impl {
         }
     }
 
-    impl AsyncWrite for Stream {
+    impl<Sub> AsyncWrite for Stream<Sub>
+    where
+        Sub: event::Subscriber,
+    {
         #[inline]
         fn poll_write(
             mut self: Pin<&mut Self>,

--- a/dc/s2n-quic-dc/src/stream/client/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/client/tokio.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    event,
     path::secret,
     stream::{
         application::Stream,
@@ -15,21 +16,29 @@ use tokio::net::TcpStream;
 
 /// Connects using the UDP transport layer
 #[inline]
-pub async fn connect_udp<H>(
+pub async fn connect_udp<H, Sub>(
     handshake: H,
     acceptor_addr: SocketAddr,
-    env: &Environment,
-) -> io::Result<Stream>
+    env: &Environment<Sub>,
+    subscriber: Sub,
+) -> io::Result<Stream<Sub>>
 where
     H: core::future::Future<Output = io::Result<secret::map::Peer>>,
+    Sub: event::Subscriber,
 {
     // ensure we have a secret for the peer
     let peer = handshake.await?;
 
-    let stream = endpoint::open_stream(env, peer, env::UdpUnbound(acceptor_addr.into()), None)?;
+    let stream = endpoint::open_stream(
+        env,
+        peer,
+        env::UdpUnbound(acceptor_addr.into()),
+        subscriber,
+        None,
+    )?;
 
     // build the stream inside the application context
-    let mut stream = stream.build_without_event()?;
+    let mut stream = stream.connect()?;
 
     debug_assert_eq!(stream.protocol(), Protocol::Udp);
 
@@ -40,21 +49,23 @@ where
 
 /// Connects using the TCP transport layer
 #[inline]
-pub async fn connect_tcp<H>(
+pub async fn connect_tcp<H, Sub>(
     handshake: H,
     acceptor_addr: SocketAddr,
-    env: &Environment,
-) -> io::Result<Stream>
+    env: &Environment<Sub>,
+    subscriber: Sub,
+) -> io::Result<Stream<Sub>>
 where
     H: core::future::Future<Output = io::Result<secret::map::Peer>>,
+    Sub: event::Subscriber,
 {
     // Race TCP handshake with the TLS handshake
     let (socket, peer) = tokio::try_join!(TcpStream::connect(acceptor_addr), handshake,)?;
 
-    let stream = endpoint::open_stream(env, peer, env::TcpRegistered(socket), None)?;
+    let stream = endpoint::open_stream(env, peer, env::TcpRegistered(socket), subscriber, None)?;
 
     // build the stream inside the application context
-    let mut stream = stream.build_without_event()?;
+    let mut stream = stream.connect()?;
 
     debug_assert_eq!(stream.protocol(), Protocol::Tcp);
 
@@ -69,15 +80,19 @@ where
 ///
 /// The provided `map` must contain a shared secret for the `handshake_addr`
 #[inline]
-pub async fn connect_tcp_with(
+pub async fn connect_tcp_with<Sub>(
     peer: secret::map::Peer,
     stream: TcpStream,
-    env: &Environment,
-) -> io::Result<Stream> {
-    let stream = endpoint::open_stream(env, peer, env::TcpRegistered(stream), None)?;
+    env: &Environment<Sub>,
+    subscriber: Sub,
+) -> io::Result<Stream<Sub>>
+where
+    Sub: event::Subscriber,
+{
+    let stream = endpoint::open_stream(env, peer, env::TcpRegistered(stream), subscriber, None)?;
 
     // build the stream inside the application context
-    let mut stream = stream.build_without_event()?;
+    let mut stream = stream.connect()?;
 
     debug_assert_eq!(stream.protocol(), Protocol::Tcp);
 
@@ -87,7 +102,10 @@ pub async fn connect_tcp_with(
 }
 
 #[inline]
-async fn write_prelude(stream: &mut Stream) -> io::Result<()> {
+async fn write_prelude<Sub>(stream: &mut Stream<Sub>) -> io::Result<()>
+where
+    Sub: event::Subscriber,
+{
     // TODO should we actually write the prelude here or should we do late sealer binding on
     // the first packet to reduce secret reordering on the peer
 

--- a/dc/s2n-quic-dc/src/stream/endpoint.rs
+++ b/dc/s2n-quic-dc/src/stream/endpoint.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    event::{self, api::Subscriber as _, IntoEvent as _},
     msg, packet,
     path::secret::{self, map, Map},
     random::Random,
@@ -15,7 +16,10 @@ use crate::{
 };
 use core::cell::UnsafeCell;
 use s2n_quic_core::{
-    dc, endpoint, inet::ExplicitCongestionNotification, time::Clock as _, varint::VarInt,
+    dc, endpoint,
+    inet::ExplicitCongestionNotification,
+    time::{Clock as _, Timestamp},
+    varint::VarInt,
 };
 use std::{io, sync::Arc};
 use tracing::{debug_span, Instrument as _};
@@ -33,8 +37,9 @@ pub fn open_stream<Env, P>(
     env: &Env,
     entry: map::Peer,
     peer: P,
+    subscriber: Env::Subscriber,
     parameter_override: Option<&dyn Fn(dc::ApplicationParams) -> dc::ApplicationParams>,
-) -> Result<application::Builder>
+) -> Result<application::Builder<Env::Subscriber>>
 where
     Env: Environment,
     P: Peer<Env>,
@@ -52,7 +57,18 @@ where
         is_bidirectional: true,
     };
 
+    let now = env.clock().get_time();
+
+    let meta = event::api::ConnectionMeta {
+        id: 0, // TODO use an actual connection ID
+        timestamp: now.into_event(),
+    };
+    let info = event::api::ConnectionInfo {};
+
+    let subscriber_ctx = subscriber.create_connection_context(&meta, &info);
+
     build_stream(
+        now,
         env,
         peer,
         stream_id,
@@ -63,19 +79,24 @@ where
         None,
         None,
         endpoint::Type::Client,
+        subscriber,
+        subscriber_ctx,
     )
 }
 
 #[inline]
 pub fn accept_stream<Env, P>(
+    now: Timestamp,
     env: &Env,
     mut peer: P,
     packet: &server::InitialPacket,
     handshake: Option<server::handshake::Receiver>,
     buffer: Option<&mut msg::recv::Message>,
     map: &Map,
+    subscriber: Env::Subscriber,
+    subscriber_ctx: <Env::Subscriber as event::Subscriber>::ConnectionContext,
     parameter_override: Option<&dyn Fn(dc::ApplicationParams) -> dc::ApplicationParams>,
-) -> Result<application::Builder, AcceptError<P>>
+) -> Result<application::Builder<Env::Subscriber>, AcceptError<P>>
 where
     Env: Environment,
     P: Peer<Env>,
@@ -105,6 +126,7 @@ where
     peer.with_source_control_port(packet.source_control_port);
 
     let res = build_stream(
+        now,
         env,
         peer,
         packet.stream_id,
@@ -115,6 +137,8 @@ where
         handshake,
         buffer,
         endpoint::Type::Server,
+        subscriber,
+        subscriber_ctx,
     );
 
     match res {
@@ -132,6 +156,7 @@ where
 
 #[inline]
 fn build_stream<Env, P>(
+    now: Timestamp,
     env: &Env,
     peer: P,
     stream_id: packet::stream::Id,
@@ -142,13 +167,13 @@ fn build_stream<Env, P>(
     handshake: Option<server::handshake::Receiver>,
     recv_buffer: Option<&mut msg::recv::Message>,
     endpoint_type: endpoint::Type,
-) -> Result<application::Builder>
+    subscriber: Env::Subscriber,
+    subscriber_ctx: <Env::Subscriber as event::Subscriber>::ConnectionContext,
+) -> Result<application::Builder<Env::Subscriber>>
 where
     Env: Environment,
     P: Peer<Env>,
 {
-    let now = env.clock().get_time();
-
     let features = peer.features();
 
     let sockets = peer.setup(env)?;
@@ -222,6 +247,8 @@ where
             last_peer_activity: Default::default(),
             fixed,
             closed_halves: 0u8.into(),
+            subscriber,
+            subscriber_ctx,
         }
     };
 

--- a/dc/s2n-quic-dc/src/stream/environment.rs
+++ b/dc/s2n-quic-dc/src/stream/environment.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    clock,
+    clock, event,
     stream::{runtime, socket, TransportFeatures},
 };
 use core::future::Future;
@@ -17,12 +17,13 @@ pub mod tokio;
 
 pub trait Environment {
     type Clock: Clone + clock::Clock;
+    type Subscriber: event::Subscriber;
 
     fn clock(&self) -> &Self::Clock;
     fn gso(&self) -> features::Gso;
-    fn reader_rt(&self) -> runtime::ArcHandle;
+    fn reader_rt(&self) -> runtime::ArcHandle<Self::Subscriber>;
     fn spawn_reader<F: 'static + Send + Future<Output = ()>>(&self, f: F);
-    fn writer_rt(&self) -> runtime::ArcHandle;
+    fn writer_rt(&self) -> runtime::ArcHandle<Self::Subscriber>;
     fn spawn_writer<F: 'static + Send + Future<Output = ()>>(&self, f: F);
 }
 

--- a/dc/s2n-quic-dc/src/stream/recv/application/builder.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/application/builder.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     clock::Timer,
-    msg,
+    event, msg,
     stream::{
         recv::application::{Inner, LocalState, Reader},
         runtime,
@@ -14,21 +14,24 @@ use crate::{
 use core::mem::ManuallyDrop;
 use s2n_quic_core::endpoint;
 
-pub struct Builder {
+pub struct Builder<Sub> {
     endpoint: endpoint::Type,
-    runtime: runtime::ArcHandle,
+    runtime: runtime::ArcHandle<Sub>,
 }
 
-impl Builder {
+impl<Sub> Builder<Sub> {
     #[inline]
-    pub fn new(endpoint: endpoint::Type, runtime: runtime::ArcHandle) -> Self {
+    pub fn new(endpoint: endpoint::Type, runtime: runtime::ArcHandle<Sub>) -> Self {
         Self { endpoint, runtime }
     }
 }
 
-impl Builder {
+impl<Sub> Builder<Sub>
+where
+    Sub: event::Subscriber,
+{
     #[inline]
-    pub fn build(self, shared: ArcShared, sockets: socket::ArcApplication) -> Reader {
+    pub fn build(self, shared: ArcShared<Sub>, sockets: socket::ArcApplication) -> Reader<Sub> {
         let Self { endpoint, runtime } = self;
 
         let remote_addr = shared.read_remote_addr();

--- a/dc/s2n-quic-dc/src/stream/recv/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/worker.rs
@@ -4,7 +4,7 @@
 use crate::{
     allocator::Allocator,
     clock::Timer,
-    msg,
+    event, msg,
     stream::{shared::ArcShared, socket::Socket},
 };
 use core::task::{Context, Poll};
@@ -55,8 +55,12 @@ pub(crate) enum ErrorCode {
     Application = 1,
 }
 
-pub struct Worker<S: Socket> {
-    shared: ArcShared,
+pub struct Worker<S, Sub>
+where
+    S: Socket,
+    Sub: event::Subscriber,
+{
+    shared: ArcShared<Sub>,
     last_observed_epoch: u64,
     send_buffer: msg::send::Message,
     state: waiting::State,
@@ -65,9 +69,13 @@ pub struct Worker<S: Socket> {
     socket: S,
 }
 
-impl<S: Socket> Worker<S> {
+impl<S, Sub> Worker<S, Sub>
+where
+    S: Socket,
+    Sub: event::Subscriber,
+{
     #[inline]
-    pub fn new(socket: S, shared: ArcShared, endpoint: endpoint::Type) -> Self {
+    pub fn new(socket: S, shared: ArcShared<Sub>, endpoint: endpoint::Type) -> Self {
         let send_buffer = msg::send::Message::new(shared.read_remote_addr(), shared.gso.clone());
         let timer = Timer::new_with_timeout(&shared.clock, INITIAL_TIMEOUT);
 

--- a/dc/s2n-quic-dc/src/stream/runtime.rs
+++ b/dc/s2n-quic-dc/src/stream/runtime.rs
@@ -1,15 +1,21 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::stream::{recv, send};
+use crate::{
+    event,
+    stream::{recv, send},
+};
 use std::sync::Arc;
 
 #[cfg(feature = "tokio")]
 pub mod tokio;
 
-pub type ArcHandle = Arc<dyn Handle>;
+pub type ArcHandle<Sub> = Arc<dyn Handle<Sub>>;
 
-pub trait Handle: 'static + Send + Sync {
-    fn spawn_recv_shutdown(&self, shutdown: recv::application::Shutdown);
-    fn spawn_send_shutdown(&self, shutdown: send::application::Shutdown);
+pub trait Handle<Sub>: 'static + Send + Sync
+where
+    Sub: event::Subscriber,
+{
+    fn spawn_recv_shutdown(&self, shutdown: recv::application::Shutdown<Sub>);
+    fn spawn_send_shutdown(&self, shutdown: send::application::Shutdown<Sub>);
 }

--- a/dc/s2n-quic-dc/src/stream/send/application/builder.rs
+++ b/dc/s2n-quic-dc/src/stream/send/application/builder.rs
@@ -1,25 +1,34 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::stream::{
-    runtime,
-    send::application::{Inner, Writer},
-    shared::ArcShared,
-    socket,
+use crate::{
+    event,
+    stream::{
+        runtime,
+        send::application::{Inner, Writer},
+        shared::ArcShared,
+        socket,
+    },
 };
 
-pub struct Builder {
-    runtime: runtime::ArcHandle,
+pub struct Builder<Sub>
+where
+    Sub: event::Subscriber,
+{
+    runtime: runtime::ArcHandle<Sub>,
 }
 
-impl Builder {
+impl<Sub> Builder<Sub>
+where
+    Sub: event::Subscriber,
+{
     #[inline]
-    pub fn new(runtime: runtime::ArcHandle) -> Self {
+    pub fn new(runtime: runtime::ArcHandle<Sub>) -> Self {
         Self { runtime }
     }
 
     #[inline]
-    pub fn build(self, shared: ArcShared, sockets: socket::ArcApplication) -> Writer {
+    pub fn build(self, shared: ArcShared<Sub>, sockets: socket::ArcApplication) -> Writer<Sub> {
         let Self { runtime } = self;
         Writer(Box::new(Inner {
             shared,

--- a/dc/s2n-quic-dc/src/stream/send/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/send/worker.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     clock::{Clock, Timer},
-    msg,
-    msg::addr,
+    event,
+    msg::{self, addr},
     packet::Packet,
     stream::{
         pacer,
@@ -60,8 +60,14 @@ mod waiting {
     }
 }
 
-pub struct Worker<S: Socket, R: random::Generator, C: Clock> {
-    shared: Arc<shared::Shared<C>>,
+pub struct Worker<S, R, Sub, C>
+where
+    S: Socket,
+    R: random::Generator,
+    Sub: event::Subscriber,
+    C: Clock,
+{
+    shared: Arc<shared::Shared<Sub, C>>,
     sender: State,
     recv_buffer: msg::recv::Message,
     random: R,
@@ -87,7 +93,11 @@ struct Snapshot {
 
 impl Snapshot {
     #[inline]
-    fn apply<C: Clock>(&self, initial: &Self, shared: &shared::Shared<C>) {
+    fn apply<Sub, C>(&self, initial: &Self, shared: &shared::Shared<Sub, C>)
+    where
+        Sub: event::Subscriber,
+        C: Clock,
+    {
         if initial.flow_offset < self.flow_offset {
             shared.sender.flow.release(self.flow_offset);
         } else if initial.has_pending_retransmissions && !self.has_pending_retransmissions {
@@ -125,17 +135,18 @@ impl Snapshot {
     }
 }
 
-impl<S, R, C> Worker<S, R, C>
+impl<S, R, Sub, C> Worker<S, R, Sub, C>
 where
     S: Socket,
     R: random::Generator,
+    Sub: event::Subscriber,
     C: Clock,
 {
     #[inline]
     pub fn new(
         socket: S,
         random: R,
-        shared: Arc<shared::Shared<C>>,
+        shared: Arc<shared::Shared<Sub, C>>,
         mut sender: State,
         endpoint: endpoint::Type,
     ) -> Self {

--- a/quic/s2n-quic-events/src/output.rs
+++ b/quic/s2n-quic-events/src/output.rs
@@ -262,7 +262,7 @@ impl ToTokens for Output {
                     ///     }
                     /// }
                     ///  ```
-                    type ConnectionContext: 'static + Send;
+                    type ConnectionContext: #trait_constraints;
 
                     /// Creates a context to be passed to each connection-related event
                     fn create_connection_context(


### PR DESCRIPTION
### Description of changes: 

This change makes it possible to emit events from s2n-quic-dc streams by threading through a generic `event::Subscriber` in all of the data structures and functions.

I haven't actually emitted any events at this point, since the change is already quite large. Actual events will come in a later PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

