### PR TITLE
docs: enable feature tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,7 +161,7 @@ jobs:
       - name: Run cargo doc
         run: cargo +nightly doc --all-features --no-deps --workspace --exclude s2n-quic-qns
         env:
-          RUSTDOCFLAGS: --cfg s2n_docsrs
+          RUSTDOCFLAGS: --cfg docsrs
 
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,17 +150,18 @@ jobs:
         with:
           submodules: true
 
-      - name: Install rust toolchain
-        id: toolchain
+      # nightly docrs features are used
+      - name: Install rust nightly toolchain
+        id: nightly-toolchain
         run: |
-          rustup toolchain install stable --profile minimal
-          rustup override set stable
-
+          rustup toolchain install nightly --profile minimal
 
       - uses: camshaft/rust-cache@v1
 
       - name: Run cargo doc
-        run: cargo doc --all-features --no-deps --workspace --exclude s2n-quic-qns
+        run: cargo +nightly doc --all-features --no-deps --workspace --exclude s2n-quic-qns
+        env:
+          RUSTDOCFLAGS: --cfg s2n_docsrs
 
       - uses: aws-actions/configure-aws-credentials@v4.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -91,3 +91,11 @@ s2n-quic-transport = { path = "../s2n-quic-transport", features = ["unstable_res
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+# Compile with the `s2n_docsrs` feature to enable feature tagging in rust docs. See
+# documentation for additional configuration options: https://docs.rs/about/metadata
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "s2n_docsrs"]
+
+[lints.rust]
+unexpected_cfgs = { level = "allow", check-cfg = ['cfg(s2n_docsrs)'] }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -91,11 +91,3 @@ s2n-quic-transport = { path = "../s2n-quic-transport", features = ["unstable_res
 tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-
-# Compile with the `s2n_docsrs` feature to enable feature tagging in rust docs. See
-# documentation for additional configuration options: https://docs.rs/about/metadata
-[package.metadata.docs.rs]
-rustdoc-args = ["--cfg", "s2n_docsrs"]
-
-[lints.rust]
-unexpected_cfgs = { level = "allow", check-cfg = ['cfg(s2n_docsrs)'] }

--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -105,9 +105,9 @@
 
 // Tag docs with the required platform and features.
 // https://doc.rust-lang.org/rustdoc/unstable-features.html
-#![cfg_attr(s2n_docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(
-    s2n_docsrs,
+    docsrs,
     feature(doc_auto_cfg),
     feature(doc_cfg_hide),
     doc(cfg_hide(doc))

--- a/quic/s2n-quic/src/lib.rs
+++ b/quic/s2n-quic/src/lib.rs
@@ -103,6 +103,16 @@
 //! [s2n-tls]: https://github.com/aws/s2n-tls
 //! [rustls]: https://github.com/rustls/rustls
 
+// Tag docs with the required platform and features.
+// https://doc.rust-lang.org/rustdoc/unstable-features.html
+#![cfg_attr(s2n_docsrs, feature(doc_cfg))]
+#![cfg_attr(
+    s2n_docsrs,
+    feature(doc_auto_cfg),
+    feature(doc_cfg_hide),
+    doc(cfg_hide(doc))
+)]
+
 #[macro_use]
 pub mod provider;
 

--- a/quic/s2n-quic/src/provider.rs
+++ b/quic/s2n-quic/src/provider.rs
@@ -26,7 +26,7 @@ pub(crate) mod sync;
 
 cfg_if!(
     if #[cfg(any(test, feature = "unstable-provider-connection-close-formatter"))] {
-        #[cfg_attr(s2n_docsrs, doc(cfg(feature = "unstable-provider-connection-close-formatter")))]
+        #[cfg_attr(docsrs, doc(cfg(feature = "unstable-provider-connection-close-formatter")))]
         pub mod connection_close_formatter;
     } else {
         #[allow(dead_code)]
@@ -36,7 +36,7 @@ cfg_if!(
 
 cfg_if!(
     if #[cfg(any(test, feature = "unstable-provider-packet-interceptor"))] {
-        #[cfg_attr(s2n_docsrs, doc(cfg(feature = "unstable-provider-packet-interceptor")))]
+        #[cfg_attr(docsrs, doc(cfg(feature = "unstable-provider-packet-interceptor")))]
         pub mod packet_interceptor;
     } else {
         #[allow(dead_code)]
@@ -46,7 +46,7 @@ cfg_if!(
 
 cfg_if!(
     if #[cfg(any(test, feature = "unstable-provider-random"))] {
-        #[cfg_attr(s2n_docsrs, doc(cfg(feature = "unstable-provider-random")))]
+        #[cfg_attr(docsrs, doc(cfg(feature = "unstable-provider-random")))]
         pub mod random;
     } else {
         #[allow(dead_code)]
@@ -56,7 +56,7 @@ cfg_if!(
 
 cfg_if!(
     if #[cfg(any(test, feature = "unstable-provider-datagram"))] {
-        #[cfg_attr(s2n_docsrs, doc(cfg(feature = "unstable-provider-datagram")))]
+        #[cfg_attr(docsrs, doc(cfg(feature = "unstable-provider-datagram")))]
         pub mod datagram;
     } else {
         #[allow(dead_code)]
@@ -66,7 +66,7 @@ cfg_if!(
 
 cfg_if!(
     if #[cfg(any(test, feature = "unstable-provider-dc"))] {
-        #[cfg_attr(s2n_docsrs, doc(cfg(feature = "unstable-provider-dc")))]
+        #[cfg_attr(docsrs, doc(cfg(feature = "unstable-provider-dc")))]
         pub mod dc;
     } else {
         #[allow(dead_code)]

--- a/quic/s2n-quic/src/provider.rs
+++ b/quic/s2n-quic/src/provider.rs
@@ -26,6 +26,7 @@ pub(crate) mod sync;
 
 cfg_if!(
     if #[cfg(any(test, feature = "unstable-provider-connection-close-formatter"))] {
+        #[cfg_attr(s2n_docsrs, doc(cfg(feature = "unstable-provider-connection-close-formatter")))]
         pub mod connection_close_formatter;
     } else {
         #[allow(dead_code)]
@@ -35,6 +36,7 @@ cfg_if!(
 
 cfg_if!(
     if #[cfg(any(test, feature = "unstable-provider-packet-interceptor"))] {
+        #[cfg_attr(s2n_docsrs, doc(cfg(feature = "unstable-provider-packet-interceptor")))]
         pub mod packet_interceptor;
     } else {
         #[allow(dead_code)]
@@ -44,6 +46,7 @@ cfg_if!(
 
 cfg_if!(
     if #[cfg(any(test, feature = "unstable-provider-random"))] {
+        #[cfg_attr(s2n_docsrs, doc(cfg(feature = "unstable-provider-random")))]
         pub mod random;
     } else {
         #[allow(dead_code)]
@@ -53,6 +56,7 @@ cfg_if!(
 
 cfg_if!(
     if #[cfg(any(test, feature = "unstable-provider-datagram"))] {
+        #[cfg_attr(s2n_docsrs, doc(cfg(feature = "unstable-provider-datagram")))]
         pub mod datagram;
     } else {
         #[allow(dead_code)]
@@ -62,6 +66,7 @@ cfg_if!(
 
 cfg_if!(
     if #[cfg(any(test, feature = "unstable-provider-dc"))] {
+        #[cfg_attr(s2n_docsrs, doc(cfg(feature = "unstable-provider-dc")))]
         pub mod dc;
     } else {
         #[allow(dead_code)]

--- a/quic/s2n-quic/src/provider/congestion_controller.rs
+++ b/quic/s2n-quic/src/provider/congestion_controller.rs
@@ -14,7 +14,7 @@ pub trait Provider {
 
 cfg_if! {
     if #[cfg(feature = "unstable-congestion-controller")] {
-        #[cfg_attr(s2n_docsrs, doc(cfg(feature = "unstable-congestion-controller")))]
+        #[cfg_attr(docsrs, doc(cfg(feature = "unstable-congestion-controller")))]
         // Export the types needed to implement the CongestionController trait
         pub use s2n_quic_core::{
             random::Generator as RandomGenerator,

--- a/quic/s2n-quic/src/provider/congestion_controller.rs
+++ b/quic/s2n-quic/src/provider/congestion_controller.rs
@@ -14,6 +14,7 @@ pub trait Provider {
 
 cfg_if! {
     if #[cfg(feature = "unstable-congestion-controller")] {
+        #[cfg_attr(s2n_docsrs, doc(cfg(feature = "unstable-congestion-controller")))]
         // Export the types needed to implement the CongestionController trait
         pub use s2n_quic_core::{
             random::Generator as RandomGenerator,

--- a/quic/s2n-quic/src/provider/tls.rs
+++ b/quic/s2n-quic/src/provider/tls.rs
@@ -22,7 +22,7 @@ impl_provider_utils!();
 
 cfg_if! {
     if #[cfg(feature = "provider-tls-default")] {
-        #[cfg_attr(s2n_docsrs, doc(cfg(feature = "provider-tls-default")))]
+        #[cfg_attr(docsrs, doc(cfg(feature = "provider-tls-default")))]
         pub mod default {
             //! Provides the recommended implementation of TLS using platform detection
             pub use super::default_tls::*;
@@ -239,7 +239,7 @@ mod default_tls {
     // TODO stub out default that fails with error when started
 }
 
-#[cfg_attr(s2n_docsrs, doc(cfg(feature = "provider-tls-rustls")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "provider-tls-rustls")))]
 #[cfg(feature = "s2n-quic-rustls")]
 pub mod rustls {
     //! Provides the [rustls](https://docs.rs/rustls/) implementation of TLS
@@ -275,7 +275,7 @@ pub mod rustls {
     }
 }
 
-#[cfg_attr(s2n_docsrs, doc(cfg(feature = "provider-tls-s2n")))]
+#[cfg_attr(docsrs, doc(cfg(feature = "provider-tls-s2n")))]
 #[cfg(feature = "s2n-quic-tls")]
 pub mod s2n_tls {
     //! Provides the [s2n-tls](https://github.com/aws/s2n-tls) implementation of TLS

--- a/quic/s2n-quic/src/provider/tls.rs
+++ b/quic/s2n-quic/src/provider/tls.rs
@@ -22,6 +22,7 @@ impl_provider_utils!();
 
 cfg_if! {
     if #[cfg(feature = "provider-tls-default")] {
+        #[cfg_attr(s2n_docsrs, doc(cfg(feature = "provider-tls-default")))]
         pub mod default {
             //! Provides the recommended implementation of TLS using platform detection
             pub use super::default_tls::*;
@@ -238,6 +239,7 @@ mod default_tls {
     // TODO stub out default that fails with error when started
 }
 
+#[cfg_attr(s2n_docsrs, doc(cfg(feature = "provider-tls-rustls")))]
 #[cfg(feature = "s2n-quic-rustls")]
 pub mod rustls {
     //! Provides the [rustls](https://docs.rs/rustls/) implementation of TLS
@@ -273,6 +275,7 @@ pub mod rustls {
     }
 }
 
+#[cfg_attr(s2n_docsrs, doc(cfg(feature = "provider-tls-s2n")))]
 #[cfg(feature = "s2n-quic-tls")]
 pub mod s2n_tls {
     //! Provides the [s2n-tls](https://github.com/aws/s2n-tls) implementation of TLS


### PR DESCRIPTION
### Resolved issues:
https://github.com/aws/s2n-quic/issues/1831

### Description of changes: 
This PR enables feature tagging in our [rust docs](https://dnglbrstg7yg.cloudfront.net/e2d8618eb0658c13f1f749afc53e7f7b3b4fdcaf/doc/s2n_quic/index.html). This is useful for customers that want to use enable APIs that require building s2n-quic with certain features.

### Call-outs:
This PR only covers the main s2n-quic crate. Future work might be to expand feature tagging to other s2n-quic crates.

We need to gate the feature on `docsrs` since it requires nightly cargo and would otherwise break stable builds.

We rely `doc_auto_cfg` to auto generate the feature tagging where applicable. However, we also require manually tagging with `doc_cfg`
- since auto isn't able to detect the use of `cfg_if!` macro
- for the tls providers since they key on the crate name
- 
### Testing:
The [example report](https://dnglbrstg7yg.cloudfront.net/e2d8618eb0658c13f1f749afc53e7f7b3b4fdcaf/doc/s2n_quic/index.html) in CI shows the feature tagging.

I also tested this on [a personal test crate](https://docs.rs/toidiu/latest/toidiu/) to verify crates.io works as intended.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

