### PR TITLE
feat(s2n-quic-dc): implement connection-level counter aggregation

### DIFF
--- a/dc/s2n-quic-dc/events/connection.rs
+++ b/dc/s2n-quic-dc/events/connection.rs
@@ -3,6 +3,7 @@
 
 #[event("stream:write_flushed")]
 #[checkpoint("latency")]
+#[measure_counter("conn")]
 pub struct StreamWriteFlushed {
     /// The number of bytes that the application tried to write
     #[measure("provided", Bytes)]
@@ -11,17 +12,20 @@ pub struct StreamWriteFlushed {
     /// The amount that was written
     #[measure("committed", Bytes)]
     #[counter("committed.total", Bytes)]
+    #[measure_counter("committed.conn", Bytes)]
     committed_len: usize,
 
     /// The amount of time it took to process the write request
     ///
     /// Note that this includes both any syscall and encryption overhead
     #[measure("processing_duration", Duration)]
+    #[measure_counter("processing_duration.conn", Duration)]
     processing_duration: core::time::Duration,
 }
 
 #[event("stream:write_fin_flushed")]
 #[checkpoint("latency")]
+#[measure_counter("conn")]
 pub struct StreamWriteFinFlushed {
     /// The number of bytes that the application tried to write
     #[measure("provided", Bytes)]
@@ -30,17 +34,20 @@ pub struct StreamWriteFinFlushed {
     /// The amount that was written
     #[measure("committed", Bytes)]
     #[counter("committed.total", Bytes)]
+    #[measure_counter("committed.conn", Bytes)]
     committed_len: usize,
 
     /// The amount of time it took to process the write request
     ///
     /// Note that this includes both any syscall and encryption overhead
     #[measure("processing_duration", Duration)]
+    #[measure_counter("processing_duration.conn", Duration)]
     processing_duration: core::time::Duration,
 }
 
 #[event("stream:write_blocked")]
 #[checkpoint("latency")]
+#[measure_counter("conn.stream.write.blocked")]
 pub struct StreamWriteBlocked {
     /// The number of bytes that the application tried to write
     #[measure("provided", Bytes)]
@@ -53,6 +60,7 @@ pub struct StreamWriteBlocked {
     ///
     /// Note that this includes both any syscall and encryption overhead
     #[measure("processing_duration", Duration)]
+    #[measure_counter("processing_duration.conn", Duration)]
     processing_duration: core::time::Duration,
 }
 
@@ -70,6 +78,7 @@ pub struct StreamWriteErrored {
     ///
     /// Note that this includes both any syscall and encryption overhead
     #[measure("processing_duration", Duration)]
+    #[measure_counter("processing_duration.conn", Duration)]
     processing_duration: core::time::Duration,
 
     /// The system `errno` from the returned error
@@ -89,6 +98,7 @@ pub struct StreamWriteShutdown {
 }
 
 #[event("stream:write_socket_flushed")]
+#[measure_counter("conn")]
 pub struct StreamWriteSocketFlushed {
     /// The number of bytes that the stream tried to write to the socket
     #[measure("provided", Bytes)]
@@ -97,10 +107,12 @@ pub struct StreamWriteSocketFlushed {
     /// The amount that was written
     #[measure("committed", Bytes)]
     #[counter("committed.total", Bytes)]
+    #[measure_counter("committed.conn", Bytes)]
     committed_len: usize,
 }
 
 #[event("stream:write_socket_blocked")]
+#[measure_counter("conn.stream.write.socket.blocked")]
 pub struct StreamWriteSocketBlocked {
     /// The number of bytes that the stream tried to write to the socket
     #[measure("provided", Bytes)]
@@ -119,6 +131,7 @@ pub struct StreamWriteSocketErrored {
 
 #[event("stream:read_flushed")]
 #[checkpoint("latency")]
+#[measure_counter("conn")]
 pub struct StreamReadFlushed {
     /// The number of bytes that the application tried to read
     #[measure("capacity", Bytes)]
@@ -127,17 +140,20 @@ pub struct StreamReadFlushed {
     /// The amount that was read into the provided buffer
     #[measure("committed", Bytes)]
     #[counter("committed.total", Bytes)]
+    #[measure_counter("committed.conn", Bytes)]
     committed_len: usize,
 
     /// The amount of time it took to process the read request
     ///
     /// Note that this includes both any syscall and decryption overhead
     #[measure("processing_duration", Duration)]
+    #[measure_counter("processing_duration.conn", Duration)]
     processing_duration: core::time::Duration,
 }
 
 #[event("stream:read_fin_flushed")]
 #[checkpoint("latency")]
+#[measure_counter("conn")]
 pub struct StreamReadFinFlushed {
     /// The number of bytes that the application tried to read
     #[measure("capacity", Bytes)]
@@ -147,6 +163,7 @@ pub struct StreamReadFinFlushed {
     ///
     /// Note that this includes both any syscall and decryption overhead
     #[measure("processing_duration", Duration)]
+    #[measure_counter("processing_duration.conn", Duration)]
     processing_duration: core::time::Duration,
 }
 
@@ -161,6 +178,7 @@ pub struct StreamReadBlocked {
     ///
     /// Note that this includes both any syscall and decryption overhead
     #[measure("processing_duration", Duration)]
+    #[measure_counter("processing_duration.conn", Duration)]
     processing_duration: core::time::Duration,
 }
 
@@ -175,6 +193,7 @@ pub struct StreamReadErrored {
     ///
     /// Note that this includes both any syscall and decryption overhead
     #[measure("processing_duration", Duration)]
+    #[measure_counter("processing_duration.conn", Duration)]
     processing_duration: core::time::Duration,
 
     /// The system `errno` from the returned error
@@ -190,6 +209,7 @@ pub struct StreamReadShutdown {
 }
 
 #[event("stream:read_socket_flushed")]
+#[measure_counter("conn")]
 pub struct StreamReadSocketFlushed {
     /// The number of bytes that the stream tried to read from the socket
     #[measure("capacity", Bytes)]
@@ -198,10 +218,12 @@ pub struct StreamReadSocketFlushed {
     /// The amount that was read into the provided buffer
     #[measure("committed", Bytes)]
     #[counter("committed.total", Bytes)]
+    #[measure_counter("committed.conn", Bytes)]
     committed_len: usize,
 }
 
 #[event("stream:read_socket_blocked")]
+#[measure_counter("conn")]
 pub struct StreamReadSocketBlocked {
     /// The number of bytes that the stream tried to read from the socket
     #[measure("capacity", Bytes)]
@@ -217,3 +239,8 @@ pub struct StreamReadSocketErrored {
     /// The system `errno` from the returned error
     errno: Option<i32>,
 }
+
+// NOTE - This event MUST come last, since connection-level aggregation depends on it
+#[event("connection:closed")]
+// #[checkpoint("latency")]
+pub struct ConnectionClosed {}

--- a/dc/s2n-quic-dc/src/event/generated.rs
+++ b/dc/s2n-quic-dc/src/event/generated.rs
@@ -964,6 +964,19 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
+    pub struct ConnectionClosed {}
+    #[cfg(any(test, feature = "testing"))]
+    impl crate::event::snapshot::Fmt for ConnectionClosed {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("ConnectionClosed");
+            fmt.finish()
+        }
+    }
+    impl Event for ConnectionClosed {
+        const NAME: &'static str = "connection:closed";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
     pub struct EndpointInitialized<'a> {
         pub acceptor_addr: SocketAddress<'a>,
         pub handshake_addr: SocketAddress<'a>,
@@ -1612,7 +1625,7 @@ pub mod tracing {
                 local_address,
                 backlog,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_started" , parent : parent , tracing :: Level :: DEBUG , id = tracing :: field :: debug (id) , local_address = tracing :: field :: debug (local_address) , backlog = tracing :: field :: debug (backlog));
+            tracing :: event ! (target : "acceptor_tcp_started" , parent : parent , tracing :: Level :: DEBUG , { id = tracing :: field :: debug (id) , local_address = tracing :: field :: debug (local_address) , backlog = tracing :: field :: debug (backlog) });
         }
         #[inline]
         fn on_acceptor_tcp_loop_iteration_completed(
@@ -1628,7 +1641,7 @@ pub mod tracing {
                 processing_duration,
                 max_sojourn_time,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_loop_iteration_completed" , parent : parent , tracing :: Level :: DEBUG , pending_streams = tracing :: field :: debug (pending_streams) , slots_idle = tracing :: field :: debug (slots_idle) , slot_utilization = tracing :: field :: debug (slot_utilization) , processing_duration = tracing :: field :: debug (processing_duration) , max_sojourn_time = tracing :: field :: debug (max_sojourn_time));
+            tracing :: event ! (target : "acceptor_tcp_loop_iteration_completed" , parent : parent , tracing :: Level :: DEBUG , { pending_streams = tracing :: field :: debug (pending_streams) , slots_idle = tracing :: field :: debug (slots_idle) , slot_utilization = tracing :: field :: debug (slot_utilization) , processing_duration = tracing :: field :: debug (processing_duration) , max_sojourn_time = tracing :: field :: debug (max_sojourn_time) });
         }
         #[inline]
         fn on_acceptor_tcp_fresh_enqueued(
@@ -1638,7 +1651,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::AcceptorTcpFreshEnqueued { remote_address } = event;
-            tracing :: event ! (target : "acceptor_tcp_fresh_enqueued" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address));
+            tracing :: event ! (target : "acceptor_tcp_fresh_enqueued" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) });
         }
         #[inline]
         fn on_acceptor_tcp_fresh_batch_completed(
@@ -1652,7 +1665,7 @@ pub mod tracing {
                 dropped,
                 errored,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_fresh_batch_completed" , parent : parent , tracing :: Level :: DEBUG , enqueued = tracing :: field :: debug (enqueued) , dropped = tracing :: field :: debug (dropped) , errored = tracing :: field :: debug (errored));
+            tracing :: event ! (target : "acceptor_tcp_fresh_batch_completed" , parent : parent , tracing :: Level :: DEBUG , { enqueued = tracing :: field :: debug (enqueued) , dropped = tracing :: field :: debug (dropped) , errored = tracing :: field :: debug (errored) });
         }
         #[inline]
         fn on_acceptor_tcp_stream_dropped(
@@ -1665,7 +1678,7 @@ pub mod tracing {
                 remote_address,
                 reason,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_stream_dropped" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , reason = tracing :: field :: debug (reason));
+            tracing :: event ! (target : "acceptor_tcp_stream_dropped" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , reason = tracing :: field :: debug (reason) });
         }
         #[inline]
         fn on_acceptor_tcp_stream_replaced(
@@ -1679,7 +1692,7 @@ pub mod tracing {
                 sojourn_time,
                 buffer_len,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_stream_replaced" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , sojourn_time = tracing :: field :: debug (sojourn_time) , buffer_len = tracing :: field :: debug (buffer_len));
+            tracing :: event ! (target : "acceptor_tcp_stream_replaced" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , sojourn_time = tracing :: field :: debug (sojourn_time) , buffer_len = tracing :: field :: debug (buffer_len) });
         }
         #[inline]
         fn on_acceptor_tcp_packet_received(
@@ -1697,7 +1710,7 @@ pub mod tracing {
                 is_fin_known,
                 sojourn_time,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_packet_received" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , payload_len = tracing :: field :: debug (payload_len) , is_fin = tracing :: field :: debug (is_fin) , is_fin_known = tracing :: field :: debug (is_fin_known) , sojourn_time = tracing :: field :: debug (sojourn_time));
+            tracing :: event ! (target : "acceptor_tcp_packet_received" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , payload_len = tracing :: field :: debug (payload_len) , is_fin = tracing :: field :: debug (is_fin) , is_fin_known = tracing :: field :: debug (is_fin_known) , sojourn_time = tracing :: field :: debug (sojourn_time) });
         }
         #[inline]
         fn on_acceptor_tcp_packet_dropped(
@@ -1711,7 +1724,7 @@ pub mod tracing {
                 reason,
                 sojourn_time,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , reason = tracing :: field :: debug (reason) , sojourn_time = tracing :: field :: debug (sojourn_time));
+            tracing :: event ! (target : "acceptor_tcp_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , reason = tracing :: field :: debug (reason) , sojourn_time = tracing :: field :: debug (sojourn_time) });
         }
         #[inline]
         fn on_acceptor_tcp_stream_enqueued(
@@ -1727,7 +1740,7 @@ pub mod tracing {
                 sojourn_time,
                 blocked_count,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_stream_enqueued" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , sojourn_time = tracing :: field :: debug (sojourn_time) , blocked_count = tracing :: field :: debug (blocked_count));
+            tracing :: event ! (target : "acceptor_tcp_stream_enqueued" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , sojourn_time = tracing :: field :: debug (sojourn_time) , blocked_count = tracing :: field :: debug (blocked_count) });
         }
         #[inline]
         fn on_acceptor_tcp_io_error(
@@ -1737,7 +1750,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::AcceptorTcpIoError { error } = event;
-            tracing :: event ! (target : "acceptor_tcp_io_error" , parent : parent , tracing :: Level :: DEBUG , error = tracing :: field :: debug (error));
+            tracing :: event ! (target : "acceptor_tcp_io_error" , parent : parent , tracing :: Level :: DEBUG , { error = tracing :: field :: debug (error) });
         }
         #[inline]
         fn on_acceptor_udp_started(
@@ -1747,7 +1760,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::AcceptorUdpStarted { id, local_address } = event;
-            tracing :: event ! (target : "acceptor_udp_started" , parent : parent , tracing :: Level :: DEBUG , id = tracing :: field :: debug (id) , local_address = tracing :: field :: debug (local_address));
+            tracing :: event ! (target : "acceptor_udp_started" , parent : parent , tracing :: Level :: DEBUG , { id = tracing :: field :: debug (id) , local_address = tracing :: field :: debug (local_address) });
         }
         #[inline]
         fn on_acceptor_udp_datagram_received(
@@ -1760,7 +1773,7 @@ pub mod tracing {
                 remote_address,
                 len,
             } = event;
-            tracing :: event ! (target : "acceptor_udp_datagram_received" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , len = tracing :: field :: debug (len));
+            tracing :: event ! (target : "acceptor_udp_datagram_received" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , len = tracing :: field :: debug (len) });
         }
         #[inline]
         fn on_acceptor_udp_packet_received(
@@ -1779,7 +1792,7 @@ pub mod tracing {
                 is_fin,
                 is_fin_known,
             } = event;
-            tracing :: event ! (target : "acceptor_udp_packet_received" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , payload_len = tracing :: field :: debug (payload_len) , is_zero_offset = tracing :: field :: debug (is_zero_offset) , is_retransmission = tracing :: field :: debug (is_retransmission) , is_fin = tracing :: field :: debug (is_fin) , is_fin_known = tracing :: field :: debug (is_fin_known));
+            tracing :: event ! (target : "acceptor_udp_packet_received" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , payload_len = tracing :: field :: debug (payload_len) , is_zero_offset = tracing :: field :: debug (is_zero_offset) , is_retransmission = tracing :: field :: debug (is_retransmission) , is_fin = tracing :: field :: debug (is_fin) , is_fin_known = tracing :: field :: debug (is_fin_known) });
         }
         #[inline]
         fn on_acceptor_udp_packet_dropped(
@@ -1792,7 +1805,7 @@ pub mod tracing {
                 remote_address,
                 reason,
             } = event;
-            tracing :: event ! (target : "acceptor_udp_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , reason = tracing :: field :: debug (reason));
+            tracing :: event ! (target : "acceptor_udp_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , reason = tracing :: field :: debug (reason) });
         }
         #[inline]
         fn on_acceptor_udp_stream_enqueued(
@@ -1806,7 +1819,7 @@ pub mod tracing {
                 credential_id,
                 stream_id,
             } = event;
-            tracing :: event ! (target : "acceptor_udp_stream_enqueued" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id));
+            tracing :: event ! (target : "acceptor_udp_stream_enqueued" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) });
         }
         #[inline]
         fn on_acceptor_udp_io_error(
@@ -1816,7 +1829,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::AcceptorUdpIoError { error } = event;
-            tracing :: event ! (target : "acceptor_udp_io_error" , parent : parent , tracing :: Level :: DEBUG , error = tracing :: field :: debug (error));
+            tracing :: event ! (target : "acceptor_udp_io_error" , parent : parent , tracing :: Level :: DEBUG , { error = tracing :: field :: debug (error) });
         }
         #[inline]
         fn on_acceptor_stream_pruned(
@@ -1832,7 +1845,7 @@ pub mod tracing {
                 sojourn_time,
                 reason,
             } = event;
-            tracing :: event ! (target : "acceptor_stream_pruned" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , sojourn_time = tracing :: field :: debug (sojourn_time) , reason = tracing :: field :: debug (reason));
+            tracing :: event ! (target : "acceptor_stream_pruned" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , sojourn_time = tracing :: field :: debug (sojourn_time) , reason = tracing :: field :: debug (reason) });
         }
         #[inline]
         fn on_acceptor_stream_dequeued(
@@ -1847,7 +1860,7 @@ pub mod tracing {
                 stream_id,
                 sojourn_time,
             } = event;
-            tracing :: event ! (target : "acceptor_stream_dequeued" , parent : parent , tracing :: Level :: DEBUG , remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , sojourn_time = tracing :: field :: debug (sojourn_time));
+            tracing :: event ! (target : "acceptor_stream_dequeued" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , sojourn_time = tracing :: field :: debug (sojourn_time) });
         }
         #[inline]
         fn on_stream_write_flushed(
@@ -1862,7 +1875,7 @@ pub mod tracing {
                 committed_len,
                 processing_duration,
             } = event;
-            tracing :: event ! (target : "stream_write_flushed" , parent : id , tracing :: Level :: DEBUG , provided_len = tracing :: field :: debug (provided_len) , committed_len = tracing :: field :: debug (committed_len) , processing_duration = tracing :: field :: debug (processing_duration));
+            tracing :: event ! (target : "stream_write_flushed" , parent : id , tracing :: Level :: DEBUG , { provided_len = tracing :: field :: debug (provided_len) , committed_len = tracing :: field :: debug (committed_len) , processing_duration = tracing :: field :: debug (processing_duration) });
         }
         #[inline]
         fn on_stream_write_fin_flushed(
@@ -1877,7 +1890,7 @@ pub mod tracing {
                 committed_len,
                 processing_duration,
             } = event;
-            tracing :: event ! (target : "stream_write_fin_flushed" , parent : id , tracing :: Level :: DEBUG , provided_len = tracing :: field :: debug (provided_len) , committed_len = tracing :: field :: debug (committed_len) , processing_duration = tracing :: field :: debug (processing_duration));
+            tracing :: event ! (target : "stream_write_fin_flushed" , parent : id , tracing :: Level :: DEBUG , { provided_len = tracing :: field :: debug (provided_len) , committed_len = tracing :: field :: debug (committed_len) , processing_duration = tracing :: field :: debug (processing_duration) });
         }
         #[inline]
         fn on_stream_write_blocked(
@@ -1892,7 +1905,7 @@ pub mod tracing {
                 is_fin,
                 processing_duration,
             } = event;
-            tracing :: event ! (target : "stream_write_blocked" , parent : id , tracing :: Level :: DEBUG , provided_len = tracing :: field :: debug (provided_len) , is_fin = tracing :: field :: debug (is_fin) , processing_duration = tracing :: field :: debug (processing_duration));
+            tracing :: event ! (target : "stream_write_blocked" , parent : id , tracing :: Level :: DEBUG , { provided_len = tracing :: field :: debug (provided_len) , is_fin = tracing :: field :: debug (is_fin) , processing_duration = tracing :: field :: debug (processing_duration) });
         }
         #[inline]
         fn on_stream_write_errored(
@@ -1908,7 +1921,7 @@ pub mod tracing {
                 processing_duration,
                 errno,
             } = event;
-            tracing :: event ! (target : "stream_write_errored" , parent : id , tracing :: Level :: DEBUG , provided_len = tracing :: field :: debug (provided_len) , is_fin = tracing :: field :: debug (is_fin) , processing_duration = tracing :: field :: debug (processing_duration) , errno = tracing :: field :: debug (errno));
+            tracing :: event ! (target : "stream_write_errored" , parent : id , tracing :: Level :: DEBUG , { provided_len = tracing :: field :: debug (provided_len) , is_fin = tracing :: field :: debug (is_fin) , processing_duration = tracing :: field :: debug (processing_duration) , errno = tracing :: field :: debug (errno) });
         }
         #[inline]
         fn on_stream_write_shutdown(
@@ -1922,7 +1935,7 @@ pub mod tracing {
                 buffer_len,
                 background,
             } = event;
-            tracing :: event ! (target : "stream_write_shutdown" , parent : id , tracing :: Level :: DEBUG , buffer_len = tracing :: field :: debug (buffer_len) , background = tracing :: field :: debug (background));
+            tracing :: event ! (target : "stream_write_shutdown" , parent : id , tracing :: Level :: DEBUG , { buffer_len = tracing :: field :: debug (buffer_len) , background = tracing :: field :: debug (background) });
         }
         #[inline]
         fn on_stream_write_socket_flushed(
@@ -1936,7 +1949,7 @@ pub mod tracing {
                 provided_len,
                 committed_len,
             } = event;
-            tracing :: event ! (target : "stream_write_socket_flushed" , parent : id , tracing :: Level :: DEBUG , provided_len = tracing :: field :: debug (provided_len) , committed_len = tracing :: field :: debug (committed_len));
+            tracing :: event ! (target : "stream_write_socket_flushed" , parent : id , tracing :: Level :: DEBUG , { provided_len = tracing :: field :: debug (provided_len) , committed_len = tracing :: field :: debug (committed_len) });
         }
         #[inline]
         fn on_stream_write_socket_blocked(
@@ -1947,7 +1960,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::StreamWriteSocketBlocked { provided_len } = event;
-            tracing :: event ! (target : "stream_write_socket_blocked" , parent : id , tracing :: Level :: DEBUG , provided_len = tracing :: field :: debug (provided_len));
+            tracing :: event ! (target : "stream_write_socket_blocked" , parent : id , tracing :: Level :: DEBUG , { provided_len = tracing :: field :: debug (provided_len) });
         }
         #[inline]
         fn on_stream_write_socket_errored(
@@ -1961,7 +1974,7 @@ pub mod tracing {
                 provided_len,
                 errno,
             } = event;
-            tracing :: event ! (target : "stream_write_socket_errored" , parent : id , tracing :: Level :: DEBUG , provided_len = tracing :: field :: debug (provided_len) , errno = tracing :: field :: debug (errno));
+            tracing :: event ! (target : "stream_write_socket_errored" , parent : id , tracing :: Level :: DEBUG , { provided_len = tracing :: field :: debug (provided_len) , errno = tracing :: field :: debug (errno) });
         }
         #[inline]
         fn on_stream_read_flushed(
@@ -1976,7 +1989,7 @@ pub mod tracing {
                 committed_len,
                 processing_duration,
             } = event;
-            tracing :: event ! (target : "stream_read_flushed" , parent : id , tracing :: Level :: DEBUG , capacity = tracing :: field :: debug (capacity) , committed_len = tracing :: field :: debug (committed_len) , processing_duration = tracing :: field :: debug (processing_duration));
+            tracing :: event ! (target : "stream_read_flushed" , parent : id , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) , committed_len = tracing :: field :: debug (committed_len) , processing_duration = tracing :: field :: debug (processing_duration) });
         }
         #[inline]
         fn on_stream_read_fin_flushed(
@@ -1990,7 +2003,7 @@ pub mod tracing {
                 capacity,
                 processing_duration,
             } = event;
-            tracing :: event ! (target : "stream_read_fin_flushed" , parent : id , tracing :: Level :: DEBUG , capacity = tracing :: field :: debug (capacity) , processing_duration = tracing :: field :: debug (processing_duration));
+            tracing :: event ! (target : "stream_read_fin_flushed" , parent : id , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) , processing_duration = tracing :: field :: debug (processing_duration) });
         }
         #[inline]
         fn on_stream_read_blocked(
@@ -2004,7 +2017,7 @@ pub mod tracing {
                 capacity,
                 processing_duration,
             } = event;
-            tracing :: event ! (target : "stream_read_blocked" , parent : id , tracing :: Level :: DEBUG , capacity = tracing :: field :: debug (capacity) , processing_duration = tracing :: field :: debug (processing_duration));
+            tracing :: event ! (target : "stream_read_blocked" , parent : id , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) , processing_duration = tracing :: field :: debug (processing_duration) });
         }
         #[inline]
         fn on_stream_read_errored(
@@ -2019,7 +2032,7 @@ pub mod tracing {
                 processing_duration,
                 errno,
             } = event;
-            tracing :: event ! (target : "stream_read_errored" , parent : id , tracing :: Level :: DEBUG , capacity = tracing :: field :: debug (capacity) , processing_duration = tracing :: field :: debug (processing_duration) , errno = tracing :: field :: debug (errno));
+            tracing :: event ! (target : "stream_read_errored" , parent : id , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) , processing_duration = tracing :: field :: debug (processing_duration) , errno = tracing :: field :: debug (errno) });
         }
         #[inline]
         fn on_stream_read_shutdown(
@@ -2030,7 +2043,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::StreamReadShutdown { background } = event;
-            tracing :: event ! (target : "stream_read_shutdown" , parent : id , tracing :: Level :: DEBUG , background = tracing :: field :: debug (background));
+            tracing :: event ! (target : "stream_read_shutdown" , parent : id , tracing :: Level :: DEBUG , { background = tracing :: field :: debug (background) });
         }
         #[inline]
         fn on_stream_read_socket_flushed(
@@ -2044,7 +2057,7 @@ pub mod tracing {
                 capacity,
                 committed_len,
             } = event;
-            tracing :: event ! (target : "stream_read_socket_flushed" , parent : id , tracing :: Level :: DEBUG , capacity = tracing :: field :: debug (capacity) , committed_len = tracing :: field :: debug (committed_len));
+            tracing :: event ! (target : "stream_read_socket_flushed" , parent : id , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) , committed_len = tracing :: field :: debug (committed_len) });
         }
         #[inline]
         fn on_stream_read_socket_blocked(
@@ -2055,7 +2068,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::StreamReadSocketBlocked { capacity } = event;
-            tracing :: event ! (target : "stream_read_socket_blocked" , parent : id , tracing :: Level :: DEBUG , capacity = tracing :: field :: debug (capacity));
+            tracing :: event ! (target : "stream_read_socket_blocked" , parent : id , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) });
         }
         #[inline]
         fn on_stream_read_socket_errored(
@@ -2066,7 +2079,18 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::StreamReadSocketErrored { capacity, errno } = event;
-            tracing :: event ! (target : "stream_read_socket_errored" , parent : id , tracing :: Level :: DEBUG , capacity = tracing :: field :: debug (capacity) , errno = tracing :: field :: debug (errno));
+            tracing :: event ! (target : "stream_read_socket_errored" , parent : id , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) , errno = tracing :: field :: debug (errno) });
+        }
+        #[inline]
+        fn on_connection_closed(
+            &self,
+            context: &Self::ConnectionContext,
+            _meta: &api::ConnectionMeta,
+            event: &api::ConnectionClosed,
+        ) {
+            let id = context.id();
+            let api::ConnectionClosed {} = event;
+            tracing :: event ! (target : "connection_closed" , parent : id , tracing :: Level :: DEBUG , { });
         }
         #[inline]
         fn on_endpoint_initialized(
@@ -2081,7 +2105,7 @@ pub mod tracing {
                 tcp,
                 udp,
             } = event;
-            tracing :: event ! (target : "endpoint_initialized" , parent : parent , tracing :: Level :: DEBUG , acceptor_addr = tracing :: field :: debug (acceptor_addr) , handshake_addr = tracing :: field :: debug (handshake_addr) , tcp = tracing :: field :: debug (tcp) , udp = tracing :: field :: debug (udp));
+            tracing :: event ! (target : "endpoint_initialized" , parent : parent , tracing :: Level :: DEBUG , { acceptor_addr = tracing :: field :: debug (acceptor_addr) , handshake_addr = tracing :: field :: debug (handshake_addr) , tcp = tracing :: field :: debug (tcp) , udp = tracing :: field :: debug (udp) });
         }
         #[inline]
         fn on_path_secret_map_initialized(
@@ -2091,7 +2115,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PathSecretMapInitialized { capacity } = event;
-            tracing :: event ! (target : "path_secret_map_initialized" , parent : parent , tracing :: Level :: DEBUG , capacity = tracing :: field :: debug (capacity));
+            tracing :: event ! (target : "path_secret_map_initialized" , parent : parent , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) });
         }
         #[inline]
         fn on_path_secret_map_uninitialized(
@@ -2105,7 +2129,7 @@ pub mod tracing {
                 entries,
                 lifetime,
             } = event;
-            tracing :: event ! (target : "path_secret_map_uninitialized" , parent : parent , tracing :: Level :: DEBUG , capacity = tracing :: field :: debug (capacity) , entries = tracing :: field :: debug (entries) , lifetime = tracing :: field :: debug (lifetime));
+            tracing :: event ! (target : "path_secret_map_uninitialized" , parent : parent , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) , entries = tracing :: field :: debug (entries) , lifetime = tracing :: field :: debug (lifetime) });
         }
         #[inline]
         fn on_path_secret_map_background_handshake_requested(
@@ -2115,7 +2139,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PathSecretMapBackgroundHandshakeRequested { peer_address } = event;
-            tracing :: event ! (target : "path_secret_map_background_handshake_requested" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address));
+            tracing :: event ! (target : "path_secret_map_background_handshake_requested" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) });
         }
         #[inline]
         fn on_path_secret_map_entry_inserted(
@@ -2128,7 +2152,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "path_secret_map_entry_inserted" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "path_secret_map_entry_inserted" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_path_secret_map_entry_ready(
@@ -2141,7 +2165,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "path_secret_map_entry_ready" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "path_secret_map_entry_ready" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_path_secret_map_entry_replaced(
@@ -2155,7 +2179,7 @@ pub mod tracing {
                 new_credential_id,
                 previous_credential_id,
             } = event;
-            tracing :: event ! (target : "path_secret_map_entry_replaced" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , new_credential_id = tracing :: field :: debug (new_credential_id) , previous_credential_id = tracing :: field :: debug (previous_credential_id));
+            tracing :: event ! (target : "path_secret_map_entry_replaced" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , new_credential_id = tracing :: field :: debug (new_credential_id) , previous_credential_id = tracing :: field :: debug (previous_credential_id) });
         }
         #[inline]
         fn on_unknown_path_secret_packet_sent(
@@ -2168,7 +2192,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "unknown_path_secret_packet_sent" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "unknown_path_secret_packet_sent" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_unknown_path_secret_packet_received(
@@ -2181,7 +2205,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "unknown_path_secret_packet_received" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "unknown_path_secret_packet_received" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_unknown_path_secret_packet_accepted(
@@ -2194,7 +2218,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "unknown_path_secret_packet_accepted" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "unknown_path_secret_packet_accepted" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_unknown_path_secret_packet_rejected(
@@ -2207,7 +2231,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "unknown_path_secret_packet_rejected" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "unknown_path_secret_packet_rejected" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_unknown_path_secret_packet_dropped(
@@ -2220,7 +2244,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "unknown_path_secret_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "unknown_path_secret_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_key_accepted(&self, meta: &api::EndpointMeta, event: &api::KeyAccepted) {
@@ -2231,7 +2255,7 @@ pub mod tracing {
                 gap,
                 forward_shift,
             } = event;
-            tracing :: event ! (target : "key_accepted" , parent : parent , tracing :: Level :: DEBUG , credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id) , gap = tracing :: field :: debug (gap) , forward_shift = tracing :: field :: debug (forward_shift));
+            tracing :: event ! (target : "key_accepted" , parent : parent , tracing :: Level :: DEBUG , { credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id) , gap = tracing :: field :: debug (gap) , forward_shift = tracing :: field :: debug (forward_shift) });
         }
         #[inline]
         fn on_replay_definitely_detected(
@@ -2244,7 +2268,7 @@ pub mod tracing {
                 credential_id,
                 key_id,
             } = event;
-            tracing :: event ! (target : "replay_definitely_detected" , parent : parent , tracing :: Level :: DEBUG , credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id));
+            tracing :: event ! (target : "replay_definitely_detected" , parent : parent , tracing :: Level :: DEBUG , { credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id) });
         }
         #[inline]
         fn on_replay_potentially_detected(
@@ -2258,7 +2282,7 @@ pub mod tracing {
                 key_id,
                 gap,
             } = event;
-            tracing :: event ! (target : "replay_potentially_detected" , parent : parent , tracing :: Level :: DEBUG , credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id) , gap = tracing :: field :: debug (gap));
+            tracing :: event ! (target : "replay_potentially_detected" , parent : parent , tracing :: Level :: DEBUG , { credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id) , gap = tracing :: field :: debug (gap) });
         }
         #[inline]
         fn on_replay_detected_packet_sent(
@@ -2271,7 +2295,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "replay_detected_packet_sent" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "replay_detected_packet_sent" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_replay_detected_packet_received(
@@ -2284,7 +2308,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "replay_detected_packet_received" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "replay_detected_packet_received" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_replay_detected_packet_accepted(
@@ -2298,7 +2322,7 @@ pub mod tracing {
                 credential_id,
                 key_id,
             } = event;
-            tracing :: event ! (target : "replay_detected_packet_accepted" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id));
+            tracing :: event ! (target : "replay_detected_packet_accepted" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id) });
         }
         #[inline]
         fn on_replay_detected_packet_rejected(
@@ -2311,7 +2335,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "replay_detected_packet_rejected" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "replay_detected_packet_rejected" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_replay_detected_packet_dropped(
@@ -2324,7 +2348,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "replay_detected_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "replay_detected_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_stale_key_packet_sent(
@@ -2337,7 +2361,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "stale_key_packet_sent" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "stale_key_packet_sent" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_stale_key_packet_received(
@@ -2350,7 +2374,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "stale_key_packet_received" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "stale_key_packet_received" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_stale_key_packet_accepted(
@@ -2363,7 +2387,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "stale_key_packet_accepted" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "stale_key_packet_accepted" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_stale_key_packet_rejected(
@@ -2376,7 +2400,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "stale_key_packet_rejected" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "stale_key_packet_rejected" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_stale_key_packet_dropped(
@@ -2389,7 +2413,7 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "stale_key_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id));
+            tracing :: event ! (target : "stale_key_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
         }
         #[inline]
         fn on_path_secret_map_address_cache_accessed(
@@ -2399,7 +2423,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PathSecretMapAddressCacheAccessed { peer_address, hit } = event;
-            tracing :: event ! (target : "path_secret_map_address_cache_accessed" , parent : parent , tracing :: Level :: DEBUG , peer_address = tracing :: field :: debug (peer_address) , hit = tracing :: field :: debug (hit));
+            tracing :: event ! (target : "path_secret_map_address_cache_accessed" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , hit = tracing :: field :: debug (hit) });
         }
         #[inline]
         fn on_path_secret_map_id_cache_accessed(
@@ -2409,7 +2433,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PathSecretMapIdCacheAccessed { credential_id, hit } = event;
-            tracing :: event ! (target : "path_secret_map_id_cache_accessed" , parent : parent , tracing :: Level :: DEBUG , credential_id = tracing :: field :: debug (credential_id) , hit = tracing :: field :: debug (hit));
+            tracing :: event ! (target : "path_secret_map_id_cache_accessed" , parent : parent , tracing :: Level :: DEBUG , { credential_id = tracing :: field :: debug (credential_id) , hit = tracing :: field :: debug (hit) });
         }
         #[inline]
         fn on_path_secret_map_cleaner_cycled(
@@ -2430,7 +2454,7 @@ pub mod tracing {
                 handshake_requests,
                 handshake_requests_retired,
             } = event;
-            tracing :: event ! (target : "path_secret_map_cleaner_cycled" , parent : parent , tracing :: Level :: DEBUG , id_entries = tracing :: field :: debug (id_entries) , id_entries_retired = tracing :: field :: debug (id_entries_retired) , id_entries_utilization = tracing :: field :: debug (id_entries_utilization) , id_entries_initial_utilization = tracing :: field :: debug (id_entries_initial_utilization) , address_entries = tracing :: field :: debug (address_entries) , address_entries_retired = tracing :: field :: debug (address_entries_retired) , address_entries_utilization = tracing :: field :: debug (address_entries_utilization) , address_entries_initial_utilization = tracing :: field :: debug (address_entries_initial_utilization) , handshake_requests = tracing :: field :: debug (handshake_requests) , handshake_requests_retired = tracing :: field :: debug (handshake_requests_retired));
+            tracing :: event ! (target : "path_secret_map_cleaner_cycled" , parent : parent , tracing :: Level :: DEBUG , { id_entries = tracing :: field :: debug (id_entries) , id_entries_retired = tracing :: field :: debug (id_entries_retired) , id_entries_utilization = tracing :: field :: debug (id_entries_utilization) , id_entries_initial_utilization = tracing :: field :: debug (id_entries_initial_utilization) , address_entries = tracing :: field :: debug (address_entries) , address_entries_retired = tracing :: field :: debug (address_entries_retired) , address_entries_utilization = tracing :: field :: debug (address_entries_utilization) , address_entries_initial_utilization = tracing :: field :: debug (address_entries_initial_utilization) , handshake_requests = tracing :: field :: debug (handshake_requests) , handshake_requests_retired = tracing :: field :: debug (handshake_requests_retired) });
         }
     }
 }
@@ -3339,6 +3363,15 @@ pub mod builder {
                 capacity: capacity.into_event(),
                 errno: errno.into_event(),
             }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct ConnectionClosed {}
+    impl IntoEvent<api::ConnectionClosed> for ConnectionClosed {
+        #[inline]
+        fn into_event(self) -> api::ConnectionClosed {
+            let ConnectionClosed {} = self;
+            api::ConnectionClosed {}
         }
     }
     #[derive(Clone, Debug)]
@@ -4370,6 +4403,18 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
+        #[doc = "Called when the `ConnectionClosed` event is triggered"]
+        #[inline]
+        fn on_connection_closed(
+            &self,
+            context: &Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &api::ConnectionClosed,
+        ) {
+            let _ = context;
+            let _ = meta;
+            let _ = event;
+        }
         #[doc = "Called when the `EndpointInitialized` event is triggered"]
         #[inline]
         fn on_endpoint_initialized(
@@ -4982,6 +5027,15 @@ mod traits {
                 .on_stream_read_socket_errored(context, meta, event);
         }
         #[inline]
+        fn on_connection_closed(
+            &self,
+            context: &Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &api::ConnectionClosed,
+        ) {
+            self.as_ref().on_connection_closed(context, meta, event);
+        }
+        #[inline]
         fn on_endpoint_initialized(
             &self,
             meta: &api::EndpointMeta,
@@ -5566,6 +5620,16 @@ mod traits {
         ) {
             (self.0).on_stream_read_socket_errored(&context.0, meta, event);
             (self.1).on_stream_read_socket_errored(&context.1, meta, event);
+        }
+        #[inline]
+        fn on_connection_closed(
+            &self,
+            context: &Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &api::ConnectionClosed,
+        ) {
+            (self.0).on_connection_closed(&context.0, meta, event);
+            (self.1).on_connection_closed(&context.1, meta, event);
         }
         #[inline]
         fn on_endpoint_initialized(
@@ -6372,6 +6436,8 @@ mod traits {
         fn on_stream_read_socket_blocked(&self, event: builder::StreamReadSocketBlocked);
         #[doc = "Publishes a `StreamReadSocketErrored` event to the publisher's subscriber"]
         fn on_stream_read_socket_errored(&self, event: builder::StreamReadSocketErrored);
+        #[doc = "Publishes a `ConnectionClosed` event to the publisher's subscriber"]
+        fn on_connection_closed(&self, event: builder::ConnectionClosed);
         #[doc = r" Returns the QUIC version negotiated for the current connection, if any"]
         fn quic_version(&self) -> u32;
         #[doc = r" Returns the [`Subject`] for the current publisher"]
@@ -6553,6 +6619,15 @@ mod traits {
             self.subscriber.on_event(&self.meta, &event);
         }
         #[inline]
+        fn on_connection_closed(&self, event: builder::ConnectionClosed) {
+            let event = event.into_event();
+            self.subscriber
+                .on_connection_closed(self.context, &self.meta, &event);
+            self.subscriber
+                .on_connection_event(self.context, &self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
         fn quic_version(&self) -> u32 {
             self.quic_version
         }
@@ -6566,59 +6641,59 @@ mod traits {
 pub mod testing {
     use super::*;
     use crate::event::snapshot::Location;
-    use core::sync::atomic::{AtomicU32, Ordering};
+    use core::sync::atomic::{AtomicU64, Ordering};
     use std::sync::Mutex;
     pub mod endpoint {
         use super::*;
         pub struct Subscriber {
             location: Option<Location>,
             output: Mutex<Vec<String>>,
-            pub acceptor_tcp_started: AtomicU32,
-            pub acceptor_tcp_loop_iteration_completed: AtomicU32,
-            pub acceptor_tcp_fresh_enqueued: AtomicU32,
-            pub acceptor_tcp_fresh_batch_completed: AtomicU32,
-            pub acceptor_tcp_stream_dropped: AtomicU32,
-            pub acceptor_tcp_stream_replaced: AtomicU32,
-            pub acceptor_tcp_packet_received: AtomicU32,
-            pub acceptor_tcp_packet_dropped: AtomicU32,
-            pub acceptor_tcp_stream_enqueued: AtomicU32,
-            pub acceptor_tcp_io_error: AtomicU32,
-            pub acceptor_udp_started: AtomicU32,
-            pub acceptor_udp_datagram_received: AtomicU32,
-            pub acceptor_udp_packet_received: AtomicU32,
-            pub acceptor_udp_packet_dropped: AtomicU32,
-            pub acceptor_udp_stream_enqueued: AtomicU32,
-            pub acceptor_udp_io_error: AtomicU32,
-            pub acceptor_stream_pruned: AtomicU32,
-            pub acceptor_stream_dequeued: AtomicU32,
-            pub endpoint_initialized: AtomicU32,
-            pub path_secret_map_initialized: AtomicU32,
-            pub path_secret_map_uninitialized: AtomicU32,
-            pub path_secret_map_background_handshake_requested: AtomicU32,
-            pub path_secret_map_entry_inserted: AtomicU32,
-            pub path_secret_map_entry_ready: AtomicU32,
-            pub path_secret_map_entry_replaced: AtomicU32,
-            pub unknown_path_secret_packet_sent: AtomicU32,
-            pub unknown_path_secret_packet_received: AtomicU32,
-            pub unknown_path_secret_packet_accepted: AtomicU32,
-            pub unknown_path_secret_packet_rejected: AtomicU32,
-            pub unknown_path_secret_packet_dropped: AtomicU32,
-            pub key_accepted: AtomicU32,
-            pub replay_definitely_detected: AtomicU32,
-            pub replay_potentially_detected: AtomicU32,
-            pub replay_detected_packet_sent: AtomicU32,
-            pub replay_detected_packet_received: AtomicU32,
-            pub replay_detected_packet_accepted: AtomicU32,
-            pub replay_detected_packet_rejected: AtomicU32,
-            pub replay_detected_packet_dropped: AtomicU32,
-            pub stale_key_packet_sent: AtomicU32,
-            pub stale_key_packet_received: AtomicU32,
-            pub stale_key_packet_accepted: AtomicU32,
-            pub stale_key_packet_rejected: AtomicU32,
-            pub stale_key_packet_dropped: AtomicU32,
-            pub path_secret_map_address_cache_accessed: AtomicU32,
-            pub path_secret_map_id_cache_accessed: AtomicU32,
-            pub path_secret_map_cleaner_cycled: AtomicU32,
+            pub acceptor_tcp_started: AtomicU64,
+            pub acceptor_tcp_loop_iteration_completed: AtomicU64,
+            pub acceptor_tcp_fresh_enqueued: AtomicU64,
+            pub acceptor_tcp_fresh_batch_completed: AtomicU64,
+            pub acceptor_tcp_stream_dropped: AtomicU64,
+            pub acceptor_tcp_stream_replaced: AtomicU64,
+            pub acceptor_tcp_packet_received: AtomicU64,
+            pub acceptor_tcp_packet_dropped: AtomicU64,
+            pub acceptor_tcp_stream_enqueued: AtomicU64,
+            pub acceptor_tcp_io_error: AtomicU64,
+            pub acceptor_udp_started: AtomicU64,
+            pub acceptor_udp_datagram_received: AtomicU64,
+            pub acceptor_udp_packet_received: AtomicU64,
+            pub acceptor_udp_packet_dropped: AtomicU64,
+            pub acceptor_udp_stream_enqueued: AtomicU64,
+            pub acceptor_udp_io_error: AtomicU64,
+            pub acceptor_stream_pruned: AtomicU64,
+            pub acceptor_stream_dequeued: AtomicU64,
+            pub endpoint_initialized: AtomicU64,
+            pub path_secret_map_initialized: AtomicU64,
+            pub path_secret_map_uninitialized: AtomicU64,
+            pub path_secret_map_background_handshake_requested: AtomicU64,
+            pub path_secret_map_entry_inserted: AtomicU64,
+            pub path_secret_map_entry_ready: AtomicU64,
+            pub path_secret_map_entry_replaced: AtomicU64,
+            pub unknown_path_secret_packet_sent: AtomicU64,
+            pub unknown_path_secret_packet_received: AtomicU64,
+            pub unknown_path_secret_packet_accepted: AtomicU64,
+            pub unknown_path_secret_packet_rejected: AtomicU64,
+            pub unknown_path_secret_packet_dropped: AtomicU64,
+            pub key_accepted: AtomicU64,
+            pub replay_definitely_detected: AtomicU64,
+            pub replay_potentially_detected: AtomicU64,
+            pub replay_detected_packet_sent: AtomicU64,
+            pub replay_detected_packet_received: AtomicU64,
+            pub replay_detected_packet_accepted: AtomicU64,
+            pub replay_detected_packet_rejected: AtomicU64,
+            pub replay_detected_packet_dropped: AtomicU64,
+            pub stale_key_packet_sent: AtomicU64,
+            pub stale_key_packet_received: AtomicU64,
+            pub stale_key_packet_accepted: AtomicU64,
+            pub stale_key_packet_rejected: AtomicU64,
+            pub stale_key_packet_dropped: AtomicU64,
+            pub path_secret_map_address_cache_accessed: AtomicU64,
+            pub path_secret_map_id_cache_accessed: AtomicU64,
+            pub path_secret_map_cleaner_cycled: AtomicU64,
         }
         impl Drop for Subscriber {
             fn drop(&mut self) {
@@ -6650,52 +6725,52 @@ pub mod testing {
                 Self {
                     location: None,
                     output: Default::default(),
-                    acceptor_tcp_started: AtomicU32::new(0),
-                    acceptor_tcp_loop_iteration_completed: AtomicU32::new(0),
-                    acceptor_tcp_fresh_enqueued: AtomicU32::new(0),
-                    acceptor_tcp_fresh_batch_completed: AtomicU32::new(0),
-                    acceptor_tcp_stream_dropped: AtomicU32::new(0),
-                    acceptor_tcp_stream_replaced: AtomicU32::new(0),
-                    acceptor_tcp_packet_received: AtomicU32::new(0),
-                    acceptor_tcp_packet_dropped: AtomicU32::new(0),
-                    acceptor_tcp_stream_enqueued: AtomicU32::new(0),
-                    acceptor_tcp_io_error: AtomicU32::new(0),
-                    acceptor_udp_started: AtomicU32::new(0),
-                    acceptor_udp_datagram_received: AtomicU32::new(0),
-                    acceptor_udp_packet_received: AtomicU32::new(0),
-                    acceptor_udp_packet_dropped: AtomicU32::new(0),
-                    acceptor_udp_stream_enqueued: AtomicU32::new(0),
-                    acceptor_udp_io_error: AtomicU32::new(0),
-                    acceptor_stream_pruned: AtomicU32::new(0),
-                    acceptor_stream_dequeued: AtomicU32::new(0),
-                    endpoint_initialized: AtomicU32::new(0),
-                    path_secret_map_initialized: AtomicU32::new(0),
-                    path_secret_map_uninitialized: AtomicU32::new(0),
-                    path_secret_map_background_handshake_requested: AtomicU32::new(0),
-                    path_secret_map_entry_inserted: AtomicU32::new(0),
-                    path_secret_map_entry_ready: AtomicU32::new(0),
-                    path_secret_map_entry_replaced: AtomicU32::new(0),
-                    unknown_path_secret_packet_sent: AtomicU32::new(0),
-                    unknown_path_secret_packet_received: AtomicU32::new(0),
-                    unknown_path_secret_packet_accepted: AtomicU32::new(0),
-                    unknown_path_secret_packet_rejected: AtomicU32::new(0),
-                    unknown_path_secret_packet_dropped: AtomicU32::new(0),
-                    key_accepted: AtomicU32::new(0),
-                    replay_definitely_detected: AtomicU32::new(0),
-                    replay_potentially_detected: AtomicU32::new(0),
-                    replay_detected_packet_sent: AtomicU32::new(0),
-                    replay_detected_packet_received: AtomicU32::new(0),
-                    replay_detected_packet_accepted: AtomicU32::new(0),
-                    replay_detected_packet_rejected: AtomicU32::new(0),
-                    replay_detected_packet_dropped: AtomicU32::new(0),
-                    stale_key_packet_sent: AtomicU32::new(0),
-                    stale_key_packet_received: AtomicU32::new(0),
-                    stale_key_packet_accepted: AtomicU32::new(0),
-                    stale_key_packet_rejected: AtomicU32::new(0),
-                    stale_key_packet_dropped: AtomicU32::new(0),
-                    path_secret_map_address_cache_accessed: AtomicU32::new(0),
-                    path_secret_map_id_cache_accessed: AtomicU32::new(0),
-                    path_secret_map_cleaner_cycled: AtomicU32::new(0),
+                    acceptor_tcp_started: AtomicU64::new(0),
+                    acceptor_tcp_loop_iteration_completed: AtomicU64::new(0),
+                    acceptor_tcp_fresh_enqueued: AtomicU64::new(0),
+                    acceptor_tcp_fresh_batch_completed: AtomicU64::new(0),
+                    acceptor_tcp_stream_dropped: AtomicU64::new(0),
+                    acceptor_tcp_stream_replaced: AtomicU64::new(0),
+                    acceptor_tcp_packet_received: AtomicU64::new(0),
+                    acceptor_tcp_packet_dropped: AtomicU64::new(0),
+                    acceptor_tcp_stream_enqueued: AtomicU64::new(0),
+                    acceptor_tcp_io_error: AtomicU64::new(0),
+                    acceptor_udp_started: AtomicU64::new(0),
+                    acceptor_udp_datagram_received: AtomicU64::new(0),
+                    acceptor_udp_packet_received: AtomicU64::new(0),
+                    acceptor_udp_packet_dropped: AtomicU64::new(0),
+                    acceptor_udp_stream_enqueued: AtomicU64::new(0),
+                    acceptor_udp_io_error: AtomicU64::new(0),
+                    acceptor_stream_pruned: AtomicU64::new(0),
+                    acceptor_stream_dequeued: AtomicU64::new(0),
+                    endpoint_initialized: AtomicU64::new(0),
+                    path_secret_map_initialized: AtomicU64::new(0),
+                    path_secret_map_uninitialized: AtomicU64::new(0),
+                    path_secret_map_background_handshake_requested: AtomicU64::new(0),
+                    path_secret_map_entry_inserted: AtomicU64::new(0),
+                    path_secret_map_entry_ready: AtomicU64::new(0),
+                    path_secret_map_entry_replaced: AtomicU64::new(0),
+                    unknown_path_secret_packet_sent: AtomicU64::new(0),
+                    unknown_path_secret_packet_received: AtomicU64::new(0),
+                    unknown_path_secret_packet_accepted: AtomicU64::new(0),
+                    unknown_path_secret_packet_rejected: AtomicU64::new(0),
+                    unknown_path_secret_packet_dropped: AtomicU64::new(0),
+                    key_accepted: AtomicU64::new(0),
+                    replay_definitely_detected: AtomicU64::new(0),
+                    replay_potentially_detected: AtomicU64::new(0),
+                    replay_detected_packet_sent: AtomicU64::new(0),
+                    replay_detected_packet_received: AtomicU64::new(0),
+                    replay_detected_packet_accepted: AtomicU64::new(0),
+                    replay_detected_packet_rejected: AtomicU64::new(0),
+                    replay_detected_packet_dropped: AtomicU64::new(0),
+                    stale_key_packet_sent: AtomicU64::new(0),
+                    stale_key_packet_received: AtomicU64::new(0),
+                    stale_key_packet_accepted: AtomicU64::new(0),
+                    stale_key_packet_rejected: AtomicU64::new(0),
+                    stale_key_packet_dropped: AtomicU64::new(0),
+                    path_secret_map_address_cache_accessed: AtomicU64::new(0),
+                    path_secret_map_id_cache_accessed: AtomicU64::new(0),
+                    path_secret_map_cleaner_cycled: AtomicU64::new(0),
                 }
             }
         }
@@ -7253,68 +7328,69 @@ pub mod testing {
     pub struct Subscriber {
         location: Option<Location>,
         output: Mutex<Vec<String>>,
-        pub acceptor_tcp_started: AtomicU32,
-        pub acceptor_tcp_loop_iteration_completed: AtomicU32,
-        pub acceptor_tcp_fresh_enqueued: AtomicU32,
-        pub acceptor_tcp_fresh_batch_completed: AtomicU32,
-        pub acceptor_tcp_stream_dropped: AtomicU32,
-        pub acceptor_tcp_stream_replaced: AtomicU32,
-        pub acceptor_tcp_packet_received: AtomicU32,
-        pub acceptor_tcp_packet_dropped: AtomicU32,
-        pub acceptor_tcp_stream_enqueued: AtomicU32,
-        pub acceptor_tcp_io_error: AtomicU32,
-        pub acceptor_udp_started: AtomicU32,
-        pub acceptor_udp_datagram_received: AtomicU32,
-        pub acceptor_udp_packet_received: AtomicU32,
-        pub acceptor_udp_packet_dropped: AtomicU32,
-        pub acceptor_udp_stream_enqueued: AtomicU32,
-        pub acceptor_udp_io_error: AtomicU32,
-        pub acceptor_stream_pruned: AtomicU32,
-        pub acceptor_stream_dequeued: AtomicU32,
-        pub stream_write_flushed: AtomicU32,
-        pub stream_write_fin_flushed: AtomicU32,
-        pub stream_write_blocked: AtomicU32,
-        pub stream_write_errored: AtomicU32,
-        pub stream_write_shutdown: AtomicU32,
-        pub stream_write_socket_flushed: AtomicU32,
-        pub stream_write_socket_blocked: AtomicU32,
-        pub stream_write_socket_errored: AtomicU32,
-        pub stream_read_flushed: AtomicU32,
-        pub stream_read_fin_flushed: AtomicU32,
-        pub stream_read_blocked: AtomicU32,
-        pub stream_read_errored: AtomicU32,
-        pub stream_read_shutdown: AtomicU32,
-        pub stream_read_socket_flushed: AtomicU32,
-        pub stream_read_socket_blocked: AtomicU32,
-        pub stream_read_socket_errored: AtomicU32,
-        pub endpoint_initialized: AtomicU32,
-        pub path_secret_map_initialized: AtomicU32,
-        pub path_secret_map_uninitialized: AtomicU32,
-        pub path_secret_map_background_handshake_requested: AtomicU32,
-        pub path_secret_map_entry_inserted: AtomicU32,
-        pub path_secret_map_entry_ready: AtomicU32,
-        pub path_secret_map_entry_replaced: AtomicU32,
-        pub unknown_path_secret_packet_sent: AtomicU32,
-        pub unknown_path_secret_packet_received: AtomicU32,
-        pub unknown_path_secret_packet_accepted: AtomicU32,
-        pub unknown_path_secret_packet_rejected: AtomicU32,
-        pub unknown_path_secret_packet_dropped: AtomicU32,
-        pub key_accepted: AtomicU32,
-        pub replay_definitely_detected: AtomicU32,
-        pub replay_potentially_detected: AtomicU32,
-        pub replay_detected_packet_sent: AtomicU32,
-        pub replay_detected_packet_received: AtomicU32,
-        pub replay_detected_packet_accepted: AtomicU32,
-        pub replay_detected_packet_rejected: AtomicU32,
-        pub replay_detected_packet_dropped: AtomicU32,
-        pub stale_key_packet_sent: AtomicU32,
-        pub stale_key_packet_received: AtomicU32,
-        pub stale_key_packet_accepted: AtomicU32,
-        pub stale_key_packet_rejected: AtomicU32,
-        pub stale_key_packet_dropped: AtomicU32,
-        pub path_secret_map_address_cache_accessed: AtomicU32,
-        pub path_secret_map_id_cache_accessed: AtomicU32,
-        pub path_secret_map_cleaner_cycled: AtomicU32,
+        pub acceptor_tcp_started: AtomicU64,
+        pub acceptor_tcp_loop_iteration_completed: AtomicU64,
+        pub acceptor_tcp_fresh_enqueued: AtomicU64,
+        pub acceptor_tcp_fresh_batch_completed: AtomicU64,
+        pub acceptor_tcp_stream_dropped: AtomicU64,
+        pub acceptor_tcp_stream_replaced: AtomicU64,
+        pub acceptor_tcp_packet_received: AtomicU64,
+        pub acceptor_tcp_packet_dropped: AtomicU64,
+        pub acceptor_tcp_stream_enqueued: AtomicU64,
+        pub acceptor_tcp_io_error: AtomicU64,
+        pub acceptor_udp_started: AtomicU64,
+        pub acceptor_udp_datagram_received: AtomicU64,
+        pub acceptor_udp_packet_received: AtomicU64,
+        pub acceptor_udp_packet_dropped: AtomicU64,
+        pub acceptor_udp_stream_enqueued: AtomicU64,
+        pub acceptor_udp_io_error: AtomicU64,
+        pub acceptor_stream_pruned: AtomicU64,
+        pub acceptor_stream_dequeued: AtomicU64,
+        pub stream_write_flushed: AtomicU64,
+        pub stream_write_fin_flushed: AtomicU64,
+        pub stream_write_blocked: AtomicU64,
+        pub stream_write_errored: AtomicU64,
+        pub stream_write_shutdown: AtomicU64,
+        pub stream_write_socket_flushed: AtomicU64,
+        pub stream_write_socket_blocked: AtomicU64,
+        pub stream_write_socket_errored: AtomicU64,
+        pub stream_read_flushed: AtomicU64,
+        pub stream_read_fin_flushed: AtomicU64,
+        pub stream_read_blocked: AtomicU64,
+        pub stream_read_errored: AtomicU64,
+        pub stream_read_shutdown: AtomicU64,
+        pub stream_read_socket_flushed: AtomicU64,
+        pub stream_read_socket_blocked: AtomicU64,
+        pub stream_read_socket_errored: AtomicU64,
+        pub connection_closed: AtomicU64,
+        pub endpoint_initialized: AtomicU64,
+        pub path_secret_map_initialized: AtomicU64,
+        pub path_secret_map_uninitialized: AtomicU64,
+        pub path_secret_map_background_handshake_requested: AtomicU64,
+        pub path_secret_map_entry_inserted: AtomicU64,
+        pub path_secret_map_entry_ready: AtomicU64,
+        pub path_secret_map_entry_replaced: AtomicU64,
+        pub unknown_path_secret_packet_sent: AtomicU64,
+        pub unknown_path_secret_packet_received: AtomicU64,
+        pub unknown_path_secret_packet_accepted: AtomicU64,
+        pub unknown_path_secret_packet_rejected: AtomicU64,
+        pub unknown_path_secret_packet_dropped: AtomicU64,
+        pub key_accepted: AtomicU64,
+        pub replay_definitely_detected: AtomicU64,
+        pub replay_potentially_detected: AtomicU64,
+        pub replay_detected_packet_sent: AtomicU64,
+        pub replay_detected_packet_received: AtomicU64,
+        pub replay_detected_packet_accepted: AtomicU64,
+        pub replay_detected_packet_rejected: AtomicU64,
+        pub replay_detected_packet_dropped: AtomicU64,
+        pub stale_key_packet_sent: AtomicU64,
+        pub stale_key_packet_received: AtomicU64,
+        pub stale_key_packet_accepted: AtomicU64,
+        pub stale_key_packet_rejected: AtomicU64,
+        pub stale_key_packet_dropped: AtomicU64,
+        pub path_secret_map_address_cache_accessed: AtomicU64,
+        pub path_secret_map_id_cache_accessed: AtomicU64,
+        pub path_secret_map_cleaner_cycled: AtomicU64,
     }
     impl Drop for Subscriber {
         fn drop(&mut self) {
@@ -7346,68 +7422,69 @@ pub mod testing {
             Self {
                 location: None,
                 output: Default::default(),
-                acceptor_tcp_started: AtomicU32::new(0),
-                acceptor_tcp_loop_iteration_completed: AtomicU32::new(0),
-                acceptor_tcp_fresh_enqueued: AtomicU32::new(0),
-                acceptor_tcp_fresh_batch_completed: AtomicU32::new(0),
-                acceptor_tcp_stream_dropped: AtomicU32::new(0),
-                acceptor_tcp_stream_replaced: AtomicU32::new(0),
-                acceptor_tcp_packet_received: AtomicU32::new(0),
-                acceptor_tcp_packet_dropped: AtomicU32::new(0),
-                acceptor_tcp_stream_enqueued: AtomicU32::new(0),
-                acceptor_tcp_io_error: AtomicU32::new(0),
-                acceptor_udp_started: AtomicU32::new(0),
-                acceptor_udp_datagram_received: AtomicU32::new(0),
-                acceptor_udp_packet_received: AtomicU32::new(0),
-                acceptor_udp_packet_dropped: AtomicU32::new(0),
-                acceptor_udp_stream_enqueued: AtomicU32::new(0),
-                acceptor_udp_io_error: AtomicU32::new(0),
-                acceptor_stream_pruned: AtomicU32::new(0),
-                acceptor_stream_dequeued: AtomicU32::new(0),
-                stream_write_flushed: AtomicU32::new(0),
-                stream_write_fin_flushed: AtomicU32::new(0),
-                stream_write_blocked: AtomicU32::new(0),
-                stream_write_errored: AtomicU32::new(0),
-                stream_write_shutdown: AtomicU32::new(0),
-                stream_write_socket_flushed: AtomicU32::new(0),
-                stream_write_socket_blocked: AtomicU32::new(0),
-                stream_write_socket_errored: AtomicU32::new(0),
-                stream_read_flushed: AtomicU32::new(0),
-                stream_read_fin_flushed: AtomicU32::new(0),
-                stream_read_blocked: AtomicU32::new(0),
-                stream_read_errored: AtomicU32::new(0),
-                stream_read_shutdown: AtomicU32::new(0),
-                stream_read_socket_flushed: AtomicU32::new(0),
-                stream_read_socket_blocked: AtomicU32::new(0),
-                stream_read_socket_errored: AtomicU32::new(0),
-                endpoint_initialized: AtomicU32::new(0),
-                path_secret_map_initialized: AtomicU32::new(0),
-                path_secret_map_uninitialized: AtomicU32::new(0),
-                path_secret_map_background_handshake_requested: AtomicU32::new(0),
-                path_secret_map_entry_inserted: AtomicU32::new(0),
-                path_secret_map_entry_ready: AtomicU32::new(0),
-                path_secret_map_entry_replaced: AtomicU32::new(0),
-                unknown_path_secret_packet_sent: AtomicU32::new(0),
-                unknown_path_secret_packet_received: AtomicU32::new(0),
-                unknown_path_secret_packet_accepted: AtomicU32::new(0),
-                unknown_path_secret_packet_rejected: AtomicU32::new(0),
-                unknown_path_secret_packet_dropped: AtomicU32::new(0),
-                key_accepted: AtomicU32::new(0),
-                replay_definitely_detected: AtomicU32::new(0),
-                replay_potentially_detected: AtomicU32::new(0),
-                replay_detected_packet_sent: AtomicU32::new(0),
-                replay_detected_packet_received: AtomicU32::new(0),
-                replay_detected_packet_accepted: AtomicU32::new(0),
-                replay_detected_packet_rejected: AtomicU32::new(0),
-                replay_detected_packet_dropped: AtomicU32::new(0),
-                stale_key_packet_sent: AtomicU32::new(0),
-                stale_key_packet_received: AtomicU32::new(0),
-                stale_key_packet_accepted: AtomicU32::new(0),
-                stale_key_packet_rejected: AtomicU32::new(0),
-                stale_key_packet_dropped: AtomicU32::new(0),
-                path_secret_map_address_cache_accessed: AtomicU32::new(0),
-                path_secret_map_id_cache_accessed: AtomicU32::new(0),
-                path_secret_map_cleaner_cycled: AtomicU32::new(0),
+                acceptor_tcp_started: AtomicU64::new(0),
+                acceptor_tcp_loop_iteration_completed: AtomicU64::new(0),
+                acceptor_tcp_fresh_enqueued: AtomicU64::new(0),
+                acceptor_tcp_fresh_batch_completed: AtomicU64::new(0),
+                acceptor_tcp_stream_dropped: AtomicU64::new(0),
+                acceptor_tcp_stream_replaced: AtomicU64::new(0),
+                acceptor_tcp_packet_received: AtomicU64::new(0),
+                acceptor_tcp_packet_dropped: AtomicU64::new(0),
+                acceptor_tcp_stream_enqueued: AtomicU64::new(0),
+                acceptor_tcp_io_error: AtomicU64::new(0),
+                acceptor_udp_started: AtomicU64::new(0),
+                acceptor_udp_datagram_received: AtomicU64::new(0),
+                acceptor_udp_packet_received: AtomicU64::new(0),
+                acceptor_udp_packet_dropped: AtomicU64::new(0),
+                acceptor_udp_stream_enqueued: AtomicU64::new(0),
+                acceptor_udp_io_error: AtomicU64::new(0),
+                acceptor_stream_pruned: AtomicU64::new(0),
+                acceptor_stream_dequeued: AtomicU64::new(0),
+                stream_write_flushed: AtomicU64::new(0),
+                stream_write_fin_flushed: AtomicU64::new(0),
+                stream_write_blocked: AtomicU64::new(0),
+                stream_write_errored: AtomicU64::new(0),
+                stream_write_shutdown: AtomicU64::new(0),
+                stream_write_socket_flushed: AtomicU64::new(0),
+                stream_write_socket_blocked: AtomicU64::new(0),
+                stream_write_socket_errored: AtomicU64::new(0),
+                stream_read_flushed: AtomicU64::new(0),
+                stream_read_fin_flushed: AtomicU64::new(0),
+                stream_read_blocked: AtomicU64::new(0),
+                stream_read_errored: AtomicU64::new(0),
+                stream_read_shutdown: AtomicU64::new(0),
+                stream_read_socket_flushed: AtomicU64::new(0),
+                stream_read_socket_blocked: AtomicU64::new(0),
+                stream_read_socket_errored: AtomicU64::new(0),
+                connection_closed: AtomicU64::new(0),
+                endpoint_initialized: AtomicU64::new(0),
+                path_secret_map_initialized: AtomicU64::new(0),
+                path_secret_map_uninitialized: AtomicU64::new(0),
+                path_secret_map_background_handshake_requested: AtomicU64::new(0),
+                path_secret_map_entry_inserted: AtomicU64::new(0),
+                path_secret_map_entry_ready: AtomicU64::new(0),
+                path_secret_map_entry_replaced: AtomicU64::new(0),
+                unknown_path_secret_packet_sent: AtomicU64::new(0),
+                unknown_path_secret_packet_received: AtomicU64::new(0),
+                unknown_path_secret_packet_accepted: AtomicU64::new(0),
+                unknown_path_secret_packet_rejected: AtomicU64::new(0),
+                unknown_path_secret_packet_dropped: AtomicU64::new(0),
+                key_accepted: AtomicU64::new(0),
+                replay_definitely_detected: AtomicU64::new(0),
+                replay_potentially_detected: AtomicU64::new(0),
+                replay_detected_packet_sent: AtomicU64::new(0),
+                replay_detected_packet_received: AtomicU64::new(0),
+                replay_detected_packet_accepted: AtomicU64::new(0),
+                replay_detected_packet_rejected: AtomicU64::new(0),
+                replay_detected_packet_dropped: AtomicU64::new(0),
+                stale_key_packet_sent: AtomicU64::new(0),
+                stale_key_packet_received: AtomicU64::new(0),
+                stale_key_packet_accepted: AtomicU64::new(0),
+                stale_key_packet_rejected: AtomicU64::new(0),
+                stale_key_packet_dropped: AtomicU64::new(0),
+                path_secret_map_address_cache_accessed: AtomicU64::new(0),
+                path_secret_map_id_cache_accessed: AtomicU64::new(0),
+                path_secret_map_cleaner_cycled: AtomicU64::new(0),
             }
         }
     }
@@ -7861,6 +7938,20 @@ pub mod testing {
                 self.output.lock().unwrap().push(out);
             }
         }
+        fn on_connection_closed(
+            &self,
+            _context: &Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &api::ConnectionClosed,
+        ) {
+            self.connection_closed.fetch_add(1, Ordering::Relaxed);
+            if self.location.is_some() {
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+        }
         fn on_endpoint_initialized(
             &self,
             meta: &api::EndpointMeta,
@@ -8195,68 +8286,69 @@ pub mod testing {
     pub struct Publisher {
         location: Option<Location>,
         output: Mutex<Vec<String>>,
-        pub acceptor_tcp_started: AtomicU32,
-        pub acceptor_tcp_loop_iteration_completed: AtomicU32,
-        pub acceptor_tcp_fresh_enqueued: AtomicU32,
-        pub acceptor_tcp_fresh_batch_completed: AtomicU32,
-        pub acceptor_tcp_stream_dropped: AtomicU32,
-        pub acceptor_tcp_stream_replaced: AtomicU32,
-        pub acceptor_tcp_packet_received: AtomicU32,
-        pub acceptor_tcp_packet_dropped: AtomicU32,
-        pub acceptor_tcp_stream_enqueued: AtomicU32,
-        pub acceptor_tcp_io_error: AtomicU32,
-        pub acceptor_udp_started: AtomicU32,
-        pub acceptor_udp_datagram_received: AtomicU32,
-        pub acceptor_udp_packet_received: AtomicU32,
-        pub acceptor_udp_packet_dropped: AtomicU32,
-        pub acceptor_udp_stream_enqueued: AtomicU32,
-        pub acceptor_udp_io_error: AtomicU32,
-        pub acceptor_stream_pruned: AtomicU32,
-        pub acceptor_stream_dequeued: AtomicU32,
-        pub stream_write_flushed: AtomicU32,
-        pub stream_write_fin_flushed: AtomicU32,
-        pub stream_write_blocked: AtomicU32,
-        pub stream_write_errored: AtomicU32,
-        pub stream_write_shutdown: AtomicU32,
-        pub stream_write_socket_flushed: AtomicU32,
-        pub stream_write_socket_blocked: AtomicU32,
-        pub stream_write_socket_errored: AtomicU32,
-        pub stream_read_flushed: AtomicU32,
-        pub stream_read_fin_flushed: AtomicU32,
-        pub stream_read_blocked: AtomicU32,
-        pub stream_read_errored: AtomicU32,
-        pub stream_read_shutdown: AtomicU32,
-        pub stream_read_socket_flushed: AtomicU32,
-        pub stream_read_socket_blocked: AtomicU32,
-        pub stream_read_socket_errored: AtomicU32,
-        pub endpoint_initialized: AtomicU32,
-        pub path_secret_map_initialized: AtomicU32,
-        pub path_secret_map_uninitialized: AtomicU32,
-        pub path_secret_map_background_handshake_requested: AtomicU32,
-        pub path_secret_map_entry_inserted: AtomicU32,
-        pub path_secret_map_entry_ready: AtomicU32,
-        pub path_secret_map_entry_replaced: AtomicU32,
-        pub unknown_path_secret_packet_sent: AtomicU32,
-        pub unknown_path_secret_packet_received: AtomicU32,
-        pub unknown_path_secret_packet_accepted: AtomicU32,
-        pub unknown_path_secret_packet_rejected: AtomicU32,
-        pub unknown_path_secret_packet_dropped: AtomicU32,
-        pub key_accepted: AtomicU32,
-        pub replay_definitely_detected: AtomicU32,
-        pub replay_potentially_detected: AtomicU32,
-        pub replay_detected_packet_sent: AtomicU32,
-        pub replay_detected_packet_received: AtomicU32,
-        pub replay_detected_packet_accepted: AtomicU32,
-        pub replay_detected_packet_rejected: AtomicU32,
-        pub replay_detected_packet_dropped: AtomicU32,
-        pub stale_key_packet_sent: AtomicU32,
-        pub stale_key_packet_received: AtomicU32,
-        pub stale_key_packet_accepted: AtomicU32,
-        pub stale_key_packet_rejected: AtomicU32,
-        pub stale_key_packet_dropped: AtomicU32,
-        pub path_secret_map_address_cache_accessed: AtomicU32,
-        pub path_secret_map_id_cache_accessed: AtomicU32,
-        pub path_secret_map_cleaner_cycled: AtomicU32,
+        pub acceptor_tcp_started: AtomicU64,
+        pub acceptor_tcp_loop_iteration_completed: AtomicU64,
+        pub acceptor_tcp_fresh_enqueued: AtomicU64,
+        pub acceptor_tcp_fresh_batch_completed: AtomicU64,
+        pub acceptor_tcp_stream_dropped: AtomicU64,
+        pub acceptor_tcp_stream_replaced: AtomicU64,
+        pub acceptor_tcp_packet_received: AtomicU64,
+        pub acceptor_tcp_packet_dropped: AtomicU64,
+        pub acceptor_tcp_stream_enqueued: AtomicU64,
+        pub acceptor_tcp_io_error: AtomicU64,
+        pub acceptor_udp_started: AtomicU64,
+        pub acceptor_udp_datagram_received: AtomicU64,
+        pub acceptor_udp_packet_received: AtomicU64,
+        pub acceptor_udp_packet_dropped: AtomicU64,
+        pub acceptor_udp_stream_enqueued: AtomicU64,
+        pub acceptor_udp_io_error: AtomicU64,
+        pub acceptor_stream_pruned: AtomicU64,
+        pub acceptor_stream_dequeued: AtomicU64,
+        pub stream_write_flushed: AtomicU64,
+        pub stream_write_fin_flushed: AtomicU64,
+        pub stream_write_blocked: AtomicU64,
+        pub stream_write_errored: AtomicU64,
+        pub stream_write_shutdown: AtomicU64,
+        pub stream_write_socket_flushed: AtomicU64,
+        pub stream_write_socket_blocked: AtomicU64,
+        pub stream_write_socket_errored: AtomicU64,
+        pub stream_read_flushed: AtomicU64,
+        pub stream_read_fin_flushed: AtomicU64,
+        pub stream_read_blocked: AtomicU64,
+        pub stream_read_errored: AtomicU64,
+        pub stream_read_shutdown: AtomicU64,
+        pub stream_read_socket_flushed: AtomicU64,
+        pub stream_read_socket_blocked: AtomicU64,
+        pub stream_read_socket_errored: AtomicU64,
+        pub connection_closed: AtomicU64,
+        pub endpoint_initialized: AtomicU64,
+        pub path_secret_map_initialized: AtomicU64,
+        pub path_secret_map_uninitialized: AtomicU64,
+        pub path_secret_map_background_handshake_requested: AtomicU64,
+        pub path_secret_map_entry_inserted: AtomicU64,
+        pub path_secret_map_entry_ready: AtomicU64,
+        pub path_secret_map_entry_replaced: AtomicU64,
+        pub unknown_path_secret_packet_sent: AtomicU64,
+        pub unknown_path_secret_packet_received: AtomicU64,
+        pub unknown_path_secret_packet_accepted: AtomicU64,
+        pub unknown_path_secret_packet_rejected: AtomicU64,
+        pub unknown_path_secret_packet_dropped: AtomicU64,
+        pub key_accepted: AtomicU64,
+        pub replay_definitely_detected: AtomicU64,
+        pub replay_potentially_detected: AtomicU64,
+        pub replay_detected_packet_sent: AtomicU64,
+        pub replay_detected_packet_received: AtomicU64,
+        pub replay_detected_packet_accepted: AtomicU64,
+        pub replay_detected_packet_rejected: AtomicU64,
+        pub replay_detected_packet_dropped: AtomicU64,
+        pub stale_key_packet_sent: AtomicU64,
+        pub stale_key_packet_received: AtomicU64,
+        pub stale_key_packet_accepted: AtomicU64,
+        pub stale_key_packet_rejected: AtomicU64,
+        pub stale_key_packet_dropped: AtomicU64,
+        pub path_secret_map_address_cache_accessed: AtomicU64,
+        pub path_secret_map_id_cache_accessed: AtomicU64,
+        pub path_secret_map_cleaner_cycled: AtomicU64,
     }
     impl Publisher {
         #[doc = r" Creates a publisher with snapshot assertions enabled"]
@@ -8278,68 +8370,69 @@ pub mod testing {
             Self {
                 location: None,
                 output: Default::default(),
-                acceptor_tcp_started: AtomicU32::new(0),
-                acceptor_tcp_loop_iteration_completed: AtomicU32::new(0),
-                acceptor_tcp_fresh_enqueued: AtomicU32::new(0),
-                acceptor_tcp_fresh_batch_completed: AtomicU32::new(0),
-                acceptor_tcp_stream_dropped: AtomicU32::new(0),
-                acceptor_tcp_stream_replaced: AtomicU32::new(0),
-                acceptor_tcp_packet_received: AtomicU32::new(0),
-                acceptor_tcp_packet_dropped: AtomicU32::new(0),
-                acceptor_tcp_stream_enqueued: AtomicU32::new(0),
-                acceptor_tcp_io_error: AtomicU32::new(0),
-                acceptor_udp_started: AtomicU32::new(0),
-                acceptor_udp_datagram_received: AtomicU32::new(0),
-                acceptor_udp_packet_received: AtomicU32::new(0),
-                acceptor_udp_packet_dropped: AtomicU32::new(0),
-                acceptor_udp_stream_enqueued: AtomicU32::new(0),
-                acceptor_udp_io_error: AtomicU32::new(0),
-                acceptor_stream_pruned: AtomicU32::new(0),
-                acceptor_stream_dequeued: AtomicU32::new(0),
-                stream_write_flushed: AtomicU32::new(0),
-                stream_write_fin_flushed: AtomicU32::new(0),
-                stream_write_blocked: AtomicU32::new(0),
-                stream_write_errored: AtomicU32::new(0),
-                stream_write_shutdown: AtomicU32::new(0),
-                stream_write_socket_flushed: AtomicU32::new(0),
-                stream_write_socket_blocked: AtomicU32::new(0),
-                stream_write_socket_errored: AtomicU32::new(0),
-                stream_read_flushed: AtomicU32::new(0),
-                stream_read_fin_flushed: AtomicU32::new(0),
-                stream_read_blocked: AtomicU32::new(0),
-                stream_read_errored: AtomicU32::new(0),
-                stream_read_shutdown: AtomicU32::new(0),
-                stream_read_socket_flushed: AtomicU32::new(0),
-                stream_read_socket_blocked: AtomicU32::new(0),
-                stream_read_socket_errored: AtomicU32::new(0),
-                endpoint_initialized: AtomicU32::new(0),
-                path_secret_map_initialized: AtomicU32::new(0),
-                path_secret_map_uninitialized: AtomicU32::new(0),
-                path_secret_map_background_handshake_requested: AtomicU32::new(0),
-                path_secret_map_entry_inserted: AtomicU32::new(0),
-                path_secret_map_entry_ready: AtomicU32::new(0),
-                path_secret_map_entry_replaced: AtomicU32::new(0),
-                unknown_path_secret_packet_sent: AtomicU32::new(0),
-                unknown_path_secret_packet_received: AtomicU32::new(0),
-                unknown_path_secret_packet_accepted: AtomicU32::new(0),
-                unknown_path_secret_packet_rejected: AtomicU32::new(0),
-                unknown_path_secret_packet_dropped: AtomicU32::new(0),
-                key_accepted: AtomicU32::new(0),
-                replay_definitely_detected: AtomicU32::new(0),
-                replay_potentially_detected: AtomicU32::new(0),
-                replay_detected_packet_sent: AtomicU32::new(0),
-                replay_detected_packet_received: AtomicU32::new(0),
-                replay_detected_packet_accepted: AtomicU32::new(0),
-                replay_detected_packet_rejected: AtomicU32::new(0),
-                replay_detected_packet_dropped: AtomicU32::new(0),
-                stale_key_packet_sent: AtomicU32::new(0),
-                stale_key_packet_received: AtomicU32::new(0),
-                stale_key_packet_accepted: AtomicU32::new(0),
-                stale_key_packet_rejected: AtomicU32::new(0),
-                stale_key_packet_dropped: AtomicU32::new(0),
-                path_secret_map_address_cache_accessed: AtomicU32::new(0),
-                path_secret_map_id_cache_accessed: AtomicU32::new(0),
-                path_secret_map_cleaner_cycled: AtomicU32::new(0),
+                acceptor_tcp_started: AtomicU64::new(0),
+                acceptor_tcp_loop_iteration_completed: AtomicU64::new(0),
+                acceptor_tcp_fresh_enqueued: AtomicU64::new(0),
+                acceptor_tcp_fresh_batch_completed: AtomicU64::new(0),
+                acceptor_tcp_stream_dropped: AtomicU64::new(0),
+                acceptor_tcp_stream_replaced: AtomicU64::new(0),
+                acceptor_tcp_packet_received: AtomicU64::new(0),
+                acceptor_tcp_packet_dropped: AtomicU64::new(0),
+                acceptor_tcp_stream_enqueued: AtomicU64::new(0),
+                acceptor_tcp_io_error: AtomicU64::new(0),
+                acceptor_udp_started: AtomicU64::new(0),
+                acceptor_udp_datagram_received: AtomicU64::new(0),
+                acceptor_udp_packet_received: AtomicU64::new(0),
+                acceptor_udp_packet_dropped: AtomicU64::new(0),
+                acceptor_udp_stream_enqueued: AtomicU64::new(0),
+                acceptor_udp_io_error: AtomicU64::new(0),
+                acceptor_stream_pruned: AtomicU64::new(0),
+                acceptor_stream_dequeued: AtomicU64::new(0),
+                stream_write_flushed: AtomicU64::new(0),
+                stream_write_fin_flushed: AtomicU64::new(0),
+                stream_write_blocked: AtomicU64::new(0),
+                stream_write_errored: AtomicU64::new(0),
+                stream_write_shutdown: AtomicU64::new(0),
+                stream_write_socket_flushed: AtomicU64::new(0),
+                stream_write_socket_blocked: AtomicU64::new(0),
+                stream_write_socket_errored: AtomicU64::new(0),
+                stream_read_flushed: AtomicU64::new(0),
+                stream_read_fin_flushed: AtomicU64::new(0),
+                stream_read_blocked: AtomicU64::new(0),
+                stream_read_errored: AtomicU64::new(0),
+                stream_read_shutdown: AtomicU64::new(0),
+                stream_read_socket_flushed: AtomicU64::new(0),
+                stream_read_socket_blocked: AtomicU64::new(0),
+                stream_read_socket_errored: AtomicU64::new(0),
+                connection_closed: AtomicU64::new(0),
+                endpoint_initialized: AtomicU64::new(0),
+                path_secret_map_initialized: AtomicU64::new(0),
+                path_secret_map_uninitialized: AtomicU64::new(0),
+                path_secret_map_background_handshake_requested: AtomicU64::new(0),
+                path_secret_map_entry_inserted: AtomicU64::new(0),
+                path_secret_map_entry_ready: AtomicU64::new(0),
+                path_secret_map_entry_replaced: AtomicU64::new(0),
+                unknown_path_secret_packet_sent: AtomicU64::new(0),
+                unknown_path_secret_packet_received: AtomicU64::new(0),
+                unknown_path_secret_packet_accepted: AtomicU64::new(0),
+                unknown_path_secret_packet_rejected: AtomicU64::new(0),
+                unknown_path_secret_packet_dropped: AtomicU64::new(0),
+                key_accepted: AtomicU64::new(0),
+                replay_definitely_detected: AtomicU64::new(0),
+                replay_potentially_detected: AtomicU64::new(0),
+                replay_detected_packet_sent: AtomicU64::new(0),
+                replay_detected_packet_received: AtomicU64::new(0),
+                replay_detected_packet_accepted: AtomicU64::new(0),
+                replay_detected_packet_rejected: AtomicU64::new(0),
+                replay_detected_packet_dropped: AtomicU64::new(0),
+                stale_key_packet_sent: AtomicU64::new(0),
+                stale_key_packet_received: AtomicU64::new(0),
+                stale_key_packet_accepted: AtomicU64::new(0),
+                stale_key_packet_rejected: AtomicU64::new(0),
+                stale_key_packet_dropped: AtomicU64::new(0),
+                path_secret_map_address_cache_accessed: AtomicU64::new(0),
+                path_secret_map_id_cache_accessed: AtomicU64::new(0),
+                path_secret_map_cleaner_cycled: AtomicU64::new(0),
             }
         }
     }
@@ -8880,6 +8973,15 @@ pub mod testing {
         fn on_stream_read_socket_errored(&self, event: builder::StreamReadSocketErrored) {
             self.stream_read_socket_errored
                 .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            if self.location.is_some() {
+                let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+                let out = format!("{event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+        }
+        fn on_connection_closed(&self, event: builder::ConnectionClosed) {
+            self.connection_closed.fetch_add(1, Ordering::Relaxed);
             let event = event.into_event();
             if self.location.is_some() {
                 let event = crate::event::snapshot::Fmt::to_snapshot(&event);

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -12,7 +12,8 @@ use crate::event::{
         AsVariant, BoolRecorder, Info, Metric, NominalRecorder, Recorder, Registry, Units,
     },
 };
-static INFO: &[Info; 179usize] = &[
+use core::sync::atomic::{AtomicU64, Ordering};
+static INFO: &[Info; 202usize] = &[
     info::Builder {
         id: 0usize,
         name: Str::new("acceptor_tcp_started\0"),
@@ -309,793 +310,953 @@ static INFO: &[Info; 179usize] = &[
     .build(),
     info::Builder {
         id: 49usize,
+        name: Str::new("stream_write_flushed.conn\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 50usize,
         name: Str::new("stream_write_flushed.provided\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 50usize,
+        id: 51usize,
         name: Str::new("stream_write_flushed.committed.total\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 51usize,
+        id: 52usize,
         name: Str::new("stream_write_flushed.committed\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 52usize,
+        id: 53usize,
+        name: Str::new("stream_write_flushed.committed.conn\0"),
+        units: Units::Bytes,
+    }
+    .build(),
+    info::Builder {
+        id: 54usize,
         name: Str::new("stream_write_flushed.processing_duration\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 53usize,
+        id: 55usize,
+        name: Str::new("stream_write_flushed.processing_duration.conn\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
+        id: 56usize,
         name: Str::new("stream_write_fin_flushed\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 54usize,
+        id: 57usize,
         name: Str::new("stream_write_fin_flushed.latency\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 55usize,
+        id: 58usize,
+        name: Str::new("stream_write_fin_flushed.conn\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 59usize,
         name: Str::new("stream_write_fin_flushed.provided\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 56usize,
+        id: 60usize,
         name: Str::new("stream_write_fin_flushed.committed.total\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 57usize,
+        id: 61usize,
         name: Str::new("stream_write_fin_flushed.committed\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 58usize,
+        id: 62usize,
+        name: Str::new("stream_write_fin_flushed.committed.conn\0"),
+        units: Units::Bytes,
+    }
+    .build(),
+    info::Builder {
+        id: 63usize,
         name: Str::new("stream_write_fin_flushed.processing_duration\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 59usize,
-        name: Str::new("stream_write_blocked\0"),
-        units: Units::None,
-    }
-    .build(),
-    info::Builder {
-        id: 60usize,
-        name: Str::new("stream_write_blocked.latency\0"),
-        units: Units::Duration,
-    }
-    .build(),
-    info::Builder {
-        id: 61usize,
-        name: Str::new("stream_write_blocked.provided\0"),
-        units: Units::Bytes,
-    }
-    .build(),
-    info::Builder {
-        id: 62usize,
-        name: Str::new("stream_write_blocked.processing_duration\0"),
-        units: Units::Duration,
-    }
-    .build(),
-    info::Builder {
-        id: 63usize,
-        name: Str::new("stream_write_errored\0"),
-        units: Units::None,
-    }
-    .build(),
-    info::Builder {
         id: 64usize,
-        name: Str::new("stream_write_errored.latency\0"),
+        name: Str::new("stream_write_fin_flushed.processing_duration.conn\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 65usize,
-        name: Str::new("stream_write_errored.provided\0"),
-        units: Units::Bytes,
+        name: Str::new("stream_write_blocked\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 66usize,
-        name: Str::new("stream_write_errored.processing_duration\0"),
+        name: Str::new("stream_write_blocked.latency\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 67usize,
-        name: Str::new("stream_write_shutdown\0"),
+        name: Str::new("stream_write_blocked.conn.stream.write.blocked\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 68usize,
-        name: Str::new("stream_write_shutdown.latency\0"),
-        units: Units::Duration,
-    }
-    .build(),
-    info::Builder {
-        id: 69usize,
-        name: Str::new("stream_write_shutdown.buffer_len\0"),
+        name: Str::new("stream_write_blocked.provided\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
+        id: 69usize,
+        name: Str::new("stream_write_blocked.processing_duration\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
         id: 70usize,
-        name: Str::new("stream_write_shutdown.background\0"),
-        units: Units::None,
+        name: Str::new("stream_write_blocked.processing_duration.conn\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 71usize,
-        name: Str::new("stream_write_socket_flushed\0"),
+        name: Str::new("stream_write_errored\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 72usize,
-        name: Str::new("stream_write_socket_flushed.provided\0"),
-        units: Units::Bytes,
+        name: Str::new("stream_write_errored.latency\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 73usize,
-        name: Str::new("stream_write_socket_flushed.committed.total\0"),
+        name: Str::new("stream_write_errored.provided\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 74usize,
-        name: Str::new("stream_write_socket_flushed.committed\0"),
-        units: Units::Bytes,
+        name: Str::new("stream_write_errored.processing_duration\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 75usize,
-        name: Str::new("stream_write_socket_blocked\0"),
-        units: Units::None,
+        name: Str::new("stream_write_errored.processing_duration.conn\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 76usize,
-        name: Str::new("stream_write_socket_blocked.provided\0"),
-        units: Units::Bytes,
-    }
-    .build(),
-    info::Builder {
-        id: 77usize,
-        name: Str::new("stream_write_socket_errored\0"),
+        name: Str::new("stream_write_shutdown\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
+        id: 77usize,
+        name: Str::new("stream_write_shutdown.latency\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
         id: 78usize,
-        name: Str::new("stream_write_socket_errored.provided\0"),
+        name: Str::new("stream_write_shutdown.buffer_len\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 79usize,
-        name: Str::new("stream_read_flushed\0"),
+        name: Str::new("stream_write_shutdown.background\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 80usize,
-        name: Str::new("stream_read_flushed.latency\0"),
-        units: Units::Duration,
+        name: Str::new("stream_write_socket_flushed\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 81usize,
-        name: Str::new("stream_read_flushed.capacity\0"),
-        units: Units::Bytes,
+        name: Str::new("stream_write_socket_flushed.conn\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 82usize,
-        name: Str::new("stream_read_flushed.committed.total\0"),
+        name: Str::new("stream_write_socket_flushed.provided\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 83usize,
-        name: Str::new("stream_read_flushed.committed\0"),
+        name: Str::new("stream_write_socket_flushed.committed.total\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 84usize,
-        name: Str::new("stream_read_flushed.processing_duration\0"),
-        units: Units::Duration,
-    }
-    .build(),
-    info::Builder {
-        id: 85usize,
-        name: Str::new("stream_read_fin_flushed\0"),
-        units: Units::None,
-    }
-    .build(),
-    info::Builder {
-        id: 86usize,
-        name: Str::new("stream_read_fin_flushed.latency\0"),
-        units: Units::Duration,
-    }
-    .build(),
-    info::Builder {
-        id: 87usize,
-        name: Str::new("stream_read_fin_flushed.capacity\0"),
+        name: Str::new("stream_write_socket_flushed.committed\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
+        id: 85usize,
+        name: Str::new("stream_write_socket_flushed.committed.conn\0"),
+        units: Units::Bytes,
+    }
+    .build(),
+    info::Builder {
+        id: 86usize,
+        name: Str::new("stream_write_socket_blocked\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 87usize,
+        name: Str::new("stream_write_socket_blocked.conn.stream.write.socket.blocked\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
         id: 88usize,
-        name: Str::new("stream_read_fin_flushed.processing_duration\0"),
-        units: Units::Duration,
+        name: Str::new("stream_write_socket_blocked.provided\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 89usize,
-        name: Str::new("stream_read_blocked\0"),
+        name: Str::new("stream_write_socket_errored\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 90usize,
-        name: Str::new("stream_read_blocked.latency\0"),
-        units: Units::Duration,
-    }
-    .build(),
-    info::Builder {
-        id: 91usize,
-        name: Str::new("stream_read_blocked.capacity\0"),
+        name: Str::new("stream_write_socket_errored.provided\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
+        id: 91usize,
+        name: Str::new("stream_read_flushed\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
         id: 92usize,
-        name: Str::new("stream_read_blocked.processing_duration\0"),
+        name: Str::new("stream_read_flushed.latency\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 93usize,
-        name: Str::new("stream_read_errored\0"),
+        name: Str::new("stream_read_flushed.conn\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 94usize,
-        name: Str::new("stream_read_errored.latency\0"),
-        units: Units::Duration,
+        name: Str::new("stream_read_flushed.capacity\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 95usize,
-        name: Str::new("stream_read_errored.capacity\0"),
+        name: Str::new("stream_read_flushed.committed.total\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 96usize,
-        name: Str::new("stream_read_errored.processing_duration\0"),
-        units: Units::Duration,
+        name: Str::new("stream_read_flushed.committed\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 97usize,
-        name: Str::new("stream_read_shutdown\0"),
-        units: Units::None,
+        name: Str::new("stream_read_flushed.committed.conn\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 98usize,
-        name: Str::new("stream_read_shutdown.latency\0"),
+        name: Str::new("stream_read_flushed.processing_duration\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 99usize,
-        name: Str::new("stream_read_shutdown.background\0"),
-        units: Units::None,
+        name: Str::new("stream_read_flushed.processing_duration.conn\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 100usize,
-        name: Str::new("stream_read_socket_flushed\0"),
+        name: Str::new("stream_read_fin_flushed\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 101usize,
-        name: Str::new("stream_read_socket_flushed.capacity\0"),
-        units: Units::Bytes,
+        name: Str::new("stream_read_fin_flushed.latency\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 102usize,
-        name: Str::new("stream_read_socket_flushed.committed.total\0"),
-        units: Units::Bytes,
+        name: Str::new("stream_read_fin_flushed.conn\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 103usize,
-        name: Str::new("stream_read_socket_flushed.committed\0"),
+        name: Str::new("stream_read_fin_flushed.capacity\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 104usize,
-        name: Str::new("stream_read_socket_blocked\0"),
-        units: Units::None,
+        name: Str::new("stream_read_fin_flushed.processing_duration\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 105usize,
-        name: Str::new("stream_read_socket_blocked.capacity\0"),
-        units: Units::Bytes,
+        name: Str::new("stream_read_fin_flushed.processing_duration.conn\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 106usize,
-        name: Str::new("stream_read_socket_errored\0"),
+        name: Str::new("stream_read_blocked\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 107usize,
-        name: Str::new("stream_read_socket_errored.capacity\0"),
-        units: Units::Bytes,
+        name: Str::new("stream_read_blocked.latency\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 108usize,
-        name: Str::new("endpoint_initialized\0"),
-        units: Units::None,
+        name: Str::new("stream_read_blocked.capacity\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 109usize,
-        name: Str::new("endpoint_initialized.acceptor.protocol\0"),
-        units: Units::None,
+        name: Str::new("stream_read_blocked.processing_duration\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 110usize,
-        name: Str::new("endpoint_initialized.handshake.protocol\0"),
-        units: Units::None,
+        name: Str::new("stream_read_blocked.processing_duration.conn\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 111usize,
-        name: Str::new("endpoint_initialized.tcp\0"),
+        name: Str::new("stream_read_errored\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 112usize,
-        name: Str::new("endpoint_initialized.udp\0"),
-        units: Units::None,
+        name: Str::new("stream_read_errored.latency\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 113usize,
-        name: Str::new("path_secret_map_initialized\0"),
-        units: Units::None,
+        name: Str::new("stream_read_errored.capacity\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 114usize,
-        name: Str::new("path_secret_map_initialized.capacity\0"),
-        units: Units::None,
+        name: Str::new("stream_read_errored.processing_duration\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 115usize,
-        name: Str::new("path_secret_map_uninitialized\0"),
-        units: Units::None,
+        name: Str::new("stream_read_errored.processing_duration.conn\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 116usize,
-        name: Str::new("path_secret_map_uninitialized.capacity\0"),
+        name: Str::new("stream_read_shutdown\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 117usize,
-        name: Str::new("path_secret_map_uninitialized.entries\0"),
-        units: Units::None,
-    }
-    .build(),
-    info::Builder {
-        id: 118usize,
-        name: Str::new("path_secret_map_uninitialized.lifetime\0"),
+        name: Str::new("stream_read_shutdown.latency\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
+        id: 118usize,
+        name: Str::new("stream_read_shutdown.background\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
         id: 119usize,
-        name: Str::new("path_secret_map_background_handshake_requested\0"),
+        name: Str::new("stream_read_socket_flushed\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 120usize,
-        name: Str::new("path_secret_map_background_handshake_requested.peer_address.protocol\0"),
+        name: Str::new("stream_read_socket_flushed.conn\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 121usize,
-        name: Str::new("path_secret_map_entry_inserted\0"),
-        units: Units::None,
+        name: Str::new("stream_read_socket_flushed.capacity\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 122usize,
-        name: Str::new("path_secret_map_entry_inserted.peer_address.protocol\0"),
-        units: Units::None,
+        name: Str::new("stream_read_socket_flushed.committed.total\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 123usize,
-        name: Str::new("path_secret_map_entry_ready\0"),
-        units: Units::None,
+        name: Str::new("stream_read_socket_flushed.committed\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 124usize,
-        name: Str::new("path_secret_map_entry_ready.peer_address.protocol\0"),
-        units: Units::None,
+        name: Str::new("stream_read_socket_flushed.committed.conn\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 125usize,
-        name: Str::new("path_secret_map_entry_replaced\0"),
+        name: Str::new("stream_read_socket_blocked\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 126usize,
-        name: Str::new("path_secret_map_entry_replaced.peer_address.protocol\0"),
+        name: Str::new("stream_read_socket_blocked.conn\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 127usize,
-        name: Str::new("unknown_path_secret_packet_sent\0"),
-        units: Units::None,
+        name: Str::new("stream_read_socket_blocked.capacity\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 128usize,
-        name: Str::new("unknown_path_secret_packet_sent.peer_address.protocol\0"),
+        name: Str::new("stream_read_socket_errored\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 129usize,
-        name: Str::new("unknown_path_secret_packet_received\0"),
-        units: Units::None,
+        name: Str::new("stream_read_socket_errored.capacity\0"),
+        units: Units::Bytes,
     }
     .build(),
     info::Builder {
         id: 130usize,
-        name: Str::new("unknown_path_secret_packet_received.peer_address.protocol\0"),
+        name: Str::new("connection_closed\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 131usize,
-        name: Str::new("unknown_path_secret_packet_accepted\0"),
+        name: Str::new("endpoint_initialized\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 132usize,
-        name: Str::new("unknown_path_secret_packet_accepted.peer_address.protocol\0"),
+        name: Str::new("endpoint_initialized.acceptor.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 133usize,
-        name: Str::new("unknown_path_secret_packet_rejected\0"),
+        name: Str::new("endpoint_initialized.handshake.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 134usize,
-        name: Str::new("unknown_path_secret_packet_rejected.peer_address.protocol\0"),
+        name: Str::new("endpoint_initialized.tcp\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 135usize,
-        name: Str::new("unknown_path_secret_packet_dropped\0"),
+        name: Str::new("endpoint_initialized.udp\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 136usize,
-        name: Str::new("unknown_path_secret_packet_dropped.peer_address.protocol\0"),
+        name: Str::new("path_secret_map_initialized\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 137usize,
-        name: Str::new("key_accepted\0"),
+        name: Str::new("path_secret_map_initialized.capacity\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 138usize,
-        name: Str::new("key_accepted.gap\0"),
+        name: Str::new("path_secret_map_uninitialized\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 139usize,
-        name: Str::new("key_accepted.forward_shift\0"),
+        name: Str::new("path_secret_map_uninitialized.capacity\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 140usize,
-        name: Str::new("replay_definitely_detected\0"),
+        name: Str::new("path_secret_map_uninitialized.entries\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 141usize,
-        name: Str::new("replay_potentially_detected\0"),
-        units: Units::None,
+        name: Str::new("path_secret_map_uninitialized.lifetime\0"),
+        units: Units::Duration,
     }
     .build(),
     info::Builder {
         id: 142usize,
-        name: Str::new("replay_potentially_detected.gap\0"),
+        name: Str::new("path_secret_map_background_handshake_requested\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 143usize,
-        name: Str::new("replay_detected_packet_sent\0"),
+        name: Str::new("path_secret_map_background_handshake_requested.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 144usize,
-        name: Str::new("replay_detected_packet_sent.peer_address.protocol\0"),
+        name: Str::new("path_secret_map_entry_inserted\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 145usize,
-        name: Str::new("replay_detected_packet_received\0"),
+        name: Str::new("path_secret_map_entry_inserted.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 146usize,
-        name: Str::new("replay_detected_packet_received.peer_address.protocol\0"),
+        name: Str::new("path_secret_map_entry_ready\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 147usize,
-        name: Str::new("replay_detected_packet_accepted\0"),
+        name: Str::new("path_secret_map_entry_ready.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 148usize,
-        name: Str::new("replay_detected_packet_accepted.peer_address.protocol\0"),
+        name: Str::new("path_secret_map_entry_replaced\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 149usize,
-        name: Str::new("replay_detected_packet_rejected\0"),
+        name: Str::new("path_secret_map_entry_replaced.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 150usize,
-        name: Str::new("replay_detected_packet_rejected.peer_address.protocol\0"),
+        name: Str::new("unknown_path_secret_packet_sent\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 151usize,
-        name: Str::new("replay_detected_packet_dropped\0"),
+        name: Str::new("unknown_path_secret_packet_sent.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 152usize,
-        name: Str::new("replay_detected_packet_dropped.peer_address.protocol\0"),
+        name: Str::new("unknown_path_secret_packet_received\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 153usize,
-        name: Str::new("stale_key_packet_sent\0"),
+        name: Str::new("unknown_path_secret_packet_received.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 154usize,
-        name: Str::new("stale_key_packet_sent.peer_address.protocol\0"),
+        name: Str::new("unknown_path_secret_packet_accepted\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 155usize,
-        name: Str::new("stale_key_packet_received\0"),
+        name: Str::new("unknown_path_secret_packet_accepted.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 156usize,
-        name: Str::new("stale_key_packet_received.peer_address.protocol\0"),
+        name: Str::new("unknown_path_secret_packet_rejected\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 157usize,
-        name: Str::new("stale_key_packet_accepted\0"),
+        name: Str::new("unknown_path_secret_packet_rejected.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 158usize,
-        name: Str::new("stale_key_packet_accepted.peer_address.protocol\0"),
+        name: Str::new("unknown_path_secret_packet_dropped\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 159usize,
-        name: Str::new("stale_key_packet_rejected\0"),
+        name: Str::new("unknown_path_secret_packet_dropped.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 160usize,
-        name: Str::new("stale_key_packet_rejected.peer_address.protocol\0"),
+        name: Str::new("key_accepted\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 161usize,
-        name: Str::new("stale_key_packet_dropped\0"),
+        name: Str::new("key_accepted.gap\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 162usize,
-        name: Str::new("stale_key_packet_dropped.peer_address.protocol\0"),
+        name: Str::new("key_accepted.forward_shift\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 163usize,
-        name: Str::new("path_secret_map_address_cache_accessed\0"),
+        name: Str::new("replay_definitely_detected\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 164usize,
-        name: Str::new("path_secret_map_address_cache_accessed.peer_address.protocol\0"),
+        name: Str::new("replay_potentially_detected\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 165usize,
-        name: Str::new("path_secret_map_address_cache_accessed.hit\0"),
+        name: Str::new("replay_potentially_detected.gap\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 166usize,
-        name: Str::new("path_secret_map_id_cache_accessed\0"),
+        name: Str::new("replay_detected_packet_sent\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 167usize,
-        name: Str::new("path_secret_map_id_cache_accessed.hit\0"),
+        name: Str::new("replay_detected_packet_sent.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 168usize,
-        name: Str::new("path_secret_map_cleaner_cycled\0"),
+        name: Str::new("replay_detected_packet_received\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 169usize,
-        name: Str::new("path_secret_map_cleaner_cycled.entries.id\0"),
+        name: Str::new("replay_detected_packet_received.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 170usize,
-        name: Str::new("path_secret_map_cleaner_cycled.entries.id.retired\0"),
+        name: Str::new("replay_detected_packet_accepted\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 171usize,
-        name: Str::new("path_secret_map_cleaner_cycled.entries.id.utilization\0"),
-        units: Units::Percent,
+        name: Str::new("replay_detected_packet_accepted.peer_address.protocol\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 172usize,
-        name: Str::new("path_secret_map_cleaner_cycled.entries.id.utilization.initial\0"),
-        units: Units::Percent,
+        name: Str::new("replay_detected_packet_rejected\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 173usize,
-        name: Str::new("path_secret_map_cleaner_cycled.entries.address\0"),
+        name: Str::new("replay_detected_packet_rejected.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 174usize,
-        name: Str::new("path_secret_map_cleaner_cycled.entries.address.retired\0"),
+        name: Str::new("replay_detected_packet_dropped\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 175usize,
-        name: Str::new("path_secret_map_cleaner_cycled.entries.address.utilization\0"),
-        units: Units::Percent,
+        name: Str::new("replay_detected_packet_dropped.peer_address.protocol\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 176usize,
-        name: Str::new("path_secret_map_cleaner_cycled.entries.address.utilization.initial\0"),
-        units: Units::Percent,
+        name: Str::new("stale_key_packet_sent\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
         id: 177usize,
-        name: Str::new("path_secret_map_cleaner_cycled.handshake_requests\0"),
+        name: Str::new("stale_key_packet_sent.peer_address.protocol\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
         id: 178usize,
+        name: Str::new("stale_key_packet_received\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 179usize,
+        name: Str::new("stale_key_packet_received.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 180usize,
+        name: Str::new("stale_key_packet_accepted\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 181usize,
+        name: Str::new("stale_key_packet_accepted.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 182usize,
+        name: Str::new("stale_key_packet_rejected\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 183usize,
+        name: Str::new("stale_key_packet_rejected.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 184usize,
+        name: Str::new("stale_key_packet_dropped\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 185usize,
+        name: Str::new("stale_key_packet_dropped.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 186usize,
+        name: Str::new("path_secret_map_address_cache_accessed\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 187usize,
+        name: Str::new("path_secret_map_address_cache_accessed.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 188usize,
+        name: Str::new("path_secret_map_address_cache_accessed.hit\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 189usize,
+        name: Str::new("path_secret_map_id_cache_accessed\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 190usize,
+        name: Str::new("path_secret_map_id_cache_accessed.hit\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 191usize,
+        name: Str::new("path_secret_map_cleaner_cycled\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 192usize,
+        name: Str::new("path_secret_map_cleaner_cycled.entries.id\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 193usize,
+        name: Str::new("path_secret_map_cleaner_cycled.entries.id.retired\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 194usize,
+        name: Str::new("path_secret_map_cleaner_cycled.entries.id.utilization\0"),
+        units: Units::Percent,
+    }
+    .build(),
+    info::Builder {
+        id: 195usize,
+        name: Str::new("path_secret_map_cleaner_cycled.entries.id.utilization.initial\0"),
+        units: Units::Percent,
+    }
+    .build(),
+    info::Builder {
+        id: 196usize,
+        name: Str::new("path_secret_map_cleaner_cycled.entries.address\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 197usize,
+        name: Str::new("path_secret_map_cleaner_cycled.entries.address.retired\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 198usize,
+        name: Str::new("path_secret_map_cleaner_cycled.entries.address.utilization\0"),
+        units: Units::Percent,
+    }
+    .build(),
+    info::Builder {
+        id: 199usize,
+        name: Str::new("path_secret_map_cleaner_cycled.entries.address.utilization.initial\0"),
+        units: Units::Percent,
+    }
+    .build(),
+    info::Builder {
+        id: 200usize,
+        name: Str::new("path_secret_map_cleaner_cycled.handshake_requests\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 201usize,
         name: Str::new("path_secret_map_cleaner_cycled.handshake_requests.retired\0"),
         units: Units::None,
     }
     .build(),
 ];
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 #[allow(dead_code)]
 pub struct ConnectionContext {
     start_time: crate::event::Timestamp,
+    ctr_12: AtomicU64,
+    ctr_15: AtomicU64,
+    ctr_17: AtomicU64,
+    ctr_18: AtomicU64,
+    ctr_21: AtomicU64,
+    ctr_23: AtomicU64,
+    ctr_24: AtomicU64,
+    ctr_27: AtomicU64,
+    ctr_30: AtomicU64,
+    ctr_32: AtomicU64,
+    ctr_35: AtomicU64,
+    ctr_36: AtomicU64,
+    ctr_39: AtomicU64,
+    ctr_42: AtomicU64,
+    ctr_44: AtomicU64,
+    ctr_45: AtomicU64,
+    ctr_48: AtomicU64,
+    ctr_51: AtomicU64,
+    ctr_54: AtomicU64,
+    ctr_55: AtomicU64,
+    ctr_58: AtomicU64,
+    ctr_59: AtomicU64,
 }
 pub struct Subscriber<R: Registry> {
     #[allow(dead_code)]
-    counters: Box<[R::Counter; 67usize]>,
+    counters: Box<[R::Counter; 68usize]>,
     #[allow(dead_code)]
     bool_counters: Box<[R::BoolCounter; 12usize]>,
     #[allow(dead_code)]
@@ -1103,7 +1264,7 @@ pub struct Subscriber<R: Registry> {
     #[allow(dead_code)]
     nominal_counter_offsets: Box<[usize; 26usize]>,
     #[allow(dead_code)]
-    measures: Box<[R::Measure; 57usize]>,
+    measures: Box<[R::Measure; 79usize]>,
     #[allow(dead_code)]
     gauges: Box<[R::Gauge; 0usize]>,
     #[allow(dead_code)]
@@ -1130,11 +1291,11 @@ impl<R: Registry> Subscriber<R> {
     #[allow(unused_mut)]
     #[inline]
     pub fn new(registry: R) -> Self {
-        let mut counters = Vec::with_capacity(67usize);
+        let mut counters = Vec::with_capacity(68usize);
         let mut bool_counters = Vec::with_capacity(12usize);
         let mut nominal_counters = Vec::with_capacity(26usize);
         let mut nominal_counter_offsets = Vec::with_capacity(26usize);
-        let mut measures = Vec::with_capacity(57usize);
+        let mut measures = Vec::with_capacity(79usize);
         let mut gauges = Vec::with_capacity(0usize);
         let mut timers = Vec::with_capacity(17usize);
         let mut nominal_timers = Vec::with_capacity(0usize);
@@ -1158,66 +1319,67 @@ impl<R: Registry> Subscriber<R> {
         counters.push(registry.register_counter(&INFO[42usize]));
         counters.push(registry.register_counter(&INFO[45usize]));
         counters.push(registry.register_counter(&INFO[47usize]));
-        counters.push(registry.register_counter(&INFO[50usize]));
-        counters.push(registry.register_counter(&INFO[53usize]));
+        counters.push(registry.register_counter(&INFO[51usize]));
         counters.push(registry.register_counter(&INFO[56usize]));
-        counters.push(registry.register_counter(&INFO[59usize]));
-        counters.push(registry.register_counter(&INFO[63usize]));
-        counters.push(registry.register_counter(&INFO[67usize]));
+        counters.push(registry.register_counter(&INFO[60usize]));
+        counters.push(registry.register_counter(&INFO[65usize]));
         counters.push(registry.register_counter(&INFO[71usize]));
-        counters.push(registry.register_counter(&INFO[73usize]));
-        counters.push(registry.register_counter(&INFO[75usize]));
-        counters.push(registry.register_counter(&INFO[77usize]));
-        counters.push(registry.register_counter(&INFO[79usize]));
-        counters.push(registry.register_counter(&INFO[82usize]));
-        counters.push(registry.register_counter(&INFO[85usize]));
+        counters.push(registry.register_counter(&INFO[76usize]));
+        counters.push(registry.register_counter(&INFO[80usize]));
+        counters.push(registry.register_counter(&INFO[83usize]));
+        counters.push(registry.register_counter(&INFO[86usize]));
         counters.push(registry.register_counter(&INFO[89usize]));
-        counters.push(registry.register_counter(&INFO[93usize]));
-        counters.push(registry.register_counter(&INFO[97usize]));
+        counters.push(registry.register_counter(&INFO[91usize]));
+        counters.push(registry.register_counter(&INFO[95usize]));
         counters.push(registry.register_counter(&INFO[100usize]));
-        counters.push(registry.register_counter(&INFO[102usize]));
-        counters.push(registry.register_counter(&INFO[104usize]));
         counters.push(registry.register_counter(&INFO[106usize]));
-        counters.push(registry.register_counter(&INFO[108usize]));
-        counters.push(registry.register_counter(&INFO[113usize]));
-        counters.push(registry.register_counter(&INFO[115usize]));
+        counters.push(registry.register_counter(&INFO[111usize]));
+        counters.push(registry.register_counter(&INFO[116usize]));
         counters.push(registry.register_counter(&INFO[119usize]));
-        counters.push(registry.register_counter(&INFO[121usize]));
-        counters.push(registry.register_counter(&INFO[123usize]));
+        counters.push(registry.register_counter(&INFO[122usize]));
         counters.push(registry.register_counter(&INFO[125usize]));
-        counters.push(registry.register_counter(&INFO[127usize]));
-        counters.push(registry.register_counter(&INFO[129usize]));
+        counters.push(registry.register_counter(&INFO[128usize]));
+        counters.push(registry.register_counter(&INFO[130usize]));
         counters.push(registry.register_counter(&INFO[131usize]));
-        counters.push(registry.register_counter(&INFO[133usize]));
-        counters.push(registry.register_counter(&INFO[135usize]));
-        counters.push(registry.register_counter(&INFO[137usize]));
-        counters.push(registry.register_counter(&INFO[140usize]));
-        counters.push(registry.register_counter(&INFO[141usize]));
-        counters.push(registry.register_counter(&INFO[143usize]));
-        counters.push(registry.register_counter(&INFO[145usize]));
-        counters.push(registry.register_counter(&INFO[147usize]));
-        counters.push(registry.register_counter(&INFO[149usize]));
-        counters.push(registry.register_counter(&INFO[151usize]));
-        counters.push(registry.register_counter(&INFO[153usize]));
-        counters.push(registry.register_counter(&INFO[155usize]));
-        counters.push(registry.register_counter(&INFO[157usize]));
-        counters.push(registry.register_counter(&INFO[159usize]));
-        counters.push(registry.register_counter(&INFO[161usize]));
+        counters.push(registry.register_counter(&INFO[136usize]));
+        counters.push(registry.register_counter(&INFO[138usize]));
+        counters.push(registry.register_counter(&INFO[142usize]));
+        counters.push(registry.register_counter(&INFO[144usize]));
+        counters.push(registry.register_counter(&INFO[146usize]));
+        counters.push(registry.register_counter(&INFO[148usize]));
+        counters.push(registry.register_counter(&INFO[150usize]));
+        counters.push(registry.register_counter(&INFO[152usize]));
+        counters.push(registry.register_counter(&INFO[154usize]));
+        counters.push(registry.register_counter(&INFO[156usize]));
+        counters.push(registry.register_counter(&INFO[158usize]));
+        counters.push(registry.register_counter(&INFO[160usize]));
         counters.push(registry.register_counter(&INFO[163usize]));
+        counters.push(registry.register_counter(&INFO[164usize]));
         counters.push(registry.register_counter(&INFO[166usize]));
         counters.push(registry.register_counter(&INFO[168usize]));
+        counters.push(registry.register_counter(&INFO[170usize]));
+        counters.push(registry.register_counter(&INFO[172usize]));
+        counters.push(registry.register_counter(&INFO[174usize]));
+        counters.push(registry.register_counter(&INFO[176usize]));
+        counters.push(registry.register_counter(&INFO[178usize]));
+        counters.push(registry.register_counter(&INFO[180usize]));
+        counters.push(registry.register_counter(&INFO[182usize]));
+        counters.push(registry.register_counter(&INFO[184usize]));
+        counters.push(registry.register_counter(&INFO[186usize]));
+        counters.push(registry.register_counter(&INFO[189usize]));
+        counters.push(registry.register_counter(&INFO[191usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[19usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[20usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[34usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[35usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[36usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[37usize]));
-        bool_counters.push(registry.register_bool_counter(&INFO[70usize]));
-        bool_counters.push(registry.register_bool_counter(&INFO[99usize]));
-        bool_counters.push(registry.register_bool_counter(&INFO[111usize]));
-        bool_counters.push(registry.register_bool_counter(&INFO[112usize]));
-        bool_counters.push(registry.register_bool_counter(&INFO[165usize]));
-        bool_counters.push(registry.register_bool_counter(&INFO[167usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[79usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[118usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[134usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[135usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[188usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[190usize]));
         {
             #[allow(unused_imports)]
             use api::*;
@@ -1270,94 +1432,6 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[109usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[110usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[120usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[122usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[124usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[126usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[128usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[130usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
                         .push(registry.register_nominal_counter(&INFO[132usize], variant));
                     count += 1;
                 }
@@ -1369,7 +1443,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[134usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[133usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1380,7 +1454,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[136usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[143usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1391,7 +1465,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[144usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[145usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1402,7 +1476,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[146usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[147usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1413,7 +1487,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[148usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[149usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1424,7 +1498,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[150usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[151usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1435,7 +1509,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[152usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[153usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1446,7 +1520,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[154usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[155usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1457,7 +1531,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[156usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[157usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1468,7 +1542,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[158usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[159usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1479,7 +1553,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[160usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[167usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1490,7 +1564,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[162usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[169usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1501,7 +1575,95 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[164usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[171usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[173usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[175usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[177usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[179usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[181usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[183usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[185usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[187usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1521,50 +1683,72 @@ impl<R: Registry> Subscriber<R> {
         measures.push(registry.register_measure(&INFO[31usize]));
         measures.push(registry.register_measure(&INFO[33usize]));
         measures.push(registry.register_measure(&INFO[49usize]));
-        measures.push(registry.register_measure(&INFO[51usize]));
+        measures.push(registry.register_measure(&INFO[50usize]));
         measures.push(registry.register_measure(&INFO[52usize]));
+        measures.push(registry.register_measure(&INFO[53usize]));
+        measures.push(registry.register_measure(&INFO[54usize]));
         measures.push(registry.register_measure(&INFO[55usize]));
-        measures.push(registry.register_measure(&INFO[57usize]));
         measures.push(registry.register_measure(&INFO[58usize]));
+        measures.push(registry.register_measure(&INFO[59usize]));
         measures.push(registry.register_measure(&INFO[61usize]));
         measures.push(registry.register_measure(&INFO[62usize]));
-        measures.push(registry.register_measure(&INFO[65usize]));
-        measures.push(registry.register_measure(&INFO[66usize]));
+        measures.push(registry.register_measure(&INFO[63usize]));
+        measures.push(registry.register_measure(&INFO[64usize]));
+        measures.push(registry.register_measure(&INFO[67usize]));
+        measures.push(registry.register_measure(&INFO[68usize]));
         measures.push(registry.register_measure(&INFO[69usize]));
-        measures.push(registry.register_measure(&INFO[72usize]));
+        measures.push(registry.register_measure(&INFO[70usize]));
+        measures.push(registry.register_measure(&INFO[73usize]));
         measures.push(registry.register_measure(&INFO[74usize]));
-        measures.push(registry.register_measure(&INFO[76usize]));
+        measures.push(registry.register_measure(&INFO[75usize]));
         measures.push(registry.register_measure(&INFO[78usize]));
         measures.push(registry.register_measure(&INFO[81usize]));
-        measures.push(registry.register_measure(&INFO[83usize]));
+        measures.push(registry.register_measure(&INFO[82usize]));
         measures.push(registry.register_measure(&INFO[84usize]));
+        measures.push(registry.register_measure(&INFO[85usize]));
         measures.push(registry.register_measure(&INFO[87usize]));
         measures.push(registry.register_measure(&INFO[88usize]));
-        measures.push(registry.register_measure(&INFO[91usize]));
-        measures.push(registry.register_measure(&INFO[92usize]));
-        measures.push(registry.register_measure(&INFO[95usize]));
+        measures.push(registry.register_measure(&INFO[90usize]));
+        measures.push(registry.register_measure(&INFO[93usize]));
+        measures.push(registry.register_measure(&INFO[94usize]));
         measures.push(registry.register_measure(&INFO[96usize]));
-        measures.push(registry.register_measure(&INFO[101usize]));
+        measures.push(registry.register_measure(&INFO[97usize]));
+        measures.push(registry.register_measure(&INFO[98usize]));
+        measures.push(registry.register_measure(&INFO[99usize]));
+        measures.push(registry.register_measure(&INFO[102usize]));
         measures.push(registry.register_measure(&INFO[103usize]));
+        measures.push(registry.register_measure(&INFO[104usize]));
         measures.push(registry.register_measure(&INFO[105usize]));
-        measures.push(registry.register_measure(&INFO[107usize]));
+        measures.push(registry.register_measure(&INFO[108usize]));
+        measures.push(registry.register_measure(&INFO[109usize]));
+        measures.push(registry.register_measure(&INFO[110usize]));
+        measures.push(registry.register_measure(&INFO[113usize]));
         measures.push(registry.register_measure(&INFO[114usize]));
-        measures.push(registry.register_measure(&INFO[116usize]));
-        measures.push(registry.register_measure(&INFO[117usize]));
-        measures.push(registry.register_measure(&INFO[118usize]));
-        measures.push(registry.register_measure(&INFO[138usize]));
+        measures.push(registry.register_measure(&INFO[115usize]));
+        measures.push(registry.register_measure(&INFO[120usize]));
+        measures.push(registry.register_measure(&INFO[121usize]));
+        measures.push(registry.register_measure(&INFO[123usize]));
+        measures.push(registry.register_measure(&INFO[124usize]));
+        measures.push(registry.register_measure(&INFO[126usize]));
+        measures.push(registry.register_measure(&INFO[127usize]));
+        measures.push(registry.register_measure(&INFO[129usize]));
+        measures.push(registry.register_measure(&INFO[137usize]));
         measures.push(registry.register_measure(&INFO[139usize]));
-        measures.push(registry.register_measure(&INFO[142usize]));
-        measures.push(registry.register_measure(&INFO[169usize]));
-        measures.push(registry.register_measure(&INFO[170usize]));
-        measures.push(registry.register_measure(&INFO[171usize]));
-        measures.push(registry.register_measure(&INFO[172usize]));
-        measures.push(registry.register_measure(&INFO[173usize]));
-        measures.push(registry.register_measure(&INFO[174usize]));
-        measures.push(registry.register_measure(&INFO[175usize]));
-        measures.push(registry.register_measure(&INFO[176usize]));
-        measures.push(registry.register_measure(&INFO[177usize]));
-        measures.push(registry.register_measure(&INFO[178usize]));
+        measures.push(registry.register_measure(&INFO[140usize]));
+        measures.push(registry.register_measure(&INFO[141usize]));
+        measures.push(registry.register_measure(&INFO[161usize]));
+        measures.push(registry.register_measure(&INFO[162usize]));
+        measures.push(registry.register_measure(&INFO[165usize]));
+        measures.push(registry.register_measure(&INFO[192usize]));
+        measures.push(registry.register_measure(&INFO[193usize]));
+        measures.push(registry.register_measure(&INFO[194usize]));
+        measures.push(registry.register_measure(&INFO[195usize]));
+        measures.push(registry.register_measure(&INFO[196usize]));
+        measures.push(registry.register_measure(&INFO[197usize]));
+        measures.push(registry.register_measure(&INFO[198usize]));
+        measures.push(registry.register_measure(&INFO[199usize]));
+        measures.push(registry.register_measure(&INFO[200usize]));
+        measures.push(registry.register_measure(&INFO[201usize]));
         timers.push(registry.register_timer(&INFO[5usize]));
         timers.push(registry.register_timer(&INFO[15usize]));
         timers.push(registry.register_timer(&INFO[21usize]));
@@ -1573,15 +1757,15 @@ impl<R: Registry> Subscriber<R> {
         timers.push(registry.register_timer(&INFO[43usize]));
         timers.push(registry.register_timer(&INFO[46usize]));
         timers.push(registry.register_timer(&INFO[48usize]));
-        timers.push(registry.register_timer(&INFO[54usize]));
-        timers.push(registry.register_timer(&INFO[60usize]));
-        timers.push(registry.register_timer(&INFO[64usize]));
-        timers.push(registry.register_timer(&INFO[68usize]));
-        timers.push(registry.register_timer(&INFO[80usize]));
-        timers.push(registry.register_timer(&INFO[86usize]));
-        timers.push(registry.register_timer(&INFO[90usize]));
-        timers.push(registry.register_timer(&INFO[94usize]));
-        timers.push(registry.register_timer(&INFO[98usize]));
+        timers.push(registry.register_timer(&INFO[57usize]));
+        timers.push(registry.register_timer(&INFO[66usize]));
+        timers.push(registry.register_timer(&INFO[72usize]));
+        timers.push(registry.register_timer(&INFO[77usize]));
+        timers.push(registry.register_timer(&INFO[92usize]));
+        timers.push(registry.register_timer(&INFO[101usize]));
+        timers.push(registry.register_timer(&INFO[107usize]));
+        timers.push(registry.register_timer(&INFO[112usize]));
+        timers.push(registry.register_timer(&INFO[117usize]));
         {
             #[allow(unused_imports)]
             use api::*;
@@ -1635,54 +1819,55 @@ impl<R: Registry> Subscriber<R> {
                 16usize => (&INFO[42usize], entry),
                 17usize => (&INFO[45usize], entry),
                 18usize => (&INFO[47usize], entry),
-                19usize => (&INFO[50usize], entry),
-                20usize => (&INFO[53usize], entry),
-                21usize => (&INFO[56usize], entry),
-                22usize => (&INFO[59usize], entry),
-                23usize => (&INFO[63usize], entry),
-                24usize => (&INFO[67usize], entry),
-                25usize => (&INFO[71usize], entry),
-                26usize => (&INFO[73usize], entry),
-                27usize => (&INFO[75usize], entry),
-                28usize => (&INFO[77usize], entry),
-                29usize => (&INFO[79usize], entry),
-                30usize => (&INFO[82usize], entry),
-                31usize => (&INFO[85usize], entry),
-                32usize => (&INFO[89usize], entry),
-                33usize => (&INFO[93usize], entry),
-                34usize => (&INFO[97usize], entry),
-                35usize => (&INFO[100usize], entry),
-                36usize => (&INFO[102usize], entry),
-                37usize => (&INFO[104usize], entry),
-                38usize => (&INFO[106usize], entry),
-                39usize => (&INFO[108usize], entry),
-                40usize => (&INFO[113usize], entry),
-                41usize => (&INFO[115usize], entry),
-                42usize => (&INFO[119usize], entry),
-                43usize => (&INFO[121usize], entry),
-                44usize => (&INFO[123usize], entry),
-                45usize => (&INFO[125usize], entry),
-                46usize => (&INFO[127usize], entry),
-                47usize => (&INFO[129usize], entry),
-                48usize => (&INFO[131usize], entry),
-                49usize => (&INFO[133usize], entry),
-                50usize => (&INFO[135usize], entry),
-                51usize => (&INFO[137usize], entry),
-                52usize => (&INFO[140usize], entry),
-                53usize => (&INFO[141usize], entry),
-                54usize => (&INFO[143usize], entry),
-                55usize => (&INFO[145usize], entry),
-                56usize => (&INFO[147usize], entry),
-                57usize => (&INFO[149usize], entry),
-                58usize => (&INFO[151usize], entry),
-                59usize => (&INFO[153usize], entry),
-                60usize => (&INFO[155usize], entry),
-                61usize => (&INFO[157usize], entry),
-                62usize => (&INFO[159usize], entry),
-                63usize => (&INFO[161usize], entry),
-                64usize => (&INFO[163usize], entry),
-                65usize => (&INFO[166usize], entry),
-                66usize => (&INFO[168usize], entry),
+                19usize => (&INFO[51usize], entry),
+                20usize => (&INFO[56usize], entry),
+                21usize => (&INFO[60usize], entry),
+                22usize => (&INFO[65usize], entry),
+                23usize => (&INFO[71usize], entry),
+                24usize => (&INFO[76usize], entry),
+                25usize => (&INFO[80usize], entry),
+                26usize => (&INFO[83usize], entry),
+                27usize => (&INFO[86usize], entry),
+                28usize => (&INFO[89usize], entry),
+                29usize => (&INFO[91usize], entry),
+                30usize => (&INFO[95usize], entry),
+                31usize => (&INFO[100usize], entry),
+                32usize => (&INFO[106usize], entry),
+                33usize => (&INFO[111usize], entry),
+                34usize => (&INFO[116usize], entry),
+                35usize => (&INFO[119usize], entry),
+                36usize => (&INFO[122usize], entry),
+                37usize => (&INFO[125usize], entry),
+                38usize => (&INFO[128usize], entry),
+                39usize => (&INFO[130usize], entry),
+                40usize => (&INFO[131usize], entry),
+                41usize => (&INFO[136usize], entry),
+                42usize => (&INFO[138usize], entry),
+                43usize => (&INFO[142usize], entry),
+                44usize => (&INFO[144usize], entry),
+                45usize => (&INFO[146usize], entry),
+                46usize => (&INFO[148usize], entry),
+                47usize => (&INFO[150usize], entry),
+                48usize => (&INFO[152usize], entry),
+                49usize => (&INFO[154usize], entry),
+                50usize => (&INFO[156usize], entry),
+                51usize => (&INFO[158usize], entry),
+                52usize => (&INFO[160usize], entry),
+                53usize => (&INFO[163usize], entry),
+                54usize => (&INFO[164usize], entry),
+                55usize => (&INFO[166usize], entry),
+                56usize => (&INFO[168usize], entry),
+                57usize => (&INFO[170usize], entry),
+                58usize => (&INFO[172usize], entry),
+                59usize => (&INFO[174usize], entry),
+                60usize => (&INFO[176usize], entry),
+                61usize => (&INFO[178usize], entry),
+                62usize => (&INFO[180usize], entry),
+                63usize => (&INFO[182usize], entry),
+                64usize => (&INFO[184usize], entry),
+                65usize => (&INFO[186usize], entry),
+                66usize => (&INFO[189usize], entry),
+                67usize => (&INFO[191usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -1706,12 +1891,12 @@ impl<R: Registry> Subscriber<R> {
                 3usize => (&INFO[35usize], entry),
                 4usize => (&INFO[36usize], entry),
                 5usize => (&INFO[37usize], entry),
-                6usize => (&INFO[70usize], entry),
-                7usize => (&INFO[99usize], entry),
-                8usize => (&INFO[111usize], entry),
-                9usize => (&INFO[112usize], entry),
-                10usize => (&INFO[165usize], entry),
-                11usize => (&INFO[167usize], entry),
+                6usize => (&INFO[79usize], entry),
+                7usize => (&INFO[118usize], entry),
+                8usize => (&INFO[134usize], entry),
+                9usize => (&INFO[135usize], entry),
+                10usize => (&INFO[188usize], entry),
+                11usize => (&INFO[190usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -1760,133 +1945,133 @@ impl<R: Registry> Subscriber<R> {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[109usize], entries, variants)
+                    (&INFO[132usize], entries, variants)
                 }
                 5usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[110usize], entries, variants)
+                    (&INFO[133usize], entries, variants)
                 }
                 6usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[120usize], entries, variants)
+                    (&INFO[143usize], entries, variants)
                 }
                 7usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[122usize], entries, variants)
+                    (&INFO[145usize], entries, variants)
                 }
                 8usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[124usize], entries, variants)
+                    (&INFO[147usize], entries, variants)
                 }
                 9usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[126usize], entries, variants)
+                    (&INFO[149usize], entries, variants)
                 }
                 10usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[128usize], entries, variants)
+                    (&INFO[151usize], entries, variants)
                 }
                 11usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[130usize], entries, variants)
+                    (&INFO[153usize], entries, variants)
                 }
                 12usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[132usize], entries, variants)
+                    (&INFO[155usize], entries, variants)
                 }
                 13usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[134usize], entries, variants)
+                    (&INFO[157usize], entries, variants)
                 }
                 14usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[136usize], entries, variants)
+                    (&INFO[159usize], entries, variants)
                 }
                 15usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[144usize], entries, variants)
+                    (&INFO[167usize], entries, variants)
                 }
                 16usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[146usize], entries, variants)
+                    (&INFO[169usize], entries, variants)
                 }
                 17usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[148usize], entries, variants)
+                    (&INFO[171usize], entries, variants)
                 }
                 18usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[150usize], entries, variants)
+                    (&INFO[173usize], entries, variants)
                 }
                 19usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[152usize], entries, variants)
+                    (&INFO[175usize], entries, variants)
                 }
                 20usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[154usize], entries, variants)
+                    (&INFO[177usize], entries, variants)
                 }
                 21usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[156usize], entries, variants)
+                    (&INFO[179usize], entries, variants)
                 }
                 22usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[158usize], entries, variants)
+                    (&INFO[181usize], entries, variants)
                 }
                 23usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[160usize], entries, variants)
+                    (&INFO[183usize], entries, variants)
                 }
                 24usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[162usize], entries, variants)
+                    (&INFO[185usize], entries, variants)
                 }
                 25usize => {
                     let offset = *entry;
                     let variants = <SocketAddress as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[164usize], entries, variants)
+                    (&INFO[187usize], entries, variants)
                 }
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
@@ -1919,50 +2104,72 @@ impl<R: Registry> Subscriber<R> {
                 10usize => (&INFO[31usize], entry),
                 11usize => (&INFO[33usize], entry),
                 12usize => (&INFO[49usize], entry),
-                13usize => (&INFO[51usize], entry),
+                13usize => (&INFO[50usize], entry),
                 14usize => (&INFO[52usize], entry),
-                15usize => (&INFO[55usize], entry),
-                16usize => (&INFO[57usize], entry),
-                17usize => (&INFO[58usize], entry),
-                18usize => (&INFO[61usize], entry),
-                19usize => (&INFO[62usize], entry),
-                20usize => (&INFO[65usize], entry),
-                21usize => (&INFO[66usize], entry),
-                22usize => (&INFO[69usize], entry),
-                23usize => (&INFO[72usize], entry),
-                24usize => (&INFO[74usize], entry),
-                25usize => (&INFO[76usize], entry),
-                26usize => (&INFO[78usize], entry),
-                27usize => (&INFO[81usize], entry),
-                28usize => (&INFO[83usize], entry),
-                29usize => (&INFO[84usize], entry),
-                30usize => (&INFO[87usize], entry),
-                31usize => (&INFO[88usize], entry),
-                32usize => (&INFO[91usize], entry),
-                33usize => (&INFO[92usize], entry),
-                34usize => (&INFO[95usize], entry),
-                35usize => (&INFO[96usize], entry),
-                36usize => (&INFO[101usize], entry),
-                37usize => (&INFO[103usize], entry),
-                38usize => (&INFO[105usize], entry),
-                39usize => (&INFO[107usize], entry),
-                40usize => (&INFO[114usize], entry),
-                41usize => (&INFO[116usize], entry),
-                42usize => (&INFO[117usize], entry),
-                43usize => (&INFO[118usize], entry),
-                44usize => (&INFO[138usize], entry),
-                45usize => (&INFO[139usize], entry),
-                46usize => (&INFO[142usize], entry),
-                47usize => (&INFO[169usize], entry),
-                48usize => (&INFO[170usize], entry),
-                49usize => (&INFO[171usize], entry),
-                50usize => (&INFO[172usize], entry),
-                51usize => (&INFO[173usize], entry),
-                52usize => (&INFO[174usize], entry),
-                53usize => (&INFO[175usize], entry),
-                54usize => (&INFO[176usize], entry),
-                55usize => (&INFO[177usize], entry),
-                56usize => (&INFO[178usize], entry),
+                15usize => (&INFO[53usize], entry),
+                16usize => (&INFO[54usize], entry),
+                17usize => (&INFO[55usize], entry),
+                18usize => (&INFO[58usize], entry),
+                19usize => (&INFO[59usize], entry),
+                20usize => (&INFO[61usize], entry),
+                21usize => (&INFO[62usize], entry),
+                22usize => (&INFO[63usize], entry),
+                23usize => (&INFO[64usize], entry),
+                24usize => (&INFO[67usize], entry),
+                25usize => (&INFO[68usize], entry),
+                26usize => (&INFO[69usize], entry),
+                27usize => (&INFO[70usize], entry),
+                28usize => (&INFO[73usize], entry),
+                29usize => (&INFO[74usize], entry),
+                30usize => (&INFO[75usize], entry),
+                31usize => (&INFO[78usize], entry),
+                32usize => (&INFO[81usize], entry),
+                33usize => (&INFO[82usize], entry),
+                34usize => (&INFO[84usize], entry),
+                35usize => (&INFO[85usize], entry),
+                36usize => (&INFO[87usize], entry),
+                37usize => (&INFO[88usize], entry),
+                38usize => (&INFO[90usize], entry),
+                39usize => (&INFO[93usize], entry),
+                40usize => (&INFO[94usize], entry),
+                41usize => (&INFO[96usize], entry),
+                42usize => (&INFO[97usize], entry),
+                43usize => (&INFO[98usize], entry),
+                44usize => (&INFO[99usize], entry),
+                45usize => (&INFO[102usize], entry),
+                46usize => (&INFO[103usize], entry),
+                47usize => (&INFO[104usize], entry),
+                48usize => (&INFO[105usize], entry),
+                49usize => (&INFO[108usize], entry),
+                50usize => (&INFO[109usize], entry),
+                51usize => (&INFO[110usize], entry),
+                52usize => (&INFO[113usize], entry),
+                53usize => (&INFO[114usize], entry),
+                54usize => (&INFO[115usize], entry),
+                55usize => (&INFO[120usize], entry),
+                56usize => (&INFO[121usize], entry),
+                57usize => (&INFO[123usize], entry),
+                58usize => (&INFO[124usize], entry),
+                59usize => (&INFO[126usize], entry),
+                60usize => (&INFO[127usize], entry),
+                61usize => (&INFO[129usize], entry),
+                62usize => (&INFO[137usize], entry),
+                63usize => (&INFO[139usize], entry),
+                64usize => (&INFO[140usize], entry),
+                65usize => (&INFO[141usize], entry),
+                66usize => (&INFO[161usize], entry),
+                67usize => (&INFO[162usize], entry),
+                68usize => (&INFO[165usize], entry),
+                69usize => (&INFO[192usize], entry),
+                70usize => (&INFO[193usize], entry),
+                71usize => (&INFO[194usize], entry),
+                72usize => (&INFO[195usize], entry),
+                73usize => (&INFO[196usize], entry),
+                74usize => (&INFO[197usize], entry),
+                75usize => (&INFO[198usize], entry),
+                76usize => (&INFO[199usize], entry),
+                77usize => (&INFO[200usize], entry),
+                78usize => (&INFO[201usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -2000,15 +2207,15 @@ impl<R: Registry> Subscriber<R> {
                 5usize => (&INFO[43usize], entry),
                 6usize => (&INFO[46usize], entry),
                 7usize => (&INFO[48usize], entry),
-                8usize => (&INFO[54usize], entry),
-                9usize => (&INFO[60usize], entry),
-                10usize => (&INFO[64usize], entry),
-                11usize => (&INFO[68usize], entry),
-                12usize => (&INFO[80usize], entry),
-                13usize => (&INFO[86usize], entry),
-                14usize => (&INFO[90usize], entry),
-                15usize => (&INFO[94usize], entry),
-                16usize => (&INFO[98usize], entry),
+                8usize => (&INFO[57usize], entry),
+                9usize => (&INFO[66usize], entry),
+                10usize => (&INFO[72usize], entry),
+                11usize => (&INFO[77usize], entry),
+                12usize => (&INFO[92usize], entry),
+                13usize => (&INFO[101usize], entry),
+                14usize => (&INFO[107usize], entry),
+                15usize => (&INFO[112usize], entry),
+                16usize => (&INFO[117usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -2043,6 +2250,28 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) -> Self::ConnectionContext {
         Self::ConnectionContext {
             start_time: meta.timestamp,
+            ctr_12: AtomicU64::new(0),
+            ctr_15: AtomicU64::new(0),
+            ctr_17: AtomicU64::new(0),
+            ctr_18: AtomicU64::new(0),
+            ctr_21: AtomicU64::new(0),
+            ctr_23: AtomicU64::new(0),
+            ctr_24: AtomicU64::new(0),
+            ctr_27: AtomicU64::new(0),
+            ctr_30: AtomicU64::new(0),
+            ctr_32: AtomicU64::new(0),
+            ctr_35: AtomicU64::new(0),
+            ctr_36: AtomicU64::new(0),
+            ctr_39: AtomicU64::new(0),
+            ctr_42: AtomicU64::new(0),
+            ctr_44: AtomicU64::new(0),
+            ctr_45: AtomicU64::new(0),
+            ctr_48: AtomicU64::new(0),
+            ctr_51: AtomicU64::new(0),
+            ctr_54: AtomicU64::new(0),
+            ctr_55: AtomicU64::new(0),
+            ctr_58: AtomicU64::new(0),
+            ctr_59: AtomicU64::new(0),
         }
     }
     #[inline]
@@ -2289,10 +2518,17 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
             7usize,
             meta.timestamp.saturating_duration_since(context.start_time),
         );
-        self.measure(49usize, 12usize, event.provided_len);
-        self.count(50usize, 19usize, event.committed_len);
-        self.measure(51usize, 13usize, event.committed_len);
-        self.measure(52usize, 14usize, event.processing_duration);
+        context.ctr_12.fetch_add(1, Ordering::Relaxed);
+        self.measure(50usize, 13usize, event.provided_len);
+        self.count(51usize, 19usize, event.committed_len);
+        self.measure(52usize, 14usize, event.committed_len);
+        context
+            .ctr_15
+            .fetch_add(event.committed_len.as_u64(), Ordering::Relaxed);
+        self.measure(54usize, 16usize, event.processing_duration);
+        context
+            .ctr_17
+            .fetch_add(event.processing_duration.as_u64(), Ordering::Relaxed);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2306,16 +2542,23 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(53usize, 20usize, 1usize);
+        self.count(56usize, 20usize, 1usize);
         self.time(
-            54usize,
+            57usize,
             8usize,
             meta.timestamp.saturating_duration_since(context.start_time),
         );
-        self.measure(55usize, 15usize, event.provided_len);
-        self.count(56usize, 21usize, event.committed_len);
-        self.measure(57usize, 16usize, event.committed_len);
-        self.measure(58usize, 17usize, event.processing_duration);
+        context.ctr_18.fetch_add(1, Ordering::Relaxed);
+        self.measure(59usize, 19usize, event.provided_len);
+        self.count(60usize, 21usize, event.committed_len);
+        self.measure(61usize, 20usize, event.committed_len);
+        context
+            .ctr_21
+            .fetch_add(event.committed_len.as_u64(), Ordering::Relaxed);
+        self.measure(63usize, 22usize, event.processing_duration);
+        context
+            .ctr_23
+            .fetch_add(event.processing_duration.as_u64(), Ordering::Relaxed);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2329,14 +2572,18 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(59usize, 22usize, 1usize);
+        self.count(65usize, 22usize, 1usize);
         self.time(
-            60usize,
+            66usize,
             9usize,
             meta.timestamp.saturating_duration_since(context.start_time),
         );
-        self.measure(61usize, 18usize, event.provided_len);
-        self.measure(62usize, 19usize, event.processing_duration);
+        context.ctr_24.fetch_add(1, Ordering::Relaxed);
+        self.measure(68usize, 25usize, event.provided_len);
+        self.measure(69usize, 26usize, event.processing_duration);
+        context
+            .ctr_27
+            .fetch_add(event.processing_duration.as_u64(), Ordering::Relaxed);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2350,14 +2597,17 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(63usize, 23usize, 1usize);
+        self.count(71usize, 23usize, 1usize);
         self.time(
-            64usize,
+            72usize,
             10usize,
             meta.timestamp.saturating_duration_since(context.start_time),
         );
-        self.measure(65usize, 20usize, event.provided_len);
-        self.measure(66usize, 21usize, event.processing_duration);
+        self.measure(73usize, 28usize, event.provided_len);
+        self.measure(74usize, 29usize, event.processing_duration);
+        context
+            .ctr_30
+            .fetch_add(event.processing_duration.as_u64(), Ordering::Relaxed);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2371,14 +2621,14 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(67usize, 24usize, 1usize);
+        self.count(76usize, 24usize, 1usize);
         self.time(
-            68usize,
+            77usize,
             11usize,
             meta.timestamp.saturating_duration_since(context.start_time),
         );
-        self.measure(69usize, 22usize, event.buffer_len);
-        self.count_bool(70usize, 6usize, event.background);
+        self.measure(78usize, 31usize, event.buffer_len);
+        self.count_bool(79usize, 6usize, event.background);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2392,10 +2642,14 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(71usize, 25usize, 1usize);
-        self.measure(72usize, 23usize, event.provided_len);
-        self.count(73usize, 26usize, event.committed_len);
-        self.measure(74usize, 24usize, event.committed_len);
+        self.count(80usize, 25usize, 1usize);
+        context.ctr_32.fetch_add(1, Ordering::Relaxed);
+        self.measure(82usize, 33usize, event.provided_len);
+        self.count(83usize, 26usize, event.committed_len);
+        self.measure(84usize, 34usize, event.committed_len);
+        context
+            .ctr_35
+            .fetch_add(event.committed_len.as_u64(), Ordering::Relaxed);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2409,8 +2663,9 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(75usize, 27usize, 1usize);
-        self.measure(76usize, 25usize, event.provided_len);
+        self.count(86usize, 27usize, 1usize);
+        context.ctr_36.fetch_add(1, Ordering::Relaxed);
+        self.measure(88usize, 37usize, event.provided_len);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2424,8 +2679,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(77usize, 28usize, 1usize);
-        self.measure(78usize, 26usize, event.provided_len);
+        self.count(89usize, 28usize, 1usize);
+        self.measure(90usize, 38usize, event.provided_len);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2439,16 +2694,23 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(79usize, 29usize, 1usize);
+        self.count(91usize, 29usize, 1usize);
         self.time(
-            80usize,
+            92usize,
             12usize,
             meta.timestamp.saturating_duration_since(context.start_time),
         );
-        self.measure(81usize, 27usize, event.capacity);
-        self.count(82usize, 30usize, event.committed_len);
-        self.measure(83usize, 28usize, event.committed_len);
-        self.measure(84usize, 29usize, event.processing_duration);
+        context.ctr_39.fetch_add(1, Ordering::Relaxed);
+        self.measure(94usize, 40usize, event.capacity);
+        self.count(95usize, 30usize, event.committed_len);
+        self.measure(96usize, 41usize, event.committed_len);
+        context
+            .ctr_42
+            .fetch_add(event.committed_len.as_u64(), Ordering::Relaxed);
+        self.measure(98usize, 43usize, event.processing_duration);
+        context
+            .ctr_44
+            .fetch_add(event.processing_duration.as_u64(), Ordering::Relaxed);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2462,14 +2724,18 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(85usize, 31usize, 1usize);
+        self.count(100usize, 31usize, 1usize);
         self.time(
-            86usize,
+            101usize,
             13usize,
             meta.timestamp.saturating_duration_since(context.start_time),
         );
-        self.measure(87usize, 30usize, event.capacity);
-        self.measure(88usize, 31usize, event.processing_duration);
+        context.ctr_45.fetch_add(1, Ordering::Relaxed);
+        self.measure(103usize, 46usize, event.capacity);
+        self.measure(104usize, 47usize, event.processing_duration);
+        context
+            .ctr_48
+            .fetch_add(event.processing_duration.as_u64(), Ordering::Relaxed);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2483,14 +2749,17 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(89usize, 32usize, 1usize);
+        self.count(106usize, 32usize, 1usize);
         self.time(
-            90usize,
+            107usize,
             14usize,
             meta.timestamp.saturating_duration_since(context.start_time),
         );
-        self.measure(91usize, 32usize, event.capacity);
-        self.measure(92usize, 33usize, event.processing_duration);
+        self.measure(108usize, 49usize, event.capacity);
+        self.measure(109usize, 50usize, event.processing_duration);
+        context
+            .ctr_51
+            .fetch_add(event.processing_duration.as_u64(), Ordering::Relaxed);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2504,14 +2773,17 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(93usize, 33usize, 1usize);
+        self.count(111usize, 33usize, 1usize);
         self.time(
-            94usize,
+            112usize,
             15usize,
             meta.timestamp.saturating_duration_since(context.start_time),
         );
-        self.measure(95usize, 34usize, event.capacity);
-        self.measure(96usize, 35usize, event.processing_duration);
+        self.measure(113usize, 52usize, event.capacity);
+        self.measure(114usize, 53usize, event.processing_duration);
+        context
+            .ctr_54
+            .fetch_add(event.processing_duration.as_u64(), Ordering::Relaxed);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2525,13 +2797,13 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(97usize, 34usize, 1usize);
+        self.count(116usize, 34usize, 1usize);
         self.time(
-            98usize,
+            117usize,
             16usize,
             meta.timestamp.saturating_duration_since(context.start_time),
         );
-        self.count_bool(99usize, 7usize, event.background);
+        self.count_bool(118usize, 7usize, event.background);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2545,10 +2817,14 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(100usize, 35usize, 1usize);
-        self.measure(101usize, 36usize, event.capacity);
-        self.count(102usize, 36usize, event.committed_len);
-        self.measure(103usize, 37usize, event.committed_len);
+        self.count(119usize, 35usize, 1usize);
+        context.ctr_55.fetch_add(1, Ordering::Relaxed);
+        self.measure(121usize, 56usize, event.capacity);
+        self.count(122usize, 36usize, event.committed_len);
+        self.measure(123usize, 57usize, event.committed_len);
+        context
+            .ctr_58
+            .fetch_add(event.committed_len.as_u64(), Ordering::Relaxed);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2562,8 +2838,9 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(104usize, 37usize, 1usize);
-        self.measure(105usize, 38usize, event.capacity);
+        self.count(125usize, 37usize, 1usize);
+        context.ctr_59.fetch_add(1, Ordering::Relaxed);
+        self.measure(127usize, 60usize, event.capacity);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2577,8 +2854,76 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(106usize, 38usize, 1usize);
-        self.measure(107usize, 39usize, event.capacity);
+        self.count(128usize, 38usize, 1usize);
+        self.measure(129usize, 61usize, event.capacity);
+        let _ = context;
+        let _ = meta;
+        let _ = event;
+    }
+    #[inline]
+    fn on_connection_closed(
+        &self,
+        context: &Self::ConnectionContext,
+        meta: &api::ConnectionMeta,
+        event: &api::ConnectionClosed,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(130usize, 39usize, 1usize);
+        self.measure(49usize, 12usize, context.ctr_12.load(Ordering::Relaxed));
+        self.measure(53usize, 15usize, context.ctr_15.load(Ordering::Relaxed));
+        self.measure(
+            55usize,
+            17usize,
+            core::time::Duration::from_micros(context.ctr_17.load(Ordering::Relaxed)),
+        );
+        self.measure(58usize, 18usize, context.ctr_18.load(Ordering::Relaxed));
+        self.measure(62usize, 21usize, context.ctr_21.load(Ordering::Relaxed));
+        self.measure(
+            64usize,
+            23usize,
+            core::time::Duration::from_micros(context.ctr_23.load(Ordering::Relaxed)),
+        );
+        self.measure(67usize, 24usize, context.ctr_24.load(Ordering::Relaxed));
+        self.measure(
+            70usize,
+            27usize,
+            core::time::Duration::from_micros(context.ctr_27.load(Ordering::Relaxed)),
+        );
+        self.measure(
+            75usize,
+            30usize,
+            core::time::Duration::from_micros(context.ctr_30.load(Ordering::Relaxed)),
+        );
+        self.measure(81usize, 32usize, context.ctr_32.load(Ordering::Relaxed));
+        self.measure(85usize, 35usize, context.ctr_35.load(Ordering::Relaxed));
+        self.measure(87usize, 36usize, context.ctr_36.load(Ordering::Relaxed));
+        self.measure(93usize, 39usize, context.ctr_39.load(Ordering::Relaxed));
+        self.measure(97usize, 42usize, context.ctr_42.load(Ordering::Relaxed));
+        self.measure(
+            99usize,
+            44usize,
+            core::time::Duration::from_micros(context.ctr_44.load(Ordering::Relaxed)),
+        );
+        self.measure(102usize, 45usize, context.ctr_45.load(Ordering::Relaxed));
+        self.measure(
+            105usize,
+            48usize,
+            core::time::Duration::from_micros(context.ctr_48.load(Ordering::Relaxed)),
+        );
+        self.measure(
+            110usize,
+            51usize,
+            core::time::Duration::from_micros(context.ctr_51.load(Ordering::Relaxed)),
+        );
+        self.measure(
+            115usize,
+            54usize,
+            core::time::Duration::from_micros(context.ctr_54.load(Ordering::Relaxed)),
+        );
+        self.measure(120usize, 55usize, context.ctr_55.load(Ordering::Relaxed));
+        self.measure(124usize, 58usize, context.ctr_58.load(Ordering::Relaxed));
+        self.measure(126usize, 59usize, context.ctr_59.load(Ordering::Relaxed));
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2587,11 +2932,11 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     fn on_endpoint_initialized(&self, meta: &api::EndpointMeta, event: &api::EndpointInitialized) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(108usize, 39usize, 1usize);
-        self.count_nominal(109usize, 4usize, &event.acceptor_addr);
-        self.count_nominal(110usize, 5usize, &event.handshake_addr);
-        self.count_bool(111usize, 8usize, event.tcp);
-        self.count_bool(112usize, 9usize, event.udp);
+        self.count(131usize, 40usize, 1usize);
+        self.count_nominal(132usize, 4usize, &event.acceptor_addr);
+        self.count_nominal(133usize, 5usize, &event.handshake_addr);
+        self.count_bool(134usize, 8usize, event.tcp);
+        self.count_bool(135usize, 9usize, event.udp);
         let _ = event;
         let _ = meta;
     }
@@ -2603,8 +2948,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(113usize, 40usize, 1usize);
-        self.measure(114usize, 40usize, event.capacity);
+        self.count(136usize, 41usize, 1usize);
+        self.measure(137usize, 62usize, event.capacity);
         let _ = event;
         let _ = meta;
     }
@@ -2616,10 +2961,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(115usize, 41usize, 1usize);
-        self.measure(116usize, 41usize, event.capacity);
-        self.measure(117usize, 42usize, event.entries);
-        self.measure(118usize, 43usize, event.lifetime);
+        self.count(138usize, 42usize, 1usize);
+        self.measure(139usize, 63usize, event.capacity);
+        self.measure(140usize, 64usize, event.entries);
+        self.measure(141usize, 65usize, event.lifetime);
         let _ = event;
         let _ = meta;
     }
@@ -2631,8 +2976,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(119usize, 42usize, 1usize);
-        self.count_nominal(120usize, 6usize, &event.peer_address);
+        self.count(142usize, 43usize, 1usize);
+        self.count_nominal(143usize, 6usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2644,8 +2989,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(121usize, 43usize, 1usize);
-        self.count_nominal(122usize, 7usize, &event.peer_address);
+        self.count(144usize, 44usize, 1usize);
+        self.count_nominal(145usize, 7usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2657,8 +3002,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(123usize, 44usize, 1usize);
-        self.count_nominal(124usize, 8usize, &event.peer_address);
+        self.count(146usize, 45usize, 1usize);
+        self.count_nominal(147usize, 8usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2670,8 +3015,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(125usize, 45usize, 1usize);
-        self.count_nominal(126usize, 9usize, &event.peer_address);
+        self.count(148usize, 46usize, 1usize);
+        self.count_nominal(149usize, 9usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2683,8 +3028,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(127usize, 46usize, 1usize);
-        self.count_nominal(128usize, 10usize, &event.peer_address);
+        self.count(150usize, 47usize, 1usize);
+        self.count_nominal(151usize, 10usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2696,8 +3041,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(129usize, 47usize, 1usize);
-        self.count_nominal(130usize, 11usize, &event.peer_address);
+        self.count(152usize, 48usize, 1usize);
+        self.count_nominal(153usize, 11usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2709,8 +3054,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(131usize, 48usize, 1usize);
-        self.count_nominal(132usize, 12usize, &event.peer_address);
+        self.count(154usize, 49usize, 1usize);
+        self.count_nominal(155usize, 12usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2722,8 +3067,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(133usize, 49usize, 1usize);
-        self.count_nominal(134usize, 13usize, &event.peer_address);
+        self.count(156usize, 50usize, 1usize);
+        self.count_nominal(157usize, 13usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2735,8 +3080,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(135usize, 50usize, 1usize);
-        self.count_nominal(136usize, 14usize, &event.peer_address);
+        self.count(158usize, 51usize, 1usize);
+        self.count_nominal(159usize, 14usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2744,9 +3089,9 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     fn on_key_accepted(&self, meta: &api::EndpointMeta, event: &api::KeyAccepted) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(137usize, 51usize, 1usize);
-        self.measure(138usize, 44usize, event.gap);
-        self.measure(139usize, 45usize, event.forward_shift);
+        self.count(160usize, 52usize, 1usize);
+        self.measure(161usize, 66usize, event.gap);
+        self.measure(162usize, 67usize, event.forward_shift);
         let _ = event;
         let _ = meta;
     }
@@ -2758,7 +3103,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(140usize, 52usize, 1usize);
+        self.count(163usize, 53usize, 1usize);
         let _ = event;
         let _ = meta;
     }
@@ -2770,8 +3115,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(141usize, 53usize, 1usize);
-        self.measure(142usize, 46usize, event.gap);
+        self.count(164usize, 54usize, 1usize);
+        self.measure(165usize, 68usize, event.gap);
         let _ = event;
         let _ = meta;
     }
@@ -2783,8 +3128,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(143usize, 54usize, 1usize);
-        self.count_nominal(144usize, 15usize, &event.peer_address);
+        self.count(166usize, 55usize, 1usize);
+        self.count_nominal(167usize, 15usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2796,8 +3141,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(145usize, 55usize, 1usize);
-        self.count_nominal(146usize, 16usize, &event.peer_address);
+        self.count(168usize, 56usize, 1usize);
+        self.count_nominal(169usize, 16usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2809,8 +3154,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(147usize, 56usize, 1usize);
-        self.count_nominal(148usize, 17usize, &event.peer_address);
+        self.count(170usize, 57usize, 1usize);
+        self.count_nominal(171usize, 17usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2822,8 +3167,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(149usize, 57usize, 1usize);
-        self.count_nominal(150usize, 18usize, &event.peer_address);
+        self.count(172usize, 58usize, 1usize);
+        self.count_nominal(173usize, 18usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2835,8 +3180,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(151usize, 58usize, 1usize);
-        self.count_nominal(152usize, 19usize, &event.peer_address);
+        self.count(174usize, 59usize, 1usize);
+        self.count_nominal(175usize, 19usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2844,8 +3189,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     fn on_stale_key_packet_sent(&self, meta: &api::EndpointMeta, event: &api::StaleKeyPacketSent) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(153usize, 59usize, 1usize);
-        self.count_nominal(154usize, 20usize, &event.peer_address);
+        self.count(176usize, 60usize, 1usize);
+        self.count_nominal(177usize, 20usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2857,8 +3202,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(155usize, 60usize, 1usize);
-        self.count_nominal(156usize, 21usize, &event.peer_address);
+        self.count(178usize, 61usize, 1usize);
+        self.count_nominal(179usize, 21usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2870,8 +3215,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(157usize, 61usize, 1usize);
-        self.count_nominal(158usize, 22usize, &event.peer_address);
+        self.count(180usize, 62usize, 1usize);
+        self.count_nominal(181usize, 22usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2883,8 +3228,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(159usize, 62usize, 1usize);
-        self.count_nominal(160usize, 23usize, &event.peer_address);
+        self.count(182usize, 63usize, 1usize);
+        self.count_nominal(183usize, 23usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2896,8 +3241,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(161usize, 63usize, 1usize);
-        self.count_nominal(162usize, 24usize, &event.peer_address);
+        self.count(184usize, 64usize, 1usize);
+        self.count_nominal(185usize, 24usize, &event.peer_address);
         let _ = event;
         let _ = meta;
     }
@@ -2909,9 +3254,9 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(163usize, 64usize, 1usize);
-        self.count_nominal(164usize, 25usize, &event.peer_address);
-        self.count_bool(165usize, 10usize, event.hit);
+        self.count(186usize, 65usize, 1usize);
+        self.count_nominal(187usize, 25usize, &event.peer_address);
+        self.count_bool(188usize, 10usize, event.hit);
         let _ = event;
         let _ = meta;
     }
@@ -2923,8 +3268,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(166usize, 65usize, 1usize);
-        self.count_bool(167usize, 11usize, event.hit);
+        self.count(189usize, 66usize, 1usize);
+        self.count_bool(190usize, 11usize, event.hit);
         let _ = event;
         let _ = meta;
     }
@@ -2936,17 +3281,17 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(168usize, 66usize, 1usize);
-        self.measure(169usize, 47usize, event.id_entries);
-        self.measure(170usize, 48usize, event.id_entries_retired);
-        self.measure(171usize, 49usize, event.id_entries_utilization);
-        self.measure(172usize, 50usize, event.id_entries_initial_utilization);
-        self.measure(173usize, 51usize, event.address_entries);
-        self.measure(174usize, 52usize, event.address_entries_retired);
-        self.measure(175usize, 53usize, event.address_entries_utilization);
-        self.measure(176usize, 54usize, event.address_entries_initial_utilization);
-        self.measure(177usize, 55usize, event.handshake_requests);
-        self.measure(178usize, 56usize, event.handshake_requests_retired);
+        self.count(191usize, 67usize, 1usize);
+        self.measure(192usize, 69usize, event.id_entries);
+        self.measure(193usize, 70usize, event.id_entries_retired);
+        self.measure(194usize, 71usize, event.id_entries_utilization);
+        self.measure(195usize, 72usize, event.id_entries_initial_utilization);
+        self.measure(196usize, 73usize, event.address_entries);
+        self.measure(197usize, 74usize, event.address_entries_retired);
+        self.measure(198usize, 75usize, event.address_entries_utilization);
+        self.measure(199usize, 76usize, event.address_entries_initial_utilization);
+        self.measure(200usize, 77usize, event.handshake_requests);
+        self.measure(201usize, 78usize, event.handshake_requests_retired);
         let _ = event;
         let _ = meta;
     }

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -36,54 +36,55 @@ mod counter {
                 42usize => Self(acceptor_stream_pruned),
                 45usize => Self(acceptor_stream_dequeued),
                 47usize => Self(stream_write_flushed),
-                50usize => Self(stream_write_flushed__committed__total),
-                53usize => Self(stream_write_fin_flushed),
-                56usize => Self(stream_write_fin_flushed__committed__total),
-                59usize => Self(stream_write_blocked),
-                63usize => Self(stream_write_errored),
-                67usize => Self(stream_write_shutdown),
-                71usize => Self(stream_write_socket_flushed),
-                73usize => Self(stream_write_socket_flushed__committed__total),
-                75usize => Self(stream_write_socket_blocked),
-                77usize => Self(stream_write_socket_errored),
-                79usize => Self(stream_read_flushed),
-                82usize => Self(stream_read_flushed__committed__total),
-                85usize => Self(stream_read_fin_flushed),
-                89usize => Self(stream_read_blocked),
-                93usize => Self(stream_read_errored),
-                97usize => Self(stream_read_shutdown),
-                100usize => Self(stream_read_socket_flushed),
-                102usize => Self(stream_read_socket_flushed__committed__total),
-                104usize => Self(stream_read_socket_blocked),
-                106usize => Self(stream_read_socket_errored),
-                108usize => Self(endpoint_initialized),
-                113usize => Self(path_secret_map_initialized),
-                115usize => Self(path_secret_map_uninitialized),
-                119usize => Self(path_secret_map_background_handshake_requested),
-                121usize => Self(path_secret_map_entry_inserted),
-                123usize => Self(path_secret_map_entry_ready),
-                125usize => Self(path_secret_map_entry_replaced),
-                127usize => Self(unknown_path_secret_packet_sent),
-                129usize => Self(unknown_path_secret_packet_received),
-                131usize => Self(unknown_path_secret_packet_accepted),
-                133usize => Self(unknown_path_secret_packet_rejected),
-                135usize => Self(unknown_path_secret_packet_dropped),
-                137usize => Self(key_accepted),
-                140usize => Self(replay_definitely_detected),
-                141usize => Self(replay_potentially_detected),
-                143usize => Self(replay_detected_packet_sent),
-                145usize => Self(replay_detected_packet_received),
-                147usize => Self(replay_detected_packet_accepted),
-                149usize => Self(replay_detected_packet_rejected),
-                151usize => Self(replay_detected_packet_dropped),
-                153usize => Self(stale_key_packet_sent),
-                155usize => Self(stale_key_packet_received),
-                157usize => Self(stale_key_packet_accepted),
-                159usize => Self(stale_key_packet_rejected),
-                161usize => Self(stale_key_packet_dropped),
-                163usize => Self(path_secret_map_address_cache_accessed),
-                166usize => Self(path_secret_map_id_cache_accessed),
-                168usize => Self(path_secret_map_cleaner_cycled),
+                51usize => Self(stream_write_flushed__committed__total),
+                56usize => Self(stream_write_fin_flushed),
+                60usize => Self(stream_write_fin_flushed__committed__total),
+                65usize => Self(stream_write_blocked),
+                71usize => Self(stream_write_errored),
+                76usize => Self(stream_write_shutdown),
+                80usize => Self(stream_write_socket_flushed),
+                83usize => Self(stream_write_socket_flushed__committed__total),
+                86usize => Self(stream_write_socket_blocked),
+                89usize => Self(stream_write_socket_errored),
+                91usize => Self(stream_read_flushed),
+                95usize => Self(stream_read_flushed__committed__total),
+                100usize => Self(stream_read_fin_flushed),
+                106usize => Self(stream_read_blocked),
+                111usize => Self(stream_read_errored),
+                116usize => Self(stream_read_shutdown),
+                119usize => Self(stream_read_socket_flushed),
+                122usize => Self(stream_read_socket_flushed__committed__total),
+                125usize => Self(stream_read_socket_blocked),
+                128usize => Self(stream_read_socket_errored),
+                130usize => Self(connection_closed),
+                131usize => Self(endpoint_initialized),
+                136usize => Self(path_secret_map_initialized),
+                138usize => Self(path_secret_map_uninitialized),
+                142usize => Self(path_secret_map_background_handshake_requested),
+                144usize => Self(path_secret_map_entry_inserted),
+                146usize => Self(path_secret_map_entry_ready),
+                148usize => Self(path_secret_map_entry_replaced),
+                150usize => Self(unknown_path_secret_packet_sent),
+                152usize => Self(unknown_path_secret_packet_received),
+                154usize => Self(unknown_path_secret_packet_accepted),
+                156usize => Self(unknown_path_secret_packet_rejected),
+                158usize => Self(unknown_path_secret_packet_dropped),
+                160usize => Self(key_accepted),
+                163usize => Self(replay_definitely_detected),
+                164usize => Self(replay_potentially_detected),
+                166usize => Self(replay_detected_packet_sent),
+                168usize => Self(replay_detected_packet_received),
+                170usize => Self(replay_detected_packet_accepted),
+                172usize => Self(replay_detected_packet_rejected),
+                174usize => Self(replay_detected_packet_dropped),
+                176usize => Self(stale_key_packet_sent),
+                178usize => Self(stale_key_packet_received),
+                180usize => Self(stale_key_packet_accepted),
+                182usize => Self(stale_key_packet_rejected),
+                184usize => Self(stale_key_packet_dropped),
+                186usize => Self(path_secret_map_address_cache_accessed),
+                189usize => Self(path_secret_map_id_cache_accessed),
+                191usize => Self(path_secret_map_cleaner_cycled),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }
@@ -173,6 +174,8 @@ mod counter {
             fn stream_read_socket_blocked(value: u64);
             # [link_name = s2n_quic_dc__event__counter__stream_read_socket_errored]
             fn stream_read_socket_errored(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__connection_closed]
+            fn connection_closed(value: u64);
             # [link_name = s2n_quic_dc__event__counter__endpoint_initialized]
             fn endpoint_initialized(value: u64);
             # [link_name = s2n_quic_dc__event__counter__path_secret_map_initialized]
@@ -244,12 +247,12 @@ mod counter {
                     35usize => Self(acceptor_udp_packet_received__is_retransmisson),
                     36usize => Self(acceptor_udp_packet_received__is_fin),
                     37usize => Self(acceptor_udp_packet_received__is_fin_known),
-                    70usize => Self(stream_write_shutdown__background),
-                    99usize => Self(stream_read_shutdown__background),
-                    111usize => Self(endpoint_initialized__tcp),
-                    112usize => Self(endpoint_initialized__udp),
-                    165usize => Self(path_secret_map_address_cache_accessed__hit),
-                    167usize => Self(path_secret_map_id_cache_accessed__hit),
+                    79usize => Self(stream_write_shutdown__background),
+                    118usize => Self(stream_read_shutdown__background),
+                    134usize => Self(endpoint_initialized__tcp),
+                    135usize => Self(endpoint_initialized__udp),
+                    188usize => Self(path_secret_map_address_cache_accessed__hit),
+                    190usize => Self(path_secret_map_id_cache_accessed__hit),
                     _ => unreachable!("invalid info: {info:?}"),
                 }
             }
@@ -300,30 +303,30 @@ mod counter {
                     23usize => Self(acceptor_tcp_packet_dropped__reason),
                     39usize => Self(acceptor_udp_packet_dropped__reason),
                     44usize => Self(acceptor_stream_pruned__reason),
-                    109usize => Self(endpoint_initialized__acceptor__protocol),
-                    110usize => Self(endpoint_initialized__handshake__protocol),
-                    120usize => {
+                    132usize => Self(endpoint_initialized__acceptor__protocol),
+                    133usize => Self(endpoint_initialized__handshake__protocol),
+                    143usize => {
                         Self(path_secret_map_background_handshake_requested__peer_address__protocol)
                     }
-                    122usize => Self(path_secret_map_entry_inserted__peer_address__protocol),
-                    124usize => Self(path_secret_map_entry_ready__peer_address__protocol),
-                    126usize => Self(path_secret_map_entry_replaced__peer_address__protocol),
-                    128usize => Self(unknown_path_secret_packet_sent__peer_address__protocol),
-                    130usize => Self(unknown_path_secret_packet_received__peer_address__protocol),
-                    132usize => Self(unknown_path_secret_packet_accepted__peer_address__protocol),
-                    134usize => Self(unknown_path_secret_packet_rejected__peer_address__protocol),
-                    136usize => Self(unknown_path_secret_packet_dropped__peer_address__protocol),
-                    144usize => Self(replay_detected_packet_sent__peer_address__protocol),
-                    146usize => Self(replay_detected_packet_received__peer_address__protocol),
-                    148usize => Self(replay_detected_packet_accepted__peer_address__protocol),
-                    150usize => Self(replay_detected_packet_rejected__peer_address__protocol),
-                    152usize => Self(replay_detected_packet_dropped__peer_address__protocol),
-                    154usize => Self(stale_key_packet_sent__peer_address__protocol),
-                    156usize => Self(stale_key_packet_received__peer_address__protocol),
-                    158usize => Self(stale_key_packet_accepted__peer_address__protocol),
-                    160usize => Self(stale_key_packet_rejected__peer_address__protocol),
-                    162usize => Self(stale_key_packet_dropped__peer_address__protocol),
-                    164usize => {
+                    145usize => Self(path_secret_map_entry_inserted__peer_address__protocol),
+                    147usize => Self(path_secret_map_entry_ready__peer_address__protocol),
+                    149usize => Self(path_secret_map_entry_replaced__peer_address__protocol),
+                    151usize => Self(unknown_path_secret_packet_sent__peer_address__protocol),
+                    153usize => Self(unknown_path_secret_packet_received__peer_address__protocol),
+                    155usize => Self(unknown_path_secret_packet_accepted__peer_address__protocol),
+                    157usize => Self(unknown_path_secret_packet_rejected__peer_address__protocol),
+                    159usize => Self(unknown_path_secret_packet_dropped__peer_address__protocol),
+                    167usize => Self(replay_detected_packet_sent__peer_address__protocol),
+                    169usize => Self(replay_detected_packet_received__peer_address__protocol),
+                    171usize => Self(replay_detected_packet_accepted__peer_address__protocol),
+                    173usize => Self(replay_detected_packet_rejected__peer_address__protocol),
+                    175usize => Self(replay_detected_packet_dropped__peer_address__protocol),
+                    177usize => Self(stale_key_packet_sent__peer_address__protocol),
+                    179usize => Self(stale_key_packet_received__peer_address__protocol),
+                    181usize => Self(stale_key_packet_accepted__peer_address__protocol),
+                    183usize => Self(stale_key_packet_rejected__peer_address__protocol),
+                    185usize => Self(stale_key_packet_dropped__peer_address__protocol),
+                    187usize => {
                         Self(path_secret_map_address_cache_accessed__peer_address__protocol)
                     }
                     _ => unreachable!("invalid info: {info:?}"),
@@ -522,53 +525,75 @@ mod measure {
                 27usize => Self(acceptor_tcp_stream_enqueued__blocked_count),
                 31usize => Self(acceptor_udp_datagram_received__len),
                 33usize => Self(acceptor_udp_packet_received__payload_len),
-                49usize => Self(stream_write_flushed__provided),
-                51usize => Self(stream_write_flushed__committed),
-                52usize => Self(stream_write_flushed__processing_duration),
-                55usize => Self(stream_write_fin_flushed__provided),
-                57usize => Self(stream_write_fin_flushed__committed),
-                58usize => Self(stream_write_fin_flushed__processing_duration),
-                61usize => Self(stream_write_blocked__provided),
-                62usize => Self(stream_write_blocked__processing_duration),
-                65usize => Self(stream_write_errored__provided),
-                66usize => Self(stream_write_errored__processing_duration),
-                69usize => Self(stream_write_shutdown__buffer_len),
-                72usize => Self(stream_write_socket_flushed__provided),
-                74usize => Self(stream_write_socket_flushed__committed),
-                76usize => Self(stream_write_socket_blocked__provided),
-                78usize => Self(stream_write_socket_errored__provided),
-                81usize => Self(stream_read_flushed__capacity),
-                83usize => Self(stream_read_flushed__committed),
-                84usize => Self(stream_read_flushed__processing_duration),
-                87usize => Self(stream_read_fin_flushed__capacity),
-                88usize => Self(stream_read_fin_flushed__processing_duration),
-                91usize => Self(stream_read_blocked__capacity),
-                92usize => Self(stream_read_blocked__processing_duration),
-                95usize => Self(stream_read_errored__capacity),
-                96usize => Self(stream_read_errored__processing_duration),
-                101usize => Self(stream_read_socket_flushed__capacity),
-                103usize => Self(stream_read_socket_flushed__committed),
-                105usize => Self(stream_read_socket_blocked__capacity),
-                107usize => Self(stream_read_socket_errored__capacity),
-                114usize => Self(path_secret_map_initialized__capacity),
-                116usize => Self(path_secret_map_uninitialized__capacity),
-                117usize => Self(path_secret_map_uninitialized__entries),
-                118usize => Self(path_secret_map_uninitialized__lifetime),
-                138usize => Self(key_accepted__gap),
-                139usize => Self(key_accepted__forward_shift),
-                142usize => Self(replay_potentially_detected__gap),
-                169usize => Self(path_secret_map_cleaner_cycled__entries__id),
-                170usize => Self(path_secret_map_cleaner_cycled__entries__id__retired),
-                171usize => Self(path_secret_map_cleaner_cycled__entries__id__utilization),
-                172usize => Self(path_secret_map_cleaner_cycled__entries__id__utilization__initial),
-                173usize => Self(path_secret_map_cleaner_cycled__entries__address),
-                174usize => Self(path_secret_map_cleaner_cycled__entries__address__retired),
-                175usize => Self(path_secret_map_cleaner_cycled__entries__address__utilization),
-                176usize => {
+                49usize => Self(stream_write_flushed__conn),
+                50usize => Self(stream_write_flushed__provided),
+                52usize => Self(stream_write_flushed__committed),
+                53usize => Self(stream_write_flushed__committed__conn),
+                54usize => Self(stream_write_flushed__processing_duration),
+                55usize => Self(stream_write_flushed__processing_duration__conn),
+                58usize => Self(stream_write_fin_flushed__conn),
+                59usize => Self(stream_write_fin_flushed__provided),
+                61usize => Self(stream_write_fin_flushed__committed),
+                62usize => Self(stream_write_fin_flushed__committed__conn),
+                63usize => Self(stream_write_fin_flushed__processing_duration),
+                64usize => Self(stream_write_fin_flushed__processing_duration__conn),
+                67usize => Self(stream_write_blocked__conn__stream__write__blocked),
+                68usize => Self(stream_write_blocked__provided),
+                69usize => Self(stream_write_blocked__processing_duration),
+                70usize => Self(stream_write_blocked__processing_duration__conn),
+                73usize => Self(stream_write_errored__provided),
+                74usize => Self(stream_write_errored__processing_duration),
+                75usize => Self(stream_write_errored__processing_duration__conn),
+                78usize => Self(stream_write_shutdown__buffer_len),
+                81usize => Self(stream_write_socket_flushed__conn),
+                82usize => Self(stream_write_socket_flushed__provided),
+                84usize => Self(stream_write_socket_flushed__committed),
+                85usize => Self(stream_write_socket_flushed__committed__conn),
+                87usize => Self(stream_write_socket_blocked__conn__stream__write__socket__blocked),
+                88usize => Self(stream_write_socket_blocked__provided),
+                90usize => Self(stream_write_socket_errored__provided),
+                93usize => Self(stream_read_flushed__conn),
+                94usize => Self(stream_read_flushed__capacity),
+                96usize => Self(stream_read_flushed__committed),
+                97usize => Self(stream_read_flushed__committed__conn),
+                98usize => Self(stream_read_flushed__processing_duration),
+                99usize => Self(stream_read_flushed__processing_duration__conn),
+                102usize => Self(stream_read_fin_flushed__conn),
+                103usize => Self(stream_read_fin_flushed__capacity),
+                104usize => Self(stream_read_fin_flushed__processing_duration),
+                105usize => Self(stream_read_fin_flushed__processing_duration__conn),
+                108usize => Self(stream_read_blocked__capacity),
+                109usize => Self(stream_read_blocked__processing_duration),
+                110usize => Self(stream_read_blocked__processing_duration__conn),
+                113usize => Self(stream_read_errored__capacity),
+                114usize => Self(stream_read_errored__processing_duration),
+                115usize => Self(stream_read_errored__processing_duration__conn),
+                120usize => Self(stream_read_socket_flushed__conn),
+                121usize => Self(stream_read_socket_flushed__capacity),
+                123usize => Self(stream_read_socket_flushed__committed),
+                124usize => Self(stream_read_socket_flushed__committed__conn),
+                126usize => Self(stream_read_socket_blocked__conn),
+                127usize => Self(stream_read_socket_blocked__capacity),
+                129usize => Self(stream_read_socket_errored__capacity),
+                137usize => Self(path_secret_map_initialized__capacity),
+                139usize => Self(path_secret_map_uninitialized__capacity),
+                140usize => Self(path_secret_map_uninitialized__entries),
+                141usize => Self(path_secret_map_uninitialized__lifetime),
+                161usize => Self(key_accepted__gap),
+                162usize => Self(key_accepted__forward_shift),
+                165usize => Self(replay_potentially_detected__gap),
+                192usize => Self(path_secret_map_cleaner_cycled__entries__id),
+                193usize => Self(path_secret_map_cleaner_cycled__entries__id__retired),
+                194usize => Self(path_secret_map_cleaner_cycled__entries__id__utilization),
+                195usize => Self(path_secret_map_cleaner_cycled__entries__id__utilization__initial),
+                196usize => Self(path_secret_map_cleaner_cycled__entries__address),
+                197usize => Self(path_secret_map_cleaner_cycled__entries__address__retired),
+                198usize => Self(path_secret_map_cleaner_cycled__entries__address__utilization),
+                199usize => {
                     Self(path_secret_map_cleaner_cycled__entries__address__utilization__initial)
                 }
-                177usize => Self(path_secret_map_cleaner_cycled__handshake_requests),
-                178usize => Self(path_secret_map_cleaner_cycled__handshake_requests__retired),
+                200usize => Self(path_secret_map_cleaner_cycled__handshake_requests),
+                201usize => Self(path_secret_map_cleaner_cycled__handshake_requests__retired),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }
@@ -604,58 +629,102 @@ mod measure {
             fn acceptor_udp_datagram_received__len(value: u64);
             # [link_name = s2n_quic_dc__event__measure__acceptor_udp_packet_received__payload_len]
             fn acceptor_udp_packet_received__payload_len(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_write_flushed__conn]
+            fn stream_write_flushed__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_flushed__provided]
             fn stream_write_flushed__provided(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_flushed__committed]
             fn stream_write_flushed__committed(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_write_flushed__committed__conn]
+            fn stream_write_flushed__committed__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_flushed__processing_duration]
             fn stream_write_flushed__processing_duration(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_write_flushed__processing_duration__conn]
+            fn stream_write_flushed__processing_duration__conn(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_write_fin_flushed__conn]
+            fn stream_write_fin_flushed__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_fin_flushed__provided]
             fn stream_write_fin_flushed__provided(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_fin_flushed__committed]
             fn stream_write_fin_flushed__committed(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_write_fin_flushed__committed__conn]
+            fn stream_write_fin_flushed__committed__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_fin_flushed__processing_duration]
             fn stream_write_fin_flushed__processing_duration(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_write_fin_flushed__processing_duration__conn]
+            fn stream_write_fin_flushed__processing_duration__conn(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_write_blocked__conn__stream__write__blocked]
+            fn stream_write_blocked__conn__stream__write__blocked(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_blocked__provided]
             fn stream_write_blocked__provided(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_blocked__processing_duration]
             fn stream_write_blocked__processing_duration(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_write_blocked__processing_duration__conn]
+            fn stream_write_blocked__processing_duration__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_errored__provided]
             fn stream_write_errored__provided(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_errored__processing_duration]
             fn stream_write_errored__processing_duration(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_write_errored__processing_duration__conn]
+            fn stream_write_errored__processing_duration__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_shutdown__buffer_len]
             fn stream_write_shutdown__buffer_len(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_write_socket_flushed__conn]
+            fn stream_write_socket_flushed__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_socket_flushed__provided]
             fn stream_write_socket_flushed__provided(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_socket_flushed__committed]
             fn stream_write_socket_flushed__committed(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_write_socket_flushed__committed__conn]
+            fn stream_write_socket_flushed__committed__conn(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_write_socket_blocked__conn__stream__write__socket__blocked]
+            fn stream_write_socket_blocked__conn__stream__write__socket__blocked(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_socket_blocked__provided]
             fn stream_write_socket_blocked__provided(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_socket_errored__provided]
             fn stream_write_socket_errored__provided(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_read_flushed__conn]
+            fn stream_read_flushed__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_read_flushed__capacity]
             fn stream_read_flushed__capacity(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_read_flushed__committed]
             fn stream_read_flushed__committed(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_read_flushed__committed__conn]
+            fn stream_read_flushed__committed__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_read_flushed__processing_duration]
             fn stream_read_flushed__processing_duration(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_read_flushed__processing_duration__conn]
+            fn stream_read_flushed__processing_duration__conn(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_read_fin_flushed__conn]
+            fn stream_read_fin_flushed__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_read_fin_flushed__capacity]
             fn stream_read_fin_flushed__capacity(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_read_fin_flushed__processing_duration]
             fn stream_read_fin_flushed__processing_duration(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_read_fin_flushed__processing_duration__conn]
+            fn stream_read_fin_flushed__processing_duration__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_read_blocked__capacity]
             fn stream_read_blocked__capacity(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_read_blocked__processing_duration]
             fn stream_read_blocked__processing_duration(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_read_blocked__processing_duration__conn]
+            fn stream_read_blocked__processing_duration__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_read_errored__capacity]
             fn stream_read_errored__capacity(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_read_errored__processing_duration]
             fn stream_read_errored__processing_duration(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_read_errored__processing_duration__conn]
+            fn stream_read_errored__processing_duration__conn(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_read_socket_flushed__conn]
+            fn stream_read_socket_flushed__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_read_socket_flushed__capacity]
             fn stream_read_socket_flushed__capacity(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_read_socket_flushed__committed]
             fn stream_read_socket_flushed__committed(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_read_socket_flushed__committed__conn]
+            fn stream_read_socket_flushed__committed__conn(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_read_socket_blocked__conn]
+            fn stream_read_socket_blocked__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_read_socket_blocked__capacity]
             fn stream_read_socket_blocked__capacity(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_read_socket_errored__capacity]
@@ -729,15 +798,15 @@ mod timer {
                 43usize => Self(acceptor_stream_pruned__sojourn_time),
                 46usize => Self(acceptor_stream_dequeued__sojourn_time),
                 48usize => Self(stream_write_flushed__latency),
-                54usize => Self(stream_write_fin_flushed__latency),
-                60usize => Self(stream_write_blocked__latency),
-                64usize => Self(stream_write_errored__latency),
-                68usize => Self(stream_write_shutdown__latency),
-                80usize => Self(stream_read_flushed__latency),
-                86usize => Self(stream_read_fin_flushed__latency),
-                90usize => Self(stream_read_blocked__latency),
-                94usize => Self(stream_read_errored__latency),
-                98usize => Self(stream_read_shutdown__latency),
+                57usize => Self(stream_write_fin_flushed__latency),
+                66usize => Self(stream_write_blocked__latency),
+                72usize => Self(stream_write_errored__latency),
+                77usize => Self(stream_write_shutdown__latency),
+                92usize => Self(stream_read_flushed__latency),
+                101usize => Self(stream_read_fin_flushed__latency),
+                107usize => Self(stream_read_blocked__latency),
+                112usize => Self(stream_read_errored__latency),
+                117usize => Self(stream_read_shutdown__latency),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }

--- a/quic/s2n-quic-core/events/connection.rs
+++ b/quic/s2n-quic-core/events/connection.rs
@@ -213,15 +213,6 @@ struct ConnectionStarted<'a> {
     path: Path<'a>,
 }
 
-#[event("connectivity:connection_closed")]
-//= https://tools.ietf.org/id/draft-marx-qlog-event-definitions-quic-h3-02#5.1.3
-/// Connection closed
-#[checkpoint("latency")]
-struct ConnectionClosed {
-    #[nominal_counter("error")]
-    error: crate::connection::Error,
-}
-
 #[event("transport:duplicate_packet")]
 /// Duplicate packet received
 struct DuplicatePacket<'a> {
@@ -418,4 +409,14 @@ struct BbrStateChanged {
 struct DcStateChanged {
     #[nominal_counter("state")]
     state: DcState,
+}
+
+// NOTE - This event MUST come last, since connection-level aggregation depends on it
+#[event("connectivity:connection_closed")]
+//= https://tools.ietf.org/id/draft-marx-qlog-event-definitions-quic-h3-02#5.1.3
+/// Connection closed
+#[checkpoint("latency")]
+struct ConnectionClosed {
+    #[nominal_counter("error")]
+    error: crate::connection::Error,
 }

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -2167,23 +2167,6 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Connection closed"]
-    pub struct ConnectionClosed {
-        pub error: crate::connection::Error,
-    }
-    #[cfg(any(test, feature = "testing"))]
-    impl crate::event::snapshot::Fmt for ConnectionClosed {
-        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
-            let mut fmt = fmt.debug_struct("ConnectionClosed");
-            fmt.field("error", &self.error);
-            fmt.finish()
-        }
-    }
-    impl Event for ConnectionClosed {
-        const NAME: &'static str = "connectivity:connection_closed";
-    }
-    #[derive(Clone, Debug)]
-    #[non_exhaustive]
     #[doc = " Duplicate packet received"]
     pub struct DuplicatePacket<'a> {
         pub packet_header: PacketHeader,
@@ -2597,6 +2580,23 @@ pub mod api {
     }
     impl Event for DcStateChanged {
         const NAME: &'static str = "transport:dc_state_changed";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    #[doc = " Connection closed"]
+    pub struct ConnectionClosed {
+        pub error: crate::connection::Error,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl crate::event::snapshot::Fmt for ConnectionClosed {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("ConnectionClosed");
+            fmt.field("error", &self.error);
+            fmt.finish()
+        }
+    }
+    impl Event for ConnectionClosed {
+        const NAME: &'static str = "connectivity:connection_closed";
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
@@ -3495,7 +3495,7 @@ pub mod tracing {
             let api::ApplicationProtocolInformation {
                 chosen_application_protocol,
             } = event;
-            tracing :: event ! (target : "application_protocol_information" , parent : id , tracing :: Level :: DEBUG , chosen_application_protocol = tracing :: field :: debug (chosen_application_protocol));
+            tracing :: event ! (target : "application_protocol_information" , parent : id , tracing :: Level :: DEBUG , { chosen_application_protocol = tracing :: field :: debug (chosen_application_protocol) });
         }
         #[inline]
         fn on_server_name_information(
@@ -3506,7 +3506,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::ServerNameInformation { chosen_server_name } = event;
-            tracing :: event ! (target : "server_name_information" , parent : id , tracing :: Level :: DEBUG , chosen_server_name = tracing :: field :: debug (chosen_server_name));
+            tracing :: event ! (target : "server_name_information" , parent : id , tracing :: Level :: DEBUG , { chosen_server_name = tracing :: field :: debug (chosen_server_name) });
         }
         #[inline]
         fn on_packet_skipped(
@@ -3521,7 +3521,7 @@ pub mod tracing {
                 space,
                 reason,
             } = event;
-            tracing :: event ! (target : "packet_skipped" , parent : id , tracing :: Level :: DEBUG , number = tracing :: field :: debug (number) , space = tracing :: field :: debug (space) , reason = tracing :: field :: debug (reason));
+            tracing :: event ! (target : "packet_skipped" , parent : id , tracing :: Level :: DEBUG , { number = tracing :: field :: debug (number) , space = tracing :: field :: debug (space) , reason = tracing :: field :: debug (reason) });
         }
         #[inline]
         fn on_packet_sent(
@@ -3535,7 +3535,7 @@ pub mod tracing {
                 packet_header,
                 packet_len,
             } = event;
-            tracing :: event ! (target : "packet_sent" , parent : id , tracing :: Level :: DEBUG , packet_header = tracing :: field :: debug (packet_header) , packet_len = tracing :: field :: debug (packet_len));
+            tracing :: event ! (target : "packet_sent" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , packet_len = tracing :: field :: debug (packet_len) });
         }
         #[inline]
         fn on_packet_received(
@@ -3546,7 +3546,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::PacketReceived { packet_header } = event;
-            tracing :: event ! (target : "packet_received" , parent : id , tracing :: Level :: DEBUG , packet_header = tracing :: field :: debug (packet_header));
+            tracing :: event ! (target : "packet_received" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) });
         }
         #[inline]
         fn on_active_path_updated(
@@ -3557,7 +3557,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::ActivePathUpdated { previous, active } = event;
-            tracing :: event ! (target : "active_path_updated" , parent : id , tracing :: Level :: DEBUG , previous = tracing :: field :: debug (previous) , active = tracing :: field :: debug (active));
+            tracing :: event ! (target : "active_path_updated" , parent : id , tracing :: Level :: DEBUG , { previous = tracing :: field :: debug (previous) , active = tracing :: field :: debug (active) });
         }
         #[inline]
         fn on_path_created(
@@ -3568,7 +3568,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::PathCreated { active, new } = event;
-            tracing :: event ! (target : "path_created" , parent : id , tracing :: Level :: DEBUG , active = tracing :: field :: debug (active) , new = tracing :: field :: debug (new));
+            tracing :: event ! (target : "path_created" , parent : id , tracing :: Level :: DEBUG , { active = tracing :: field :: debug (active) , new = tracing :: field :: debug (new) });
         }
         #[inline]
         fn on_frame_sent(
@@ -3583,7 +3583,7 @@ pub mod tracing {
                 path_id,
                 frame,
             } = event;
-            tracing :: event ! (target : "frame_sent" , parent : id , tracing :: Level :: DEBUG , packet_header = tracing :: field :: debug (packet_header) , path_id = tracing :: field :: debug (path_id) , frame = tracing :: field :: debug (frame));
+            tracing :: event ! (target : "frame_sent" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , path_id = tracing :: field :: debug (path_id) , frame = tracing :: field :: debug (frame) });
         }
         #[inline]
         fn on_frame_received(
@@ -3598,7 +3598,7 @@ pub mod tracing {
                 path,
                 frame,
             } = event;
-            tracing :: event ! (target : "frame_received" , parent : id , tracing :: Level :: DEBUG , packet_header = tracing :: field :: debug (packet_header) , path = tracing :: field :: debug (path) , frame = tracing :: field :: debug (frame));
+            tracing :: event ! (target : "frame_received" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , path = tracing :: field :: debug (path) , frame = tracing :: field :: debug (frame) });
         }
         #[inline]
         fn on_packet_lost(
@@ -3614,7 +3614,7 @@ pub mod tracing {
                 bytes_lost,
                 is_mtu_probe,
             } = event;
-            tracing :: event ! (target : "packet_lost" , parent : id , tracing :: Level :: DEBUG , packet_header = tracing :: field :: debug (packet_header) , path = tracing :: field :: debug (path) , bytes_lost = tracing :: field :: debug (bytes_lost) , is_mtu_probe = tracing :: field :: debug (is_mtu_probe));
+            tracing :: event ! (target : "packet_lost" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , path = tracing :: field :: debug (path) , bytes_lost = tracing :: field :: debug (bytes_lost) , is_mtu_probe = tracing :: field :: debug (is_mtu_probe) });
         }
         #[inline]
         fn on_recovery_metrics(
@@ -3636,7 +3636,7 @@ pub mod tracing {
                 bytes_in_flight,
                 congestion_limited,
             } = event;
-            tracing :: event ! (target : "recovery_metrics" , parent : id , tracing :: Level :: DEBUG , path = tracing :: field :: debug (path) , min_rtt = tracing :: field :: debug (min_rtt) , smoothed_rtt = tracing :: field :: debug (smoothed_rtt) , latest_rtt = tracing :: field :: debug (latest_rtt) , rtt_variance = tracing :: field :: debug (rtt_variance) , max_ack_delay = tracing :: field :: debug (max_ack_delay) , pto_count = tracing :: field :: debug (pto_count) , congestion_window = tracing :: field :: debug (congestion_window) , bytes_in_flight = tracing :: field :: debug (bytes_in_flight) , congestion_limited = tracing :: field :: debug (congestion_limited));
+            tracing :: event ! (target : "recovery_metrics" , parent : id , tracing :: Level :: DEBUG , { path = tracing :: field :: debug (path) , min_rtt = tracing :: field :: debug (min_rtt) , smoothed_rtt = tracing :: field :: debug (smoothed_rtt) , latest_rtt = tracing :: field :: debug (latest_rtt) , rtt_variance = tracing :: field :: debug (rtt_variance) , max_ack_delay = tracing :: field :: debug (max_ack_delay) , pto_count = tracing :: field :: debug (pto_count) , congestion_window = tracing :: field :: debug (congestion_window) , bytes_in_flight = tracing :: field :: debug (bytes_in_flight) , congestion_limited = tracing :: field :: debug (congestion_limited) });
         }
         #[inline]
         fn on_congestion(
@@ -3647,7 +3647,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::Congestion { path, source } = event;
-            tracing :: event ! (target : "congestion" , parent : id , tracing :: Level :: DEBUG , path = tracing :: field :: debug (path) , source = tracing :: field :: debug (source));
+            tracing :: event ! (target : "congestion" , parent : id , tracing :: Level :: DEBUG , { path = tracing :: field :: debug (path) , source = tracing :: field :: debug (source) });
         }
         #[inline]
         #[allow(deprecated)]
@@ -3659,7 +3659,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::AckProcessed { action, path } = event;
-            tracing :: event ! (target : "ack_processed" , parent : id , tracing :: Level :: DEBUG , action = tracing :: field :: debug (action) , path = tracing :: field :: debug (path));
+            tracing :: event ! (target : "ack_processed" , parent : id , tracing :: Level :: DEBUG , { action = tracing :: field :: debug (action) , path = tracing :: field :: debug (path) });
         }
         #[inline]
         fn on_rx_ack_range_dropped(
@@ -3675,7 +3675,7 @@ pub mod tracing {
                 capacity,
                 stored_range,
             } = event;
-            tracing :: event ! (target : "rx_ack_range_dropped" , parent : id , tracing :: Level :: DEBUG , path = tracing :: field :: debug (path) , packet_number_range = tracing :: field :: debug (packet_number_range) , capacity = tracing :: field :: debug (capacity) , stored_range = tracing :: field :: debug (stored_range));
+            tracing :: event ! (target : "rx_ack_range_dropped" , parent : id , tracing :: Level :: DEBUG , { path = tracing :: field :: debug (path) , packet_number_range = tracing :: field :: debug (packet_number_range) , capacity = tracing :: field :: debug (capacity) , stored_range = tracing :: field :: debug (stored_range) });
         }
         #[inline]
         fn on_ack_range_received(
@@ -3690,7 +3690,7 @@ pub mod tracing {
                 path,
                 ack_range,
             } = event;
-            tracing :: event ! (target : "ack_range_received" , parent : id , tracing :: Level :: DEBUG , packet_header = tracing :: field :: debug (packet_header) , path = tracing :: field :: debug (path) , ack_range = tracing :: field :: debug (ack_range));
+            tracing :: event ! (target : "ack_range_received" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , path = tracing :: field :: debug (path) , ack_range = tracing :: field :: debug (ack_range) });
         }
         #[inline]
         fn on_ack_range_sent(
@@ -3705,7 +3705,7 @@ pub mod tracing {
                 path_id,
                 ack_range,
             } = event;
-            tracing :: event ! (target : "ack_range_sent" , parent : id , tracing :: Level :: DEBUG , packet_header = tracing :: field :: debug (packet_header) , path_id = tracing :: field :: debug (path_id) , ack_range = tracing :: field :: debug (ack_range));
+            tracing :: event ! (target : "ack_range_sent" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , path_id = tracing :: field :: debug (path_id) , ack_range = tracing :: field :: debug (ack_range) });
         }
         #[inline]
         fn on_packet_dropped(
@@ -3716,7 +3716,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::PacketDropped { reason } = event;
-            tracing :: event ! (target : "packet_dropped" , parent : id , tracing :: Level :: DEBUG , reason = tracing :: field :: debug (reason));
+            tracing :: event ! (target : "packet_dropped" , parent : id , tracing :: Level :: DEBUG , { reason = tracing :: field :: debug (reason) });
         }
         #[inline]
         fn on_key_update(
@@ -3730,7 +3730,7 @@ pub mod tracing {
                 key_type,
                 cipher_suite,
             } = event;
-            tracing :: event ! (target : "key_update" , parent : id , tracing :: Level :: DEBUG , key_type = tracing :: field :: debug (key_type) , cipher_suite = tracing :: field :: debug (cipher_suite));
+            tracing :: event ! (target : "key_update" , parent : id , tracing :: Level :: DEBUG , { key_type = tracing :: field :: debug (key_type) , cipher_suite = tracing :: field :: debug (cipher_suite) });
         }
         #[inline]
         fn on_key_space_discarded(
@@ -3741,7 +3741,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::KeySpaceDiscarded { space } = event;
-            tracing :: event ! (target : "key_space_discarded" , parent : id , tracing :: Level :: DEBUG , space = tracing :: field :: debug (space));
+            tracing :: event ! (target : "key_space_discarded" , parent : id , tracing :: Level :: DEBUG , { space = tracing :: field :: debug (space) });
         }
         #[inline]
         fn on_connection_started(
@@ -3752,18 +3752,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::ConnectionStarted { path } = event;
-            tracing :: event ! (target : "connection_started" , parent : id , tracing :: Level :: DEBUG , path = tracing :: field :: debug (path));
-        }
-        #[inline]
-        fn on_connection_closed(
-            &mut self,
-            context: &mut Self::ConnectionContext,
-            _meta: &api::ConnectionMeta,
-            event: &api::ConnectionClosed,
-        ) {
-            let id = context.id();
-            let api::ConnectionClosed { error } = event;
-            tracing :: event ! (target : "connection_closed" , parent : id , tracing :: Level :: DEBUG , error = tracing :: field :: debug (error));
+            tracing :: event ! (target : "connection_started" , parent : id , tracing :: Level :: DEBUG , { path = tracing :: field :: debug (path) });
         }
         #[inline]
         fn on_duplicate_packet(
@@ -3778,7 +3767,7 @@ pub mod tracing {
                 path,
                 error,
             } = event;
-            tracing :: event ! (target : "duplicate_packet" , parent : id , tracing :: Level :: DEBUG , packet_header = tracing :: field :: debug (packet_header) , path = tracing :: field :: debug (path) , error = tracing :: field :: debug (error));
+            tracing :: event ! (target : "duplicate_packet" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , path = tracing :: field :: debug (path) , error = tracing :: field :: debug (error) });
         }
         #[inline]
         fn on_transport_parameters_received(
@@ -3791,7 +3780,7 @@ pub mod tracing {
             let api::TransportParametersReceived {
                 transport_parameters,
             } = event;
-            tracing :: event ! (target : "transport_parameters_received" , parent : id , tracing :: Level :: DEBUG , transport_parameters = tracing :: field :: debug (transport_parameters));
+            tracing :: event ! (target : "transport_parameters_received" , parent : id , tracing :: Level :: DEBUG , { transport_parameters = tracing :: field :: debug (transport_parameters) });
         }
         #[inline]
         fn on_datagram_sent(
@@ -3802,7 +3791,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::DatagramSent { len, gso_offset } = event;
-            tracing :: event ! (target : "datagram_sent" , parent : id , tracing :: Level :: DEBUG , len = tracing :: field :: debug (len) , gso_offset = tracing :: field :: debug (gso_offset));
+            tracing :: event ! (target : "datagram_sent" , parent : id , tracing :: Level :: DEBUG , { len = tracing :: field :: debug (len) , gso_offset = tracing :: field :: debug (gso_offset) });
         }
         #[inline]
         fn on_datagram_received(
@@ -3813,7 +3802,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::DatagramReceived { len } = event;
-            tracing :: event ! (target : "datagram_received" , parent : id , tracing :: Level :: DEBUG , len = tracing :: field :: debug (len));
+            tracing :: event ! (target : "datagram_received" , parent : id , tracing :: Level :: DEBUG , { len = tracing :: field :: debug (len) });
         }
         #[inline]
         fn on_datagram_dropped(
@@ -3824,7 +3813,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::DatagramDropped { len, reason } = event;
-            tracing :: event ! (target : "datagram_dropped" , parent : id , tracing :: Level :: DEBUG , len = tracing :: field :: debug (len) , reason = tracing :: field :: debug (reason));
+            tracing :: event ! (target : "datagram_dropped" , parent : id , tracing :: Level :: DEBUG , { len = tracing :: field :: debug (len) , reason = tracing :: field :: debug (reason) });
         }
         #[inline]
         fn on_connection_id_updated(
@@ -3840,7 +3829,7 @@ pub mod tracing {
                 previous,
                 current,
             } = event;
-            tracing :: event ! (target : "connection_id_updated" , parent : id , tracing :: Level :: DEBUG , path_id = tracing :: field :: debug (path_id) , cid_consumer = tracing :: field :: debug (cid_consumer) , previous = tracing :: field :: debug (previous) , current = tracing :: field :: debug (current));
+            tracing :: event ! (target : "connection_id_updated" , parent : id , tracing :: Level :: DEBUG , { path_id = tracing :: field :: debug (path_id) , cid_consumer = tracing :: field :: debug (cid_consumer) , previous = tracing :: field :: debug (previous) , current = tracing :: field :: debug (current) });
         }
         #[inline]
         fn on_ecn_state_changed(
@@ -3851,7 +3840,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::EcnStateChanged { path, state } = event;
-            tracing :: event ! (target : "ecn_state_changed" , parent : id , tracing :: Level :: DEBUG , path = tracing :: field :: debug (path) , state = tracing :: field :: debug (state));
+            tracing :: event ! (target : "ecn_state_changed" , parent : id , tracing :: Level :: DEBUG , { path = tracing :: field :: debug (path) , state = tracing :: field :: debug (state) });
         }
         #[inline]
         fn on_connection_migration_denied(
@@ -3862,7 +3851,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::ConnectionMigrationDenied { reason } = event;
-            tracing :: event ! (target : "connection_migration_denied" , parent : id , tracing :: Level :: DEBUG , reason = tracing :: field :: debug (reason));
+            tracing :: event ! (target : "connection_migration_denied" , parent : id , tracing :: Level :: DEBUG , { reason = tracing :: field :: debug (reason) });
         }
         #[inline]
         fn on_handshake_status_updated(
@@ -3873,7 +3862,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::HandshakeStatusUpdated { status } = event;
-            tracing :: event ! (target : "handshake_status_updated" , parent : id , tracing :: Level :: DEBUG , status = tracing :: field :: debug (status));
+            tracing :: event ! (target : "handshake_status_updated" , parent : id , tracing :: Level :: DEBUG , { status = tracing :: field :: debug (status) });
         }
         #[inline]
         fn on_tls_exporter_ready(
@@ -3884,7 +3873,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::TlsExporterReady { session } = event;
-            tracing :: event ! (target : "tls_exporter_ready" , parent : id , tracing :: Level :: DEBUG , session = tracing :: field :: debug (session));
+            tracing :: event ! (target : "tls_exporter_ready" , parent : id , tracing :: Level :: DEBUG , { session = tracing :: field :: debug (session) });
         }
         #[inline]
         fn on_path_challenge_updated(
@@ -3899,7 +3888,7 @@ pub mod tracing {
                 path,
                 challenge_data,
             } = event;
-            tracing :: event ! (target : "path_challenge_updated" , parent : id , tracing :: Level :: DEBUG , path_challenge_status = tracing :: field :: debug (path_challenge_status) , path = tracing :: field :: debug (path) , challenge_data = tracing :: field :: debug (challenge_data));
+            tracing :: event ! (target : "path_challenge_updated" , parent : id , tracing :: Level :: DEBUG , { path_challenge_status = tracing :: field :: debug (path_challenge_status) , path = tracing :: field :: debug (path) , challenge_data = tracing :: field :: debug (challenge_data) });
         }
         #[inline]
         fn on_tls_client_hello(
@@ -3910,7 +3899,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::TlsClientHello { payload } = event;
-            tracing :: event ! (target : "tls_client_hello" , parent : id , tracing :: Level :: DEBUG , payload = tracing :: field :: debug (payload));
+            tracing :: event ! (target : "tls_client_hello" , parent : id , tracing :: Level :: DEBUG , { payload = tracing :: field :: debug (payload) });
         }
         #[inline]
         fn on_tls_server_hello(
@@ -3921,7 +3910,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::TlsServerHello { payload } = event;
-            tracing :: event ! (target : "tls_server_hello" , parent : id , tracing :: Level :: DEBUG , payload = tracing :: field :: debug (payload));
+            tracing :: event ! (target : "tls_server_hello" , parent : id , tracing :: Level :: DEBUG , { payload = tracing :: field :: debug (payload) });
         }
         #[inline]
         fn on_rx_stream_progress(
@@ -3932,7 +3921,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::RxStreamProgress { bytes } = event;
-            tracing :: event ! (target : "rx_stream_progress" , parent : id , tracing :: Level :: DEBUG , bytes = tracing :: field :: debug (bytes));
+            tracing :: event ! (target : "rx_stream_progress" , parent : id , tracing :: Level :: DEBUG , { bytes = tracing :: field :: debug (bytes) });
         }
         #[inline]
         fn on_tx_stream_progress(
@@ -3943,7 +3932,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::TxStreamProgress { bytes } = event;
-            tracing :: event ! (target : "tx_stream_progress" , parent : id , tracing :: Level :: DEBUG , bytes = tracing :: field :: debug (bytes));
+            tracing :: event ! (target : "tx_stream_progress" , parent : id , tracing :: Level :: DEBUG , { bytes = tracing :: field :: debug (bytes) });
         }
         #[inline]
         fn on_keep_alive_timer_expired(
@@ -3954,7 +3943,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::KeepAliveTimerExpired { timeout } = event;
-            tracing :: event ! (target : "keep_alive_timer_expired" , parent : id , tracing :: Level :: DEBUG , timeout = tracing :: field :: debug (timeout));
+            tracing :: event ! (target : "keep_alive_timer_expired" , parent : id , tracing :: Level :: DEBUG , { timeout = tracing :: field :: debug (timeout) });
         }
         #[inline]
         fn on_mtu_updated(
@@ -3970,7 +3959,7 @@ pub mod tracing {
                 cause,
                 search_complete,
             } = event;
-            tracing :: event ! (target : "mtu_updated" , parent : id , tracing :: Level :: DEBUG , path_id = tracing :: field :: debug (path_id) , mtu = tracing :: field :: debug (mtu) , cause = tracing :: field :: debug (cause) , search_complete = tracing :: field :: debug (search_complete));
+            tracing :: event ! (target : "mtu_updated" , parent : id , tracing :: Level :: DEBUG , { path_id = tracing :: field :: debug (path_id) , mtu = tracing :: field :: debug (mtu) , cause = tracing :: field :: debug (cause) , search_complete = tracing :: field :: debug (search_complete) });
         }
         #[inline]
         fn on_slow_start_exited(
@@ -3985,7 +3974,7 @@ pub mod tracing {
                 cause,
                 congestion_window,
             } = event;
-            tracing :: event ! (target : "slow_start_exited" , parent : id , tracing :: Level :: DEBUG , path_id = tracing :: field :: debug (path_id) , cause = tracing :: field :: debug (cause) , congestion_window = tracing :: field :: debug (congestion_window));
+            tracing :: event ! (target : "slow_start_exited" , parent : id , tracing :: Level :: DEBUG , { path_id = tracing :: field :: debug (path_id) , cause = tracing :: field :: debug (cause) , congestion_window = tracing :: field :: debug (congestion_window) });
         }
         #[inline]
         fn on_delivery_rate_sampled(
@@ -3999,7 +3988,7 @@ pub mod tracing {
                 path_id,
                 rate_sample,
             } = event;
-            tracing :: event ! (target : "delivery_rate_sampled" , parent : id , tracing :: Level :: DEBUG , path_id = tracing :: field :: debug (path_id) , rate_sample = tracing :: field :: debug (rate_sample));
+            tracing :: event ! (target : "delivery_rate_sampled" , parent : id , tracing :: Level :: DEBUG , { path_id = tracing :: field :: debug (path_id) , rate_sample = tracing :: field :: debug (rate_sample) });
         }
         #[inline]
         fn on_pacing_rate_updated(
@@ -4015,7 +4004,7 @@ pub mod tracing {
                 burst_size,
                 pacing_gain,
             } = event;
-            tracing :: event ! (target : "pacing_rate_updated" , parent : id , tracing :: Level :: DEBUG , path_id = tracing :: field :: debug (path_id) , bytes_per_second = tracing :: field :: debug (bytes_per_second) , burst_size = tracing :: field :: debug (burst_size) , pacing_gain = tracing :: field :: debug (pacing_gain));
+            tracing :: event ! (target : "pacing_rate_updated" , parent : id , tracing :: Level :: DEBUG , { path_id = tracing :: field :: debug (path_id) , bytes_per_second = tracing :: field :: debug (bytes_per_second) , burst_size = tracing :: field :: debug (burst_size) , pacing_gain = tracing :: field :: debug (pacing_gain) });
         }
         #[inline]
         fn on_bbr_state_changed(
@@ -4026,7 +4015,7 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::BbrStateChanged { path_id, state } = event;
-            tracing :: event ! (target : "bbr_state_changed" , parent : id , tracing :: Level :: DEBUG , path_id = tracing :: field :: debug (path_id) , state = tracing :: field :: debug (state));
+            tracing :: event ! (target : "bbr_state_changed" , parent : id , tracing :: Level :: DEBUG , { path_id = tracing :: field :: debug (path_id) , state = tracing :: field :: debug (state) });
         }
         #[inline]
         fn on_dc_state_changed(
@@ -4037,7 +4026,18 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::DcStateChanged { state } = event;
-            tracing :: event ! (target : "dc_state_changed" , parent : id , tracing :: Level :: DEBUG , state = tracing :: field :: debug (state));
+            tracing :: event ! (target : "dc_state_changed" , parent : id , tracing :: Level :: DEBUG , { state = tracing :: field :: debug (state) });
+        }
+        #[inline]
+        fn on_connection_closed(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            _meta: &api::ConnectionMeta,
+            event: &api::ConnectionClosed,
+        ) {
+            let id = context.id();
+            let api::ConnectionClosed { error } = event;
+            tracing :: event ! (target : "connection_closed" , parent : id , tracing :: Level :: DEBUG , { error = tracing :: field :: debug (error) });
         }
         #[inline]
         fn on_version_information(
@@ -4051,7 +4051,7 @@ pub mod tracing {
                 client_versions,
                 chosen_version,
             } = event;
-            tracing :: event ! (target : "version_information" , parent : parent , tracing :: Level :: DEBUG , server_versions = tracing :: field :: debug (server_versions) , client_versions = tracing :: field :: debug (client_versions) , chosen_version = tracing :: field :: debug (chosen_version));
+            tracing :: event ! (target : "version_information" , parent : parent , tracing :: Level :: DEBUG , { server_versions = tracing :: field :: debug (server_versions) , client_versions = tracing :: field :: debug (client_versions) , chosen_version = tracing :: field :: debug (chosen_version) });
         }
         #[inline]
         fn on_endpoint_packet_sent(
@@ -4061,7 +4061,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::EndpointPacketSent { packet_header } = event;
-            tracing :: event ! (target : "endpoint_packet_sent" , parent : parent , tracing :: Level :: DEBUG , packet_header = tracing :: field :: debug (packet_header));
+            tracing :: event ! (target : "endpoint_packet_sent" , parent : parent , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) });
         }
         #[inline]
         fn on_endpoint_packet_received(
@@ -4071,7 +4071,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::EndpointPacketReceived { packet_header } = event;
-            tracing :: event ! (target : "endpoint_packet_received" , parent : parent , tracing :: Level :: DEBUG , packet_header = tracing :: field :: debug (packet_header));
+            tracing :: event ! (target : "endpoint_packet_received" , parent : parent , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) });
         }
         #[inline]
         fn on_endpoint_datagram_sent(
@@ -4081,7 +4081,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::EndpointDatagramSent { len, gso_offset } = event;
-            tracing :: event ! (target : "endpoint_datagram_sent" , parent : parent , tracing :: Level :: DEBUG , len = tracing :: field :: debug (len) , gso_offset = tracing :: field :: debug (gso_offset));
+            tracing :: event ! (target : "endpoint_datagram_sent" , parent : parent , tracing :: Level :: DEBUG , { len = tracing :: field :: debug (len) , gso_offset = tracing :: field :: debug (gso_offset) });
         }
         #[inline]
         fn on_endpoint_datagram_received(
@@ -4091,7 +4091,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::EndpointDatagramReceived { len } = event;
-            tracing :: event ! (target : "endpoint_datagram_received" , parent : parent , tracing :: Level :: DEBUG , len = tracing :: field :: debug (len));
+            tracing :: event ! (target : "endpoint_datagram_received" , parent : parent , tracing :: Level :: DEBUG , { len = tracing :: field :: debug (len) });
         }
         #[inline]
         fn on_endpoint_datagram_dropped(
@@ -4101,7 +4101,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::EndpointDatagramDropped { len, reason } = event;
-            tracing :: event ! (target : "endpoint_datagram_dropped" , parent : parent , tracing :: Level :: DEBUG , len = tracing :: field :: debug (len) , reason = tracing :: field :: debug (reason));
+            tracing :: event ! (target : "endpoint_datagram_dropped" , parent : parent , tracing :: Level :: DEBUG , { len = tracing :: field :: debug (len) , reason = tracing :: field :: debug (reason) });
         }
         #[inline]
         fn on_endpoint_connection_attempt_failed(
@@ -4111,7 +4111,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::EndpointConnectionAttemptFailed { error } = event;
-            tracing :: event ! (target : "endpoint_connection_attempt_failed" , parent : parent , tracing :: Level :: DEBUG , error = tracing :: field :: debug (error));
+            tracing :: event ! (target : "endpoint_connection_attempt_failed" , parent : parent , tracing :: Level :: DEBUG , { error = tracing :: field :: debug (error) });
         }
         #[inline]
         fn on_platform_tx(&mut self, meta: &api::EndpointMeta, event: &api::PlatformTx) {
@@ -4123,13 +4123,13 @@ pub mod tracing {
                 total_errors,
                 dropped_errors,
             } = event;
-            tracing :: event ! (target : "platform_tx" , parent : parent , tracing :: Level :: DEBUG , count = tracing :: field :: debug (count) , syscalls = tracing :: field :: debug (syscalls) , blocked_syscalls = tracing :: field :: debug (blocked_syscalls) , total_errors = tracing :: field :: debug (total_errors) , dropped_errors = tracing :: field :: debug (dropped_errors));
+            tracing :: event ! (target : "platform_tx" , parent : parent , tracing :: Level :: DEBUG , { count = tracing :: field :: debug (count) , syscalls = tracing :: field :: debug (syscalls) , blocked_syscalls = tracing :: field :: debug (blocked_syscalls) , total_errors = tracing :: field :: debug (total_errors) , dropped_errors = tracing :: field :: debug (dropped_errors) });
         }
         #[inline]
         fn on_platform_tx_error(&mut self, meta: &api::EndpointMeta, event: &api::PlatformTxError) {
             let parent = self.parent(meta);
             let api::PlatformTxError { errno } = event;
-            tracing :: event ! (target : "platform_tx_error" , parent : parent , tracing :: Level :: DEBUG , errno = tracing :: field :: debug (errno));
+            tracing :: event ! (target : "platform_tx_error" , parent : parent , tracing :: Level :: DEBUG , { errno = tracing :: field :: debug (errno) });
         }
         #[inline]
         fn on_platform_rx(&mut self, meta: &api::EndpointMeta, event: &api::PlatformRx) {
@@ -4141,13 +4141,13 @@ pub mod tracing {
                 total_errors,
                 dropped_errors,
             } = event;
-            tracing :: event ! (target : "platform_rx" , parent : parent , tracing :: Level :: DEBUG , count = tracing :: field :: debug (count) , syscalls = tracing :: field :: debug (syscalls) , blocked_syscalls = tracing :: field :: debug (blocked_syscalls) , total_errors = tracing :: field :: debug (total_errors) , dropped_errors = tracing :: field :: debug (dropped_errors));
+            tracing :: event ! (target : "platform_rx" , parent : parent , tracing :: Level :: DEBUG , { count = tracing :: field :: debug (count) , syscalls = tracing :: field :: debug (syscalls) , blocked_syscalls = tracing :: field :: debug (blocked_syscalls) , total_errors = tracing :: field :: debug (total_errors) , dropped_errors = tracing :: field :: debug (dropped_errors) });
         }
         #[inline]
         fn on_platform_rx_error(&mut self, meta: &api::EndpointMeta, event: &api::PlatformRxError) {
             let parent = self.parent(meta);
             let api::PlatformRxError { errno } = event;
-            tracing :: event ! (target : "platform_rx_error" , parent : parent , tracing :: Level :: DEBUG , errno = tracing :: field :: debug (errno));
+            tracing :: event ! (target : "platform_rx_error" , parent : parent , tracing :: Level :: DEBUG , { errno = tracing :: field :: debug (errno) });
         }
         #[inline]
         fn on_platform_feature_configured(
@@ -4157,7 +4157,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PlatformFeatureConfigured { configuration } = event;
-            tracing :: event ! (target : "platform_feature_configured" , parent : parent , tracing :: Level :: DEBUG , configuration = tracing :: field :: debug (configuration));
+            tracing :: event ! (target : "platform_feature_configured" , parent : parent , tracing :: Level :: DEBUG , { configuration = tracing :: field :: debug (configuration) });
         }
         #[inline]
         fn on_platform_event_loop_wakeup(
@@ -4172,7 +4172,7 @@ pub mod tracing {
                 tx_ready,
                 application_wakeup,
             } = event;
-            tracing :: event ! (target : "platform_event_loop_wakeup" , parent : parent , tracing :: Level :: DEBUG , timeout_expired = tracing :: field :: debug (timeout_expired) , rx_ready = tracing :: field :: debug (rx_ready) , tx_ready = tracing :: field :: debug (tx_ready) , application_wakeup = tracing :: field :: debug (application_wakeup));
+            tracing :: event ! (target : "platform_event_loop_wakeup" , parent : parent , tracing :: Level :: DEBUG , { timeout_expired = tracing :: field :: debug (timeout_expired) , rx_ready = tracing :: field :: debug (rx_ready) , tx_ready = tracing :: field :: debug (tx_ready) , application_wakeup = tracing :: field :: debug (application_wakeup) });
         }
         #[inline]
         fn on_platform_event_loop_sleep(
@@ -4185,7 +4185,7 @@ pub mod tracing {
                 timeout,
                 processing_duration,
             } = event;
-            tracing :: event ! (target : "platform_event_loop_sleep" , parent : parent , tracing :: Level :: DEBUG , timeout = tracing :: field :: debug (timeout) , processing_duration = tracing :: field :: debug (processing_duration));
+            tracing :: event ! (target : "platform_event_loop_sleep" , parent : parent , tracing :: Level :: DEBUG , { timeout = tracing :: field :: debug (timeout) , processing_duration = tracing :: field :: debug (processing_duration) });
         }
         #[inline]
         fn on_platform_event_loop_started(
@@ -4195,7 +4195,7 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PlatformEventLoopStarted { local_address } = event;
-            tracing :: event ! (target : "platform_event_loop_started" , parent : parent , tracing :: Level :: DEBUG , local_address = tracing :: field :: debug (local_address));
+            tracing :: event ! (target : "platform_event_loop_started" , parent : parent , tracing :: Level :: DEBUG , { local_address = tracing :: field :: debug (local_address) });
         }
     }
 }
@@ -5720,20 +5720,6 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Connection closed"]
-    pub struct ConnectionClosed {
-        pub error: crate::connection::Error,
-    }
-    impl IntoEvent<api::ConnectionClosed> for ConnectionClosed {
-        #[inline]
-        fn into_event(self) -> api::ConnectionClosed {
-            let ConnectionClosed { error } = self;
-            api::ConnectionClosed {
-                error: error.into_event(),
-            }
-        }
-    }
-    #[derive(Clone, Debug)]
     #[doc = " Duplicate packet received"]
     pub struct DuplicatePacket<'a> {
         pub packet_header: PacketHeader,
@@ -6112,6 +6098,20 @@ pub mod builder {
             let DcStateChanged { state } = self;
             api::DcStateChanged {
                 state: state.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[doc = " Connection closed"]
+    pub struct ConnectionClosed {
+        pub error: crate::connection::Error,
+    }
+    impl IntoEvent<api::ConnectionClosed> for ConnectionClosed {
+        #[inline]
+        fn into_event(self) -> api::ConnectionClosed {
+            let ConnectionClosed { error } = self;
+            api::ConnectionClosed {
+                error: error.into_event(),
             }
         }
     }
@@ -6833,18 +6833,6 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ConnectionClosed` event is triggered"]
-        #[inline]
-        fn on_connection_closed(
-            &mut self,
-            context: &mut Self::ConnectionContext,
-            meta: &api::ConnectionMeta,
-            event: &api::ConnectionClosed,
-        ) {
-            let _ = context;
-            let _ = meta;
-            let _ = event;
-        }
         #[doc = "Called when the `DuplicatePacket` event is triggered"]
         #[inline]
         fn on_duplicate_packet(
@@ -7104,6 +7092,18 @@ mod traits {
             context: &mut Self::ConnectionContext,
             meta: &api::ConnectionMeta,
             event: &api::DcStateChanged,
+        ) {
+            let _ = context;
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `ConnectionClosed` event is triggered"]
+        #[inline]
+        fn on_connection_closed(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &api::ConnectionClosed,
         ) {
             let _ = context;
             let _ = meta;
@@ -7543,16 +7543,6 @@ mod traits {
             (self.1).on_connection_started(&mut context.1, meta, event);
         }
         #[inline]
-        fn on_connection_closed(
-            &mut self,
-            context: &mut Self::ConnectionContext,
-            meta: &api::ConnectionMeta,
-            event: &api::ConnectionClosed,
-        ) {
-            (self.0).on_connection_closed(&mut context.0, meta, event);
-            (self.1).on_connection_closed(&mut context.1, meta, event);
-        }
-        #[inline]
         fn on_duplicate_packet(
             &mut self,
             context: &mut Self::ConnectionContext,
@@ -7771,6 +7761,16 @@ mod traits {
         ) {
             (self.0).on_dc_state_changed(&mut context.0, meta, event);
             (self.1).on_dc_state_changed(&mut context.1, meta, event);
+        }
+        #[inline]
+        fn on_connection_closed(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &api::ConnectionClosed,
+        ) {
+            (self.0).on_connection_closed(&mut context.0, meta, event);
+            (self.1).on_connection_closed(&mut context.1, meta, event);
         }
         #[inline]
         fn on_version_information(
@@ -8143,8 +8143,6 @@ mod traits {
         fn on_key_space_discarded(&mut self, event: builder::KeySpaceDiscarded);
         #[doc = "Publishes a `ConnectionStarted` event to the publisher's subscriber"]
         fn on_connection_started(&mut self, event: builder::ConnectionStarted);
-        #[doc = "Publishes a `ConnectionClosed` event to the publisher's subscriber"]
-        fn on_connection_closed(&mut self, event: builder::ConnectionClosed);
         #[doc = "Publishes a `DuplicatePacket` event to the publisher's subscriber"]
         fn on_duplicate_packet(&mut self, event: builder::DuplicatePacket);
         #[doc = "Publishes a `TransportParametersReceived` event to the publisher's subscriber"]
@@ -8189,6 +8187,8 @@ mod traits {
         fn on_bbr_state_changed(&mut self, event: builder::BbrStateChanged);
         #[doc = "Publishes a `DcStateChanged` event to the publisher's subscriber"]
         fn on_dc_state_changed(&mut self, event: builder::DcStateChanged);
+        #[doc = "Publishes a `ConnectionClosed` event to the publisher's subscriber"]
+        fn on_connection_closed(&mut self, event: builder::ConnectionClosed);
         #[doc = r" Returns the QUIC version negotiated for the current connection, if any"]
         fn quic_version(&self) -> u32;
         #[doc = r" Returns the [`Subject`] for the current publisher"]
@@ -8410,15 +8410,6 @@ mod traits {
             self.subscriber.on_event(&self.meta, &event);
         }
         #[inline]
-        fn on_connection_closed(&mut self, event: builder::ConnectionClosed) {
-            let event = event.into_event();
-            self.subscriber
-                .on_connection_closed(self.context, &self.meta, &event);
-            self.subscriber
-                .on_connection_event(self.context, &self.meta, &event);
-            self.subscriber.on_event(&self.meta, &event);
-        }
-        #[inline]
         fn on_duplicate_packet(&mut self, event: builder::DuplicatePacket) {
             let event = event.into_event();
             self.subscriber
@@ -8620,6 +8611,15 @@ mod traits {
             self.subscriber.on_event(&self.meta, &event);
         }
         #[inline]
+        fn on_connection_closed(&mut self, event: builder::ConnectionClosed) {
+            let event = event.into_event();
+            self.subscriber
+                .on_connection_closed(self.context, &self.meta, &event);
+            self.subscriber
+                .on_connection_event(self.context, &self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
         fn quic_version(&self) -> u32 {
             self.quic_version
         }
@@ -8638,21 +8638,21 @@ pub mod testing {
         pub struct Subscriber {
             location: Option<Location>,
             output: Vec<String>,
-            pub version_information: u32,
-            pub endpoint_packet_sent: u32,
-            pub endpoint_packet_received: u32,
-            pub endpoint_datagram_sent: u32,
-            pub endpoint_datagram_received: u32,
-            pub endpoint_datagram_dropped: u32,
-            pub endpoint_connection_attempt_failed: u32,
-            pub platform_tx: u32,
-            pub platform_tx_error: u32,
-            pub platform_rx: u32,
-            pub platform_rx_error: u32,
-            pub platform_feature_configured: u32,
-            pub platform_event_loop_wakeup: u32,
-            pub platform_event_loop_sleep: u32,
-            pub platform_event_loop_started: u32,
+            pub version_information: u64,
+            pub endpoint_packet_sent: u64,
+            pub endpoint_packet_received: u64,
+            pub endpoint_datagram_sent: u64,
+            pub endpoint_datagram_received: u64,
+            pub endpoint_datagram_dropped: u64,
+            pub endpoint_connection_attempt_failed: u64,
+            pub platform_tx: u64,
+            pub platform_tx_error: u64,
+            pub platform_rx: u64,
+            pub platform_rx_error: u64,
+            pub platform_feature_configured: u64,
+            pub platform_event_loop_wakeup: u64,
+            pub platform_event_loop_sleep: u64,
+            pub platform_event_loop_started: u64,
         }
         impl Drop for Subscriber {
             fn drop(&mut self) {
@@ -8873,64 +8873,64 @@ pub mod testing {
     pub struct Subscriber {
         location: Option<Location>,
         output: Vec<String>,
-        pub application_protocol_information: u32,
-        pub server_name_information: u32,
-        pub packet_skipped: u32,
-        pub packet_sent: u32,
-        pub packet_received: u32,
-        pub active_path_updated: u32,
-        pub path_created: u32,
-        pub frame_sent: u32,
-        pub frame_received: u32,
-        pub packet_lost: u32,
-        pub recovery_metrics: u32,
-        pub congestion: u32,
-        pub ack_processed: u32,
-        pub rx_ack_range_dropped: u32,
-        pub ack_range_received: u32,
-        pub ack_range_sent: u32,
-        pub packet_dropped: u32,
-        pub key_update: u32,
-        pub key_space_discarded: u32,
-        pub connection_started: u32,
-        pub connection_closed: u32,
-        pub duplicate_packet: u32,
-        pub transport_parameters_received: u32,
-        pub datagram_sent: u32,
-        pub datagram_received: u32,
-        pub datagram_dropped: u32,
-        pub connection_id_updated: u32,
-        pub ecn_state_changed: u32,
-        pub connection_migration_denied: u32,
-        pub handshake_status_updated: u32,
-        pub tls_exporter_ready: u32,
-        pub path_challenge_updated: u32,
-        pub tls_client_hello: u32,
-        pub tls_server_hello: u32,
-        pub rx_stream_progress: u32,
-        pub tx_stream_progress: u32,
-        pub keep_alive_timer_expired: u32,
-        pub mtu_updated: u32,
-        pub slow_start_exited: u32,
-        pub delivery_rate_sampled: u32,
-        pub pacing_rate_updated: u32,
-        pub bbr_state_changed: u32,
-        pub dc_state_changed: u32,
-        pub version_information: u32,
-        pub endpoint_packet_sent: u32,
-        pub endpoint_packet_received: u32,
-        pub endpoint_datagram_sent: u32,
-        pub endpoint_datagram_received: u32,
-        pub endpoint_datagram_dropped: u32,
-        pub endpoint_connection_attempt_failed: u32,
-        pub platform_tx: u32,
-        pub platform_tx_error: u32,
-        pub platform_rx: u32,
-        pub platform_rx_error: u32,
-        pub platform_feature_configured: u32,
-        pub platform_event_loop_wakeup: u32,
-        pub platform_event_loop_sleep: u32,
-        pub platform_event_loop_started: u32,
+        pub application_protocol_information: u64,
+        pub server_name_information: u64,
+        pub packet_skipped: u64,
+        pub packet_sent: u64,
+        pub packet_received: u64,
+        pub active_path_updated: u64,
+        pub path_created: u64,
+        pub frame_sent: u64,
+        pub frame_received: u64,
+        pub packet_lost: u64,
+        pub recovery_metrics: u64,
+        pub congestion: u64,
+        pub ack_processed: u64,
+        pub rx_ack_range_dropped: u64,
+        pub ack_range_received: u64,
+        pub ack_range_sent: u64,
+        pub packet_dropped: u64,
+        pub key_update: u64,
+        pub key_space_discarded: u64,
+        pub connection_started: u64,
+        pub duplicate_packet: u64,
+        pub transport_parameters_received: u64,
+        pub datagram_sent: u64,
+        pub datagram_received: u64,
+        pub datagram_dropped: u64,
+        pub connection_id_updated: u64,
+        pub ecn_state_changed: u64,
+        pub connection_migration_denied: u64,
+        pub handshake_status_updated: u64,
+        pub tls_exporter_ready: u64,
+        pub path_challenge_updated: u64,
+        pub tls_client_hello: u64,
+        pub tls_server_hello: u64,
+        pub rx_stream_progress: u64,
+        pub tx_stream_progress: u64,
+        pub keep_alive_timer_expired: u64,
+        pub mtu_updated: u64,
+        pub slow_start_exited: u64,
+        pub delivery_rate_sampled: u64,
+        pub pacing_rate_updated: u64,
+        pub bbr_state_changed: u64,
+        pub dc_state_changed: u64,
+        pub connection_closed: u64,
+        pub version_information: u64,
+        pub endpoint_packet_sent: u64,
+        pub endpoint_packet_received: u64,
+        pub endpoint_datagram_sent: u64,
+        pub endpoint_datagram_received: u64,
+        pub endpoint_datagram_dropped: u64,
+        pub endpoint_connection_attempt_failed: u64,
+        pub platform_tx: u64,
+        pub platform_tx_error: u64,
+        pub platform_rx: u64,
+        pub platform_rx_error: u64,
+        pub platform_feature_configured: u64,
+        pub platform_event_loop_wakeup: u64,
+        pub platform_event_loop_sleep: u64,
+        pub platform_event_loop_started: u64,
     }
     impl Drop for Subscriber {
         fn drop(&mut self) {
@@ -8982,7 +8982,6 @@ pub mod testing {
                 key_update: 0,
                 key_space_discarded: 0,
                 connection_started: 0,
-                connection_closed: 0,
                 duplicate_packet: 0,
                 transport_parameters_received: 0,
                 datagram_sent: 0,
@@ -9005,6 +9004,7 @@ pub mod testing {
                 pacing_rate_updated: 0,
                 bbr_state_changed: 0,
                 dc_state_changed: 0,
+                connection_closed: 0,
                 version_information: 0,
                 endpoint_packet_sent: 0,
                 endpoint_packet_received: 0,
@@ -9305,20 +9305,6 @@ pub mod testing {
             event: &api::ConnectionStarted,
         ) {
             self.connection_started += 1;
-            if self.location.is_some() {
-                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
-                let event = crate::event::snapshot::Fmt::to_snapshot(event);
-                let out = format!("{meta:?} {event:?}");
-                self.output.push(out);
-            }
-        }
-        fn on_connection_closed(
-            &mut self,
-            _context: &mut Self::ConnectionContext,
-            meta: &api::ConnectionMeta,
-            event: &api::ConnectionClosed,
-        ) {
-            self.connection_closed += 1;
             if self.location.is_some() {
                 let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
                 let event = crate::event::snapshot::Fmt::to_snapshot(event);
@@ -9634,6 +9620,20 @@ pub mod testing {
                 self.output.push(out);
             }
         }
+        fn on_connection_closed(
+            &mut self,
+            _context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &api::ConnectionClosed,
+        ) {
+            self.connection_closed += 1;
+            if self.location.is_some() {
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.push(out);
+            }
+        }
         fn on_version_information(
             &mut self,
             meta: &api::EndpointMeta,
@@ -9788,64 +9788,64 @@ pub mod testing {
     pub struct Publisher {
         location: Option<Location>,
         output: Vec<String>,
-        pub application_protocol_information: u32,
-        pub server_name_information: u32,
-        pub packet_skipped: u32,
-        pub packet_sent: u32,
-        pub packet_received: u32,
-        pub active_path_updated: u32,
-        pub path_created: u32,
-        pub frame_sent: u32,
-        pub frame_received: u32,
-        pub packet_lost: u32,
-        pub recovery_metrics: u32,
-        pub congestion: u32,
-        pub ack_processed: u32,
-        pub rx_ack_range_dropped: u32,
-        pub ack_range_received: u32,
-        pub ack_range_sent: u32,
-        pub packet_dropped: u32,
-        pub key_update: u32,
-        pub key_space_discarded: u32,
-        pub connection_started: u32,
-        pub connection_closed: u32,
-        pub duplicate_packet: u32,
-        pub transport_parameters_received: u32,
-        pub datagram_sent: u32,
-        pub datagram_received: u32,
-        pub datagram_dropped: u32,
-        pub connection_id_updated: u32,
-        pub ecn_state_changed: u32,
-        pub connection_migration_denied: u32,
-        pub handshake_status_updated: u32,
-        pub tls_exporter_ready: u32,
-        pub path_challenge_updated: u32,
-        pub tls_client_hello: u32,
-        pub tls_server_hello: u32,
-        pub rx_stream_progress: u32,
-        pub tx_stream_progress: u32,
-        pub keep_alive_timer_expired: u32,
-        pub mtu_updated: u32,
-        pub slow_start_exited: u32,
-        pub delivery_rate_sampled: u32,
-        pub pacing_rate_updated: u32,
-        pub bbr_state_changed: u32,
-        pub dc_state_changed: u32,
-        pub version_information: u32,
-        pub endpoint_packet_sent: u32,
-        pub endpoint_packet_received: u32,
-        pub endpoint_datagram_sent: u32,
-        pub endpoint_datagram_received: u32,
-        pub endpoint_datagram_dropped: u32,
-        pub endpoint_connection_attempt_failed: u32,
-        pub platform_tx: u32,
-        pub platform_tx_error: u32,
-        pub platform_rx: u32,
-        pub platform_rx_error: u32,
-        pub platform_feature_configured: u32,
-        pub platform_event_loop_wakeup: u32,
-        pub platform_event_loop_sleep: u32,
-        pub platform_event_loop_started: u32,
+        pub application_protocol_information: u64,
+        pub server_name_information: u64,
+        pub packet_skipped: u64,
+        pub packet_sent: u64,
+        pub packet_received: u64,
+        pub active_path_updated: u64,
+        pub path_created: u64,
+        pub frame_sent: u64,
+        pub frame_received: u64,
+        pub packet_lost: u64,
+        pub recovery_metrics: u64,
+        pub congestion: u64,
+        pub ack_processed: u64,
+        pub rx_ack_range_dropped: u64,
+        pub ack_range_received: u64,
+        pub ack_range_sent: u64,
+        pub packet_dropped: u64,
+        pub key_update: u64,
+        pub key_space_discarded: u64,
+        pub connection_started: u64,
+        pub duplicate_packet: u64,
+        pub transport_parameters_received: u64,
+        pub datagram_sent: u64,
+        pub datagram_received: u64,
+        pub datagram_dropped: u64,
+        pub connection_id_updated: u64,
+        pub ecn_state_changed: u64,
+        pub connection_migration_denied: u64,
+        pub handshake_status_updated: u64,
+        pub tls_exporter_ready: u64,
+        pub path_challenge_updated: u64,
+        pub tls_client_hello: u64,
+        pub tls_server_hello: u64,
+        pub rx_stream_progress: u64,
+        pub tx_stream_progress: u64,
+        pub keep_alive_timer_expired: u64,
+        pub mtu_updated: u64,
+        pub slow_start_exited: u64,
+        pub delivery_rate_sampled: u64,
+        pub pacing_rate_updated: u64,
+        pub bbr_state_changed: u64,
+        pub dc_state_changed: u64,
+        pub connection_closed: u64,
+        pub version_information: u64,
+        pub endpoint_packet_sent: u64,
+        pub endpoint_packet_received: u64,
+        pub endpoint_datagram_sent: u64,
+        pub endpoint_datagram_received: u64,
+        pub endpoint_datagram_dropped: u64,
+        pub endpoint_connection_attempt_failed: u64,
+        pub platform_tx: u64,
+        pub platform_tx_error: u64,
+        pub platform_rx: u64,
+        pub platform_rx_error: u64,
+        pub platform_feature_configured: u64,
+        pub platform_event_loop_wakeup: u64,
+        pub platform_event_loop_sleep: u64,
+        pub platform_event_loop_started: u64,
     }
     impl Publisher {
         #[doc = r" Creates a publisher with snapshot assertions enabled"]
@@ -9887,7 +9887,6 @@ pub mod testing {
                 key_update: 0,
                 key_space_discarded: 0,
                 connection_started: 0,
-                connection_closed: 0,
                 duplicate_packet: 0,
                 transport_parameters_received: 0,
                 datagram_sent: 0,
@@ -9910,6 +9909,7 @@ pub mod testing {
                 pacing_rate_updated: 0,
                 bbr_state_changed: 0,
                 dc_state_changed: 0,
+                connection_closed: 0,
                 version_information: 0,
                 endpoint_packet_sent: 0,
                 endpoint_packet_received: 0,
@@ -10226,15 +10226,6 @@ pub mod testing {
                 self.output.push(out);
             }
         }
-        fn on_connection_closed(&mut self, event: builder::ConnectionClosed) {
-            self.connection_closed += 1;
-            let event = event.into_event();
-            if self.location.is_some() {
-                let event = crate::event::snapshot::Fmt::to_snapshot(&event);
-                let out = format!("{event:?}");
-                self.output.push(out);
-            }
-        }
         fn on_duplicate_packet(&mut self, event: builder::DuplicatePacket) {
             self.duplicate_packet += 1;
             let event = event.into_event();
@@ -10429,6 +10420,15 @@ pub mod testing {
         }
         fn on_dc_state_changed(&mut self, event: builder::DcStateChanged) {
             self.dc_state_changed += 1;
+            let event = event.into_event();
+            if self.location.is_some() {
+                let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+                let out = format!("{event:?}");
+                self.output.push(out);
+            }
+        }
+        fn on_connection_closed(&mut self, event: builder::ConnectionClosed) {
+            self.connection_closed += 1;
             let event = event.into_event();
             if self.location.is_some() {
                 let event = crate::event::snapshot::Fmt::to_snapshot(&event);

--- a/quic/s2n-quic-core/src/event/generated/metrics.rs
+++ b/quic/s2n-quic-core/src/event/generated/metrics.rs
@@ -26,49 +26,49 @@ where
 }
 pub struct Context<R: Recorder> {
     recorder: R,
-    application_protocol_information: u32,
-    server_name_information: u32,
-    packet_skipped: u32,
-    packet_sent: u32,
-    packet_received: u32,
-    active_path_updated: u32,
-    path_created: u32,
-    frame_sent: u32,
-    frame_received: u32,
-    packet_lost: u32,
-    recovery_metrics: u32,
-    congestion: u32,
-    ack_processed: u32,
-    rx_ack_range_dropped: u32,
-    ack_range_received: u32,
-    ack_range_sent: u32,
-    packet_dropped: u32,
-    key_update: u32,
-    key_space_discarded: u32,
-    connection_started: u32,
-    connection_closed: u32,
-    duplicate_packet: u32,
-    transport_parameters_received: u32,
-    datagram_sent: u32,
-    datagram_received: u32,
-    datagram_dropped: u32,
-    connection_id_updated: u32,
-    ecn_state_changed: u32,
-    connection_migration_denied: u32,
-    handshake_status_updated: u32,
-    tls_exporter_ready: u32,
-    path_challenge_updated: u32,
-    tls_client_hello: u32,
-    tls_server_hello: u32,
-    rx_stream_progress: u32,
-    tx_stream_progress: u32,
-    keep_alive_timer_expired: u32,
-    mtu_updated: u32,
-    slow_start_exited: u32,
-    delivery_rate_sampled: u32,
-    pacing_rate_updated: u32,
-    bbr_state_changed: u32,
-    dc_state_changed: u32,
+    application_protocol_information: u64,
+    server_name_information: u64,
+    packet_skipped: u64,
+    packet_sent: u64,
+    packet_received: u64,
+    active_path_updated: u64,
+    path_created: u64,
+    frame_sent: u64,
+    frame_received: u64,
+    packet_lost: u64,
+    recovery_metrics: u64,
+    congestion: u64,
+    ack_processed: u64,
+    rx_ack_range_dropped: u64,
+    ack_range_received: u64,
+    ack_range_sent: u64,
+    packet_dropped: u64,
+    key_update: u64,
+    key_space_discarded: u64,
+    connection_started: u64,
+    duplicate_packet: u64,
+    transport_parameters_received: u64,
+    datagram_sent: u64,
+    datagram_received: u64,
+    datagram_dropped: u64,
+    connection_id_updated: u64,
+    ecn_state_changed: u64,
+    connection_migration_denied: u64,
+    handshake_status_updated: u64,
+    tls_exporter_ready: u64,
+    path_challenge_updated: u64,
+    tls_client_hello: u64,
+    tls_server_hello: u64,
+    rx_stream_progress: u64,
+    tx_stream_progress: u64,
+    keep_alive_timer_expired: u64,
+    mtu_updated: u64,
+    slow_start_exited: u64,
+    delivery_rate_sampled: u64,
+    pacing_rate_updated: u64,
+    bbr_state_changed: u64,
+    dc_state_changed: u64,
+    connection_closed: u64,
 }
 impl<S: event::Subscriber> event::Subscriber for Subscriber<S>
 where
@@ -102,7 +102,6 @@ where
             key_update: 0,
             key_space_discarded: 0,
             connection_started: 0,
-            connection_closed: 0,
             duplicate_packet: 0,
             transport_parameters_received: 0,
             datagram_sent: 0,
@@ -125,6 +124,7 @@ where
             pacing_rate_updated: 0,
             bbr_state_changed: 0,
             dc_state_changed: 0,
+            connection_closed: 0,
         }
     }
     #[inline]
@@ -347,17 +347,6 @@ where
         context.connection_started += 1;
         self.subscriber
             .on_connection_started(&mut context.recorder, meta, event);
-    }
-    #[inline]
-    fn on_connection_closed(
-        &mut self,
-        context: &mut Self::ConnectionContext,
-        meta: &api::ConnectionMeta,
-        event: &api::ConnectionClosed,
-    ) {
-        context.connection_closed += 1;
-        self.subscriber
-            .on_connection_closed(&mut context.recorder, meta, event);
     }
     #[inline]
     fn on_duplicate_packet(
@@ -601,6 +590,17 @@ where
         self.subscriber
             .on_dc_state_changed(&mut context.recorder, meta, event);
     }
+    #[inline]
+    fn on_connection_closed(
+        &mut self,
+        context: &mut Self::ConnectionContext,
+        meta: &api::ConnectionMeta,
+        event: &api::ConnectionClosed,
+    ) {
+        context.connection_closed += 1;
+        self.subscriber
+            .on_connection_closed(&mut context.recorder, meta, event);
+    }
 }
 impl<R: Recorder> Drop for Context<R> {
     fn drop(&mut self) {
@@ -646,8 +646,6 @@ impl<R: Recorder> Drop for Context<R> {
             .increment_counter("key_space_discarded", self.key_space_discarded as _);
         self.recorder
             .increment_counter("connection_started", self.connection_started as _);
-        self.recorder
-            .increment_counter("connection_closed", self.connection_closed as _);
         self.recorder
             .increment_counter("duplicate_packet", self.duplicate_packet as _);
         self.recorder.increment_counter(
@@ -700,5 +698,7 @@ impl<R: Recorder> Drop for Context<R> {
             .increment_counter("bbr_state_changed", self.bbr_state_changed as _);
         self.recorder
             .increment_counter("dc_state_changed", self.dc_state_changed as _);
+        self.recorder
+            .increment_counter("connection_closed", self.connection_closed as _);
     }
 }

--- a/quic/s2n-quic-core/src/event/generated/metrics/aggregate.rs
+++ b/quic/s2n-quic-core/src/event/generated/metrics/aggregate.rs
@@ -316,385 +316,385 @@ static INFO: &[Info; 159usize] = &[
     .build(),
     info::Builder {
         id: 50usize,
-        name: Str::new("connection_closed\0"),
-        units: Units::None,
-    }
-    .build(),
-    info::Builder {
-        id: 51usize,
-        name: Str::new("connection_closed.latency\0"),
-        units: Units::Duration,
-    }
-    .build(),
-    info::Builder {
-        id: 52usize,
-        name: Str::new("connection_closed.error\0"),
-        units: Units::None,
-    }
-    .build(),
-    info::Builder {
-        id: 53usize,
         name: Str::new("duplicate_packet\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 54usize,
+        id: 51usize,
         name: Str::new("duplicate_packet.kind\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 55usize,
+        id: 52usize,
         name: Str::new("duplicate_packet.error\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 56usize,
+        id: 53usize,
         name: Str::new("transport_parameters_received\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 57usize,
+        id: 54usize,
         name: Str::new("transport_parameters_received.latency\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 58usize,
+        id: 55usize,
         name: Str::new("datagram_sent\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 59usize,
+        id: 56usize,
         name: Str::new("datagram_sent.bytes.total\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 60usize,
+        id: 57usize,
         name: Str::new("datagram_sent.bytes\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 61usize,
+        id: 58usize,
         name: Str::new("datagram_sent.gso_offset\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 62usize,
+        id: 59usize,
         name: Str::new("datagram_received\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 63usize,
+        id: 60usize,
         name: Str::new("datagram_received.bytes.total\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 64usize,
+        id: 61usize,
         name: Str::new("datagram_received.bytes\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 65usize,
+        id: 62usize,
         name: Str::new("datagram_dropped\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 66usize,
+        id: 63usize,
         name: Str::new("datagram_dropped.bytes.total\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 67usize,
+        id: 64usize,
         name: Str::new("datagram_dropped.bytes\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 68usize,
+        id: 65usize,
         name: Str::new("datagram_dropped.reason\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 69usize,
+        id: 66usize,
         name: Str::new("connection_id_updated\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 70usize,
+        id: 67usize,
         name: Str::new("ecn_state_changed\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 71usize,
+        id: 68usize,
         name: Str::new("ecn_state_changed.state\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 72usize,
+        id: 69usize,
         name: Str::new("connection_migration_denied\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 73usize,
+        id: 70usize,
         name: Str::new("connection_migration_denied.reason\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 74usize,
+        id: 71usize,
         name: Str::new("handshake_status_updated\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 75usize,
+        id: 72usize,
         name: Str::new("handshake_status_updated.complete.latency\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 76usize,
+        id: 73usize,
         name: Str::new("handshake_status_updated.confirmed.latency\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 77usize,
+        id: 74usize,
         name: Str::new("handshake_status_updated.handshake_done_acked.latency\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 78usize,
+        id: 75usize,
         name: Str::new("handshake_status_updated.status\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 79usize,
+        id: 76usize,
         name: Str::new("tls_exporter_ready\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 80usize,
+        id: 77usize,
         name: Str::new("path_challenge_updated\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 81usize,
+        id: 78usize,
         name: Str::new("path_challenge_updated.status\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 82usize,
+        id: 79usize,
         name: Str::new("tls_client_hello\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 83usize,
+        id: 80usize,
         name: Str::new("tls_client_hello.latency\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 84usize,
+        id: 81usize,
         name: Str::new("tls_server_hello\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 85usize,
+        id: 82usize,
         name: Str::new("tls_server_hello.latency\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 86usize,
+        id: 83usize,
         name: Str::new("rx_stream_progress\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 87usize,
+        id: 84usize,
         name: Str::new("rx_stream_progress.bytes.total\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 88usize,
+        id: 85usize,
         name: Str::new("rx_stream_progress.bytes\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 89usize,
+        id: 86usize,
         name: Str::new("tx_stream_progress\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 90usize,
+        id: 87usize,
         name: Str::new("tx_stream_progress.bytes.total\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 91usize,
+        id: 88usize,
         name: Str::new("tx_stream_progress.bytes\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 92usize,
+        id: 89usize,
         name: Str::new("keep_alive_timer_expired\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 93usize,
+        id: 90usize,
         name: Str::new("mtu_updated\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 94usize,
+        id: 91usize,
         name: Str::new("mtu_updated.mtu\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 95usize,
+        id: 92usize,
         name: Str::new("mtu_updated.cause\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 96usize,
+        id: 93usize,
         name: Str::new("mtu_updated.search_complete\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 97usize,
+        id: 94usize,
         name: Str::new("slow_start_exited\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 98usize,
+        id: 95usize,
         name: Str::new("slow_start_exited.cause\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 99usize,
+        id: 96usize,
         name: Str::new("slow_start_exited.latency\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 100usize,
+        id: 97usize,
         name: Str::new("slow_start_exited.congestion_window\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 101usize,
+        id: 98usize,
         name: Str::new("delivery_rate_sampled\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 102usize,
+        id: 99usize,
         name: Str::new("pacing_rate_updated\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 103usize,
+        id: 100usize,
         name: Str::new("pacing_rate_updated.bytes_per_second\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 104usize,
+        id: 101usize,
         name: Str::new("pacing_rate_updated.burst_size\0"),
         units: Units::Bytes,
     }
     .build(),
     info::Builder {
-        id: 105usize,
+        id: 102usize,
         name: Str::new("pacing_rate_updated.pacing_gain\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 106usize,
+        id: 103usize,
         name: Str::new("bbr_state_changed\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 107usize,
+        id: 104usize,
         name: Str::new("bbr_state_changed.state\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 108usize,
+        id: 105usize,
         name: Str::new("dc_state_changed\0"),
         units: Units::None,
     }
     .build(),
     info::Builder {
-        id: 109usize,
+        id: 106usize,
         name: Str::new("dc_state_changed.version_negotiated.latency\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 110usize,
+        id: 107usize,
         name: Str::new("dc_state_changed.no_version_negotiated.latency\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 111usize,
+        id: 108usize,
         name: Str::new("dc_state_changed.path_secrets.latency\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 112usize,
+        id: 109usize,
         name: Str::new("dc_state_changed.complete.latency\0"),
         units: Units::Duration,
     }
     .build(),
     info::Builder {
-        id: 113usize,
+        id: 110usize,
         name: Str::new("dc_state_changed.state\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 111usize,
+        name: Str::new("connection_closed\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 112usize,
+        name: Str::new("connection_closed.latency\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
+        id: 113usize,
+        name: Str::new("connection_closed.error\0"),
         units: Units::None,
     }
     .build(),
@@ -969,7 +969,7 @@ static INFO: &[Info; 159usize] = &[
     }
     .build(),
 ];
-#[derive(Clone, Copy, Debug)]
+#[derive(Debug)]
 #[allow(dead_code)]
 pub struct ConnectionContext {
     start_time: crate::event::Timestamp,
@@ -1043,32 +1043,32 @@ impl<R: Registry> Subscriber<R> {
         counters.push(registry.register_counter(&INFO[49usize]));
         counters.push(registry.register_counter(&INFO[50usize]));
         counters.push(registry.register_counter(&INFO[53usize]));
+        counters.push(registry.register_counter(&INFO[55usize]));
         counters.push(registry.register_counter(&INFO[56usize]));
-        counters.push(registry.register_counter(&INFO[58usize]));
         counters.push(registry.register_counter(&INFO[59usize]));
+        counters.push(registry.register_counter(&INFO[60usize]));
         counters.push(registry.register_counter(&INFO[62usize]));
         counters.push(registry.register_counter(&INFO[63usize]));
-        counters.push(registry.register_counter(&INFO[65usize]));
         counters.push(registry.register_counter(&INFO[66usize]));
+        counters.push(registry.register_counter(&INFO[67usize]));
         counters.push(registry.register_counter(&INFO[69usize]));
-        counters.push(registry.register_counter(&INFO[70usize]));
-        counters.push(registry.register_counter(&INFO[72usize]));
-        counters.push(registry.register_counter(&INFO[74usize]));
+        counters.push(registry.register_counter(&INFO[71usize]));
+        counters.push(registry.register_counter(&INFO[76usize]));
+        counters.push(registry.register_counter(&INFO[77usize]));
         counters.push(registry.register_counter(&INFO[79usize]));
-        counters.push(registry.register_counter(&INFO[80usize]));
-        counters.push(registry.register_counter(&INFO[82usize]));
+        counters.push(registry.register_counter(&INFO[81usize]));
+        counters.push(registry.register_counter(&INFO[83usize]));
         counters.push(registry.register_counter(&INFO[84usize]));
         counters.push(registry.register_counter(&INFO[86usize]));
         counters.push(registry.register_counter(&INFO[87usize]));
         counters.push(registry.register_counter(&INFO[89usize]));
         counters.push(registry.register_counter(&INFO[90usize]));
-        counters.push(registry.register_counter(&INFO[92usize]));
-        counters.push(registry.register_counter(&INFO[93usize]));
-        counters.push(registry.register_counter(&INFO[97usize]));
-        counters.push(registry.register_counter(&INFO[101usize]));
-        counters.push(registry.register_counter(&INFO[102usize]));
-        counters.push(registry.register_counter(&INFO[106usize]));
-        counters.push(registry.register_counter(&INFO[108usize]));
+        counters.push(registry.register_counter(&INFO[94usize]));
+        counters.push(registry.register_counter(&INFO[98usize]));
+        counters.push(registry.register_counter(&INFO[99usize]));
+        counters.push(registry.register_counter(&INFO[103usize]));
+        counters.push(registry.register_counter(&INFO[105usize]));
+        counters.push(registry.register_counter(&INFO[111usize]));
         counters.push(registry.register_counter(&INFO[114usize]));
         counters.push(registry.register_counter(&INFO[115usize]));
         counters.push(registry.register_counter(&INFO[116usize]));
@@ -1096,7 +1096,7 @@ impl<R: Registry> Subscriber<R> {
         counters.push(registry.register_counter(&INFO[158usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[21usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[31usize]));
-        bool_counters.push(registry.register_bool_counter(&INFO[96usize]));
+        bool_counters.push(registry.register_bool_counter(&INFO[93usize]));
         {
             #[allow(unused_imports)]
             use api::*;
@@ -1257,20 +1257,9 @@ impl<R: Registry> Subscriber<R> {
             {
                 let offset = nominal_counters.len();
                 let mut count = 0;
-                for variant in <crate::connection::Error as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[52usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
                 for variant in <PacketHeader as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[54usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[51usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1281,7 +1270,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <DuplicatePacketError as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[55usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[52usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1292,7 +1281,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <DatagramDropReason as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[68usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[65usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1303,7 +1292,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <EcnState as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[71usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[68usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1314,7 +1303,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <MigrationDenyReason as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[73usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[70usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1325,7 +1314,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <HandshakeStatus as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[78usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[75usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1336,7 +1325,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <PathChallengeStatus as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[81usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[78usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1347,7 +1336,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <MtuUpdatedCause as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[95usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[92usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1358,7 +1347,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <SlowStartExitCause as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[98usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[95usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1369,7 +1358,7 @@ impl<R: Registry> Subscriber<R> {
                 let mut count = 0;
                 for variant in <BbrState as AsVariant>::VARIANTS.iter() {
                     nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[107usize], variant));
+                        .push(registry.register_nominal_counter(&INFO[104usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1379,6 +1368,17 @@ impl<R: Registry> Subscriber<R> {
                 let offset = nominal_counters.len();
                 let mut count = 0;
                 for variant in <DcState as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[110usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <crate::connection::Error as AsVariant>::VARIANTS.iter() {
                     nominal_counters
                         .push(registry.register_nominal_counter(&INFO[113usize], variant));
                     count += 1;
@@ -1419,17 +1419,17 @@ impl<R: Registry> Subscriber<R> {
         measures.push(registry.register_measure(&INFO[28usize]));
         measures.push(registry.register_measure(&INFO[29usize]));
         measures.push(registry.register_measure(&INFO[30usize]));
-        measures.push(registry.register_measure(&INFO[60usize]));
+        measures.push(registry.register_measure(&INFO[57usize]));
+        measures.push(registry.register_measure(&INFO[58usize]));
         measures.push(registry.register_measure(&INFO[61usize]));
         measures.push(registry.register_measure(&INFO[64usize]));
-        measures.push(registry.register_measure(&INFO[67usize]));
+        measures.push(registry.register_measure(&INFO[85usize]));
         measures.push(registry.register_measure(&INFO[88usize]));
         measures.push(registry.register_measure(&INFO[91usize]));
-        measures.push(registry.register_measure(&INFO[94usize]));
+        measures.push(registry.register_measure(&INFO[97usize]));
         measures.push(registry.register_measure(&INFO[100usize]));
-        measures.push(registry.register_measure(&INFO[103usize]));
-        measures.push(registry.register_measure(&INFO[104usize]));
-        measures.push(registry.register_measure(&INFO[105usize]));
+        measures.push(registry.register_measure(&INFO[101usize]));
+        measures.push(registry.register_measure(&INFO[102usize]));
         measures.push(registry.register_measure(&INFO[118usize]));
         measures.push(registry.register_measure(&INFO[119usize]));
         measures.push(registry.register_measure(&INFO[120usize]));
@@ -1450,16 +1450,16 @@ impl<R: Registry> Subscriber<R> {
         timers.push(registry.register_timer(&INFO[45usize]));
         timers.push(registry.register_timer(&INFO[46usize]));
         timers.push(registry.register_timer(&INFO[47usize]));
-        timers.push(registry.register_timer(&INFO[51usize]));
-        timers.push(registry.register_timer(&INFO[57usize]));
-        timers.push(registry.register_timer(&INFO[75usize]));
-        timers.push(registry.register_timer(&INFO[76usize]));
-        timers.push(registry.register_timer(&INFO[77usize]));
-        timers.push(registry.register_timer(&INFO[83usize]));
-        timers.push(registry.register_timer(&INFO[85usize]));
+        timers.push(registry.register_timer(&INFO[54usize]));
+        timers.push(registry.register_timer(&INFO[72usize]));
+        timers.push(registry.register_timer(&INFO[73usize]));
+        timers.push(registry.register_timer(&INFO[74usize]));
+        timers.push(registry.register_timer(&INFO[80usize]));
+        timers.push(registry.register_timer(&INFO[82usize]));
+        timers.push(registry.register_timer(&INFO[106usize]));
+        timers.push(registry.register_timer(&INFO[107usize]));
+        timers.push(registry.register_timer(&INFO[108usize]));
         timers.push(registry.register_timer(&INFO[109usize]));
-        timers.push(registry.register_timer(&INFO[110usize]));
-        timers.push(registry.register_timer(&INFO[111usize]));
         timers.push(registry.register_timer(&INFO[112usize]));
         timers.push(registry.register_timer(&INFO[157usize]));
         {
@@ -1469,7 +1469,7 @@ impl<R: Registry> Subscriber<R> {
                 let offset = nominal_timers.len();
                 let mut count = 0;
                 for variant in <SlowStartExitCause as AsVariant>::VARIANTS.iter() {
-                    nominal_timers.push(registry.register_nominal_timer(&INFO[99usize], variant));
+                    nominal_timers.push(registry.register_nominal_timer(&INFO[96usize], variant));
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -1529,32 +1529,32 @@ impl<R: Registry> Subscriber<R> {
                 20usize => (&INFO[49usize], entry),
                 21usize => (&INFO[50usize], entry),
                 22usize => (&INFO[53usize], entry),
-                23usize => (&INFO[56usize], entry),
-                24usize => (&INFO[58usize], entry),
+                23usize => (&INFO[55usize], entry),
+                24usize => (&INFO[56usize], entry),
                 25usize => (&INFO[59usize], entry),
-                26usize => (&INFO[62usize], entry),
-                27usize => (&INFO[63usize], entry),
-                28usize => (&INFO[65usize], entry),
+                26usize => (&INFO[60usize], entry),
+                27usize => (&INFO[62usize], entry),
+                28usize => (&INFO[63usize], entry),
                 29usize => (&INFO[66usize], entry),
-                30usize => (&INFO[69usize], entry),
-                31usize => (&INFO[70usize], entry),
-                32usize => (&INFO[72usize], entry),
-                33usize => (&INFO[74usize], entry),
-                34usize => (&INFO[79usize], entry),
-                35usize => (&INFO[80usize], entry),
-                36usize => (&INFO[82usize], entry),
-                37usize => (&INFO[84usize], entry),
-                38usize => (&INFO[86usize], entry),
-                39usize => (&INFO[87usize], entry),
-                40usize => (&INFO[89usize], entry),
-                41usize => (&INFO[90usize], entry),
-                42usize => (&INFO[92usize], entry),
-                43usize => (&INFO[93usize], entry),
-                44usize => (&INFO[97usize], entry),
-                45usize => (&INFO[101usize], entry),
-                46usize => (&INFO[102usize], entry),
-                47usize => (&INFO[106usize], entry),
-                48usize => (&INFO[108usize], entry),
+                30usize => (&INFO[67usize], entry),
+                31usize => (&INFO[69usize], entry),
+                32usize => (&INFO[71usize], entry),
+                33usize => (&INFO[76usize], entry),
+                34usize => (&INFO[77usize], entry),
+                35usize => (&INFO[79usize], entry),
+                36usize => (&INFO[81usize], entry),
+                37usize => (&INFO[83usize], entry),
+                38usize => (&INFO[84usize], entry),
+                39usize => (&INFO[86usize], entry),
+                40usize => (&INFO[87usize], entry),
+                41usize => (&INFO[89usize], entry),
+                42usize => (&INFO[90usize], entry),
+                43usize => (&INFO[94usize], entry),
+                44usize => (&INFO[98usize], entry),
+                45usize => (&INFO[99usize], entry),
+                46usize => (&INFO[103usize], entry),
+                47usize => (&INFO[105usize], entry),
+                48usize => (&INFO[111usize], entry),
                 49usize => (&INFO[114usize], entry),
                 50usize => (&INFO[115usize], entry),
                 51usize => (&INFO[116usize], entry),
@@ -1599,7 +1599,7 @@ impl<R: Registry> Subscriber<R> {
             .map(|(idx, entry)| match idx {
                 0usize => (&INFO[21usize], entry),
                 1usize => (&INFO[31usize], entry),
-                2usize => (&INFO[96usize], entry),
+                2usize => (&INFO[93usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -1706,73 +1706,73 @@ impl<R: Registry> Subscriber<R> {
                 }
                 14usize => {
                     let offset = *entry;
-                    let variants = <crate::connection::Error as AsVariant>::VARIANTS;
+                    let variants = <PacketHeader as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[52usize], entries, variants)
+                    (&INFO[51usize], entries, variants)
                 }
                 15usize => {
                     let offset = *entry;
-                    let variants = <PacketHeader as AsVariant>::VARIANTS;
+                    let variants = <DuplicatePacketError as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[54usize], entries, variants)
+                    (&INFO[52usize], entries, variants)
                 }
                 16usize => {
                     let offset = *entry;
-                    let variants = <DuplicatePacketError as AsVariant>::VARIANTS;
+                    let variants = <DatagramDropReason as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[55usize], entries, variants)
+                    (&INFO[65usize], entries, variants)
                 }
                 17usize => {
                     let offset = *entry;
-                    let variants = <DatagramDropReason as AsVariant>::VARIANTS;
+                    let variants = <EcnState as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
                     (&INFO[68usize], entries, variants)
                 }
                 18usize => {
                     let offset = *entry;
-                    let variants = <EcnState as AsVariant>::VARIANTS;
+                    let variants = <MigrationDenyReason as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[71usize], entries, variants)
+                    (&INFO[70usize], entries, variants)
                 }
                 19usize => {
                     let offset = *entry;
-                    let variants = <MigrationDenyReason as AsVariant>::VARIANTS;
+                    let variants = <HandshakeStatus as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[73usize], entries, variants)
+                    (&INFO[75usize], entries, variants)
                 }
                 20usize => {
                     let offset = *entry;
-                    let variants = <HandshakeStatus as AsVariant>::VARIANTS;
+                    let variants = <PathChallengeStatus as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
                     (&INFO[78usize], entries, variants)
                 }
                 21usize => {
                     let offset = *entry;
-                    let variants = <PathChallengeStatus as AsVariant>::VARIANTS;
+                    let variants = <MtuUpdatedCause as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[81usize], entries, variants)
+                    (&INFO[92usize], entries, variants)
                 }
                 22usize => {
                     let offset = *entry;
-                    let variants = <MtuUpdatedCause as AsVariant>::VARIANTS;
+                    let variants = <SlowStartExitCause as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
                     (&INFO[95usize], entries, variants)
                 }
                 23usize => {
                     let offset = *entry;
-                    let variants = <SlowStartExitCause as AsVariant>::VARIANTS;
+                    let variants = <BbrState as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[98usize], entries, variants)
+                    (&INFO[104usize], entries, variants)
                 }
                 24usize => {
                     let offset = *entry;
-                    let variants = <BbrState as AsVariant>::VARIANTS;
+                    let variants = <DcState as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[107usize], entries, variants)
+                    (&INFO[110usize], entries, variants)
                 }
                 25usize => {
                     let offset = *entry;
-                    let variants = <DcState as AsVariant>::VARIANTS;
+                    let variants = <crate::connection::Error as AsVariant>::VARIANTS;
                     let entries = &self.nominal_counters[offset..offset + variants.len()];
                     (&INFO[113usize], entries, variants)
                 }
@@ -1816,17 +1816,17 @@ impl<R: Registry> Subscriber<R> {
                 7usize => (&INFO[28usize], entry),
                 8usize => (&INFO[29usize], entry),
                 9usize => (&INFO[30usize], entry),
-                10usize => (&INFO[60usize], entry),
-                11usize => (&INFO[61usize], entry),
-                12usize => (&INFO[64usize], entry),
-                13usize => (&INFO[67usize], entry),
-                14usize => (&INFO[88usize], entry),
-                15usize => (&INFO[91usize], entry),
-                16usize => (&INFO[94usize], entry),
-                17usize => (&INFO[100usize], entry),
-                18usize => (&INFO[103usize], entry),
-                19usize => (&INFO[104usize], entry),
-                20usize => (&INFO[105usize], entry),
+                10usize => (&INFO[57usize], entry),
+                11usize => (&INFO[58usize], entry),
+                12usize => (&INFO[61usize], entry),
+                13usize => (&INFO[64usize], entry),
+                14usize => (&INFO[85usize], entry),
+                15usize => (&INFO[88usize], entry),
+                16usize => (&INFO[91usize], entry),
+                17usize => (&INFO[97usize], entry),
+                18usize => (&INFO[100usize], entry),
+                19usize => (&INFO[101usize], entry),
+                20usize => (&INFO[102usize], entry),
                 21usize => (&INFO[118usize], entry),
                 22usize => (&INFO[119usize], entry),
                 23usize => (&INFO[120usize], entry),
@@ -1876,16 +1876,16 @@ impl<R: Registry> Subscriber<R> {
                 0usize => (&INFO[45usize], entry),
                 1usize => (&INFO[46usize], entry),
                 2usize => (&INFO[47usize], entry),
-                3usize => (&INFO[51usize], entry),
-                4usize => (&INFO[57usize], entry),
-                5usize => (&INFO[75usize], entry),
-                6usize => (&INFO[76usize], entry),
-                7usize => (&INFO[77usize], entry),
-                8usize => (&INFO[83usize], entry),
-                9usize => (&INFO[85usize], entry),
-                10usize => (&INFO[109usize], entry),
-                11usize => (&INFO[110usize], entry),
-                12usize => (&INFO[111usize], entry),
+                3usize => (&INFO[54usize], entry),
+                4usize => (&INFO[72usize], entry),
+                5usize => (&INFO[73usize], entry),
+                6usize => (&INFO[74usize], entry),
+                7usize => (&INFO[80usize], entry),
+                8usize => (&INFO[82usize], entry),
+                9usize => (&INFO[106usize], entry),
+                10usize => (&INFO[107usize], entry),
+                11usize => (&INFO[108usize], entry),
+                12usize => (&INFO[109usize], entry),
                 13usize => (&INFO[112usize], entry),
                 14usize => (&INFO[157usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
@@ -2255,26 +2255,6 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
         let _ = event;
     }
     #[inline]
-    fn on_connection_closed(
-        &mut self,
-        context: &mut Self::ConnectionContext,
-        meta: &api::ConnectionMeta,
-        event: &api::ConnectionClosed,
-    ) {
-        #[allow(unused_imports)]
-        use api::*;
-        self.count(50usize, 21usize, 1usize);
-        self.time(
-            51usize,
-            3usize,
-            meta.timestamp.saturating_duration_since(context.start_time),
-        );
-        self.count_nominal(52usize, 14usize, &event.error);
-        let _ = context;
-        let _ = meta;
-        let _ = event;
-    }
-    #[inline]
     fn on_duplicate_packet(
         &mut self,
         context: &mut Self::ConnectionContext,
@@ -2283,9 +2263,9 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(53usize, 22usize, 1usize);
-        self.count_nominal(54usize, 15usize, &event.packet_header);
-        self.count_nominal(55usize, 16usize, &event.error);
+        self.count(50usize, 21usize, 1usize);
+        self.count_nominal(51usize, 14usize, &event.packet_header);
+        self.count_nominal(52usize, 15usize, &event.error);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2299,10 +2279,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(56usize, 23usize, 1usize);
+        self.count(53usize, 22usize, 1usize);
         self.time(
-            57usize,
-            4usize,
+            54usize,
+            3usize,
             meta.timestamp.saturating_duration_since(context.start_time),
         );
         let _ = context;
@@ -2318,10 +2298,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(58usize, 24usize, 1usize);
-        self.count(59usize, 25usize, event.len);
-        self.measure(60usize, 10usize, event.len);
-        self.measure(61usize, 11usize, event.gso_offset);
+        self.count(55usize, 23usize, 1usize);
+        self.count(56usize, 24usize, event.len);
+        self.measure(57usize, 10usize, event.len);
+        self.measure(58usize, 11usize, event.gso_offset);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2335,9 +2315,9 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(62usize, 26usize, 1usize);
-        self.count(63usize, 27usize, event.len);
-        self.measure(64usize, 12usize, event.len);
+        self.count(59usize, 25usize, 1usize);
+        self.count(60usize, 26usize, event.len);
+        self.measure(61usize, 12usize, event.len);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2351,10 +2331,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(65usize, 28usize, 1usize);
-        self.count(66usize, 29usize, event.len);
-        self.measure(67usize, 13usize, event.len);
-        self.count_nominal(68usize, 17usize, &event.reason);
+        self.count(62usize, 27usize, 1usize);
+        self.count(63usize, 28usize, event.len);
+        self.measure(64usize, 13usize, event.len);
+        self.count_nominal(65usize, 16usize, &event.reason);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2368,7 +2348,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(69usize, 30usize, 1usize);
+        self.count(66usize, 29usize, 1usize);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2382,8 +2362,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(70usize, 31usize, 1usize);
-        self.count_nominal(71usize, 18usize, &event.state);
+        self.count(67usize, 30usize, 1usize);
+        self.count_nominal(68usize, 17usize, &event.state);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2397,8 +2377,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(72usize, 32usize, 1usize);
-        self.count_nominal(73usize, 19usize, &event.reason);
+        self.count(69usize, 31usize, 1usize);
+        self.count_nominal(70usize, 18usize, &event.reason);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2412,15 +2392,15 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(74usize, 33usize, 1usize);
+        self.count(71usize, 32usize, 1usize);
         {
             fn check(evt: &api::HandshakeStatusUpdated) -> bool {
                 matches!(evt.status, HandshakeStatus::Complete { .. })
             }
             if check(event) {
                 self.time(
-                    75usize,
-                    5usize,
+                    72usize,
+                    4usize,
                     meta.timestamp.saturating_duration_since(context.start_time),
                 );
             }
@@ -2431,8 +2411,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
             }
             if check(event) {
                 self.time(
-                    76usize,
-                    6usize,
+                    73usize,
+                    5usize,
                     meta.timestamp.saturating_duration_since(context.start_time),
                 );
             }
@@ -2443,13 +2423,13 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
             }
             if check(event) {
                 self.time(
-                    77usize,
-                    7usize,
+                    74usize,
+                    6usize,
                     meta.timestamp.saturating_duration_since(context.start_time),
                 );
             }
         }
-        self.count_nominal(78usize, 20usize, &event.status);
+        self.count_nominal(75usize, 19usize, &event.status);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2463,7 +2443,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(79usize, 34usize, 1usize);
+        self.count(76usize, 33usize, 1usize);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2477,8 +2457,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(80usize, 35usize, 1usize);
-        self.count_nominal(81usize, 21usize, &event.path_challenge_status);
+        self.count(77usize, 34usize, 1usize);
+        self.count_nominal(78usize, 20usize, &event.path_challenge_status);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2492,10 +2472,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(82usize, 36usize, 1usize);
+        self.count(79usize, 35usize, 1usize);
         self.time(
-            83usize,
-            8usize,
+            80usize,
+            7usize,
             meta.timestamp.saturating_duration_since(context.start_time),
         );
         let _ = context;
@@ -2511,10 +2491,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(84usize, 37usize, 1usize);
+        self.count(81usize, 36usize, 1usize);
         self.time(
-            85usize,
-            9usize,
+            82usize,
+            8usize,
             meta.timestamp.saturating_duration_since(context.start_time),
         );
         let _ = context;
@@ -2530,9 +2510,9 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(86usize, 38usize, 1usize);
-        self.count(87usize, 39usize, event.bytes);
-        self.measure(88usize, 14usize, event.bytes);
+        self.count(83usize, 37usize, 1usize);
+        self.count(84usize, 38usize, event.bytes);
+        self.measure(85usize, 14usize, event.bytes);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2546,9 +2526,9 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(89usize, 40usize, 1usize);
-        self.count(90usize, 41usize, event.bytes);
-        self.measure(91usize, 15usize, event.bytes);
+        self.count(86usize, 39usize, 1usize);
+        self.count(87usize, 40usize, event.bytes);
+        self.measure(88usize, 15usize, event.bytes);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2562,7 +2542,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(92usize, 42usize, 1usize);
+        self.count(89usize, 41usize, 1usize);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2576,10 +2556,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(93usize, 43usize, 1usize);
-        self.measure(94usize, 16usize, event.mtu);
-        self.count_nominal(95usize, 22usize, &event.cause);
-        self.count_bool(96usize, 2usize, event.search_complete);
+        self.count(90usize, 42usize, 1usize);
+        self.measure(91usize, 16usize, event.mtu);
+        self.count_nominal(92usize, 21usize, &event.cause);
+        self.count_bool(93usize, 2usize, event.search_complete);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2593,15 +2573,15 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(97usize, 44usize, 1usize);
-        self.count_nominal(98usize, 23usize, &event.cause);
+        self.count(94usize, 43usize, 1usize);
+        self.count_nominal(95usize, 22usize, &event.cause);
         self.time_nominal(
-            99usize,
+            96usize,
             0usize,
             &event.cause,
             meta.timestamp.saturating_duration_since(context.start_time),
         );
-        self.measure(100usize, 17usize, event.congestion_window);
+        self.measure(97usize, 17usize, event.congestion_window);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2615,7 +2595,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(101usize, 45usize, 1usize);
+        self.count(98usize, 44usize, 1usize);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2629,10 +2609,10 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(102usize, 46usize, 1usize);
-        self.measure(103usize, 18usize, event.bytes_per_second);
-        self.measure(104usize, 19usize, event.burst_size);
-        self.measure(105usize, 20usize, event.pacing_gain);
+        self.count(99usize, 45usize, 1usize);
+        self.measure(100usize, 18usize, event.bytes_per_second);
+        self.measure(101usize, 19usize, event.burst_size);
+        self.measure(102usize, 20usize, event.pacing_gain);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2646,8 +2626,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(106usize, 47usize, 1usize);
-        self.count_nominal(107usize, 24usize, &event.state);
+        self.count(103usize, 46usize, 1usize);
+        self.count_nominal(104usize, 23usize, &event.state);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -2661,15 +2641,15 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     ) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(108usize, 48usize, 1usize);
+        self.count(105usize, 47usize, 1usize);
         {
             fn check(evt: &api::DcStateChanged) -> bool {
                 matches!(evt.state, DcState::VersionNegotiated { .. })
             }
             if check(event) {
                 self.time(
-                    109usize,
-                    10usize,
+                    106usize,
+                    9usize,
                     meta.timestamp.saturating_duration_since(context.start_time),
                 );
             }
@@ -2680,8 +2660,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
             }
             if check(event) {
                 self.time(
-                    110usize,
-                    11usize,
+                    107usize,
+                    10usize,
                     meta.timestamp.saturating_duration_since(context.start_time),
                 );
             }
@@ -2692,8 +2672,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
             }
             if check(event) {
                 self.time(
-                    111usize,
-                    12usize,
+                    108usize,
+                    11usize,
                     meta.timestamp.saturating_duration_since(context.start_time),
                 );
             }
@@ -2704,13 +2684,33 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
             }
             if check(event) {
                 self.time(
-                    112usize,
-                    13usize,
+                    109usize,
+                    12usize,
                     meta.timestamp.saturating_duration_since(context.start_time),
                 );
             }
         }
-        self.count_nominal(113usize, 25usize, &event.state);
+        self.count_nominal(110usize, 24usize, &event.state);
+        let _ = context;
+        let _ = meta;
+        let _ = event;
+    }
+    #[inline]
+    fn on_connection_closed(
+        &mut self,
+        context: &mut Self::ConnectionContext,
+        meta: &api::ConnectionMeta,
+        event: &api::ConnectionClosed,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(111usize, 48usize, 1usize);
+        self.time(
+            112usize,
+            13usize,
+            meta.timestamp.saturating_duration_since(context.start_time),
+        );
+        self.count_nominal(113usize, 25usize, &event.error);
         let _ = context;
         let _ = meta;
         let _ = event;

--- a/quic/s2n-quic-core/src/event/generated/metrics/probe.rs
+++ b/quic/s2n-quic-core/src/event/generated/metrics/probe.rs
@@ -40,34 +40,34 @@ mod counter {
                 41usize => Self(key_update),
                 44usize => Self(key_space_discarded),
                 49usize => Self(connection_started),
-                50usize => Self(connection_closed),
-                53usize => Self(duplicate_packet),
-                56usize => Self(transport_parameters_received),
-                58usize => Self(datagram_sent),
-                59usize => Self(datagram_sent__bytes__total),
-                62usize => Self(datagram_received),
-                63usize => Self(datagram_received__bytes__total),
-                65usize => Self(datagram_dropped),
-                66usize => Self(datagram_dropped__bytes__total),
-                69usize => Self(connection_id_updated),
-                70usize => Self(ecn_state_changed),
-                72usize => Self(connection_migration_denied),
-                74usize => Self(handshake_status_updated),
-                79usize => Self(tls_exporter_ready),
-                80usize => Self(path_challenge_updated),
-                82usize => Self(tls_client_hello),
-                84usize => Self(tls_server_hello),
-                86usize => Self(rx_stream_progress),
-                87usize => Self(rx_stream_progress__bytes__total),
-                89usize => Self(tx_stream_progress),
-                90usize => Self(tx_stream_progress__bytes__total),
-                92usize => Self(keep_alive_timer_expired),
-                93usize => Self(mtu_updated),
-                97usize => Self(slow_start_exited),
-                101usize => Self(delivery_rate_sampled),
-                102usize => Self(pacing_rate_updated),
-                106usize => Self(bbr_state_changed),
-                108usize => Self(dc_state_changed),
+                50usize => Self(duplicate_packet),
+                53usize => Self(transport_parameters_received),
+                55usize => Self(datagram_sent),
+                56usize => Self(datagram_sent__bytes__total),
+                59usize => Self(datagram_received),
+                60usize => Self(datagram_received__bytes__total),
+                62usize => Self(datagram_dropped),
+                63usize => Self(datagram_dropped__bytes__total),
+                66usize => Self(connection_id_updated),
+                67usize => Self(ecn_state_changed),
+                69usize => Self(connection_migration_denied),
+                71usize => Self(handshake_status_updated),
+                76usize => Self(tls_exporter_ready),
+                77usize => Self(path_challenge_updated),
+                79usize => Self(tls_client_hello),
+                81usize => Self(tls_server_hello),
+                83usize => Self(rx_stream_progress),
+                84usize => Self(rx_stream_progress__bytes__total),
+                86usize => Self(tx_stream_progress),
+                87usize => Self(tx_stream_progress__bytes__total),
+                89usize => Self(keep_alive_timer_expired),
+                90usize => Self(mtu_updated),
+                94usize => Self(slow_start_exited),
+                98usize => Self(delivery_rate_sampled),
+                99usize => Self(pacing_rate_updated),
+                103usize => Self(bbr_state_changed),
+                105usize => Self(dc_state_changed),
+                111usize => Self(connection_closed),
                 114usize => Self(version_information),
                 115usize => Self(endpoint_packet_sent),
                 116usize => Self(endpoint_packet_received),
@@ -146,8 +146,6 @@ mod counter {
             fn key_space_discarded(value: u64);
             # [link_name = s2n_quic__event__counter__connection_started]
             fn connection_started(value: u64);
-            # [link_name = s2n_quic__event__counter__connection_closed]
-            fn connection_closed(value: u64);
             # [link_name = s2n_quic__event__counter__duplicate_packet]
             fn duplicate_packet(value: u64);
             # [link_name = s2n_quic__event__counter__transport_parameters_received]
@@ -202,6 +200,8 @@ mod counter {
             fn bbr_state_changed(value: u64);
             # [link_name = s2n_quic__event__counter__dc_state_changed]
             fn dc_state_changed(value: u64);
+            # [link_name = s2n_quic__event__counter__connection_closed]
+            fn connection_closed(value: u64);
             # [link_name = s2n_quic__event__counter__version_information]
             fn version_information(value: u64);
             # [link_name = s2n_quic__event__counter__endpoint_packet_sent]
@@ -263,7 +263,7 @@ mod counter {
                 match info.id {
                     21usize => Self(packet_lost__is_mtu_probe),
                     31usize => Self(recovery_metrics__congestion_limited),
-                    96usize => Self(mtu_updated__search_complete),
+                    93usize => Self(mtu_updated__search_complete),
                     _ => unreachable!("invalid info: {info:?}"),
                 }
             }
@@ -306,18 +306,18 @@ mod counter {
                     42usize => Self(key_update__key_type),
                     43usize => Self(key_update__cipher_suite),
                     48usize => Self(key_space_discarded__space),
-                    52usize => Self(connection_closed__error),
-                    54usize => Self(duplicate_packet__kind),
-                    55usize => Self(duplicate_packet__error),
-                    68usize => Self(datagram_dropped__reason),
-                    71usize => Self(ecn_state_changed__state),
-                    73usize => Self(connection_migration_denied__reason),
-                    78usize => Self(handshake_status_updated__status),
-                    81usize => Self(path_challenge_updated__status),
-                    95usize => Self(mtu_updated__cause),
-                    98usize => Self(slow_start_exited__cause),
-                    107usize => Self(bbr_state_changed__state),
-                    113usize => Self(dc_state_changed__state),
+                    51usize => Self(duplicate_packet__kind),
+                    52usize => Self(duplicate_packet__error),
+                    65usize => Self(datagram_dropped__reason),
+                    68usize => Self(ecn_state_changed__state),
+                    70usize => Self(connection_migration_denied__reason),
+                    75usize => Self(handshake_status_updated__status),
+                    78usize => Self(path_challenge_updated__status),
+                    92usize => Self(mtu_updated__cause),
+                    95usize => Self(slow_start_exited__cause),
+                    104usize => Self(bbr_state_changed__state),
+                    110usize => Self(dc_state_changed__state),
+                    113usize => Self(connection_closed__error),
                     127usize => Self(endpoint_datagram_dropped__reason),
                     129usize => Self(endpoint_connection_attempt_failed__error),
                     _ => unreachable!("invalid info: {info:?}"),
@@ -364,8 +364,6 @@ mod counter {
                 fn key_update__cipher_suite(value: u64, variant: u64, variant_name: &info::Str);
                 # [link_name = s2n_quic__event__counter__nominal__key_space_discarded__space]
                 fn key_space_discarded__space(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__connection_closed__error]
-                fn connection_closed__error(value: u64, variant: u64, variant_name: &info::Str);
                 # [link_name = s2n_quic__event__counter__nominal__duplicate_packet__kind]
                 fn duplicate_packet__kind(value: u64, variant: u64, variant_name: &info::Str);
                 # [link_name = s2n_quic__event__counter__nominal__duplicate_packet__error]
@@ -400,6 +398,8 @@ mod counter {
                 fn bbr_state_changed__state(value: u64, variant: u64, variant_name: &info::Str);
                 # [link_name = s2n_quic__event__counter__nominal__dc_state_changed__state]
                 fn dc_state_changed__state(value: u64, variant: u64, variant_name: &info::Str);
+                # [link_name = s2n_quic__event__counter__nominal__connection_closed__error]
+                fn connection_closed__error(value: u64, variant: u64, variant_name: &info::Str);
                 # [link_name = s2n_quic__event__counter__nominal__endpoint_datagram_dropped__reason]
                 fn endpoint_datagram_dropped__reason(
                     value: u64,
@@ -434,17 +434,17 @@ mod measure {
                 28usize => Self(recovery_metrics__pto_count),
                 29usize => Self(recovery_metrics__congestion_window),
                 30usize => Self(recovery_metrics__bytes_in_flight),
-                60usize => Self(datagram_sent__bytes),
-                61usize => Self(datagram_sent__gso_offset),
-                64usize => Self(datagram_received__bytes),
-                67usize => Self(datagram_dropped__bytes),
-                88usize => Self(rx_stream_progress__bytes),
-                91usize => Self(tx_stream_progress__bytes),
-                94usize => Self(mtu_updated__mtu),
-                100usize => Self(slow_start_exited__congestion_window),
-                103usize => Self(pacing_rate_updated__bytes_per_second),
-                104usize => Self(pacing_rate_updated__burst_size),
-                105usize => Self(pacing_rate_updated__pacing_gain),
+                57usize => Self(datagram_sent__bytes),
+                58usize => Self(datagram_sent__gso_offset),
+                61usize => Self(datagram_received__bytes),
+                64usize => Self(datagram_dropped__bytes),
+                85usize => Self(rx_stream_progress__bytes),
+                88usize => Self(tx_stream_progress__bytes),
+                91usize => Self(mtu_updated__mtu),
+                97usize => Self(slow_start_exited__congestion_window),
+                100usize => Self(pacing_rate_updated__bytes_per_second),
+                101usize => Self(pacing_rate_updated__burst_size),
+                102usize => Self(pacing_rate_updated__pacing_gain),
                 118usize => Self(endpoint_datagram_sent__bytes),
                 119usize => Self(endpoint_datagram_sent__bytes__total),
                 120usize => Self(endpoint_datagram_sent__gso_offset),
@@ -579,17 +579,17 @@ mod timer {
                 45usize => Self(key_space_discarded__initial__latency),
                 46usize => Self(key_space_discarded__handshake__latency),
                 47usize => Self(key_space_discarded__one_rtt__latency),
-                51usize => Self(connection_closed__latency),
-                57usize => Self(transport_parameters_received__latency),
-                75usize => Self(handshake_status_updated__complete__latency),
-                76usize => Self(handshake_status_updated__confirmed__latency),
-                77usize => Self(handshake_status_updated__handshake_done_acked__latency),
-                83usize => Self(tls_client_hello__latency),
-                85usize => Self(tls_server_hello__latency),
-                109usize => Self(dc_state_changed__version_negotiated__latency),
-                110usize => Self(dc_state_changed__no_version_negotiated__latency),
-                111usize => Self(dc_state_changed__path_secrets__latency),
-                112usize => Self(dc_state_changed__complete__latency),
+                54usize => Self(transport_parameters_received__latency),
+                72usize => Self(handshake_status_updated__complete__latency),
+                73usize => Self(handshake_status_updated__confirmed__latency),
+                74usize => Self(handshake_status_updated__handshake_done_acked__latency),
+                80usize => Self(tls_client_hello__latency),
+                82usize => Self(tls_server_hello__latency),
+                106usize => Self(dc_state_changed__version_negotiated__latency),
+                107usize => Self(dc_state_changed__no_version_negotiated__latency),
+                108usize => Self(dc_state_changed__path_secrets__latency),
+                109usize => Self(dc_state_changed__complete__latency),
+                112usize => Self(connection_closed__latency),
                 157usize => Self(platform_event_loop_sleep__processing_duration),
                 _ => unreachable!("invalid info: {info:?}"),
             }
@@ -608,8 +608,6 @@ mod timer {
             fn key_space_discarded__handshake__latency(value: core::time::Duration);
             # [link_name = s2n_quic__event__timer__key_space_discarded__one_rtt__latency]
             fn key_space_discarded__one_rtt__latency(value: core::time::Duration);
-            # [link_name = s2n_quic__event__timer__connection_closed__latency]
-            fn connection_closed__latency(value: core::time::Duration);
             # [link_name = s2n_quic__event__timer__transport_parameters_received__latency]
             fn transport_parameters_received__latency(value: core::time::Duration);
             # [link_name = s2n_quic__event__timer__handshake_status_updated__complete__latency]
@@ -630,6 +628,8 @@ mod timer {
             fn dc_state_changed__path_secrets__latency(value: core::time::Duration);
             # [link_name = s2n_quic__event__timer__dc_state_changed__complete__latency]
             fn dc_state_changed__complete__latency(value: core::time::Duration);
+            # [link_name = s2n_quic__event__timer__connection_closed__latency]
+            fn connection_closed__latency(value: core::time::Duration);
             # [link_name = s2n_quic__event__timer__platform_event_loop_sleep__processing_duration]
             fn platform_event_loop_sleep__processing_duration(value: core::time::Duration);
         }
@@ -642,7 +642,7 @@ mod timer {
         impl Recorder {
             pub(crate) fn new(info: &'static Info, _variant: &'static info::Variant) -> Self {
                 match info.id {
-                    99usize => Self(slow_start_exited__latency),
+                    96usize => Self(slow_start_exited__latency),
                     _ => unreachable!("invalid info: {info:?}"),
                 }
             }

--- a/quic/s2n-quic-events/src/output_mode.rs
+++ b/quic/s2n-quic-events/src/output_mode.rs
@@ -30,14 +30,14 @@ impl OutputMode {
 
     pub fn counter_type(&self) -> TokenStream {
         match self {
-            OutputMode::Ref => quote!(AtomicU32),
-            OutputMode::Mut => quote!(u32),
+            OutputMode::Ref => quote!(AtomicU64),
+            OutputMode::Mut => quote!(u64),
         }
     }
 
     pub fn counter_init(&self) -> TokenStream {
         match self {
-            OutputMode::Ref => quote!(AtomicU32::new(0)),
+            OutputMode::Ref => quote!(AtomicU64::new(0)),
             OutputMode::Mut => quote!(0),
         }
     }
@@ -46,6 +46,13 @@ impl OutputMode {
         match self {
             OutputMode::Ref => quote!(.fetch_add(1, Ordering::Relaxed)),
             OutputMode::Mut => quote!(+= 1),
+        }
+    }
+
+    pub fn counter_increment_by(&self, value: TokenStream) -> TokenStream {
+        match self {
+            OutputMode::Ref => quote!(.fetch_add(#value, Ordering::Relaxed)),
+            OutputMode::Mut => quote!(+= #value),
         }
     }
 
@@ -66,7 +73,7 @@ impl OutputMode {
     pub fn imports(&self) -> TokenStream {
         match self {
             OutputMode::Ref => quote!(
-                use core::sync::atomic::{AtomicU32, Ordering};
+                use core::sync::atomic::{AtomicU64, Ordering};
             ),
             OutputMode::Mut => quote!(),
         }


### PR DESCRIPTION
### Description of changes: 

This change implements connection-level counter aggregation. This allows aggregating counters at the connection level and then aggregating them as metrics, as opposed to them being pure counters or measurements, which don't have enough granularity to give insight into distribution of connection behaviors. For example, this change allows getting a distribution of the number of bytes sent and received on streams.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

