### PR TITLE
fix(s2n-quic-dc): set TCP_NODELAY on TCP sockets

### DIFF
--- a/dc/s2n-quic-dc/src/stream/client/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/client/tokio.rs
@@ -62,6 +62,9 @@ where
     // Race TCP handshake with the TLS handshake
     let (socket, peer) = tokio::try_join!(TcpStream::connect(acceptor_addr), handshake,)?;
 
+    // Make sure TCP_NODELAY is set
+    let _ = socket.set_nodelay(true);
+
     let stream = endpoint::open_stream(env, peer, env::TcpRegistered(socket), subscriber, None)?;
 
     // build the stream inside the application context

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp.rs
@@ -501,6 +501,9 @@ where
     ) where
         Pub: EndpointPublisher,
     {
+        // Make sure TCP_NODELAY is set
+        let _ = stream.set_nodelay(true);
+
         let meta = event::api::ConnectionMeta {
             id: 0, // TODO use an actual connection ID
             timestamp: now.into_event(),


### PR DESCRIPTION
### Description of changes: 

This change ensures `TCP_NODELAY` is set to `true` on TCP sockets, as it can greatly affect latencies, especially with smaller payloads.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

