### PR TITLE
fix(s2n-quic-dc): remove redundant measure_counter naming suffix

### DIFF
--- a/dc/s2n-quic-dc/events/connection.rs
+++ b/dc/s2n-quic-dc/events/connection.rs
@@ -47,7 +47,7 @@ pub struct StreamWriteFinFlushed {
 
 #[event("stream:write_blocked")]
 #[checkpoint("latency")]
-#[measure_counter("conn.stream.write.blocked")]
+#[measure_counter("conn")]
 pub struct StreamWriteBlocked {
     /// The number of bytes that the application tried to write
     #[measure("provided", Bytes)]
@@ -112,7 +112,7 @@ pub struct StreamWriteSocketFlushed {
 }
 
 #[event("stream:write_socket_blocked")]
-#[measure_counter("conn.stream.write.socket.blocked")]
+#[measure_counter("conn")]
 pub struct StreamWriteSocketBlocked {
     /// The number of bytes that the stream tried to write to the socket
     #[measure("provided", Bytes)]

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -418,7 +418,7 @@ static INFO: &[Info; 202usize] = &[
     .build(),
     info::Builder {
         id: 67usize,
-        name: Str::new("stream_write_blocked.conn.stream.write.blocked\0"),
+        name: Str::new("stream_write_blocked.conn\0"),
         units: Units::None,
     }
     .build(),
@@ -538,7 +538,7 @@ static INFO: &[Info; 202usize] = &[
     .build(),
     info::Builder {
         id: 87usize,
-        name: Str::new("stream_write_socket_blocked.conn.stream.write.socket.blocked\0"),
+        name: Str::new("stream_write_socket_blocked.conn\0"),
         units: Units::None,
     }
     .build(),

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -537,7 +537,7 @@ mod measure {
                 62usize => Self(stream_write_fin_flushed__committed__conn),
                 63usize => Self(stream_write_fin_flushed__processing_duration),
                 64usize => Self(stream_write_fin_flushed__processing_duration__conn),
-                67usize => Self(stream_write_blocked__conn__stream__write__blocked),
+                67usize => Self(stream_write_blocked__conn),
                 68usize => Self(stream_write_blocked__provided),
                 69usize => Self(stream_write_blocked__processing_duration),
                 70usize => Self(stream_write_blocked__processing_duration__conn),
@@ -549,7 +549,7 @@ mod measure {
                 82usize => Self(stream_write_socket_flushed__provided),
                 84usize => Self(stream_write_socket_flushed__committed),
                 85usize => Self(stream_write_socket_flushed__committed__conn),
-                87usize => Self(stream_write_socket_blocked__conn__stream__write__socket__blocked),
+                87usize => Self(stream_write_socket_blocked__conn),
                 88usize => Self(stream_write_socket_blocked__provided),
                 90usize => Self(stream_write_socket_errored__provided),
                 93usize => Self(stream_read_flushed__conn),
@@ -653,8 +653,8 @@ mod measure {
             fn stream_write_fin_flushed__processing_duration(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_fin_flushed__processing_duration__conn]
             fn stream_write_fin_flushed__processing_duration__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_blocked__conn__stream__write__blocked]
-            fn stream_write_blocked__conn__stream__write__blocked(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_write_blocked__conn]
+            fn stream_write_blocked__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_blocked__provided]
             fn stream_write_blocked__provided(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_blocked__processing_duration]
@@ -677,8 +677,8 @@ mod measure {
             fn stream_write_socket_flushed__committed(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_socket_flushed__committed__conn]
             fn stream_write_socket_flushed__committed__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_socket_blocked__conn__stream__write__socket__blocked]
-            fn stream_write_socket_blocked__conn__stream__write__socket__blocked(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__stream_write_socket_blocked__conn]
+            fn stream_write_socket_blocked__conn(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_socket_blocked__provided]
             fn stream_write_socket_blocked__provided(value: u64);
             # [link_name = s2n_quic_dc__event__measure__stream_write_socket_errored__provided]


### PR DESCRIPTION
### Description of changes: 

This fixes some redundantly suffixed measurement names from #2397, since measurements are already prefixed by the event name they're attached to.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

