### PR TITLE
refactor(s2n-quic-dc): reduce the number of `peer_addr` calls

### DIFF
--- a/dc/s2n-quic-dc/src/stream/application.rs
+++ b/dc/s2n-quic-dc/src/stream/application.rs
@@ -114,10 +114,18 @@ where
     Sub: event::Subscriber,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Stream")
-            .field("peer_addr", &self.peer_addr().unwrap())
-            .field("local_addr", &self.local_addr().unwrap())
-            .finish()
+        let mut s = f.debug_struct("Stream");
+
+        for (name, addr) in [
+            ("peer_addr", self.peer_addr()),
+            ("local_addr", self.local_addr()),
+        ] {
+            if let Ok(addr) = addr {
+                s.field(name, &addr);
+            }
+        }
+
+        s.finish()
     }
 }
 

--- a/dc/s2n-quic-dc/src/stream/environment/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/tokio.rs
@@ -289,7 +289,7 @@ where
 }
 
 /// A socket that should be reregistered with the application runtime
-pub struct TcpReregistered(pub TcpStream);
+pub struct TcpReregistered(pub TcpStream, pub SocketAddress);
 
 impl<Sub> super::Peer<Environment<Sub>> for TcpReregistered
 where
@@ -308,7 +308,7 @@ where
 
     #[inline]
     fn setup(self, _env: &Environment<Sub>) -> super::Result<super::SocketSet<Self::WorkerSocket>> {
-        let remote_addr = self.0.peer_addr()?.into();
+        let remote_addr = self.1;
         let source_control_port = self.0.local_addr()?.port();
         let application = Box::new(self.0.into_std()?);
         Ok(super::SocketSet {

--- a/dc/s2n-quic-dc/src/stream/recv/application.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/application.rs
@@ -60,10 +60,18 @@ where
     Sub: event::Subscriber,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Reader")
-            .field("peer_addr", &self.peer_addr().unwrap())
-            .field("local_addr", &self.local_addr().unwrap())
-            .finish()
+        let mut s = f.debug_struct("Reader");
+
+        for (name, addr) in [
+            ("peer_addr", self.peer_addr()),
+            ("local_addr", self.local_addr()),
+        ] {
+            if let Ok(addr) = addr {
+                s.field(name, &addr);
+            }
+        }
+
+        s.finish()
     }
 }
 

--- a/dc/s2n-quic-dc/src/stream/send/application.rs
+++ b/dc/s2n-quic-dc/src/stream/send/application.rs
@@ -47,10 +47,18 @@ where
     Sub: event::Subscriber,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.debug_struct("Writer")
-            .field("peer_addr", &self.peer_addr().unwrap())
-            .field("local_addr", &self.local_addr().unwrap())
-            .finish()
+        let mut s = f.debug_struct("Writer");
+
+        for (name, addr) in [
+            ("peer_addr", self.peer_addr()),
+            ("local_addr", self.local_addr()),
+        ] {
+            if let Ok(addr) = addr {
+                s.field(name, &addr);
+            }
+        }
+
+        s.finish()
     }
 }
 


### PR DESCRIPTION
### Description of changes: 

The current TCP acceptor calls `peer_addr` quite a few times, especially after events were added. This change, instead, caches the value and uses that everywhere.

### Call-outs:

I noticed that our `fmt::Debug` impls were calling `peer_addr().unwrap()`, which isn't good. So I refactored those to not panic.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

