### PR TITLE
fix(s2n-quic-dc): make TCP shutdown a no-op

### DIFF
--- a/dc/s2n-quic-dc/src/stream/socket/fd/tcp.rs
+++ b/dc/s2n-quic-dc/src/stream/socket/fd/tcp.rs
@@ -60,12 +60,3 @@ where
         unsafe { libc::sendmsg(fd, &msg, flags) }
     } as _)
 }
-
-#[inline]
-pub fn shutdown<T>(fd: &T) -> io::Result<()>
-where
-    T: AsRawFd,
-{
-    libc_call(|| unsafe { libc::shutdown(fd.as_raw_fd(), libc::SHUT_WR) as _ })?;
-    Ok(())
-}

--- a/dc/s2n-quic-dc/src/stream/socket/tokio/tcp.rs
+++ b/dc/s2n-quic-dc/src/stream/socket/tokio/tcp.rs
@@ -138,7 +138,7 @@ impl Socket for TcpStream {
 
     #[inline]
     fn send_finish(&self) -> io::Result<()> {
-        // AsyncWrite::poll_shutdown requires a `&mut self` so we just use libc directly
-        tcp::shutdown(self)
+        // Since we authenticate socket closures, no need to also shutdown the TCP layer
+        Ok(())
     }
 }


### PR DESCRIPTION
### Description of changes: 

This change makes TCP shutdown a no-op. This is done for a few reasons:

* We already authenticate stream closures at the record layer so doing it in TCP is redundant
* It avoids an extra syscall

Above all, we can avoid more complex shutdown behavior in the TCP layer:

https://datatracker.ietf.org/doc/html/rfc9293#section-3.3.2

> A RST can be sent from any state with a corresponding transition to TIME-WAIT (see [[70](https://doi.org/10.1109/INFCOM.1999.752180)] for rationale). These transitions are not explicitly shown; otherwise, the diagram would become very difficult to read. Similarly, receipt of a RST from any state results in a transition to LISTEN or CLOSED, though this is also omitted from the diagram for legibility.

Basically, we don't need to go through the 4-way finalization flow but instead jump directly to TIME-WAIT. When combined with linger=0, this can release sockets a lot sooner to the OS which enables busy machines to handle higher TPS (see https://doi.org/10.1109/INFCOM.1999.752180).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

