### PR TITLE
feat(s2n-quic-xdp): Make io::rx::Channel::for_each public

### DIFF
--- a/tools/xdp/s2n-quic-xdp/src/io/rx.rs
+++ b/tools/xdp/s2n-quic-xdp/src/io/rx.rs
@@ -117,7 +117,7 @@ impl<D: Driver> Channel<D> {
 
     /// Iterates over all of the acquired entries in the ring and calls `on_packet`
     #[inline]
-    fn for_each<F: FnMut(RxTxDescriptor)>(&mut self, mut on_packet: F) {
+    pub fn for_each<F: FnMut(RxTxDescriptor)>(&mut self, mut on_packet: F) {
         // one last effort to acquire any packets
         let len = self.rx.acquire(1);
         let len = self.fill.acquire(len);


### PR DESCRIPTION
This allows iteration over descriptors in the rx channel.

### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

resolves #2404

### Description of changes: 

Makes io::rx::Channel::for_each public so it can be used directly without higher level s2n implementations.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

`cargo build --release`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

