### PR TITLE
feat(s2n-quic-dc): set linger to 0

### DIFF
--- a/dc/s2n-quic-dc/src/stream/client/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/client/tokio.rs
@@ -64,6 +64,7 @@ where
 
     // Make sure TCP_NODELAY is set
     let _ = socket.set_nodelay(true);
+    let _ = socket.set_linger(Some(core::time::Duration::ZERO));
 
     let local_port = socket.local_addr()?.port();
     let stream = endpoint::open_stream(

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp.rs
@@ -502,6 +502,7 @@ where
     {
         // Make sure TCP_NODELAY is set
         let _ = stream.set_nodelay(true);
+        let _ = stream.set_linger(Some(Duration::ZERO));
 
         let meta = event::api::ConnectionMeta {
             id: 0, // TODO use an actual connection ID


### PR DESCRIPTION
### Description of changes: 

As a follow up to https://github.com/aws/s2n-quic/pull/2402#pullrequestreview-2479762567, this change sets linger to 0 on TCP sockets.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

