### PR TITLE
fix(s2n-quic-dc): separate address lookup functionality in path secret map

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map/store.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/store.rs
@@ -6,7 +6,7 @@ use crate::{
     credentials::{Credentials, Id},
     fixed_map::ReadGuard,
     packet::{secret_control as control, Packet, WireVersion},
-    path::secret::{receiver, stateless_reset, HandshakeKind},
+    path::secret::{receiver, stateless_reset},
 };
 use core::time::Duration;
 use s2n_codec::EncoderBuffer;
@@ -21,17 +21,17 @@ pub trait Store: 'static + Send + Sync {
 
     fn drop_state(&self);
 
-    fn contains(&self, peer: SocketAddr) -> bool;
-
     fn on_new_path_secrets(&self, entry: Arc<Entry>);
 
     fn on_handshake_complete(&self, entry: Arc<Entry>);
 
-    fn get_by_addr_tracked(
-        &self,
-        peer: &SocketAddr,
-        handshake: HandshakeKind,
-    ) -> Option<ReadGuard<Arc<Entry>>>;
+    fn contains(&self, peer: &SocketAddr) -> bool;
+
+    fn needs_handshake(&self, peer: &SocketAddr) -> bool;
+
+    fn get_by_addr_untracked(&self, peer: &SocketAddr) -> Option<ReadGuard<Arc<Entry>>>;
+
+    fn get_by_addr_tracked(&self, peer: &SocketAddr) -> Option<ReadGuard<Arc<Entry>>>;
 
     fn get_by_id_untracked(&self, id: &Id) -> Option<ReadGuard<Arc<Entry>>>;
 


### PR DESCRIPTION
### Description of changes: 

Before this change, we had a single function to get path secrets by address: `get_tracked`. The logic in that function caused path secrets to return `None` if a handshake had been requested, causing issues for servers that are unable to initiate handshakes with clients.

This change, instead, separates concerns into multiple functions, which fixes behaviors for servers.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

