### PR TITLE
test: update snapshots from s2n-tls 0.3.8 behavior

### DIFF
--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -35,6 +35,8 @@ openssl = { version = "0.10" }
 openssl-sys = { version = "0.9", features = ["vendored"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-rustls = { path = "../s2n-quic-rustls" }
+# tests depend on alert behavior from >=0.3.8
+s2n-tls = { version = "0.3.8", features = ["quic"] }
 
 # we don't use openssl-sys directly; it's just here to pin and vendor in dev
 [package.metadata.cargo-udeps.ignore]

--- a/quic/s2n-quic-tls/src/tests.rs
+++ b/quic/s2n-quic-tls/src/tests.rs
@@ -433,7 +433,7 @@ fn s2n_client_with_client_auth_s2n_server_does_not_trust_client_certificate() {
     // application level host verification check on the cert.
     assert!(test_result.is_err());
     let e = test_result.unwrap_err();
-    assert_eq!(e.description().unwrap(), "HANDSHAKE_FAILURE");
+    assert_eq!(e.description().unwrap(), "CERTIFICATE_UNKNOWN");
 }
 
 #[test]
@@ -448,7 +448,7 @@ fn s2n_client_with_client_auth_s2n_server_does_not_trust_issuer() {
     // by a CA that is not in the server trust store, even though the host name is validated.
     assert!(test_result.is_err());
     let e = test_result.unwrap_err();
-    assert_eq!(e.description().unwrap(), "HANDSHAKE_FAILURE");
+    assert_eq!(e.description().unwrap(), "CERTIFICATE_UNKNOWN");
 }
 
 #[test]
@@ -462,7 +462,7 @@ fn s2n_client_with_custom_hostname_auth_rejects_server_name() {
     // The handshake should fail because the hostname ("localhost") is not validated
     assert!(test_result.is_err());
     let e = test_result.unwrap_err();
-    assert_eq!(e.description().unwrap(), "HANDSHAKE_FAILURE");
+    assert_eq!(e.description().unwrap(), "CERTIFICATE_UNKNOWN");
 }
 
 #[test]

--- a/quic/s2n-quic/src/tests/snapshots/tests__dc__dc_mtls_handshake_auth_failure_self_test__events.snap
+++ b/quic/s2n-quic/src/tests/snapshots/tests__dc__dc_mtls_handshake_auth_failure_self_test__events.snap
@@ -1,6 +1,7 @@
 ---
 source: quic/s2n-quic-core/src/event/snapshot.rs
 input_file: quic/s2n-quic/src/tests/dc.rs
+snapshot_kind: text
 ---
 === client ===
 count#platform_event_loop_started=1
@@ -451,7 +452,7 @@ count#packet_dropped=1
 count#packet_dropped.reason|CONNECTION_ERROR=1
 count#connection_closed=1
 timer#connection_closed.latency=100ms
-count#connection_closed.error|TLS_HANDSHAKE_FAILURE=1
+count#connection_closed.error|TLS_CERTIFICATE_UNKNOWN=1
 count#frame_sent=1
 count#frame_sent.packet|HANDSHAKE=1
 count#frame_sent.frame|CONNECTION_CLOSE=1


### PR DESCRIPTION
### Description of changes: 

In https://github.com/aws/s2n-tls/pull/4919, certificate-related errors started mapping to alerts for better debugging. As such, this causes failures for tests that assert specific errors.

This change updates which errors we are asserting.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

