### PR TITLE
build: do fewer optimizations in release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,9 @@ exclude = [
 bolero = "0.12"
 bolero-generator = { version = "0.12", default-features = false }
 
-[profile.release]
-lto = true
-codegen-units = 1
-incremental = false
+[profile.release-debug]
+inherits = "dev"
+opt-level = 3
 
 [profile.bench]
 lto = true

--- a/tools/xdp/Cargo.toml
+++ b/tools/xdp/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 members = ["s2n-quic-xdp", "tester", "xtask"]
 resolver = "2"
+
+[workspace.dependencies]
+bolero = "0.12"
+bolero-generator = { version = "0.12", default-features = false }

--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -23,7 +23,7 @@ s2n-quic-core = { version = "=0.51.0", path = "../../../quic/s2n-quic-core" }
 tokio = { version = "1", features = ["net"], optional = true }
 
 [dev-dependencies]
-bolero = "0.12"
+bolero.workspace = true
 futures = "0.3"
 pin-project-lite = "0.2"
 rand = "0.8"


### PR DESCRIPTION
### Description of changes: 

This change reworks the `release` profile to be less aggressive. Currently it does _a lot_ of optimizations which takes forever in most cases. Instead, the `bench` profile can be used for those cases.

I've also added a `release-debug` that's the same as `release`, just with better debug info.

Additionally, we have some issues with dependabot not being able to resolve workspace dependencies in the `tools/xdp` directory so i've fixed that as well.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

