### PR TITLE
ci: add neqo from required resumption test client

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -648,6 +648,7 @@
       "server"
     ],
     "neqo": [
+      "client",
       "server"
     ],
     "ngtcp2": [


### PR DESCRIPTION
### Description of changes: 

Revert changes from [PR#2191](https://github.com/aws/s2n-quic/pull/2191). Test if the resumption interop test with neqo client will success. This PR is related to [Issue#2192](https://github.com/aws/s2n-quic/issues/2192).

### Testing:

CI test. The interop neqo test is successful in CI: [test result 1](https://github.com/aws/s2n-quic/actions/runs/12302805857/job/34336691879?pr=2420), [test result 2](https://github.com/aws/s2n-quic/actions/runs/12302805857/job/34336696699?pr=2420).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

