### PR TITLE
test(s2n-quic-dc): ignore read errors for send tests

### DIFF
--- a/dc/s2n-quic-dc/src/stream/send/tests.rs
+++ b/dc/s2n-quic-dc/src/stream/send/tests.rs
@@ -56,7 +56,9 @@ async fn run(protocol: Protocol, buffer_len: usize, iterations: usize, features:
                     async move {
                         let mut data = vec![0; 1 << 17];
                         loop {
-                            let len = stream.read(&mut data).await.unwrap();
+                            let Ok(len) = stream.read(&mut data).await else {
+                                break;
+                            };
                             if len == 0 {
                                 break;
                             }


### PR DESCRIPTION
### Description of changes: 

When we moved to use linger=0 (#2407) and not calling shutdown (#2402)  on TCP sockets, this made the send tests a bit flaky due to an `unwrap` on connection reset, even though all of the data was transmitted.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

