### PR TITLE
fix(ci): fix the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 
       - uses: aws-actions/configure-aws-credentials@v4.0.2
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCEcrRole
           role-session-name: S2nQuicGHAECRSession


### PR DESCRIPTION
### Description of changes: 

The release check in CI won't load credential if the PR is created from a forked `s2n-quic` repo. The error report is in this [test result](https://github.com/aws/s2n-quic/actions/runs/12287529137/job/34289718607). Therefore, we should add a check to load the credential.

### Testing:

This PR is created from @boquan-fang's forked `s2n-quic` repo. We test this PR with the release qns test in the CI to see whether it actually works.

The test result is [here](https://github.com/aws/s2n-quic/actions/runs/12306881305/job/34349444526?pr=2423).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

