### PR TITLE
ci: specify specific bolero dependency rather than workspace dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,10 +15,6 @@ exclude = [
     "tools",
 ]
 
-[workspace.dependencies]
-bolero = "0.12"
-bolero-generator = { version = "0.12", default-features = false }
-
 [profile.release-debug]
 inherits = "dev"
 opt-level = 3

--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -19,14 +19,14 @@ checked_range_unsafe = []
 generator = ["bolero-generator"]
 
 [dependencies]
-bolero-generator = { workspace = true, optional = true }
+bolero-generator = { version = "0.12", default-features = false, optional = true }
 byteorder = { version = "1.1", default-features = false }
 bytes = { version = "1", default-features = false, optional = true }
 zerocopy = { version = "0.7", features = ["derive"] }
 
 [dev-dependencies]
-bolero.workspace = true
-bolero-generator.workspace = true
+bolero = "0.12"
+bolero-generator = "0.12"
 
 [package.metadata.kani]
 flags = { tests = true }

--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -20,7 +20,7 @@ arrayvec = "0.7"
 atomic-waker = "1"
 aws-lc-rs = "1"
 bitflags = "2"
-bolero-generator = { version = "0.12", optional = true }
+bolero-generator = { version = "0.12", default-features = false, optional = true }
 bytes = "1"
 crossbeam-channel = "0.5"
 crossbeam-epoch = "0.9"

--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -20,7 +20,7 @@ arrayvec = "0.7"
 atomic-waker = "1"
 aws-lc-rs = "1"
 bitflags = "2"
-bolero-generator = { workspace = true, optional = true }
+bolero-generator = { version = "0.12", optional = true }
 bytes = "1"
 crossbeam-channel = "0.5"
 crossbeam-epoch = "0.9"
@@ -46,8 +46,8 @@ zeroize = "1"
 parking_lot = "0.12"
 
 [dev-dependencies]
-bolero.workspace = true
-bolero-generator.workspace = true
+bolero = "0.12"
+bolero-generator = "0.12"
 insta = "1"
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
 s2n-quic-core = { path = "../../quic/s2n-quic-core", features = ["testing"] }

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -29,7 +29,7 @@ usdt = ["dep:probe"]
 
 [dependencies]
 atomic-waker = { version = "1", optional = true }
-bolero-generator = { version = "0.12", optional = true }
+bolero-generator = { version = "0.12", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false }
 bytes = { version = "1", optional = true, default-features = false }
 crossbeam-utils = { version = "0.8", optional = true }

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -29,7 +29,7 @@ usdt = ["dep:probe"]
 
 [dependencies]
 atomic-waker = { version = "1", optional = true }
-bolero-generator = { workspace = true, optional = true }
+bolero-generator = { version = "0.12", optional = true }
 byteorder = { version = "1", default-features = false }
 bytes = { version = "1", optional = true, default-features = false }
 crossbeam-utils = { version = "0.8", optional = true }
@@ -49,8 +49,8 @@ futures-test = { version = "0.3", optional = true } # For testing Waker interact
 once_cell = { version = "1", optional = true }
 
 [dev-dependencies]
-bolero.workspace = true
-bolero-generator.workspace = true
+bolero = "0.12"
+bolero-generator = "0.12"
 insta = { version = "1", features = ["json"] }
 futures = "0.3"
 futures-test = "0.3"

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -21,7 +21,7 @@ xdp = ["s2n-quic-xdp"]
 
 [dependencies]
 bach = { version = "0.0.6", optional = true }
-bolero-generator = { version = "0.12", optional = true }
+bolero-generator = { version = "0.12", default-features = false, optional = true }
 cfg-if = "1"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 lazy_static = { version = "1", optional = true }

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -21,7 +21,7 @@ xdp = ["s2n-quic-xdp"]
 
 [dependencies]
 bach = { version = "0.0.6", optional = true }
-bolero-generator = { workspace = true, optional = true }
+bolero-generator = { version = "0.12", optional = true }
 cfg-if = "1"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 lazy_static = { version = "1", optional = true }
@@ -37,8 +37,8 @@ libc = "0.2"
 
 [dev-dependencies]
 bach = { version = "0.0.6" }
-bolero.workspace = true
-bolero-generator.workspace = true
+bolero = "0.12"
+bolero-generator = "0.12"
 futures = { version = "0.3", features = ["std"] }
 insta = { version = "1", features = ["json"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -29,7 +29,7 @@ siphasher = "1.0"
 smallvec = { version = "1", default-features = false }
 
 [dev-dependencies]
-bolero.workspace = true
+bolero = "0.12"
 futures-test = "0.3" # For testing Waker interactions
 insta = { version = "1", features = ["json"] }
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -84,7 +84,7 @@ zerocopy = { version = "0.7", optional = true, features = ["derive"] }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-bolero.workspace = true
+bolero = { version = "0.12" }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "probe-tracing", "testing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }
 s2n-quic-transport = { path = "../s2n-quic-transport", features = ["unstable_resumption", "unstable-provider-dc"] }


### PR DESCRIPTION
### Description of changes: 

Dependabot for `s2n-quic` is currently down with this [error message](https://github.com/aws/s2n-quic/network/updates/931720310). I checked the dependabot update log and found this [error message](https://github.com/aws/s2n-quic/actions/runs/12284577998/job/34280654957):
```
updater | 2024/12/11 20:45:13 INFO <job_931351966> Handled error whilst updating rbpf: 
dependency_file_not_resolvable {:message=>"info: syncing channel updates for '1.80.0-x86_64-unknown-linux-
gnu'\ninfo: latest update on 2024-07-25, rust version 1.80.0 (051478957 2024-07-21)\ninfo: downloading component 
'cargo'\ninfo: downloading component 'clippy'\ninfo: downloading component 'rust-docs'\ninfo: downloading component 
'rust-std'\ninfo: downloading component 'rustc'\ninfo: downloading component 'rustfmt'\ninfo: installing component 
'cargo'\ninfo: installing component 'clippy'\ninfo: installing component 'rust-docs'\ninfo: installing component 'rust-
std'\ninfo: installing component 'rustc'\ninfo: installing component 'rustfmt'\nerror: failed to load manifest for workspace 
member `dependabot_tmp_dir/tools/xdp/s2n-quic-xdp`\nreferenced by workspace at 
`dependabot_tmp_dir/tools/xdp/Cargo.toml`\n\nCaused by:\n  failed to load manifest for dependency `s2n-
codec`\n\nCaused by:\n  failed to parse manifest at `dependabot_tmp_dir/common/s2n-codec/Cargo.toml`\n\nCaused 
by:\n  error inheriting `bolero-generator` from workspace root manifest's `workspace.dependencies.bolero-
generator`\n\nCaused by:\n  failed to find a workspace root"}
```

Seems like the Dependabot can't resolve dependency that we are currently doing in `s2n-quic`:
https://github.com/aws/s2n-quic/blob/5dd0c47159868d3ee190f8d0f701b81c6cc39a03/Cargo.toml#L18-L20

https://github.com/aws/s2n-quic/blob/5dd0c47159868d3ee190f8d0f701b81c6cc39a03/quic/s2n-quic-transport/Cargo.toml#L31-L33

This problem is also mentioned in [Dependabot-core repo](https://github.com/dependabot/dependabot-core):
They to implement features to support workspace in dependabot, but later reverted the change due to regression: https://github.com/dependabot/dependabot-core/pull/10550#issuecomment-2348447466.

They then try to reimplement such feature, but hasn't merge it: https://github.com/dependabot/dependabot-core/pull/10629.

We do want to use `workspace` for this library in the future as mentioned in a [previous PR#2400](https://github.com/aws/s2n-quic/pull/2400). However, we want to fix dependabot for now.

Therefore, this PR remove `workspace` in [Cargo.toml](https://github.com/aws/s2n-quic/blob/main/Cargo.toml) and ping version 0.12 for bolero dependency. We believe such change could potentially fix our dependabot.

### Call-outs:

* This PR can only be tested after merge. Dependabot should be triggered again on this PR is merge, and we will see whether this fix it or not. If not, then we need to revert this change and investigate other causes and solutions.

* We can still use workspace dependency if the dependabot team merge [their PR](https://github.com/dependabot/dependabot-core/pull/10629).

### Testing:

Merge this PR to test dependabot.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

