### PR TITLE
ci: specify specific bolero dependency rather than workspace dependency in s2n-quic-xdp

### DIFF
--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -23,7 +23,7 @@ s2n-quic-core = { version = "=0.51.0", path = "../../../quic/s2n-quic-core" }
 tokio = { version = "1", features = ["net"], optional = true }
 
 [dev-dependencies]
-bolero.workspace = true
+bolero = "0.12"
 futures = "0.3"
 pin-project-lite = "0.2"
 rand = "0.8"


### PR DESCRIPTION
### Description of changes: 

This PR follows up [PR#2424](https://github.com/aws/s2n-quic/pull/2424). The previous PR missed one `bolero.workspace = true` that needs to be removed:

https://github.com/aws/s2n-quic/blob/1d2aaa74fcbf5778d358b2eabc867619ec79c5b9/tools/xdp/s2n-quic-xdp/Cargo.toml#L25-L26

Hence, this PR will fix that problem as well.

### Call-outs:

I have done a search in the entire codebase for `bolero.workspace`. Hence, there shouldn't be any more `bolero.workspace` left after this PR is merged.

### Testing:

Merge this PR and see if Dependabot can properly update. Same as [PR#2424](https://github.com/aws/s2n-quic/pull/2424).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

