### PR TITLE
fix(s2n-quic-dc): handle spurious TCP acceptor worker wakeups

### DIFF
--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp/manager/tests.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp/manager/tests.rs
@@ -171,9 +171,8 @@ impl Harness {
         let Entry { worker, waker, .. } = &mut self.manager.inner.workers[idx];
         let is_active = worker.is_active();
 
-        if is_active {
-            waker.wake_by_ref();
-        }
+        // wake the worker even if it's not active so we can test more paths
+        waker.wake_by_ref();
 
         is_active
     }


### PR DESCRIPTION
### Description of changes: 

This change fixes an issue where the following happens:

* The TCP acceptor removes a stream at index `N`, due to it being expired
* The tokio runtime is notified of stream readiness at index `N` and wakes the task
* The task polls the worker, which is no longer reading from the stream, which was previously assumed to not happen

### Testing:

I've made the fuzz tests less constrained to trigger this series of events. If I simply apply the test change, then it shows the error:

```
---- stream::server::tokio::tcp::manager::tests::invariants_test stdout ----

======================== Test Failure ========================

BOLERO_RANDOM_SEED=148028850864596720821768053785163681304

Input: 
[
    Wake {
        idx: 1,
    },
    Insert,
]

Error: 
panicked at dc/s2n-quic-dc/src/stream/server/tokio/tcp/manager/tests.rs:94:17:
internal error: entered unreachable code: shouldn't be polled when idle
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

