### PR TITLE
events: adding detail to DatagramDropped event

### DIFF
--- a/quic/s2n-quic-core/events/connection.rs
+++ b/quic/s2n-quic-core/events/connection.rs
@@ -272,7 +272,11 @@ struct DatagramReceived {
 #[event("transport:datagram_dropped")]
 //= https://tools.ietf.org/id/draft-marx-qlog-event-definitions-quic-h3-02#5.3.12
 /// Datagram dropped by a connection
-struct DatagramDropped {
+struct DatagramDropped<'a> {
+    local_addr: SocketAddress<'a>,
+    remote_addr: SocketAddress<'a>,
+    destination_cid: ConnectionId<'a>,
+    source_cid: Option<ConnectionId<'a>>,
     #[measure("bytes", Bytes)]
     #[counter("bytes.total", Bytes)]
     len: u16,

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -2289,20 +2289,28 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     #[doc = " Datagram dropped by a connection"]
-    pub struct DatagramDropped {
+    pub struct DatagramDropped<'a> {
+        pub local_addr: SocketAddress<'a>,
+        pub remote_addr: SocketAddress<'a>,
+        pub destination_cid: ConnectionId<'a>,
+        pub source_cid: Option<ConnectionId<'a>>,
         pub len: u16,
         pub reason: DatagramDropReason,
     }
     #[cfg(any(test, feature = "testing"))]
-    impl crate::event::snapshot::Fmt for DatagramDropped {
+    impl<'a> crate::event::snapshot::Fmt for DatagramDropped<'a> {
         fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
             let mut fmt = fmt.debug_struct("DatagramDropped");
+            fmt.field("local_addr", &self.local_addr);
+            fmt.field("remote_addr", &self.remote_addr);
+            fmt.field("destination_cid", &self.destination_cid);
+            fmt.field("source_cid", &self.source_cid);
             fmt.field("len", &self.len);
             fmt.field("reason", &self.reason);
             fmt.finish()
         }
     }
-    impl Event for DatagramDropped {
+    impl<'a> Event for DatagramDropped<'a> {
         const NAME: &'static str = "transport:datagram_dropped";
     }
     #[derive(Clone, Debug)]
@@ -3902,8 +3910,15 @@ pub mod tracing {
             event: &api::DatagramDropped,
         ) {
             let id = context.id();
-            let api::DatagramDropped { len, reason } = event;
-            tracing :: event ! (target : "datagram_dropped" , parent : id , tracing :: Level :: DEBUG , { len = tracing :: field :: debug (len) , reason = tracing :: field :: debug (reason) });
+            let api::DatagramDropped {
+                local_addr,
+                remote_addr,
+                destination_cid,
+                source_cid,
+                len,
+                reason,
+            } = event;
+            tracing :: event ! (target : "datagram_dropped" , parent : id , tracing :: Level :: DEBUG , { local_addr = tracing :: field :: debug (local_addr) , remote_addr = tracing :: field :: debug (remote_addr) , destination_cid = tracing :: field :: debug (destination_cid) , source_cid = tracing :: field :: debug (source_cid) , len = tracing :: field :: debug (len) , reason = tracing :: field :: debug (reason) });
         }
         #[inline]
         fn on_connection_id_updated(
@@ -5931,15 +5946,30 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     #[doc = " Datagram dropped by a connection"]
-    pub struct DatagramDropped {
+    pub struct DatagramDropped<'a> {
+        pub local_addr: SocketAddress<'a>,
+        pub remote_addr: SocketAddress<'a>,
+        pub destination_cid: ConnectionId<'a>,
+        pub source_cid: Option<ConnectionId<'a>>,
         pub len: u16,
         pub reason: DatagramDropReason,
     }
-    impl IntoEvent<api::DatagramDropped> for DatagramDropped {
+    impl<'a> IntoEvent<api::DatagramDropped<'a>> for DatagramDropped<'a> {
         #[inline]
-        fn into_event(self) -> api::DatagramDropped {
-            let DatagramDropped { len, reason } = self;
+        fn into_event(self) -> api::DatagramDropped<'a> {
+            let DatagramDropped {
+                local_addr,
+                remote_addr,
+                destination_cid,
+                source_cid,
+                len,
+                reason,
+            } = self;
             api::DatagramDropped {
+                local_addr: local_addr.into_event(),
+                remote_addr: remote_addr.into_event(),
+                destination_cid: destination_cid.into_event(),
+                source_cid: source_cid.into_event(),
                 len: len.into_event(),
                 reason: reason.into_event(),
             }

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -338,6 +338,13 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                         endpoint_context.event_subscriber,
                         |publisher, _path| {
                             publisher.on_datagram_dropped(event::builder::DatagramDropped {
+                                local_addr: header.path.local_address().into_event(),
+                                remote_addr: header.path.remote_address().into_event(),
+                                destination_cid: datagram.destination_connection_id.into_event(),
+                                source_cid: datagram
+                                    .source_connection_id
+                                    .as_ref()
+                                    .map(|cid| cid.into_event()),
                                 len: datagram.payload_len as u16,
                                 reason: err,
                             });

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -575,6 +575,13 @@ impl<Cfg: Config> Endpoint<Cfg> {
                             endpoint_context.event_subscriber,
                             |publisher, _path| {
                                 publisher.on_datagram_dropped(event::builder::DatagramDropped {
+                                    local_addr: header.path.local_address().into_event(),
+                                    remote_addr: header.path.remote_address().into_event(),
+                                    destination_cid: datagram.destination_connection_id.into_event(),
+                                    source_cid: datagram
+                                        .source_connection_id
+                                        .as_ref()
+                                        .map(|cid| cid.into_event()),
                                     len: datagram.payload_len as u16,
                                     reason: datagram_drop_reason,
                                 });

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -577,7 +577,9 @@ impl<Cfg: Config> Endpoint<Cfg> {
                                 publisher.on_datagram_dropped(event::builder::DatagramDropped {
                                     local_addr: header.path.local_address().into_event(),
                                     remote_addr: header.path.remote_address().into_event(),
-                                    destination_cid: datagram.destination_connection_id.into_event(),
+                                    destination_cid: datagram
+                                        .destination_connection_id
+                                        .into_event(),
                                     source_cid: datagram
                                         .source_connection_id
                                         .as_ref()

--- a/quic/s2n-quic/src/tests/recorder.rs
+++ b/quic/s2n-quic/src/tests/recorder.rs
@@ -165,3 +165,32 @@ event_recorder!(
         storage.push(addr);
     }
 );
+
+use s2n_quic_core::event::api::DatagramDropReason;
+pub struct DatagramDroppedEvent {
+    pub local_addr: SocketAddr,
+    pub remote_addr: SocketAddr,
+    pub len: u16,
+    pub reason: DatagramDropReason,
+}
+
+impl<'a> From<&events::DatagramDropped<'a>> for DatagramDroppedEvent {
+    fn from(value: &events::DatagramDropped<'a>) -> Self {
+        DatagramDroppedEvent {
+            local_addr: value.local_addr.to_string().parse().unwrap(),
+            remote_addr: value.remote_addr.to_string().parse().unwrap(),
+            len: value.len,
+            reason: value.reason.clone(),
+        }
+    }
+}
+
+event_recorder!(
+    DatagramDropped,
+    DatagramDropped,
+    on_datagram_dropped,
+    DatagramDroppedEvent,
+    |event: &events::DatagramDropped, storage: &mut Vec<DatagramDroppedEvent>| {
+        storage.push(event.into());
+    }
+);

--- a/quic/s2n-quic/src/tests/recorder.rs
+++ b/quic/s2n-quic/src/tests/recorder.rs
@@ -168,18 +168,14 @@ event_recorder!(
 
 use s2n_quic_core::event::api::DatagramDropReason;
 pub struct DatagramDroppedEvent {
-    pub local_addr: SocketAddr,
     pub remote_addr: SocketAddr,
-    pub len: u16,
     pub reason: DatagramDropReason,
 }
 
 impl<'a> From<&events::DatagramDropped<'a>> for DatagramDroppedEvent {
     fn from(value: &events::DatagramDropped<'a>) -> Self {
         DatagramDroppedEvent {
-            local_addr: value.local_addr.to_string().parse().unwrap(),
             remote_addr: value.remote_addr.to_string().parse().unwrap(),
-            len: value.len,
             reason: value.reason.clone(),
         }
     }


### PR DESCRIPTION
### Release Summary:
Adds address and connection ID information to the on_datagram_dropped event. 

NOTE: This is a breaking change if your application stores the `DatagramDropped` events, as a named lifetime was added to the struct. 

### Description of changes: 

This change adds additional details (local/remote address, src/dst connection ID) to the `on_datagram_dropped` event, to assist with debugging. 

### Call-outs:

This is technically a breaking change, as a named lifetime was added to the struct. 

### Testing:

Added an integration test that changes the port before the handshake is confirmed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

