### PR TITLE
fix(s2n-quic-dc): derive crypto before opening TCP stream

### DIFF
--- a/dc/s2n-quic-dc/src/stream/endpoint.rs
+++ b/dc/s2n-quic-dc/src/stream/endpoint.rs
@@ -4,7 +4,7 @@
 use crate::{
     event::{self, api::Subscriber as _, IntoEvent as _},
     msg, packet,
-    path::secret::{self, map, Map},
+    path::secret::{self, Map},
     random::Random,
     stream::{
         application,
@@ -35,21 +35,16 @@ pub struct AcceptError<Peer> {
 #[inline]
 pub fn open_stream<Env, P>(
     env: &Env,
-    entry: map::Peer,
+    map: &Map,
+    crypto: secret::map::Bidirectional,
+    parameters: dc::ApplicationParams,
     peer: P,
     subscriber: Env::Subscriber,
-    parameter_override: Option<&dyn Fn(dc::ApplicationParams) -> dc::ApplicationParams>,
 ) -> Result<application::Builder<Env::Subscriber>>
 where
     Env: Environment,
     P: Peer<Env>,
 {
-    let (crypto, mut parameters) = entry.pair(&peer.features());
-
-    if let Some(o) = parameter_override {
-        parameters = o(parameters);
-    }
-
     let key_id = crypto.credentials.key_id;
     let stream_id = packet::stream::Id {
         key_id,
@@ -74,7 +69,7 @@ where
         stream_id,
         None,
         crypto,
-        entry.map(),
+        map,
         parameters,
         None,
         None,


### PR DESCRIPTION
### Description of changes: 

While benchmarking TCP streams, we found that deriving the crypto before opening the stream stream can increase the likelihood that when the client can write the first packet quickly after the first round trip. This increases the chances of the first read on the server being successful and not having to fall back to epoll to wait for it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

