### PR TITLE
ci(duvet): add version input to duvet action

### DIFF
--- a/.github/actions/duvet/action.yml
+++ b/.github/actions/duvet/action.yml
@@ -1,6 +1,10 @@
 name: 'Duvet'
 description: 'Uses Duvet to generate a compliance report and uploads it to S3'
 inputs:
+  duvet-version:
+    description: 'Version string for Duvet'
+    default: latest
+    required: false
   report-script:
     description: 'Path to script that generates a Duvet report'
     required: true
@@ -41,6 +45,7 @@ runs:
     - uses: camshaft/install@v1
       with:
         crate: duvet
+        version: ${{ inputs.duvet-version }}
 
     - name: Generate Duvet report
       shell: bash


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 
s2n-tls uses the s2n-quic duvet github action, and the latest update to duvet broke our CI. We need to pin to an older version of duvet.

This PR adds an input to the action so that s2n-tls can set a specific version of duvet.


### Testing:

I can minimally prove that this doesn't break anything, because the ci / compliance check succeeded.
I manually tested that it actually sets the version by opening a separate PR with the s2n-quic compliance job duvet version [changed to 0.3.0](https://github.com/aws/s2n-quic/pull/2453/commits/924b58f486434476a4beeccb62c2c0deb1d7048c). [The job](https://github.com/aws/s2n-quic/actions/runs/12919220310/job/36029282431?pr=2453#step:3:165) used that version:
```
Installing duvet with cargo
...
Cache restored successfully
Using cached `duvet` with version 0.3.0
```
Compare that to this PR, where 0.4.1 is used:
```
Installing duvet with cargo
Installing "duvet = 0.4.1"
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

