### PR TITLE
fix: correctly unmap IPv4-mapped local addresses

### DIFF
--- a/quic/s2n-quic-core/src/inet/ip.rs
+++ b/quic/s2n-quic-core/src/inet/ip.rs
@@ -35,6 +35,14 @@ impl IpAddress {
         }
     }
 
+    /// Returns `true` if the two addresses are equal from a network perspective.
+    ///
+    /// This will unmap IPv4-mapped addresses to IpV4 tagged enum values
+    #[inline]
+    pub fn unmapped_eq(&self, other: &Self) -> bool {
+        self.unmap() == other.unmap()
+    }
+
     /// Converts the IP address into IPv6 if it is IPv4, otherwise the address is unchanged
     #[inline]
     #[must_use]
@@ -166,6 +174,14 @@ impl SocketAddress {
             Self::IpV4(_) => self,
             Self::IpV6(addr) => addr.unmap(),
         }
+    }
+
+    /// Returns `true` if the two addresses are equal from a network perspective.
+    ///
+    /// This will unmap IPv4-mapped addresses to IpV4 tagged enum values
+    #[inline]
+    pub fn unmapped_eq(&self, other: &Self) -> bool {
+        self.unmap() == other.unmap()
     }
 }
 

--- a/quic/s2n-quic-core/src/packet/interceptor.rs
+++ b/quic/s2n-quic-core/src/packet/interceptor.rs
@@ -58,12 +58,6 @@ pub trait Interceptor: 'static + Send {
     }
 
     #[inline(always)]
-    fn intercept_rx_remote_port(&mut self, subject: &Subject, port: &mut u16) {
-        let _ = subject;
-        let _ = port;
-    }
-
-    #[inline(always)]
     fn intercept_rx_datagram<'a>(
         &mut self,
         subject: &Subject,
@@ -141,12 +135,6 @@ where
     }
 
     #[inline(always)]
-    fn intercept_rx_remote_port(&mut self, subject: &Subject, port: &mut u16) {
-        self.0.intercept_rx_remote_port(subject, port);
-        self.1.intercept_rx_remote_port(subject, port);
-    }
-
-    #[inline(always)]
     fn intercept_rx_datagram<'a>(
         &mut self,
         subject: &Subject,
@@ -213,8 +201,10 @@ where
     R: 'static + Send + havoc::Random,
 {
     #[inline]
-    fn intercept_rx_remote_port(&mut self, _subject: &Subject, port: &mut u16) {
-        *port = self.port.havoc_u16(&mut self.random, *port);
+    fn intercept_rx_remote_address(&mut self, _subject: &Subject, addr: &mut RemoteAddress) {
+        let port = addr.port();
+        let port = self.port.havoc_u16(&mut self.random, port);
+        addr.set_port(port);
     }
 
     #[inline]
@@ -264,13 +254,6 @@ impl<T: Interceptor> Interceptor for Option<T> {
     fn intercept_rx_remote_address(&mut self, subject: &Subject, addr: &mut RemoteAddress) {
         if let Some(inner) = self.as_mut() {
             inner.intercept_rx_remote_address(subject, addr)
-        }
-    }
-
-    #[inline]
-    fn intercept_rx_remote_port(&mut self, subject: &Subject, port: &mut u16) {
-        if let Some(inner) = self.as_mut() {
-            inner.intercept_rx_remote_port(subject, port)
         }
     }
 

--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -65,7 +65,7 @@ pub trait Handle: 'static + Copy + Send + fmt::Debug {
     /// Returns the local address for the given handle
     fn local_address(&self) -> LocalAddress;
 
-    /// Returns the local address for the given handle
+    /// Updates the local address to the given value
     fn set_local_address(&mut self, addr: LocalAddress);
 
     /// Returns `true` if the two handles are equal from a network perspective

--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -104,7 +104,7 @@ macro_rules! impl_addr {
             /// This will unmap IPv4-mapped addresses to IpV4 tagged enum values
             #[inline]
             pub fn unmapped_eq(&self, other: &Self) -> bool {
-                self.0.unmap().eq(&other.0.unmap())
+                self.0.unmapped_eq(&other.0)
             }
         }
 

--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -59,17 +59,20 @@ pub trait Handle: 'static + Copy + Send + fmt::Debug {
     /// Returns the remote address for the given handle
     fn remote_address(&self) -> RemoteAddress;
 
-    /// Updates the remote port to the given value
-    fn set_remote_port(&mut self, port: u16);
+    /// Updates the remote address to the given value
+    fn set_remote_address(&mut self, addr: RemoteAddress);
 
     /// Returns the local address for the given handle
     fn local_address(&self) -> LocalAddress;
+
+    /// Returns the local address for the given handle
+    fn set_local_address(&mut self, addr: LocalAddress);
 
     /// Returns `true` if the two handles are equal from a network perspective
     ///
     /// This function is used to determine if a connection has migrated to another
     /// path.
-    fn eq(&self, other: &Self) -> bool;
+    fn unmapped_eq(&self, other: &Self) -> bool;
 
     /// Returns `true` if the two handles are strictly equal to each other, i.e.
     /// byte-for-byte.
@@ -94,6 +97,16 @@ macro_rules! impl_addr {
         #[cfg_attr(any(test, feature = "generator"), derive(TypeGenerator))]
         #[cfg_attr(kani, derive(kani::Arbitrary))]
         pub struct $name(pub SocketAddress);
+
+        impl $name {
+            /// Returns `true` if the two addresses are equal from a network perspective.
+            ///
+            /// This will unmap IPv4-mapped addresses to IpV4 tagged enum values
+            #[inline]
+            pub fn unmapped_eq(&self, other: &Self) -> bool {
+                self.0.unmap().eq(&other.0.unmap())
+            }
+        }
 
         impl From<event::api::SocketAddress<'_>> for $name {
             #[inline]
@@ -162,8 +175,8 @@ impl Handle for RemoteAddress {
     }
 
     #[inline]
-    fn set_remote_port(&mut self, port: u16) {
-        self.0.set_port(port)
+    fn set_remote_address(&mut self, addr: RemoteAddress) {
+        *self = addr;
     }
 
     #[inline]
@@ -172,8 +185,13 @@ impl Handle for RemoteAddress {
     }
 
     #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        PartialEq::eq(&self.unmap(), &other.unmap())
+    fn set_local_address(&mut self, _addr: LocalAddress) {
+        // nothing to update
+    }
+
+    #[inline]
+    fn unmapped_eq(&self, other: &Self) -> bool {
+        Self::unmapped_eq(self, other)
     }
 
     #[inline]
@@ -218,8 +236,8 @@ impl Handle for Tuple {
     }
 
     #[inline]
-    fn set_remote_port(&mut self, port: u16) {
-        self.remote_address.set_port(port)
+    fn set_remote_address(&mut self, addr: RemoteAddress) {
+        self.remote_address = addr;
     }
 
     #[inline]
@@ -228,9 +246,14 @@ impl Handle for Tuple {
     }
 
     #[inline]
-    fn eq(&self, other: &Self) -> bool {
-        PartialEq::eq(&self.local_address.unmap(), &other.local_address.unmap())
-            && Handle::eq(&self.remote_address, &other.remote_address)
+    fn set_local_address(&mut self, addr: LocalAddress) {
+        self.local_address = addr;
+    }
+
+    #[inline]
+    fn unmapped_eq(&self, other: &Self) -> bool {
+        self.local_address.unmapped_eq(&other.local_address)
+            && self.remote_address.unmapped_eq(&other.remote_address)
     }
 
     #[inline]

--- a/quic/s2n-quic-core/src/xdp/encoder.rs
+++ b/quic/s2n-quic-core/src/xdp/encoder.rs
@@ -409,7 +409,7 @@ mod tests {
 
             header.path.swap();
 
-            assert!(Handle::eq(&header.path, &message.path));
+            assert!(header.path.unmapped_eq(&message.path));
             assert_eq!(header.ecn, message.ecn);
             assert_eq!(payload.into_less_safe_slice(), &message.payload);
         });

--- a/quic/s2n-quic-core/src/xdp/path.rs
+++ b/quic/s2n-quic-core/src/xdp/path.rs
@@ -97,8 +97,9 @@ impl Handle for Tuple {
     }
 
     #[inline]
-    fn set_remote_port(&mut self, port: u16) {
-        self.remote_address.port = port;
+    fn set_remote_address(&mut self, addr: path::RemoteAddress) {
+        self.remote_address.ip = addr.ip();
+        self.remote_address.port = addr.port();
     }
 
     #[inline]
@@ -107,7 +108,13 @@ impl Handle for Tuple {
     }
 
     #[inline]
-    fn eq(&self, other: &Self) -> bool {
+    fn set_local_address(&mut self, addr: path::LocalAddress) {
+        self.local_address.ip = addr.ip();
+        self.local_address.port = addr.port();
+    }
+
+    #[inline]
+    fn unmapped_eq(&self, other: &Self) -> bool {
         // TODO only compare everything if the other is all filled out
         PartialEq::eq(&self.local_address.unmap(), &other.local_address.unmap())
             && PartialEq::eq(&self.remote_address.unmap(), &other.remote_address.unmap())

--- a/quic/s2n-quic-platform/src/message/msg/handle.rs
+++ b/quic/s2n-quic-platform/src/message/msg/handle.rs
@@ -77,9 +77,7 @@ impl path::Handle for Handle {
         );
 
         // only compare local addresses if the OS returns them
-        if !features::pktinfo::IS_SUPPORTED {
-            return true;
-        }
+        ensure!(features::pktinfo::IS_SUPPORTED, true);
 
         // Make sure to only compare the fields if they're both set
         //

--- a/quic/s2n-quic-qns/src/intercept.rs
+++ b/quic/s2n-quic-qns/src/intercept.rs
@@ -7,8 +7,11 @@ use s2n_codec::encoder::scatter;
 use s2n_quic_core::{
     event::api::Subject,
     havoc::{self, Strategy as _, *},
-    packet,
-    packet::interceptor::{DecoderBufferMut, Havoc},
+    packet::{
+        self,
+        interceptor::{DecoderBufferMut, Havoc},
+    },
+    path::RemoteAddress,
 };
 use structopt::StructOpt;
 
@@ -113,10 +116,10 @@ impl Interceptor {
 
 impl packet::interceptor::Interceptor for Interceptor {
     #[inline]
-    fn intercept_rx_remote_port(&mut self, subject: &Subject, port: &mut u16) {
+    fn intercept_rx_remote_address(&mut self, subject: &Subject, addr: &mut RemoteAddress) {
         if self.port {
             self.strategy_for(subject)
-                .intercept_rx_remote_port(subject, port)
+                .intercept_rx_remote_address(subject, addr)
         }
     }
 

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -435,14 +435,6 @@ impl<Cfg: Config> Endpoint<Cfg> {
                 endpoint_context
                     .packet_interceptor
                     .intercept_rx_remote_address(&subject, &mut remote_address);
-
-                let mut port = remote_address.port();
-                endpoint_context
-                    .packet_interceptor
-                    .intercept_rx_remote_port(&subject, &mut port);
-
-                remote_address.set_port(port);
-
                 header.path.set_remote_address(remote_address);
             }
 

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -430,14 +430,29 @@ impl<Cfg: Config> Endpoint<Cfg> {
         let buffer = {
             let subject = event::builder::Subject::Endpoint {}.into_event();
 
-            let mut port = header.path.remote_address().port();
-            endpoint_context
-                .packet_interceptor
-                .intercept_rx_remote_port(&subject, &mut port);
-            header.path.set_remote_port(port);
+            let mut remote_address = header.path.remote_address();
+            {
+                endpoint_context
+                    .packet_interceptor
+                    .intercept_rx_remote_address(&subject, &mut remote_address);
 
-            let remote_address = header.path.remote_address();
-            let local_address = header.path.local_address();
+                let mut port = remote_address.port();
+                endpoint_context
+                    .packet_interceptor
+                    .intercept_rx_remote_port(&subject, &mut port);
+
+                remote_address.set_port(port);
+
+                header.path.set_remote_address(remote_address);
+            }
+
+            let mut local_address = header.path.local_address();
+            {
+                endpoint_context
+                    .packet_interceptor
+                    .intercept_rx_local_address(&subject, &mut local_address);
+                header.path.set_local_address(local_address);
+            }
 
             let datagram = s2n_quic_core::packet::interceptor::Datagram {
                 remote_address: remote_address.into_event(),

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -549,9 +549,11 @@ impl<Config: endpoint::Config> Path<Config> {
     #[inline]
     fn eq_by_handle(&self, handle: &Config::PathHandle) -> bool {
         if Config::ENDPOINT_TYPE.is_client() || self.handle.local_address().port() == 0 {
-            s2n_quic_core::path::Handle::eq(&self.handle.remote_address(), &handle.remote_address())
+            self.handle
+                .remote_address()
+                .unmapped_eq(&handle.remote_address())
         } else {
-            self.handle.eq(handle)
+            self.handle.unmapped_eq(handle)
         }
     }
 }

--- a/quic/s2n-quic/src/tests/connection_migration.rs
+++ b/quic/s2n-quic/src/tests/connection_migration.rs
@@ -137,9 +137,10 @@ struct RebindPortBeforeLastHandshakePacket {
 
 impl Interceptor for RebindPortBeforeLastHandshakePacket {
     // Change the port after the first Handshake packet is received
-    fn intercept_rx_remote_port(&mut self, _subject: &Subject, port: &mut u16) {
+    fn intercept_rx_remote_address(&mut self, _subject: &Subject, addr: &mut RemoteAddress) {
         if self.handshake_packet_count == 1 && !self.changed_port {
-            *port += 1;
+            let port = addr.port();
+            addr.set_port(port + 1);
             self.changed_port = true;
         }
     }
@@ -229,9 +230,9 @@ struct RebindPortBeforeHandshakeConfirmed {
 
 const REBIND_PORT: u16 = 55555;
 impl Interceptor for RebindPortBeforeHandshakeConfirmed {
-    fn intercept_rx_remote_port(&mut self, _subject: &Subject, port: &mut u16) {
+    fn intercept_rx_remote_address(&mut self, _subject: &Subject, addr: &mut RemoteAddress) {
         if self.datagram_count == 1 && !self.changed_port {
-            *port = REBIND_PORT;
+            addr.set_port(REBIND_PORT);
             self.changed_port = true;
         }
     }

--- a/quic/s2n-quic/src/tests/connection_migration.rs
+++ b/quic/s2n-quic/src/tests/connection_migration.rs
@@ -6,6 +6,7 @@ use s2n_codec::DecoderBufferMut;
 use s2n_quic_core::{
     event::api::{DatagramDropReason, Subject},
     packet::interceptor::{Datagram, Interceptor},
+    path::{LocalAddress, RemoteAddress},
 };
 
 fn run_test<F>(mut on_rebind: F)
@@ -285,4 +286,89 @@ fn rebind_before_handshake_confirmed() {
         DatagramDropReason::ConnectionMigrationDuringHandshake { .. },
     ));
     assert_eq!(REBIND_PORT, event.remote_addr.port());
+}
+
+// Changes the remote address to ipv4-mapped after the first packet
+#[derive(Default)]
+struct RebindMappedAddrBeforeHandshakeConfirmed {
+    local: bool,
+    remote: bool,
+    datagram_count: usize,
+}
+
+impl Interceptor for RebindMappedAddrBeforeHandshakeConfirmed {
+    fn intercept_rx_local_address(&mut self, _subject: &Subject, addr: &mut LocalAddress) {
+        if self.datagram_count > 0 && self.local {
+            *addr = (*addr).to_ipv6_mapped().into();
+        }
+    }
+
+    fn intercept_rx_remote_address(&mut self, _subject: &Subject, addr: &mut RemoteAddress) {
+        if self.datagram_count > 0 && self.remote {
+            *addr = (*addr).to_ipv6_mapped().into();
+        }
+    }
+
+    fn intercept_rx_datagram<'a>(
+        &mut self,
+        _subject: &Subject,
+        _datagram: &Datagram,
+        payload: DecoderBufferMut<'a>,
+    ) -> DecoderBufferMut<'a> {
+        self.datagram_count += 1;
+        payload
+    }
+}
+
+/// Ensures that a datagram received from a client that changes from ipv4 to ipv4-mapped
+/// is still accepted
+#[test]
+fn rebind_ipv4_mapped_before_handshake_confirmed() {
+    fn run_test(interceptor: RebindMappedAddrBeforeHandshakeConfirmed) {
+        let model = Model::default();
+        let subscriber = recorder::DatagramDropped::new();
+        let datagram_dropped_events = subscriber.events();
+
+        test(model, move |handle| {
+            let server = Server::builder()
+                .with_io(handle.builder().build()?)?
+                .with_tls(SERVER_CERTS)?
+                .with_event((tracing_events(), subscriber))?
+                .with_random(Random::with_seed(456))?
+                .with_packet_interceptor(interceptor)?
+                .start()?;
+
+            let client = Client::builder()
+                .with_io(handle.builder().build()?)?
+                .with_tls(certificates::CERT_PEM)?
+                .with_event(tracing_events())?
+                .with_random(Random::with_seed(456))?
+                .start()?;
+
+            let addr = start_server(server)?;
+            start_client(client, addr, Data::new(1000))?;
+            Ok(addr)
+        })
+        .unwrap();
+
+        let datagram_dropped_events = datagram_dropped_events.lock().unwrap();
+        let datagram_dropped_events = &datagram_dropped_events[..];
+
+        assert!(
+            datagram_dropped_events.is_empty(),
+            "s2n-quic should not drop IPv4-mapped packets {datagram_dropped_events:?}"
+        );
+    }
+
+    // test all combinations
+    for local in [false, true] {
+        for remote in [false, true] {
+            let interceptor = RebindMappedAddrBeforeHandshakeConfirmed {
+                local,
+                remote,
+                ..Default::default()
+            };
+            run_test(interceptor);
+        }
+    }
 }

--- a/quic/s2n-quic/src/tests/recorder.rs
+++ b/quic/s2n-quic/src/tests/recorder.rs
@@ -167,6 +167,7 @@ event_recorder!(
 );
 
 use s2n_quic_core::event::api::DatagramDropReason;
+#[derive(Debug)]
 pub struct DatagramDroppedEvent {
     pub remote_addr: SocketAddr,
     pub reason: DatagramDropReason,


### PR DESCRIPTION
### Description of changes: 

The `msg::Handle::eq` check currently misses unmapping IPv4-mapped local addresses when trying to check if a path has migrated. This causes issues if packets are arriving on both IPv4 and IPv4-mapped spaces.

This change fixes this issue. Additionally, I've renamed the `Path::eq` method to `unmapped_eq` to make it very clear which function is being dispatched to; otherwise you end up getting `PartialEq::eq` in scope and it ends up doing a strict comparison. 

### Testing:

I've added some integration tests to test that things are mostly wired up correctly. Note that these tests do not use the `msg::Handle`, so this specific instance wouldn't have been caught with those alone but are good to have in general. For that, I've added an explicit unit test asserting the behavior that we want. Without the fix, the test fails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

