### PR TITLE
fix: ignore local address when considering path migration

### DIFF
--- a/quic/s2n-quic-platform/src/message/msg/handle.rs
+++ b/quic/s2n-quic-platform/src/message/msg/handle.rs
@@ -109,14 +109,7 @@ impl path::Handle for Handle {
 
     #[inline]
     fn maybe_update(&mut self, other: &Self) {
-        if other.local_address.port() == 0 {
-            return;
-        }
-
-        // once we discover our path, or the port changes, update the address with the new information
-        if self.local_address.port() != other.local_address.port() {
-            self.local_address = other.local_address;
-        }
+        self.local_address.maybe_update(&other.local_address);
     }
 }
 

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -540,21 +540,15 @@ impl<Config: endpoint::Config> Path<Config> {
 
     /// Compare a Path based on its PathHandle.
     ///
-    /// In case the local_address on the connection is unknown and set to
-    /// a default un-specified value only the remote_address is used
-    /// to compare Paths.
-    ///
-    /// In the case of the local endpoint being a client, the remote address is only used
-    /// since the client might experience address rebinding.
+    /// QUIC only considers the remote address when identifying paths
+    //= https://www.rfc-editor.org/rfc/rfc9000#section-9.3
+    //# Receiving a packet from a new peer address containing a non-probing frame
+    //# indicates that the peer has migrated to that address.
     #[inline]
     fn eq_by_handle(&self, handle: &Config::PathHandle) -> bool {
-        if Config::ENDPOINT_TYPE.is_client() || self.handle.local_address().port() == 0 {
-            self.handle
-                .remote_address()
-                .unmapped_eq(&handle.remote_address())
-        } else {
-            self.handle.unmapped_eq(handle)
-        }
+        self.handle
+            .remote_address()
+            .unmapped_eq(&handle.remote_address())
     }
 }
 


### PR DESCRIPTION
### Description of changes: 

We currently consider the full 4-tuple (local + remote IP addresses and ports) when identifying a path. This seems to be an overly strict interpretation of how paths are considered in the RFC. I don't see any text indicating this is the correct approach. In fact, I see the following:

```
//= https://www.rfc-editor.org/rfc/rfc9000#section-9.3
//# Receiving a packet from a new peer address containing a non-probing frame
//# indicates that the peer has migrated to that address.
```

That text seems to indicate that we should really only be considering the peer address when deciding if it tried to migrate. So I've implemented that change here.

Additionally, I've ensured that the server does _not_ update the local address it is sending on, even if received a packet on a new one, since this would also go against what the RFC recommends:

```
//= https://www.rfc-editor.org/rfc/rfc9000#section-9
//# If a client receives packets from an unknown server address, the client MUST discard these packets.
```

There's a high probability the client isn't aware that packets are being sent to different server IPs and would result in the client dropping packets, since the server's source IP would be different. As such, the server will not change its path at all after the initial packet is received.

### Testing:

I've added a test for the server which forces the local IP to change before the handshake completes. Before this change, this test would fail, since we'd drop all packets with a different IP. After this change, this test passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

