### PR TITLE
Revert "derive crypto before opening TCP stream"

### DIFF
--- a/dc/s2n-quic-dc/src/stream/client/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/client/tokio.rs
@@ -9,7 +9,6 @@ use crate::{
         endpoint,
         environment::tokio::{self as env, Environment},
         socket::Protocol,
-        TransportFeatures,
     },
 };
 use std::{io, net::SocketAddr};
@@ -30,15 +29,12 @@ where
     // ensure we have a secret for the peer
     let peer = handshake.await?;
 
-    let (crypto, parameters) = peer.pair(&TransportFeatures::UDP);
-
     let stream = endpoint::open_stream(
         env,
-        peer.map(),
-        crypto,
-        parameters,
+        peer,
         env::UdpUnbound(acceptor_addr.into()),
         subscriber,
+        None,
     )?;
 
     // build the stream inside the application context
@@ -64,14 +60,7 @@ where
     Sub: event::Subscriber,
 {
     // Race TCP handshake with the TLS handshake
-    let handshake = async {
-        let peer = handshake.await?;
-        let (crypto, parameters) = peer.pair(&TransportFeatures::TCP);
-        Ok((peer, crypto, parameters))
-    };
-    // poll the crypto first so the server can read the first packet on accept in the happy path
-    let ((peer, crypto, parameters), socket) =
-        tokio::try_join!(handshake, TcpStream::connect(acceptor_addr))?;
+    let (socket, peer) = tokio::try_join!(TcpStream::connect(acceptor_addr), handshake,)?;
 
     // Make sure TCP_NODELAY is set
     let _ = socket.set_nodelay(true);
@@ -88,15 +77,14 @@ where
 
     let stream = endpoint::open_stream(
         env,
-        peer.map(),
-        crypto,
-        parameters,
+        peer,
         env::TcpRegistered {
             socket,
             peer_addr,
             local_port,
         },
         subscriber,
+        None,
     )?;
 
     // build the stream inside the application context
@@ -126,20 +114,16 @@ where
 {
     let local_port = socket.local_addr()?.port();
     let peer_addr = socket.peer_addr()?.into();
-
-    let (crypto, parameters) = peer.pair(&TransportFeatures::TCP);
-
     let stream = endpoint::open_stream(
         env,
-        peer.map(),
-        crypto,
-        parameters,
+        peer,
         env::TcpRegistered {
             socket,
             peer_addr,
             local_port,
         },
         subscriber,
+        None,
     )?;
 
     // build the stream inside the application context


### PR DESCRIPTION
In further testing, this introduces too much reordering under high concurrency for our dedup tracking to mitigate. connect() can "complete" in reverse order of starts (e.g., due to queueing of the wake events) which leads to huge gaps (up to concurrency) in the chosen key IDs.

We can likely get the best of both worlds by deriving crypto beforehand but only associating it with a stream just-in-time as connect()s complete (keeping a per-peer pool just for opening connections) but that's a more invasive change, for now just revert this.

This reverts commit 71e56fe25d7fc793ce857bdda5e16ebc6365a86b (#2451).

### Testing:

This was caught in a more thorough integration test. I think it's likely possible to simulate that within a unit-ish test (TCP connect to localhost or so), but it feels a bit artificial to write it directly. In any case, that can come in a separate PR since this is just a revert.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

