### PR TITLE
Replace requested_handshakes set with a callback

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map.rs
@@ -90,13 +90,8 @@ impl Map {
         self.store.contains(peer)
     }
 
-    /// Check whether we would like to (re-)handshake with this peer.
-    ///
-    /// Note that this is distinct from `contains`, we may already have *some* credentials for a
-    /// peer but still be interested in handshaking (e.g., due to periodic refresh of the
-    /// credentials).
-    pub fn needs_handshake(&self, peer: &SocketAddr) -> bool {
-        self.store.needs_handshake(peer)
+    pub fn register_request_handshake(&self, cb: Box<dyn Fn(SocketAddr) + Send + Sync>) {
+        self.store.register_request_handshake(cb);
     }
 
     /// Gets the [`Peer`] entry for the given address

--- a/dc/s2n-quic-dc/src/path/secret/map/store.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/store.rs
@@ -27,8 +27,6 @@ pub trait Store: 'static + Send + Sync {
 
     fn contains(&self, peer: &SocketAddr) -> bool;
 
-    fn needs_handshake(&self, peer: &SocketAddr) -> bool;
-
     fn get_by_addr_untracked(&self, peer: &SocketAddr) -> Option<ReadGuard<Arc<Entry>>>;
 
     fn get_by_addr_tracked(&self, peer: &SocketAddr) -> Option<ReadGuard<Arc<Entry>>>;
@@ -46,6 +44,8 @@ pub trait Store: 'static + Send + Sync {
     fn send_control_packet(&self, dst: &SocketAddr, buffer: &mut [u8]);
 
     fn rehandshake_period(&self) -> Duration;
+
+    fn register_request_handshake(&self, cb: Box<dyn Fn(SocketAddr) + Send + Sync>);
 
     fn check_dedup(
         &self,


### PR DESCRIPTION
### Release Summary:

n/a

### Resolved issues:

n/a

### Description of changes: 

This drops the requested handshakes map in favor of supporting registering a callback. I initially tried/considered doing this as a Subscriber, but it gets pretty tricky to integrate that -- the Map is already getting passed *into* s2n-quic endpoints as a dc::Endpoint. Plus, the detailed logic on how to handshake interacts with application layer concerns (e.g., possibly throttling) that I'm not sure should live in s2n-quic.

### Call-outs:

n/a

### Testing:

No additional tests here - this sort of implies we *have* no tests for this functionality in s2n-quic-dc, which makes sense since that doesn't have any actual s2n-quic dependency. I'm not sure whether we should add one or otherwise tweak things in that regard. It should get caught in the internal integration tests. (Note that this is not safe by itself, all users of s2n-quic-dc need to add the registration to client handshake endpoints).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

