### PR TITLE
fix: allow configurable IPv4/IPv6 socket binding

### DIFF
--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -59,6 +59,7 @@ impl Io {
             gro_enabled,
             reuse_address,
             reuse_port,
+            only_v6,
         } = self.builder;
 
         let clock = Clock::default();
@@ -91,7 +92,7 @@ impl Io {
         let rx_socket = if let Some(rx_socket) = rx_socket {
             rx_socket
         } else if let Some(recv_addr) = recv_addr {
-            syscall::bind_udp(recv_addr, reuse_address, reuse_port)?
+            syscall::bind_udp(recv_addr, reuse_address, reuse_port, only_v6)?
         } else {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -104,7 +105,7 @@ impl Io {
         let tx_socket = if let Some(tx_socket) = tx_socket {
             tx_socket
         } else if let Some(send_addr) = send_addr {
-            syscall::bind_udp(send_addr, reuse_address, reuse_port)?
+            syscall::bind_udp(send_addr, reuse_address, reuse_port, only_v6)?
         } else {
             // No tx_socket or send address was specified, so the tx socket
             // will be a handle to the rx socket.

--- a/quic/s2n-quic-platform/src/io/tokio/builder.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/builder.rs
@@ -19,6 +19,7 @@ pub struct Builder {
     pub(super) gro_enabled: Option<bool>,
     pub(super) reuse_address: bool,
     pub(super) reuse_port: bool,
+    pub(super) only_v6: bool,
 }
 
 impl Builder {
@@ -233,6 +234,11 @@ impl Builder {
             ));
         }
         self.reuse_port = true;
+        Ok(self)
+    }
+
+    pub fn with_only_v6(mut self, only_v6: bool) -> io::Result<Self> {
+        self.only_v6 = only_v6;
         Ok(self)
     }
 

--- a/quic/s2n-quic-platform/src/io/tokio/tests.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/tests.rs
@@ -212,6 +212,7 @@ async fn test<A: ToSocketAddrs>(
 
 static IPV4_LOCALHOST: &str = "127.0.0.1:0";
 static IPV6_LOCALHOST: &str = "[::1]:0";
+static IPV6_ANY_ADDRESS: &str = "[::]:0";
 
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
@@ -290,4 +291,20 @@ async fn only_v6_enabled_test() -> io::Result<()> {
         Err(err) if err.kind() == std::io::ErrorKind::TimedOut => Ok(()),
         other => other,
     }
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn only_v6_test() -> io::Result<()> {
+    let mut only_v6 = true;
+
+    let socket = syscall::bind_udp(IPV6_ANY_ADDRESS, false, false, only_v6)?;
+    assert_eq!(socket.only_v6()?, only_v6);
+
+    only_v6 = false;
+
+    let socket = syscall::bind_udp(IPV6_ANY_ADDRESS, false, false, only_v6)?;
+    assert_eq!(socket.only_v6()?, only_v6);
+
+    Ok(())
 }

--- a/quic/s2n-quic-platform/src/io/tokio/tests.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/tests.rs
@@ -276,32 +276,13 @@ async fn ipv6_two_socket_test() -> io::Result<()> {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn only_v6_test() -> io::Result<()> {
-    let client_addr = IPV4_LOCALHOST.to_socket_addrs()?.next().unwrap();
-
     let mut only_v6 = false;
-
     let server_socket = syscall::bind_udp(IPV6_ANY_ADDRESS, false, false, only_v6)?;
     assert_eq!(server_socket.only_v6()?, only_v6);
-
-    server_socket.connect(&client_addr.into())?;
 
     only_v6 = true;
-
     let server_socket = syscall::bind_udp(IPV6_ANY_ADDRESS, false, false, only_v6)?;
     assert_eq!(server_socket.only_v6()?, only_v6);
 
-    let result = server_socket.connect(&client_addr.into());
-    // We should expect this error, since we restrict the server_socket to only accept connection from ipv6
-    // Error: Os { code: 97, kind: Uncategorized, message: "Address family not supported by protocol" }
-    match result {
-        Err(err)
-            if err.raw_os_error() == Some(97)
-                && err
-                    .to_string()
-                    .contains("Address family not supported by protocol") =>
-        {
-            Ok(())
-        }
-        other => other,
-    }
+    Ok(())
 }

--- a/quic/s2n-quic-platform/src/io/tokio/tests.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/tests.rs
@@ -141,16 +141,19 @@ impl<const IS_SERVER: bool> Endpoint for TestEndpoint<IS_SERVER> {
 async fn runtime<A: ToSocketAddrs>(
     receive_addr: A,
     send_addr: Option<A>,
+    only_v6: bool,
 ) -> io::Result<(super::Io, SocketAddress)> {
-    let rx_socket = syscall::bind_udp(receive_addr, false, false)?;
+    let mut io_builder = Io::builder().with_only_v6(only_v6)?;
+
+    let rx_socket = syscall::bind_udp(receive_addr, false, false, only_v6)?;
     rx_socket.set_nonblocking(true)?;
     let rx_socket: std::net::UdpSocket = rx_socket.into();
     let rx_addr = rx_socket.local_addr()?;
 
-    let mut io_builder = Io::builder().with_rx_socket(rx_socket)?;
+    io_builder = io_builder.with_rx_socket(rx_socket)?;
 
     if let Some(tx_addr) = send_addr {
-        let tx_socket = syscall::bind_udp(tx_addr, false, false)?;
+        let tx_socket = syscall::bind_udp(tx_addr, false, false, only_v6)?;
         tx_socket.set_nonblocking(true)?;
         let tx_socket: std::net::UdpSocket = tx_socket.into();
         io_builder = io_builder.with_tx_socket(tx_socket)?
@@ -177,9 +180,10 @@ async fn test<A: ToSocketAddrs>(
     server_tx_addr: Option<A>,
     client_rx_addr: A,
     client_tx_addr: Option<A>,
+    only_v6: bool,
 ) -> io::Result<()> {
-    let (server_io, server_addr) = runtime(server_rx_addr, server_tx_addr).await?;
-    let (client_io, client_addr) = runtime(client_rx_addr, client_tx_addr).await?;
+    let (server_io, server_addr) = runtime(server_rx_addr, server_tx_addr, only_v6).await?;
+    let (client_io, client_addr) = runtime(client_rx_addr, client_tx_addr, only_v6).await?;
 
     let server_endpoint = {
         let mut handle = PathHandle::from_remote_address(client_addr.into());
@@ -212,17 +216,20 @@ static IPV6_LOCALHOST: &str = "[::1]:0";
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn ipv4_test() -> io::Result<()> {
-    test(IPV4_LOCALHOST, None, IPV4_LOCALHOST, None).await
+    let only_v6: bool = false;
+    test(IPV4_LOCALHOST, None, IPV4_LOCALHOST, None, only_v6).await
 }
 
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn ipv4_two_socket_test() -> io::Result<()> {
+    let only_v6: bool = false;
     test(
         IPV4_LOCALHOST,
         Some(IPV4_LOCALHOST),
         IPV4_LOCALHOST,
         Some(IPV4_LOCALHOST),
+        only_v6,
     )
     .await
 }
@@ -230,7 +237,8 @@ async fn ipv4_two_socket_test() -> io::Result<()> {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn ipv6_test() -> io::Result<()> {
-    let result = test(IPV6_LOCALHOST, None, IPV6_LOCALHOST, None).await;
+    let only_v6: bool = false;
+    let result = test(IPV6_LOCALHOST, None, IPV6_LOCALHOST, None, only_v6).await;
 
     match result {
         Err(err) if err.kind() == io::ErrorKind::AddrNotAvailable => {
@@ -244,11 +252,13 @@ async fn ipv6_test() -> io::Result<()> {
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn ipv6_two_socket_test() -> io::Result<()> {
+    let only_v6: bool = false;
     let result = test(
         IPV6_LOCALHOST,
         Some(IPV6_LOCALHOST),
         IPV6_LOCALHOST,
         Some(IPV6_LOCALHOST),
+        only_v6,
     )
     .await;
 
@@ -259,4 +269,20 @@ async fn ipv6_two_socket_test() -> io::Result<()> {
         }
         other => other,
     }
+}
+
+#[tokio::test]
+#[cfg_attr(miri, ignore)]
+async fn only_v6_test() -> io::Result<()> {
+    let mut only_v6 = true;
+
+    let socket = syscall::bind_udp(IPV6_LOCALHOST, false, false, only_v6)?;
+    assert_eq!(socket.only_v6()?, only_v6);
+
+    only_v6 = false;
+
+    let socket = syscall::bind_udp(IPV6_LOCALHOST, false, false, only_v6)?;
+    assert_eq!(socket.only_v6()?, only_v6);
+
+    Ok(())
 }

--- a/quic/s2n-quic-platform/src/io/tokio/tests.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/tests.rs
@@ -272,39 +272,36 @@ async fn ipv6_two_socket_test() -> io::Result<()> {
     }
 }
 
-#[tokio::test]
-#[cfg_attr(miri, ignore)]
-async fn only_v6_enabled_test() -> io::Result<()> {
-    let only_v6: bool = true;
-    let result = test(
-        IPV6_LOCALHOST,
-        Some(IPV6_LOCALHOST),
-        IPV4_LOCALHOST,
-        Some(IPV4_LOCALHOST),
-        only_v6,
-    )
-    .await;
-
-    match result {
-        // The client can't send IPv4 message to the server is only_v6 is enabled.
-        // test() times out after 60 seconds.
-        Err(err) if err.kind() == std::io::ErrorKind::TimedOut => Ok(()),
-        other => other,
-    }
-}
-
+#[cfg(unix)]
 #[tokio::test]
 #[cfg_attr(miri, ignore)]
 async fn only_v6_test() -> io::Result<()> {
-    let mut only_v6 = true;
+    let client_addr = IPV4_LOCALHOST.to_socket_addrs()?.next().unwrap();
 
-    let socket = syscall::bind_udp(IPV6_ANY_ADDRESS, false, false, only_v6)?;
-    assert_eq!(socket.only_v6()?, only_v6);
+    let mut only_v6 = false;
 
-    only_v6 = false;
+    let server_socket = syscall::bind_udp(IPV6_ANY_ADDRESS, false, false, only_v6)?;
+    assert_eq!(server_socket.only_v6()?, only_v6);
 
-    let socket = syscall::bind_udp(IPV6_ANY_ADDRESS, false, false, only_v6)?;
-    assert_eq!(socket.only_v6()?, only_v6);
+    server_socket.connect(&client_addr.into())?;
 
-    Ok(())
+    only_v6 = true;
+
+    let server_socket = syscall::bind_udp(IPV6_ANY_ADDRESS, false, false, only_v6)?;
+    assert_eq!(server_socket.only_v6()?, only_v6);
+
+    let result = server_socket.connect(&client_addr.into());
+    // We should expect this error, since we restrict the server_socket to only accept connection from ipv6
+    // Error: Os { code: 97, kind: Uncategorized, message: "Address family not supported by protocol" }
+    match result {
+        Err(err)
+            if err.raw_os_error() == Some(97)
+                && err
+                    .to_string()
+                    .contains("Address family not supported by protocol") =>
+        {
+            Ok(())
+        }
+        other => other,
+    }
 }

--- a/quic/s2n-quic-platform/src/io/xdp.rs
+++ b/quic/s2n-quic-platform/src/io/xdp.rs
@@ -28,7 +28,8 @@ pub mod socket {
         interface: &::std::ffi::CStr,
         addr: ::std::net::SocketAddr,
     ) -> ::std::io::Result<::std::net::UdpSocket> {
-        let socket = crate::syscall::udp_socket(addr)?;
+        let only_v6 = false;
+        let socket = crate::syscall::udp_socket(addr, only_v6)?;
 
         // associate the socket with a single interface
         crate::syscall::bind_to_interface(&socket, interface)?;

--- a/quic/s2n-quic-platform/src/socket/options.rs
+++ b/quic/s2n-quic-platform/src/socket/options.rs
@@ -32,6 +32,7 @@ pub struct Options {
     pub send_buffer: Option<usize>,
     pub recv_buffer: Option<usize>,
     pub backlog: usize,
+    pub only_v6: bool,
 }
 
 impl Default for Options {
@@ -47,6 +48,7 @@ impl Default for Options {
             recv_buffer: None,
             delay: false,
             backlog: 4096,
+            only_v6: false,
         }
     }
 }
@@ -62,7 +64,7 @@ impl Options {
 
     #[inline]
     pub fn build_udp(&self) -> io::Result<UdpSocket> {
-        let socket = syscall::udp_socket(self.addr)?;
+        let socket = syscall::udp_socket(self.addr, self.only_v6)?;
 
         if self.gro {
             let _ = syscall::configure_gro(&socket);

--- a/quic/s2n-quic-platform/src/syscall.rs
+++ b/quic/s2n-quic-platform/src/syscall.rs
@@ -66,15 +66,14 @@ pub trait UnixMessage: crate::message::Message {
     );
 }
 
-pub fn udp_socket(addr: std::net::SocketAddr) -> io::Result<Socket> {
+pub fn udp_socket(addr: std::net::SocketAddr, only_v6: bool) -> io::Result<Socket> {
     let domain = Domain::for_address(addr);
     let socket_type = Type::DGRAM;
     let protocol = Some(Protocol::UDP);
 
     let socket = Socket::new(domain, socket_type, protocol)?;
 
-    // allow ipv4 to also connect - ignore the error if it fails
-    let _ = socket.set_only_v6(false);
+    let _ = socket.set_only_v6(only_v6);
 
     Ok(socket)
 }
@@ -84,6 +83,7 @@ pub fn bind_udp<A: std::net::ToSocketAddrs>(
     addr: A,
     reuse_address: bool,
     reuse_port: bool,
+    only_v6: bool,
 ) -> io::Result<Socket> {
     let addr = addr.to_socket_addrs()?.next().ok_or_else(|| {
         std::io::Error::new(
@@ -91,7 +91,7 @@ pub fn bind_udp<A: std::net::ToSocketAddrs>(
             "the provided bind address was empty",
         )
     })?;
-    let socket = udp_socket(addr)?;
+    let socket = udp_socket(addr, only_v6)?;
 
     socket.set_reuse_address(reuse_address)?;
 


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary. If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff. -->

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

