### PR TITLE
feat(s2n-quic-platform): add a new Tokio IO API to configure only_v6

### DIFF
--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -59,6 +59,7 @@ impl Io {
             gro_enabled,
             reuse_address,
             reuse_port,
+            only_v6,
         } = self.builder;
 
         let clock = Clock::default();
@@ -91,7 +92,7 @@ impl Io {
         let rx_socket = if let Some(rx_socket) = rx_socket {
             rx_socket
         } else if let Some(recv_addr) = recv_addr {
-            syscall::bind_udp(recv_addr, reuse_address, reuse_port)?
+            syscall::bind_udp(recv_addr, reuse_address, reuse_port, only_v6)?
         } else {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -104,7 +105,7 @@ impl Io {
         let tx_socket = if let Some(tx_socket) = tx_socket {
             tx_socket
         } else if let Some(send_addr) = send_addr {
-            syscall::bind_udp(send_addr, reuse_address, reuse_port)?
+            syscall::bind_udp(send_addr, reuse_address, reuse_port, only_v6)?
         } else {
             // No tx_socket or send address was specified, so the tx socket
             // will be a handle to the rx socket.

--- a/quic/s2n-quic-platform/src/io/tokio/builder.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/builder.rs
@@ -19,6 +19,7 @@ pub struct Builder {
     pub(super) gro_enabled: Option<bool>,
     pub(super) reuse_address: bool,
     pub(super) reuse_port: bool,
+    pub(super) only_v6: bool,
 }
 
 impl Builder {
@@ -233,6 +234,11 @@ impl Builder {
             ));
         }
         self.reuse_port = true;
+        Ok(self)
+    }
+
+    pub fn with_only_v6(mut self, only_v6: bool) -> io::Result<Self> {
+        self.only_v6 = only_v6;
         Ok(self)
     }
 

--- a/quic/s2n-quic-platform/src/io/xdp.rs
+++ b/quic/s2n-quic-platform/src/io/xdp.rs
@@ -28,7 +28,8 @@ pub mod socket {
         interface: &::std::ffi::CStr,
         addr: ::std::net::SocketAddr,
     ) -> ::std::io::Result<::std::net::UdpSocket> {
-        let socket = crate::syscall::udp_socket(addr)?;
+        let only_v6 = false;
+        let socket = crate::syscall::udp_socket(addr, only_v6)?;
 
         // associate the socket with a single interface
         crate::syscall::bind_to_interface(&socket, interface)?;

--- a/quic/s2n-quic-platform/src/socket/options.rs
+++ b/quic/s2n-quic-platform/src/socket/options.rs
@@ -32,6 +32,7 @@ pub struct Options {
     pub send_buffer: Option<usize>,
     pub recv_buffer: Option<usize>,
     pub backlog: usize,
+    pub only_v6: bool,
 }
 
 impl Default for Options {
@@ -47,6 +48,7 @@ impl Default for Options {
             recv_buffer: None,
             delay: false,
             backlog: 4096,
+            only_v6: false,
         }
     }
 }
@@ -62,7 +64,7 @@ impl Options {
 
     #[inline]
     pub fn build_udp(&self) -> io::Result<UdpSocket> {
-        let socket = syscall::udp_socket(self.addr)?;
+        let socket = syscall::udp_socket(self.addr, self.only_v6)?;
 
         if self.gro {
             let _ = syscall::configure_gro(&socket);

--- a/quic/s2n-quic-platform/src/syscall.rs
+++ b/quic/s2n-quic-platform/src/syscall.rs
@@ -66,15 +66,14 @@ pub trait UnixMessage: crate::message::Message {
     );
 }
 
-pub fn udp_socket(addr: std::net::SocketAddr) -> io::Result<Socket> {
+pub fn udp_socket(addr: std::net::SocketAddr, only_v6: bool) -> io::Result<Socket> {
     let domain = Domain::for_address(addr);
     let socket_type = Type::DGRAM;
     let protocol = Some(Protocol::UDP);
 
     let socket = Socket::new(domain, socket_type, protocol)?;
 
-    // allow ipv4 to also connect - ignore the error if it fails
-    let _ = socket.set_only_v6(false);
+    let _ = socket.set_only_v6(only_v6);
 
     Ok(socket)
 }
@@ -84,6 +83,7 @@ pub fn bind_udp<A: std::net::ToSocketAddrs>(
     addr: A,
     reuse_address: bool,
     reuse_port: bool,
+    only_v6: bool,
 ) -> io::Result<Socket> {
     let addr = addr.to_socket_addrs()?.next().ok_or_else(|| {
         std::io::Error::new(
@@ -91,7 +91,7 @@ pub fn bind_udp<A: std::net::ToSocketAddrs>(
             "the provided bind address was empty",
         )
     })?;
-    let socket = udp_socket(addr)?;
+    let socket = udp_socket(addr, only_v6)?;
 
     socket.set_reuse_address(reuse_address)?;
 


### PR DESCRIPTION
### Release Summary:

Allow users to configure only_v6 settings through a new Tokio IO API.

### Resolved issues:

resolves #2316

### Description of changes: 

* Add a new attribute `only_v6` in the Tokio builder and a `with_only_v6()` method to configure it.
* Allow users to pass in only_v6 parameter into `syscall::bind_udp()`, so that the value will be passed top down.
    * Our `syscall::udp_socket()` function calls `.set_only_v6()` to configure if the socket should only communicate in IPV6 or not.
* Refactor the codebase to reflect that parameter change.

### Call-outs:

* The default for only_v6 is `false`, since the default value for boolean is `false`. The default is not changed.
    * `xdp.rs` also calls for `udp_socket()` and I set the only_v6 to false. We shouldn't change that behavior.
* The unit test for this change will be ran on UNIX system, since Windows handled sockets's only_v6 attribute very differently.

### Testing:

* Add a unit test to test the parameter change for `syscall::bind_udp()`. We should verify if the resultant socket has only_v6 set up as expected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

