### PR TITLE
build(deps): update rand requirement in /tools/xdp

### DIFF
--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "1", features = ["net"], optional = true }
 bolero = "0.12"
 futures = "0.3"
 pin-project-lite = "0.2"
-rand = "0.8"
+rand = "0.9"
 s2n-quic-core = { path = "../../../quic/s2n-quic-core", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }
 

--- a/tools/xdp/s2n-quic-xdp/src/io/tests.rs
+++ b/tools/xdp/s2n-quic-xdp/src/io/tests.rs
@@ -7,7 +7,7 @@ use super::{
 };
 use crate::{if_xdp::RingFlags, ring, umem::Umem};
 use core::{mem::size_of, time::Duration};
-use rand::prelude::*;
+use rand::Rng;
 use s2n_quic_core::{
     inet::ExplicitCongestionNotification,
     io::{
@@ -131,7 +131,7 @@ async fn send(count: u32, outputs: Vec<tx::Channel<atomic_waker::Handle>>, umem:
 
         tx.queue(|queue| {
             let max = queue.capacity().min((count - counter) as usize);
-            let count = thread_rng().gen_range(0..=max);
+            let count = rand::rng().random_range(0..=max);
             trace!("max: {max}, count: {count}");
 
             for _ in 0..count {
@@ -182,7 +182,7 @@ async fn recv(packets: u32, inputs: Vec<rx::Channel<atomic_waker::Handle>>, umem
 
 /// Randomly yields to other tasks
 async fn maybe_yield() {
-    if thread_rng().gen() {
+    if rand::rng().random() {
         trace!("yielding");
         tokio::task::yield_now().await;
     }


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

Update dependency according to [PR#2460](https://github.com/aws/s2n-quic/pull/2460). As mentioned in [this comment](https://github.com/aws/s2n-quic/pull/2460#issuecomment-2622614026), the latest `rand` release contains some breaking changes that we need to fix.

`thread_rng()` and `gen_range()` have been renamed to `rand::rng()` and `random_range()`. They have also been removed from `rand::prelude`. Hence, I have updated the function names and the used crate.

### Call-outs:

For more details of the breaking change that `rand` release has introduced, refer to their [release summary](https://github.com/rust-random/rand/releases/tag/0.9.0), and specifically to their PR that [rename `thread_rng()`](https://github.com/rust-random/rand/pull/1506).

### Testing:

This PR will be tested by the existing tests in our CI. `ci / xdp (pull_request)` should pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

