### PR TITLE
build(deps): update rand requirement except for s2n-quic-sim

### DIFF
--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -31,8 +31,8 @@ libc = "0.2"
 num-rational = { version = "0.4", default-features = false }
 once_cell = "1"
 pin-project-lite = "0.2"
-rand = { version = "0.8", features = ["small_rng"] }
-rand_chacha = "0.3"
+rand = { version = "0.9", features = ["small_rng"] }
+rand_chacha = "0.9"
 s2n-codec = { version = "=0.53.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.53.0", path = "../../quic/s2n-quic-core", default-features = false }
 s2n-quic-platform = { version = "=0.53.0", path = "../../quic/s2n-quic-platform" }

--- a/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
@@ -68,7 +68,7 @@ impl Cleaner {
                 let pause = if cfg!(test) {
                     60
                 } else {
-                    rand::thread_rng().gen_range(5..60)
+                    rand::rng().random_range(5..60)
                 };
                 std::thread::park_timeout(Duration::from_secs(pause));
 

--- a/dc/s2n-quic-dc/src/path/secret/map/entry.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/entry.rs
@@ -257,7 +257,7 @@ impl Entry {
         // The goal of rescheduling is to avoid continuously re-handshaking for N (possibly stale)
         // peers every cleaner loop, instead we defer handshakes out again. This effectively acts
         // as a (slow) retry mechanism.
-        let delta = rand::thread_rng().gen_range(
+        let delta = rand::rng().random_range(
             std::cmp::min(rehandshake_period.as_secs(), 360)..rehandshake_period.as_secs(),
         ) as u32;
         // This can't practically overflow -- each time we add we push out the next add by at least

--- a/dc/s2n-quic-dc/src/path/secret/receiver/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/receiver/tests.rs
@@ -197,7 +197,7 @@ fn check_delayed_inner(seed: u64, delay: u16) {
         // explanation for what guarantees we're actually trying to provide here).
         if id % 128 != 0 {
             // ...until some random interval no more than WINDOW away.
-            let insert_before = rng.gen_range(id + 1 + delay..id + WINDOW as u64);
+            let insert_before = rng.random_range(id + 1 + delay..id + WINDOW as u64);
             buffered.push((std::cmp::Reverse(insert_before), id));
         } else {
             model.insert(id);

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3"
 http = "1.0"
 humansize = "2"
 lru = "0.13"
-rand = "0.8"
+rand = "0.9"
 s2n-codec = { path = "../../common/s2n-codec" }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-h3 = { path = "../s2n-quic-h3" }

--- a/quic/s2n-quic-qns/src/intercept.rs
+++ b/quic/s2n-quic-qns/src/intercept.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use lru::LruCache;
-use rand::prelude::*;
+use rand::{Rng as _, RngCore};
 use s2n_codec::encoder::scatter;
 use s2n_quic_core::{
     event::api::Subject,
@@ -31,7 +31,7 @@ struct Random;
 
 impl havoc::Random for Random {
     fn fill(&mut self, bytes: &mut [u8]) {
-        thread_rng().fill_bytes(bytes);
+        rand::rng().fill_bytes(bytes);
     }
 
     fn gen_range(&mut self, range: std::ops::Range<u64>) -> u64 {
@@ -43,7 +43,7 @@ impl havoc::Random for Random {
             return start;
         }
 
-        thread_rng().gen_range(start..end)
+        rand::rng().random_range(start..end)
     }
 }
 

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -69,8 +69,8 @@ cuckoofilter = { version = "0.5", optional = true }
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hash_hasher = { version = "2", optional = true }
 humansize = { version = "2", optional = true }
-rand = "0.8"
-rand_chacha = "0.3"
+rand = "0.9"
+rand_chacha = "0.9"
 s2n-codec = { version = "=0.53.0", path = "../../common/s2n-codec" }
 s2n-quic-core = { version = "=0.53.0", path = "../s2n-quic-core" }
 s2n-quic-crypto = { version = "=0.53.0", path = "../s2n-quic-crypto", optional = true }

--- a/quic/s2n-quic/src/provider/connection_id.rs
+++ b/quic/s2n-quic/src/provider/connection_id.rs
@@ -143,7 +143,7 @@ pub mod default {
         fn generate(&mut self, _connection_info: &ConnectionInfo) -> connection::LocalId {
             let mut id = [0u8; connection::id::MAX_LEN];
             let id = &mut id[..self.len];
-            rand::thread_rng().fill_bytes(id);
+            rand::rng().fill_bytes(id);
             (&*id).try_into().expect("length already checked")
         }
 

--- a/quic/s2n-quic/src/provider/random.rs
+++ b/quic/s2n-quic/src/provider/random.rs
@@ -19,7 +19,7 @@ mod rand {
     use core::convert::Infallible;
     use rand::{
         prelude::*,
-        rngs::{adapter::ReseedingRng, OsRng},
+        rngs::{OsRng, ReseedingRng},
     };
     use rand_chacha::ChaChaCore;
     use s2n_quic_core::random;
@@ -71,9 +71,8 @@ mod rand {
     // Constructs a `ReseedingRng` with a ChaCha RNG initially seeded from the OS,
     // that will reseed from the OS after RESEED_THRESHOLD is exceeded
     fn build_rng() -> ReseedingRng<ChaChaCore, OsRng> {
-        let prng = ChaChaCore::from_rng(OsRng)
-            .unwrap_or_else(|err| panic!("could not initialize random generator: {err}"));
-        ReseedingRng::new(prng, RESEED_THRESHOLD, OsRng)
+        ReseedingRng::<ChaChaCore, OsRng>::new(RESEED_THRESHOLD, OsRng)
+            .unwrap_or_else(|err| panic!("could not initialize random generator: {err}"))
     }
 
     impl random::Generator for Generator {

--- a/quic/s2n-quic/src/provider/stateless_reset_token.rs
+++ b/quic/s2n-quic/src/provider/stateless_reset_token.rs
@@ -83,7 +83,7 @@ mod random {
         // be generated the same for a given `local_connection_id` before and after loss of state.
         fn generate(&mut self, _local_connection_id: &[u8]) -> stateless_reset::Token {
             let mut token = [0u8; STATELESS_RESET_TOKEN_LEN];
-            rand::thread_rng().fill_bytes(&mut token);
+            rand::rng().fill_bytes(&mut token);
             token.into()
         }
     }

--- a/quic/s2n-quic/src/tests/setup.rs
+++ b/quic/s2n-quic/src/tests/setup.rs
@@ -175,15 +175,11 @@ impl havoc::Random for Random {
     }
 
     fn gen_range(&mut self, range: std::ops::Range<u64>) -> u64 {
-        self.inner.gen_range(range)
+        self.inner.random_range(range)
     }
 }
 
 impl RngCore for Random {
-    fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand::Error> {
-        self.inner.try_fill_bytes(dest)
-    }
-
     fn fill_bytes(&mut self, dest: &mut [u8]) {
         self.inner.fill_bytes(dest)
     }


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

This PR is used to update `rand` dependencies' versions in the codebase. This PR should address problems occurred in [PR#2466](https://github.com/aws/s2n-quic/pull/2466).

The `rand` library has a version bump and introduces some API changes. Those changes involves some renaming function names, and changing some functions' parameters. Refer to the [release note](https://github.com/rust-random/rand/releases/tag/0.9.0) for more details.

### Call-outs:

#### General Call-outs:

* In `rand v0.9.0`, the `RngCore` trait no longer has the function `try_fill_bytes()`, so I have removed that function.
* `rand::rng()` function has been taken out of `rand::prelude::*`. We can find it in `rang::{Rng, RngCore}`.
* In `rand v0.9.0`, `rand::Error::new` no longer exists. We should return the `Unspecified` Error that AWSLC returns in case of failure when filling bytes.
* The `ReseedingRng::new()` method no longer needs its first parameter. Instead, we just have to specify what the generic type has to be for the returned `ReseedingRng`.
* I have also updates `rand_cahcha` dep versions which should also resolve [PR#2468](https://github.com/aws/s2n-quic/pull/2468).

#### We can't update `rand` dep in `s2n-quic-sim` for now:

In the latest update, `rand` v0.9.0 has renamed `rand::distributions` to `rand::distr`. Accordingly, we also need to refactor the `T`'s requirement from `rand::distributions` to `rand::distr`:
https://github.com/aws/s2n-quic/blob/00e33714d74b0646bc18ab65c90a45504a185828/quic/s2n-quic-sim/src/run/range.rs#L48-L59

However, the `rand::gen_range()` function is taken from `bach` which depends on [`rand v0.8.5`](https://github.com/camshaft/bach/blob/579c5a0f0c30bb6ead32511b18dbe817b0cf5f9c/bach/Cargo.toml#L27). Therefore, if we update `rand` version in `s2n-quic-sim` but not in `bach`, then the input type T will encounter syntax issue, since `s2n-quic` is expecting `rand::distr::uniform::SampleUniform`, but `bach` is expecting `rand::distributions::uniform::SampleUniform`.

In order to solve this, `bach` needs to update its `rand` dependency, and there is a [PR](https://github.com/camshaft/bach/pull/32) trying to do that. I recommend that we update `rand` versions in other modules first, and then cut a ticket to `bach` to facilitate its `rand` version updates. Once a new `bach` release is published. thenupdate `rand` version in `s2n-quic-sim`.

### Testing:

This change will be tested by the CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

