### PR TITLE
ci: pin litemap and zerofrom versions to support current MSRV

### DIFF
--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -21,6 +21,7 @@ cfg-if = "1"
 futures = "0.3"
 http = "1.0"
 humansize = "2"
+litemap = "=0.7.4" # newer versions require rust 1.81
 lru = "0.13"
 rand = "0.9"
 s2n-codec = { path = "../../common/s2n-codec" }
@@ -31,6 +32,7 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2"
+zerofrom = "=0.1.5" # newer versions require rust 1.81
 
 [target.'cfg(unix)'.dependencies]
 s2n-quic = { path = "../s2n-quic", features = ["provider-event-console-perf", "provider-event-tracing", "provider-tls-rustls", "provider-tls-s2n"] }


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

Pin `litemap` and `zerofrom` versions to prior versions which support our current MSRV rust v1.74.1.

These two dependencies are from the `url` dep in `s2n-quic-qns` crate:
```
𝄞 cargo tree --invert zerofrom
zerofrom v0.1.6
├── icu_collections v1.5.0
│   ├── icu_normalizer v1.5.0
│   │   └── idna_adapter v1.2.0
│   │       └── idna v1.0.3
│   │           └── url v2.5.4
│   │               └── s2n-quic-qns v0.1.0 (/home/cameron/Projects/aws/s2n-quic/quic/s2n-quic-qns)
│   └── icu_properties v1.5.1
│       ├── icu_normalizer v1.5.0 (*)
│       └── idna_adapter v1.2.0 (*)
├── icu_provider v1.5.0
│   ├── icu_locid_transform v1.5.0
│   │   └── icu_properties v1.5.1 (*)
│   ├── icu_normalizer v1.5.0 (*)
│   └── icu_properties v1.5.1 (*)
├── yoke v0.7.5
│   ├── icu_collections v1.5.0 (*)
│   ├── icu_provider v1.5.0 (*)
│   └── zerovec v0.10.4
│       ├── icu_collections v1.5.0 (*)
│       ├── icu_locid v1.5.0
│       │   ├── icu_locid_transform v1.5.0 (*)
│       │   └── icu_provider v1.5.0 (*)
│       ├── icu_locid_transform v1.5.0 (*)
│       ├── icu_normalizer v1.5.0 (*)
│       ├── icu_properties v1.5.1 (*)
│       ├── icu_provider v1.5.0 (*)
│       └── tinystr v0.7.6
│           ├── icu_locid v1.5.0 (*)
│           ├── icu_locid_transform v1.5.0 (*)
│           ├── icu_properties v1.5.1 (*)
│           └── icu_provider v1.5.0 (*)
└── zerovec v0.10.4 (*)
```

```
𝄞 cargo tree --invert litemap 
litemap v0.7.5
└── icu_locid v1.5.0
    ├── icu_locid_transform v1.5.0
    │   └── icu_properties v1.5.1
    │       ├── icu_normalizer v1.5.0
    │       │   └── idna_adapter v1.2.0
    │       │       └── idna v1.0.3
    │       │           └── url v2.5.4
    │       │               └── s2n-quic-qns v0.1.0 (/home/cameron/Projects/aws/s2n-quic/quic/s2n-quic-qns)
    │       └── idna_adapter v1.2.0 (*)
    └── icu_provider v1.5.0
        ├── icu_locid_transform v1.5.0 (*)
        ├── icu_normalizer v1.5.0 (*)
        └── icu_properties v1.5.1 (*)
```

Those two dependencies did a [release](https://crates.io/crates/zerofrom/0.1.6) today which bumped their MSRV to rust v1.81. That change breaks our CI, which is noticed in https://github.com/camshaft/bolero/pull/270.

Hence, I am pining the prior versions of those two dependencies, so the integration tests with S2N-QUIC won't fail.

### Call-outs:

I have pined those two versions to `litemapv0.7.4` and `zerofromv0.1.5`. If our MSRV got updated to 1.81 or higher, then we can remove those pins.

Tracking this in [Issue#2334](https://github.com/aws/s2n-quic/issues/2334).

### Testing:

CI will test this PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

