### PR TITLE
(ci):Remove kwik from required interop tests

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -637,7 +637,6 @@
       "server"
     ],
     "kwik": [
-      "client"
     ],
     "lsquic": [
       "client",


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

N/A
### Description of changes: 
The kwik interop test for resumption started failing consistently this week. I suspect something broke in kwik since we haven't been doing any interesting changes to s2n-quic this week.

### Call-outs:

Very weird that resumption was the only kwik test that was required to pass.
### Testing:

CI should pass on this PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

