### PR TITLE
build(deps): update bolero requirements

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -19,14 +19,14 @@ checked_range_unsafe = []
 generator = ["bolero-generator"]
 
 [dependencies]
-bolero-generator = { version = "0.12", default-features = false, optional = true }
+bolero-generator = { version = "0.13", default-features = false, optional = true }
 byteorder = { version = "1.1", default-features = false }
 bytes = { version = "1", default-features = false, optional = true }
 zerocopy = { version = "0.7", features = ["derive"] }
 
 [dev-dependencies]
-bolero = "0.12"
-bolero-generator = "0.12"
+bolero = "0.13"
+bolero-generator = "0.13"
 
 [package.metadata.kani]
 flags = { tests = true }

--- a/common/s2n-codec/src/decoder/checked_range.rs
+++ b/common/s2n-codec/src/decoder/checked_range.rs
@@ -17,7 +17,7 @@ impl bolero::TypeGenerator for CheckedRange {
     fn generate<D: bolero::Driver>(driver: &mut D) -> Option<Self> {
         use bolero::ValueGenerator;
 
-        let start = bolero::gen::<usize>().generate(driver)?;
+        let start = bolero::produce::<usize>().generate(driver)?;
         let end = (start..).generate(driver)?;
         Some(CheckedRange::new(start, end, core::ptr::null()))
     }

--- a/common/s2n-codec/src/unaligned.rs
+++ b/common/s2n-codec/src/unaligned.rs
@@ -43,7 +43,7 @@ macro_rules! unaligned_integer_type {
         #[cfg(any(test, feature = "generator"))]
         impl bolero_generator::TypeGenerator for $name {
             fn generate<D: bolero_generator::Driver>(driver: &mut D) -> Option<Self> {
-                Some(Self::new_truncated(driver.gen()?))
+                Some(Self::new_truncated(driver.produce()?))
             }
         }
 

--- a/common/s2n-codec/src/zerocopy.rs
+++ b/common/s2n-codec/src/zerocopy.rs
@@ -294,7 +294,7 @@ macro_rules! zerocopy_network_integer {
         #[cfg(feature = "generator")]
         impl TypeGenerator for $name {
             fn generate<D: bolero_generator::Driver>(driver: &mut D) -> Option<Self> {
-                Some(Self::new(driver.gen()?))
+                Some(Self::new(driver.produce()?))
             }
         }
 

--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -20,7 +20,7 @@ arrayvec = "0.7"
 atomic-waker = "1"
 aws-lc-rs = "1"
 bitflags = "2"
-bolero-generator = { version = "0.12", default-features = false, optional = true }
+bolero-generator = { version = "0.13", default-features = false, optional = true }
 bytes = "1"
 crossbeam-channel = "0.5"
 crossbeam-epoch = "0.9"
@@ -48,8 +48,8 @@ parking_lot = "0.12"
 bitvec = { version = "1.0.1", default-features = false }
 
 [dev-dependencies]
-bolero = "0.12"
-bolero-generator = "0.12"
+bolero = "0.13"
+bolero-generator = "0.13"
 insta = "1"
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
 s2n-quic-core = { path = "../../quic/s2n-quic-core", features = ["testing"] }

--- a/dc/s2n-quic-dc/src/path/secret/receiver/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/receiver/tests.rs
@@ -306,7 +306,7 @@ fn unseen() {
 #[cfg_attr(miri, ignore)] // this test is too expensive for miri
 fn insert_unequal() {
     // Make sure the two packet numbers are not the same
-    let gen = bolero::gen::<(KeyId, KeyId)>().filter_gen(|(a, b)| a != b);
+    let gen = bolero::produce::<(KeyId, KeyId)>().filter_gen(|(a, b)| a != b);
 
     check!()
         .with_generator(gen)

--- a/dc/wireshark/Cargo.toml
+++ b/dc/wireshark/Cargo.toml
@@ -14,7 +14,7 @@ s2n-quic-core = { path = "../../quic/s2n-quic-core" }
 s2n-quic-dc = { path = "../s2n-quic-dc" }
 
 [dev-dependencies]
-bolero = "0.12"
+bolero = "0.13"
 s2n-quic-core = { path = "../../quic/s2n-quic-core", features = ["testing", "generator"] }
 s2n-quic-dc = { path = "../s2n-quic-dc", features = ["testing"] }
 

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -29,7 +29,7 @@ usdt = ["dep:probe"]
 
 [dependencies]
 atomic-waker = { version = "1", optional = true }
-bolero-generator = { version = "0.12", default-features = false, optional = true }
+bolero-generator = { version = "0.13", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false }
 bytes = { version = "1", optional = true, default-features = false }
 crossbeam-utils = { version = "0.8", optional = true }
@@ -49,8 +49,8 @@ futures-test = { version = "0.3", optional = true } # For testing Waker interact
 once_cell = { version = "1", optional = true }
 
 [dev-dependencies]
-bolero = "0.12"
-bolero-generator = "0.12"
+bolero = "0.13"
+bolero-generator = "0.13"
 insta = { version = "1", features = ["json"] }
 futures = "0.3"
 futures-test = "0.3"

--- a/quic/s2n-quic-core/src/buffer/deque/tests.rs
+++ b/quic/s2n-quic-core/src/buffer/deque/tests.rs
@@ -160,7 +160,7 @@ impl Model {
 // even with the minimal amount of parameter bounds, this proof's memory consumption explodes
 #[cfg_attr(kani, cfg(kani_slow))]
 fn model_test() {
-    let ops = bolero::gen::<Vec<Op>>().with().len(..=OPS_LEN);
+    let ops = bolero::produce::<Vec<Op>>().with().len(..=OPS_LEN);
 
     check!().with_generator(ops).for_each(|ops| {
         let mut model = Model::default();

--- a/quic/s2n-quic-core/src/crypto/tests.rs
+++ b/quic/s2n-quic-core/src/crypto/tests.rs
@@ -16,10 +16,10 @@ use std::convert::TryInto;
 fn round_trip() {
     check!()
         .with_generator((
-            gen()
+            produce()
                 .map_gen(VarInt::from_u32)
                 .map_gen(|value| PacketNumberSpace::Initial.new_packet_number(value)),
-            gen::<Vec<u8>>(),
+            produce::<Vec<u8>>(),
         ))
         .for_each(|(largest_packet_number, input)| {
             let mut buffer = input.clone();

--- a/quic/s2n-quic-core/src/inet/ipv4.rs
+++ b/quic/s2n-quic-core/src/inet/ipv4.rs
@@ -757,7 +757,7 @@ mod tests {
     #[test]
     #[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(kissat))]
     fn scope_test() {
-        let g = gen::<[u8; 4]>().map_gen(IpV4Address::from);
+        let g = produce::<[u8; 4]>().map_gen(IpV4Address::from);
         check!().with_generator(g).cloned().for_each(|subject| {
             use ip::UnicastScope::*;
 

--- a/quic/s2n-quic-core/src/inet/ipv6.rs
+++ b/quic/s2n-quic-core/src/inet/ipv6.rs
@@ -669,7 +669,7 @@ mod tests {
     #[test]
     #[cfg_attr(kani, kani::proof, kani::unwind(17), kani::solver(kissat))]
     fn scope_test() {
-        let g = gen::<[u8; 16]>().map_gen(IpV6Address::from);
+        let g = produce::<[u8; 16]>().map_gen(IpV6Address::from);
         check!().with_generator(g).cloned().for_each(|subject| {
             use ip::UnicastScope::*;
 

--- a/quic/s2n-quic-core/src/interval_set/tests.rs
+++ b/quic/s2n-quic-core/src/interval_set/tests.rs
@@ -113,7 +113,7 @@ fn interval_set_test() {
 #[cfg_attr(miri, ignore)] // This test is too expensive for miri to complete in a reasonable amount of time
 fn interval_set_inset_range_test() {
     // Generate valid ranges (lb <= ub)
-    let gen = gen::<(i32, i32, i32)>().filter_gen(|(a, b, _c)| a <= b);
+    let gen = produce::<(i32, i32, i32)>().filter_gen(|(a, b, _c)| a <= b);
 
     check!().with_generator(gen).for_each(|(lb, ub, elem)| {
         let mut set: IntervalSet<i32> = IntervalSet::new();

--- a/quic/s2n-quic-core/src/packet/number/sliding_window.rs
+++ b/quic/s2n-quic-core/src/packet/number/sliding_window.rs
@@ -475,7 +475,7 @@ mod test {
     #[cfg_attr(miri, ignore)] // this test is too expensive for miri
     fn insert_test() {
         // Make sure the two packet numbers are not the same
-        let gen = gen::<(VarInt, VarInt)>().filter_gen(|(a, b)| a != b);
+        let gen = produce::<(VarInt, VarInt)>().filter_gen(|(a, b)| a != b);
 
         check!()
             .with_generator(gen)

--- a/quic/s2n-quic-core/src/packet/number/tests.rs
+++ b/quic/s2n-quic-core/src/packet/number/tests.rs
@@ -41,7 +41,7 @@ fn gen_packet_number_space() -> impl ValueGenerator<Output = PacketNumberSpace> 
 }
 
 fn gen_packet_number(space: PacketNumberSpace) -> impl ValueGenerator<Output = PacketNumber> {
-    gen().map_gen(move |packet_number| {
+    produce().map_gen(move |packet_number| {
         space.new_packet_number(match VarInt::new(packet_number) {
             Ok(packet_number) => packet_number,
             Err(_) => VarInt::from_u32(packet_number as u32),

--- a/quic/s2n-quic-core/src/recovery/congestion_controller/fuzz_target.rs
+++ b/quic/s2n-quic-core/src/recovery/congestion_controller/fuzz_target.rs
@@ -247,8 +247,8 @@ fn cubic_fuzz() {
     check!()
         .with_generator((
             MINIMUM_MAX_DATAGRAM_SIZE..=9000,
-            gen(),
-            gen::<Vec<Operation>>(),
+            produce(),
+            produce::<Vec<Operation>>(),
         ))
         .for_each(|(max_datagram_size, seed, operations)| {
             let mut model = Model::new(CubicCongestionController::new(
@@ -271,8 +271,8 @@ fn bbr_fuzz() {
     check!()
         .with_generator((
             MINIMUM_MAX_DATAGRAM_SIZE..=9000,
-            gen(),
-            gen::<Vec<Operation>>(),
+            produce(),
+            produce::<Vec<Operation>>(),
         ))
         .for_each(|(max_datagram_size, seed, operations)| {
             let mut model = Model::new(BbrCongestionController::new(

--- a/quic/s2n-quic-core/src/recovery/pacing/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/pacing/tests.rs
@@ -274,7 +274,7 @@ fn interval_differential_test() {
             1_000_000..u32::MAX,              // RTT ranges from 1ms to ~4sec
             2400..u32::MAX, // congestion window ranges from the minimum window (2 * MINIMUM_MAX_DATAGRAM_SIZE) to u32::MAX
             MINIMUM_MAX_DATAGRAM_SIZE..=9000, // max_datagram_size ranges from MINIMUM_MAX_DATAGRAM_SIZE to 9000
-            gen(),
+            produce(),
         ))
         .cloned()
         .for_each(|(rtt, congestion_window, max_datagram_size, slow_start)| {

--- a/quic/s2n-quic-core/src/stream/testing.rs
+++ b/quic/s2n-quic-core/src/stream/testing.rs
@@ -38,8 +38,8 @@ pub struct Data {
 #[cfg(any(feature = "generator", test))]
 impl TypeGenerator for Data {
     fn generate<D: bolero_generator::Driver>(driver: &mut D) -> Option<Self> {
-        let offset = gen::<u64>().generate(driver)?;
-        let final_offset = gen::<Option<u64>>()
+        let offset = produce::<u64>().generate(driver)?;
+        let final_offset = produce::<Option<u64>>()
             .with()
             .value(offset..)
             .generate(driver)?;

--- a/quic/s2n-quic-core/src/sync/cursor.rs
+++ b/quic/s2n-quic-core/src/sync/cursor.rs
@@ -540,7 +540,7 @@ mod tests {
     #[cfg_attr(kani, kani::proof, kani::unwind(5), kani::solver(kissat))]
     fn oracle_test() {
         check!()
-            .with_generator((1..=MAX_POWER_OF_TWO, gen(), gen::<Ops>()))
+            .with_generator((1..=MAX_POWER_OF_TWO, produce(), produce::<Ops>()))
             .for_each(|(power_of_two, init_cursor, ops)| model(*power_of_two, *init_cursor, ops));
     }
 }

--- a/quic/s2n-quic-core/src/sync/spsc/tests.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/tests.rs
@@ -250,7 +250,7 @@ type Operations = Vec<Operation>;
 fn model() {
     let max_capacity = if cfg!(any(kani, miri)) { 2 } else { 64 };
 
-    let generator = (1usize..max_capacity, gen::<Operations>());
+    let generator = (1usize..max_capacity, produce::<Operations>());
 
     check!()
         .with_generator(generator)
@@ -272,7 +272,7 @@ fn model() {
 fn model_zst() {
     let max_capacity = if cfg!(any(kani, miri)) { 2 } else { 64 };
 
-    let generator = (1usize..max_capacity, gen::<Operations>());
+    let generator = (1usize..max_capacity, produce::<Operations>());
 
     check!()
         .with_generator(generator)
@@ -295,7 +295,7 @@ fn alloc_test() {
     };
 
     check!()
-        .with_generator((capacity, gen::<u8>()))
+        .with_generator((capacity, produce::<u8>()))
         .cloned()
         .for_each(|(capacity, push_value)| {
             let (mut send, mut recv) = channel(capacity);

--- a/quic/s2n-quic-core/src/varint/tests.rs
+++ b/quic/s2n-quic-core/src/varint/tests.rs
@@ -115,7 +115,7 @@ fn two_byte_sequence_test() {
     // the s2n-quic implementation always chooses the smallest encoding possible.
     // this means if we wish to test two-byte sequences, we need to encode a number
     // that is > 63.
-    let g = gen::<(u8, u8)>().filter_gen(|(_, b)| *b > 63);
+    let g = produce::<(u8, u8)>().filter_gen(|(_, b)| *b > 63);
 
     bolero::check!()
         .with_generator(g)
@@ -138,7 +138,7 @@ fn four_byte_sequence_test() {
     // The s2n-quic implementation always chooses the smallest encoding possible.
     // This means if we wish to test the four-byte sequences, we need to encode a number
     // that is > 16383 or 0b0011 1111 1111 1111.
-    let g = gen::<(u8, u8, u8)>().filter_gen(|(_, _, c)| *c > 0x3f);
+    let g = produce::<(u8, u8, u8)>().filter_gen(|(_, _, c)| *c > 0x3f);
 
     bolero::check!().with_generator(g).cloned().for_each(
         |(mut first_byte, second_byte, third_byte)| {
@@ -161,7 +161,7 @@ fn eight_byte_sequence_test() {
     // The s2n-quic implementation always chooses the smallest encoding possible.
     // This means if we wish to test eight-byte sequences, we need to encode a number
     // that is > 1073741823 or 0b0011 1111 1111 1111 1111 1111 1111 1111
-    let g = gen::<(u8, u8, u8, u8)>().filter_gen(|(_, _, _, d)| *d > 0x3f);
+    let g = produce::<(u8, u8, u8, u8)>().filter_gen(|(_, _, _, d)| *d > 0x3f);
 
     bolero::check!().with_generator(g).cloned().for_each(
         |(mut first_byte, second_byte, third_byte, fourth_byte)| {

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -21,7 +21,7 @@ xdp = ["s2n-quic-xdp"]
 
 [dependencies]
 bach = { version = "0.0.6", optional = true }
-bolero-generator = { version = "0.12", default-features = false, optional = true }
+bolero-generator = { version = "0.13", default-features = false, optional = true }
 cfg-if = "1"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 lazy_static = { version = "1", optional = true }
@@ -37,8 +37,8 @@ libc = "0.2"
 
 [dev-dependencies]
 bach = { version = "0.0.6" }
-bolero = "0.12"
-bolero-generator = "0.12"
+bolero = "0.13"
+bolero-generator = "0.13"
 futures = { version = "0.3", features = ["std"] }
 insta = { version = "1", features = ["json"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }

--- a/quic/s2n-quic-platform/src/message.rs
+++ b/quic/s2n-quic-platform/src/message.rs
@@ -162,9 +162,9 @@ mod tests {
     #[test]
     #[cfg_attr(kani, kani::proof, kani::unwind(17), kani::solver(minisat))]
     fn rx_message_test() {
-        let path = bolero::gen::<path::RemoteAddress>();
-        let ecn = bolero::gen();
-        let segment_size = bolero::gen();
+        let path = bolero::produce::<path::RemoteAddress>();
+        let ecn = bolero::produce();
+        let segment_size = bolero::produce();
         let max_payload_len = if cfg!(kani) { 16 } else { u16::MAX as usize };
         let payload_len = 0..=max_payload_len;
 

--- a/quic/s2n-quic-platform/src/message/msg/tests.rs
+++ b/quic/s2n-quic-platform/src/message/msg/tests.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use bolero::{check, gen};
+use bolero::{check, produce};
 use core::mem::zeroed;
 use s2n_quic_core::inet::{SocketAddress, Unspecified};
 
@@ -73,7 +73,7 @@ fn address_inverse_pair_test() {
 fn handle_get_set_test() {
     check!()
         .with_generator((
-            gen::<Handle>(),
+            produce::<Handle>(),
             1..=crate::features::gso::MaxSegments::MAX.into(),
         ))
         .cloned()

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -29,7 +29,7 @@ siphasher = "1.0"
 smallvec = { version = "1", default-features = false }
 
 [dev-dependencies]
-bolero = "0.12"
+bolero = "0.13"
 futures-test = "0.3" # For testing Waker interactions
 insta = { version = "1", features = ["json"] }
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }

--- a/quic/s2n-quic-transport/src/connection/close_sender.rs
+++ b/quic/s2n-quic-transport/src/connection/close_sender.rs
@@ -335,12 +335,12 @@ mod tests {
         let rtt = close_time.clone().map_gen(|t| t / 3);
         let packet_durations = (0..=5000).map_gen(Duration::from_millis);
         let packet_sizes = 1..=9000;
-        let events = gen::<Vec<_>>()
+        let events = produce::<Vec<_>>()
             .with()
             .values((packet_durations, packet_sizes));
 
         bolero::check!()
-            .with_generator((close_time, rtt, events, gen()))
+            .with_generator((close_time, rtt, events, produce()))
             .for_each(|(close_time, rtt, events, is_validated)| {
                 let mut sender = CloseSender::default();
                 let mut clock = Clock::default();

--- a/quic/s2n-quic-transport/src/sync/data_sender.rs
+++ b/quic/s2n-quic-transport/src/sync/data_sender.rs
@@ -753,7 +753,7 @@ mod tests {
     #[test]
     fn model() {
         check!()
-            .with_generator((gen(), gen::<Vec<Event>>().with().len(1usize..128)))
+            .with_generator((produce(), produce::<Vec<Event>>().with().len(1usize..128)))
             .for_each(|(id, events)| {
                 check_model(events, id);
             });

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -84,7 +84,7 @@ zerocopy = { version = "0.7", optional = true, features = ["derive"] }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
-bolero = { version = "0.12" }
+bolero = { version = "0.13" }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "probe-tracing", "testing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }
 s2n-quic-transport = { path = "../s2n-quic-transport", features = ["unstable_resumption", "unstable-provider-dc"] }

--- a/quic/s2n-quic/src/provider/address_token/default.rs
+++ b/quic/s2n-quic/src/provider/address_token/default.rs
@@ -748,7 +748,7 @@ mod tests {
         //# For this design to work,
         //# the token MUST be covered by integrity protection against
         //# modification or falsification by clients.
-        let generator = bolero::generator::gen::<Vec<u8>>()
+        let generator = bolero::generator::produce::<Vec<u8>>()
             .with()
             .len(Format::TOKEN_LEN);
         bolero::check!()

--- a/tools/xdp/Cargo.toml
+++ b/tools/xdp/Cargo.toml
@@ -3,5 +3,5 @@ members = ["s2n-quic-xdp", "tester", "xtask"]
 resolver = "2"
 
 [workspace.dependencies]
-bolero = "0.12"
-bolero-generator = { version = "0.12", default-features = false }
+bolero = "0.13"
+bolero-generator = { version = "0.13", default-features = false }

--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -23,7 +23,7 @@ s2n-quic-core = { version = "=0.54.0", path = "../../../quic/s2n-quic-core" }
 tokio = { version = "1", features = ["net"], optional = true }
 
 [dev-dependencies]
-bolero = "0.12"
+bolero = "0.13"
 futures = "0.3"
 pin-project-lite = "0.2"
 rand = "0.9"

--- a/tools/xdp/xtask/src/bindings.rs
+++ b/tools/xdp/xtask/src/bindings.rs
@@ -10,7 +10,7 @@ pub fn run() -> Result<(), anyhow::Error> {
         .header(root.join("src/bindings/input.h").display().to_string())
         .allowlist_var("ETHTOOL_GCHANNELS")
         .allowlist_type("ethtool_channels")
-        .rust_target(bindgen::RustTarget::Stable_1_47)
+        .rust_target(bindgen::RustTarget::stable(1, 47).map_err(|e| anyhow::anyhow!("{}", e))?)
         .layout_tests(false)
         .raw_line(
             r#"


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

Update the `Bolero` requirement for S2N-QUIC. This PR should resolve all dependabot PRs that attempt to update `Bolero` requirements: https://github.com/aws/s2n-quic/pull/2495, https://github.com/aws/s2n-quic/pull/2494, https://github.com/aws/s2n-quic/pull/2493, https://github.com/aws/s2n-quic/pull/2492.

### Call-outs:

* In the latest Bolero release, the keyword `gen` is renamed to `produce` in https://github.com/camshaft/bolero/pull/270. I made necessary changes to reflect such change.
* [RustTarget](https://docs.rs/bindgen/latest/bindgen/struct.RustTarget.html) deprecates the `Stable_1_47` impl. We need to use the new `stable()` function. I converted the `InvalidRustTarget` object to a `anyhow::Error`.

### Testing:

This PR should be fully tested by the CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

