### PR TITLE
build(deps): bach and rand updates

### DIFF
--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -20,7 +20,7 @@ tokio-runtime = ["futures", "tokio"]
 xdp = ["s2n-quic-xdp"]
 
 [dependencies]
-bach = { version = "0.0.6", optional = true }
+bach = { version = "0.0.10", optional = true }
 bolero-generator = { version = "0.13", default-features = false, optional = true }
 cfg-if = "1"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
@@ -36,7 +36,7 @@ turmoil = { version = "0.6.0", optional = true }
 libc = "0.2"
 
 [dev-dependencies]
-bach = { version = "0.0.6" }
+bach = { version = "0.0.10" }
 bolero = "0.13"
 bolero-generator = "0.13"
 futures = { version = "0.3", features = ["std"] }

--- a/quic/s2n-quic-platform/src/io/testing/model.rs
+++ b/quic/s2n-quic-platform/src/io/testing/model.rs
@@ -1,7 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::network::{Buffers, Network, Packet};
+use super::{
+    network::{Buffers, Network, Packet},
+    rand::Any,
+};
 use core::time::Duration;
 use s2n_quic_core::{havoc, path::MaxMtu};
 use std::{
@@ -241,7 +244,7 @@ impl Network for Model {
         #[inline]
         fn gen_rate(rate: u64) -> bool {
             // ensure the rate isn't 0 before actually generating a random number
-            rate > 0 && super::rand::gen::<u64>() < rate
+            rate > 0 && super::rand::produce::<u64>().any() < rate
         }
 
         let mut transmit = |packet: Cow<Packet>| {
@@ -360,7 +363,7 @@ impl Network for Model {
 }
 
 fn gen_jitter(max_jitter: Duration) -> Duration {
-    let micros = super::rand::gen_range(0..max_jitter.as_micros() as u64);
+    let micros = Any::any(&(0..max_jitter.as_micros() as u64));
     let micros = micros as f64;
     // even though we're generated micros, we round to the nearest millisecond
     // so packets can be grouped together

--- a/quic/s2n-quic-platform/src/io/testing/time.rs
+++ b/quic/s2n-quic-platform/src/io/testing/time.rs
@@ -11,7 +11,7 @@ use core::{
 use s2n_quic_core::time::{clock, Timestamp};
 
 pub fn now() -> Timestamp {
-    unsafe { Timestamp::from_duration(time::now()) }
+    unsafe { Timestamp::from_duration(time::Instant::now().elapsed_since_start()) }
 }
 
 pub fn delay(duration: Duration) -> Timer {

--- a/quic/s2n-quic-sim/Cargo.toml
+++ b/quic/s2n-quic-sim/Cargo.toml
@@ -13,11 +13,12 @@ publish = false
 [dependencies]
 anyhow = "1"
 bytes = "1"
+bolero-generator = "0.13.0"
 humantime = "2"
 indicatif = { version = "0.17", features = ["rayon"] }
 once_cell = "1"
 prost = "0.13"
-rand = "0.8"
+rand = "0.9"
 rayon = "1"
 s2n-quic = { path = "../s2n-quic", features = ["unstable-provider-io-testing", "provider-event-tracing"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }

--- a/quic/s2n-quic-sim/src/run.rs
+++ b/quic/s2n-quic-sim/src/run.rs
@@ -108,7 +108,7 @@ impl Run {
                 .while_some()
                 .for_each(|_| {
                     use ::rand::prelude::*;
-                    let seed = thread_rng().gen();
+                    let seed = rand::rng().random();
                     test(seed);
                 });
         } else {

--- a/quic/s2n-quic-sim/src/run/endpoint.rs
+++ b/quic/s2n-quic-sim/src/run/endpoint.rs
@@ -60,7 +60,8 @@ pub fn client(
         total_delay += delay.gen_duration();
 
         // pick a random server to connect to
-        let server_addr = *rand::one_of(servers);
+        let server_addr_idx = rand::Any::any(&(0..servers.len()));
+        let server_addr = servers[server_addr_idx];
         let delay = total_delay;
 
         let client = client.clone();

--- a/quic/s2n-quic-sim/src/run/endpoint.rs
+++ b/quic/s2n-quic-sim/src/run/endpoint.rs
@@ -60,8 +60,7 @@ pub fn client(
         total_delay += delay.gen_duration();
 
         // pick a random server to connect to
-        let server_addr_idx = rand::Any::any(&(0..servers.len()));
-        let server_addr = servers[server_addr_idx];
+        let server_addr = *rand::pick(servers);
         let delay = total_delay;
 
         let client = client.clone();

--- a/quic/s2n-quic-sim/src/run/range.rs
+++ b/quic/s2n-quic-sim/src/run/range.rs
@@ -47,14 +47,14 @@ impl<T: PartialEq + fmt::Display> fmt::Display for CliRange<T> {
 
 impl<T> CliRange<T>
 where
-    T: Copy + PartialOrd + ::rand::distributions::uniform::SampleUniform,
+    T: Copy + PartialOrd + ::bolero_generator::bounded::BoundedValue,
 {
     pub fn gen(&self) -> T {
         if self.start == self.end {
             return self.start;
         }
 
-        rand::gen_range(self.start..self.end)
+        rand::Any::any(&(self.start..self.end))
     }
 }
 
@@ -67,7 +67,7 @@ impl CliRange<humantime::Duration> {
             return Duration::from_nanos(start as _);
         }
 
-        let nanos = rand::gen_range(start..end);
+        let nanos = rand::Any::any(&(start..end));
         Duration::from_nanos(nanos as _)
     }
 }

--- a/quic/s2n-quic/src/tests/issue_1427.rs
+++ b/quic/s2n-quic/src/tests/issue_1427.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::*;
+use super::{rand::Any, *};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 /// Ensures tokio `AsyncRead` implementation functions properly
@@ -31,7 +31,7 @@ fn tokio_read_exact_test() {
                 while read_len < LEN {
                     let max_len = buf.len().min(LEN - read_len);
                     // generate a random amount of bytes to read
-                    let len = rand::gen_range(1..=max_len);
+                    let len = Any::any(&(1..=max_len));
 
                     let buf = &mut buf[0..len];
                     recv.read_exact(buf).await.unwrap();


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolve https://github.com/aws/s2n-quic/issues/2479

### Description of changes: 

I have updated all `bach` and `rand` requirements in S2N-QUIC. This PR will close the [dependabot PR to update bach](https://github.com/aws/s2n-quic/pull/2385).

### Call-outs:

After `bachv0.0.6`, it no longer provides rand backend implementation. Instead, `bach` use the Bolero generator to do the rand updates. That's why there are many `rand::Any::any()` calls to get random bits.

### Testing:

CI test should fix it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

