### PR TITLE
feat(s2n-quic-dc): add channel recv buffer impl

### DIFF
--- a/dc/s2n-quic-dc/src/stream.rs
+++ b/dc/s2n-quic-dc/src/stream.rs
@@ -70,3 +70,9 @@ impl TransportFeatures {
     is_feature!(is_stream, STREAM);
     is_feature!(is_connected, CONNECTED);
 }
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Actor {
+    Application,
+    Worker,
+}

--- a/dc/s2n-quic-dc/src/stream/client/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/client/tokio.rs
@@ -161,5 +161,6 @@ where
 #[inline]
 fn recv_buffer() -> recv::shared::RecvBuffer {
     // TODO replace this with a parameter once everything is in place
-    recv::buffer::Local::new(msg::recv::Message::new(9000), None)
+    let recv_buffer = recv::buffer::Local::new(msg::recv::Message::new(9000), None);
+    recv::buffer::Either::A(recv_buffer)
 }

--- a/dc/s2n-quic-dc/src/stream/recv/application.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/application.rs
@@ -5,7 +5,7 @@ use crate::{
     clock::Timer,
     event::{self, ConnectionPublisher as _},
     msg,
-    stream::{recv, runtime, shared::ArcShared, socket},
+    stream::{recv, runtime, shared::ArcShared, socket, Actor},
 };
 use core::{
     fmt,
@@ -265,6 +265,7 @@ where
 
             let recv = reader.poll_fill_recv_buffer(
                 cx,
+                Actor::Application,
                 self.sockets.read_application(),
                 &self.shared.clock,
                 &self.shared.subscriber,

--- a/dc/s2n-quic-dc/src/stream/recv/buffer/channel.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/buffer/channel.rs
@@ -1,0 +1,134 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Dispatch;
+use crate::{
+    event,
+    socket::recv::descriptor::Filled,
+    stream::{
+        recv::{
+            self,
+            dispatch::{Control, Stream},
+        },
+        socket::Socket,
+        Actor, TransportFeatures,
+    },
+};
+use core::task::{Context, Poll};
+use s2n_quic_core::ensure;
+use std::{collections::VecDeque, io};
+
+#[derive(Debug)]
+pub struct Channel<Recv = Stream> {
+    pending: VecDeque<Filled>,
+    receiver: Recv,
+}
+
+impl<Recv> Channel<Recv> {
+    #[inline]
+    pub fn new(receiver: Recv) -> Self {
+        Self {
+            pending: VecDeque::new(),
+            receiver,
+        }
+    }
+}
+
+macro_rules! impl_buffer {
+    ($recv:ident) => {
+        impl super::Buffer for Channel<$recv> {
+            #[inline]
+            fn is_empty(&self) -> bool {
+                self.pending.is_empty()
+            }
+
+            #[inline]
+            fn poll_fill<S, Pub>(
+                &mut self,
+                cx: &mut Context,
+                actor: Actor,
+                socket: &S,
+                publisher: &mut Pub,
+            ) -> Poll<io::Result<usize>>
+            where
+                S: ?Sized + Socket,
+                Pub: event::ConnectionPublisher,
+            {
+                // check if we've already filled the queue
+                ensure!(self.pending.is_empty(), Ok(1).into());
+
+                let capacity = u16::MAX as usize;
+
+                // the socket isn't actually used since we're relying on another task to fill the `receiver` channel
+                let _ = socket;
+
+                let result = self
+                    .receiver
+                    .poll_swap(cx, actor, &mut self.pending)
+                    .map_err(|_err| io::Error::from(io::ErrorKind::BrokenPipe));
+
+                match result {
+                    Poll::Ready(Ok(())) => {
+                        let committed_len = self
+                            .pending
+                            .iter()
+                            .map(|segment| {
+                                debug_assert!(
+                                    !segment.is_empty(),
+                                    "the channel should not contain empty packets"
+                                );
+                                segment.len() as usize
+                            })
+                            .sum::<usize>();
+                        publisher.on_stream_read_socket_flushed(
+                            event::builder::StreamReadSocketFlushed {
+                                capacity,
+                                committed_len,
+                            },
+                        );
+                        Ok(committed_len).into()
+                    }
+                    Poll::Ready(Err(error)) => {
+                        let errno = error.raw_os_error();
+                        publisher.on_stream_read_socket_errored(
+                            event::builder::StreamReadSocketErrored { capacity, errno },
+                        );
+                        Err(error).into()
+                    }
+                    Poll::Pending => {
+                        publisher.on_stream_read_socket_blocked(
+                            event::builder::StreamReadSocketBlocked { capacity },
+                        );
+                        Poll::Pending
+                    }
+                }
+            }
+
+            #[inline]
+            fn process<R>(
+                &mut self,
+                features: TransportFeatures,
+                router: &mut R,
+            ) -> Result<(), recv::Error>
+            where
+                R: Dispatch,
+            {
+                debug_assert!(
+                    !features.is_stream(),
+                    "only datagram oriented transport is supported"
+                );
+
+                for mut segment in self.pending.drain(..) {
+                    let remote_addr = segment.remote_address().get();
+                    let ecn = segment.ecn();
+                    router.on_datagram_segment(&remote_addr, ecn, segment.payload_mut())?;
+                }
+
+                Ok(())
+            }
+        }
+    };
+}
+
+impl_buffer!(Stream);
+impl_buffer!(Control);

--- a/dc/s2n-quic-dc/src/stream/recv/buffer/local.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/buffer/local.rs
@@ -4,7 +4,7 @@
 use super::Dispatch;
 use crate::{
     event, msg,
-    stream::{recv, server::handshake, socket::Socket, TransportFeatures},
+    stream::{recv, server::handshake, socket::Socket, Actor, TransportFeatures},
 };
 use core::task::{Context, Poll};
 use s2n_codec::{DecoderBufferMut, DecoderError};
@@ -37,6 +37,7 @@ impl super::Buffer for Local {
     fn poll_fill<S, Pub>(
         &mut self,
         cx: &mut Context,
+        _actor: Actor,
         socket: &S,
         publisher: &mut Pub,
     ) -> Poll<io::Result<usize>>

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/handle.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/handle.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{descriptor::Descriptor, queue::Error};
-use crate::sync::ring_deque;
+use crate::{stream::Actor, sync::ring_deque};
 use core::{
     fmt,
     task::{Context, Poll},
@@ -41,22 +41,27 @@ macro_rules! impl_recv {
             }
 
             #[inline]
-            pub async fn recv(&self) -> Result<T, ring_deque::Closed> {
-                core::future::poll_fn(|cx| self.poll_recv(cx)).await
+            pub async fn recv(&self, actor: Actor) -> Result<T, ring_deque::Closed> {
+                core::future::poll_fn(|cx| self.poll_recv(cx, actor)).await
             }
 
             #[inline]
-            pub fn poll_recv(&self, cx: &mut Context) -> Poll<Result<T, ring_deque::Closed>> {
-                unsafe { self.descriptor.$field().poll_pop(cx) }
+            pub fn poll_recv(
+                &self,
+                cx: &mut Context,
+                actor: Actor,
+            ) -> Poll<Result<T, ring_deque::Closed>> {
+                unsafe { self.descriptor.$field().poll_pop(cx, actor) }
             }
 
             #[inline]
             pub fn poll_swap(
                 &self,
                 cx: &mut Context,
+                actor: Actor,
                 out: &mut VecDeque<T>,
             ) -> Poll<Result<(), ring_deque::Closed>> {
-                unsafe { self.descriptor.$field().poll_swap(cx, out) }
+                unsafe { self.descriptor.$field().poll_swap(cx, actor, out) }
             }
         }
 

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/tests.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/tests.rs
@@ -4,6 +4,7 @@
 use super::*;
 use crate::{
     socket::recv,
+    stream::Actor,
     testing::{ext::*, sim},
 };
 use bolero::{check, TypeGenerator};
@@ -284,13 +285,13 @@ fn alloc_drop_notify() {
             let (stream, control) = alloc.alloc_or_grow();
 
             async move {
-                stream.recv().await.unwrap_err();
+                stream.recv(Actor::Application).await.unwrap_err();
             }
             .primary()
             .spawn();
 
             async move {
-                control.recv().await.unwrap_err();
+                control.recv(Actor::Application).await.unwrap_err();
             }
             .primary()
             .spawn();

--- a/dc/s2n-quic-dc/src/stream/recv/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/worker.rs
@@ -5,7 +5,7 @@ use crate::{
     allocator::Allocator,
     clock::Timer,
     event, msg,
-    stream::{shared::ArcShared, socket::Socket},
+    stream::{shared::ArcShared, socket::Socket, Actor},
 };
 use core::task::{Context, Poll};
 use s2n_quic_core::{buffer, endpoint, ensure, ready, time::clock::Timer as _};
@@ -306,6 +306,7 @@ where
 
             let res = recv.poll_fill_recv_buffer(
                 cx,
+                Actor::Worker,
                 &self.socket,
                 &self.shared.clock,
                 &self.shared.subscriber,

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
@@ -317,6 +317,7 @@ impl WorkerState {
             // TCP doesn't use the route key so just pick 0
             let queue_id = VarInt::ZERO;
             let recv_buffer = recv::buffer::Local::new(recv_buffer.take(), None);
+            let recv_buffer = recv::buffer::Either::A(recv_buffer);
 
             let stream_builder = match endpoint::accept_stream(
                 now,

--- a/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
@@ -114,6 +114,7 @@ where
         // TODO allocate a queue for this stream
         let queue_id = VarInt::ZERO;
         let recv_buffer = recv::buffer::Local::new(self.recv_buffer.take(), Some(handshake));
+        let recv_buffer = recv::buffer::Either::A(recv_buffer);
 
         let stream = match endpoint::accept_stream(
             now,


### PR DESCRIPTION
### Description of changes: 

This change implements a channel-based recv buffer. This uses the queue allocator channels implemented in #2517.

### Call-outs:

I've included a couple of related, small changes in here as well:

* Added an `Actor` argument to the `Buffer` traits and queues to be able to treat application and worker wakers separately.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

