### PR TITLE
feat(s2n-quic): New function added to Connection Limits provider

### DIFF
--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -1,9 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
+#[cfg(feature = "alloc")]
+use crate::application::ServerName;
 use crate::{
     ack,
-    application::ServerName,
     event::{api::SocketAddress, IntoEvent},
     inet, recovery, stream,
     transport::parameters::{
@@ -13,6 +13,7 @@ use crate::{
         MaxDatagramFrameSize, MaxIdleTimeout, MigrationSupport, TransportParameters,
     },
 };
+#[cfg(feature = "alloc")]
 use bytes::Bytes;
 use core::time::Duration;
 use s2n_codec::decoder_invariant;
@@ -57,12 +58,14 @@ impl<'a> ConnectionInfo<'a> {
 
 #[non_exhaustive]
 #[derive(Debug)]
+#[cfg(feature = "alloc")]
 pub struct HandshakeInfo<'a> {
     pub remote_address: SocketAddress<'a>,
     pub server_name: Option<&'a ServerName>,
     pub application_protocol: &'a Bytes,
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> HandshakeInfo<'a> {
     pub fn new(
         remote_address: &'a inet::SocketAddress,
@@ -442,6 +445,7 @@ pub trait Limiter: 'static + Send {
     /// Provides another opportunity to change connection limits with information
     /// from the handshake
     #[inline]
+    #[cfg(feature = "alloc")]
     fn on_post_handshake(&mut self, info: &HandshakeInfo, limits: &mut UpdatableLimits) {
         let _ = info;
         let _ = limits;
@@ -453,7 +457,7 @@ impl Limiter for Limits {
     fn on_connection(&mut self, _into: &ConnectionInfo) -> Limits {
         *self
     }
-
+    #[cfg(feature = "alloc")]
     fn on_post_handshake(&mut self, _info: &HandshakeInfo, _limits: &mut UpdatableLimits) {}
 }
 

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -481,4 +481,15 @@ mod tests {
         assert!(limits.with_bidirectional_remote_data_window(data).is_ok());
         assert!(limits.with_unidirectional_data_window(data).is_ok());
     }
+
+    // Limits can be updated through the UpdatableLimits wrapper
+    #[test]
+    fn updatable_limits() {
+        let mut limits = Limits::default();
+        assert_eq!(limits.stream_batch_size, 1);
+        let mut updatable_limits = UpdatableLimits::new(&mut limits);
+        let new_size = 10;
+        updatable_limits.stream_batch_size(new_size);
+        assert_eq!(limits.stream_batch_size, new_size);
+    }
 }

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -433,7 +433,7 @@ impl<'a> UpdatableLimits<'a> {
         UpdatableLimits(limits)
     }
 
-    pub fn stream_batch_size(&mut self, size: u8) {
+    pub fn with_stream_batch_size(&mut self, size: u8) {
         self.0.stream_batch_size = size;
     }
 }
@@ -489,7 +489,7 @@ mod tests {
         assert_eq!(limits.stream_batch_size, 1);
         let mut updatable_limits = UpdatableLimits::new(&mut limits);
         let new_size = 10;
-        updatable_limits.stream_batch_size(new_size);
+        updatable_limits.with_stream_batch_size(new_size);
         assert_eq!(limits.stream_batch_size, new_size);
     }
 }

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -57,18 +57,18 @@ impl<'a> ConnectionInfo<'a> {
 
 #[non_exhaustive]
 #[derive(Debug)]
-pub struct PostHandshakeInfo<'a> {
+pub struct HandshakeInfo<'a> {
     pub remote_address: SocketAddress<'a>,
     pub server_name: Option<&'a ServerName>,
     pub application_protocol: &'a Bytes,
 }
 
-impl<'a> PostHandshakeInfo<'a> {
+impl<'a> HandshakeInfo<'a> {
     pub fn new(
         remote_address: &'a inet::SocketAddress,
         server_name: Option<&'a ServerName>,
         application_protocol: &'a Bytes,
-    ) -> PostHandshakeInfo<'a> {
+    ) -> HandshakeInfo<'a> {
         Self {
             remote_address: remote_address.into_event(),
             server_name,
@@ -442,7 +442,7 @@ pub trait Limiter: 'static + Send {
     /// Provides another opportunity to change connection limits with information
     /// from the handshake
     #[inline]
-    fn on_post_handshake(&mut self, info: &PostHandshakeInfo, limits: &mut UpdatableLimits) {
+    fn on_post_handshake(&mut self, info: &HandshakeInfo, limits: &mut UpdatableLimits) {
         let _ = info;
         let _ = limits;
     }
@@ -454,7 +454,7 @@ impl Limiter for Limits {
         *self
     }
 
-    fn on_post_handshake(&mut self, _info: &PostHandshakeInfo, _limits: &mut UpdatableLimits) {}
+    fn on_post_handshake(&mut self, _info: &HandshakeInfo, _limits: &mut UpdatableLimits) {}
 }
 
 #[cfg(test)]

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -134,6 +134,7 @@ impl connection::Trait for TestConnection {
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         _datagram: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
+        _conn_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
     ) -> Result<(), connection::Error> {
         Ok(())
     }
@@ -148,6 +149,7 @@ impl connection::Trait for TestConnection {
         _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         _datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
+        _conn_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -163,6 +165,7 @@ impl connection::Trait for TestConnection {
         _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         _datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
+        _conn_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -178,6 +181,7 @@ impl connection::Trait for TestConnection {
         _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         _datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
+        _connection_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -193,6 +197,7 @@ impl connection::Trait for TestConnection {
         _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         _datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
+        _limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -111,6 +111,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         datagram: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
+        conn_limits: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
     ) -> Result<(), connection::Error>;
 
     // Packet handling
@@ -126,6 +127,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
+        connection_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
     ) -> Result<(), ProcessingError>;
 
     /// Is called when an unprotected initial packet had been received
@@ -139,6 +141,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
+        connection_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
     ) -> Result<(), ProcessingError>;
 
     /// Is called when a handshake packet had been received
@@ -152,6 +155,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
+        connection_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
     ) -> Result<(), ProcessingError>;
 
     /// Is called when a short packet had been received
@@ -165,6 +169,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
+        limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
     ) -> Result<(), ProcessingError>;
 
     /// Is called when a version negotiation packet had been received
@@ -225,6 +230,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
+        connection_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
         check_for_stateless_reset: &mut bool,
     ) -> Result<(), connection::Error> {
         macro_rules! emit_drop_reason {
@@ -286,6 +292,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 packet_interceptor,
                 datagram_endpoint,
                 dc_endpoint,
+                connection_limits_endpoint,
             ),
             ProtectedPacket::VersionNegotiation(packet) => self.handle_version_negotiation_packet(
                 datagram,
@@ -303,6 +310,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 packet_interceptor,
                 datagram_endpoint,
                 dc_endpoint,
+                connection_limits_endpoint,
             ),
             ProtectedPacket::ZeroRtt(packet) => self.handle_zero_rtt_packet(
                 datagram,
@@ -320,6 +328,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 packet_interceptor,
                 datagram_endpoint,
                 dc_endpoint,
+                connection_limits_endpoint,
             ),
             ProtectedPacket::Retry(packet) => {
                 self.handle_retry_packet(datagram, path_id, packet, subscriber, packet_interceptor)
@@ -378,6 +387,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
+        connection_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
         check_for_stateless_reset: &mut bool,
     ) -> Result<(), connection::Error> {
         macro_rules! emit_drop_reason {
@@ -432,6 +442,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 packet_interceptor,
                 datagram_endpoint,
                 dc_endpoint,
+                connection_limits_endpoint,
                 check_for_stateless_reset,
             );
 

--- a/quic/s2n-quic-transport/src/connection/mod.rs
+++ b/quic/s2n-quic-transport/src/connection/mod.rs
@@ -87,4 +87,6 @@ pub struct Parameters<'a, Cfg: endpoint::Config> {
     pub dc_endpoint: &'a mut Cfg::DcEndpoint,
     /// The event subscriber for the endpoint
     pub event_subscriber: &'a mut Cfg::EventSubscriber,
+    /// The connection limits provider
+    pub limits_endpoint: &'a mut Cfg::ConnectionLimits,
 }

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -315,6 +315,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             datagram_endpoint: endpoint_context.datagram,
             dc_endpoint: endpoint_context.dc,
             open_registry: None,
+            limits_endpoint: endpoint_context.connection_limits,
         };
 
         let mut connection = <Config as endpoint::Config>::Connection::new(connection_parameters)?;
@@ -367,6 +368,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                         endpoint_context.packet_interceptor,
                         endpoint_context.datagram,
                         endpoint_context.dc,
+                        endpoint_context.connection_limits,
                     )
                     .map_err(|err| {
                         use connection::ProcessingError;
@@ -391,6 +393,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                     endpoint_context.packet_interceptor,
                     endpoint_context.datagram,
                     endpoint_context.dc,
+                    endpoint_context.connection_limits,
                     &mut false,
                 )?;
 

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -214,6 +214,7 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
                     endpoint_context.event_subscriber,
                     endpoint_context.datagram,
                     endpoint_context.dc,
+                    endpoint_context.connection_limits,
                 ) {
                     conn.close(
                         error,
@@ -607,6 +608,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                     endpoint_context.packet_interceptor,
                     endpoint_context.datagram,
                     endpoint_context.dc,
+                    endpoint_context.connection_limits,
                     &mut check_for_stateless_reset,
                 ) {
                     //= https://www.rfc-editor.org/rfc/rfc9000#section-10.2.1
@@ -633,6 +635,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                     endpoint_context.packet_interceptor,
                     endpoint_context.datagram,
                     endpoint_context.dc,
+                    endpoint_context.connection_limits,
                     &mut check_for_stateless_reset,
                 ) {
                     //= https://www.rfc-editor.org/rfc/rfc9000#section-10.2.1
@@ -1228,6 +1231,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
             datagram_endpoint: endpoint_context.datagram,
             dc_endpoint: endpoint_context.dc,
             open_registry,
+            limits_endpoint: endpoint_context.connection_limits,
         };
         let connection = <Cfg as crate::endpoint::Config>::Connection::new(connection_parameters)?;
         self.connections

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -248,6 +248,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         publisher: &mut Pub,
         datagram: &mut Config::DatagramEndpoint,
         dc: &mut Config::DcEndpoint,
+        limits_endpoint: &mut Config::ConnectionLimits,
     ) -> Poll<Result<(), transport::Error>> {
         if let Some(session_info) = self.session_info.as_mut() {
             let mut context: SessionContext<Config, Pub> = SessionContext {
@@ -268,6 +269,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
                 publisher,
                 datagram,
                 dc,
+                limits_endpoint,
             };
 
             match session_info.session.poll(&mut context)? {
@@ -295,6 +297,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         publisher: &mut Pub,
         datagram: &mut Config::DatagramEndpoint,
         dc: &mut Config::DcEndpoint,
+        limits_endpoint: &mut Config::ConnectionLimits,
     ) -> Result<(), transport::Error> {
         if let Some(session_info) = self.session_info.as_mut() {
             let mut context: SessionContext<Config, Pub> = SessionContext {
@@ -315,6 +318,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
                 publisher,
                 datagram,
                 dc,
+                limits_endpoint,
             };
 
             session_info

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -18,7 +18,7 @@ use s2n_quic_core::{
     ack,
     application::ServerName,
     connection::{
-        limits::{Limiter, PostHandshakeInfo, UpdatableLimits},
+        limits::{HandshakeInfo, Limiter, UpdatableLimits},
         InitialId, PeerId,
     },
     crypto::{
@@ -418,7 +418,7 @@ impl<Config: endpoint::Config, Pub: event::ConnectionPublisher>
         };
 
         let remote_address = self.path_manager.active_path().remote_address().0;
-        let info = PostHandshakeInfo::new(
+        let info = HandshakeInfo::new(
             &remote_address,
             self.server_name.as_ref(),
             self.application_protocol,
@@ -426,8 +426,6 @@ impl<Config: endpoint::Config, Pub: event::ConnectionPublisher>
         let mut updatable_limits = UpdatableLimits::new(self.limits);
         self.limits_endpoint
             .on_post_handshake(&info, &mut updatable_limits);
-
-        println!("{:?}", self.limits);
 
         self.local_id_registry
             .set_active_connection_id_limit(active_connection_id_limit.as_u64());
@@ -516,7 +514,6 @@ impl<Config: endpoint::Config, Pub: event::ConnectionPublisher>
                 chosen_server_name: &server_name,
             });
         *self.server_name = Some(server_name);
-        println!("SERVER NAME: {:?}", self.server_name);
 
         Ok(())
     }

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -17,15 +17,20 @@ use s2n_codec::{DecoderBuffer, DecoderValue};
 use s2n_quic_core::{
     ack,
     application::ServerName,
-    connection::{InitialId, PeerId},
-    crypto,
-    crypto::{tls, tls::ApplicationParameters, CryptoSuite, Key},
+    connection::{
+        limits::{Limiter, PostHandshakeInfo, UpdatableLimits},
+        InitialId, PeerId,
+    },
+    crypto::{
+        self,
+        tls::{self, ApplicationParameters},
+        CryptoSuite, Key,
+    },
     ct::ConstantTimeEq,
     datagram::{ConnectionInfo, Endpoint},
-    dc,
-    dc::Endpoint as _,
-    event,
+    dc::{self, Endpoint as _},
     event::{
+        self,
         builder::{DcState, DcStateChanged},
         IntoEvent,
     },
@@ -62,6 +67,7 @@ pub struct SessionContext<'a, Config: endpoint::Config, Pub: event::ConnectionPu
     pub publisher: &'a mut Pub,
     pub datagram: &'a mut Config::DatagramEndpoint,
     pub dc: &'a mut Config::DcEndpoint,
+    pub limits_endpoint: &'a mut Config::ConnectionLimits,
 }
 
 impl<Config: endpoint::Config, Pub: event::ConnectionPublisher> SessionContext<'_, Config, Pub> {
@@ -411,6 +417,18 @@ impl<Config: endpoint::Config, Pub: event::ConnectionPublisher>
             endpoint::Type::Server => self.on_client_params(param_decoder)?,
         };
 
+        let remote_address = self.path_manager.active_path().remote_address().0;
+        let info = PostHandshakeInfo::new(
+            &remote_address,
+            self.server_name.as_ref(),
+            self.application_protocol,
+        );
+        let mut updatable_limits = UpdatableLimits::new(self.limits);
+        self.limits_endpoint
+            .on_post_handshake(&info, &mut updatable_limits);
+
+        println!("{:?}", self.limits);
+
         self.local_id_registry
             .set_active_connection_id_limit(active_connection_id_limit.as_u64());
 
@@ -498,6 +516,7 @@ impl<Config: endpoint::Config, Pub: event::ConnectionPublisher>
                 chosen_server_name: &server_name,
             });
         *self.server_name = Some(server_name);
+        println!("SERVER NAME: {:?}", self.server_name);
 
         Ok(())
     }

--- a/quic/s2n-quic/src/provider/limits.rs
+++ b/quic/s2n-quic/src/provider/limits.rs
@@ -4,7 +4,7 @@
 //! Provides limits support for a connection
 
 pub use s2n_quic_core::connection::limits::{
-    ConnectionInfo, Limiter, Limits, PostHandshakeInfo, UpdatableLimits,
+    ConnectionInfo, Limiter, Limits, HandshakeInfo, UpdatableLimits,
 };
 
 pub trait Provider {

--- a/quic/s2n-quic/src/provider/limits.rs
+++ b/quic/s2n-quic/src/provider/limits.rs
@@ -4,7 +4,7 @@
 //! Provides limits support for a connection
 
 pub use s2n_quic_core::connection::limits::{
-    ConnectionInfo, Limiter, Limits, HandshakeInfo, UpdatableLimits,
+    ConnectionInfo, HandshakeInfo, Limiter, Limits, UpdatableLimits,
 };
 
 pub trait Provider {

--- a/quic/s2n-quic/src/provider/limits.rs
+++ b/quic/s2n-quic/src/provider/limits.rs
@@ -3,7 +3,9 @@
 
 //! Provides limits support for a connection
 
-pub use s2n_quic_core::connection::limits::{ConnectionInfo, Limiter, Limits};
+pub use s2n_quic_core::connection::limits::{
+    ConnectionInfo, Limiter, Limits, PostHandshakeInfo, UpdatableLimits,
+};
 
 pub trait Provider {
     type Limits: 'static + Send + Limiter;

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -26,6 +26,7 @@ mod recorder;
 
 mod resumption;
 mod setup;
+mod connection_limits;
 use setup::*;
 
 mod blackhole;

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -24,9 +24,9 @@ use std::{
 #[macro_use]
 mod recorder;
 
+mod connection_limits;
 mod resumption;
 mod setup;
-mod connection_limits;
 use setup::*;
 
 mod blackhole;

--- a/quic/s2n-quic/src/tests/connection_limits.rs
+++ b/quic/s2n-quic/src/tests/connection_limits.rs
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use s2n_quic_core::connection::limits::{
+    ConnectionInfo, HandshakeInfo, Limiter, Limits, UpdatableLimits,
+};
+
+#[test]
+fn connection_limits() {
+    struct LimitsProvider;
+    impl Limiter for LimitsProvider {
+        fn on_connection(&mut self, info: &ConnectionInfo) -> Limits {
+            let addr: [u8; 4] = [1, 0, 0, 1];
+            let port = 49153;
+            assert_eq!(info.remote_address.ip(), addr);
+            assert_eq!(info.remote_address.port(), port);
+            Limits::default()
+        }
+
+        fn on_post_handshake(&mut self, info: &HandshakeInfo, limits: &mut UpdatableLimits) {
+            let addr: [u8; 4] = [1, 0, 0, 1];
+            let port = 49153;
+            assert_eq!(info.remote_address.ip(), addr);
+            assert_eq!(info.remote_address.port(), port);
+            assert_eq!(*info.server_name.unwrap(), "localhost".into());
+            assert_eq!(info.application_protocol, "h3");
+            limits.stream_batch_size(100);
+        }
+    }
+
+    let model = Model::default();
+    test(model, |handle| {
+        let server = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(SERVER_CERTS)?
+            .with_limits(LimitsProvider)?
+            .start()?;
+
+        let client = Client::builder()
+            .with_io(handle.builder().build().unwrap())?
+            .with_tls(certificates::CERT_PEM)?
+            .start()?;
+        let addr = start_server(server)?;
+        start_client(client, addr, Data::new(1000))?;
+
+        Ok(addr)
+    })
+    .unwrap();
+}

--- a/quic/s2n-quic/src/tests/connection_limits.rs
+++ b/quic/s2n-quic/src/tests/connection_limits.rs
@@ -25,7 +25,7 @@ fn connection_limits() {
             assert_eq!(info.remote_address.port(), port);
             assert_eq!(*info.server_name.unwrap(), "localhost".into());
             assert_eq!(info.application_protocol, "h3");
-            limits.stream_batch_size(100);
+            limits.stream_batch_size(10);
         }
     }
 

--- a/quic/s2n-quic/src/tests/connection_limits.rs
+++ b/quic/s2n-quic/src/tests/connection_limits.rs
@@ -25,7 +25,7 @@ fn connection_limits() {
             assert_eq!(info.remote_address.port(), port);
             assert_eq!(*info.server_name.unwrap(), "localhost".into());
             assert_eq!(info.application_protocol, "h3");
-            limits.stream_batch_size(10);
+            limits.with_stream_batch_size(10);
         }
     }
 


### PR DESCRIPTION
### Release Summary:
New API added to allow users to change connection limits based on the information in the TLS handshake, such as server name and application protocol. Previously users could only change connection limits based on their peer's remote address. 
### Resolved issues:

resolves #1445

### Description of changes: 

Added a new function to the connection limits provider. Had to feed the limits provider through to the place where we want it to be called. Currently on stream batching can be dynamically configured. However we can always add more setters on user request.

### Call-outs:

Not all connection limits should be allowed to be altered, given that some are transport parameters. Currently it's hard for me to tell which ones should be altered so I created a single setter for stream batching.
### Testing:
I added a integ test for the Connection limits. Unsure if this is the right place for this test.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

