### PR TITLE
feat(s2n-quic-dc): Support storing ApplicationData in Entry

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map.rs
@@ -8,6 +8,7 @@ use crate::{
     path::secret::{open, seal, stateless_reset},
     stream::TransportFeatures,
 };
+pub use entry::ApplicationData;
 use s2n_quic_core::{dc, time};
 use std::{net::SocketAddr, sync::Arc};
 
@@ -26,7 +27,7 @@ pub mod testing;
 #[cfg(test)]
 mod event_tests;
 
-use entry::Entry;
+pub use entry::Entry;
 use store::Store;
 
 pub use entry::{ApplicationPair, Bidirectional, ControlPair};
@@ -202,6 +203,7 @@ impl Map {
                 receiver::State::new(),
                 dc::testing::TEST_APPLICATION_PARAMS,
                 dc::testing::TEST_REHANDSHAKE_PERIOD,
+                Arc::new(()),
             );
             let entry = Arc::new(entry);
             provider.store.test_insert(entry);
@@ -255,6 +257,7 @@ impl Map {
                 super::receiver::State::new(),
                 dc::testing::TEST_APPLICATION_PARAMS,
                 dc::testing::TEST_REHANDSHAKE_PERIOD,
+                Arc::new(()),
             );
             let entry = Arc::new(entry);
             map.store.test_insert(entry);
@@ -268,5 +271,15 @@ impl Map {
         assert_eq!(client_id, server_id);
 
         client_id
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub fn register_make_application_data(
+        &self,
+        cb: Box<
+            dyn Fn(&dyn s2n_quic_core::crypto::tls::TlsSession) -> ApplicationData + Send + Sync,
+        >,
+    ) {
+        self.store.register_make_application_data(cb);
     }
 }

--- a/dc/s2n-quic-dc/src/path/secret/map/entry/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/entry/tests.rs
@@ -15,7 +15,7 @@ fn entry_size() {
     if should_check {
         assert_eq!(
             Entry::fake((std::net::Ipv4Addr::LOCALHOST, 0).into(), None).size(),
-            295
+            311
         );
     }
 }

--- a/dc/s2n-quic-dc/src/path/secret/map/handshake.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/handshake.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{Entry, Map};
+use super::{entry::ApplicationData, Entry, Map};
 use crate::{
     packet::secret_control as control,
     path::secret::{receiver, schedule, sender},
@@ -24,6 +24,7 @@ pub struct HandshakingPath {
     endpoint_type: s2n_quic_core::endpoint::Type,
     secret: Option<schedule::Secret>,
     entry: Option<Arc<Entry>>,
+    application_data: Option<ApplicationData>,
     map: Map,
 }
 
@@ -41,6 +42,7 @@ impl HandshakingPath {
             endpoint_type,
             secret: None,
             entry: None,
+            application_data: None,
             map,
         }
     }
@@ -82,6 +84,8 @@ impl dc::Path for HandshakingPath {
         &mut self,
         session: &impl s2n_quic_core::crypto::tls::TlsSession,
     ) -> Result<Vec<s2n_quic_core::stateless_reset::Token>, s2n_quic_core::transport::Error> {
+        self.application_data = Some(self.map.store.application_data(session));
+
         let mut material = Zeroizing::new([0; TLS_EXPORTER_LENGTH]);
         session
             .tls_exporter(
@@ -134,6 +138,7 @@ impl dc::Path for HandshakingPath {
             receiver,
             self.parameters.clone(),
             self.map.store.rehandshake_period(),
+            self.application_data.take().unwrap(),
         );
         let entry = Arc::new(entry);
         self.entry = Some(entry.clone());

--- a/dc/s2n-quic-dc/src/path/secret/map/state/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state/tests.rs
@@ -139,6 +139,7 @@ impl Model {
                     receiver::State::new(),
                     dc::testing::TEST_APPLICATION_PARAMS,
                     dc::testing::TEST_REHANDSHAKE_PERIOD,
+                    Arc::new(()),
                 )));
 
                 self.invariants.insert(Invariant::ContainsIp(ip));

--- a/dc/s2n-quic-dc/src/path/secret/map/store.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/store.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::Entry;
+use super::{entry::ApplicationData, Entry};
 use crate::{
     credentials::{Credentials, Id},
     packet::{secret_control as control, Packet, WireVersion},
@@ -101,4 +101,17 @@ pub trait Store: 'static + Send + Sync {
 
         Some(state.clone())
     }
+
+    #[allow(clippy::type_complexity)]
+    fn register_make_application_data(
+        &self,
+        cb: Box<
+            dyn Fn(&dyn s2n_quic_core::crypto::tls::TlsSession) -> ApplicationData + Send + Sync,
+        >,
+    );
+
+    fn application_data(
+        &self,
+        session: &dyn s2n_quic_core::crypto::tls::TlsSession,
+    ) -> ApplicationData;
 }


### PR DESCRIPTION
### Release Summary:

* feat(dc): Support storing arbitrary application-provided data in Entry

### Resolved issues:

n/a

### Description of changes: 

This stores arbitrary metadata (Arc<dyn Any>) in each Entry. By default, we share a single `Arc<()>` across all entries, but applications can register a callback to produce different dat per path secret.

### Call-outs:

None.

### Testing:

No tests added, but the functionality is pretty obvious.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

