### PR TITLE
fix(s2n-quic-transport): allow migrations even when disable_active_migrations is sent

### DIFF
--- a/quic/s2n-quic-core/events/common.rs
+++ b/quic/s2n-quic-core/events/common.rs
@@ -782,12 +782,16 @@ enum DatagramDropReason {
     /// A datagram was received from an unknown server address.
     UnknownServerAddress,
     /// The peer initiated a connection migration before the handshake was confirmed.
+    ///
+    /// Note: This drop reason is no longer emitted
     ConnectionMigrationDuringHandshake,
     /// The attempted connection migration was rejected.
     RejectedConnectionMigration { reason: MigrationDenyReason },
     /// The maximum number of paths per connection was exceeded.
     PathLimitExceeded,
     /// The peer initiated a connection migration without supplying enough connection IDs to use.
+    ///
+    /// Note: This drop reason is no longer emitted
     InsufficientConnectionIds,
 }
 

--- a/quic/s2n-quic-transport/src/path/manager/snapshots/path__manager__tests__active_connection_migration_disabled__events.snap
+++ b/quic/s2n-quic-transport/src/path/manager/snapshots/path__manager__tests__active_connection_migration_disabled__events.snap
@@ -3,8 +3,9 @@ source: quic/s2n-quic-core/src/event/snapshot.rs
 input_file: quic/s2n-quic-transport/src/path/manager/tests.rs
 ---
 ConnectionIdUpdated { path_id: 0, cid_consumer: Local, previous: 0x01, current: 0x69643032 }
-ConnectionMigrationDenied { reason: ConnectionMigrationDisabled }
 PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:1, remote_cid: 0x69643032, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x69643032, remote_addr: 127.0.0.2:1, remote_cid: 0x69643033, id: 1, is_active: false } }
 MtuUpdated { path_id: 1, mtu: 1200, cause: NewPath, search_complete: false }
-PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:1, remote_cid: 0x69643032, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.3:1, remote_cid: 0x69643032, id: 2, is_active: false } }
+PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:1, remote_cid: 0x69643032, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x69643033, remote_addr: 127.0.0.2:1, remote_cid: 0x69643032, id: 2, is_active: false } }
 MtuUpdated { path_id: 2, mtu: 1200, cause: NewPath, search_complete: false }
+PathCreated { active: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.1:1, remote_cid: 0x69643032, id: 0, is_active: true }, new: Path { local_addr: 0.0.0.0:0, local_cid: 0x4c6f63616c4900000000000000004c6f63616c49, remote_addr: 127.0.0.3:1, remote_cid: 0x69643032, id: 3, is_active: false } }
+MtuUpdated { path_id: 3, mtu: 1200, cause: NewPath, search_complete: false }

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -14,7 +14,7 @@ use crate::{
 use core::time::Duration;
 use s2n_quic_core::{
     connection::limits::ANTI_AMPLIFICATION_MULTIPLIER,
-    event::{builder::MigrationDenyReason, testing::Publisher},
+    event::testing::Publisher,
     inet::{DatagramInfo, ExplicitCongestionNotification, SocketAddress},
     path::{migration, RemoteAddress},
     random::{self, Generator},
@@ -982,6 +982,9 @@ fn limit_number_of_connection_migrations() {
     assert_eq!(total_paths, MAX_ALLOWED_PATHS);
 }
 
+// Connection migration is still allowed to proceed even if the `disable_active_migration`
+// transport parameter is sent, as there is no way to definitely distinguish an active
+// migration from a NAT rebind.
 #[test]
 fn active_connection_migration_disabled() {
     // Setup:
@@ -1015,13 +1018,14 @@ fn active_connection_migration_disabled() {
     let new_addr: SocketAddr = "127.0.0.2:1".parse().unwrap();
     let new_addr = SocketAddress::from(new_addr);
     let new_addr = RemoteAddress::from(new_addr);
-    let new_cid = connection::LocalId::try_from_bytes(b"id02").unwrap();
+    let new_cid_1 = connection::LocalId::try_from_bytes(b"id02").unwrap();
+    let new_cid_2 = connection::LocalId::try_from_bytes(b"id03").unwrap();
     let now = NoopClock {}.get_time();
     let mut datagram = DatagramInfo {
         timestamp: now,
         payload_len: 0,
         ecn: ExplicitCongestionNotification::default(),
-        destination_connection_id: new_cid,
+        destination_connection_id: new_cid_1,
         destination_connection_id_classification: connection::id::Classification::Local,
         source_connection_id: None,
     };
@@ -1040,16 +1044,21 @@ fn active_connection_migration_disabled() {
         &mut publisher,
     );
 
-    // The active migration is rejected
-    assert!(matches!(
-        res,
-        Err(DatagramDropReason::RejectedConnectionMigration {
-            reason: MigrationDenyReason::ConnectionMigrationDisabled { .. }
-        })
-    ));
-    assert_eq!(1, manager.paths.len());
+    // The migration succeeds
+    assert!(res.is_ok());
+    assert_eq!(2, manager.paths.len());
+    // The new path uses a new CID since there were enough supplied
+    assert_eq!(
+        manager.paths[res.unwrap().0.as_u8() as usize].peer_connection_id,
+        id_3
+    );
+
+    // Clear the pending packet authentication to allow another migration to proceed
+    manager.pending_packet_authentication = None;
 
     // Try an active connection migration with active migration enabled (default)
+    datagram.destination_connection_id = new_cid_2;
+
     let res = manager.handle_connection_migration(
         &new_addr,
         &datagram,
@@ -1062,7 +1071,12 @@ fn active_connection_migration_disabled() {
 
     // The migration succeeds
     assert!(res.is_ok());
-    assert_eq!(2, manager.paths.len());
+    assert_eq!(3, manager.paths.len());
+    // The new path uses the existing id since there wasn't a new one available
+    assert_eq!(
+        manager.paths[res.unwrap().0.as_u8() as usize].peer_connection_id,
+        id_2
+    );
 
     // Now try a non-active (passive) migration, with active migration disabled
     // the same CID is used, so it's not an active migration
@@ -1088,7 +1102,12 @@ fn active_connection_migration_disabled() {
 
     // The passive migration succeeds
     assert!(res.is_ok());
-    assert_eq!(3, manager.paths.len());
+    assert_eq!(4, manager.paths.len());
+    // The new path uses the existing id since the peer did not change their destination CID
+    assert_eq!(
+        manager.paths[res.unwrap().0.as_u8() as usize].peer_connection_id,
+        id_2
+    );
 }
 
 #[test]


### PR DESCRIPTION
### Release Summary:
Connection migrations are now allowed even when the `disable_active_migration` is set to true, as it is not possible to distinguish between the peer performing an active migration, and a NAT rebind. 

### Description of changes: 

This change loosens two restrictions on connection migration:

1. Migrations are now allowed even if the `disable_active_migration` transport parameter is set to true
2. Migrations are allowed even if the peer did not supply sufficient connection IDs to allow for using a new connection ID on the new path

The reasoning for allowing migrations in these cases is that there is no way a server can definitely determine that a migration from the peer was intentional/active versus just a NAT rebind. The peer is allowed to change destination connection IDs at any time, so if a peer undergoes a NAT rebind at the same time they change destination CID, that would appear identical to an active migration. To increase availability, we will allow such cases to proceed with migration.

### Testing:

Updated existing unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

