### PR TITLE
feat(s2n-quic-dc): implement queue allocator/dispatcher

### DIFF
--- a/dc/s2n-quic-dc/src/socket/recv/router.rs
+++ b/dc/s2n-quic-dc/src/socket/recv/router.rs
@@ -11,6 +11,8 @@ use s2n_quic_core::inet::{ExplicitCongestionNotification, SocketAddress};
 
 /// Routes incoming packet segments to the appropriate destination
 pub trait Router {
+    fn is_open(&self) -> bool;
+
     #[inline(always)]
     fn tag_len(&self) -> usize {
         16

--- a/dc/s2n-quic-dc/src/stream/recv.rs
+++ b/dc/s2n-quic-dc/src/stream/recv.rs
@@ -4,6 +4,7 @@
 mod ack;
 pub mod application;
 pub(crate) mod buffer;
+pub mod dispatch;
 mod error;
 mod packet;
 mod probes;

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch.rs
@@ -1,0 +1,218 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{credentials, packet, path, socket::recv::descriptor as desc, sync::mpsc};
+use s2n_quic_core::inet::SocketAddress;
+use tracing::debug;
+
+mod descriptor;
+mod pool;
+mod sender;
+
+#[cfg(test)]
+mod tests;
+
+/// Allocate this many channels at a time
+const PAGE_SIZE: usize = 256;
+
+pub type Control = descriptor::Control<desc::Filled>;
+pub type Stream = descriptor::Stream<desc::Filled>;
+pub type StreamSender = descriptor::StreamSender<desc::Filled>;
+
+#[derive(Clone)]
+pub struct Allocator {
+    pool: pool::Pool<desc::Filled, PAGE_SIZE>,
+    map: path::secret::Map,
+}
+
+impl Allocator {
+    pub fn new(
+        map: path::secret::Map,
+        stream_capacity: impl Into<mpsc::Capacity>,
+        control_capacity: impl Into<mpsc::Capacity>,
+    ) -> Self {
+        Self {
+            pool: pool::Pool::new(stream_capacity.into(), control_capacity.into()),
+            map,
+        }
+    }
+
+    #[inline]
+    pub fn dispatcher(&self) -> Dispatch {
+        Dispatch {
+            senders: self.pool.senders(),
+            map: self.map.clone(),
+            is_open: true,
+        }
+    }
+
+    #[inline]
+    pub fn alloc(&mut self) -> Option<(Control, Stream)> {
+        self.pool.alloc()
+    }
+
+    #[inline]
+    pub fn alloc_or_grow(&mut self) -> (Control, Stream) {
+        self.pool.alloc_or_grow()
+    }
+}
+
+#[derive(Clone)]
+pub struct Dispatch {
+    senders: sender::Senders<desc::Filled, PAGE_SIZE>,
+    map: path::secret::Map,
+    is_open: bool,
+}
+
+impl crate::socket::recv::router::Router for Dispatch {
+    #[inline(always)]
+    fn is_open(&self) -> bool {
+        self.is_open
+    }
+
+    #[inline(always)]
+    fn tag_len(&self) -> usize {
+        16
+    }
+
+    /// implement this so we don't get warnings about not handling it
+    #[inline(always)]
+    fn handle_control_packet(
+        &mut self,
+        _remote_address: SocketAddress,
+        _ecn: s2n_quic_core::inet::ExplicitCongestionNotification,
+        _packet: packet::control::decoder::Packet,
+    ) {
+    }
+
+    #[inline]
+    fn dispatch_control_packet(
+        &mut self,
+        _tag: packet::control::Tag,
+        id: Option<packet::stream::Id>,
+        credentials: credentials::Credentials,
+        segment: desc::Filled,
+    ) {
+        let Some(id) = id else {
+            return;
+        };
+
+        let mut did_send = false;
+        let mut prev = None;
+        self.senders.lookup(id.queue_id, |sender| {
+            did_send = true;
+            match sender.control.send_back(segment) {
+                Ok(new_prev) => {
+                    // drop the previous segment outside of the lookup call
+                    prev = new_prev;
+                }
+                Err(_) => {
+                    // if any channels are closed then the whole thing is dropped
+                    self.is_open = false;
+                }
+            }
+        });
+
+        if !did_send {
+            // TODO increment metrics
+            debug!(stream_id = ?id, ?credentials, "unroutable control packet");
+            return;
+        }
+
+        if prev.is_some() {
+            // TODO increment metrics
+            debug!(queue_id = %id.queue_id, "control queue overflow");
+        }
+    }
+
+    /// implement this so we don't get warnings about not handling it
+    #[inline(always)]
+    fn handle_stream_packet(
+        &mut self,
+        _remote_address: SocketAddress,
+        _ecn: s2n_quic_core::inet::ExplicitCongestionNotification,
+        _packet: packet::stream::decoder::Packet,
+    ) {
+    }
+
+    #[inline]
+    fn dispatch_stream_packet(
+        &mut self,
+        _tag: packet::stream::Tag,
+        id: packet::stream::Id,
+        credentials: credentials::Credentials,
+        segment: desc::Filled,
+    ) {
+        let mut did_send = false;
+        let mut prev = None;
+        self.senders.lookup(id.queue_id, |sender| {
+            did_send = true;
+            match sender.stream.send_back(segment) {
+                Ok(new_prev) => {
+                    // drop the previous segment outside of the lookup call
+                    prev = new_prev;
+                }
+                Err(_) => {
+                    // if any channels are closed then the whole thing is dropped
+                    self.is_open = false;
+                }
+            }
+        });
+
+        if !did_send {
+            // TODO increment metrics
+            debug!(stream_id = ?id, ?credentials, "unroutable stream packet");
+            return;
+        }
+
+        if prev.is_some() {
+            // TODO increment metrics
+            debug!(queue_id = %id.queue_id, "stream queue overflow");
+        }
+    }
+
+    #[inline]
+    fn handle_stale_key_packet(
+        &mut self,
+        packet: packet::secret_control::stale_key::Packet,
+        remote_address: SocketAddress,
+    ) {
+        self.map
+            .handle_control_packet(&packet.into(), &remote_address.into());
+    }
+
+    #[inline]
+    fn handle_replay_detected_packet(
+        &mut self,
+        packet: packet::secret_control::replay_detected::Packet,
+        remote_address: SocketAddress,
+    ) {
+        self.map
+            .handle_control_packet(&packet.into(), &remote_address.into());
+    }
+
+    #[inline]
+    fn handle_unknown_path_secret_packet(
+        &mut self,
+        packet: packet::secret_control::unknown_path_secret::Packet,
+        remote_address: SocketAddress,
+    ) {
+        self.map
+            .handle_control_packet(&packet.into(), &remote_address.into());
+    }
+
+    #[inline(always)]
+    fn on_decode_error(
+        &mut self,
+        error: s2n_codec::DecoderError,
+        remote_address: SocketAddress,
+        segment: desc::Filled,
+    ) {
+        tracing::warn!(
+            ?error,
+            ?remote_address,
+            packet_len = segment.len(),
+            "failed to decode packet"
+        );
+    }
+}

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/__fuzz__/stream__recv__dispatch__tests__model/corpus.tar.gz
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/__fuzz__/stream__recv__dispatch__tests__model/corpus.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64dc6c1ff0f7c89de06fcc817360f949a95b2d524afe99789e2429c9e082603f
+size 2488320

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/descriptor.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/descriptor.rs
@@ -1,0 +1,225 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::sync::mpsc;
+use core::{
+    fmt,
+    task::{Context, Poll},
+};
+use s2n_quic_core::{sync::CachePadded, varint::VarInt};
+use std::{
+    marker::PhantomData,
+    ptr::NonNull,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+use tracing::trace;
+
+/// Callback which releases a descriptor back into the free list
+pub(super) trait FreeList<T>: 'static + Send + Sync {
+    /// Frees a descriptor back into the free list
+    ///
+    /// Once the free list has been closed and all descriptors returned, the `free` function
+    /// should return an object that can be dropped to release all of the memory associated
+    /// with the descriptor pool. This works around any issues around the "Stacked Borrows"
+    /// model by deferring freeing memory borrowed by `self`.
+    fn free(&self, descriptor: Descriptor<T>) -> Option<Box<dyn 'static + Send>>;
+}
+
+/// A pointer to a single descriptor in a group
+///
+/// Fundamentally, this is similar to something like `Arc<DescriptorInner>`. However,
+/// unlike [`Arc`] which frees back to the global allocator, a Descriptor deallocates into
+/// the backing [`FreeList`].
+pub(super) struct Descriptor<T> {
+    ptr: NonNull<DescriptorInner<T>>,
+    phantom: PhantomData<DescriptorInner<T>>,
+}
+
+impl<T: 'static> Descriptor<T> {
+    #[inline]
+    pub(super) fn new(ptr: NonNull<DescriptorInner<T>>) -> Self {
+        Self {
+            ptr,
+            phantom: PhantomData,
+        }
+    }
+
+    #[inline]
+    pub(super) fn is_active(&self) -> bool {
+        self.inner().references.load(Ordering::Relaxed) > 0
+    }
+
+    /// # Safety
+    ///
+    /// This should only be called once the caller can guarantee the descriptor is no longer
+    /// used.
+    #[inline]
+    pub(super) unsafe fn drop_in_place(&self) {
+        core::ptr::drop_in_place(self.ptr.as_ptr());
+    }
+
+    #[inline]
+    fn inner(&self) -> &DescriptorInner<T> {
+        unsafe { self.ptr.as_ref() }
+    }
+
+    /// # Safety
+    ///
+    /// * The [`Descriptor`] needs to be exclusively owned
+    #[inline]
+    pub(super) unsafe fn into_owned(self) -> (Control<T>, Stream<T>) {
+        let inner = self.inner();
+
+        // we can use relaxed since this only happens after it is filled, which was done by a single owner
+        inner.references.store(2, Ordering::Relaxed);
+
+        let stream = Stream(Self {
+            ptr: self.ptr,
+            phantom: PhantomData,
+        });
+        let control = Control(self);
+
+        (control, stream)
+    }
+
+    /// # Safety
+    ///
+    /// * The descriptor must be in an owned state.
+    /// * After calling this method, the descriptor handle should not be used
+    #[inline]
+    unsafe fn drop_owned(&self) {
+        let inner = self.inner();
+        let desc_ref = inner.references.fetch_sub(1, Ordering::Release);
+        debug_assert_ne!(desc_ref, 0, "reference count underflow");
+
+        // based on the implementation in:
+        // https://github.com/rust-lang/rust/blob/28b83ee59698ae069f5355b8e03f976406f410f5/library/alloc/src/sync.rs#L2551
+        if desc_ref != 1 {
+            trace!(drop_desc_ref = ?inner.id);
+            return;
+        }
+
+        core::sync::atomic::fence(Ordering::Acquire);
+
+        // drain any remaining items
+        for recv in [&inner.control, &inner.stream] {
+            while let Ok(Some(item)) = recv.try_recv_front() {
+                drop(item);
+            }
+        }
+
+        let storage = inner.free_list.free(Descriptor {
+            ptr: self.ptr,
+            phantom: PhantomData,
+        });
+        trace!(free_desc = ?inner.id, state = %"owned");
+        drop(storage);
+    }
+}
+
+unsafe impl<T: Send> Send for Descriptor<T> {}
+unsafe impl<T: Sync> Sync for Descriptor<T> {}
+
+pub(super) struct DescriptorInner<T> {
+    id: VarInt,
+    references: CachePadded<AtomicUsize>,
+    stream: CachePadded<mpsc::Receiver<T>>,
+    control: CachePadded<mpsc::Receiver<T>>,
+    /// A reference back to the free list
+    free_list: Arc<dyn FreeList<T>>,
+}
+
+impl<T> DescriptorInner<T> {
+    pub(super) fn new(
+        id: VarInt,
+        stream: mpsc::Receiver<T>,
+        control: mpsc::Receiver<T>,
+        free_list: Arc<dyn FreeList<T>>,
+    ) -> Self {
+        Self {
+            id,
+            stream: CachePadded::new(stream),
+            control: CachePadded::new(control),
+            references: CachePadded::new(AtomicUsize::new(0)),
+            free_list,
+        }
+    }
+}
+
+macro_rules! impl_recv {
+    ($name:ident, $field:ident) => {
+        pub struct $name<T: 'static>(Descriptor<T>);
+
+        impl<T: 'static> $name<T> {
+            #[inline]
+            pub fn queue_id(&self) -> VarInt {
+                self.0.inner().id
+            }
+
+            #[inline]
+            pub fn try_recv(&self) -> Result<Option<T>, mpsc::Closed> {
+                self.0.inner().$field.try_recv_front()
+            }
+
+            #[inline]
+            pub fn poll_recv(&self, cx: &mut Context) -> Poll<Result<T, mpsc::Closed>> {
+                self.0.inner().$field.poll_recv_front(cx)
+            }
+
+            #[inline]
+            pub fn poll_swap(
+                &self,
+                cx: &mut Context,
+                out: &mut std::collections::VecDeque<T>,
+            ) -> Poll<Result<(), mpsc::Closed>> {
+                self.0.inner().$field.poll_swap(cx, out)
+            }
+        }
+
+        impl<T: 'static> fmt::Debug for $name<T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct(stringify!($name))
+                    .field("queue_id", &self.queue_id())
+                    .finish()
+            }
+        }
+
+        impl<T: 'static> Drop for $name<T> {
+            #[inline]
+            fn drop(&mut self) {
+                unsafe {
+                    self.0.drop_owned();
+                }
+            }
+        }
+    };
+}
+
+impl_recv!(Control, control);
+impl_recv!(Stream, stream);
+
+impl<T: 'static> Stream<T> {
+    #[inline]
+    pub fn sender(&self) -> StreamSender<T> {
+        StreamSender(self.0.inner().stream.sender())
+    }
+}
+
+pub struct StreamSender<T>(mpsc::Sender<T>);
+
+impl<T> Clone for StreamSender<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self(self.0.clone())
+    }
+}
+
+impl<T: 'static> StreamSender<T> {
+    #[inline]
+    pub fn send(&self, item: T) -> Result<Option<T>, mpsc::Closed> {
+        self.0.send_back(item)
+    }
+}

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/free_list.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/free_list.rs
@@ -1,0 +1,148 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    descriptor::Descriptor,
+    handle::{Control, Stream},
+    pool::Region,
+};
+use std::sync::{Arc, Mutex};
+
+/// Callback which releases a descriptor back into the free list
+pub(super) trait FreeList<T>: 'static + Send + Sync {
+    /// Frees a descriptor back into the free list
+    ///
+    /// Once the free list has been closed and all descriptors returned, the `free` function
+    /// should return an object that can be dropped to release all of the memory associated
+    /// with the descriptor pool. This works around any issues around the "Stacked Borrows"
+    /// model by deferring freeing memory borrowed by `self`.
+    fn free(&self, descriptor: Descriptor<T>) -> Option<Box<dyn 'static + Send>>;
+}
+
+/// A free list of unfilled descriptors
+///
+/// Note that this uses a [`Vec`] instead of [`std::collections::VecDeque`], which acts more
+/// like a stack than a queue. This is to prefer more-recently used descriptors which should
+/// hopefully reduce the number of cache misses.
+pub(super) struct FreeVec<T: 'static>(Mutex<FreeInner<T>>);
+
+impl<T: 'static> FreeVec<T> {
+    #[inline]
+    pub fn new(initial_cap: usize) -> (Arc<Self>, Arc<Memory<T>>) {
+        let descriptors = Vec::with_capacity(initial_cap);
+        let regions = Vec::with_capacity(1);
+        let inner = FreeInner {
+            descriptors,
+            regions,
+            total: 0,
+            open: true,
+        };
+        let free = Arc::new(Self(Mutex::new(inner)));
+        let memory = Arc::new(Memory(free.clone()));
+        (free, memory)
+    }
+
+    #[inline]
+    pub fn alloc(&self) -> Option<(Control<T>, Stream<T>)> {
+        self.0.lock().unwrap().descriptors.pop().map(|v| unsafe {
+            // SAFETY: the descriptor is only owned by the free list
+            let (control, stream) = v.into_receiver_pair();
+            (Control::new(control), Stream::new(stream))
+        })
+    }
+
+    #[inline]
+    pub fn record_region(&self, region: Region<T>, mut descriptors: Vec<Descriptor<T>>) {
+        let mut inner = self.0.lock().unwrap();
+        inner.regions.push(region);
+        inner.total += descriptors.len();
+        inner.descriptors.append(&mut descriptors);
+        // Even though the `descriptors` is now empty (`len=0`), it still owns
+        // capacity and will need to be freed. Drop the lock before interacting
+        // with the global allocator.
+        drop(inner);
+        drop(descriptors);
+    }
+
+    #[inline]
+    fn try_free(&self) -> Option<FreeInner<T>> {
+        let mut inner = self.0.lock().unwrap();
+        inner.open = false;
+        inner.try_free()
+    }
+}
+
+/// A memory reference to the free list
+///
+/// Once dropped, the pool and all associated descriptors will be
+/// freed after the last handle is dropped.
+pub(super) struct Memory<T: 'static>(Arc<FreeVec<T>>);
+
+impl<T: 'static> Drop for Memory<T> {
+    #[inline]
+    fn drop(&mut self) {
+        drop(self.0.try_free());
+    }
+}
+
+impl<T: 'static + Send> FreeList<T> for FreeVec<T> {
+    #[inline]
+    fn free(&self, descriptor: Descriptor<T>) -> Option<Box<dyn 'static + Send>> {
+        let mut inner = self.0.lock().unwrap();
+        inner.descriptors.push(descriptor);
+        if inner.open {
+            return None;
+        }
+        inner
+            .try_free()
+            .map(|to_free| Box::new(to_free) as Box<dyn 'static + Send>)
+    }
+}
+
+struct FreeInner<T: 'static> {
+    descriptors: Vec<Descriptor<T>>,
+    regions: Vec<Region<T>>,
+    total: usize,
+    open: bool,
+}
+
+impl<T: 'static> FreeInner<T> {
+    #[inline(never)] // this is rarely called
+    fn try_free(&mut self) -> Option<Self> {
+        if self.descriptors.len() < self.total {
+            tracing::trace!("waiting for more descriptors to be freed");
+            return None;
+        }
+
+        tracing::trace!("all descriptors freed back to pool");
+
+        // move all of the allocations out of itself, since this is self-referential
+        Some(core::mem::replace(
+            self,
+            FreeInner {
+                descriptors: Vec::new(),
+                regions: Vec::new(),
+                total: 0,
+                open: false,
+            },
+        ))
+    }
+}
+
+impl<T: 'static> Drop for FreeInner<T> {
+    #[inline]
+    fn drop(&mut self) {
+        if self.descriptors.is_empty() {
+            return;
+        }
+
+        tracing::trace!("dropping {} descriptors", self.descriptors.len());
+
+        for descriptor in self.descriptors.drain(..) {
+            unsafe {
+                // SAFETY: the free list is closed and there are no outstanding descriptors
+                descriptor.drop_in_place();
+            }
+        }
+    }
+}

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/handle.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/handle.rs
@@ -1,0 +1,124 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{descriptor::Descriptor, queue::Error};
+use crate::sync::ring_deque;
+use core::{
+    fmt,
+    task::{Context, Poll},
+};
+use s2n_quic_core::varint::VarInt;
+use std::collections::VecDeque;
+
+macro_rules! impl_recv {
+    ($name:ident, $field:ident, $drop:ident) => {
+        pub struct $name<T: 'static> {
+            descriptor: Descriptor<T>,
+        }
+
+        impl<T: 'static> $name<T> {
+            #[inline]
+            pub(super) fn new(descriptor: Descriptor<T>) -> Self {
+                Self { descriptor }
+            }
+
+            /// Returns the associated `queue_id` for the channel
+            ///
+            /// This can be sent to a peer, which can be used to route packets back to the channel.
+            #[inline]
+            pub fn queue_id(&self) -> VarInt {
+                unsafe { self.descriptor.queue_id() }
+            }
+
+            #[inline]
+            pub fn push(&self, item: T) -> Option<T> {
+                unsafe { self.descriptor.$field().force_push(item) }
+            }
+
+            #[inline]
+            pub fn try_recv(&self) -> Result<Option<T>, ring_deque::Closed> {
+                unsafe { self.descriptor.$field().pop() }
+            }
+
+            #[inline]
+            pub async fn recv(&self) -> Result<T, ring_deque::Closed> {
+                core::future::poll_fn(|cx| self.poll_recv(cx)).await
+            }
+
+            #[inline]
+            pub fn poll_recv(&self, cx: &mut Context) -> Poll<Result<T, ring_deque::Closed>> {
+                unsafe { self.descriptor.$field().poll_pop(cx) }
+            }
+
+            #[inline]
+            pub fn poll_swap(
+                &self,
+                cx: &mut Context,
+                out: &mut VecDeque<T>,
+            ) -> Poll<Result<(), ring_deque::Closed>> {
+                unsafe { self.descriptor.$field().poll_swap(cx, out) }
+            }
+        }
+
+        impl<T: 'static> fmt::Debug for $name<T> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct(stringify!($name))
+                    .field("queue_id", &self.queue_id())
+                    .finish()
+            }
+        }
+
+        impl<T: 'static> Drop for $name<T> {
+            #[inline]
+            fn drop(&mut self) {
+                unsafe {
+                    self.descriptor.$drop();
+                }
+            }
+        }
+    };
+}
+
+impl_recv!(Control, control_queue, drop_control_receiver);
+impl_recv!(Stream, stream_queue, drop_stream_receiver);
+
+pub struct Sender<T: 'static> {
+    descriptor: Descriptor<T>,
+}
+
+impl<T: 'static> Clone for Sender<T> {
+    #[inline]
+    fn clone(&self) -> Self {
+        unsafe {
+            Self {
+                descriptor: self.descriptor.clone_for_sender(),
+            }
+        }
+    }
+}
+
+impl<T: 'static> Sender<T> {
+    #[inline]
+    pub(super) fn new(descriptor: Descriptor<T>) -> Self {
+        Self { descriptor }
+    }
+
+    #[inline]
+    pub fn send_stream(&self, item: T) -> Result<Option<T>, Error> {
+        unsafe { self.descriptor.stream_queue().push(item) }
+    }
+
+    #[inline]
+    pub fn send_control(&self, item: T) -> Result<Option<T>, Error> {
+        unsafe { self.descriptor.control_queue().push(item) }
+    }
+}
+
+impl<T: 'static> Drop for Sender<T> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            self.descriptor.drop_sender();
+        }
+    }
+}

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/pool.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/pool.rs
@@ -2,21 +2,25 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    descriptor::{Control, Descriptor, DescriptorInner, FreeList, Stream},
-    sender::{Sender, SenderEntry, SenderPages, Senders},
+    descriptor::{Descriptor, DescriptorInner},
+    free_list::{self, FreeVec},
+    handle::{Control, Sender, Stream},
+    sender::{SenderPages, Senders},
 };
-use crate::sync::mpsc::{self, Capacity};
+use crate::sync::ring_deque::Capacity;
 use s2n_quic_core::varint::VarInt;
 use std::{
     alloc::Layout,
     marker::PhantomData,
     ptr::NonNull,
-    sync::{Arc, Mutex, RwLock},
+    sync::{Arc, RwLock},
 };
 
 pub struct Pool<T: 'static + Send, const PAGE_SIZE: usize> {
-    free: Arc<Free<T>>,
     senders: Arc<RwLock<SenderPages<T>>>,
+    free: Arc<FreeVec<T>>,
+    /// Holds the backing memory allocated as long as there's at least one reference
+    memory_handle: Arc<free_list::Memory<T>>,
     stream_capacity: Capacity,
     control_capacity: Capacity,
     epoch: VarInt,
@@ -27,6 +31,7 @@ impl<T: 'static + Send, const PAGE_SIZE: usize> Clone for Pool<T, PAGE_SIZE> {
     fn clone(&self) -> Self {
         Self {
             free: self.free.clone(),
+            memory_handle: self.memory_handle.clone(),
             senders: self.senders.clone(),
             stream_capacity: self.stream_capacity,
             control_capacity: self.control_capacity,
@@ -37,14 +42,16 @@ impl<T: 'static + Send, const PAGE_SIZE: usize> Clone for Pool<T, PAGE_SIZE> {
 
 impl<T: 'static + Send, const PAGE_SIZE: usize> Pool<T, PAGE_SIZE> {
     #[inline]
-    pub fn new(stream_capacity: Capacity, control_capacity: Capacity) -> Self {
-        let free = Free::new(PAGE_SIZE);
+    pub fn new(epoch: VarInt, stream_capacity: Capacity, control_capacity: Capacity) -> Self {
+        let (free, memory_handle) = FreeVec::new(PAGE_SIZE);
+        let senders = Arc::new(RwLock::new(SenderPages::new(epoch)));
         let mut pool = Pool {
             free,
-            senders: Default::default(),
+            memory_handle,
+            senders,
             stream_capacity,
             control_capacity,
-            epoch: VarInt::ZERO,
+            epoch,
         };
         pool.grow();
         pool
@@ -54,6 +61,8 @@ impl<T: 'static + Send, const PAGE_SIZE: usize> Pool<T, PAGE_SIZE> {
     pub fn senders(&self) -> Senders<T, PAGE_SIZE> {
         Senders {
             senders: self.senders.clone(),
+            // make sure the memory lives as long as this sender is alive
+            memory_handle: self.memory_handle.clone(),
             local: Default::default(),
         }
     }
@@ -66,7 +75,7 @@ impl<T: 'static + Send, const PAGE_SIZE: usize> Pool<T, PAGE_SIZE> {
     #[inline]
     pub fn alloc_or_grow(&mut self) -> (Control<T>, Stream<T>) {
         loop {
-            if let Some(descriptor) = self.free.alloc() {
+            if let Some(descriptor) = self.alloc() {
                 return descriptor;
             }
             self.grow();
@@ -85,33 +94,29 @@ impl<T: 'static + Send, const PAGE_SIZE: usize> Pool<T, PAGE_SIZE> {
         for idx in 0..PAGE_SIZE {
             let offset = layout.size() * idx;
 
-            let (stream_s, stream_r) = mpsc::new(self.stream_capacity);
-            let (control_s, control_r) = mpsc::new(self.control_capacity);
-
             unsafe {
                 let descriptor = ptr.as_ptr().add(offset).cast::<DescriptorInner<T>>();
-                // initialize the descriptor - note that it is self-referential to `addr`, `data`, and `free`
-                // SAFETY: address, payload, and memory are all initialized
+
+                // Give the descriptor a non-`Strong` reference to the free list, since this will be the
+                // last reference to get dropped.
+                let free_list = self.free.clone();
+
+                // initialize the descriptor with the channels
                 descriptor.write(DescriptorInner::new(
                     self.epoch + idx,
-                    stream_r,
-                    control_r,
-                    self.free.clone(),
+                    self.stream_capacity,
+                    self.control_capacity,
+                    free_list,
                 ));
 
                 let descriptor = NonNull::new_unchecked(descriptor);
+                let descriptor = Descriptor::new(descriptor);
+                let sender = Sender::new(descriptor.clone_for_sender());
 
                 // push the descriptor into the free list
-                pending_desc.push(Descriptor::new(descriptor));
+                pending_desc.push(descriptor);
 
                 // push the senders into the sender page
-                let sender = SenderEntry {
-                    inner: Sender {
-                        stream: stream_s,
-                        control: control_s,
-                    },
-                    descriptor: Descriptor::new(descriptor),
-                };
                 pending_senders.push(sender);
             }
         }
@@ -151,14 +156,7 @@ impl<T: 'static + Send, const PAGE_SIZE: usize> Pool<T, PAGE_SIZE> {
     }
 }
 
-impl<T: 'static + Send, const PAGE_SIZE: usize> Drop for Pool<T, PAGE_SIZE> {
-    #[inline]
-    fn drop(&mut self) {
-        let _ = self.free.close();
-    }
-}
-
-struct Region<T: 'static> {
+pub(super) struct Region<T: 'static> {
     ptr: NonNull<u8>,
     layout: Layout,
     phantom: PhantomData<T>,
@@ -208,115 +206,6 @@ impl<T> Drop for Region<T> {
     fn drop(&mut self) {
         unsafe {
             std::alloc::dealloc(self.ptr.as_ptr(), self.layout);
-        }
-    }
-}
-
-/// A free list of unfilled descriptors
-///
-/// Note that this uses a [`Vec`] instead of [`std::collections::VecDeque`], which acts more
-/// like a stack than a queue. This is to prefer more-recently used descriptors which should
-/// hopefully reduce the number of cache misses.
-struct Free<T: 'static>(Mutex<FreeInner<T>>);
-
-impl<T: 'static> Free<T> {
-    #[inline]
-    fn new(initial_cap: usize) -> Arc<Self> {
-        let descriptors = Vec::with_capacity(initial_cap);
-        let regions = Vec::with_capacity(1);
-        let inner = FreeInner {
-            descriptors,
-            regions,
-            total: 0,
-            open: true,
-        };
-        Arc::new(Self(Mutex::new(inner)))
-    }
-
-    #[inline]
-    fn alloc(&self) -> Option<(Control<T>, Stream<T>)> {
-        self.0.lock().unwrap().descriptors.pop().map(|v| unsafe {
-            // SAFETY: the descriptor is only owned by the free list
-            v.into_owned()
-        })
-    }
-
-    #[inline]
-    fn record_region(&self, region: Region<T>, mut descriptors: Vec<Descriptor<T>>) {
-        let mut inner = self.0.lock().unwrap();
-        inner.regions.push(region);
-        inner.total += descriptors.len();
-        inner.descriptors.append(&mut descriptors);
-        // Even though the `descriptors` is now empty (`len=0`), it still owns
-        // capacity and will need to be freed. Drop the lock before interacting
-        // with the global allocator.
-        drop(inner);
-        drop(descriptors);
-    }
-
-    #[inline]
-    fn close(&self) -> Option<FreeInner<T>> {
-        let mut inner = self.0.lock().unwrap();
-        inner.open = false;
-        inner.try_free()
-    }
-}
-
-impl<T: 'static + Send> FreeList<T> for Free<T> {
-    #[inline]
-    fn free(&self, descriptor: Descriptor<T>) -> Option<Box<dyn 'static + Send>> {
-        let mut inner = self.0.lock().unwrap();
-        inner.descriptors.push(descriptor);
-        if inner.open {
-            return None;
-        }
-        inner
-            .try_free()
-            .map(|to_free| Box::new(to_free) as Box<dyn 'static + Send>)
-    }
-}
-
-struct FreeInner<T: 'static> {
-    descriptors: Vec<Descriptor<T>>,
-    regions: Vec<Region<T>>,
-    total: usize,
-    open: bool,
-}
-
-impl<T: 'static> FreeInner<T> {
-    #[inline(never)] // this is rarely called
-    fn try_free(&mut self) -> Option<Self> {
-        if self.descriptors.len() < self.total {
-            return None;
-        }
-
-        // move all of the allocations out of itself, since this is self-referential
-        Some(core::mem::replace(
-            self,
-            FreeInner {
-                descriptors: Vec::new(),
-                regions: Vec::new(),
-                total: 0,
-                open: false,
-            },
-        ))
-    }
-}
-
-impl<T: 'static> Drop for FreeInner<T> {
-    #[inline]
-    fn drop(&mut self) {
-        if self.descriptors.is_empty() {
-            return;
-        }
-
-        tracing::trace!("releasing free list");
-
-        for descriptor in self.descriptors.drain(..) {
-            unsafe {
-                // SAFETY: the free list is closed and there are no outstanding descriptors
-                descriptor.drop_in_place();
-            }
         }
     }
 }

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/pool.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/pool.rs
@@ -1,0 +1,322 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{
+    descriptor::{Control, Descriptor, DescriptorInner, FreeList, Stream},
+    sender::{Sender, SenderEntry, SenderPages, Senders},
+};
+use crate::sync::mpsc::{self, Capacity};
+use s2n_quic_core::varint::VarInt;
+use std::{
+    alloc::Layout,
+    marker::PhantomData,
+    ptr::NonNull,
+    sync::{Arc, Mutex, RwLock},
+};
+
+pub struct Pool<T: 'static + Send, const PAGE_SIZE: usize> {
+    free: Arc<Free<T>>,
+    senders: Arc<RwLock<SenderPages<T>>>,
+    stream_capacity: Capacity,
+    control_capacity: Capacity,
+    epoch: VarInt,
+}
+
+impl<T: 'static + Send, const PAGE_SIZE: usize> Clone for Pool<T, PAGE_SIZE> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            free: self.free.clone(),
+            senders: self.senders.clone(),
+            stream_capacity: self.stream_capacity,
+            control_capacity: self.control_capacity,
+            epoch: self.epoch,
+        }
+    }
+}
+
+impl<T: 'static + Send, const PAGE_SIZE: usize> Pool<T, PAGE_SIZE> {
+    #[inline]
+    pub fn new(stream_capacity: Capacity, control_capacity: Capacity) -> Self {
+        let free = Free::new(PAGE_SIZE);
+        let mut pool = Pool {
+            free,
+            senders: Default::default(),
+            stream_capacity,
+            control_capacity,
+            epoch: VarInt::ZERO,
+        };
+        pool.grow();
+        pool
+    }
+
+    #[inline]
+    pub fn senders(&self) -> Senders<T, PAGE_SIZE> {
+        Senders {
+            senders: self.senders.clone(),
+            local: Default::default(),
+        }
+    }
+
+    #[inline]
+    pub fn alloc(&self) -> Option<(Control<T>, Stream<T>)> {
+        self.free.alloc()
+    }
+
+    #[inline]
+    pub fn alloc_or_grow(&mut self) -> (Control<T>, Stream<T>) {
+        loop {
+            if let Some(descriptor) = self.free.alloc() {
+                return descriptor;
+            }
+            self.grow();
+        }
+    }
+
+    #[inline(never)] // this should happen rarely
+    fn grow(&mut self) {
+        let (region, layout) = Region::alloc(PAGE_SIZE);
+
+        let ptr = region.ptr;
+
+        let mut pending_desc = vec![];
+        let mut pending_senders = vec![];
+
+        for idx in 0..PAGE_SIZE {
+            let offset = layout.size() * idx;
+
+            let (stream_s, stream_r) = mpsc::new(self.stream_capacity);
+            let (control_s, control_r) = mpsc::new(self.control_capacity);
+
+            unsafe {
+                let descriptor = ptr.as_ptr().add(offset).cast::<DescriptorInner<T>>();
+                // initialize the descriptor - note that it is self-referential to `addr`, `data`, and `free`
+                // SAFETY: address, payload, and memory are all initialized
+                descriptor.write(DescriptorInner::new(
+                    self.epoch + idx,
+                    stream_r,
+                    control_r,
+                    self.free.clone(),
+                ));
+
+                let descriptor = NonNull::new_unchecked(descriptor);
+
+                // push the descriptor into the free list
+                pending_desc.push(Descriptor::new(descriptor));
+
+                // push the senders into the sender page
+                let sender = SenderEntry {
+                    inner: Sender {
+                        stream: stream_s,
+                        control: control_s,
+                    },
+                    descriptor: Descriptor::new(descriptor),
+                };
+                pending_senders.push(sender);
+            }
+        }
+
+        let pending_senders: Arc<[_]> = pending_senders.into();
+
+        let mut senders = self.senders.write().unwrap();
+
+        // check if another pool instance already updated the senders list
+        if senders.epoch != self.epoch {
+            // update our local copy
+            self.epoch = senders.epoch;
+
+            // free what we just allocated, since we raced with the other pool instance
+            for desc in pending_desc {
+                unsafe {
+                    desc.drop_in_place();
+                }
+            }
+
+            // return back to the alloc method, which may have a free descriptor now
+            return;
+        }
+
+        // update the epoch with the latest value
+        let target_epoch = self.epoch + PAGE_SIZE;
+        senders.epoch = target_epoch;
+        self.epoch = target_epoch;
+
+        // update the sender list with the newly allocated channels
+        senders.pages.push(pending_senders);
+        // we don't need to synchronize with the senders any more so drop the local
+        drop(senders);
+
+        // push all of the descriptors into the free list
+        self.free.record_region(region, pending_desc);
+    }
+}
+
+impl<T: 'static + Send, const PAGE_SIZE: usize> Drop for Pool<T, PAGE_SIZE> {
+    #[inline]
+    fn drop(&mut self) {
+        let _ = self.free.close();
+    }
+}
+
+struct Region<T: 'static> {
+    ptr: NonNull<u8>,
+    layout: Layout,
+    phantom: PhantomData<T>,
+}
+
+unsafe impl<T: Send> Send for Region<T> {}
+unsafe impl<T: Sync> Sync for Region<T> {}
+
+impl<T: 'static> Region<T> {
+    #[inline]
+    fn alloc(page_size: usize) -> (Self, Layout) {
+        debug_assert!(page_size > 0, "need at least 1 entry in page");
+
+        // first create the descriptor layout
+        let descriptor = Layout::new::<DescriptorInner<T>>().pad_to_align();
+
+        let descriptors = {
+            // TODO use `descriptor.repeat(page_size)` once stable
+            // https://doc.rust-lang.org/stable/core/alloc/struct.Layout.html#method.repeat
+            Layout::from_size_align(
+                descriptor.size().checked_mul(page_size).unwrap(),
+                descriptor.align(),
+            )
+            .unwrap()
+        };
+
+        let ptr = unsafe {
+            // SAFETY: the layout is non-zero size
+            debug_assert_ne!(descriptors.size(), 0);
+            // ensure that the allocation is zeroed out so we don't have to worry about MaybeUninit
+            std::alloc::alloc_zeroed(descriptors)
+        };
+        let ptr = NonNull::new(ptr).unwrap_or_else(|| std::alloc::handle_alloc_error(descriptors));
+
+        let region = Self {
+            ptr,
+            layout: descriptors,
+            phantom: PhantomData,
+        };
+
+        (region, descriptor)
+    }
+}
+
+impl<T> Drop for Region<T> {
+    #[inline]
+    fn drop(&mut self) {
+        unsafe {
+            std::alloc::dealloc(self.ptr.as_ptr(), self.layout);
+        }
+    }
+}
+
+/// A free list of unfilled descriptors
+///
+/// Note that this uses a [`Vec`] instead of [`std::collections::VecDeque`], which acts more
+/// like a stack than a queue. This is to prefer more-recently used descriptors which should
+/// hopefully reduce the number of cache misses.
+struct Free<T: 'static>(Mutex<FreeInner<T>>);
+
+impl<T: 'static> Free<T> {
+    #[inline]
+    fn new(initial_cap: usize) -> Arc<Self> {
+        let descriptors = Vec::with_capacity(initial_cap);
+        let regions = Vec::with_capacity(1);
+        let inner = FreeInner {
+            descriptors,
+            regions,
+            total: 0,
+            open: true,
+        };
+        Arc::new(Self(Mutex::new(inner)))
+    }
+
+    #[inline]
+    fn alloc(&self) -> Option<(Control<T>, Stream<T>)> {
+        self.0.lock().unwrap().descriptors.pop().map(|v| unsafe {
+            // SAFETY: the descriptor is only owned by the free list
+            v.into_owned()
+        })
+    }
+
+    #[inline]
+    fn record_region(&self, region: Region<T>, mut descriptors: Vec<Descriptor<T>>) {
+        let mut inner = self.0.lock().unwrap();
+        inner.regions.push(region);
+        inner.total += descriptors.len();
+        inner.descriptors.append(&mut descriptors);
+        // Even though the `descriptors` is now empty (`len=0`), it still owns
+        // capacity and will need to be freed. Drop the lock before interacting
+        // with the global allocator.
+        drop(inner);
+        drop(descriptors);
+    }
+
+    #[inline]
+    fn close(&self) -> Option<FreeInner<T>> {
+        let mut inner = self.0.lock().unwrap();
+        inner.open = false;
+        inner.try_free()
+    }
+}
+
+impl<T: 'static + Send> FreeList<T> for Free<T> {
+    #[inline]
+    fn free(&self, descriptor: Descriptor<T>) -> Option<Box<dyn 'static + Send>> {
+        let mut inner = self.0.lock().unwrap();
+        inner.descriptors.push(descriptor);
+        if inner.open {
+            return None;
+        }
+        inner
+            .try_free()
+            .map(|to_free| Box::new(to_free) as Box<dyn 'static + Send>)
+    }
+}
+
+struct FreeInner<T: 'static> {
+    descriptors: Vec<Descriptor<T>>,
+    regions: Vec<Region<T>>,
+    total: usize,
+    open: bool,
+}
+
+impl<T: 'static> FreeInner<T> {
+    #[inline(never)] // this is rarely called
+    fn try_free(&mut self) -> Option<Self> {
+        if self.descriptors.len() < self.total {
+            return None;
+        }
+
+        // move all of the allocations out of itself, since this is self-referential
+        Some(core::mem::replace(
+            self,
+            FreeInner {
+                descriptors: Vec::new(),
+                regions: Vec::new(),
+                total: 0,
+                open: false,
+            },
+        ))
+    }
+}
+
+impl<T: 'static> Drop for FreeInner<T> {
+    #[inline]
+    fn drop(&mut self) {
+        if self.descriptors.is_empty() {
+            return;
+        }
+
+        tracing::trace!("releasing free list");
+
+        for descriptor in self.descriptors.drain(..) {
+            unsafe {
+                // SAFETY: the free list is closed and there are no outstanding descriptors
+                descriptor.drop_in_place();
+            }
+        }
+    }
+}

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/queue.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/queue.rs
@@ -1,0 +1,184 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::sync::ring_deque::{Capacity, Closed, RecvWaker};
+use core::task::{Context, Poll};
+use s2n_quic_core::ensure;
+use std::{collections::VecDeque, sync::Mutex, task::Waker};
+use tracing::trace;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Error {
+    /// The queue ID is not associated with a stream
+    Unallocated,
+    /// The queue has been closed and won't reopen
+    Closed,
+}
+
+impl From<Closed> for Error {
+    #[inline]
+    fn from(_: Closed) -> Self {
+        Self::Closed
+    }
+}
+
+struct Inner<T> {
+    queue: VecDeque<T>,
+    capacity: usize,
+    is_open: bool,
+    has_receiver: bool,
+    waker: Option<Waker>,
+}
+
+pub struct Queue<T> {
+    inner: Mutex<Inner<T>>,
+}
+
+impl<T> Queue<T> {
+    #[inline]
+    pub fn new(capacity: Capacity) -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                queue: VecDeque::with_capacity(capacity.initial),
+                capacity: capacity.max,
+                is_open: true,
+                has_receiver: false,
+                waker: None,
+            }),
+        }
+    }
+
+    #[inline]
+    pub fn push(&self, value: T) -> Result<Option<T>, Error> {
+        let mut inner = self.lock()?;
+        // check if the queue is permanently closed
+        ensure!(inner.is_open, Err(Error::Closed));
+        // check if the queue is temporarily closed
+        ensure!(inner.has_receiver, Err(Error::Unallocated));
+
+        let prev = if inner.capacity == inner.queue.len() {
+            inner.queue.pop_front()
+        } else {
+            None
+        };
+
+        trace!(has_overflow = prev.is_some(), "push");
+
+        inner.queue.push_back(value);
+        let waker = inner.waker.take();
+        drop(inner);
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+
+        Ok(prev)
+    }
+
+    /// Bypasses closed checks and pushes items into the queue
+    #[inline]
+    pub fn force_push(&self, value: T) -> Option<T> {
+        let Ok(mut inner) = self.lock() else {
+            return Some(value);
+        };
+
+        let prev = if inner.capacity == inner.queue.len() {
+            inner.queue.pop_front()
+        } else {
+            None
+        };
+
+        trace!(has_overflow = prev.is_some(), "push");
+
+        inner.queue.push_back(value);
+        let waker = inner.waker.take();
+        drop(inner);
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+
+        prev
+    }
+
+    #[inline]
+    pub fn pop(&self) -> Result<Option<T>, Closed> {
+        let mut inner = self.lock()?;
+        trace!(has_items = !inner.queue.is_empty(), "pop");
+        if let Some(item) = inner.queue.pop_front() {
+            Ok(Some(item))
+        } else {
+            ensure!(inner.is_open, Err(Closed));
+            Ok(None)
+        }
+    }
+
+    #[inline]
+    pub fn poll_pop(&self, cx: &mut Context) -> Poll<Result<T, Closed>> {
+        let mut inner = self.lock()?;
+        trace!(has_items = !inner.queue.is_empty(), "poll_pop");
+        if let Some(item) = inner.queue.pop_front() {
+            Ok(item).into()
+        } else {
+            ensure!(inner.is_open, Err(Closed).into());
+            inner.waker.update(cx);
+            Poll::Pending
+        }
+    }
+
+    #[inline]
+    pub fn poll_swap(&self, cx: &mut Context, items: &mut VecDeque<T>) -> Poll<Result<(), Closed>> {
+        let mut inner = self.lock()?;
+        trace!(items = 0, "poll_swap");
+        if inner.queue.is_empty() {
+            ensure!(inner.is_open, Err(Closed).into());
+            inner.waker.update(cx);
+            return Poll::Pending;
+        }
+        core::mem::swap(items, &mut inner.queue);
+        Ok(()).into()
+    }
+
+    #[inline]
+    pub fn has_receiver(&self) -> bool {
+        self.lock().map(|inner| inner.has_receiver).unwrap_or(false)
+    }
+
+    #[inline]
+    pub fn open_receiver(&self) {
+        let Ok(mut inner) = self.lock() else {
+            return;
+        };
+        trace!("opening receiver");
+        inner.has_receiver = true;
+    }
+
+    #[inline]
+    pub fn close_receiver(&self) {
+        let Ok(mut inner) = self.lock() else {
+            return;
+        };
+        trace!("closing receiver");
+        inner.has_receiver = false;
+        inner.waker = None;
+        inner.queue.clear();
+    }
+
+    #[inline]
+    pub fn close(&self) {
+        let Ok(mut inner) = self.lock() else {
+            return;
+        };
+        trace!("close queue");
+        inner.is_open = false;
+        // Leave the remaining items in the queue in case the receiver wants them.
+
+        // Notify the receiver that the queue is now closed
+        if let Some(waker) = inner.waker.take() {
+            waker.wake();
+        }
+    }
+
+    #[inline]
+    fn lock(&self) -> Result<std::sync::MutexGuard<Inner<T>>, Closed> {
+        self.inner.lock().map_err(|_| Closed)
+    }
+}

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/sender.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/sender.rs
@@ -1,0 +1,79 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::descriptor::Descriptor;
+use crate::sync::mpsc;
+use s2n_quic_core::varint::VarInt;
+use std::sync::{Arc, RwLock};
+
+pub struct Senders<T, const PAGE_SIZE: usize> {
+    pub(super) senders: Arc<RwLock<SenderPages<T>>>,
+    pub(super) local: Vec<Arc<[SenderEntry<T>]>>,
+}
+
+impl<T: 'static, const PAGE_SIZE: usize> Clone for Senders<T, PAGE_SIZE> {
+    fn clone(&self) -> Self {
+        Self {
+            senders: self.senders.clone(),
+            local: self.local.clone(),
+        }
+    }
+}
+
+impl<T: 'static, const PAGE_SIZE: usize> Senders<T, PAGE_SIZE> {
+    #[inline]
+    pub fn lookup<F: FnOnce(&Sender<T>)>(&mut self, queue_id: VarInt, f: F) {
+        let queue_id = queue_id.as_u64() as usize;
+        let page = queue_id / PAGE_SIZE;
+        let offset = queue_id % PAGE_SIZE;
+
+        if self.local.len() <= page {
+            let Ok(senders) = self.senders.read() else {
+                return;
+            };
+
+            // the senders haven't been updated
+            if self.local.len() == senders.pages.len() {
+                return;
+            }
+
+            self.local
+                .extend_from_slice(&senders.pages[self.local.len()..]);
+        }
+
+        let Some(page) = self.local.get(page) else {
+            return;
+        };
+        let Some(sender) = page.get(offset) else {
+            return;
+        };
+        if !sender.descriptor.is_active() {
+            return;
+        }
+        f(&sender.inner)
+    }
+}
+
+pub struct Sender<T> {
+    pub stream: mpsc::Sender<T>,
+    pub control: mpsc::Sender<T>,
+}
+
+pub(super) struct SenderPages<T> {
+    pub(super) pages: Vec<Arc<[SenderEntry<T>]>>,
+    pub(super) epoch: VarInt,
+}
+
+impl<T> Default for SenderPages<T> {
+    fn default() -> Self {
+        Self {
+            pages: Vec::with_capacity(8),
+            epoch: VarInt::ZERO,
+        }
+    }
+}
+
+pub(super) struct SenderEntry<T> {
+    pub(super) inner: Sender<T>,
+    pub(super) descriptor: Descriptor<T>,
+}

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/tests.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/tests.rs
@@ -1,0 +1,259 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::{
+    credentials::Credentials,
+    path::secret::Map,
+    socket::recv::{self, router::Router as _},
+};
+use bolero::{check, TypeGenerator};
+use s2n_quic_core::varint::VarInt;
+use std::{collections::BTreeMap, panic::AssertUnwindSafe};
+
+#[derive(Clone, Debug, TypeGenerator)]
+enum Op {
+    Alloc,
+    FreeControl { idx: u16 },
+    FreeStream { idx: u16 },
+    SendControl { idx: u16 },
+    SendStream { idx: u16, inject: bool },
+}
+
+struct Model {
+    oracle: Oracle,
+    alloc: Allocator,
+    dispatch: Dispatch,
+}
+
+impl Model {
+    fn new(map: Map, packets: Packets) -> Self {
+        let stream_cap = 32;
+        let control_cap = 8;
+        let alloc = Allocator::new(map, stream_cap, control_cap);
+        let dispatch = alloc.dispatcher();
+        let oracle = Oracle::new(packets);
+
+        Self {
+            oracle,
+            alloc,
+            dispatch,
+        }
+    }
+
+    fn apply(&mut self, op: &Op) {
+        match op {
+            Op::Alloc => {
+                self.alloc();
+            }
+            Op::FreeControl { idx } => {
+                self.free_control((*idx).into());
+            }
+            Op::FreeStream { idx } => {
+                self.free_stream((*idx).into());
+            }
+            Op::SendControl { idx } => {
+                self.send_control((*idx).into());
+            }
+            Op::SendStream { idx, inject } => {
+                self.send_stream((*idx).into(), *inject);
+            }
+        }
+    }
+
+    fn alloc(&mut self) {
+        let (control, stream) = self.alloc.alloc_or_grow();
+        self.oracle.on_alloc(control, stream);
+    }
+
+    fn free_control(&mut self, idx: VarInt) {
+        let _ = self.oracle.control.remove(&idx);
+    }
+
+    fn free_stream(&mut self, idx: VarInt) {
+        let _ = self.oracle.stream.remove(&idx);
+    }
+
+    fn send_control(&mut self, queue_id: VarInt) {
+        let tag = Default::default();
+        let id = packet::stream::Id {
+            queue_id,
+            is_reliable: true,
+            is_bidirectional: true,
+        };
+        let credentials = Credentials {
+            id: Default::default(),
+            key_id: VarInt::ZERO,
+        };
+        let (packet_id, packet) = self.oracle.packets.create();
+        self.dispatch
+            .dispatch_control_packet(tag, Some(id), credentials, packet);
+        self.oracle.on_control_dispatch(queue_id, packet_id);
+    }
+
+    fn send_stream(&mut self, queue_id: VarInt, inject: bool) {
+        if inject {
+            return self.oracle.send_stream_inject(queue_id);
+        }
+
+        let tag = Default::default();
+        let id = packet::stream::Id {
+            queue_id,
+            is_reliable: true,
+            is_bidirectional: true,
+        };
+        let credentials = Credentials {
+            id: Default::default(),
+            key_id: VarInt::ZERO,
+        };
+        let (packet_id, packet) = self.oracle.packets.create();
+        self.dispatch
+            .dispatch_stream_packet(tag, id, credentials, packet);
+        self.oracle.on_stream_dispatch(queue_id, packet_id);
+    }
+}
+
+struct Oracle {
+    stream: BTreeMap<VarInt, Stream>,
+    control: BTreeMap<VarInt, Control>,
+    packets: Packets,
+}
+
+impl Oracle {
+    fn new(packets: Packets) -> Self {
+        Self {
+            packets,
+            stream: Default::default(),
+            control: Default::default(),
+        }
+    }
+
+    fn on_alloc(&mut self, control: Control, stream: Stream) {
+        let queue_id = control.queue_id();
+        assert_eq!(queue_id, stream.queue_id(), "queue IDs should match");
+
+        assert!(
+            control.try_recv().unwrap().is_none(),
+            "queue should be empty"
+        );
+        assert!(
+            stream.try_recv().unwrap().is_none(),
+            "queue should be empty"
+        );
+
+        assert!(
+            self.control.insert(queue_id, control).is_none(),
+            "queue ID should be unique"
+        );
+        assert!(
+            self.stream.insert(queue_id, stream).is_none(),
+            "queue ID should be unique"
+        );
+    }
+
+    fn on_control_dispatch(&mut self, idx: VarInt, packet_id: u64) {
+        let Some(channel) = self.control.get(&idx) else {
+            return;
+        };
+        let actual = channel.try_recv().unwrap().unwrap();
+        assert_eq!(
+            actual.payload(),
+            packet_id.to_be_bytes(),
+            "queue should contain expected packet id"
+        );
+        assert!(
+            channel.try_recv().unwrap().is_none(),
+            "queue should be empty now"
+        );
+    }
+
+    fn on_stream_dispatch(&mut self, idx: VarInt, packet_id: u64) {
+        let Some(channel) = self.stream.get(&idx) else {
+            return;
+        };
+        let actual = channel.try_recv().unwrap().unwrap();
+        assert_eq!(
+            actual.payload(),
+            packet_id.to_be_bytes(),
+            "queue should contain expected packet id"
+        );
+        assert!(
+            channel.try_recv().unwrap().is_none(),
+            "queue should be empty now"
+        );
+    }
+
+    fn send_stream_inject(&mut self, idx: VarInt) {
+        let Some(channel) = self
+            .stream
+            .get(&idx)
+            .or_else(|| self.stream.first_key_value().map(|(_k, v)| v))
+        else {
+            return;
+        };
+        let (packet_id, packet) = self.packets.create();
+        assert!(
+            channel.sender().send(packet).unwrap().is_none(),
+            "queue should accept packet"
+        );
+        let actual = channel.try_recv().unwrap().unwrap();
+        assert_eq!(
+            actual.payload(),
+            packet_id.to_be_bytes(),
+            "queue should contain expected packet id"
+        );
+        assert!(
+            channel.try_recv().unwrap().is_none(),
+            "queue should be empty now"
+        );
+    }
+}
+
+#[derive(Clone)]
+struct Packets {
+    packets: recv::pool::Pool,
+    packet_id: u64,
+}
+
+impl Default for Packets {
+    fn default() -> Self {
+        Self {
+            packets: recv::pool::Pool::new(8, 8),
+            packet_id: Default::default(),
+        }
+    }
+}
+
+impl Packets {
+    fn create(&mut self) -> (u64, recv::descriptor::Filled) {
+        let packet_id = self.packet_id;
+        self.packet_id += 1;
+        let unfilled = self.packets.alloc_or_grow();
+        let packet = unfilled
+            .recv_with(|_addr, _cmsg, mut payload| {
+                let v = packet_id.to_be_bytes();
+                payload[..v.len()].copy_from_slice(&v);
+                <std::io::Result<_>>::Ok(v.len())
+            })
+            .unwrap()
+            .next()
+            .unwrap();
+        (packet_id, packet)
+    }
+}
+
+#[test]
+fn model_test() {
+    crate::testing::init_tracing();
+
+    // create a Map and Packet allocator once to avoid setup/teardown costs
+    let map = AssertUnwindSafe(crate::path::secret::map::testing::new(1));
+    let pool = AssertUnwindSafe(Packets::default());
+
+    check!().with_type::<Vec<Op>>().for_each(move |ops| {
+        let mut model = Model::new(map.clone(), pool.clone());
+        for op in ops {
+            model.apply(op);
+        }
+    });
+}


### PR DESCRIPTION
### Description of changes: 

With the changes in #2507, we now use the `queue_id` field to route packets to the correct queues, which will be read by the target stream. This means we need a way to allocate `queue_id`s from a pool and free them once they're no longer used for another stream to pick up.

This change implements exactly that - a queue allocator.

Additionally, it includes a packet dispatcher implementation that looks up the queue by its ID and sends the packet if there is an active owner.

### Call-outs:

A lot of the allocator code has been copied/modified from #2483. I considered trying to make some generic code between the two, but decided against it for now, since I want the implementations to settle before trying to extract the overlap and try to figure out an interface that works for both.

### Testing:

I added a model that tests random operations against the allocator/dispatcher and does some checks to make sure things were routed correctly. I ran the model for several hours and collected and committed a corpus to capture that testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

