### PR TITLE
chore(ci): cargo timing cb job

### DIFF
--- a/codebuild/spec/cargotiming.yml
+++ b/codebuild/spec/cargotiming.yml
@@ -1,0 +1,29 @@
+---
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+version: 0.2
+env:
+  shell: bash
+  variables:
+    # This assumes you have a Rust toolchain installed
+    CARGO: "cargo +nightly"
+phases:
+  install:
+    commands:
+      - which cargo || true
+      - echo "Installing Rust ..."
+      - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+      - . $HOME/.cargo/env
+  build:
+    commands:
+      - cargo build --timings --release
+  post_build:
+    commands:
+      - cargo test --exclude s2n-quic-platform --exclude s2n-quic-dc --workspace
+
+artifacts:
+  # upload timing reports
+  files:
+    - '**/*'
+  base-directory: target/cargo-timings
+

--- a/codebuild/spec/cargotiming.yml
+++ b/codebuild/spec/cargotiming.yml
@@ -19,7 +19,7 @@ phases:
       - cargo build --timings --release
   post_build:
     commands:
-      - cargo test --exclude s2n-quic-platform --exclude s2n-quic-dc --workspace
+      - cargo test --workspace -- --skip ipv4_two_socket_test --skip ipv4_test
 
 artifacts:
   # upload timing reports


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

n/a

### Description of changes: 

Checks in a CodeBuild buildspec for a `cargo build` timing job.  The report at the end is uploaded to s3, example: https://d2vvhsim0lzm9u.cloudfront.net/cargotiming/cargo-timing.html

### Call-outs:

The job is scheduled to run once a day, and the metrics are used to track cargo build historical timing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

