### PR TITLE
feat(s2n-quic-dc): add WithMap router

### DIFF
--- a/dc/s2n-quic-dc/src/socket/recv/udp.rs
+++ b/dc/s2n-quic-dc/src/socket/recv/udp.rs
@@ -3,15 +3,15 @@
 
 use crate::{
     socket::recv::{pool, router::Router},
-    stream::socket::fd::udp,
+    stream::socket::{fd::udp, Socket},
 };
-use std::net::UdpSocket;
+use std::{io, os::fd::AsRawFd, task::Poll};
 
-/// Receives packets from a blocking [`UdpSocket`] and dispatches into the provided [`Router`]
-pub fn blocking<R: Router>(socket: UdpSocket, mut pool: pool::Pool, mut router: R) {
-    loop {
-        let mut unfilled = pool.alloc_or_grow();
-        loop {
+/// Receives packets from a blocking [`std::net::UdpSocket`] and dispatches into the provided [`Router`]
+pub fn blocking<S: AsRawFd, R: Router>(socket: S, mut alloc: pool::Pool, mut router: R) {
+    while router.is_open() {
+        let mut unfilled = alloc.alloc_or_grow();
+        while router.is_open() {
             let res = unfilled.recv_with(|addr, cmsg, buffer| {
                 udp::recv(&socket, addr, cmsg, &mut [buffer], Default::default())
             });
@@ -31,4 +31,55 @@ pub fn blocking<R: Router>(socket: UdpSocket, mut pool: pool::Pool, mut router: 
             }
         }
     }
+}
+
+/// Receives packets from a non-blocking [`std::net::UdpSocket`] and dispatches into the provided [`Router`]
+pub async fn non_blocking<S: Socket, R: Router>(socket: S, mut alloc: pool::Pool, mut router: R) {
+    let mut pending = None;
+    core::future::poll_fn(move |cx| {
+        while router.is_open() {
+            let unfilled = pending.take().unwrap_or_else(|| alloc.alloc_or_grow());
+
+            let res = unfilled.recv_with(|addr, cmsg, buffer| {
+                match socket.poll_recv(cx, addr, cmsg, &mut [buffer]) {
+                    Poll::Pending => Err(io::ErrorKind::WouldBlock.into()),
+                    Poll::Ready(Ok(len)) => Ok(len),
+                    Poll::Ready(Err(err)) => Err(err),
+                }
+            });
+
+            match res {
+                Ok(segments) => {
+                    for segment in segments {
+                        router.on_segment(segment);
+                    }
+
+                    // poll the socket again
+                    continue;
+                }
+                Err((desc, err)) => {
+                    // put the unfilled segment back in the pool
+                    pending = Some(desc);
+
+                    let kind = err.kind();
+
+                    // if we got blocked then yield the future
+                    if kind == io::ErrorKind::WouldBlock {
+                        return Poll::Pending;
+                    }
+
+                    // if tokio is shutting down, it starts returning an `Other` error
+                    if kind == io::ErrorKind::Other {
+                        tracing::info!("worker shutting down due to: {err}");
+                        break;
+                    }
+
+                    tracing::error!("socket recv error (kind={:?}): {err}", err.kind());
+                }
+            }
+        }
+
+        Poll::Ready(())
+    })
+    .await;
 }

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/pool.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/pool.rs
@@ -24,6 +24,7 @@ pub struct Pool<T: 'static + Send, const PAGE_SIZE: usize> {
     stream_capacity: Capacity,
     control_capacity: Capacity,
     epoch: VarInt,
+    base: VarInt,
 }
 
 impl<T: 'static + Send, const PAGE_SIZE: usize> Clone for Pool<T, PAGE_SIZE> {
@@ -36,6 +37,7 @@ impl<T: 'static + Send, const PAGE_SIZE: usize> Clone for Pool<T, PAGE_SIZE> {
             stream_capacity: self.stream_capacity,
             control_capacity: self.control_capacity,
             epoch: self.epoch,
+            base: self.base,
         }
     }
 }
@@ -52,6 +54,7 @@ impl<T: 'static + Send, const PAGE_SIZE: usize> Pool<T, PAGE_SIZE> {
             stream_capacity,
             control_capacity,
             epoch,
+            base: epoch,
         };
         pool.grow();
         pool
@@ -64,6 +67,7 @@ impl<T: 'static + Send, const PAGE_SIZE: usize> Pool<T, PAGE_SIZE> {
             // make sure the memory lives as long as this sender is alive
             memory_handle: self.memory_handle.clone(),
             local: Default::default(),
+            base: self.base,
         }
     }
 


### PR DESCRIPTION
### Description of changes: 

This change adds a `WithMap` packet router. This will forward any secret control packets to the path secret map to handle.

### Call-outs:

I fixed a few small things as part of this PR as well:

* When creating a non-zero dispatch pool, we weren't considering that in the sender lookup code. This change fixes that and adds a test for it.
* The `recv::udp` module was missing a non-blocking counterpart so I've also added that.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

