### PR TITLE
test(s2n-quic-dc): fix flaky UDP stream tests

### DIFF
--- a/dc/s2n-quic-dc/src/stream/send/tests.rs
+++ b/dc/s2n-quic-dc/src/stream/send/tests.rs
@@ -79,7 +79,9 @@ async fn run(protocol: Protocol, buffer_len: usize, iterations: usize, features:
     let expected = buffer_len * iterations;
     println!("expected={expected}");
 
-    tokio::spawn(
+    tokio::spawn({
+        let client = client.clone();
+
         async move {
             let mut stream = client.connect_to(&server_handle).await.unwrap();
             let mut total = 0;
@@ -97,11 +99,16 @@ async fn run(protocol: Protocol, buffer_len: usize, iterations: usize, features:
                 let _ = stream.shutdown().await;
             }
         }
-        .instrument(tracing::debug_span!("application")),
-    );
+        .instrument(tracing::debug_span!("client"))
+    });
 
     let actual = client_response.await.unwrap();
     assert_eq!(expected, actual);
+
+    tokio::time::sleep(core::time::Duration::from_secs(1)).await;
+
+    // make sure the client lives long enough to complete the streams
+    drop(client);
 
     // TODO make sure the worker shut down correctly
     //worker.await.unwrap();
@@ -254,7 +261,6 @@ mod tcp {
     negative_suite!();
 }
 
-#[cfg(todo)] // These tests are currently flaky
 mod udp {
     use super::*;
     const PROTOCOL: Protocol = Protocol::Udp;

--- a/dc/s2n-quic-dc/src/stream/testing.rs
+++ b/dc/s2n-quic-dc/src/stream/testing.rs
@@ -18,6 +18,7 @@ use tracing::Instrument;
 
 type Subscriber = (Arc<event::testing::Subscriber>, event::tracing::Subscriber);
 
+#[derive(Clone)]
 pub struct Client {
     map: secret::Map,
     env: env::Environment<Subscriber>,


### PR DESCRIPTION
### Description of changes: 

The UDP stream tests were disabled due to being flaky. After investigation, this was due to the `Client` and its associated background tokio runtimes were dropped before it could finalize the stream state with the server.

After moving the client to be dropped after the server's stream is complete, I haven't seen any failures after running it in a loop for about an hour.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

