### PR TITLE
feat(s2n-quic-dc): add SendOnly UDP socket

### DIFF
--- a/dc/s2n-quic-dc/src/stream/socket.rs
+++ b/dc/s2n-quic-dc/src/stream/socket.rs
@@ -6,6 +6,7 @@ use super::TransportFeatures;
 pub mod application;
 pub mod fd;
 mod handle;
+mod send_only;
 #[cfg(feature = "tokio")]
 mod tokio;
 mod tracing;
@@ -14,6 +15,7 @@ pub use self::tracing::Tracing;
 pub use crate::socket::*;
 pub use application::Application;
 pub use handle::{Ext, Flags, Socket};
+pub use send_only::SendOnly;
 
 pub type ArcApplication = std::sync::Arc<dyn Application>;
 

--- a/dc/s2n-quic-dc/src/stream/socket/fd/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/socket/fd/udp.rs
@@ -9,8 +9,41 @@ use crate::msg::{
 use s2n_quic_core::inet::ExplicitCongestionNotification;
 use std::{
     io::{self, IoSlice, IoSliceMut},
+    net::SocketAddr,
     os::fd::AsRawFd,
 };
+
+pub trait Socket: 'static + AsRawFd + Send + Sync {
+    fn local_addr(&self) -> io::Result<SocketAddr>;
+}
+
+impl Socket for std::net::UdpSocket {
+    #[inline]
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        (*self).local_addr()
+    }
+}
+
+impl Socket for tokio::net::UdpSocket {
+    #[inline]
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        (*self).local_addr()
+    }
+}
+
+impl<T: Socket> Socket for std::sync::Arc<T> {
+    #[inline]
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        (**self).local_addr()
+    }
+}
+
+impl<T: Socket> Socket for Box<T> {
+    #[inline]
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        (**self).local_addr()
+    }
+}
 
 pub use super::peek;
 
@@ -66,12 +99,13 @@ pub fn send<T>(
     addr: &Addr,
     ecn: ExplicitCongestionNotification,
     buffer: &[IoSlice],
+    flags: Flags,
 ) -> io::Result<usize>
 where
     T: AsRawFd,
 {
     send_msghdr(addr, ecn, buffer, |msghdr| {
-        libc_call(|| unsafe { libc::sendmsg(fd.as_raw_fd(), msghdr, 0) as _ })
+        libc_call(|| unsafe { libc::sendmsg(fd.as_raw_fd(), msghdr, flags) as _ })
     })
 }
 

--- a/dc/s2n-quic-dc/src/stream/socket/send_only.rs
+++ b/dc/s2n-quic-dc/src/stream/socket/send_only.rs
@@ -1,0 +1,102 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{fd::udp, Protocol, Socket, TransportFeatures};
+use crate::msg::{addr::Addr, cmsg};
+use core::task::{Context, Poll};
+use s2n_quic_core::{ensure, inet::ExplicitCongestionNotification};
+use std::{
+    io::{self, IoSlice, IoSliceMut},
+    net::SocketAddr,
+};
+
+#[derive(Clone, Debug)]
+pub struct SendOnly<T: udp::Socket>(pub T);
+
+impl<T> Socket for SendOnly<T>
+where
+    T: udp::Socket,
+{
+    #[inline]
+    fn local_addr(&self) -> io::Result<SocketAddr> {
+        self.0.local_addr()
+    }
+
+    #[inline]
+    fn protocol(&self) -> Protocol {
+        Protocol::Udp
+    }
+
+    #[inline]
+    fn features(&self) -> TransportFeatures {
+        TransportFeatures::UDP
+    }
+
+    #[inline]
+    fn poll_peek_len(&self, _cx: &mut Context) -> Poll<io::Result<usize>> {
+        unimplemented!()
+    }
+
+    #[inline]
+    fn poll_recv(
+        &self,
+        _cx: &mut Context,
+        _addr: &mut Addr,
+        _cmsg: &mut cmsg::Receiver,
+        _buffer: &mut [IoSliceMut],
+    ) -> Poll<io::Result<usize>> {
+        unimplemented!()
+    }
+
+    #[inline]
+    fn try_send(
+        &self,
+        addr: &Addr,
+        ecn: ExplicitCongestionNotification,
+        buffer: &[IoSlice],
+    ) -> io::Result<usize> {
+        // no point in sending empty packets
+        ensure!(!buffer.is_empty(), Ok(0));
+
+        debug_assert!(
+            buffer.iter().any(|s| !s.is_empty()),
+            "trying to send from an empty buffer"
+        );
+
+        debug_assert!(
+            addr.get().port() != 0,
+            "cannot send packet to unspecified port"
+        );
+
+        loop {
+            match udp::send(&self.0, addr, ecn, buffer, libc::MSG_DONTWAIT) {
+                Err(ref e) if e.kind() == io::ErrorKind::Interrupted => {
+                    // try the operation again if we were interrupted
+                    continue;
+                }
+                Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
+                    // we got a WouldBlock so pretend we sent it - we have no way of registering interest
+                    return Ok(buffer.iter().map(|s| s.len()).sum());
+                }
+                res => return res,
+            }
+        }
+    }
+
+    #[inline]
+    fn poll_send(
+        &self,
+        _cx: &mut Context,
+        addr: &Addr,
+        ecn: ExplicitCongestionNotification,
+        buffer: &[IoSlice],
+    ) -> Poll<io::Result<usize>> {
+        self.try_send(addr, ecn, buffer).into()
+    }
+
+    #[inline]
+    fn send_finish(&self) -> io::Result<()> {
+        // UDP sockets don't need a shut down
+        Ok(())
+    }
+}


### PR DESCRIPTION
### Description of changes: 

This change adds a send-only UDP socket wrapper. Rather than trying to coordinate between multiple shared actors, this socket will never register waker interest and will drop any packets that get a `WouldBlock` error.

As part of a follow-up PR, this socket type will be used for transmission when coupled with the pooled recv sockets.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

