### PR TITLE
refactor(s2n-quic-dc): wire up recv buffer trait to stream workers

### DIFF
--- a/dc/s2n-quic-dc/src/stream/environment.rs
+++ b/dc/s2n-quic-dc/src/stream/environment.rs
@@ -3,12 +3,14 @@
 
 use crate::{
     clock, event,
-    stream::{runtime, socket, TransportFeatures},
+    stream::{recv, runtime, socket, TransportFeatures},
 };
 use core::future::Future;
 use s2n_quic_core::{inet::SocketAddress, varint::VarInt};
 use s2n_quic_platform::features;
-use std::io;
+use std::{io, sync::Arc};
+
+use super::recv::buffer::Buffer;
 
 type Result<T = (), E = io::Error> = core::result::Result<T, E>;
 
@@ -27,21 +29,76 @@ pub trait Environment {
     fn spawn_writer<F: 'static + Send + Future<Output = ()>>(&self, f: F);
 }
 
-pub struct SocketSet<S> {
+pub struct SocketSet<R, W = R> {
     pub application: Box<dyn socket::application::Builder>,
-    pub read_worker: Option<S>,
-    pub write_worker: Option<S>,
+    pub read_worker: Option<R>,
+    pub write_worker: Option<W>,
     pub remote_addr: SocketAddress,
     pub source_control_port: u16,
     pub source_queue_id: Option<VarInt>,
 }
 
+type SetupResult<ReadWorker, WriteWorker> =
+    Result<(SocketSet<ReadWorker, WriteWorker>, recv::shared::RecvBuffer)>;
+
 pub trait Peer<E: Environment> {
-    type WorkerSocket: socket::Socket;
+    type ReadWorkerSocket: ReadWorkerSocket;
+    type WriteWorkerSocket: WriteWorkerSocket;
 
     fn features(&self) -> TransportFeatures;
     fn with_source_control_port(&mut self, port: u16);
-    fn setup(self, env: &E) -> Result<SocketSet<Self::WorkerSocket>>;
+    fn setup(self, env: &E) -> SetupResult<Self::ReadWorkerSocket, Self::WriteWorkerSocket>;
+}
+
+pub trait ReadWorkerSocket {
+    type Socket: super::socket::Socket;
+
+    fn setup(self) -> Self::Socket;
+}
+
+impl ReadWorkerSocket for () {
+    type Socket = super::socket::SendOnly<Arc<std::net::UdpSocket>>;
+
+    #[inline]
+    fn setup(self) -> Self::Socket {
+        unreachable!()
+    }
+}
+
+impl<T: super::socket::Socket> ReadWorkerSocket for T {
+    type Socket = T;
+
+    #[inline]
+    fn setup(self) -> Self::Socket {
+        self
+    }
+}
+
+pub trait WriteWorkerSocket {
+    type Socket: super::socket::Socket;
+    type Buffer: 'static + Buffer + Send;
+
+    fn setup(self) -> (Self::Socket, Self::Buffer);
+}
+
+impl WriteWorkerSocket for () {
+    type Socket = super::socket::SendOnly<Arc<std::net::UdpSocket>>;
+    type Buffer = recv::buffer::Local;
+
+    #[inline]
+    fn setup(self) -> (Self::Socket, Self::Buffer) {
+        unreachable!()
+    }
+}
+
+impl<T: super::socket::Socket, B: 'static + Buffer + Send> WriteWorkerSocket for (T, B) {
+    type Socket = T;
+    type Buffer = B;
+
+    #[inline]
+    fn setup(self) -> (Self::Socket, Self::Buffer) {
+        self
+    }
 }
 
 pub struct AcceptError<Peer> {

--- a/dc/s2n-quic-dc/src/stream/environment/tokio/tcp.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/tokio/tcp.rs
@@ -1,0 +1,101 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    event,
+    stream::{
+        environment::{tokio::Environment, Peer, SetupResult, SocketSet},
+        recv::shared::RecvBuffer,
+        TransportFeatures,
+    },
+};
+use s2n_quic_core::inet::SocketAddress;
+use tokio::net::TcpStream;
+
+/// A socket that is already registered with the application runtime
+pub struct Registered {
+    pub socket: TcpStream,
+    pub peer_addr: SocketAddress,
+    pub local_port: u16,
+    pub recv_buffer: RecvBuffer,
+}
+
+impl<Sub> Peer<Environment<Sub>> for Registered
+where
+    Sub: event::Subscriber,
+{
+    type ReadWorkerSocket = ();
+    type WriteWorkerSocket = ();
+
+    fn features(&self) -> TransportFeatures {
+        TransportFeatures::TCP
+    }
+
+    #[inline]
+    fn with_source_control_port(&mut self, port: u16) {
+        let _ = port;
+    }
+
+    #[inline]
+    fn setup(
+        self,
+        _env: &Environment<Sub>,
+    ) -> SetupResult<Self::ReadWorkerSocket, Self::WriteWorkerSocket> {
+        let remote_addr = self.peer_addr;
+        let source_control_port = self.local_port;
+        let application = Box::new(self.socket);
+        let socket = SocketSet {
+            application,
+            read_worker: None,
+            write_worker: None,
+            remote_addr,
+            source_control_port,
+            source_queue_id: None,
+        };
+        Ok((socket, self.recv_buffer))
+    }
+}
+
+/// A socket that should be reregistered with the application runtime
+pub struct Reregistered {
+    pub socket: TcpStream,
+    pub peer_addr: SocketAddress,
+    pub local_port: u16,
+    pub recv_buffer: RecvBuffer,
+}
+
+impl<Sub> Peer<Environment<Sub>> for Reregistered
+where
+    Sub: event::Subscriber,
+{
+    type ReadWorkerSocket = ();
+    type WriteWorkerSocket = ();
+
+    fn features(&self) -> TransportFeatures {
+        TransportFeatures::TCP
+    }
+
+    #[inline]
+    fn with_source_control_port(&mut self, port: u16) {
+        let _ = port;
+    }
+
+    #[inline]
+    fn setup(
+        self,
+        _env: &Environment<Sub>,
+    ) -> SetupResult<Self::ReadWorkerSocket, Self::WriteWorkerSocket> {
+        let source_control_port = self.local_port;
+        let remote_addr = self.peer_addr;
+        let application = Box::new(self.socket.into_std()?);
+        let socket = SocketSet {
+            application,
+            read_worker: None,
+            write_worker: None,
+            remote_addr,
+            source_control_port,
+            source_queue_id: None,
+        };
+        Ok((socket, self.recv_buffer))
+    }
+}

--- a/dc/s2n-quic-dc/src/stream/environment/tokio/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/tokio/udp.rs
@@ -1,0 +1,119 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    event,
+    stream::{
+        environment::{tokio::Environment, Peer, SetupResult, SocketSet},
+        recv::{buffer, shared::RecvBuffer},
+        socket::{self, Socket as _},
+        TransportFeatures,
+    },
+};
+use s2n_quic_core::{
+    ensure,
+    inet::{SocketAddress, Unspecified},
+};
+use std::{io, net::UdpSocket, sync::Arc};
+use tokio::io::unix::AsyncFd;
+
+type AsyncUdpSocket = AsyncFd<Arc<UdpSocket>>;
+
+#[derive(Debug)]
+pub struct Owned(pub SocketAddress, pub RecvBuffer);
+
+impl<Sub> Peer<Environment<Sub>> for Owned
+where
+    Sub: event::Subscriber,
+{
+    type ReadWorkerSocket = AsyncUdpSocket;
+    type WriteWorkerSocket = (AsyncUdpSocket, buffer::Local);
+
+    #[inline]
+    fn features(&self) -> TransportFeatures {
+        TransportFeatures::UDP
+    }
+
+    #[inline]
+    fn with_source_control_port(&mut self, port: u16) {
+        self.0.set_port(port);
+    }
+
+    #[inline]
+    fn setup(
+        self,
+        env: &Environment<Sub>,
+    ) -> SetupResult<Self::ReadWorkerSocket, Self::WriteWorkerSocket> {
+        let remote_addr = self.0;
+        let recv_buffer = self.1;
+        let mut options = env.socket_options.clone();
+
+        match remote_addr {
+            SocketAddress::IpV6(_) if options.addr.is_ipv4() => {
+                let addr: SocketAddress = options.addr.into();
+                if addr.ip().is_unspecified() {
+                    options.addr.set_ip(std::net::Ipv6Addr::UNSPECIFIED.into());
+                } else {
+                    let addr = addr.to_ipv6_mapped();
+                    options.addr = addr.into();
+                }
+            }
+            SocketAddress::IpV4(_) if options.addr.is_ipv6() => {
+                let addr: SocketAddress = options.addr.into();
+                if addr.ip().is_unspecified() {
+                    options.addr.set_ip(std::net::Ipv4Addr::UNSPECIFIED.into());
+                } else {
+                    let addr = addr.unmap();
+                    // ensure the local IP maps to v4, otherwise it won't bind correctly
+                    ensure!(
+                        matches!(addr, SocketAddress::IpV4(_)),
+                        Err(io::ErrorKind::Unsupported.into())
+                    );
+                    options.addr = addr.into();
+                }
+            }
+            _ => {}
+        }
+
+        let socket::Pair { writer, reader } = socket::Pair::open(options)?;
+
+        let writer = Arc::new(writer);
+        let reader = Arc::new(reader);
+
+        let read_worker = {
+            let _guard = env.reader_rt.enter();
+            AsyncFd::new(reader.clone())?
+        };
+
+        let write_worker = {
+            let _guard = env.writer_rt.enter();
+            AsyncFd::new(writer.clone())?
+        };
+
+        debug_assert_eq!(
+            read_worker.local_port()?,
+            write_worker.local_port()?,
+            "worker ports must match with owned socket implementation"
+        );
+
+        let source_control_port = write_worker.local_port()?;
+
+        let application = Box::new(reader);
+
+        let read_worker = Some(read_worker);
+        let write_worker_buffer = crate::msg::recv::Message::new(u16::MAX);
+        let write_worker_buffer = buffer::Local::new(write_worker_buffer, None);
+        let write_worker = Some((write_worker, write_worker_buffer));
+
+        let socket = SocketSet {
+            application,
+            read_worker,
+            write_worker,
+            remote_addr,
+            source_control_port,
+            source_queue_id: None,
+        };
+
+        Ok((socket, recv_buffer))
+    }
+}

--- a/dc/s2n-quic-dc/src/stream/recv/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/worker.rs
@@ -133,9 +133,13 @@ where
                     // check to see if the application is progressing before peeking the socket
                     ensure!(!self.is_application_progressing(), continue);
 
-                    // peek the socket buffer size - we don't care how big, just that there is at
-                    // least one packet there
-                    let _len = ready!(self.socket.poll_peek_len(cx))?;
+                    // check if we have something pending
+                    ready!(self.shared.receiver.poll_peek_worker(
+                        cx,
+                        &self.socket,
+                        &self.shared.clock,
+                        &self.shared.subscriber,
+                    ));
 
                     self.arm_timer();
                     self.state.on_peek_packet().unwrap();

--- a/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
@@ -111,16 +111,16 @@ where
 
         let subscriber_ctx = self.subscriber.create_connection_context(&meta, &info);
 
-        // TODO allocate a queue for this stream
         let recv_buffer = recv::buffer::Local::new(self.recv_buffer.take(), Some(handshake));
         let recv_buffer = recv::buffer::Either::A(recv_buffer);
+
+        let peer = env::udp::Owned(remote_addr, recv_buffer);
 
         let stream = match endpoint::accept_stream(
             now,
             &self.env,
-            env::UdpUnbound(remote_addr),
+            peer,
             &packet,
-            recv_buffer,
             &self.secrets,
             self.subscriber.clone(),
             subscriber_ctx,


### PR DESCRIPTION
### Description of changes: 

This change wires up the recv buffer trait from #2505 to the UDP stream workers. In order to do this, I refactored the `environment` traits a bit to return the appropriate buffer impl for the chosen socket type.

### Testing:

Since this is mostly a refactor, the existing tests should be sufficient to show it all working.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

