### PR TITLE
refactor(s2n-quic-sim): replace unmaintained humantime library with jiff

### DIFF
--- a/quic/s2n-quic-sim/Cargo.toml
+++ b/quic/s2n-quic-sim/Cargo.toml
@@ -14,8 +14,8 @@ publish = false
 anyhow = "1"
 bytes = "1"
 bolero-generator = "0.13.0"
-humantime = "2"
 indicatif = { version = "0.17", features = ["rayon"] }
+jiff = "0.2"
 once_cell = "1"
 prost = "0.13"
 rand = "0.9"

--- a/quic/s2n-quic-sim/src/run/config.rs
+++ b/quic/s2n-quic-sim/src/run/config.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::CliRange;
-use humantime::Duration;
+use jiff::SignedDuration;
 use serde::Deserialize;
 use structopt::StructOpt;
 
@@ -57,15 +57,15 @@ config!(
 
         #[name = "jitter"]
         #[default = "0ms"]
-        jitter: CliRange<Duration>,
+        jitter: CliRange<SignedDuration>,
 
         #[name = "network_jitter"]
         #[default = "0ms"]
-        network_jitter: CliRange<Duration>,
+        network_jitter: CliRange<SignedDuration>,
 
         #[name = "delay"]
         #[default = "100ms"]
-        delay: CliRange<Duration>,
+        delay: CliRange<SignedDuration>,
 
         #[name = "transmit_rate"]
         #[default = "0"]
@@ -85,7 +85,7 @@ config!(
 
         #[name = "inflight_delay"]
         #[default = "0ms"]
-        inflight_delay: CliRange<Duration>,
+        inflight_delay: CliRange<SignedDuration>,
 
         #[name = "inflight_delay_threshold"]
         #[default = "0"]
@@ -101,7 +101,7 @@ config!(
 
         #[name = "connect_delay"]
         #[default = "0ms"]
-        connect_delay: CliRange<Duration>,
+        connect_delay: CliRange<SignedDuration>,
 
         #[name = "connections"]
         #[default = "1"]

--- a/quic/s2n-quic-sim/src/run/endpoint.rs
+++ b/quic/s2n-quic-sim/src/run/endpoint.rs
@@ -44,7 +44,7 @@ pub fn client(
     events: events::Events,
     servers: &[SocketAddr],
     count: usize,
-    delay: CliRange<humantime::Duration>,
+    delay: CliRange<jiff::SignedDuration>,
     streams: CliRange<u32>,
     stream_data: CliRange<u64>,
 ) -> Result {

--- a/quic/s2n-quic-sim/src/run/range.rs
+++ b/quic/s2n-quic-sim/src/run/range.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::{fmt, marker::PhantomData, str::FromStr, time::Duration};
+use jiff::SignedDuration;
 use s2n_quic::provider::io::testing::rand;
 use serde::Deserialize;
 
@@ -26,11 +27,11 @@ impl Default for CliRange<u64> {
     }
 }
 
-impl Default for CliRange<humantime::Duration> {
+impl Default for CliRange<jiff::SignedDuration> {
     fn default() -> Self {
         Self {
-            start: Duration::ZERO.into(),
-            end: Duration::ZERO.into(),
+            start: SignedDuration::ZERO,
+            end: SignedDuration::ZERO,
         }
     }
 }
@@ -58,7 +59,7 @@ where
     }
 }
 
-impl CliRange<humantime::Duration> {
+impl CliRange<jiff::SignedDuration> {
     pub fn gen_duration(&self) -> Duration {
         let start = self.start.as_nanos();
         let end = self.end.as_nanos();

--- a/quic/s2n-quic-sim/src/stats.rs
+++ b/quic/s2n-quic-sim/src/stats.rs
@@ -405,7 +405,7 @@ impl Type {
                 }
             }
             Self::Duration => {
-                if let Ok(v) = value.parse::<humantime::Duration>() {
+                if let Ok(v) = value.parse::<jiff::SignedDuration>() {
                     Ok(v.as_secs_f64())
                 } else {
                     Ok(value.parse()?)


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2524.

### Description of changes: 

This PR will replace our `humantime` library with `jiff`.

One of our dependency `humantime` hasn't been updated for four years and is currently not maintained. Github action has cut us a ticket, asking us to consider alternatives. The recommended alternative for `humantime` is [`jiff`](https://github.com/BurntSushi/jiff), a newly developed daytime library.

I have incorporated `jiff` in `s2n-quic-sim`.

### Call-outs:

Instead of `Duration`, `jiff` provides [`SignedDuration`](https://docs.rs/jiff/0.2.4/jiff/struct.SignedDuration.html):
> Unlike [std::time::Duration](https://doc.rust-lang.org/nightly/core/time/struct.Duration.html), this duration is signed. The sign applies to the entire duration.
> That is, either both the seconds and the fractional nanoseconds are negative or neither are.

We primarily use it in `CliRange`:
https://github.com/aws/s2n-quic/blob/e1e80bdc65766c39113f27476e0f7dce6440d422/quic/s2n-quic-sim/src/run/range.rs#L8-L12

### Testing:

This will be tested by the CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

