### PR TITLE
fix(s2n-quic-dc): don't restrict TCP writes to limits for UDP

### DIFF
--- a/dc/s2n-quic-dc/src/stream/send/queue.rs
+++ b/dc/s2n-quic-dc/src/stream/send/queue.rs
@@ -250,11 +250,14 @@ impl Queue {
     {
         while !self.segments.is_empty() {
             let mut provided_len = 0;
-            let segments = segment::Batch::new(self.segments.iter().map(|v| {
-                let slice = v.as_slice();
-                provided_len += slice.len();
-                (v.ecn, v.as_slice())
-            }));
+            let segments = segment::Batch::new(
+                self.segments.iter().map(|v| {
+                    let slice = v.as_slice();
+                    provided_len += slice.len();
+                    (v.ecn, v.as_slice())
+                }),
+                &socket.features(),
+            );
 
             let ecn = segments.ecn();
 
@@ -369,6 +372,7 @@ impl Queue {
                         (v.ecn, slice)
                     })
                     .take(max_segments),
+                &socket.features(),
             );
 
             let ecn = segments.ecn();

--- a/dc/s2n-quic-dc/src/stream/send/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/send/worker.rs
@@ -416,8 +416,10 @@ where
             ready!(self.pacer.poll_pacing(cx, &self.shared.clock));
 
             // construct all of the segments we're going to send in this batch
-            let segments =
-                msg::segment::Batch::new(self.sender.transmit_queue_iter(clock).take(max_segments));
+            let segments = msg::segment::Batch::new(
+                self.sender.transmit_queue_iter(clock).take(max_segments),
+                &self.socket.features(),
+            );
 
             let ecn = segments.ecn();
             let res = ready!(self.socket.poll_send(cx, &addr, ecn, &segments));


### PR DESCRIPTION
### Description of changes: 

`s2n-quic-dc` packets carried over UDP are required to respect several limits related to maximum payload size and flow control, as well as respecting the MTU of the path. For packets carried over TCP, however, these limits are not applicable, and actually can result in payloads being unnecessarily broken up into many more write syscalls. This can lead to lower throughput as TCP send buffers may not be saturated, causing the congestion controller window to remain limited as the flow will be "application limited". This change removes these limits when the selected underlying transport protocol is TCP.

### Testing:

Tested manually, additional unit tests can be added as a follow up


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

