### PR TITLE
Adjust background handshake rates

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -626,7 +626,7 @@ where
         let id = *entry.id();
         let peer = *entry.peer();
 
-        if let Some(prev) = self.peers.insert(entry) {
+        if let Some(prev) = self.peers.insert(entry.clone()) {
             // This shouldn't happen due to the panic in on_new_path_secrets, but just
             // in case something went wrong with the secret map we double check here.
             // FIXME: Make insertion fallible and fail handshakes instead?
@@ -634,6 +634,8 @@ where
             assert_ne!(prev_id, id, "duplicate path secret id");
 
             prev.retire(self.cleaner.epoch());
+
+            entry.inherit_rehandshake(&prev);
 
             self.subscriber().on_path_secret_map_entry_replaced(
                 event::builder::PathSecretMapEntryReplaced {


### PR DESCRIPTION
### Release Summary:

* fix(s2n-quic-dc): correct background handshake rate

### Resolved issues:

n/a

### Description of changes: 

Our design goal is to aim for 1 handshake every 24 hours (rehandshake_period).

Previously, a handshake occurred at rand(24 hours) for each entry, which makes a single peer on average see *two* handshakes every 24 hours. This produces several bad behaviors:

* The first 24 hours after coordinated handshakes (e.g., deployment) have a linear curve of total handshake rate, because the second half sees repeated handshakes from the first half (the peers that handshake quickly have opportunity to handshake again overlapping with those that handshake slowly).
* Overall rates are 2x higher than expected, since we handshake on average twice per 24 hours period.

The new approach fixes both problems.

### Call-outs:

n/a

### Testing:

In-progress (running a longer-running test to confirm behavior over time, but it will take a few days for full results -- but only around 3-4 hours are needed to check that we have fixed the problem if we observe steady-state ~flat line).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

