### PR TITLE
feat(s2n-quic-dc): add source_queue_id to control packets

### DIFF
--- a/dc/s2n-quic-dc/src/packet/control.rs
+++ b/dc/s2n-quic-dc/src/packet/control.rs
@@ -24,6 +24,7 @@ impl Default for Tag {
 impl fmt::Debug for Tag {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.debug_struct("control::Tag")
+            .field("has_source_queue_id", &self.has_source_queue_id())
             .field("is_stream", &self.is_stream())
             .field("has_application_header", &self.has_application_header())
             .finish()
@@ -31,11 +32,22 @@ impl fmt::Debug for Tag {
 }
 
 impl Tag {
+    pub const HAS_SOURCE_QUEUE_ID: u8 = 0b1000;
     pub const IS_STREAM_MASK: u8 = 0b0100;
     pub const HAS_APPLICATION_HEADER_MASK: u8 = 0b0010;
 
     pub const MIN: u8 = 0b0101_0000;
     pub const MAX: u8 = 0b0101_1111;
+
+    #[inline]
+    pub fn set_has_source_queue_id(&mut self, enabled: bool) {
+        self.0.set(Self::HAS_SOURCE_QUEUE_ID, enabled)
+    }
+
+    #[inline]
+    pub fn has_source_queue_id(&self) -> bool {
+        self.0.get(Self::HAS_SOURCE_QUEUE_ID)
+    }
 
     #[inline]
     pub fn set_is_stream(&mut self, enabled: bool) {

--- a/dc/s2n-quic-dc/src/packet/control/decoder.rs
+++ b/dc/s2n-quic-dc/src/packet/control/decoder.rs
@@ -49,7 +49,7 @@ pub struct Packet<'a> {
     tag: Tag,
     wire_version: WireVersion,
     credentials: Credentials,
-    source_control_port: u16,
+    source_queue_id: Option<VarInt>,
     stream_id: Option<stream::Id>,
     packet_number: PacketNumber,
     header: &'a mut [u8],
@@ -75,8 +75,8 @@ impl Packet<'_> {
     }
 
     #[inline]
-    pub fn source_control_port(&self) -> u16 {
-        self.source_control_port
+    pub fn source_queue_id(&self) -> Option<VarInt> {
+        self.source_queue_id
     }
 
     #[inline]
@@ -124,7 +124,7 @@ impl Packet<'_> {
             tag,
             wire_version,
             credentials,
-            source_control_port,
+            source_queue_id,
             stream_id,
             packet_number,
             header_len,
@@ -149,11 +149,16 @@ impl Packet<'_> {
             let (credentials, buffer) = buffer.decode()?;
             let (wire_version, buffer) = buffer.decode()?;
 
-            let (source_control_port, buffer) = buffer.decode()?;
-
             let (stream_id, buffer) = if tag.is_stream() {
                 let (stream_id, buffer) = buffer.decode()?;
                 (Some(stream_id), buffer)
+            } else {
+                (None, buffer)
+            };
+
+            let (source_queue_id, buffer) = if tag.has_source_queue_id() {
+                let (v, buffer) = buffer.decode()?;
+                (Some(v), buffer)
             } else {
                 (None, buffer)
             };
@@ -183,7 +188,7 @@ impl Packet<'_> {
                 tag,
                 wire_version,
                 credentials,
-                source_control_port,
+                source_queue_id,
                 stream_id,
                 packet_number,
                 header_len,
@@ -225,7 +230,7 @@ impl Packet<'_> {
             tag,
             wire_version,
             credentials,
-            source_control_port,
+            source_queue_id,
             stream_id,
             packet_number,
             header,

--- a/dc/s2n-quic-dc/src/packet/control/encoder.rs
+++ b/dc/s2n-quic-dc/src/packet/control/encoder.rs
@@ -12,7 +12,7 @@ use s2n_quic_core::{assume, buffer, varint::VarInt};
 #[inline(always)]
 pub fn encode<H, CD, C>(
     mut encoder: EncoderBuffer,
-    source_control_port: u16,
+    source_queue_id: Option<VarInt>,
     stream_id: Option<stream::Id>,
     packet_number: VarInt,
     header_len: VarInt,
@@ -27,9 +27,8 @@ where
     CD: EncoderValue,
     C: crypto::seal::control::Stream,
 {
-    debug_assert_ne!(source_control_port, 0);
-
     let mut tag = Tag::default();
+    tag.set_has_source_queue_id(source_queue_id.is_some());
     tag.set_is_stream(stream_id.is_some());
     tag.set_has_application_header(*header_len > 0);
     encoder.encode(&tag);
@@ -40,9 +39,8 @@ where
     // wire version - we only support `0` currently
     encoder.encode(&WireVersion::ZERO);
 
-    encoder.encode(&source_control_port);
-
     encoder.encode(&stream_id);
+    encoder.encode(&source_queue_id);
 
     encoder.encode(&packet_number);
 

--- a/dc/s2n-quic-dc/src/packet/stream.rs
+++ b/dc/s2n-quic-dc/src/packet/stream.rs
@@ -3,7 +3,7 @@
 
 use super::tag::Common;
 use core::fmt;
-use s2n_quic_core::{packet::KeyPhase, probe};
+use s2n_quic_core::{packet::KeyPhase, probe, state::is};
 use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
 
 pub mod decoder;
@@ -22,6 +22,11 @@ pub use id::Id;
 pub enum PacketSpace {
     Stream,
     Recovery,
+}
+
+impl PacketSpace {
+    is!(is_stream, Stream);
+    is!(is_recovery, Recovery);
 }
 
 impl probe::Arg for PacketSpace {

--- a/dc/s2n-quic-dc/src/packet/stream/decoder.rs
+++ b/dc/s2n-quic-dc/src/packet/stream/decoder.rs
@@ -54,7 +54,6 @@ pub struct Owned {
     pub tag: Tag,
     pub wire_version: WireVersion,
     pub credentials: Credentials,
-    pub source_control_port: u16,
     pub source_queue_id: Option<VarInt>,
     pub stream_id: stream::Id,
     pub original_packet_number: PacketNumber,
@@ -78,7 +77,6 @@ impl<'a> From<Packet<'a>> for Owned {
             tag: packet.tag,
             wire_version: packet.wire_version,
             credentials: packet.credentials,
-            source_control_port: packet.source_control_port,
             source_queue_id: packet.source_queue_id,
             stream_id: packet.stream_id,
             original_packet_number: packet.original_packet_number,
@@ -99,7 +97,6 @@ pub struct Packet<'a> {
     tag: Tag,
     wire_version: WireVersion,
     credentials: Credentials,
-    source_control_port: u16,
     source_queue_id: Option<VarInt>,
     stream_id: stream::Id,
     original_packet_number: PacketNumber,
@@ -121,7 +118,6 @@ impl fmt::Debug for Packet<'_> {
             .field("tag", &self.tag)
             .field("wire_version", &self.wire_version)
             .field("credentials", &self.credentials)
-            .field("source_control_port", &self.source_control_port)
             .field("source_queue_id", &self.source_queue_id)
             .field("stream_id", &self.stream_id)
             .field("packet_number", &self.packet_number())
@@ -148,11 +144,6 @@ impl Packet<'_> {
     #[inline]
     pub fn credentials(&self) -> &Credentials {
         &self.credentials
-    }
-
-    #[inline]
-    pub fn source_control_port(&self) -> u16 {
-        self.source_control_port
     }
 
     #[inline]
@@ -503,7 +494,6 @@ impl Packet<'_> {
             tag,
             wire_version,
             credentials,
-            source_control_port,
             source_queue_id,
             stream_id,
             original_packet_number,
@@ -535,7 +525,9 @@ impl Packet<'_> {
             let (credentials, buffer) = buffer.decode()?;
             let (wire_version, buffer) = buffer.decode()?;
 
-            let (source_control_port, buffer) = buffer.decode()?;
+            // unused space - was source_control_port when we did port migration but that has
+            // been replaced with `source_queue_id`, which is more flexible
+            let (_source_control_port, buffer) = buffer.decode::<u16>()?;
 
             let (stream_id, buffer) = buffer.decode::<stream::Id>()?;
 
@@ -598,7 +590,6 @@ impl Packet<'_> {
                 tag,
                 wire_version,
                 credentials,
-                source_control_port,
                 source_queue_id,
                 stream_id,
                 original_packet_number,
@@ -650,7 +641,6 @@ impl Packet<'_> {
             tag,
             wire_version,
             credentials,
-            source_control_port,
             source_queue_id,
             stream_id,
             original_packet_number,

--- a/dc/s2n-quic-dc/src/packet/stream/id.rs
+++ b/dc/s2n-quic-dc/src/packet/stream/id.rs
@@ -60,25 +60,6 @@ impl Id {
     }
 
     #[inline]
-    pub fn next(&self) -> Option<Self> {
-        Some(Self {
-            queue_id: self.queue_id.checked_add_usize(1)?,
-            is_reliable: self.is_reliable,
-            is_bidirectional: self.is_bidirectional,
-        })
-    }
-
-    #[inline]
-    pub fn iter(&self) -> impl Iterator<Item = Self> {
-        let mut next = Some(*self);
-        core::iter::from_fn(move || {
-            let current = next;
-            next = next.and_then(|v| v.next());
-            current
-        })
-    }
-
-    #[inline]
     pub fn into_varint(self) -> VarInt {
         let key_id = *self.queue_id;
         let is_reliable = if self.is_reliable {

--- a/dc/s2n-quic-dc/src/stream/application.rs
+++ b/dc/s2n-quic-dc/src/stream/application.rs
@@ -30,10 +30,11 @@ where
     #[inline]
     pub(crate) fn accept(self) -> io::Result<(Stream<Sub>, Duration)> {
         let sojourn_time = {
-            let remote_address = self.shared.read_remote_addr();
+            let remote_address = self.shared.remote_addr();
             let remote_address = &remote_address;
-            let credential_id = &*self.shared.credentials().id;
-            let stream_id = self.shared.application().stream_id.into_varint().as_u64();
+            let creds = self.shared.credentials();
+            let credential_id = &*creds.id;
+            let stream_id = creds.key_id.as_u64();
             let now = self.shared.common.clock.get_time();
             let sojourn_time = now.saturating_duration_since(self.queue_time);
 
@@ -81,10 +82,11 @@ where
     #[inline]
     pub(crate) fn prune(self, reason: event::builder::AcceptorStreamPruneReason) {
         let now = self.shared.clock.get_time();
-        let remote_address = self.shared.read_remote_addr();
+        let remote_address = self.shared.remote_addr();
         let remote_address = &remote_address;
-        let credential_id = &*self.shared.credentials().id;
-        let stream_id = self.shared.application().stream_id.into_varint().as_u64();
+        let creds = self.shared.credentials();
+        let credential_id = &*creds.id;
+        let stream_id = creds.key_id.as_u64();
         let sojourn_time = now.saturating_duration_since(self.queue_time);
 
         self.shared

--- a/dc/s2n-quic-dc/src/stream/environment.rs
+++ b/dc/s2n-quic-dc/src/stream/environment.rs
@@ -35,7 +35,6 @@ pub struct SocketSet<R, W = R> {
     pub read_worker: Option<R>,
     pub write_worker: Option<W>,
     pub remote_addr: SocketAddress,
-    pub source_control_port: u16,
     pub source_queue_id: Option<VarInt>,
 }
 
@@ -47,7 +46,6 @@ pub trait Peer<E: Environment> {
     type WriteWorkerSocket: WriteWorkerSocket;
 
     fn features(&self) -> TransportFeatures;
-    fn with_source_control_port(&mut self, port: u16);
     fn setup(self, env: &E) -> SetupResult<Self::ReadWorkerSocket, Self::WriteWorkerSocket>;
 }
 

--- a/dc/s2n-quic-dc/src/stream/environment/tokio/tcp.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/tokio/tcp.rs
@@ -32,24 +32,17 @@ where
     }
 
     #[inline]
-    fn with_source_control_port(&mut self, port: u16) {
-        let _ = port;
-    }
-
-    #[inline]
     fn setup(
         self,
         _env: &Environment<Sub>,
     ) -> SetupResult<Self::ReadWorkerSocket, Self::WriteWorkerSocket> {
         let remote_addr = self.peer_addr;
-        let source_control_port = self.local_port;
         let application = Box::new(self.socket);
         let socket = SocketSet {
             application,
             read_worker: None,
             write_worker: None,
             remote_addr,
-            source_control_port,
             source_queue_id: None,
         };
         Ok((socket, self.recv_buffer))
@@ -76,16 +69,10 @@ where
     }
 
     #[inline]
-    fn with_source_control_port(&mut self, port: u16) {
-        let _ = port;
-    }
-
-    #[inline]
     fn setup(
         self,
         _env: &Environment<Sub>,
     ) -> SetupResult<Self::ReadWorkerSocket, Self::WriteWorkerSocket> {
-        let source_control_port = self.local_port;
         let remote_addr = self.peer_addr;
         let application = Box::new(self.socket.into_std()?);
         let socket = SocketSet {
@@ -93,7 +80,6 @@ where
             read_worker: None,
             write_worker: None,
             remote_addr,
-            source_control_port,
             source_queue_id: None,
         };
         Ok((socket, self.recv_buffer))

--- a/dc/s2n-quic-dc/src/stream/environment/tokio/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/tokio/udp.rs
@@ -43,11 +43,6 @@ where
     }
 
     #[inline]
-    fn with_source_control_port(&mut self, port: u16) {
-        self.0.set_port(port);
-    }
-
-    #[inline]
     fn setup(
         self,
         env: &Environment<Sub>,
@@ -105,8 +100,6 @@ where
             "worker ports must match with owned socket implementation"
         );
 
-        let source_control_port = write_worker.local_port()?;
-
         let application = Box::new(TokioUdpSocket(reader));
 
         let read_worker = Some(read_worker);
@@ -119,7 +112,6 @@ where
             read_worker,
             write_worker,
             remote_addr,
-            source_control_port,
             source_queue_id: None,
         };
 
@@ -140,11 +132,6 @@ where
     #[inline]
     fn features(&self) -> TransportFeatures {
         TransportFeatures::UDP
-    }
-
-    #[inline]
-    fn with_source_control_port(&mut self, port: u16) {
-        self.0.set_port(port);
     }
 
     #[inline]

--- a/dc/s2n-quic-dc/src/stream/environment/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/udp.rs
@@ -37,17 +37,11 @@ where
     }
 
     #[inline]
-    fn with_source_control_port(&mut self, port: u16) {
-        self.peer_addr.set_port(port);
-    }
-
-    #[inline]
     fn setup(self, _env: &E) -> SetupResult<Self::ReadWorkerSocket, Self::WriteWorkerSocket> {
         let remote_addr = self.peer_addr;
         let control = self.control;
         let stream = self.stream;
         let queue_id = control.queue_id();
-        let source_control_port = self.worker_socket.local_port()?;
 
         let application = Box::new(self.application_socket);
         let read_worker = Some(self.worker_socket.clone());
@@ -58,7 +52,6 @@ where
             read_worker,
             write_worker,
             remote_addr,
-            source_control_port,
             source_queue_id: Some(queue_id),
         };
 

--- a/dc/s2n-quic-dc/src/stream/recv/application.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/application.rs
@@ -122,7 +122,7 @@ where
     #[inline]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         self.0.shared.common.ensure_open()?;
-        Ok(self.0.shared.read_remote_addr().into())
+        Ok(self.0.shared.remote_addr().into())
     }
 
     #[inline]

--- a/dc/s2n-quic-dc/src/stream/recv/application/builder.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/application/builder.rs
@@ -34,7 +34,7 @@ where
     pub fn build(self, shared: ArcShared<Sub>, sockets: socket::ArcApplication) -> Reader<Sub> {
         let Self { endpoint, runtime } = self;
 
-        let remote_addr = shared.read_remote_addr();
+        let remote_addr = shared.remote_addr();
         // we only need a timer for unreliable transports
         let is_reliable = sockets.features().is_reliable();
         let timer = if is_reliable {

--- a/dc/s2n-quic-dc/src/stream/recv/state.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/state.rs
@@ -36,7 +36,6 @@ use s2n_quic_core::{
 
 #[derive(Debug)]
 pub struct State {
-    stream_id: stream::Id,
     ecn_counts: EcnCounts,
     control_packet_number: u64,
     stream_ack: ack::Space,
@@ -47,6 +46,7 @@ pub struct State {
     // maintains a stable tick timer to avoid timer churn in the platform timer
     tick_timer: Timer,
     _should_transmit: bool,
+    is_reliable: bool,
     max_data: VarInt,
     max_data_window: VarInt,
     error: Option<Error>,
@@ -63,7 +63,7 @@ impl State {
     ) -> Self {
         let initial_max_data = params.local_recv_max_data;
         Self {
-            stream_id,
+            is_reliable: stream_id.is_reliable,
             ecn_counts: Default::default(),
             control_packet_number: Default::default(),
             stream_ack: Default::default(),
@@ -79,11 +79,6 @@ impl State {
             fin_ack_packet_number: None,
             features,
         }
-    }
-
-    #[inline]
-    pub fn id(&self) -> stream::Id {
-        self.stream_id
     }
 
     #[inline]
@@ -237,7 +232,7 @@ impl State {
     {
         probes::on_stream_packet(
             credentials.id,
-            self.stream_id,
+            *packet.stream_id(),
             packet.tag().packet_space(),
             packet.packet_number(),
             packet.stream_offset(),
@@ -345,7 +340,7 @@ impl State {
 
         probes::on_stream_packet_decrypted(
             credentials.id,
-            self.stream_id,
+            *packet.stream_id(),
             packet.tag().packet_space(),
             packet.packet_number(),
             packet.stream_offset(),
@@ -381,7 +376,7 @@ impl State {
 
         probes::on_stream_packet_decrypted(
             credentials.id,
-            self.stream_id,
+            *packet.stream_id(),
             packet.tag().packet_space(),
             packet.packet_number(),
             packet.stream_offset(),
@@ -454,7 +449,7 @@ impl State {
 
         self.ecn_counts.increment(ecn);
 
-        if !self.stream_id.is_reliable {
+        if !self.is_reliable {
             // TODO should we perform loss detection on the receiver and reset the stream if we have a big
             // enough gap?
         }
@@ -636,6 +631,7 @@ impl State {
         self.tick_timer.cancel();
         self.stream_ack.clear();
         self.recovery_ack.clear();
+        tracing::trace!("silent_shutdown");
     }
 
     #[inline]
@@ -643,7 +639,8 @@ impl State {
         &mut self,
         key: &K,
         credentials: &Credentials,
-        source_control_port: u16,
+        stream_id: stream::Id,
+        source_queue_id: Option<VarInt>,
         output: &mut A,
         clock: &Clk,
     ) where
@@ -659,7 +656,8 @@ impl State {
             self,
             key,
             credentials,
-            source_control_port,
+            stream_id,
+            source_queue_id,
             output,
             // avoid querying the clock for every transmitted packet
             &clock::Cached::new(clock),
@@ -671,7 +669,8 @@ impl State {
         &mut self,
         key: &K,
         credentials: &Credentials,
-        source_control_port: u16,
+        stream_id: stream::Id,
+        source_queue_id: Option<VarInt>,
         output: &mut A,
         _clock: &Clk,
     ) where
@@ -720,8 +719,8 @@ impl State {
 
         let result = control::encoder::encode(
             encoder,
-            source_control_port,
-            Some(self.stream_id),
+            source_queue_id,
+            Some(stream_id),
             packet_number,
             VarInt::ZERO,
             &mut &[][..],
@@ -755,7 +754,7 @@ impl State {
             if let (Some(min), Some(max), Some(gaps)) = metrics {
                 probes::on_transmit_control(
                     credentials.id,
-                    self.stream_id,
+                    stream_id,
                     space,
                     packet_number,
                     min,
@@ -780,7 +779,8 @@ impl State {
         &mut self,
         control_key: &K,
         credentials: &Credentials,
-        source_control_port: u16,
+        stream_id: stream::Id,
+        source_queue_id: Option<VarInt>,
         output: &mut A,
         _clock: &Clk,
     ) where
@@ -813,8 +813,8 @@ impl State {
 
         let result = control::encoder::encode(
             encoder,
-            source_control_port,
-            Some(self.stream_id),
+            source_queue_id,
+            Some(stream_id),
             packet_number,
             VarInt::ZERO,
             &mut &[][..],
@@ -841,12 +841,7 @@ impl State {
         self.stream_ack.clear();
         self.recovery_ack.clear();
 
-        probes::on_transmit_close(
-            credentials.id,
-            self.stream_id,
-            packet_number,
-            frame.error_code,
-        );
+        probes::on_transmit_close(credentials.id, stream_id, packet_number, frame.error_code);
 
         self.on_packet_sent(packet_number);
     }

--- a/dc/s2n-quic-dc/src/stream/recv/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/worker.rs
@@ -76,7 +76,7 @@ where
 {
     #[inline]
     pub fn new(socket: S, shared: ArcShared<Sub>, endpoint: endpoint::Type) -> Self {
-        let send_buffer = msg::send::Message::new(shared.read_remote_addr(), shared.gso.clone());
+        let send_buffer = msg::send::Message::new(shared.remote_addr(), shared.gso.clone());
         let timer = Timer::new_with_timeout(&shared.clock, INITIAL_TIMEOUT);
 
         let state = match endpoint {

--- a/dc/s2n-quic-dc/src/stream/send/application.rs
+++ b/dc/s2n-quic-dc/src/stream/send/application.rs
@@ -70,7 +70,7 @@ where
     #[inline]
     pub fn peer_addr(&self) -> io::Result<SocketAddr> {
         self.0.shared.common.ensure_open()?;
-        Ok(self.0.shared.write_remote_addr().into())
+        Ok(self.0.shared.remote_addr().into())
     }
 
     #[inline]
@@ -204,6 +204,9 @@ where
             Some(batch)
         };
 
+        let stream_id = self.shared.stream_id();
+        let local_queue_id = self.shared.local_queue_id();
+
         self.queue.push_buffer(
             buf,
             &mut batch,
@@ -220,6 +223,8 @@ where
                             &self.shared.sender.packet_number,
                             sealer,
                             self.shared.credentials(),
+                            &stream_id,
+                            local_queue_id,
                             &clock::Cached::new(&self.shared.clock),
                             message,
                             &features,
@@ -262,7 +267,7 @@ where
             cx,
             limit,
             self.sockets.write_application(),
-            &msg::addr::Addr::new(self.shared.write_remote_addr()),
+            &msg::addr::Addr::new(self.shared.remote_addr()),
             &self.shared.sender.segment_alloc,
             &self.shared.gso,
             &self.shared.clock,
@@ -495,7 +500,7 @@ where
             cx,
             usize::MAX,
             sockets.write_application(),
-            &msg::addr::Addr::new(shared.write_remote_addr()),
+            &msg::addr::Addr::new(shared.remote_addr()),
             &shared.sender.segment_alloc,
             &shared.gso,
             &shared.clock,

--- a/dc/s2n-quic-dc/src/stream/send/probes.rs
+++ b/dc/s2n-quic-dc/src/stream/send/probes.rs
@@ -11,7 +11,7 @@ probe::define!(
         #[link_name = s2n_quic_dc__stream__send__control_packet]
         pub fn on_control_packet(
             credential_id: credentials::Id,
-            stream_id: stream::Id,
+            key_id: VarInt,
             packet_number: VarInt,
             control_data_len: usize,
         );
@@ -20,7 +20,7 @@ probe::define!(
         #[link_name = s2n_quic_dc__stream__send__control_packet_decrypted]
         pub fn on_control_packet_decrypted(
             credential_id: credentials::Id,
-            stream_id: stream::Id,
+            key_id: VarInt,
             packet_number: VarInt,
             control_data_len: usize,
             valid: bool,
@@ -30,7 +30,7 @@ probe::define!(
         #[link_name = s2n_quic_dc__stream__send__control_packet_decrypted]
         pub fn on_control_packet_duplicate(
             credential_id: credentials::Id,
-            stream_id: stream::Id,
+            key_id: VarInt,
             packet_number: VarInt,
             control_data_len: usize,
         );
@@ -39,7 +39,7 @@ probe::define!(
         #[link_name = s2n_quic_dc__stream__send__packet_ack]
         pub fn on_packet_ack(
             credential_id: credentials::Id,
-            stream_id: stream::Id,
+            key_id: VarInt,
             packet_space: stream::PacketSpace,
             packet_number: u64,
             packet_len: u16,
@@ -52,7 +52,7 @@ probe::define!(
         #[link_name = s2n_quic_dc__stream__send__packet_lost]
         pub fn on_packet_lost(
             credential_id: credentials::Id,
-            stream_id: stream::Id,
+            key_id: VarInt,
             packet_space: stream::PacketSpace,
             packet_number: u64,
             packet_len: u16,
@@ -66,7 +66,7 @@ probe::define!(
         #[link_name = s2n_quic_dc__stream__send__pto_backoff_reset]
         pub fn on_pto_backoff_reset(
             credential_id: credentials::Id,
-            stream_id: stream::Id,
+            key_id: VarInt,
             previous_value: u32,
         );
 
@@ -74,7 +74,7 @@ probe::define!(
         #[link_name = s2n_quic_dc__stream__send__pto_armed]
         pub fn on_pto_armed(
             credential_id: credentials::Id,
-            stream_id: stream::Id,
+            key_id: VarInt,
             pto_period: Duration,
             pto_backoff: u32,
         );
@@ -83,7 +83,7 @@ probe::define!(
         #[link_name = s2n_quic_dc__stream__send__transmit_stream]
         pub fn on_transmit_stream(
             credential_id: credentials::Id,
-            stream_id: stream::Id,
+            key_id: VarInt,
             packet_space: stream::PacketSpace,
             packet_number: PacketNumber,
             stream_offset: VarInt,
@@ -96,7 +96,7 @@ probe::define!(
         #[link_name = s2n_quic_dc__stream__send__transmit_probe]
         pub fn on_transmit_probe(
             credential_id: credentials::Id,
-            stream_id: stream::Id,
+            key_id: VarInt,
             packet_space: stream::PacketSpace,
             packet_number: PacketNumber,
             stream_offset: VarInt,
@@ -109,7 +109,7 @@ probe::define!(
         #[link_name = s2n_quic_dc__stream__send__close]
         pub fn on_close(
             credential_id: credentials::Id,
-            stream_id: stream::Id,
+            key_id: VarInt,
             packet_number: VarInt,
             error_code: VarInt,
         );

--- a/dc/s2n-quic-dc/src/stream/send/state.rs
+++ b/dc/s2n-quic-dc/src/stream/send/state.rs
@@ -78,7 +78,6 @@ pub struct SentRecoveryPacket {
 
 #[derive(Debug)]
 pub struct State {
-    pub stream_id: stream::Id,
     pub rtt_estimator: RttEstimator,
     pub sent_stream_packets: PacketMap<SentStreamPacket>,
     pub stream_packet_buffers: SlotMap<BufferIndex, buffer::Segment>,
@@ -108,6 +107,7 @@ pub struct State {
     pub peer_activity: Option<PeerActivity>,
     pub max_datagram_size: u16,
     pub max_sent_segment_size: u16,
+    pub is_reliable: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -130,7 +130,6 @@ impl State {
         let max_sent_offset = VarInt::ZERO;
 
         Self {
-            stream_id,
             next_expected_control_packet: VarInt::ZERO,
             rtt_estimator: recovery::rtt_estimator(),
             cca,
@@ -160,6 +159,7 @@ impl State {
             peer_activity: None,
             max_datagram_size,
             max_sent_segment_size: 0,
+            is_reliable: stream_id.is_reliable,
         }
     }
 
@@ -261,7 +261,7 @@ impl State {
     {
         probes::on_control_packet(
             credentials.id,
-            self.stream_id,
+            credentials.key_id,
             packet.packet_number(),
             packet.control_data().len(),
         );
@@ -271,7 +271,7 @@ impl State {
 
         probes::on_control_packet_decrypted(
             credentials.id,
-            self.stream_id,
+            credentials.key_id,
             packet.packet_number(),
             packet.control_data().len(),
             res.is_ok(),
@@ -288,7 +288,7 @@ impl State {
             return {
                 probes::on_control_packet_duplicate(
                     credentials.id,
-                    self.stream_id,
+                    credentials.key_id,
                     packet.packet_number(),
                     packet.control_data().len(),
                 );
@@ -369,7 +369,7 @@ impl State {
 
                         probes::on_close(
                             credentials.id,
-                            self.stream_id,
+                            credentials.key_id,
                             packet_number,
                             close.error_code,
                         );
@@ -490,7 +490,7 @@ impl State {
 
                         probes::on_packet_ack(
                             credentials.id,
-                            self.stream_id,
+                            credentials.key_id,
                             stream::PacketSpace::$space,
                             num.as_u64(),
                             packet.info.packet_len,
@@ -594,7 +594,7 @@ impl State {
 
                     probes::on_packet_lost(
                         credentials.id,
-                        self.stream_id,
+                        credentials.key_id,
                         packet_space,
                         num.as_u64(),
                         packet.info.packet_len,
@@ -626,7 +626,7 @@ impl State {
                         self.retransmissions.push(retransmission);
                     } else {
                         // we can only recover reliable streams
-                        is_unrecoverable |= packet.info.payload_len > 0 && !self.stream_id.is_reliable;
+                        is_unrecoverable |= packet.info.payload_len > 0 && !self.is_reliable;
                     }
                 }}
             }
@@ -926,16 +926,21 @@ impl State {
         &mut self,
         control_key: &C,
         credentials: &Credentials,
-        source_control_port: u16,
+        stream_id: &stream::Id,
+        source_queue_id: Option<VarInt>,
         clock: &Clk,
     ) -> Result<(), Error>
     where
         C: crypto::seal::control::Stream,
         Clk: Clock,
     {
-        if let Err(error) =
-            self.fill_transmit_queue_impl(control_key, credentials, source_control_port, clock)
-        {
+        if let Err(error) = self.fill_transmit_queue_impl(
+            control_key,
+            credentials,
+            stream_id,
+            source_queue_id,
+            clock,
+        ) {
             self.on_error(error);
             return Err(error);
         }
@@ -948,7 +953,8 @@ impl State {
         &mut self,
         control_key: &C,
         credentials: &Credentials,
-        source_control_port: u16,
+        stream_id: &stream::Id,
+        source_queue_id: Option<VarInt>,
         clock: &Clk,
     ) -> Result<(), Error>
     where
@@ -961,7 +967,7 @@ impl State {
         }
 
         self.try_transmit_retransmissions(control_key, credentials, clock)?;
-        self.try_transmit_probe(control_key, credentials, source_control_port, clock)?;
+        self.try_transmit_probe(control_key, credentials, stream_id, source_queue_id, clock)?;
 
         Ok(())
     }
@@ -978,7 +984,7 @@ impl State {
         Clk: Clock,
     {
         // We'll only have retransmissions if we're reliable
-        ensure!(self.stream_id.is_reliable, Ok(()));
+        ensure!(self.is_reliable, Ok(()));
 
         while let Some(retransmission) = self.retransmissions.peek() {
             // make sure we fit in the current congestion window
@@ -1049,7 +1055,7 @@ impl State {
 
                 probes::on_transmit_stream(
                     credentials.id,
-                    self.stream_id,
+                    credentials.key_id,
                     stream::PacketSpace::Recovery,
                     PacketNumberSpace::Initial.new_packet_number(packet_number),
                     stream_offset,
@@ -1075,7 +1081,8 @@ impl State {
         &mut self,
         control_key: &C,
         credentials: &Credentials,
-        source_control_port: u16,
+        stream_id: &stream::Id,
+        source_queue_id: Option<VarInt>,
         clock: &Clk,
     ) -> Result<(), Error>
     where
@@ -1120,9 +1127,8 @@ impl State {
             let encoder = EncoderBuffer::new(&mut buffer);
             let packet_len = encoder::probe(
                 encoder,
-                source_control_port,
-                None,
-                self.stream_id,
+                source_queue_id,
+                *stream_id,
                 packet_number,
                 self.next_expected_control_packet,
                 VarInt::ZERO,

--- a/dc/s2n-quic-dc/src/stream/server.rs
+++ b/dc/s2n-quic-dc/src/stream/server.rs
@@ -14,7 +14,6 @@ pub mod tokio;
 pub struct InitialPacket {
     pub credentials: Credentials,
     pub stream_id: packet::stream::Id,
-    pub source_control_port: u16,
     pub source_queue_id: Option<VarInt>,
     pub payload_len: usize,
     pub is_zero_offset: bool,
@@ -51,7 +50,6 @@ impl<'a> From<packet::stream::decoder::Packet<'a>> for InitialPacket {
     fn from(packet: packet::stream::decoder::Packet<'a>) -> Self {
         let credentials = *packet.credentials();
         let stream_id = *packet.stream_id();
-        let source_control_port = packet.source_control_port();
         let source_queue_id = packet.source_queue_id();
         let payload_len = packet.payload().len();
         let is_zero_offset = packet.stream_offset().as_u64() == 0;
@@ -61,7 +59,6 @@ impl<'a> From<packet::stream::decoder::Packet<'a>> for InitialPacket {
         Self {
             credentials,
             stream_id,
-            source_control_port,
             source_queue_id,
             is_zero_offset,
             payload_len,

--- a/dc/s2n-quic-dc/src/stream/server/handshake.rs
+++ b/dc/s2n-quic-dc/src/stream/server/handshake.rs
@@ -3,12 +3,13 @@
 
 use crate::{credentials, msg::recv};
 use core::task::{Context, Poll};
+use s2n_quic_core::varint::VarInt;
 use std::sync::{Arc, Weak};
 use tokio::sync::mpsc;
 
 type Sender = mpsc::Sender<recv::Message>;
 type ReceiverChan = mpsc::Receiver<recv::Message>;
-type Key = credentials::Id;
+type Key = (credentials::Id, VarInt);
 type HashMap = flurry::HashMap<Key, Sender>;
 
 pub enum Outcome {
@@ -41,7 +42,7 @@ impl Map {
             .take()
             .unwrap_or_else(|| mpsc::channel(self.channel_size));
 
-        let key = packet.credentials.id;
+        let key = (packet.credentials.id, packet.credentials.key_id);
 
         let guard = self.inner.guard();
         match self.inner.try_insert(key, sender, &guard) {

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
@@ -357,15 +357,11 @@ impl WorkerState {
             };
 
             {
-                let remote_address: SocketAddress = stream_builder.shared.read_remote_addr();
+                let remote_address: SocketAddress = stream_builder.shared.remote_addr();
                 let remote_address = &remote_address;
-                let credential_id = &*stream_builder.shared.credentials().id;
-                let stream_id = stream_builder
-                    .shared
-                    .application()
-                    .stream_id
-                    .into_varint()
-                    .as_u64();
+                let creds = stream_builder.shared.credentials();
+                let credential_id = &*creds.id;
+                let stream_id = creds.key_id.as_u64();
                 publisher.on_acceptor_tcp_stream_enqueued(
                     event::builder::AcceptorTcpStreamEnqueued {
                         remote_address,

--- a/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
@@ -143,10 +143,11 @@ where
         };
 
         {
-            let remote_address: SocketAddress = stream.shared.read_remote_addr();
+            let remote_address: SocketAddress = stream.shared.remote_addr();
             let remote_address = &remote_address;
-            let credential_id = &*stream.shared.credentials().id;
-            let stream_id = stream.shared.application().stream_id.into_varint().as_u64();
+            let creds = stream.shared.credentials();
+            let credential_id = &*creds.id;
+            let stream_id = creds.key_id.as_u64();
             publisher.on_acceptor_udp_stream_enqueued(event::builder::AcceptorUdpStreamEnqueued {
                 remote_address,
                 credential_id,

--- a/dc/wireshark/src/dissect.rs
+++ b/dc/wireshark/src/dissect.rs
@@ -67,7 +67,7 @@ pub fn stream<T: Node>(
 
     let mut tag_tree = tree.add_subtree(tag_item, fields.tag_subtree);
     for field in [
-        fields.has_source_queue_id,
+        fields.stream_has_source_queue_id,
         fields.is_recovery_packet,
         fields.has_control_data,
         fields.has_final_offset,
@@ -88,8 +88,9 @@ pub fn stream<T: Node>(
     let wire_version = buffer.consume::<WireVersion>()?;
     wire_version.record(buffer, tree, fields.wire_version);
 
-    let source_control_port = buffer.consume::<u16>()?;
-    source_control_port.record(buffer, tree, fields.source_control_port);
+    // unused space - was source_control_port when we did port migration but that has
+    // been replaced with `source_queue_id`, which is more flexible
+    let _source_control_port = buffer.consume::<u16>()?;
 
     let stream_id = buffer.consume()?;
     let stream_id = record_stream_id(tree, fields, buffer, stream_id);
@@ -152,8 +153,13 @@ pub fn stream<T: Node>(
     auth_tag.record(buffer, tree, fields.auth_tag);
 
     info.append_delim(" ");
+    let space = if tag.packet_space().is_recovery() {
+        ", SPACE=RECOVERY"
+    } else {
+        ""
+    };
     info.append(format_args!(
-        "Stream(ID={}, PN={},{control_info} LEN={})",
+        "Stream(ID={}{space}, PN={},{control_info} LEN={})",
         key_id.value, packet_number.value, payload.len
     ));
 
@@ -171,6 +177,7 @@ pub fn control<T: Node>(
 
     let mut tag_tree = tree.add_subtree(tag_item, fields.tag_subtree);
     for field in [
+        fields.control_has_source_queue_id,
         fields.is_stream,
         fields.has_application_header,
         fields.key_phase,
@@ -189,12 +196,14 @@ pub fn control<T: Node>(
     let wire_version = buffer.consume::<WireVersion>()?;
     wire_version.record(buffer, tree, fields.wire_version);
 
-    let source_control_port = buffer.consume::<u16>()?;
-    source_control_port.record(buffer, tree, fields.source_control_port);
-
     if tag.is_stream() {
         let stream_id = buffer.consume()?;
         record_stream_id(tree, fields, buffer, stream_id);
+    }
+
+    if tag.has_source_queue_id() {
+        let source_queue_id = buffer.consume::<VarInt>()?;
+        source_queue_id.record(buffer, tree, fields.source_queue_id);
     }
 
     let packet_number = buffer.consume::<VarInt>()?;

--- a/dc/wireshark/src/field.rs
+++ b/dc/wireshark/src/field.rs
@@ -29,7 +29,8 @@ pub struct Registration {
     pub is_ack_eliciting: i32,
     pub is_connected: i32,
     pub has_application_header: i32,
-    pub has_source_queue_id: i32,
+    pub stream_has_source_queue_id: i32,
+    pub control_has_source_queue_id: i32,
     pub is_recovery_packet: i32,
     pub has_control_data: i32,
     pub has_final_offset: i32,
@@ -232,7 +233,7 @@ fn init() -> Registration {
             )
             .with_mask(masks::HAS_APPLICATION_HEADER)
             .register(),
-        has_source_queue_id: protocol
+        stream_has_source_queue_id: protocol
             .field(
                 c"Has source queue_id?",
                 c"dcquic.tag.has_source_queue_id",
@@ -240,7 +241,17 @@ fn init() -> Registration {
                 SEP_DOT,
                 c"",
             )
-            .with_mask(masks::HAS_SOURCE_QUEUE_ID)
+            .with_mask(masks::STREAM_HAS_SOURCE_QUEUE_ID)
+            .register(),
+        control_has_source_queue_id: protocol
+            .field(
+                c"Has source queue_id?",
+                c"dcquic.tag.has_source_queue_id",
+                BOOLEAN,
+                SEP_DOT,
+                c"",
+            )
+            .with_mask(masks::CONTROL_HAS_SOURCE_QUEUE_ID)
             .register(),
         is_recovery_packet: protocol
             .field(
@@ -417,7 +428,7 @@ fn init() -> Registration {
             .with_mask(0x2)
             .register(),
         queue_id: protocol
-            .field(c"Route Key", c"dcquic.queue_id", UINT64, BASE_DEC, c"")
+            .field(c"Queue ID", c"dcquic.queue_id", UINT64, BASE_DEC, c"")
             .register(),
         relative_packet_number: protocol
             .field(
@@ -556,9 +567,10 @@ mod masks {
     use s2n_quic_dc::packet::{control, datagram, stream};
 
     pub const IS_STREAM: u64 = control::Tag::IS_STREAM_MASK as _;
+    pub const CONTROL_HAS_SOURCE_QUEUE_ID: u64 = control::Tag::HAS_SOURCE_QUEUE_ID as _;
     pub const ACK_ELICITING: u64 = datagram::Tag::ACK_ELICITING_MASK as _;
     pub const IS_CONNECTED: u64 = datagram::Tag::IS_CONNECTED_MASK as _;
-    pub const HAS_SOURCE_QUEUE_ID: u64 = stream::Tag::HAS_SOURCE_QUEUE_ID as _;
+    pub const STREAM_HAS_SOURCE_QUEUE_ID: u64 = stream::Tag::HAS_SOURCE_QUEUE_ID as _;
     pub const IS_RECOVERY_PACKET: u64 = stream::Tag::IS_RECOVERY_PACKET as _;
     pub const HAS_CONTROL_DATA: u64 = stream::Tag::HAS_CONTROL_DATA_MASK as _;
     pub const HAS_FINAL_OFFSET: u64 = stream::Tag::HAS_FINAL_OFFSET_MASK as _;

--- a/dc/wireshark/src/test.rs
+++ b/dc/wireshark/src/test.rs
@@ -18,7 +18,6 @@ use std::{collections::HashMap, num::NonZeroU16, ptr, time::Duration};
 #[derive(Clone, Debug, bolero::TypeGenerator)]
 struct StreamPacket {
     credentials: s2n_quic_dc::credentials::Credentials,
-    source_control_port: NonZeroU16,
     source_queue_id: Option<VarInt>,
     stream_id: stream::Id,
     packet_space: stream::PacketSpace,
@@ -50,7 +49,6 @@ fn check_stream_parse() {
             ];
             let length = s2n_quic_dc::packet::stream::encoder::encode(
                 EncoderBuffer::new(&mut buffer),
-                NonZeroU16::get(packet.source_control_port),
                 packet.source_queue_id,
                 packet.stream_id,
                 packet.packet_number,
@@ -82,10 +80,6 @@ fn check_stream_parse() {
             assert_eq!(
                 tracker.remove(fields.key_id),
                 Field::Integer(packet.credentials.key_id.into())
-            );
-            assert_eq!(
-                tracker.remove(fields.source_control_port),
-                Field::Integer(packet.source_control_port.get() as u64)
             );
             assert_eq!(
                 tracker.take(fields.source_queue_id),
@@ -122,7 +116,7 @@ fn check_stream_parse() {
 
             // Tag fields all store the tag value itself.
             for field in [
-                fields.has_source_queue_id,
+                fields.stream_has_source_queue_id,
                 fields.is_recovery_packet,
                 fields.has_control_data,
                 fields.has_final_offset,
@@ -320,7 +314,7 @@ fn check_datagram_parse() {
 #[derive(Clone, Debug, bolero::TypeGenerator)]
 struct ControlPacket {
     credentials: s2n_quic_dc::credentials::Credentials,
-    source_control_port: NonZeroU16,
+    source_queue_id: Option<VarInt>,
     stream_id: Option<stream::Id>,
     packet_number: VarInt,
     next_expected_control_packet: Option<VarInt>,
@@ -349,7 +343,7 @@ fn check_control_parse() {
             ];
             let length = s2n_quic_dc::packet::control::encoder::encode(
                 EncoderBuffer::new(&mut buffer),
-                packet.source_control_port.get(),
+                packet.source_queue_id,
                 packet.stream_id,
                 packet.packet_number,
                 VarInt::new(packet.application_header.buffered_len() as u64).unwrap(),
@@ -369,6 +363,16 @@ fn check_control_parse() {
             assert!(dissect::control(&mut tracker, fields, tag, &mut buffer, &mut ()).is_some());
             let tag: Parsed<u8> = tag.map(|v| v.into());
 
+            // Tag fields all store the tag value itself.
+            for field in [
+                fields.control_has_source_queue_id,
+                fields.is_stream,
+                fields.has_application_header,
+                fields.key_phase,
+            ] {
+                assert_eq!(tracker.remove(field), Field::Integer(tag.value as u64));
+            }
+
             assert_eq!(tracker.remove(fields.tag), Field::Integer(tag.value as u64));
             assert_eq!(tracker.remove(fields.wire_version), Field::Integer(0));
             assert_eq!(
@@ -379,10 +383,12 @@ fn check_control_parse() {
                 tracker.remove(fields.key_id),
                 Field::Integer(packet.credentials.key_id.into())
             );
-            assert_eq!(
-                tracker.remove(fields.source_control_port),
-                Field::Integer(packet.source_control_port.get() as u64)
-            );
+            if let Some(source_queue_id) = packet.source_queue_id {
+                assert_eq!(
+                    tracker.remove(fields.source_queue_id),
+                    Field::Integer(source_queue_id.as_u64())
+                );
+            }
             assert_eq!(
                 tracker.remove(fields.packet_number),
                 Field::Integer(packet.packet_number.as_u64())


### PR DESCRIPTION
### Description of changes: 

This change adds a `source_queue_id` to control packets. This allows clients to discover the actual server's queue ID sooner rather than waiting for a stream packet to come back. I've also implemented logic to stop sending the source queue ID as soon as we get a packet back from the peer with the correct queue id.

### Call-outs:

This also moves the `source_control_port` field to be unused for Stream and Control packets. Note that streams still write a `0` for backward compatibility. The control frames are only used for UDP-based streams, which are still WIP so it can be removed entirely there. Long term, we can potentially reuse the space for something else.

The reason for the removal is it's been mostly replaced with the `source_queue_id` functionality. There is still a potential port migration on the server after it creates a dedicated owned socket for the stream but that only happens once on the initial response and it would be better to look at the `source_port` field in the UDP datagram in case there's a NAT in the middle that is translating our ports.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

