### PR TITLE
test(s2n-quic-dc): allow params to be specified for test credentials

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map/event_tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/event_tests.rs
@@ -61,7 +61,7 @@ fn control_packets() {
     let client_addr = "127.0.0.1:1234".parse().unwrap();
     let server_addr = "127.0.0.1:5678".parse().unwrap();
 
-    let id = client.test_insert_pair(client_addr, &server, server_addr);
+    let id = client.test_insert_pair(client_addr, None, &server, server_addr, None);
 
     let mut out = [0; 128];
 

--- a/dc/s2n-quic-dc/src/stream/environment/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/tokio.rs
@@ -57,6 +57,11 @@ where
         self
     }
 
+    pub fn with_socket_options(mut self, socket_options: socket::Options) -> Self {
+        self.socket_options = Some(socket_options);
+        self
+    }
+
     #[inline]
     pub fn build(self) -> io::Result<Environment<Sub>> {
         let clock = self.clock.unwrap_or_default();

--- a/dc/s2n-quic-dc/src/stream/testing.rs
+++ b/dc/s2n-quic-dc/src/stream/testing.rs
@@ -7,41 +7,58 @@ use crate::{
     event::testing,
     path::secret,
     stream::{
-        application::Stream,
+        application,
         client::tokio as stream_client,
         environment::{tokio as env, Environment as _},
+        recv, send,
         server::{tokio as stream_server, tokio::accept},
     },
 };
+use s2n_quic_core::dc::{self, ApplicationParams};
+use s2n_quic_platform::socket;
 use std::{io, net::SocketAddr, sync::Arc};
 use tracing::Instrument;
 
-type Subscriber = (Arc<event::testing::Subscriber>, event::tracing::Subscriber);
+pub type Subscriber = (Arc<event::testing::Subscriber>, event::tracing::Subscriber);
+
+pub type Stream = application::Stream<Subscriber>;
+pub type Writer = send::application::Writer<Subscriber>;
+pub type Reader = recv::application::Reader<Subscriber>;
 
 // limit the number of threads used in testing to reduce costs of harnesses
 const TEST_THREADS: usize = 2;
+
+const MAX_DATAGRAM_SIZE: Option<u16> = if cfg!(target_os = "linux") {
+    Some(8950)
+} else {
+    None
+};
 
 #[derive(Clone)]
 pub struct Client {
     map: secret::Map,
     env: env::Environment<Subscriber>,
     subscriber: Arc<event::testing::Subscriber>,
+    mtu: Option<u16>,
 }
 
 impl Default for Client {
     fn default() -> Self {
         let _span = tracing::info_span!("client").entered();
         let map = secret::map::testing::new(16);
+        let options = socket::options::Options::new("127.0.0.1:0".parse().unwrap());
         let env = env::Environment::builder()
             .with_threads(TEST_THREADS)
             // TODO enable this once ready
             // .with_pool(env::pool::Config::new(map.clone()))
+            .with_socket_options(options)
             .build()
             .unwrap();
         Self {
             map,
             env,
             subscriber: Arc::new(event::testing::Subscriber::no_snapshot()),
+            mtu: MAX_DATAGRAM_SIZE,
         }
     }
 }
@@ -58,8 +75,13 @@ impl Client {
         }
 
         let local_addr = "127.0.0.1:1337".parse().unwrap();
-        self.map
-            .test_insert_pair(local_addr, &server.map, server.local_addr);
+        self.map.test_insert_pair(
+            local_addr,
+            Some(self.params()),
+            &server.map,
+            server.local_addr,
+            Some(server.params()),
+        );
 
         // cache hit already tracked above
         self.map.get_untracked(peer).ok_or_else(|| {
@@ -67,10 +89,15 @@ impl Client {
         })
     }
 
-    pub async fn connect_to<S: AsRef<server::Handle>>(
-        &self,
-        server: &S,
-    ) -> io::Result<Stream<Subscriber>> {
+    fn params(&self) -> ApplicationParams {
+        let mut params = dc::testing::TEST_APPLICATION_PARAMS;
+        if let Some(mtu) = self.mtu {
+            params.max_datagram_size = mtu.into();
+        }
+        params
+    }
+
+    pub async fn connect_to<S: AsRef<server::Handle>>(&self, server: &S) -> io::Result<Stream> {
         let server = server.as_ref();
         let handshake = async { self.handshake_with(server) };
 
@@ -101,7 +128,7 @@ impl Client {
         &self,
         server: &S,
         stream: tokio::net::TcpStream,
-    ) -> io::Result<Stream<Subscriber>> {
+    ) -> io::Result<Stream> {
         let server = server.as_ref();
         let handshake = async { self.handshake_with(server) }.await?;
 
@@ -115,6 +142,7 @@ impl Client {
     }
 }
 
+#[derive(Clone)]
 pub struct Server {
     handle: server::Handle,
     receiver: accept::Receiver<Subscriber>,
@@ -157,7 +185,7 @@ impl Server {
         self.handle.clone()
     }
 
-    pub async fn accept(&self) -> io::Result<(Stream<Subscriber>, SocketAddr)> {
+    pub async fn accept(&self) -> io::Result<(Stream, SocketAddr)> {
         accept::accept(&self.receiver, &self.stats).await
     }
 
@@ -193,6 +221,7 @@ mod drop_handle {
         }
     }
 
+    #[derive(Clone)]
     pub struct Sender(#[allow(dead_code)] watch::Sender<()>);
 }
 
@@ -206,6 +235,17 @@ pub mod server {
         pub(super) map: secret::Map,
         pub(super) protocol: Protocol,
         pub(super) local_addr: SocketAddr,
+        pub(super) mtu: Option<u16>,
+    }
+
+    impl Handle {
+        pub(super) fn params(&self) -> ApplicationParams {
+            let mut params = dc::testing::TEST_APPLICATION_PARAMS;
+            if let Some(mtu) = self.mtu {
+                params.max_datagram_size = mtu.into();
+            }
+            params
+        }
     }
 
     impl AsRef<Handle> for Handle {
@@ -220,6 +260,7 @@ pub mod server {
         protocol: Protocol,
         map_capacity: usize,
         linger: Option<Duration>,
+        mtu: Option<u16>,
         subscriber: event::testing::Subscriber,
     }
 
@@ -231,6 +272,7 @@ pub mod server {
                 protocol: Protocol::Tcp,
                 map_capacity: 16,
                 linger: None,
+                mtu: None,
                 subscriber: event::testing::Subscriber::no_snapshot(),
             }
         }
@@ -280,6 +322,11 @@ pub mod server {
             self
         }
 
+        pub fn mtu(mut self, mtu: u16) -> Self {
+            self.mtu = Some(mtu);
+            self
+        }
+
         pub fn subscriber(mut self, subscriber: event::testing::Subscriber) -> Self {
             self.subscriber = subscriber;
             self
@@ -292,6 +339,7 @@ pub mod server {
                 protocol,
                 map_capacity,
                 linger,
+                mtu,
                 subscriber,
             } = self;
 
@@ -303,6 +351,7 @@ pub mod server {
 
             let env = env::Builder::default()
                 .with_threads(TEST_THREADS)
+                .with_socket_options(options.clone())
                 .build()
                 .unwrap();
 
@@ -369,6 +418,11 @@ pub mod server {
                 map,
                 protocol,
                 local_addr,
+                mtu: if let Some(mtu) = mtu {
+                    Some(mtu)
+                } else {
+                    MAX_DATAGRAM_SIZE
+                },
             };
 
             super::Server {


### PR DESCRIPTION
### Description of changes: 

The path secret Map `test_insert_pair` function picks the `dc::testing::TEST_APPLICATION_PARAMS`, without providing a way to override them. This change allows passing in an override, if the caller is wanting to change something, like the `max_datagram_size`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

