### PR TITLE
test(s2n-quic-dc): add debug assertions to descriptor free lists

### DIFF
--- a/dc/s2n-quic-dc/src/socket/recv/descriptor.rs
+++ b/dc/s2n-quic-dc/src/socket/recv/descriptor.rs
@@ -54,6 +54,12 @@ impl Descriptor {
         core::ptr::drop_in_place(self.ptr.as_ptr());
     }
 
+    #[cfg(debug_assertions)]
+    pub(super) fn as_usize(&self) -> usize {
+        // TODO use `.addr()` once MSRV is 1.84
+        self.ptr.as_ptr() as usize
+    }
+
     #[inline]
     pub(super) fn id(&self) -> u32 {
         self.inner().id


### PR DESCRIPTION
### Description of changes: 

This change adds some debug assertions to the descriptor free lists to try and catch any issues around free list logic. With `debug_assertions` disabled, this logic will be removed at runtime.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

