### PR TITLE
build(deps): use up to date aws-lc-rs

### DIFF
--- a/dc/s2n-quic-dc-benches/Cargo.toml
+++ b/dc/s2n-quic-dc-benches/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aws-lc-rs = "1"
+aws-lc-rs = "1.12"
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
 s2n-codec = { path = "../../common/s2n-codec" }
 s2n-quic-dc = { path = "../s2n-quic-dc", features = ["testing"] }

--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -24,7 +24,7 @@ tokio = ["tokio/io-util", "tokio/net", "tokio/rt-multi-thread", "tokio/time"]
 [dependencies]
 arrayvec = "0.7"
 atomic-waker = "1"
-aws-lc-rs = "1"
+aws-lc-rs = "1.12"
 bach = { version = "0.0.10", optional = true }
 bitflags = "2"
 bolero-generator = { version = "0.13", default-features = false, optional = true }

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -17,7 +17,7 @@ fips = ["aws-lc-rs/fips"]
 testing = []
 
 [dependencies]
-aws-lc-rs = { version = "1.9", features = ["prebuilt-nasm"] }
+aws-lc-rs = { version = "1.12", features = ["prebuilt-nasm"] }
 cfg-if = "1"
 lazy_static = "1"
 s2n-codec = { version = "=0.55.0", path = "../../common/s2n-codec", default-features = false }


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

Resolves: https://github.com/aws/s2n-quic/issues/2518

### Description of changes: 

`Paste` is archived, but it is a dependencies of `aws-ls-rs`. AWS-LC has remove that dependencies and release their `aws-lc-rs` and `aws-lc-fips-sys` crates. We should use the most up to date `aws-lc-rs` crate, so that `paste` will not be one of our dependencies.

Cargo tree before:
```
ubuntu@:~/workspace/s2n-quic$ cargo tree --invert paste
paste v1.0.15 (proc-macro)
├── aws-lc-rs v1.11.1
│   ├── rustls v0.23.19
│   │   └── s2n-quic-rustls v0.54.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic-rustls)
│   │       └── s2n-quic v1.54.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic)
│   │           ├── s2n-quic-h3 v0.1.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic-h3)
│   │           │   └── s2n-quic-qns v0.1.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic-qns)
│   │           ├── s2n-quic-qns v0.1.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic-qns)
│   │           └── s2n-quic-sim v0.1.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic-sim)
│   │       [dev-dependencies]
│   │       └── s2n-quic-tls v0.54.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic-tls)
│   │           ├── s2n-quic v1.54.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic) (*)
│   │           └── s2n-quic-tls-default v0.54.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic-tls-default)
│   │               └── s2n-quic v1.54.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic) (*)
│   ├── rustls-webpki v0.102.8
│   │   └── rustls v0.23.19 (*)
│   ├── s2n-quic-crypto v0.54.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic-crypto)
│   │   ├── s2n-quic v1.54.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic) (*)
│   │   ├── s2n-quic-rustls v0.54.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic-rustls) (*)
│   │   └── s2n-quic-tls v0.54.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic-tls) (*)
│   └── s2n-tls-sys v0.3.13
│       └── s2n-tls v0.3.13
│           └── s2n-quic-tls v0.54.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic-tls) (*)
│           [dev-dependencies]
│           └── s2n-quic-tls v0.54.0 (/home/ubuntu/workspace/s2n-quic/quic/s2n-quic-tls) (*)
└── aws-lc-sys v0.23.1
    └── aws-lc-rs v1.11.1 (*)
```

Cargo tree after this PR merged:
```
ubuntu@ip-172-31-59-74:~/workspace/s2n-quic$ cargo tree --invert paste
error: package ID specification `paste` did not match any packages
```

### Call-outs:


### Testing:

CI Tests should verify that the new `aws-lc-rs` is still compatible.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

