### PR TITLE
test(s2n-quic-core): add location to state transitions

### DIFF
--- a/quic/s2n-quic-core/src/state.rs
+++ b/quic/s2n-quic-core/src/state.rs
@@ -27,9 +27,9 @@ macro_rules! __state_transition__ {
         if matches!($state, $valid) {
             let __event__ = stringify!($event);
             if __event__.is_empty() || __event__ == "_" {
-                $crate::state::_debug!(prev = ?$state, next = ?$target);
+                $crate::state::_debug!(prev = ?$state, next = ?$target, location = %core::panic::Location::caller());
             } else {
-                $crate::state::_debug!(event = %__event__, prev = ?$state, next = ?$target);
+                $crate::state::_debug!(event = %__event__, prev = ?$state, next = ?$target, location = %core::panic::Location::caller());
             }
 
             *$state = $target;
@@ -78,6 +78,7 @@ macro_rules! __state_event__ {
             #[doc = $doc]
         )*
         #[inline]
+        #[track_caller]
         pub fn $event(&mut self) -> $crate::state::Result<Self> {
             $crate::state::transition!(
                 @build [],


### PR DESCRIPTION
### Description of changes: 

This change adds the caller location to state transitions to make it easier to debug what line of code caused the transition to occur.

### Testing:

#### Before

```
client:worker::write: s2n_quic_core::stream::state::send: event=on_send_stream prev=Ready next=Send client=0
client:worker::read: s2n_quic_dc::stream::recv::worker::waiting: event=on_cooldown_elapsed prev=Cooldown next=PeekPacket client=0
server:udp:worker::read: s2n_quic_dc::stream::recv::worker::waiting: event=on_application_progress prev=EpochTimeout next=Cooldown
client:worker::read: s2n_quic_dc::stream::recv::worker::waiting: event=on_application_progress prev=PeekPacket next=Cooldown client=0
server:udp:worker::write: s2n_quic_core::stream::state::send: event=on_send_stream prev=Ready next=Send
server:udp:worker::write: s2n_quic_core::stream::state::send: event=on_send_fin prev=Send next=DataSent
server:udp:worker::write: s2n_quic_dc::stream::send::worker::waiting: event=on_application_detach prev=Acking next=Detached
server:udp:worker::write: s2n_quic_dc::stream::send::worker::waiting: event=on_shutdown prev=Detached next=ShuttingDown
server:udp:worker::read: s2n_quic_dc::stream::recv::worker::waiting: event=on_cooldown_elapsed prev=Cooldown next=PeekPacket
client:worker::write: s2n_quic_core::stream::state::send: event=on_send_fin prev=Send next=DataSent client=0
server:udp:worker::read: s2n_quic_dc::stream::recv::worker::waiting: event=on_peek_packet prev=PeekPacket next=EpochTimeout
client:worker::write: s2n_quic_dc::stream::send::worker::waiting: event=on_application_detach prev=Acking next=Detached client=0
client:worker::write: s2n_quic_dc::stream::send::worker::waiting: event=on_shutdown prev=Detached next=ShuttingDown client=0
server:stream: s2n_quic_core::stream::state::recv: event=on_receive_fin prev=Recv next=SizeKnown server=0 stream=0
server:stream: s2n_quic_core::stream::state::recv: event=on_receive_all_data prev=SizeKnown next=DataRecvd server=0 stream=0
server:stream: s2n_quic_core::stream::state::recv: event=on_app_read_all_data prev=DataRecvd next=DataRead server=0 stream=0
server:udp:worker::read: s2n_quic_dc::stream::recv::worker::waiting: event=on_application_detach prev=EpochTimeout next=Detached
client:worker::write: s2n_quic_core::stream::state::send: event=on_recv_all_acks prev=DataSent next=DataRecvd client=0
client:worker::write: s2n_quic_dc::stream::send::worker::waiting: event=on_finished prev=ShuttingDown next=Finished client=0
client: s2n_quic_core::stream::state::recv: event=on_receive_fin prev=Recv next=SizeKnown client=0
client: s2n_quic_core::stream::state::recv: event=on_receive_all_data prev=SizeKnown next=DataRecvd client=0
client: s2n_quic_core::stream::state::recv: event=on_app_read_all_data prev=DataRecvd next=DataRead client=0
client:worker::read: s2n_quic_dc::stream::recv::worker::waiting: event=on_application_detach prev=Cooldown next=Detached client=0
server:udp:worker::write: s2n_quic_core::stream::state::send: event=on_recv_all_acks prev=DataSent next=DataRecvd
server:udp:worker::write: s2n_quic_dc::stream::send::worker::waiting: event=on_finished prev=ShuttingDown next=Finished
```

#### After

```
client:worker::write: s2n_quic_core::stream::state::send: event=on_send_stream prev=Ready next=Send location=dc/s2n-quic-dc/src/stream/send/state.rs:899:28 client=0
client:worker::read: s2n_quic_dc::stream::recv::worker::waiting: event=on_cooldown_elapsed prev=Cooldown next=PeekPacket location=dc/s2n-quic-dc/src/stream/recv/worker.rs:176:32 client=0
server:udp:worker::read: s2n_quic_dc::stream::recv::worker::waiting: event=on_application_progress prev=EpochTimeout next=Cooldown location=dc/s2n-quic-dc/src/stream/recv/worker.rs:234:28
client:worker::read: s2n_quic_dc::stream::recv::worker::waiting: event=on_application_progress prev=PeekPacket next=Cooldown location=dc/s2n-quic-dc/src/stream/recv/worker.rs:234:28 client=0
server:udp:worker::write: s2n_quic_core::stream::state::send: event=on_send_stream prev=Ready next=Send location=dc/s2n-quic-dc/src/stream/send/state.rs:899:28
server:udp:worker::read: s2n_quic_dc::stream::recv::worker::waiting: event=on_cooldown_elapsed prev=Cooldown next=PeekPacket location=dc/s2n-quic-dc/src/stream/recv/worker.rs:176:32
server:udp:worker::write: s2n_quic_core::stream::state::send: event=on_send_fin prev=Send next=DataSent location=dc/s2n-quic-dc/src/stream/send/state.rs:902:32
server:udp:worker::read: s2n_quic_dc::stream::recv::worker::waiting: event=on_peek_packet prev=PeekPacket next=EpochTimeout location=dc/s2n-quic-dc/src/stream/recv/worker.rs:145:32
server:udp:worker::write: s2n_quic_dc::stream::send::worker::waiting: event=on_application_detach prev=Acking next=Detached location=dc/s2n-quic-dc/src/stream/send/worker.rs:271:35
server:udp:worker::write: s2n_quic_dc::stream::send::worker::waiting: event=on_shutdown prev=Detached next=ShuttingDown location=dc/s2n-quic-dc/src/stream/send/worker.rs:387:40
client:worker::write: s2n_quic_core::stream::state::send: event=on_send_fin prev=Send next=DataSent location=dc/s2n-quic-dc/src/stream/send/state.rs:902:32 client=0
client:worker::write: s2n_quic_dc::stream::send::worker::waiting: event=on_application_detach prev=Acking next=Detached location=dc/s2n-quic-dc/src/stream/send/worker.rs:271:35 client=0
client:worker::write: s2n_quic_dc::stream::send::worker::waiting: event=on_shutdown prev=Detached next=ShuttingDown location=dc/s2n-quic-dc/src/stream/send/worker.rs:387:40 client=0
client:worker::read: s2n_quic_dc::stream::recv::worker::waiting: event=on_application_progress prev=Cooldown next=Cooldown location=dc/s2n-quic-dc/src/stream/recv/worker.rs:234:28 client=0
server:stream: s2n_quic_core::stream::state::recv: event=on_receive_fin prev=Recv next=SizeKnown location=dc/s2n-quic-dc/src/stream/recv/state.rs:137:32 server=0 stream=0
server:stream: s2n_quic_core::stream::state::recv: event=on_receive_all_data prev=SizeKnown next=DataRecvd location=dc/s2n-quic-dc/src/stream/recv/state.rs:141:53 server=0 stream=0
server:stream: s2n_quic_core::stream::state::recv: event=on_app_read_all_data prev=DataRecvd next=DataRead location=dc/s2n-quic-dc/src/stream/recv/state.rs:146:48 server=0 stream=0
server:udp:worker::read: s2n_quic_dc::stream::recv::worker::waiting: event=on_application_detach prev=EpochTimeout next=Detached location=dc/s2n-quic-dc/src/stream/recv/worker.rs:217:32
client:worker::write: s2n_quic_core::stream::state::send: event=on_recv_all_acks prev=DataSent next=DataRecvd location=dc/s2n-quic-dc/src/stream/send/state.rs:424:27 client=0
client: s2n_quic_core::stream::state::recv: event=on_receive_fin prev=Recv next=SizeKnown location=dc/s2n-quic-dc/src/stream/recv/state.rs:137:32 client=0
client: s2n_quic_core::stream::state::recv: event=on_receive_all_data prev=SizeKnown next=DataRecvd location=dc/s2n-quic-dc/src/stream/recv/state.rs:141:53 client=0
client: s2n_quic_core::stream::state::recv: event=on_app_read_all_data prev=DataRecvd next=DataRead location=dc/s2n-quic-dc/src/stream/recv/state.rs:146:48 client=0
client:worker::write: s2n_quic_dc::stream::send::worker::waiting: event=on_finished prev=ShuttingDown next=Finished location=dc/s2n-quic-dc/src/stream/send/worker.rs:403:44 client=0
client:worker::read: s2n_quic_dc::stream::recv::worker::waiting: event=on_application_detach prev=Cooldown next=Detached location=dc/s2n-quic-dc/src/stream/recv/worker.rs:217:32 client=0
server:udp:worker::write: s2n_quic_core::stream::state::send: event=on_recv_all_acks prev=DataSent next=DataRecvd location=dc/s2n-quic-dc/src/stream/send/state.rs:424:27
server:udp:worker::write: s2n_quic_dc::stream::send::worker::waiting: event=on_finished prev=ShuttingDown next=Finished location=dc/s2n-quic-dc/src/stream/send/worker.rs:403:44
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

