### PR TITLE
chore: include Need By Date section in github issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/s2n-quic-issue.md
+++ b/.github/ISSUE_TEMPLATE/s2n-quic-issue.md
@@ -18,6 +18,10 @@ AWS Security via our [vulnerability reporting page](http://aws.amazon.com/securi
 
 Include a trace log and packet capture (with embedded key log) if possible. See https://aws.github.io/s2n-quic/user-guide/debugging.html for instructions on how to capture these. -->
 
+### Need By Date:
+
+Do you have a date that you need this issue resolved by? What is the reason for that date, and what are the consequences of missing it? Any additional information you can provide to help prioritize the issue is appreciated. However, we cannot guarantee that this issue will be fixed by the requested date.
+
 ### Solution:
 
 <!--A description of the possible solution in terms of s2n-quic architecture. Highlight and explain any potentially controversial design decisions taken.


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

Add a `Need by Date` section in the Github Issue template for customer to provide information about their estimated timeline or deadlines. Change the `s2n-quic-issue.md`.

### Call-outs:

The same as https://github.com/aws/s2n-tls/pull/5187.

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.