### PR TITLE
fix(s2n-quic-dc): skip sending empty packets in udp acceptor

### DIFF
--- a/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
@@ -130,12 +130,15 @@ where
             Err(error) => {
                 tracing::trace!("send_start");
 
-                let addr = msg::addr::Addr::new(remote_addr);
-                let ecn = Default::default();
-                let buffer = &[io::IoSlice::new(&error.secret_control)];
+                let buffer = &error.secret_control;
+                if !buffer.is_empty() {
+                    let addr = msg::addr::Addr::new(remote_addr);
+                    let ecn = Default::default();
+                    let buffer = &[io::IoSlice::new(&error.secret_control)];
 
-                // ignore any errors since this is just for responding to invalid connect attempts
-                let _ = self.socket.try_send(&addr, ecn, buffer);
+                    // ignore any errors since this is just for responding to invalid connect attempts
+                    let _ = self.socket.try_send(&addr, ecn, buffer);
+                }
 
                 tracing::trace!("send_finish");
                 return Err(error.error);


### PR DESCRIPTION
### Description of changes: 

We have some debug sanity checks in the UDP socket `send` code to make sure we're not wasting syscalls by sending empty packets (which are meaningless here). This code was triggering that in some of the testing I've been doing. This change, instead, checks if the packet is empty before calling it.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

