### PR TITLE
build(deps): update zerocopy requirement from 0.7 to 0.8

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -22,7 +22,7 @@ generator = ["bolero-generator"]
 bolero-generator = { version = "0.13", default-features = false, optional = true }
 byteorder = { version = "1.1", default-features = false }
 bytes = { version = "1", default-features = false, optional = true }
-zerocopy = { version = "0.7", features = ["derive"] }
+zerocopy = { version = "0.8", features = ["derive"] }
 
 [dev-dependencies]
 bolero = "0.13"

--- a/common/s2n-codec/src/encoder/buffer.rs
+++ b/common/s2n-codec/src/encoder/buffer.rs
@@ -99,7 +99,7 @@ impl Encoder for EncoderBuffer<'_> {
 
     #[inline]
     fn write_zerocopy<
-        T: zerocopy::AsBytes + zerocopy::FromBytes + zerocopy::Unaligned,
+        T: zerocopy::IntoBytes + zerocopy::FromBytes + zerocopy::Unaligned,
         F: FnOnce(&mut T),
     >(
         &mut self,

--- a/common/s2n-codec/src/encoder/mod.rs
+++ b/common/s2n-codec/src/encoder/mod.rs
@@ -46,7 +46,7 @@ pub trait Encoder: Sized {
 
     /// Writes a zerocopy value to the buffer
     fn write_zerocopy<
-        T: zerocopy::AsBytes + zerocopy::FromBytes + zerocopy::Unaligned,
+        T: zerocopy::IntoBytes + zerocopy::FromBytes + zerocopy::Unaligned,
         F: FnOnce(&mut T),
     >(
         &mut self,

--- a/common/s2n-codec/src/encoder/scatter.rs
+++ b/common/s2n-codec/src/encoder/scatter.rs
@@ -132,7 +132,7 @@ impl Encoder for Buffer<'_> {
 
     #[inline]
     fn write_zerocopy<
-        T: zerocopy::AsBytes + zerocopy::FromBytes + zerocopy::Unaligned,
+        T: zerocopy::IntoBytes + zerocopy::FromBytes + zerocopy::Unaligned,
         F: FnOnce(&mut T),
     >(
         &mut self,

--- a/common/s2n-codec/src/zerocopy.rs
+++ b/common/s2n-codec/src/zerocopy.rs
@@ -12,7 +12,7 @@ pub use zerocopy::*;
 use bolero_generator::prelude::*;
 
 /// Define a codec implementation for a zerocopy value that implements
-/// `FromBytes`, `AsBytes`, and `Unaligned`.
+/// `FromBytes`, `IntoBytes`, and `Unaligned`.
 #[macro_export]
 macro_rules! zerocopy_value_codec {
     ($name:ident) => {
@@ -91,7 +91,7 @@ macro_rules! zerocopy_value_codec {
 
         impl $crate::EncoderValue for $name
         where
-            $name: $crate::zerocopy::AsBytes,
+            $name: $crate::zerocopy::IntoBytes,
         {
             #[inline]
             fn encoding_size(&self) -> usize {
@@ -106,7 +106,7 @@ macro_rules! zerocopy_value_codec {
             #[inline]
             fn encode<E: $crate::Encoder>(&self, encoder: &mut E) {
                 let bytes = unsafe {
-                    // Safety: the type implements AsBytes
+                    // Safety: the type implements IntoBytes
                     core::slice::from_raw_parts(
                         self as *const $name as *const u8,
                         core::mem::size_of::<$name>(),
@@ -118,7 +118,7 @@ macro_rules! zerocopy_value_codec {
 
         impl<'a> $crate::EncoderValue for &'a $name
         where
-            $name: $crate::zerocopy::AsBytes,
+            $name: $crate::zerocopy::IntoBytes,
         {
             #[inline]
             fn encoding_size(&self) -> usize {
@@ -133,7 +133,7 @@ macro_rules! zerocopy_value_codec {
             #[inline]
             fn encode<E: $crate::Encoder>(&self, encoder: &mut E) {
                 let bytes = unsafe {
-                    // Safety: the type implements AsBytes
+                    // Safety: the type implements IntoBytes
                     core::slice::from_raw_parts(
                         *self as *const $name as *const u8,
                         core::mem::size_of::<$name>(),
@@ -145,7 +145,7 @@ macro_rules! zerocopy_value_codec {
 
         impl<'a> $crate::EncoderValue for &'a mut $name
         where
-            $name: $crate::zerocopy::AsBytes,
+            $name: $crate::zerocopy::IntoBytes,
         {
             #[inline]
             fn encoding_size(&self) -> usize {
@@ -160,7 +160,7 @@ macro_rules! zerocopy_value_codec {
             #[inline]
             fn encode<E: $crate::Encoder>(&self, encoder: &mut E) {
                 let bytes = unsafe {
-                    // Safety: the type implements AsBytes
+                    // Safety: the type implements IntoBytes
                     core::slice::from_raw_parts(
                         *self as *const $name as *const u8,
                         core::mem::size_of::<$name>(),
@@ -182,9 +182,9 @@ macro_rules! zerocopy_network_integer {
             Copy,
             Default,
             Eq,
+            Immutable,
             $crate::zerocopy::FromBytes,
-            $crate::zerocopy::FromZeroes,
-            $crate::zerocopy::AsBytes,
+            $crate::zerocopy::IntoBytes,
             $crate::zerocopy::Unaligned,
         )]
         #[repr(C)]
@@ -215,12 +215,12 @@ macro_rules! zerocopy_network_integer {
 
             #[inline(always)]
             pub fn set(&mut self, value: $native) {
-                self.0.as_bytes_mut().copy_from_slice(&value.to_be_bytes());
+                self.0.as_mut_bytes().copy_from_slice(&value.to_be_bytes());
             }
 
             #[inline(always)]
             pub fn set_be(&mut self, value: $native) {
-                self.0.as_bytes_mut().copy_from_slice(&value.to_ne_bytes());
+                self.0.as_mut_bytes().copy_from_slice(&value.to_ne_bytes());
             }
         }
 
@@ -322,9 +322,7 @@ zerocopy_network_integer!(u128, U128);
 fn zerocopy_struct_test() {
     use crate::DecoderBuffer;
 
-    #[derive(
-        Copy, Clone, Debug, PartialEq, PartialOrd, FromZeroes, FromBytes, AsBytes, Unaligned,
-    )]
+    #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, FromBytes, IntoBytes, Unaligned)]
     #[repr(C)]
     struct UdpHeader {
         source_port: U16,

--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -51,7 +51,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = [
     "env-filter",
 ], optional = true }
-zerocopy = { version = "0.7", features = ["derive"] }
+zerocopy = { version = "0.8", features = ["derive"] }
 zeroize = "1"
 parking_lot = "0.12"
 bitvec = { version = "1.0.1", default-features = false }

--- a/dc/s2n-quic-dc/src/credentials.rs
+++ b/dc/s2n-quic-dc/src/credentials.rs
@@ -7,7 +7,7 @@ use core::{
 };
 use s2n_codec::{
     decoder_value,
-    zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned},
+    zerocopy::{FromBytes, IntoBytes, Unaligned},
     zerocopy_value_codec, Encoder, EncoderValue,
 };
 pub use s2n_quic_core::varint::VarInt as KeyId;
@@ -15,9 +15,7 @@ pub use s2n_quic_core::varint::VarInt as KeyId;
 #[cfg(any(test, feature = "testing"))]
 pub mod testing;
 
-#[derive(
-    Clone, Copy, Default, PartialEq, Eq, AsBytes, FromBytes, FromZeroes, Unaligned, PartialOrd, Ord,
-)]
+#[derive(Clone, Copy, Default, PartialEq, Eq, FromBytes, IntoBytes, Unaligned, PartialOrd, Ord)]
 #[cfg_attr(
     any(test, feature = "testing"),
     derive(bolero_generator::TypeGenerator)

--- a/dc/s2n-quic-dc/src/packet/control.rs
+++ b/dc/s2n-quic-dc/src/packet/control.rs
@@ -3,12 +3,12 @@
 
 use super::tag::Common;
 use core::fmt;
-use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
+use zerocopy::{FromBytes, Unaligned};
 
 pub mod decoder;
 pub mod encoder;
 
-#[derive(Clone, Copy, PartialEq, Eq, AsBytes, FromBytes, FromZeroes, Unaligned)]
+#[derive(Clone, Copy, PartialEq, Eq, FromBytes, Unaligned)]
 #[repr(C)]
 pub struct Tag(Common);
 

--- a/dc/s2n-quic-dc/src/packet/datagram.rs
+++ b/dc/s2n-quic-dc/src/packet/datagram.rs
@@ -4,12 +4,12 @@
 use super::{tag::Common, HeaderLen, PacketNumber, PayloadLen};
 use core::fmt;
 use s2n_quic_core::packet::KeyPhase;
-use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
+use zerocopy::{FromBytes, Unaligned};
 
 pub mod decoder;
 pub mod encoder;
 
-#[derive(Clone, Copy, PartialEq, Eq, AsBytes, FromBytes, FromZeroes, Unaligned)]
+#[derive(Clone, Copy, PartialEq, Eq, FromBytes, Unaligned)]
 #[repr(C)]
 pub struct Tag(Common);
 

--- a/dc/s2n-quic-dc/src/packet/secret_control.rs
+++ b/dc/s2n-quic-dc/src/packet/secret_control.rs
@@ -8,7 +8,7 @@ use s2n_codec::{
     EncoderBuffer, EncoderValue,
 };
 use s2n_quic_core::varint::VarInt;
-use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
+use zerocopy::{FromBytes, Unaligned};
 
 #[macro_use]
 mod decoder;
@@ -23,7 +23,7 @@ pub const TAG_LEN: usize = 16;
 
 macro_rules! impl_tag {
     ($tag:expr) => {
-        #[derive(Clone, Copy, PartialEq, Eq, AsBytes, FromBytes, FromZeroes, Unaligned)]
+        #[derive(Clone, Copy, PartialEq, Eq, FromBytes, Unaligned)]
         #[repr(C)]
         pub struct Tag(u8);
 

--- a/dc/s2n-quic-dc/src/packet/stream.rs
+++ b/dc/s2n-quic-dc/src/packet/stream.rs
@@ -4,7 +4,7 @@
 use super::tag::Common;
 use core::fmt;
 use s2n_quic_core::{packet::KeyPhase, probe, state::is};
-use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
+use zerocopy::{FromBytes, Unaligned};
 
 pub mod decoder;
 pub mod encoder;
@@ -39,7 +39,7 @@ impl probe::Arg for PacketSpace {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, AsBytes, FromBytes, FromZeroes, Unaligned)]
+#[derive(Clone, Copy, PartialEq, Eq, FromBytes, Unaligned)]
 #[repr(C)]
 pub struct Tag(Common);
 

--- a/dc/s2n-quic-dc/src/packet/tag.rs
+++ b/dc/s2n-quic-dc/src/packet/tag.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use s2n_codec::{decoder_invariant, decoder_value};
-use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
+use zerocopy::{FromBytes, Unaligned};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, AsBytes, FromBytes, FromZeroes, Unaligned)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, FromBytes, Unaligned)]
 #[repr(C)]
 pub(super) struct Common(pub(super) u8);
 

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -44,7 +44,7 @@ probe = { version = "0.5", optional = true }
 s2n-codec = { version = "=0.55.0", path = "../../common/s2n-codec", default-features = false }
 subtle = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }
-zerocopy = { version = "0.7", features = ["derive"] }
+zerocopy = { version = "0.8", features = ["derive"] }
 futures-test = { version = "0.3", optional = true } # For testing Waker interactions
 once_cell = { version = "1", optional = true }
 

--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 #[cfg(feature = "alloc")]
 pub use bytes::{Bytes, BytesMut};
 use core::fmt::Debug;
-use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
+use zerocopy::{FromBytes, IntoBytes, Unaligned};
 
 mod error;
 pub use error::Error;
@@ -323,7 +323,7 @@ impl crate::event::IntoEvent<crate::event::api::CipherSuite> for CipherSuite {
 
 macro_rules! handshake_type {
     ($($variant:ident($value:literal)),* $(,)?) => {
-        #[derive(Clone, Copy, Debug, PartialEq, Eq, AsBytes, Unaligned)]
+        #[derive(Clone, Copy, Debug, PartialEq, Eq, IntoBytes, Unaligned)]
         #[cfg_attr(any(test, feature = "bolero-generator"), derive(bolero_generator::TypeGenerator))]
         #[repr(u8)]
         pub enum HandshakeType {
@@ -383,7 +383,7 @@ handshake_type!(
 //#         case finished:            Finished;
 //#   } body;
 //# } Handshake;
-#[derive(Clone, Copy, Debug, AsBytes, FromBytes, FromZeroes, Unaligned)]
+#[derive(Clone, Copy, Debug, IntoBytes, FromBytes, Unaligned)]
 #[repr(C)]
 pub struct HandshakeHeader {
     msg_type: u8,

--- a/quic/s2n-quic-core/src/inet/macros.rs
+++ b/quic/s2n-quic-core/src/inet/macros.rs
@@ -12,7 +12,7 @@ macro_rules! define_inet_type {
         #[cfg(any(test, feature = "generator"))]
         use bolero_generator::prelude::*;
 
-        #[derive(Clone, Copy, Default, Eq, PartialEq, PartialOrd, Ord, zerocopy::FromZeroes, zerocopy::FromBytes, zerocopy::AsBytes, zerocopy::Unaligned)]
+        #[derive(Clone, Copy, Default, Eq, PartialEq, PartialOrd, Ord, zerocopy::FromBytes, zerocopy::IntoBytes, zerocopy::Unaligned, zerocopy::Immutable)]
         #[cfg_attr(any(test, feature = "generator"), derive(bolero_generator::TypeGenerator))]
         #[cfg_attr(kani, derive(kani::Arbitrary))]
         #[repr(C)]
@@ -48,12 +48,12 @@ macro_rules! define_inet_type {
 
             #[inline]
             pub fn as_bytes(&self) -> &[u8] {
-                zerocopy::AsBytes::as_bytes(self)
+                zerocopy::IntoBytes::as_bytes(self)
             }
 
             #[inline]
             pub fn as_bytes_mut(&mut self) -> &mut [u8] {
-                zerocopy::AsBytes::as_bytes_mut(self)
+                zerocopy::IntoBytes::as_mut_bytes(self)
             }
         }
 

--- a/quic/s2n-quic-core/src/stateless_reset/token.rs
+++ b/quic/s2n-quic-core/src/stateless_reset/token.rs
@@ -5,7 +5,7 @@
 
 use s2n_codec::{
     decoder_value,
-    zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned},
+    zerocopy::{FromBytes, Immutable, IntoBytes, Unaligned},
     Encoder, EncoderValue,
 };
 use subtle::ConstantTimeEq;
@@ -22,7 +22,7 @@ pub const LEN: usize = 128 / 8;
 // a derived version, except it is constant-time. Therefore
 // Hash can still be derived.
 #[allow(clippy::derived_hash_with_manual_eq)]
-#[derive(Copy, Clone, Debug, Eq, Hash, FromBytes, FromZeroes, AsBytes, Unaligned)]
+#[derive(Copy, Clone, Debug, Eq, Hash, FromBytes, IntoBytes, Unaligned, Immutable)]
 #[cfg_attr(
     any(test, feature = "generator"),
     derive(bolero_generator::TypeGenerator)

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -80,7 +80,7 @@ s2n-quic-tls = { version = "=0.55.0", path = "../s2n-quic-tls", optional = true 
 s2n-quic-tls-default = { version = "=0.55.0", path = "../s2n-quic-tls-default", optional = true }
 s2n-quic-transport = { version = "=0.55.0", path = "../s2n-quic-transport" }
 tokio = { version = "1", default-features = false, features = ["sync"] }
-zerocopy = { version = "0.7", optional = true, features = ["derive"] }
+zerocopy = { version = "0.8", optional = true, features = ["derive"] }
 zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]

--- a/quic/s2n-quic/src/provider/address_token/default.rs
+++ b/quic/s2n-quic/src/provider/address_token/default.rs
@@ -16,7 +16,7 @@ use s2n_quic_core::{
 };
 use s2n_quic_crypto::{constant_time, digest, hmac};
 use std::hash::{Hash, Hasher};
-use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
+use zerocopy::{FromBytes, IntoBytes, Unaligned};
 use zeroize::Zeroizing;
 
 struct BaseKey {
@@ -356,7 +356,7 @@ impl super::Format for Format {
     }
 }
 
-#[derive(Clone, Copy, Debug, FromBytes, FromZeroes, AsBytes, Unaligned)]
+#[derive(Clone, Copy, Debug, FromBytes, IntoBytes, Unaligned)]
 #[repr(C)]
 pub(crate) struct Header(u8);
 
@@ -416,7 +416,7 @@ impl Header {
 //= https://www.rfc-editor.org/rfc/rfc9000#section-8.1.4
 //#   There is no need for a single well-defined format for the token
 //#   because the server that generates the token also consumes it.
-#[derive(Copy, Clone, Debug, FromBytes, FromZeroes, AsBytes, Unaligned)]
+#[derive(Copy, Clone, Debug, FromBytes, IntoBytes, Unaligned)]
 #[repr(C)]
 struct Token {
     header: Header,


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

This PR should resolves https://github.com/aws/s2n-quic/pull/2343.

### Description of changes: 

Update `zerocopy` requirements in S2N-QUIC from 0.7 to 0.8 (following the [update guide](https://github.com/google/zerocopy/discussions/1680)):
* bump versions for all `zerocopy` in `Cargo.toml`s.
* Handle renaming:
    * The trait `AsByte` is renamed to `IntoBytes`.
    * The trait `Fromzeroes` is renamed to `Fromzeros`.
    * Function renames for `slice_from_prefix`, and `mut_slice_from_prefix`.
* Derive `zerocopy::{Immutable, Knownlayout}` traits into the codebase:
    * Those two traits are introduced in the new versions, and we need some of our structs (especially those setup by Macros) to derive those two traits.
* If we derive `FromBytes` trait, then we don't need to explicitly derive `TryFromBytes` and `FromZeros` traits.
```
As of 0.8, deriving a trait automatically derives any super-traits - e.g., you can now just write #[derive(FromBytes)], and TryFromBytes and FromZeros are derived automatically.
```

### Call-outs:

In `quic/s2n-quic-core/src/frame/dc_stateless_reset_tokens.rs`, we have to use `ref_from_prefix_with_elems()` to replace the deprecated `slice_from_prefix` function. However, the new function expect its `self` to have
```
Self: KnownLayout<PointerMetadata = usize> + Immutable,
```
[source](http://docs.rs/zerocopy/latest/zerocopy/trait.FromBytes.html#method.ref_from_prefix_with_elems).

However, the struct `Token` has an attribute of a fixed sized type. So the `PointerMetaData` is `()`, [instead of `usize`](https://docs.rs/zerocopy/latest/zerocopy/trait.KnownLayout.html#associatedtype.PointerMetadata).

We can't change the `Token` from a sized array to an unsized array, so I checkout the new implementation of the deprecated `slice_from_prefix` method:
```
    #[deprecated(since = "0.8.0", note = "renamed to `FromBytes::ref_from_prefix_with_elems`")]
    #[doc(hidden)]
    #[must_use = "has no side effects"]
    #[inline(always)]
    fn slice_from_prefix(source: &[u8], count: usize) -> Option<(&[Self], &[u8])>
    where
        Self: Sized + Immutable,
    {
        <[Self]>::ref_from_prefix_with_elems(source, count).ok()
    }
```

and use this kind of implementation as a workaround:
```
let (stateless_reset_tokens, remaining) =
    <[stateless_reset::Token]>::$slice_from_prefix(buffer, count)
        .map_err(|_| DecoderError::InvariantViolation("invalid encoding"))?;
```
### Testing:

This PR shouldn't introduce any behavior change. CI testings should be sufficient.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

