### PR TITLE
fix(s2n-quic-dc): clamp send quantum to max syscall size

### DIFF
--- a/dc/s2n-quic-dc/src/msg/segment.rs
+++ b/dc/s2n-quic-dc/src/msg/segment.rs
@@ -35,16 +35,24 @@ pub const MAX_COUNT: usize = if features::gso::IS_SUPPORTED {
     1
 };
 
-/// The maximum payload allowed in sendmsg calls using UDP
-///
-/// From <https://github.com/torvalds/linux/blob/8cd26fd90c1ad7acdcfb9f69ca99d13aa7b24561/net/ipv4/ip_output.c#L987-L995>
-/// > Linux enforces a u16::MAX - IP_HEADER_LEN - UDP_HEADER_LEN
-const MAX_TOTAL_IPV4: u16 = u16::MAX - IPV4_HEADER_LEN - UDP_HEADER_LEN;
+/// The maximum payload allowed in sendmsg calls using IPv4+UDP
+const MAX_TOTAL_IPV4: u16 = if cfg!(target_os = "linux") {
+    // From <https://github.com/torvalds/linux/blob/8cd26fd90c1ad7acdcfb9f69ca99d13aa7b24561/net/ipv4/ip_output.c#L987-L995>
+    // > Linux enforces a u16::MAX - IP_HEADER_LEN - UDP_HEADER_LEN
+    u16::MAX - IPV4_HEADER_LEN - UDP_HEADER_LEN
+} else {
+    9001 - IPV4_HEADER_LEN - UDP_HEADER_LEN
+};
 
-/// The IPv6 doesn't include the IP header size in the calculation
-const MAX_TOTAL_IPV6: u16 = u16::MAX - UDP_HEADER_LEN;
+/// The maximum payload allowed in sendmsg calls using IPv6+UDP
+const MAX_TOTAL_IPV6: u16 = if cfg!(target_os = "linux") {
+    // IPv6 doesn't include the IP header size in the calculation
+    u16::MAX - UDP_HEADER_LEN
+} else {
+    9001 - IPV6_HEADER_LEN - UDP_HEADER_LEN
+};
 
-/// The minimum payload size between the IPv4 and IPv6
+/// The minimum payload size between the IPv4 and IPv6 sizes
 pub const MAX_TOTAL: u16 = min_u16(MAX_TOTAL_IPV4, MAX_TOTAL_IPV6);
 
 #[test]

--- a/dc/s2n-quic-dc/src/msg/segment.rs
+++ b/dc/s2n-quic-dc/src/msg/segment.rs
@@ -8,20 +8,28 @@ use s2n_quic_core::{ensure, inet::ExplicitCongestionNotification};
 use s2n_quic_platform::features;
 use std::io::IoSlice;
 
+/// The maximum size of a IP+UDP header
+const IPV4_HEADER_LEN: u16 = 20;
+const IPV6_HEADER_LEN: u16 = 40;
+const UDP_HEADER_LEN: u16 = 8;
+
+const fn min_u16(a: u16, b: u16) -> u16 {
+    if a < b {
+        a
+    } else {
+        b
+    }
+}
+
 /// The maximum number of segments in sendmsg calls
 ///
-/// From <https://elixir.bootlin.com/linux/v6.8.7/source/include/uapi/linux/uio.h#L27>
-/// > #define UIO_FASTIOV 8
+/// From <https://elixir.bootlin.com/linux/v6.8.7/source/include/uapi/linux/uio.h#L28>
 /// > #define UIO_MAXIOV  1024
 pub const MAX_COUNT: usize = if features::gso::IS_SUPPORTED {
     // base the max segments on the max datagram size for the default ethernet mtu
-    let mut max_datagram_size = 1500;
-    // take off the IPv6 header size
-    max_datagram_size -= 40;
-    // take off the UDP header size
-    max_datagram_size -= 8;
+    let max_datagram_size = 1500 - min_u16(IPV4_HEADER_LEN, IPV6_HEADER_LEN) - UDP_HEADER_LEN;
 
-    MAX_TOTAL as usize / max_datagram_size
+    (MAX_TOTAL / max_datagram_size) as _
 } else {
     // only a single segment can be sent per syscall
     1
@@ -31,7 +39,33 @@ pub const MAX_COUNT: usize = if features::gso::IS_SUPPORTED {
 ///
 /// From <https://github.com/torvalds/linux/blob/8cd26fd90c1ad7acdcfb9f69ca99d13aa7b24561/net/ipv4/ip_output.c#L987-L995>
 /// > Linux enforces a u16::MAX - IP_HEADER_LEN - UDP_HEADER_LEN
-pub const MAX_TOTAL: u16 = u16::MAX - 50;
+const MAX_TOTAL_IPV4: u16 = u16::MAX - IPV4_HEADER_LEN - UDP_HEADER_LEN;
+
+/// The IPv6 doesn't include the IP header size in the calculation
+const MAX_TOTAL_IPV6: u16 = u16::MAX - UDP_HEADER_LEN;
+
+/// The minimum payload size between the IPv4 and IPv6
+pub const MAX_TOTAL: u16 = min_u16(MAX_TOTAL_IPV4, MAX_TOTAL_IPV6);
+
+#[test]
+fn max_total_test() {
+    let tests = [("127.0.0.1:0", MAX_TOTAL_IPV4), ("[::1]:0", MAX_TOTAL_IPV6)];
+
+    for (addr, total) in tests {
+        let socket = std::net::UdpSocket::bind(addr).unwrap();
+        let addr = socket.local_addr().unwrap();
+
+        let mut buffer = vec![0u8; total as usize + 1];
+
+        // This behavior may not be consistent across kernel versions so the check is disabled by default
+        let _ = socket.send_to(&buffer, addr);
+
+        buffer.pop().unwrap();
+        socket
+            .send_to(&buffer, addr)
+            .expect("send should succeed when limited to MAX_TOTAL");
+    }
+}
 
 type Segments<'a> = ArrayVec<IoSlice<'a>, MAX_COUNT>;
 

--- a/dc/s2n-quic-dc/src/stream/environment/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/tokio.rs
@@ -65,7 +65,11 @@ where
     #[inline]
     pub fn build(self) -> io::Result<Environment<Sub>> {
         let clock = self.clock.unwrap_or_default();
-        let gso = self.gso.unwrap_or_default();
+        let gso = self.gso.unwrap_or_else(|| {
+            // rather than clamping it to the max burst size, let the CCA be the only
+            // component that controls send quantums
+            features::gso::MAX_SEGMENTS.into()
+        });
         let socket_options = self.socket_options.unwrap_or_default();
 
         let thread_count = self.threads.unwrap_or_else(|| {

--- a/dc/s2n-quic-dc/src/stream/send/flow.rs
+++ b/dc/s2n-quic-dc/src/stream/send/flow.rs
@@ -5,7 +5,6 @@ use s2n_quic_core::varint::VarInt;
 
 pub mod blocking;
 pub mod non_blocking;
-pub use crate::msg::segment::MAX_TOTAL;
 
 /// Flow credits acquired by an application request
 #[derive(Debug)]
@@ -35,7 +34,7 @@ impl Request {
     /// Clamps the request with the given number of credits
     #[inline]
     pub fn clamp(&mut self, credits: u64) {
-        let len = self.len.min(credits.min(MAX_TOTAL as _) as usize);
+        let len = self.len.min(credits as usize);
 
         // if we didn't acquire the entire len, then clear the `is_fin` flag
         if self.len != len {


### PR DESCRIPTION
### Description of changes: 

As discovered in #2534, the amount of data acquired for flow control should align with the payload limit of the underlying syscall.

This change does exactly that by dividing the max payload by the max datagram size to get the total number of full datagrams that can be sent while staying under the syscall limit. In local testing, this resulted in a 20% increase in performance.

### Call-outs:

I've also tried to reduce the number of places where these maximums get placed. This includes the default GSO settings as well as the `msg::segment::MAX_COUNT`.

### Testing

#### Before

![2025-03-15-113744_610x280_scrot](https://github.com/user-attachments/assets/e4f48129-61e1-40a1-a97a-194725345fd8)


#### After

![2025-03-15-113358_595x328_scrot](https://github.com/user-attachments/assets/737c51f3-2929-4b73-a7de-cb75764067de)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

