### PR TITLE
dep: h3 (s2n-quic-h3)

### DIFF
--- a/quic/s2n-quic-h3/Cargo.toml
+++ b/quic/s2n-quic-h3/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 bytes = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false }
-h3 = "0.0.6"
+h3 = "0.0.7"
 s2n-quic = { path = "../s2n-quic" }
 tracing = { version = "0.1", optional = true }
 


### PR DESCRIPTION
### Release Summary:

Hi, [`h3`](https://github.com/hyperium/h3) crate was updated from 0.0.6 to 0.0.7 recently. So, I just tracked the update in `s2n-quic-h3` subcrate.

### Resolved issues:

None.

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary. If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff. -->

Just updated the dependency. Nothing is changed for the behavior of `s2n-quic` and `s2n-quic-h3` themselves.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

None.

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

There's no test in `s2n-quic-h3`. The compilation successfully finished.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

