### PR TITLE
fix(s2n-quic-dc): synchronize dispatch queue closure

### DIFF
--- a/dc/s2n-quic-dc/src/stream/recv/dispatch.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch.rs
@@ -9,6 +9,7 @@ mod descriptor;
 mod free_list;
 mod handle;
 mod pool;
+mod probes;
 mod queue;
 mod sender;
 

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/descriptor.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/descriptor.rs
@@ -1,7 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{free_list::FreeList, queue::Queue};
+use super::{
+    free_list::FreeList,
+    probes,
+    queue::{Half, Queue},
+};
 use crate::sync::ring_deque;
 use s2n_quic_core::{ensure, varint::VarInt};
 use std::{
@@ -12,7 +16,6 @@ use std::{
         Arc,
     },
 };
-use tracing::trace;
 
 /// A pointer to a single descriptor in a group
 ///
@@ -53,6 +56,12 @@ impl<T: 'static> Descriptor<T> {
         core::ptr::drop_in_place(self.ptr.as_ptr());
     }
 
+    #[cfg(debug_assertions)]
+    pub(super) fn as_usize(&self) -> usize {
+        // TODO use `.addr()` once MSRV is 1.84
+        self.ptr.as_ptr() as usize
+    }
+
     /// # Safety
     ///
     /// The caller needs to guarantee the [`Descriptor`] is still allocated.
@@ -90,8 +99,9 @@ impl<T: 'static> Descriptor<T> {
         let inner = self.inner();
 
         // open the queues back up for receiving
-        inner.control.open_receiver();
-        inner.stream.open_receiver();
+        inner.stream.open_receivers(&inner.control).unwrap();
+
+        probes::on_receiver_open(inner.id);
 
         let other = Self {
             ptr: self.ptr,
@@ -114,7 +124,7 @@ impl<T: 'static> Descriptor<T> {
         // based on the implementation in:
         // https://github.com/rust-lang/rust/blob/28b83ee59698ae069f5355b8e03f976406f410f5/library/alloc/src/sync.rs#L2551
         if desc_ref != 1 {
-            trace!(id = ?inner.id, "drop_sender");
+            probes::on_sender_drop(inner.id);
             return;
         }
 
@@ -123,7 +133,8 @@ impl<T: 'static> Descriptor<T> {
         // close both of the queues so the receivers are notified
         inner.control.close();
         inner.stream.close();
-        trace!(id = ?inner.id, "close_queue");
+
+        probes::on_sender_close(inner.id);
     }
 
     /// # Safety
@@ -131,30 +142,16 @@ impl<T: 'static> Descriptor<T> {
     /// This method can be used to drop the Descriptor, but shouldn't be called after the last receiver Descriptor
     /// is released. That implies only calling it once on a given Descriptor handle obtained from [`Self::into_receiver_pair`].
     #[inline]
-    pub unsafe fn drop_stream_receiver(&self) {
+    pub unsafe fn drop_receiver(&self, half: Half) {
         let inner = self.inner();
-        trace!(id = ?inner.id, "drop_stream_receiver");
-        inner.stream.close_receiver();
-        // check if the control is still open
-        ensure!(!inner.control.has_receiver());
-        let storage = inner.free_list.free(Descriptor {
-            ptr: self.ptr,
-            phantom: PhantomData,
-        });
-        drop(storage);
-    }
+        probes::on_receiver_drop(inner.id, half);
 
-    /// # Safety
-    ///
-    /// This method can be used to drop the Descriptor, but shouldn't be called after the last receiver Descriptor
-    /// is released. That implies only calling it once on a given Descriptor handle obtained from [`Self::into_receiver_pair`].
-    #[inline]
-    pub unsafe fn drop_control_receiver(&self) {
-        let inner = self.inner();
-        trace!(id = ?inner.id, "drop_control_receiver");
-        inner.control.close_receiver();
-        // check if the stream is still open
-        ensure!(!inner.stream.has_receiver());
+        ensure!(inner
+            .stream
+            .close_receiver(&inner.control, half)
+            .is_continue());
+
+        probes::on_receiver_free(inner.id, half);
         let storage = inner.free_list.free(Descriptor {
             ptr: self.ptr,
             phantom: PhantomData,
@@ -182,8 +179,8 @@ impl<T> DescriptorInner<T> {
         control: ring_deque::Capacity,
         free_list: Arc<dyn FreeList<T>>,
     ) -> Self {
-        let stream = Queue::new(stream);
-        let control = Queue::new(control);
+        let stream = Queue::new(stream, Half::Stream);
+        let control = Queue::new(control, Half::Control);
         Self {
             id,
             stream,

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/probes.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/probes.rs
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::queue::Half;
+use s2n_quic_core::{probe, varint::VarInt};
+
+probe::define!(
+    extern "probe" {
+        /// Called when a packet is sent on a queue
+        #[link_name = s2n_quic_dc__stream__recv__dispatch__send]
+        pub fn on_send(queue_id: VarInt, half: Half, has_overflow: bool);
+
+        /// Called when a number of packets are received on a queue
+        #[link_name = s2n_quic_dc__stream__recv__dispatch__recv]
+        pub fn on_recv(queue_id: VarInt, half: Half, count: usize);
+
+        /// Called when the receiver has been opened for both halves
+        #[link_name = s2n_quic_dc__stream__recv__dispatch__receiver_open]
+        pub fn on_receiver_open(queue_id: VarInt);
+
+        /// The half of the receiver has been dropped
+        #[link_name = s2n_quic_dc__stream__recv__dispatch__receiver_drop]
+        pub fn on_receiver_drop(queue_id: VarInt, half: Half);
+
+        /// Both sides of the receiver has been dropped and the `owner`
+        /// is now freeing the descriptor back to the pool
+        #[link_name = s2n_quic_dc__stream__recv__dispatch__receiver_free]
+        pub fn on_receiver_free(queue_id: VarInt, owner: Half);
+
+        /// Called when a sender is dropped for a queue
+        #[link_name = s2n_quic_dc__stream__recv__dispatch__sender_drop]
+        pub fn on_sender_drop(queue_id: VarInt);
+
+        /// Called when a queue is closed by the sender
+        ///
+        /// The queue will not be reopened after this point. Receivers may
+        /// still drain the remaining packets in the queue.
+        #[link_name = s2n_quic_dc__stream__recv__dispatch__sender_close]
+        pub fn on_sender_close(queue_id: VarInt);
+
+        /// Called when the pool is grown
+        #[link_name = s2n_quic_dc__stream__recv__dispatch__grow]
+        pub fn on_grow(prev_size: usize, next_size: usize);
+
+        /// Called when the pool is draining
+        #[link_name = s2n_quic_dc__stream__recv__dispatch__draining]
+        pub fn on_draining(total_size: usize, remaining: usize);
+
+        /// Called when the pool is drained
+        #[link_name = s2n_quic_dc__stream__recv__dispatch__drained]
+        pub fn on_drained(total_size: usize);
+    }
+);


### PR DESCRIPTION
### Description of changes: 

After doing some testing, the current dispatch queue closing logic has a potential race condition where the queue can end up being freed twice. This change fixes that by locking both receivers in the same order (to avoid a deadlock) and observing the other side's status before deciding to free the queue or not.

### Call-outs:

I did a little more clean up around tracing events by creating actual probes instead. I've also tried to avoid calling any of the probes while holding a mutex.

### Testing:

I added a stress test that was able to reproduce the original issue and show that the changes fixed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

