### PR TITLE
feat(s2n-quic-dc): wire up recv pool to server

### DIFF
--- a/dc/s2n-quic-dc-benches/src/streams.rs
+++ b/dc/s2n-quic-dc-benches/src/streams.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use criterion::Criterion;
-use s2n_quic_dc::stream::{self, server::tokio::accept, socket::Protocol};
+use s2n_quic_dc::stream::{self, server::accept, socket::Protocol};
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
     net::{TcpListener, TcpStream},

--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -43,6 +43,9 @@ rand_chacha = "0.9"
 s2n-codec = { version = "=0.55.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.55.0", path = "../../quic/s2n-quic-core", default-features = false }
 s2n-quic-platform = { version = "=0.55.0", path = "../../quic/s2n-quic-platform" }
+schnellru = { version = "0.2", features = [
+    "runtime-rng",
+], default-features = false }
 slotmap = "1"
 hashbrown = "0.15"
 thiserror = "2"

--- a/dc/s2n-quic-dc/src/socket/recv/router/with_map.rs
+++ b/dc/s2n-quic-dc/src/socket/recv/router/with_map.rs
@@ -1,0 +1,162 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Router;
+use crate::{
+    credentials::Credentials,
+    packet::{self, stream},
+    path::secret,
+    socket::recv::descriptor,
+};
+use s2n_quic_core::inet::{ExplicitCongestionNotification, SocketAddress};
+
+#[derive(Clone)]
+pub struct WithMap<Inner> {
+    inner: Inner,
+    map: secret::Map,
+}
+
+impl<Inner> WithMap<Inner> {
+    #[inline]
+    pub fn new(inner: Inner, map: secret::Map) -> Self {
+        Self { inner, map }
+    }
+}
+
+impl<Inner: Router> Router for WithMap<Inner> {
+    #[inline]
+    fn is_open(&self) -> bool {
+        self.inner.is_open()
+    }
+
+    #[inline]
+    fn tag_len(&self) -> usize {
+        self.inner.tag_len()
+    }
+
+    #[inline]
+    fn handle_control_packet(
+        &mut self,
+        remote_address: SocketAddress,
+        ecn: ExplicitCongestionNotification,
+        packet: packet::control::decoder::Packet,
+    ) {
+        self.inner
+            .handle_control_packet(remote_address, ecn, packet);
+    }
+
+    #[inline]
+    fn dispatch_control_packet(
+        &mut self,
+        tag: packet::control::Tag,
+        id: Option<stream::Id>,
+        credentials: Credentials,
+        segment: descriptor::Filled,
+    ) {
+        self.inner
+            .dispatch_control_packet(tag, id, credentials, segment);
+    }
+
+    #[inline]
+    fn handle_stream_packet(
+        &mut self,
+        remote_address: SocketAddress,
+        ecn: ExplicitCongestionNotification,
+        packet: packet::stream::decoder::Packet,
+    ) {
+        self.inner.handle_stream_packet(remote_address, ecn, packet);
+    }
+
+    #[inline]
+    fn dispatch_stream_packet(
+        &mut self,
+        tag: stream::Tag,
+        id: stream::Id,
+        credentials: Credentials,
+        segment: descriptor::Filled,
+    ) {
+        self.inner
+            .dispatch_stream_packet(tag, id, credentials, segment);
+    }
+
+    #[inline]
+    fn handle_datagram_packet(
+        &mut self,
+        remote_address: SocketAddress,
+        ecn: ExplicitCongestionNotification,
+        packet: packet::datagram::decoder::Packet,
+    ) {
+        self.inner
+            .handle_datagram_packet(remote_address, ecn, packet);
+    }
+
+    #[inline]
+    fn dispatch_datagram_packet(
+        &mut self,
+        tag: packet::datagram::Tag,
+        credentials: Credentials,
+        segment: descriptor::Filled,
+    ) {
+        self.inner
+            .dispatch_datagram_packet(tag, credentials, segment);
+    }
+
+    #[inline]
+    fn handle_stale_key_packet(
+        &mut self,
+        packet: packet::secret_control::stale_key::Packet,
+        remote_address: SocketAddress,
+    ) {
+        // TODO check if the packet was authentic before forwarding the packet on to inner
+        self.map.handle_control_packet(
+            &packet::secret_control::Packet::StaleKey(packet),
+            &remote_address.into(),
+        );
+        self.inner.handle_stale_key_packet(packet, remote_address);
+    }
+
+    #[inline]
+    fn handle_replay_detected_packet(
+        &mut self,
+        packet: packet::secret_control::replay_detected::Packet,
+        remote_address: SocketAddress,
+    ) {
+        // TODO check if the packet was authentic before forwarding the packet on to inner
+        self.map.handle_control_packet(
+            &packet::secret_control::Packet::ReplayDetected(packet),
+            &remote_address.into(),
+        );
+        self.inner
+            .handle_replay_detected_packet(packet, remote_address);
+    }
+
+    #[inline]
+    fn handle_unknown_path_secret_packet(
+        &mut self,
+        packet: packet::secret_control::unknown_path_secret::Packet,
+        remote_address: SocketAddress,
+    ) {
+        // TODO check if the packet was authentic before forwarding the packet on to inner
+        self.map.handle_control_packet(
+            &packet::secret_control::Packet::UnknownPathSecret(packet),
+            &remote_address.into(),
+        );
+        self.inner
+            .handle_unknown_path_secret_packet(packet, remote_address);
+    }
+
+    #[inline]
+    fn on_unhandled_packet(&mut self, remote_address: SocketAddress, packet: packet::Packet) {
+        self.inner.on_unhandled_packet(remote_address, packet);
+    }
+
+    #[inline]
+    fn on_decode_error(
+        &mut self,
+        error: s2n_codec::DecoderError,
+        remote_address: SocketAddress,
+        segment: descriptor::Filled,
+    ) {
+        self.inner.on_decode_error(error, remote_address, segment);
+    }
+}

--- a/dc/s2n-quic-dc/src/socket/recv/router/zero_router.rs
+++ b/dc/s2n-quic-dc/src/socket/recv/router/zero_router.rs
@@ -1,0 +1,172 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::Router;
+use crate::{
+    credentials::Credentials,
+    packet::{self, stream},
+    socket::recv::descriptor,
+};
+use s2n_quic_core::{
+    inet::{ExplicitCongestionNotification, SocketAddress},
+    varint::VarInt,
+};
+
+/// Routes packets to a zero or non-zero queue ID handler
+#[derive(Clone)]
+pub struct ZeroRouter<Zero, NonZero> {
+    pub zero: Zero,
+    pub non_zero: NonZero,
+}
+
+impl<Zero, NonZero> Router for ZeroRouter<Zero, NonZero>
+where
+    Zero: Router,
+    NonZero: Router,
+{
+    #[inline]
+    fn is_open(&self) -> bool {
+        self.zero.is_open() && self.non_zero.is_open()
+    }
+
+    #[inline]
+    fn tag_len(&self) -> usize {
+        debug_assert_eq!(self.zero.tag_len(), self.non_zero.tag_len());
+        self.zero.tag_len()
+    }
+
+    #[inline]
+    fn handle_control_packet(
+        &mut self,
+        remote_address: SocketAddress,
+        ecn: ExplicitCongestionNotification,
+        packet: packet::control::decoder::Packet,
+    ) {
+        if packet
+            .stream_id()
+            .is_some_and(|id| id.queue_id == VarInt::ZERO)
+        {
+            self.zero.handle_control_packet(remote_address, ecn, packet);
+        } else {
+            self.non_zero
+                .handle_control_packet(remote_address, ecn, packet);
+        }
+    }
+
+    #[inline]
+    fn dispatch_control_packet(
+        &mut self,
+        tag: packet::control::Tag,
+        id: Option<stream::Id>,
+        credentials: Credentials,
+        segment: descriptor::Filled,
+    ) {
+        if id.is_some_and(|id| id.queue_id == VarInt::ZERO) {
+            self.zero
+                .dispatch_control_packet(tag, id, credentials, segment);
+        } else {
+            self.non_zero
+                .dispatch_control_packet(tag, id, credentials, segment);
+        }
+    }
+
+    #[inline]
+    fn handle_stream_packet(
+        &mut self,
+        remote_address: SocketAddress,
+        ecn: ExplicitCongestionNotification,
+        packet: packet::stream::decoder::Packet,
+    ) {
+        if packet.stream_id().queue_id == VarInt::ZERO {
+            self.zero.handle_stream_packet(remote_address, ecn, packet);
+        } else {
+            self.non_zero
+                .handle_stream_packet(remote_address, ecn, packet);
+        }
+    }
+
+    #[inline]
+    fn dispatch_stream_packet(
+        &mut self,
+        tag: stream::Tag,
+        id: stream::Id,
+        credentials: Credentials,
+        segment: descriptor::Filled,
+    ) {
+        if id.queue_id == VarInt::ZERO {
+            self.zero
+                .dispatch_stream_packet(tag, id, credentials, segment);
+        } else {
+            self.non_zero
+                .dispatch_stream_packet(tag, id, credentials, segment);
+        }
+    }
+
+    #[inline]
+    fn handle_datagram_packet(
+        &mut self,
+        remote_address: SocketAddress,
+        ecn: ExplicitCongestionNotification,
+        packet: packet::datagram::decoder::Packet,
+    ) {
+        self.non_zero
+            .handle_datagram_packet(remote_address, ecn, packet);
+    }
+
+    #[inline]
+    fn dispatch_datagram_packet(
+        &mut self,
+        tag: packet::datagram::Tag,
+        credentials: Credentials,
+        segment: descriptor::Filled,
+    ) {
+        self.non_zero
+            .dispatch_datagram_packet(tag, credentials, segment);
+    }
+
+    #[inline]
+    fn handle_stale_key_packet(
+        &mut self,
+        packet: packet::secret_control::stale_key::Packet,
+        remote_address: SocketAddress,
+    ) {
+        self.non_zero
+            .handle_stale_key_packet(packet, remote_address);
+    }
+
+    #[inline]
+    fn handle_replay_detected_packet(
+        &mut self,
+        packet: packet::secret_control::replay_detected::Packet,
+        remote_address: SocketAddress,
+    ) {
+        self.non_zero
+            .handle_replay_detected_packet(packet, remote_address);
+    }
+
+    #[inline]
+    fn handle_unknown_path_secret_packet(
+        &mut self,
+        packet: packet::secret_control::unknown_path_secret::Packet,
+        remote_address: SocketAddress,
+    ) {
+        self.non_zero
+            .handle_unknown_path_secret_packet(packet, remote_address);
+    }
+
+    #[inline]
+    fn on_unhandled_packet(&mut self, remote_address: SocketAddress, packet: packet::Packet) {
+        self.non_zero.on_unhandled_packet(remote_address, packet);
+    }
+
+    #[inline]
+    fn on_decode_error(
+        &mut self,
+        error: s2n_codec::DecoderError,
+        remote_address: SocketAddress,
+        segment: descriptor::Filled,
+    ) {
+        self.non_zero
+            .on_decode_error(error, remote_address, segment);
+    }
+}

--- a/dc/s2n-quic-dc/src/stream/endpoint.rs
+++ b/dc/s2n-quic-dc/src/stream/endpoint.rs
@@ -39,7 +39,6 @@ pub fn open_stream<Env, P>(
     env: &Env,
     entry: map::Peer,
     peer: P,
-    subscriber: Env::Subscriber,
     parameter_override: Option<&dyn Fn(dc::ApplicationParams) -> dc::ApplicationParams>,
 ) -> Result<application::Builder<Env::Subscriber>>
 where
@@ -67,6 +66,7 @@ where
     };
     let info = event::api::ConnectionInfo {};
 
+    let subscriber = env.subscriber().clone();
     let subscriber_ctx = subscriber.create_connection_context(&meta, &info);
 
     build_stream(
@@ -90,7 +90,6 @@ pub fn accept_stream<Env, P>(
     peer: P,
     packet: &server::InitialPacket,
     map: &Map,
-    subscriber: Env::Subscriber,
     subscriber_ctx: <Env::Subscriber as event::Subscriber>::ConnectionContext,
     parameter_override: Option<&dyn Fn(dc::ApplicationParams) -> dc::ApplicationParams>,
 ) -> Result<application::Builder<Env::Subscriber>, AcceptError<P>>
@@ -125,6 +124,8 @@ where
         // inherit the rest of the parameters from the client
         ..packet.stream_id
     };
+
+    let subscriber = env.subscriber().clone();
 
     let res = build_stream(
         now,

--- a/dc/s2n-quic-dc/src/stream/environment.rs
+++ b/dc/s2n-quic-dc/src/stream/environment.rs
@@ -6,7 +6,7 @@ use crate::{
     stream::{recv, runtime, socket, TransportFeatures},
 };
 use core::future::Future;
-use s2n_quic_core::{inet::SocketAddress, varint::VarInt};
+use s2n_quic_core::{inet::SocketAddress, time::Timestamp, varint::VarInt};
 use s2n_quic_platform::features;
 use std::{io, sync::Arc};
 
@@ -20,14 +20,39 @@ pub mod udp;
 
 pub trait Environment {
     type Clock: Clone + clock::Clock;
-    type Subscriber: event::Subscriber;
+    type Subscriber: event::Subscriber + Clone;
 
+    fn subscriber(&self) -> &Self::Subscriber;
     fn clock(&self) -> &Self::Clock;
     fn gso(&self) -> features::Gso;
     fn reader_rt(&self) -> runtime::ArcHandle<Self::Subscriber>;
     fn spawn_reader<F: 'static + Send + Future<Output = ()>>(&self, f: F);
     fn writer_rt(&self) -> runtime::ArcHandle<Self::Subscriber>;
     fn spawn_writer<F: 'static + Send + Future<Output = ()>>(&self, f: F);
+
+    /// Creates an endpoint publisher with the environment's subscriber
+    #[inline]
+    fn endpoint_publisher(&self) -> event::EndpointPublisherSubscriber<Self::Subscriber> {
+        use s2n_quic_core::time::Clock as _;
+
+        self.endpoint_publisher_with_time(self.clock().get_time())
+    }
+
+    #[inline]
+    fn endpoint_publisher_with_time(
+        &self,
+        timestamp: Timestamp,
+    ) -> event::EndpointPublisherSubscriber<Self::Subscriber> {
+        use s2n_quic_core::event::IntoEvent;
+
+        let timestamp = timestamp.into_event();
+
+        event::EndpointPublisherSubscriber::new(
+            event::builder::EndpointMeta { timestamp },
+            None,
+            self.subscriber(),
+        )
+    }
 }
 
 pub struct SocketSet<R, W = R> {

--- a/dc/s2n-quic-dc/src/stream/environment/tokio/tcp.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/tokio/tcp.rs
@@ -22,7 +22,7 @@ pub struct Registered {
 
 impl<Sub> Peer<Environment<Sub>> for Registered
 where
-    Sub: event::Subscriber,
+    Sub: event::Subscriber + Clone,
 {
     type ReadWorkerSocket = ();
     type WriteWorkerSocket = ();
@@ -59,7 +59,7 @@ pub struct Reregistered {
 
 impl<Sub> Peer<Environment<Sub>> for Reregistered
 where
-    Sub: event::Subscriber,
+    Sub: event::Subscriber + Clone,
 {
     type ReadWorkerSocket = ();
     type WriteWorkerSocket = ();

--- a/dc/s2n-quic-dc/src/stream/environment/tokio/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/tokio/udp.rs
@@ -32,7 +32,7 @@ pub struct Owned(pub SocketAddress, pub RecvBuffer);
 
 impl<Sub> Peer<Environment<Sub>> for Owned
 where
-    Sub: event::Subscriber,
+    Sub: event::Subscriber + Clone,
 {
     type ReadWorkerSocket = OwnedSocket;
     type WriteWorkerSocket = (OwnedSocket, buffer::Local);
@@ -124,7 +124,7 @@ pub struct Pooled(pub SocketAddress);
 
 impl<Sub> Peer<Environment<Sub>> for Pooled
 where
-    Sub: event::Subscriber,
+    Sub: event::Subscriber + Clone,
 {
     type ReadWorkerSocket = WorkerSocket;
     type WriteWorkerSocket = (WorkerSocket, buffer::Channel<Control>);

--- a/dc/s2n-quic-dc/src/stream/server.rs
+++ b/dc/s2n-quic-dc/src/stream/server.rs
@@ -3,14 +3,20 @@
 
 #![allow(clippy::type_complexity)]
 
-use crate::{credentials::Credentials, msg::recv, packet};
+use crate::{
+    credentials::{self, Credentials},
+    msg::recv,
+    packet,
+};
 use s2n_codec::{DecoderBufferMut, DecoderError};
 use s2n_quic_core::varint::VarInt;
 
+pub mod accept;
 pub mod handshake;
 pub mod tokio;
+pub mod udp;
 
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct InitialPacket {
     pub credentials: Credentials,
     pub stream_id: packet::stream::Id,
@@ -42,6 +48,27 @@ impl InitialPacket {
         let packet: InitialPacket = packet.into();
 
         Ok(packet)
+    }
+
+    #[inline]
+    pub fn empty() -> Self {
+        Self {
+            credentials: Credentials {
+                id: credentials::Id::default(),
+                key_id: VarInt::ZERO,
+            },
+            stream_id: packet::stream::Id {
+                queue_id: VarInt::ZERO,
+                is_bidirectional: false,
+                is_reliable: false,
+            },
+            source_queue_id: None,
+            payload_len: 0,
+            is_zero_offset: false,
+            is_retransmission: false,
+            is_fin: false,
+            is_fin_known: false,
+        }
     }
 }
 

--- a/dc/s2n-quic-dc/src/stream/server/accept.rs
+++ b/dc/s2n-quic-dc/src/stream/server/accept.rs
@@ -1,0 +1,22 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{event, stream::application::Builder as StreamBuilder, sync::mpmc as channel};
+
+#[derive(Clone, Copy, Default)]
+pub enum Flavor {
+    #[default]
+    Fifo,
+    Lifo,
+}
+
+pub type Sender<Sub> = channel::Sender<StreamBuilder<Sub>>;
+pub type Receiver<Sub> = channel::Receiver<StreamBuilder<Sub>>;
+
+#[inline]
+pub fn channel<Sub>(capacity: usize) -> (Sender<Sub>, Receiver<Sub>)
+where
+    Sub: event::Subscriber,
+{
+    channel::new(capacity)
+}

--- a/dc/s2n-quic-dc/src/stream/server/tokio/accept.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/accept.rs
@@ -7,6 +7,7 @@ use crate::{
     stream::{
         application::{Builder as StreamBuilder, Stream},
         environment::{tokio::Environment, Environment as _},
+        server::accept::Receiver,
     },
     sync::mpmc as channel,
 };
@@ -14,24 +15,6 @@ use core::time::Duration;
 use s2n_quic_core::time::Clock;
 use std::{io, net::SocketAddr};
 use tokio::time::sleep;
-
-#[derive(Clone, Copy, Default)]
-pub enum Flavor {
-    #[default]
-    Fifo,
-    Lifo,
-}
-
-pub type Sender<Sub> = channel::Sender<StreamBuilder<Sub>>;
-pub type Receiver<Sub> = channel::Receiver<StreamBuilder<Sub>>;
-
-#[inline]
-pub fn channel<Sub>(capacity: usize) -> (Sender<Sub>, Receiver<Sub>)
-where
-    Sub: event::Subscriber,
-{
-    channel::new(capacity)
-}
 
 #[inline]
 pub async fn accept<Sub>(
@@ -97,7 +80,7 @@ impl Pruner {
         channel: channel::WeakReceiver<StreamBuilder<Sub>>,
         stats: stats::Stats,
     ) where
-        Sub: event::Subscriber,
+        Sub: event::Subscriber + Clone,
     {
         let Self {
             sojourn_multiplier,

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp.rs
@@ -1,11 +1,13 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::accept;
 use crate::{
     event::{self, EndpointPublisher, IntoEvent, Subscriber},
     path::secret,
-    stream::environment::{tokio::Environment, Environment as _},
+    stream::{
+        environment::{tokio::Environment, Environment as _},
+        server::accept,
+    },
 };
 use core::{future::poll_fn, task::Poll};
 use s2n_quic_core::{inet::SocketAddress, time::Clock};
@@ -28,7 +30,6 @@ where
     backlog: usize,
     accept_flavor: accept::Flavor,
     linger: Option<Duration>,
-    subscriber: Sub,
 }
 
 impl<Sub> Acceptor<Sub>
@@ -45,7 +46,6 @@ where
         backlog: usize,
         accept_flavor: accept::Flavor,
         linger: Option<Duration>,
-        subscriber: Sub,
     ) -> Self {
         let acceptor = Self {
             sender: sender.clone(),
@@ -55,18 +55,17 @@ where
             backlog,
             accept_flavor,
             linger,
-            subscriber,
         };
 
         if let Ok(addr) = acceptor.socket.local_addr() {
             let local_address: SocketAddress = addr.into();
-            acceptor
-                .publisher()
-                .on_acceptor_tcp_started(event::builder::AcceptorTcpStarted {
+            acceptor.env.endpoint_publisher().on_acceptor_tcp_started(
+                event::builder::AcceptorTcpStarted {
                     id,
                     local_address: &local_address,
                     backlog,
-                });
+                },
+            );
         }
 
         acceptor
@@ -86,7 +85,7 @@ where
             workers.poll_start(cx);
 
             let now = self.env.clock().get_time();
-            let publisher = publisher(&self.subscriber, &now);
+            let publisher = self.env.endpoint_publisher_with_time(now);
 
             fresh.fill(cx, &mut self.socket, &publisher);
 
@@ -97,7 +96,10 @@ where
                 };
                 let info = event::api::ConnectionInfo {};
 
-                let subscriber_ctx = self.subscriber.create_connection_context(&meta, &info);
+                let subscriber_ctx = self
+                    .env
+                    .subscriber()
+                    .create_connection_context(&meta, &info);
 
                 workers.insert(
                     remote_address,
@@ -133,23 +135,6 @@ where
 
         drop(drop_guard);
     }
-
-    fn publisher(&self) -> event::EndpointPublisherSubscriber<Sub> {
-        publisher(&self.subscriber, self.env.clock())
-    }
-}
-
-fn publisher<'a, Sub: Subscriber, C: Clock>(
-    subscriber: &'a Sub,
-    clock: &C,
-) -> event::EndpointPublisherSubscriber<'a, Sub> {
-    let timestamp = clock.get_time().into_event();
-
-    event::EndpointPublisherSubscriber::new(
-        event::builder::EndpointMeta { timestamp },
-        None,
-        subscriber,
-    )
 }
 
 struct DropLog;

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
@@ -38,7 +38,6 @@ where
     env: Environment<Sub>,
     secrets: secret::Map,
     accept_flavor: accept::Flavor,
-    subscriber: Sub,
     local_port: u16,
 }
 
@@ -54,7 +53,6 @@ where
             env: acceptor.env.clone(),
             secrets: acceptor.secrets.clone(),
             accept_flavor: acceptor.accept_flavor,
-            subscriber: acceptor.subscriber.clone(),
             local_port: acceptor.socket.local_addr().unwrap().port(),
         }
     }
@@ -329,7 +327,6 @@ impl WorkerState {
                 peer,
                 &initial_packet,
                 &context.secrets,
-                context.subscriber.clone(),
                 subscriber_ctx,
                 None,
             ) {

--- a/dc/s2n-quic-dc/src/stream/server/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/udp.rs
@@ -1,0 +1,241 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{accept, InitialPacket};
+use crate::{
+    credentials::Credentials,
+    event::{self, EndpointPublisher as _, Subscriber},
+    msg,
+    packet::stream,
+    path::secret,
+    socket::recv::{descriptor, router::Router},
+    stream::{
+        endpoint,
+        environment::{udp, Environment},
+        recv::dispatch::{Allocator, Dispatch},
+        socket,
+    },
+};
+use s2n_quic_core::{
+    event::IntoEvent,
+    inet::{ExplicitCongestionNotification, SocketAddress},
+    time::Clock,
+    varint::VarInt,
+};
+use schnellru::LruMap;
+use std::{io, sync::Arc};
+use tracing::debug;
+
+pub struct Acceptor<Env, S, W>
+where
+    Env: Environment,
+    S: socket::application::Application,
+    W: socket::Socket,
+{
+    sender: accept::Sender<Env::Subscriber>,
+    env: Env,
+    secrets: secret::Map,
+    accept_flavor: accept::Flavor,
+    credential_cache: CredentialCache,
+    dispatch: Dispatch,
+    queues: Allocator,
+    is_open: bool,
+    packet: InitialPacket,
+    application_socket: Arc<S>,
+    worker_socket: Arc<W>,
+}
+
+impl<Env, S, W> Acceptor<Env, S, W>
+where
+    Env: Environment,
+    S: socket::application::Application,
+    W: socket::Socket,
+{
+    pub fn new(
+        env: Env,
+        sender: accept::Sender<Env::Subscriber>,
+        secrets: secret::Map,
+        accept_flavor: accept::Flavor,
+        queues: Allocator,
+        application_socket: Arc<S>,
+        worker_socket: Arc<W>,
+        credential_cache_size: u32,
+    ) -> Self {
+        let dispatch = queues.dispatcher();
+        let credential_cache = create_credential_cache(credential_cache_size);
+        let packet = InitialPacket::empty();
+        Self {
+            sender,
+            env,
+            secrets,
+            accept_flavor,
+            credential_cache,
+            dispatch,
+            queues,
+            is_open: true,
+            packet,
+            application_socket,
+            worker_socket,
+        }
+    }
+}
+
+impl<Env, S, W> Router for Acceptor<Env, S, W>
+where
+    Env: Environment,
+    Env::Subscriber: Clone,
+    S: socket::application::Application,
+    W: socket::Socket,
+{
+    #[inline]
+    fn is_open(&self) -> bool {
+        self.is_open
+    }
+
+    #[inline]
+    fn handle_stream_packet(
+        &mut self,
+        _remote_address: SocketAddress,
+        _ecn: ExplicitCongestionNotification,
+        packet: stream::decoder::Packet,
+    ) {
+        self.packet = packet.into();
+    }
+
+    #[inline]
+    fn dispatch_stream_packet(
+        &mut self,
+        _tag: stream::Tag,
+        _id: stream::Id,
+        credentials: Credentials,
+        segment: descriptor::Filled,
+    ) {
+        let credentials = CredentialsHashable(credentials);
+        if let Some(queue_id) = self.credential_cache.get(&credentials) {
+            tracing::trace!(%queue_id, "credential_cache_hit");
+            if self.dispatch.send_stream(*queue_id, segment).is_err() {
+                // if the dispatch didn't work then remove it from the LRU
+                let _ = self.credential_cache.remove(&credentials);
+            }
+            return;
+        }
+
+        let peer_addr = segment.remote_address().get();
+
+        let (control, stream) = self.queues.alloc_or_grow();
+        let queue_id = control.queue_id();
+        // inject the packet into the stream queue
+        let _ = stream.push(segment);
+
+        let now = self.env.clock().get_time();
+        let meta = event::api::ConnectionMeta {
+            id: 0, // TODO use an actual connection ID
+            timestamp: now.into_event(),
+        };
+        let info = event::api::ConnectionInfo {};
+        let subscriber_ctx = self
+            .env
+            .subscriber()
+            .create_connection_context(&meta, &info);
+
+        let application_socket = self.application_socket.clone();
+        let worker_socket = self.worker_socket.clone();
+
+        let peer = udp::Pooled {
+            peer_addr,
+            control,
+            stream,
+            application_socket,
+            worker_socket,
+        };
+
+        // TODO is it better to accept this inline or send it off to another queue?
+        //      maybe only delegate to another task when the receiver becomes overloaded?
+
+        let stream = match endpoint::accept_stream(
+            now,
+            &self.env,
+            peer,
+            &self.packet,
+            &self.secrets,
+            subscriber_ctx,
+            None,
+        ) {
+            Ok(stream) => stream,
+            Err(error) => {
+                tracing::trace!("send_start");
+
+                if !error.secret_control.is_empty() {
+                    let addr = msg::addr::Addr::new(peer_addr);
+                    let ecn = Default::default();
+                    let buffer = &[io::IoSlice::new(&error.secret_control)];
+
+                    // ignore any errors since this is just for responding to invalid connect attempts
+                    let _ = self.worker_socket.try_send(&addr, ecn, buffer);
+                }
+
+                tracing::trace!("send_finish");
+                return;
+            }
+        };
+
+        // remember the associated queue_id for the credentials
+        self.credential_cache.insert(credentials, queue_id);
+
+        {
+            let remote_address: SocketAddress = stream.shared.remote_addr();
+            let remote_address = &remote_address;
+            let creds = stream.shared.credentials();
+            let credential_id = &creds.id[..];
+            let stream_id = creds.key_id.as_u64();
+            self.env
+                .endpoint_publisher_with_time(now)
+                .on_acceptor_udp_stream_enqueued(event::builder::AcceptorUdpStreamEnqueued {
+                    remote_address,
+                    credential_id,
+                    stream_id,
+                });
+        }
+
+        let res = match self.accept_flavor {
+            accept::Flavor::Fifo => self.sender.send_back(stream),
+            accept::Flavor::Lifo => self.sender.send_front(stream),
+        };
+
+        match res {
+            Ok(prev) => {
+                if let Some(stream) = prev {
+                    stream.prune(
+                        event::builder::AcceptorStreamPruneReason::AcceptQueueCapacityExceeded,
+                    );
+                }
+            }
+            Err(_) => {
+                debug!("application accept queue dropped; shutting down");
+                self.is_open = false;
+            }
+        }
+    }
+}
+
+type CredentialCache = LruMap<CredentialsHashable, VarInt>;
+
+fn create_credential_cache(max_length: u32) -> CredentialCache {
+    use schnellru::RandomState;
+    let limits = schnellru::ByLength::new(max_length);
+    // we need to use random state since the key is completely controlled by the peer
+    let random = RandomState::default();
+    LruMap::with_hasher(limits, random)
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct CredentialsHashable(Credentials);
+
+impl core::hash::Hash for CredentialsHashable {
+    #[inline]
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        let [a, b, c, d, e, f, g, h] = self.0.id.to_hash().to_le_bytes();
+        let [i, j, k, l, m, n, o, p] = self.0.key_id.as_u64().to_le_bytes();
+        state.write(&[a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p]);
+    }
+}

--- a/dc/s2n-quic-dc/src/stream/testing.rs
+++ b/dc/s2n-quic-dc/src/stream/testing.rs
@@ -11,7 +11,7 @@ use crate::{
         client::tokio as stream_client,
         environment::{tokio as env, Environment as _},
         recv, send,
-        server::{tokio as stream_server, tokio::accept},
+        server::{accept, tokio as stream_server},
     },
 };
 use s2n_quic_core::dc::{self, ApplicationParams};
@@ -24,6 +24,9 @@ pub type Subscriber = (Arc<event::testing::Subscriber>, event::tracing::Subscrib
 pub type Stream = application::Stream<Subscriber>;
 pub type Writer = send::application::Writer<Subscriber>;
 pub type Reader = recv::application::Reader<Subscriber>;
+
+// TODO enable this once ready
+const DEFAULT_POOLED: bool = false;
 
 // limit the number of threads used in testing to reduce costs of harnesses
 const TEST_THREADS: usize = 2;
@@ -38,7 +41,6 @@ pub(crate) const MAX_DATAGRAM_SIZE: u16 = if cfg!(target_os = "linux") {
 pub struct Client {
     map: secret::Map,
     env: env::Environment<Subscriber>,
-    subscriber: Arc<event::testing::Subscriber>,
     mtu: Option<u16>,
 }
 
@@ -88,22 +90,12 @@ impl Client {
         let server = server.as_ref();
         let handshake = async { self.handshake_with(server) };
 
-        let subscriber = (self.subscriber(), event::tracing::Subscriber::default());
-
         match server.protocol {
             Protocol::Tcp => {
-                stream_client::connect_tcp(
-                    handshake,
-                    server.local_addr,
-                    &self.env,
-                    subscriber,
-                    None,
-                )
-                .await
+                stream_client::connect_tcp(handshake, server.local_addr, &self.env, None).await
             }
             Protocol::Udp => {
-                stream_client::connect_udp(handshake, server.local_addr, &self.env, subscriber)
-                    .await
+                stream_client::connect_udp(handshake, server.local_addr, &self.env).await
             }
             Protocol::Other(name) => {
                 todo!("protocol {name:?} not implemented")
@@ -119,13 +111,11 @@ impl Client {
         let server = server.as_ref();
         let handshake = async { self.handshake_with(server) }.await?;
 
-        let subscriber = (self.subscriber(), event::tracing::Subscriber::default());
-
-        stream_client::connect_tcp_with(handshake, stream, &self.env, subscriber).await
+        stream_client::connect_tcp_with(handshake, stream, &self.env).await
     }
 
     pub fn subscriber(&self) -> Arc<testing::Subscriber> {
-        self.subscriber.clone()
+        self.env.subscriber().0.clone()
     }
 }
 
@@ -136,6 +126,7 @@ pub mod client {
         map_capacity: usize,
         mtu: Option<u16>,
         subscriber: event::testing::Subscriber,
+        pooled: bool,
     }
 
     impl Default for Builder {
@@ -144,6 +135,7 @@ pub mod client {
                 map_capacity: 16,
                 mtu: None,
                 subscriber: event::testing::Subscriber::no_snapshot(),
+                pooled: DEFAULT_POOLED,
             }
         }
     }
@@ -169,23 +161,24 @@ pub mod client {
                 map_capacity,
                 mtu,
                 subscriber,
+                pooled,
             } = self;
             let _span = tracing::info_span!("client").entered();
             let map = secret::map::testing::new(map_capacity);
             let options = socket::options::Options::new("127.0.0.1:0".parse().unwrap());
-            let env = env::Environment::builder()
+            let subscriber = Arc::new(subscriber);
+            let subscriber = (subscriber, event::tracing::Subscriber::default());
+            let mut env = env::Builder::new(subscriber)
                 .with_threads(TEST_THREADS)
-                // TODO enable this once ready
-                // .with_pool(env::pool::Config::new(map.clone()))
-                .with_socket_options(options)
-                .build()
-                .unwrap();
-            Client {
-                map,
-                env,
-                subscriber: Arc::new(subscriber),
-                mtu,
+                .with_socket_options(options);
+
+            if pooled {
+                let pool = env::pool::Config::new(map.clone());
+                env = env.with_pool(pool);
             }
+
+            let env = env.build().unwrap();
+            Client { map, env, mtu }
         }
     }
 }
@@ -234,7 +227,7 @@ impl Server {
     }
 
     pub async fn accept(&self) -> io::Result<(Stream, SocketAddr)> {
-        accept::accept(&self.receiver, &self.stats).await
+        stream_server::accept::accept(&self.receiver, &self.stats).await
     }
 
     pub fn subscriber(&self) -> Arc<testing::Subscriber> {
@@ -308,6 +301,7 @@ pub mod server {
         linger: Option<Duration>,
         mtu: Option<u16>,
         subscriber: event::testing::Subscriber,
+        pooled: bool,
     }
 
     impl Default for Builder {
@@ -320,6 +314,7 @@ pub mod server {
                 linger: None,
                 mtu: None,
                 subscriber: event::testing::Subscriber::no_snapshot(),
+                pooled: DEFAULT_POOLED,
             }
         }
     }
@@ -387,6 +382,7 @@ pub mod server {
                 linger,
                 mtu,
                 subscriber,
+                pooled,
             } = self;
 
             let _span = tracing::info_span!("server").entered();
@@ -395,17 +391,25 @@ pub mod server {
 
             let options = crate::socket::Options::new("127.0.0.1:0".parse().unwrap());
 
-            let env = env::Builder::default()
-                .with_threads(TEST_THREADS)
-                .with_socket_options(options.clone())
-                .build()
-                .unwrap();
-
             let test_subscriber = Arc::new(subscriber);
             let subscriber = (
                 test_subscriber.clone(),
                 event::tracing::Subscriber::default(),
             );
+
+            let mut env = env::Builder::new(subscriber.clone())
+                .with_threads(TEST_THREADS)
+                .with_socket_options(options.clone());
+
+            if pooled {
+                let mut pool = env::pool::Config::new(map.clone());
+                pool.accept_flavor = flavor;
+                pool.reuse_port = true;
+                env = env.with_pool(pool).with_acceptor(sender.clone());
+            }
+
+            let env = env.build().unwrap();
+
             let (drop_handle_sender, drop_handle_receiver) = drop_handle::new();
 
             let local_addr = match protocol {
@@ -415,7 +419,7 @@ pub mod server {
                     let socket = tokio::net::TcpListener::from_std(socket).unwrap();
 
                     let acceptor = stream_server::tcp::Acceptor::new(
-                        0, socket, &sender, &env, &map, backlog, flavor, linger, subscriber,
+                        0, socket, &sender, &env, &map, backlog, flavor, linger,
                     );
                     let acceptor = drop_handle_receiver.wrap(acceptor.run());
                     let acceptor = acceptor.instrument(tracing::info_span!("tcp"));
@@ -423,15 +427,18 @@ pub mod server {
 
                     local_addr
                 }
+                Protocol::Udp if pooled => {
+                    // acceptor configured in env
+                    env.pool_addr().unwrap()
+                }
                 Protocol::Udp => {
                     let socket = options.build_udp().unwrap();
                     let local_addr = socket.local_addr().unwrap();
 
                     let socket = tokio::io::unix::AsyncFd::new(socket).unwrap();
 
-                    let acceptor = stream_server::udp::Acceptor::new(
-                        0, socket, &sender, &env, &map, flavor, subscriber,
-                    );
+                    let acceptor =
+                        stream_server::udp::Acceptor::new(0, socket, &sender, &env, &map, flavor);
                     let acceptor = drop_handle_receiver.wrap(acceptor.run());
                     let acceptor = acceptor.instrument(tracing::info_span!("udp"));
                     tokio::task::spawn(acceptor);
@@ -454,7 +461,7 @@ pub mod server {
 
             if matches!(flavor, accept::Flavor::Lifo) {
                 let channel = receiver.downgrade();
-                let task = accept::Pruner::default().run(env, channel, stats);
+                let task = stream_server::accept::Pruner::default().run(env, channel, stats);
                 let task = task.instrument(tracing::info_span!("pruner"));
                 let task = drop_handle_receiver.wrap(task);
                 tokio::task::spawn(task);


### PR DESCRIPTION
### Description of changes: 

Similar to #2533, this change wires up the recv pool for servers.

I had to refactor a few things to get this all working - mostly simplifying a few interfaces and having `Environment` now hold a reference to the subscriber, which should have been done originally since it has it as a generic argument.

Most of the interesting implementation is in `dc/s2n-quic-dc/src/stream/server/udp.rs`.

One thing to note is we are now using an LRU instead of the handshake map from before. This should be a lot simpler since we don't have to synchronize any state across workers. All of it is contained in the single acceptor task since packets are routed deterministically based on 4-tuples.

Also note that this combines the acceptor task with the socket recv loop. I started going down the path of splitting packets across two different tasks using CBPF/eBPF, but realized that would likely prevent us from using GRO so decided against it, at least for now. I think it's probably ok to keep them as-is for now but I have a TODO saying that it might be worth investigating offloading the key derivation to another task if we get too overloaded, since that's the most expensive part.

### Testing:

I've got a separate testing branch that I've been using to try out these changes on both the client and server. I'm working through a couple of remaining issues and will enable them by default.

Update: the tests did all complete successfully in CI https://github.com/aws/s2n-quic/pull/2548, so it's quite close to switching over.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

