### PR TITLE
feat(s2n-quic-dc): support key association in dispatch queue allocator

### DIFF
--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -22,6 +22,7 @@ testing = [
 tokio = ["tokio/io-util", "tokio/net", "tokio/rt-multi-thread", "tokio/time"]
 
 [dependencies]
+ahash = "0.8"
 arrayvec = "0.7"
 atomic-waker = "1"
 aws-lc-rs = "1.12"
@@ -35,6 +36,7 @@ bytes = "1"
 crossbeam-channel = "0.5"
 crossbeam-epoch = "0.9"
 crossbeam-queue = { version = "0.3" }
+dashmap = "6"
 event-listener-strategy = "0.5"
 flurry = "0.5"
 libc = "0.2"
@@ -46,9 +48,6 @@ rand_chacha = "0.9"
 s2n-codec = { version = "=0.55.0", path = "../../common/s2n-codec", default-features = false }
 s2n-quic-core = { version = "=0.55.0", path = "../../quic/s2n-quic-core", default-features = false }
 s2n-quic-platform = { version = "=0.55.0", path = "../../quic/s2n-quic-platform" }
-schnellru = { version = "0.2", features = [
-    "runtime-rng",
-], default-features = false }
 slotmap = "1"
 hashbrown = "0.15"
 thiserror = "2"

--- a/dc/s2n-quic-dc/src/credentials.rs
+++ b/dc/s2n-quic-dc/src/credentials.rs
@@ -3,6 +3,7 @@
 
 use core::{
     fmt,
+    hash::Hash,
     ops::{Deref, DerefMut},
 };
 use s2n_codec::{
@@ -87,6 +88,16 @@ zerocopy_value_codec!(Id);
 pub struct Credentials {
     pub id: Id,
     pub key_id: KeyId,
+}
+
+impl Hash for Credentials {
+    #[inline]
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        let mut v = self.id.to_hash() as u128;
+        v <<= 64;
+        v |= self.key_id.as_u64() as u128;
+        v.hash(state);
+    }
 }
 
 decoder_value!(

--- a/dc/s2n-quic-dc/src/stream/environment/bach/pool.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/bach/pool.rs
@@ -3,6 +3,7 @@
 
 use super::udp::{ApplicationSocket, RecvSocket, WorkerSocket};
 use crate::{
+    credentials::Credentials,
     event,
     socket::recv::{pool::Pool as Packets, router::Router, udp},
     stream::{
@@ -115,7 +116,6 @@ impl Pool {
                     queues.clone(),
                     app_socket,
                     worker_socket,
-                    config.credential_cache_size,
                 );
 
                 let router = queues.dispatcher().with_map(config.map.clone());
@@ -136,11 +136,14 @@ impl Pool {
         })
     }
 
-    pub fn alloc(&self) -> (Control, Stream, ApplicationSocket, WorkerSocket) {
+    pub fn alloc(
+        &self,
+        credentials: Option<&Credentials>,
+    ) -> (Control, Stream, ApplicationSocket, WorkerSocket) {
         let idx = self.current.fetch_add(1, Ordering::Relaxed);
         let idx = idx & self.mask;
         let socket = &self.sockets[idx];
-        let (control, stream) = socket.queue.lock().unwrap().alloc_or_grow();
+        let (control, stream) = socket.queue.lock().unwrap().alloc_or_grow(credentials);
         let app_socket = socket.application_socket.clone();
         let worker_socket = socket.worker_socket.clone();
 

--- a/dc/s2n-quic-dc/src/stream/environment/bach/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/bach/udp.rs
@@ -40,7 +40,9 @@ where
     ) -> SetupResult<Self::ReadWorkerSocket, Self::WriteWorkerSocket> {
         let peer_addr = self.0;
         let recv_pool = env.recv_pool.as_ref().expect("pool not configured");
-        let (control, stream, application_socket, worker_socket) = recv_pool.alloc();
+        // the client doesn't need to associate credentials since it's already chosen a queue_id
+        let credentials = None;
+        let (control, stream, application_socket, worker_socket) = recv_pool.alloc(credentials);
         crate::stream::environment::udp::Pooled {
             peer_addr,
             control,

--- a/dc/s2n-quic-dc/src/stream/environment/tokio/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/tokio/udp.rs
@@ -141,7 +141,9 @@ where
     ) -> SetupResult<Self::ReadWorkerSocket, Self::WriteWorkerSocket> {
         let peer_addr = self.0;
         let recv_pool = env.recv_pool.as_ref().expect("pool not configured");
-        let (control, stream, application_socket, worker_socket) = recv_pool.alloc();
+        // the client doesn't need to associate credentials since it's already chosen a queue_id
+        let credentials = None;
+        let (control, stream, application_socket, worker_socket) = recv_pool.alloc(credentials);
         crate::stream::environment::udp::Pooled {
             peer_addr,
             control,

--- a/dc/s2n-quic-dc/src/stream/environment/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/udp.rs
@@ -28,8 +28,6 @@ pub struct Config {
     pub max_packet_size: u16,
     pub packet_count: usize,
     pub accept_flavor: accept::Flavor,
-    /// The number of entries per worker that will be cached for queue_id lookup
-    pub credential_cache_size: u32,
     pub workers: Option<usize>,
     pub map: Map,
 }
@@ -53,9 +51,6 @@ impl Config {
             packet_count: 16,
 
             accept_flavor: accept::Flavor::default(),
-
-            // TODO tune these defaults
-            credential_cache_size: 8192,
 
             workers: None,
             map,

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/handle.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/handle.rs
@@ -16,13 +16,13 @@ use std::collections::VecDeque;
 
 macro_rules! impl_recv {
     ($name:ident, $field:ident, $half:expr) => {
-        pub struct $name<T: 'static> {
-            descriptor: Descriptor<T>,
+        pub struct $name<T: 'static, Key: 'static> {
+            descriptor: Descriptor<T, Key>,
         }
 
-        impl<T: 'static> $name<T> {
+        impl<T: 'static, Key: 'static> $name<T, Key> {
             #[inline]
-            pub(super) fn new(descriptor: Descriptor<T>) -> Self {
+            pub(super) fn new(descriptor: Descriptor<T, Key>) -> Self {
                 Self { descriptor }
             }
 
@@ -101,7 +101,7 @@ macro_rules! impl_recv {
             }
         }
 
-        impl<T: 'static> fmt::Debug for $name<T> {
+        impl<T: 'static, Key: 'static> fmt::Debug for $name<T, Key> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.debug_struct(stringify!($name))
                     .field("queue_id", &self.queue_id())
@@ -109,7 +109,7 @@ macro_rules! impl_recv {
             }
         }
 
-        impl<T: 'static> Drop for $name<T> {
+        impl<T: 'static, Key: 'static> Drop for $name<T, Key> {
             #[inline]
             fn drop(&mut self) {
                 unsafe {
@@ -123,11 +123,11 @@ macro_rules! impl_recv {
 impl_recv!(Control, control_queue, Half::Control);
 impl_recv!(Stream, stream_queue, Half::Stream);
 
-pub struct Sender<T: 'static> {
-    descriptor: Descriptor<T>,
+pub struct Sender<T: 'static, Key: 'static> {
+    descriptor: Descriptor<T, Key>,
 }
 
-impl<T: 'static> Clone for Sender<T> {
+impl<T: 'static, Key: 'static> Clone for Sender<T, Key> {
     #[inline]
     fn clone(&self) -> Self {
         unsafe {
@@ -138,9 +138,9 @@ impl<T: 'static> Clone for Sender<T> {
     }
 }
 
-impl<T: 'static> Sender<T> {
+impl<T: 'static, Key: 'static> Sender<T, Key> {
     #[inline]
-    pub(super) fn new(descriptor: Descriptor<T>) -> Self {
+    pub(super) fn new(descriptor: Descriptor<T, Key>) -> Self {
         Self { descriptor }
     }
 
@@ -163,7 +163,7 @@ impl<T: 'static> Sender<T> {
     }
 }
 
-impl<T: 'static> Drop for Sender<T> {
+impl<T: 'static, Key: 'static> Drop for Sender<T, Key> {
     #[inline]
     fn drop(&mut self) {
         unsafe {

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/keys.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/keys.rs
@@ -1,0 +1,52 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use ahash::AHasher;
+use dashmap::DashMap;
+use s2n_quic_core::varint::VarInt;
+use std::{
+    hash::{BuildHasherDefault, Hash},
+    sync::Arc,
+};
+
+type Hasher = BuildHasherDefault<AHasher>;
+
+pub struct Keys<Key: 'static> {
+    keys: Arc<DashMap<Key, VarInt, Hasher>>,
+}
+
+impl<Key: 'static> Clone for Keys<Key> {
+    #[inline]
+    fn clone(&self) -> Self {
+        Self {
+            keys: self.keys.clone(),
+        }
+    }
+}
+
+impl<Key: 'static> Keys<Key>
+where
+    Key: Eq + Hash,
+{
+    #[inline]
+    pub fn new(key_capacity: usize) -> Self {
+        let keys = DashMap::with_capacity_and_hasher(key_capacity, Default::default());
+        let keys = Arc::new(keys);
+        Self { keys }
+    }
+
+    #[inline]
+    pub fn get(&self, key: &Key) -> Option<VarInt> {
+        self.keys.get(key).map(|entry| *entry.value())
+    }
+
+    #[inline]
+    pub fn insert(&self, key: Key, queue_id: VarInt) {
+        self.keys.insert(key, queue_id);
+    }
+
+    #[inline]
+    pub fn remove(&self, key: &Key) {
+        self.keys.remove(key);
+    }
+}

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/sender.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/sender.rs
@@ -3,19 +3,38 @@
 
 use super::{free_list, handle::Sender};
 use s2n_quic_core::varint::VarInt;
-use std::sync::{Arc, RwLock};
+use std::{
+    hash::Hash,
+    sync::{Arc, RwLock},
+};
 
-pub struct Senders<T: 'static, const PAGE_SIZE: usize> {
-    pub(super) senders: Arc<RwLock<SenderPages<T>>>,
-    pub(super) local: Vec<Arc<[Sender<T>]>>,
-    pub(super) memory_handle: Arc<free_list::Memory<T>>,
+pub struct State<T: 'static, Key: 'static> {
+    pub(super) pages: RwLock<SenderPages<T, Key>>,
+}
+
+impl<T: 'static, Key: 'static> State<T, Key>
+where
+    Key: Eq + Hash,
+{
+    #[inline]
+    pub fn new(epoch: VarInt) -> Arc<Self> {
+        Arc::new(Self {
+            pages: RwLock::new(SenderPages::new(epoch)),
+        })
+    }
+}
+
+pub struct Senders<T: 'static, Key: 'static, const PAGE_SIZE: usize> {
+    pub(super) state: Arc<State<T, Key>>,
+    pub(super) local: Vec<Arc<[Sender<T, Key>]>>,
+    pub(super) memory_handle: Arc<free_list::Memory<T, Key>>,
     pub(super) base: VarInt,
 }
 
-impl<T: 'static, const PAGE_SIZE: usize> Clone for Senders<T, PAGE_SIZE> {
+impl<T: 'static, Key: 'static, const PAGE_SIZE: usize> Clone for Senders<T, Key, PAGE_SIZE> {
     fn clone(&self) -> Self {
         Self {
-            senders: self.senders.clone(),
+            state: self.state.clone(),
             memory_handle: self.memory_handle.clone(),
             local: self.local.clone(),
             base: self.base,
@@ -23,9 +42,9 @@ impl<T: 'static, const PAGE_SIZE: usize> Clone for Senders<T, PAGE_SIZE> {
     }
 }
 
-impl<T: 'static, const PAGE_SIZE: usize> Senders<T, PAGE_SIZE> {
+impl<T: 'static, Key: 'static, const PAGE_SIZE: usize> Senders<T, Key, PAGE_SIZE> {
     #[inline]
-    pub fn lookup<F: FnOnce(&Sender<T>)>(&mut self, queue_id: VarInt, f: F) {
+    pub fn lookup<F: FnOnce(&Sender<T, Key>)>(&mut self, queue_id: VarInt, f: F) {
         let Some(queue_id) = queue_id.checked_sub(self.base) else {
             return;
         };
@@ -34,7 +53,7 @@ impl<T: 'static, const PAGE_SIZE: usize> Senders<T, PAGE_SIZE> {
         let offset = queue_id % PAGE_SIZE;
 
         if self.local.len() <= page {
-            let Ok(senders) = self.senders.read() else {
+            let Ok(senders) = self.state.pages.read() else {
                 return;
             };
 
@@ -57,12 +76,12 @@ impl<T: 'static, const PAGE_SIZE: usize> Senders<T, PAGE_SIZE> {
     }
 }
 
-pub(super) struct SenderPages<T: 'static> {
-    pub(super) pages: Vec<Arc<[Sender<T>]>>,
+pub(super) struct SenderPages<T: 'static, Key: 'static> {
+    pub(super) pages: Vec<Arc<[Sender<T, Key>]>>,
     pub(super) epoch: VarInt,
 }
 
-impl<T: 'static> SenderPages<T> {
+impl<T: 'static, Key: 'static> SenderPages<T, Key> {
     #[inline]
     pub(super) fn new(epoch: VarInt) -> Self {
         Self {

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/tests.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/tests.rs
@@ -83,7 +83,7 @@ impl Model {
         let Some(alloc) = self.alloc.as_mut() else {
             return;
         };
-        let (control, stream) = alloc.alloc_or_grow();
+        let (control, stream) = alloc.alloc_or_grow(None);
         self.oracle.on_alloc(control, stream);
     }
 
@@ -286,7 +286,7 @@ fn alloc_drop_notify() {
         let mut alloc = Allocator::new(stream_cap, control_cap);
 
         for _ in 0..2 {
-            let (stream, control) = alloc.alloc_or_grow();
+            let (stream, control) = alloc.alloc_or_grow(None);
 
             async move {
                 stream.recv(Actor::Application).await.unwrap_err();
@@ -307,6 +307,60 @@ fn alloc_drop_notify() {
             drop(alloc);
         }
         .spawn();
+    });
+}
+
+#[test]
+fn associated_credentials() {
+    check!().exhaustive().run(|| {
+        let mut alloc = Allocator::new(1, 1);
+        let alloc = &mut alloc;
+        let mut key_id = VarInt::ZERO;
+        let key_id = &mut key_id;
+
+        let mut alloc_one = move || {
+            let creds = Credentials {
+                id: credentials::Id::default(),
+                key_id: *key_id,
+            };
+            *key_id += 1;
+            let (stream, control) = alloc.alloc_or_grow(Some(&creds));
+            let keys = alloc.pool.keys();
+
+            move || {
+                assert_eq!(keys.get(&creds), Some(control.queue_id()));
+                assert_eq!(keys.get(&creds), Some(stream.queue_id()));
+
+                // interleave the order in which we drop channels
+                if bolero::any() {
+                    drop(stream);
+                    assert_eq!(
+                        keys.get(&creds),
+                        Some(control.queue_id()),
+                        "credentials should still match"
+                    );
+                    drop(control);
+                } else {
+                    drop(control);
+                    assert_eq!(
+                        keys.get(&creds),
+                        Some(stream.queue_id()),
+                        "credentials should still match"
+                    );
+                    drop(stream);
+                }
+
+                assert_eq!(keys.get(&creds), None, "credentials should be removed");
+            }
+        };
+
+        let mut channels = [alloc_one(), alloc_one()];
+        // change the order that channels are freed
+        channels.shuffle();
+
+        for channel in channels {
+            channel();
+        }
     });
 }
 
@@ -337,7 +391,7 @@ fn stress_test() {
 
         let alloc = s.spawn(move || {
             while IS_OPEN.load(Ordering::Relaxed) {
-                let (control, stream) = alloc.alloc_or_grow();
+                let (control, stream) = alloc.alloc_or_grow(None);
                 stream_send.send(stream).unwrap();
                 control_send.send(control).unwrap();
             }


### PR DESCRIPTION
### Description of changes: 

As a followup to https://github.com/aws/s2n-quic/pull/2556#discussion_r2005971782, this changes the credential mapping from an LRU to a DashMap that preserves the association for the lifetime of the channel. This should avoid issues where the two get out of sync and end up trying to create a new stream only to get a replay detected error.

### Testing:

I added a test showing that the association is preserved as long as one of the receivers is active. As soon as both are dropped, the association is removed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

