### PR TITLE
feat(s2n-quic-dc): Rework handshakes to use a queue

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map.rs
@@ -17,6 +17,7 @@ mod cleaner;
 mod entry;
 mod handshake;
 mod peer;
+mod rehandshake;
 mod size_of;
 mod state;
 mod status;

--- a/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
@@ -70,6 +70,8 @@ impl Cleaner {
                 } else {
                     rand::rng().random_range(5..60)
                 };
+
+                let next_start = Instant::now() + Duration::from_secs(pause);
                 std::thread::park_timeout(Duration::from_secs(pause));
 
                 let Some(state) = state.upgrade() else {
@@ -79,8 +81,9 @@ impl Cleaner {
                     break;
                 }
                 state.cleaner().clean(&state, EVICTION_CYCLES);
+
                 // pause the rest of the time to run once a minute, not twice a minute
-                std::thread::park_timeout(Duration::from_secs(60 - pause));
+                std::thread::park_timeout(next_start.saturating_duration_since(Instant::now()));
             })
             .unwrap();
         *self.thread.lock().unwrap() = Some(handle);
@@ -93,7 +96,6 @@ impl Cleaner {
         S: event::Subscriber,
     {
         let current_epoch = self.epoch.fetch_add(1, Ordering::Relaxed);
-        let now = Instant::now();
 
         let utilization = |count: usize| (count as f32 / state.secrets_capacity() as f32) * 100.0;
 
@@ -103,7 +105,6 @@ impl Cleaner {
         let address_entries_initial = state.peers.len();
         let mut address_entries_retired = 0usize;
         let mut address_entries_active = 0usize;
-        let mut handshake_requests = 0usize;
 
         // We want to avoid taking long lived locks which affect gets on the maps (where we want
         // p100 latency to be in microseconds at most).
@@ -123,6 +124,9 @@ impl Cleaner {
         // This map is only accessed with queue lock held and in cleaner, so it is in practice
         // single threaded. No concurrent access is permitted.
         state.cleaner_peer_seen.clear();
+
+        let mut rehandshake = state.rehandshake.lock().unwrap();
+        let refill_rehandshakes = rehandshake.needs_refill();
 
         // FIXME: add metrics for queue depth?
         // These are sort of equivalent to the ID map -- so maybe not worth it for now unless we
@@ -144,6 +148,12 @@ impl Cleaner {
                 address_entries_active += 1;
             }
 
+            if refill_rehandshakes {
+                // We'll dedup after we fill, we preallocate for the max capacity so this shouldn't
+                // allocate in practice.
+                rehandshake.push(*entry.peer());
+            }
+
             let retained = if let Some(retired_at) = entry.retired_at() {
                 // retain if we aren't yet ready to evict.
                 current_epoch.saturating_sub(retired_at) < eviction_cycles
@@ -163,13 +173,6 @@ impl Cleaner {
                 return false;
             }
 
-            // Schedule re-handshaking
-            if entry.rehandshake_time() <= now {
-                handshake_requests += 1;
-                state.request_handshake(*entry.peer());
-                entry.rehandshake_time_reschedule(state.rehandshake_period());
-            }
-
             true
         });
 
@@ -177,6 +180,18 @@ impl Cleaner {
         state.cleaner_peer_seen.clear();
 
         drop(queue);
+
+        if refill_rehandshakes {
+            rehandshake.adjust_post_refill();
+        }
+
+        let mut handshake_requests = 0;
+        rehandshake.next_rehandshake_batch(state.peers.len(), |peer| {
+            handshake_requests += 1;
+            state.request_handshake(peer);
+        });
+
+        drop(rehandshake);
 
         let id_entries = state.ids.len();
         let address_entries = state.peers.len();

--- a/dc/s2n-quic-dc/src/path/secret/map/entry/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/entry/tests.rs
@@ -15,7 +15,7 @@ fn entry_size() {
     if should_check {
         assert_eq!(
             Entry::fake((std::net::Ipv4Addr::LOCALHOST, 0).into(), None).size(),
-            311
+            307
         );
     }
 }

--- a/dc/s2n-quic-dc/src/path/secret/map/rehandshake.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/rehandshake.rs
@@ -1,0 +1,108 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use rand::seq::SliceRandom;
+use std::{
+    net::SocketAddr,
+    time::{Duration, Instant},
+};
+
+pub(super) struct RehandshakeState {
+    // FIXME: This is larger than it needs to be because SocketAddr is 32 bytes. We should consider
+    // some other storage form, since IPv4 is 6 bytes and IPv6 is 28 bytes (18 bytes if we ignore
+    // scope ID), almost anything would be smaller than this. But this is cheaper to implement and
+    // we can revisit memory impact separately.
+    //
+    // Splitting IPv4 and IPv6 would help, but it would also mean that we scan one and then the
+    // other, which is probably bad idea long-term -- we want to visit peers randomly.
+    queue: Vec<SocketAddr>,
+    handshake_at: Option<Instant>,
+    schedule_handshake_at: Instant,
+
+    // Duplicated in map State for lock-free access too.
+    rehandshake_period: Duration,
+}
+
+impl RehandshakeState {
+    pub(super) fn new(rehandshake_period: Duration) -> Self {
+        Self {
+            queue: Default::default(),
+            handshake_at: Default::default(),
+            schedule_handshake_at: Instant::now(),
+            rehandshake_period,
+        }
+    }
+
+    pub(super) fn needs_refill(&mut self) -> bool {
+        self.queue.is_empty()
+    }
+
+    pub(super) fn push(&mut self, peer: SocketAddr) {
+        self.queue.push(peer);
+    }
+
+    pub(super) fn adjust_post_refill(&mut self) {
+        self.queue.sort_unstable();
+        self.queue.dedup();
+
+        // Shuffling each time we pull a new queue means that we have p100 re-handshake time
+        // double the expected handshake period, because the entry handshaked at p0 on the
+        // first pass might end up at p100 on the second pass. We're OK with that tradeoff --
+        // the randomization avoids thundering herds against the same host, and while we could
+        // remember an order it's harder to get diffing that order with new entries right.
+        let mut rng = rand::rng();
+        self.queue.shuffle(&mut rng);
+    }
+
+    pub(super) fn reserve(&mut self, capacity: usize) {
+        self.queue.reserve(capacity);
+    }
+
+    pub(super) fn next_rehandshake_batch(
+        &mut self,
+        peer_count: usize,
+        mut request_handshake: impl FnMut(SocketAddr),
+    ) {
+        // Get the number of handshakes we should run during each minute.
+        let mut to_select =
+            (60.0 * peer_count as f64 / self.rehandshake_period.as_secs() as f64).trunc() as usize;
+
+        // Roll a random number *once* to schedule the tail handshake. This avoids repeatedly
+        // rolling false if we rolled every minute with a small probability of success. This mostly
+        // matters in cases where to_select is otherwise zero (i.e., with small peer counts).
+        let mut max_delay =
+            (self.rehandshake_period.as_secs() as f64 / peer_count as f64).ceil() as u64;
+
+        // Schedule when we're going to add the one handshake.
+        if self.handshake_at.is_none()
+            && max_delay > 0
+            && self.schedule_handshake_at <= Instant::now()
+        {
+            max_delay = max_delay.clamp(0, self.rehandshake_period.as_secs());
+            let delta = rand::random_range(0..max_delay);
+            self.handshake_at = Some(Instant::now() + Duration::from_secs(delta));
+            self.schedule_handshake_at = Instant::now() + Duration::from_secs(max_delay);
+        }
+
+        // If the time when we should add the single handshake, then add it.
+        if self.handshake_at.is_some_and(|t| t <= Instant::now()) {
+            to_select += 1;
+            self.handshake_at = None;
+        }
+
+        for idx in 0..to_select {
+            let Some(entry) = self.queue.pop() else {
+                break;
+            };
+
+            request_handshake(entry);
+
+            if idx % 25 == 0 && idx != 0 {
+                // Since we handshake in bursts of 25, this still allows 60*1000/50*25 = 30k
+                // handshakes/minute, which is orders of magnitude more than we should ever have. At
+                // 500k peers with a 24 hour handshake period means ~348 handshakes/minute.
+                std::thread::sleep(Duration::from_millis(50));
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Release Summary:

* feat(s2n-quic-dc): adjust re-handshaking implementation (again)

### Resolved issues:

n/a

### Description of changes: 

This changes our handshake strategy again. This time, I've implemented a small simulator and marking the PR as draft until I finish some test silo experiments.

The new approach aims to be trivially provable to handshake at the expected rate (# of peers / handshake_period), because that's exactly what it does. Prior attempts relied on lots of random rolls and the law of large numbers creating that desired rate, but that doesn't always hold (e.g., with small peer counts, we don't have large numbers), and is harder to reason about.

### Call-outs:

This implementation, like the one in mainline, expects a p100 time 2x the rehandshake period (due to the shuffling on each queue fill). See comments in code for details on why. I think we *could* improve on this -- e.g. some kind of hashing to select when a peer handshakes, randomizing in smaller buckets (e.g., 1/100 of the handshake period) to smooth out the distribution. That would put our p100 at 101% of the desired period. But in practice I don't know that we care that much about perfecting this and the implementation would be much more complex.

I didn't spend much time optimizing the memory usage. I think it's *in practice* not terrible, but also not amazing (see FIXME in code). I think we can do much better at a later point, but it'll definitely take some work to get there.

### Testing:

With a handshake period of 1000 seconds (for easy graphing), my local simulation produces these results:

![with-shuffles](https://github.com/user-attachments/assets/f8704d72-3776-4ace-95aa-1e782beb2397)

This has the expected properties of keeping avg ages around the ~500 second mark, p100 <= 2000 seconds, and handshake rate constant (~214 handshake/second under the particular choice of parameters). The bouncing average is a product of the random shuffling, if I remove that we see an exact 500 second avg and p100 <= 1000 seconds, as expected:

![without-shuffles](https://github.com/user-attachments/assets/32be36b0-8a10-4f0f-9a54-a226e7b2ac9b)

Also works with small # of peers (~2) -- though note that we only average 2 handshakes/1000 seconds, sometimes we have more. Could be mostly fixed but doesn't seem worth it, on average we should have two, and no one running this small a fleet should care :)

![two-peers](https://github.com/user-attachments/assets/44a173bc-48a4-4be2-848b-c47817f318e2)

I'd be happy to add the simulation code somewhere but not sure there's a great place. It's ~73 lines so maybe just putting it in a gist and linking it here would be the right thing?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

