### PR TITLE
test(s2n-quic-dc): disable tracing by default for tests with large output

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
@@ -60,6 +60,12 @@ impl Cleaner {
         C: 'static + time::Clock + Send + Sync,
         S: event::Subscriber,
     {
+        // check to see if we're in a simulation before spawning a thread
+        #[cfg(any(test, feature = "testing"))]
+        if bach::is_active() {
+            return;
+        }
+
         let state = Arc::downgrade(&state);
         let handle = std::thread::Builder::new()
             .name("dc_quic::cleaner".into())

--- a/dc/s2n-quic-dc/src/stream/testing.rs
+++ b/dc/s2n-quic-dc/src/stream/testing.rs
@@ -34,8 +34,7 @@ pub type Stream = application::Stream<Subscriber>;
 pub type Writer = send::application::Writer<Subscriber>;
 pub type Reader = recv::application::Reader<Subscriber>;
 
-// TODO enable this once ready
-const DEFAULT_POOLED: bool = false;
+const DEFAULT_POOLED: bool = true;
 
 // limit the number of threads used in testing to reduce costs of harnesses
 const TEST_THREADS: usize = 2;
@@ -398,7 +397,7 @@ pub mod server {
     impl Default for Builder {
         fn default() -> Self {
             Self {
-                backlog: 16,
+                backlog: 4096,
                 flavor: accept::Flavor::default(),
                 protocol: Protocol::Tcp,
                 map_capacity: 16,


### PR DESCRIPTION
### Description of changes: 

It looks like the issue in #2570 was due to the tracing logs consuming too much memory. This change fixes that issue by flagging certain tests that generate a lot of logs and disabling those by default. I've also turned down the log level from `debug` to `info` in CI so that should also help.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

