### PR TITLE
feat(s2n-quic-dc): add RPC API for streams

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,3 @@
-msrv = "1.71.0"
+msrv = "1.75.0"
 # // https://github.com/aws/s2n-quic/pull/2251
 too-many-arguments-threshold = 100

--- a/dc/s2n-quic-dc/src/stream/client.rs
+++ b/dc/s2n-quic-dc/src/stream/client.rs
@@ -3,5 +3,6 @@
 
 #[cfg(any(test, feature = "testing"))]
 pub mod bach;
+pub mod rpc;
 #[cfg(feature = "tokio")]
 pub mod tokio;

--- a/dc/s2n-quic-dc/src/stream/client/rpc.rs
+++ b/dc/s2n-quic-dc/src/stream/client/rpc.rs
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{event, stream::application::Stream};
+use s2n_quic_core::buffer::{self, writer::Storage};
+use std::{future::Future, io};
+
+pub async fn from_stream<Sub, Req, Res>(
+    stream: Stream<Sub>,
+    mut request: Req,
+    mut response: Res,
+) -> io::Result<Res::Output>
+where
+    Sub: event::Subscriber,
+    Req: Request,
+    Res: Response,
+{
+    let (mut reader, mut writer) = stream.into_split();
+
+    // TODO if the request is large enough, should we spawn a task for it?
+    let writer = async move {
+        while !request.buffer_is_empty() {
+            writer.write_from_fin(&mut request).await?;
+        }
+
+        Ok(())
+    };
+
+    let reader = async move {
+        loop {
+            let storage = response.provide_storage().await?;
+
+            if !storage.has_remaining_capacity() {
+                return Err(io::Error::new(io::ErrorKind::Other, "the provided response buffer failed to provide enough capacity for the peer's response"));
+            }
+
+            let len = reader.read_into(storage).await?;
+
+            if len == 0 {
+                let out = response.finish().await?;
+                return Ok(out);
+            }
+        }
+    };
+
+    let (_, out) = ::tokio::try_join!(writer, reader)?;
+
+    Ok(out)
+}
+
+pub trait Request: 'static + Send + buffer::reader::storage::Infallible {}
+
+impl<T: 'static + Send + buffer::reader::storage::Infallible> Request for T {}
+
+pub trait Response {
+    type Storage: buffer::writer::Storage;
+    type Output;
+
+    /// Provides storage space for the response from the peer
+    ///
+    /// The storage should have a capacity of at least 1. Otherwise the operation will be aborted.
+    fn provide_storage(&mut self) -> impl Future<Output = io::Result<&mut Self::Storage>>;
+
+    /// Indicates the peer has transmitted the entire response
+    fn finish(self) -> impl Future<Output = io::Result<Self::Output>>;
+}
+
+/// Writes the response into the provided [`buffer::writer::Storage`] implementation.
+pub struct InMemoryResponse<S>(S);
+
+impl<S> From<S> for InMemoryResponse<S>
+where
+    S: buffer::writer::Storage,
+{
+    fn from(value: S) -> Self {
+        InMemoryResponse(value)
+    }
+}
+
+impl<S> Response for InMemoryResponse<S>
+where
+    S: buffer::writer::Storage,
+{
+    type Storage = S;
+    type Output = S;
+
+    async fn provide_storage(&mut self) -> io::Result<&mut Self::Storage> {
+        Ok(&mut self.0)
+    }
+
+    async fn finish(self) -> io::Result<Self::Output> {
+        Ok(self.0)
+    }
+}

--- a/dc/s2n-quic-dc/src/stream/client/rpc.rs
+++ b/dc/s2n-quic-dc/src/stream/client/rpc.rs
@@ -23,6 +23,8 @@ where
             writer.write_from_fin(&mut request).await?;
         }
 
+        writer.shutdown()?;
+
         Ok(())
     };
 

--- a/dc/s2n-quic-dc/src/stream/endpoint.rs
+++ b/dc/s2n-quic-dc/src/stream/endpoint.rs
@@ -176,7 +176,8 @@ where
     let source_queue_id = sockets.source_queue_id;
 
     // construct shared reader state
-    let reader = recv::shared::State::new(stream_id, &parameters, features, recv_buffer);
+    let reader =
+        recv::shared::State::new(stream_id, &parameters, features, recv_buffer, endpoint_type);
 
     let writer = {
         let worker = sockets

--- a/dc/s2n-quic-dc/src/stream/send/application/builder.rs
+++ b/dc/s2n-quic-dc/src/stream/send/application/builder.rs
@@ -35,7 +35,7 @@ where
             sockets,
             queue: Default::default(),
             pacer: Default::default(),
-            open: true,
+            status: Default::default(),
             runtime,
         }))
     }

--- a/dc/s2n-quic-dc/src/stream/shared/handshake.rs
+++ b/dc/s2n-quic-dc/src/stream/shared/handshake.rs
@@ -1,0 +1,91 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_quic_core::{endpoint, state::event};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum State {
+    /// The client is in the initial state
+    ///
+    /// In this state:
+    /// * The client has chosen a local queue_id and is actively transmitting that
+    ///   value in the `source_queue_id` field.
+    /// * The client is not aware of what the server (peer) has chosen for its `queue_id`.
+    ClientInit,
+
+    /// In this state:
+    /// * The client has seen at least one packet from the server. This means it is
+    ///   now aware of the server's chosen `queue_id`.
+    ///
+    /// At this point the client can:
+    /// * Update the destination `queue_id` to use for future transmissions.
+    /// * Stop transmitting its `source_queue_id` since the client was able to observe
+    ///   at least one packet from the server with the chosen client `queue_id` value.
+    ClientQueueIdObserved,
+
+    /// The server is in the initial state
+    ///
+    /// In this state:
+    /// * The server has received at least one packet from the client. That packet included
+    ///   the client's chosen `queue_id`.
+    /// * The server has also selected its own `queue_id` and is actively transmitting
+    ///   that value in the `source_queue_id` field.
+    /// * The peer (client) is not currently aware of our chosen `queue_id` value
+    ServerInit,
+
+    /// In this state:
+    /// * The server has received a `Stream` packet containing a non-zero value of
+    ///   `next_expected_control_packet`, indicating the client has observed at least
+    ///   one control packet has been received with the server's chosen `queue_id`.
+    /// * The server has received a valid `Control` packet from the client with the
+    ///   expected `queue_id`.
+    ServerQueueIdObserved,
+
+    /// All needed observations have been made and no further state updates are required.
+    Finished,
+}
+
+impl State {
+    event! {
+        /// Called when at least one valid stream packet is received
+        on_stream_packet(ClientInit => ClientQueueIdObserved);
+
+        /// Called when at least one valid control packet is received
+        on_control_packet(ClientInit => ClientQueueIdObserved, ServerInit => ServerQueueIdObserved);
+
+        /// Called when the `read` half receives a `Stream` packet containing a non-zero
+        /// `next_expected_control_packet` value.
+        on_non_zero_next_expected_control_packet(ServerInit => ServerQueueIdObserved);
+
+        /// Called when the observations have been recorded and the stream is in a steady state
+        on_observation_finished(ClientQueueIdObserved | ServerQueueIdObserved => Finished);
+    }
+}
+
+impl From<endpoint::Type> for State {
+    #[inline]
+    fn from(value: endpoint::Type) -> Self {
+        match value {
+            endpoint::Type::Client => Self::ClientInit,
+            endpoint::Type::Server => Self::ServerInit,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::{assert_debug_snapshot, assert_snapshot};
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn snapshots() {
+        assert_debug_snapshot!(State::test_transitions());
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn dot_test() {
+        assert_snapshot!(State::dot());
+    }
+}

--- a/dc/s2n-quic-dc/src/stream/shared/snapshots/s2n_quic_dc__stream__shared__handshake__tests__dot_test.snap
+++ b/dc/s2n-quic-dc/src/stream/shared/snapshots/s2n_quic_dc__stream__shared__handshake__tests__dot_test.snap
@@ -1,0 +1,18 @@
+---
+source: dc/s2n-quic-dc/src/stream/shared/handshake.rs
+expression: "State::dot()"
+---
+digraph {
+  label = "s2n_quic_dc::stream::shared::handshake::State";
+  ClientInit;
+  ClientQueueIdObserved;
+  Finished;
+  ServerInit;
+  ServerQueueIdObserved;
+  ClientInit -> ClientQueueIdObserved [label = "on_stream_packet"];
+  ClientInit -> ClientQueueIdObserved [label = "on_control_packet"];
+  ServerInit -> ServerQueueIdObserved [label = "on_control_packet"];
+  ServerInit -> ServerQueueIdObserved [label = "on_non_zero_next_expected_control_packet"];
+  ClientQueueIdObserved -> Finished [label = "on_observation_finished"];
+  ServerQueueIdObserved -> Finished [label = "on_observation_finished"];
+}

--- a/dc/s2n-quic-dc/src/stream/shared/snapshots/s2n_quic_dc__stream__shared__handshake__tests__snapshots.snap
+++ b/dc/s2n-quic-dc/src/stream/shared/snapshots/s2n_quic_dc__stream__shared__handshake__tests__snapshots.snap
@@ -1,0 +1,115 @@
+---
+source: dc/s2n-quic-dc/src/stream/shared/handshake.rs
+expression: "State::test_transitions()"
+---
+{
+    ClientInit: {
+        on_stream_packet: Ok(
+            ClientQueueIdObserved,
+        ),
+        on_control_packet: Ok(
+            ClientQueueIdObserved,
+        ),
+        on_non_zero_next_expected_control_packet: Err(
+            InvalidTransition {
+                current: ClientInit,
+                event: "on_non_zero_next_expected_control_packet",
+            },
+        ),
+        on_observation_finished: Err(
+            InvalidTransition {
+                current: ClientInit,
+                event: "on_observation_finished",
+            },
+        ),
+    },
+    ClientQueueIdObserved: {
+        on_stream_packet: Err(
+            NoOp {
+                current: ClientQueueIdObserved,
+            },
+        ),
+        on_control_packet: Err(
+            InvalidTransition {
+                current: ClientQueueIdObserved,
+                event: "on_control_packet",
+            },
+        ),
+        on_non_zero_next_expected_control_packet: Err(
+            InvalidTransition {
+                current: ClientQueueIdObserved,
+                event: "on_non_zero_next_expected_control_packet",
+            },
+        ),
+        on_observation_finished: Ok(
+            Finished,
+        ),
+    },
+    Finished: {
+        on_stream_packet: Err(
+            InvalidTransition {
+                current: Finished,
+                event: "on_stream_packet",
+            },
+        ),
+        on_control_packet: Err(
+            InvalidTransition {
+                current: Finished,
+                event: "on_control_packet",
+            },
+        ),
+        on_non_zero_next_expected_control_packet: Err(
+            InvalidTransition {
+                current: Finished,
+                event: "on_non_zero_next_expected_control_packet",
+            },
+        ),
+        on_observation_finished: Err(
+            NoOp {
+                current: Finished,
+            },
+        ),
+    },
+    ServerInit: {
+        on_stream_packet: Err(
+            InvalidTransition {
+                current: ServerInit,
+                event: "on_stream_packet",
+            },
+        ),
+        on_control_packet: Ok(
+            ServerQueueIdObserved,
+        ),
+        on_non_zero_next_expected_control_packet: Ok(
+            ServerQueueIdObserved,
+        ),
+        on_observation_finished: Err(
+            InvalidTransition {
+                current: ServerInit,
+                event: "on_observation_finished",
+            },
+        ),
+    },
+    ServerQueueIdObserved: {
+        on_stream_packet: Err(
+            InvalidTransition {
+                current: ServerQueueIdObserved,
+                event: "on_stream_packet",
+            },
+        ),
+        on_control_packet: Err(
+            InvalidTransition {
+                current: ServerQueueIdObserved,
+                event: "on_control_packet",
+            },
+        ),
+        on_non_zero_next_expected_control_packet: Err(
+            NoOp {
+                current: ServerQueueIdObserved,
+            },
+        ),
+        on_observation_finished: Ok(
+            Finished,
+        ),
+    },
+}

--- a/dc/s2n-quic-dc/src/stream/tests.rs
+++ b/dc/s2n-quic-dc/src/stream/tests.rs
@@ -5,3 +5,4 @@ mod accept_queue;
 mod deterministic;
 mod key_update;
 mod request_response;
+mod rpc;

--- a/dc/s2n-quic-dc/src/stream/tests/deterministic.rs
+++ b/dc/s2n-quic-dc/src/stream/tests/deterministic.rs
@@ -2,15 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    stream::{
-        client::rpc,
-        testing::{Client, Server},
-    },
-    testing::{ext::*, sim, spawn, without_tracing},
+    stream::testing::{Client, Server},
+    testing::{ext::*, sim, spawn},
 };
-use bolero::check;
-use bytes::BytesMut;
-use s2n_quic_core::stream::testing::Data;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[test]
@@ -47,83 +41,5 @@ fn request_response() {
         }
         .group("server")
         .spawn();
-    });
-}
-
-#[test]
-fn rpc_simple() {
-    sim(|| {
-        async move {
-            let client = Client::builder().build();
-            let response = rpc::InMemoryResponse::from(BytesMut::default());
-            let response = client
-                .rpc_sim("server:443", &b"hello!"[..], response)
-                .await
-                .unwrap();
-
-            assert_eq!(response, b"goodbye!"[..]);
-        }
-        .group("client")
-        .primary()
-        .spawn();
-
-        async move {
-            let server = Server::udp().port(443).build();
-
-            while let Ok((mut stream, _addr)) = server.accept().await {
-                spawn(async move {
-                    let mut request = vec![];
-                    stream.read_to_end(&mut request).await.unwrap();
-
-                    stream.write_from_fin(&mut &b"goodbye!"[..]).await.unwrap();
-                });
-            }
-        }
-        .group("server")
-        .spawn();
-    });
-}
-
-#[test]
-fn rpc_echo() {
-    without_tracing(|| {
-        check!().with_test_time(30.s()).run(|| {
-            sim(|| {
-                async move {
-                    let client = Client::builder().build();
-                    let data = Data::new((0..=512_000).any());
-                    let response = rpc::InMemoryResponse::from(data);
-                    let response = client.rpc_sim("server:443", data, response).await.unwrap();
-
-                    assert!(response.is_finished());
-                }
-                .group("client")
-                .primary()
-                .spawn();
-
-                async move {
-                    let server = Server::udp().port(443).build();
-
-                    while let Ok((mut stream, _addr)) = server.accept().await {
-                        async move {
-                            let mut buffer = vec![];
-                            // echo the response back
-                            loop {
-                                let len = stream.read_buf(&mut buffer).await.unwrap();
-                                if len == 0 {
-                                    break;
-                                }
-
-                                stream.write_all(&buffer[..len]).await.unwrap();
-                                buffer.clear();
-                            }
-                        }
-                        .spawn();
-                    }
-                }
-                .group("server")
-                .spawn();
-            })
-        })
     });
 }

--- a/dc/s2n-quic-dc/src/stream/tests/deterministic.rs
+++ b/dc/s2n-quic-dc/src/stream/tests/deterministic.rs
@@ -2,9 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    stream::testing::{Client, Server},
-    testing::{ext::*, sim, spawn},
+    stream::{
+        client::rpc,
+        testing::{Client, Server},
+    },
+    testing::{ext::*, sim, spawn, without_tracing},
 };
+use bolero::check;
+use bytes::BytesMut;
+use s2n_quic_core::stream::testing::Data;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
 #[test]
@@ -12,7 +18,7 @@ fn request_response() {
     sim(|| {
         async move {
             let client = Client::builder().build();
-            let mut stream = client.connect("server:443").await.unwrap();
+            let mut stream = client.connect_sim("server:443").await.unwrap();
 
             let request = vec![42; 100_000];
             stream.write_all(&request).await.unwrap();
@@ -41,5 +47,83 @@ fn request_response() {
         }
         .group("server")
         .spawn();
+    });
+}
+
+#[test]
+fn rpc_simple() {
+    sim(|| {
+        async move {
+            let client = Client::builder().build();
+            let response = rpc::InMemoryResponse::from(BytesMut::default());
+            let response = client
+                .rpc_sim("server:443", &b"hello!"[..], response)
+                .await
+                .unwrap();
+
+            assert_eq!(response, b"goodbye!"[..]);
+        }
+        .group("client")
+        .primary()
+        .spawn();
+
+        async move {
+            let server = Server::udp().port(443).build();
+
+            while let Ok((mut stream, _addr)) = server.accept().await {
+                spawn(async move {
+                    let mut request = vec![];
+                    stream.read_to_end(&mut request).await.unwrap();
+
+                    stream.write_from_fin(&mut &b"goodbye!"[..]).await.unwrap();
+                });
+            }
+        }
+        .group("server")
+        .spawn();
+    });
+}
+
+#[test]
+fn rpc_echo() {
+    without_tracing(|| {
+        check!().with_test_time(30.s()).run(|| {
+            sim(|| {
+                async move {
+                    let client = Client::builder().build();
+                    let data = Data::new((0..=512_000).any());
+                    let response = rpc::InMemoryResponse::from(data);
+                    let response = client.rpc_sim("server:443", data, response).await.unwrap();
+
+                    assert!(response.is_finished());
+                }
+                .group("client")
+                .primary()
+                .spawn();
+
+                async move {
+                    let server = Server::udp().port(443).build();
+
+                    while let Ok((mut stream, _addr)) = server.accept().await {
+                        async move {
+                            let mut buffer = vec![];
+                            // echo the response back
+                            loop {
+                                let len = stream.read_buf(&mut buffer).await.unwrap();
+                                if len == 0 {
+                                    break;
+                                }
+
+                                stream.write_all(&buffer[..len]).await.unwrap();
+                                buffer.clear();
+                            }
+                        }
+                        .spawn();
+                    }
+                }
+                .group("server")
+                .spawn();
+            })
+        })
     });
 }

--- a/dc/s2n-quic-dc/src/stream/tests/rpc.rs
+++ b/dc/s2n-quic-dc/src/stream/tests/rpc.rs
@@ -1,0 +1,159 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    stream::{
+        client::rpc,
+        testing::{Client, Server},
+    },
+    testing::{ext::*, sim, without_tracing},
+};
+use bolero::check;
+use bytes::BytesMut;
+use s2n_quic_core::stream::testing::Data;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tracing::{info_span, Instrument};
+
+fn hello_goodbye() {
+    async move {
+        let client = Client::builder().build();
+        let response = rpc::InMemoryResponse::from(BytesMut::default());
+        let response = client
+            .rpc_sim("server:443", &b"hello!"[..], response)
+            .await
+            .unwrap();
+
+        assert_eq!(response, b"goodbye!"[..]);
+    }
+    .group("client")
+    .instrument(info_span!("client"))
+    .primary()
+    .spawn();
+
+    async move {
+        let server = Server::udp().port(443).build();
+
+        while let Ok((mut stream, peer_addr)) = server.accept().await {
+            async move {
+                let mut request = vec![];
+                stream.read_to_end(&mut request).await.unwrap();
+
+                stream.write_from_fin(&mut &b"goodbye!"[..]).await.unwrap();
+            }
+            .instrument(info_span!("stream", ?peer_addr))
+            .primary()
+            .spawn();
+        }
+    }
+    .group("server")
+    .instrument(info_span!("server"))
+    .spawn();
+}
+
+#[test]
+fn simple() {
+    sim(hello_goodbye);
+}
+
+// TODO use this with bach >= 0.0.13
+#[cfg(todo)]
+#[test]
+fn no_loss() {
+    use core::sync::atomic::{AtomicUsize, Ordering};
+
+    static COUNT: AtomicUsize = AtomicUsize::new(0);
+
+    sim(|| {
+        hello_goodbye();
+
+        {
+            ::bach::net::monitor::on_socket_write(move |write| {
+                let count = COUNT.fetch_add(1, Ordering::Relaxed) + 1;
+                assert!(count <= 4, "flow should only consume 4 packets\n{write:#?}");
+                tracing::info!(?write, "on_socket_write");
+                Ok(())
+            });
+        }
+    });
+
+    assert_eq!(COUNT.load(Ordering::Relaxed), 4);
+}
+
+// TODO use this with bach >= 0.0.13
+// Also - this test is broken... need to fix the impl
+#[cfg(todo)]
+#[test]
+fn packet_loss() {
+    check!()
+        .exhaustive()
+        .with_generator(0usize..=4)
+        .cloned()
+        .for_each(|loss_idx| {
+            sim(|| {
+                hello_goodbye();
+
+                {
+                    let mut count = 0;
+                    ::bach::net::monitor::on_packet_sent(move |packet| {
+                        let idx = count;
+                        count += 1;
+
+                        assert!(
+                            count <= 5,
+                            "flow should only consume 5 packets\n{packet:#?}"
+                        );
+
+                        if loss_idx == idx {
+                            return ::bach::net::monitor::Command::Drop;
+                        }
+
+                        Default::default()
+                    });
+                }
+            });
+        });
+}
+
+#[test]
+fn echo_stream() {
+    without_tracing(|| {
+        check!().with_test_time(30.s()).run(|| {
+            sim(|| {
+                async move {
+                    let client = Client::builder().build();
+                    let data = Data::new((0..=512_000).any());
+                    let response = rpc::InMemoryResponse::from(data);
+                    let response = client.rpc_sim("server:443", data, response).await.unwrap();
+
+                    assert!(response.is_finished());
+                }
+                .group("client")
+                .primary()
+                .spawn();
+
+                async move {
+                    let server = Server::udp().port(443).build();
+
+                    while let Ok((mut stream, _addr)) = server.accept().await {
+                        async move {
+                            let mut buffer = vec![];
+                            // echo the response back
+                            loop {
+                                let len = stream.read_buf(&mut buffer).await.unwrap();
+                                if len == 0 {
+                                    break;
+                                }
+
+                                stream.write_all(&buffer[..len]).await.unwrap();
+                                buffer.clear();
+                            }
+                        }
+                        .spawn();
+                    }
+                }
+                .group("server")
+                .spawn();
+            })
+        })
+    });
+}


### PR DESCRIPTION
### Description of changes: 

This change adds a client RPC API for streams. 

```rust
let response = client.rpc(server_addr, request, response_collector).await?;
```


This is a lot more optimized that the standard stream interface due to:

* No need for an empty "prelude" packet since the request data is all provided up front
* The stream packets indicate the final stream size from the very first packet so the client doesn't need to send an empty "fin" packet.
* Ensuring the application doesn't deadlock where the client is sending a large request and getting a large response back. Consider the following example:
  ```rust
  // client
  stream.write_all(&large_payload).await.unwrap();
  ```

  ```rust
  // server
  let mut chunk = vec![];
  loop {
        let len = stream.read_buf(&mut chunk).await.unwrap();
        if len == 0 {
            break;
        }
        stream.write_all(&chunk[..len]).await.unwrap();
        chunk.clear();
  }
  ```
  
  Greater than some size of request, this will deadlock due to the client not reading the response and the server being blocked on flow control. This RPC API avoids this issue by polling both a read and write future concurrently.

In the future we can potentially optimize things more since we're operating at a higher level interface with a lot more knowledge of what the application is wanting to do.

### Call-outs:

I had to do a couple of refactors around stream states that were leading to unoptimal packet patterns. This is what the packet capture looked like before my changes:

![2025-03-27-180332_1241x202_scrot](https://github.com/user-attachments/assets/43e4cf5c-f55b-42de-9047-74cc16e77b8b)

And with these changes we went from 11 to 4:

![2025-03-27-180410_1130x84_scrot](https://github.com/user-attachments/assets/891d08fe-311a-427c-ab0f-54ebd518b37c)

In theory, we could probably get this down to 3 where the server sends both the stream and control packets in a single datagram but it's a bit complicated to do that since both stream halves operate mostly independent right now.

### Testing:

I added some tests showing everything working. I've also got a pending change in `bach` where you can monitor the network and make assertions about what packets are sent. I have a test showing that the total number of packets is 4. I also have a test that injects some loss and shows that things still work but that's currently failing when the first client packet is lost so I will follow up with a PR to fix that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

