### PR TITLE
chore: bump MSRV to 1.75

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ s2n-quic = "1"
 ```
 
 **NOTE**: On unix-like systems, [`s2n-tls`](https://github.com/aws/s2n-tls) will be used as the default TLS provider.
-On linux systems,  [`aws-lc-rs`](https://github.com/awslabs/aws-lc-rs) will be used for cryptographic
+On linux systems, [`aws-lc-rs`](https://github.com/awslabs/aws-lc-rs) will be used for cryptographic
 operations. A C compiler and CMake may be required on these systems for installation.
 
 ## Example
@@ -111,7 +111,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 `s2n-quic` will maintain a rolling MSRV (minimum supported rust version) policy of at least 6 months. The current s2n-quic version is not guaranteed to build on Rust versions earlier than the MSRV.
 
-The current MSRV is [1.71.0][msrv-url].
+The current MSRV is [1.75.0][msrv-url].
 
 ## Security issue notifications
 
@@ -134,5 +134,5 @@ This project is licensed under the [Apache-2.0 License][license-url].
 [docs-url]: https://docs.rs/s2n-quic
 [dependencies-badge]: https://img.shields.io/librariesio/release/cargo/s2n-quic.svg
 [dependencies-url]: https://crates.io/crates/s2n-quic/dependencies
-[msrv-badge]: https://img.shields.io/badge/MSRV-1.71.0-green
-[msrv-url]: https://blog.rust-lang.org/2023/07/13/Rust-1.71.0.html
+[msrv-badge]: https://img.shields.io/badge/MSRV-1.75.0-green
+[msrv-url]: https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html

--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.75"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.75"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.75"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.75"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-events/Cargo.toml
+++ b/quic/s2n-quic-events/Cargo.toml
@@ -4,7 +4,7 @@ name = "s2n-quic-events"
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.75"
 license = "Apache-2.0"
 # This is a commit-time crate and should not be published
 publish = false

--- a/quic/s2n-quic-h3/Cargo.toml
+++ b/quic/s2n-quic-h3/Cargo.toml
@@ -4,7 +4,7 @@ name = "s2n-quic-h3"
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.75"
 license = "Apache-2.0"
 # this contains an http3 implementation for testing purposes and should not be published
 publish = false

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.75"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -4,7 +4,7 @@ name = "s2n-quic-qns"
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.75"
 license = "Apache-2.0"
 publish = false
 

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.75"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-sim/Cargo.toml
+++ b/quic/s2n-quic-sim/Cargo.toml
@@ -6,7 +6,7 @@ description = "A simulation environment for s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.75"
 license = "Apache-2.0"
 publish = false
 

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.75"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.75"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.75"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -5,7 +5,7 @@ description = "A Rust implementation of the IETF QUIC protocol"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.75"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.74.1"
+channel = "1.75.0"
 components = [ "rustc", "clippy", "rustfmt" ]

--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.75"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]


### PR DESCRIPTION
### Release Summary:

This release bumps the MSRV to 1.75.

### Description of changes: 

I need to use [`-> impl Trait`](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html#async-fn-and-return-position-impl-trait-in-traits) in #2572 and thought now was a good time to bump MSRV to enable that. 1.75 is over a year old so it's probably overdue.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

