### PR TITLE
fix(s2n-quic-dc): convert stream segments to probes when available

### DIFF
--- a/dc/s2n-quic-dc/src/recovery.rs
+++ b/dc/s2n-quic-dc/src/recovery.rs
@@ -4,5 +4,11 @@
 pub use s2n_quic_core::recovery::RttEstimator;
 
 pub fn rtt_estimator() -> RttEstimator {
-    RttEstimator::new(core::time::Duration::from_millis(10))
+    // Set the initial RTT to 2ms so we send a probe after ~6ms
+    //
+    // TODO longer term, it might be a good idea to have the handshake map
+    // entry maintain a recent RTT, or at least use the value from the original
+    // handshake. This default value is going to be difficult to get right
+    // for every environment.
+    RttEstimator::new(core::time::Duration::from_millis(2))
 }

--- a/dc/s2n-quic-dc/src/stream/send/state/transmission.rs
+++ b/dc/s2n-quic-dc/src/stream/send/state/transmission.rs
@@ -65,8 +65,31 @@ impl<Retransmission> Info<Retransmission> {
         (start, end)
     }
 
+    /// Non-inclusive offset
     #[inline]
     pub fn end_offset(&self) -> VarInt {
         self.stream_offset + VarInt::from_u16(self.payload_len)
+    }
+}
+
+impl<Retransmission: Copy> Info<Retransmission> {
+    #[inline]
+    pub fn retransmit_copy(
+        &self,
+    ) -> Option<(
+        Retransmission,
+        super::retransmission::Segment<Retransmission>,
+    )> {
+        let segment = self.retransmission?;
+
+        let retransmission = super::retransmission::Segment {
+            segment,
+            stream_offset: self.stream_offset,
+            payload_len: self.payload_len,
+            ty: super::TransmissionType::Stream,
+            included_fin: self.included_fin,
+        };
+
+        Some((segment, retransmission))
     }
 }


### PR DESCRIPTION
### Description of changes: 

This change applies the following fixes:

* When PTOs are required, the sender first looks at any outstanding stream segments and tries to use those instead of sending probes. This greatly improves recovery time in simulations - 14 packets sent to 6 (bach doesn't put the lost packet in the PCAP - I should probably fix that).

  ##### Before

  <img width="1129" alt="Screenshot 2025-03-28 at 9 48 44 AM" src="https://github.com/user-attachments/assets/931139de-c64a-47cd-9393-ae41a0abbe22" />

  ##### After

  
  <img width="1145" alt="Screenshot 2025-03-28 at 9 46 12 AM" src="https://github.com/user-attachments/assets/872f284a-baa0-4b1a-96ec-cffdf0a31617" />

* We've reduced the initial RTT from 10ms to 2ms. This will cause packets that are lost on the initial round of transmissions to be retransmitted earlier. PTOs are armed for `3 * RTT` so it goes from 30ms to 6ms. Longer term I'd like to seed this value from the handshake instead.
* Uses the `requires_fast_retransmission` flag from the CCA to bypass the CWND check when retransmitting. Not sure how I missed that originally...

### Testing:

I've got the simulation tests asserting the number of allowed packets to be transmitted for each packet index being lost, though that test is still reliant on unreleased bach changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

