### PR TITLE
Some more tweaks for rehandshake queue

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map/rehandshake.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/rehandshake.rs
@@ -1,9 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use rand::seq::SliceRandom;
 use s2n_quic_core::inet::{SocketAddress, SocketAddressV6};
 use std::{
+    collections::hash_map::RandomState,
+    hash::BuildHasher,
     net::SocketAddr,
     time::{Duration, Instant},
 };
@@ -15,6 +16,8 @@ pub(super) struct RehandshakeState {
 
     // Duplicated in map State for lock-free access too.
     rehandshake_period: Duration,
+
+    hasher: RandomState,
 }
 
 impl RehandshakeState {
@@ -24,6 +27,10 @@ impl RehandshakeState {
             handshake_at: Default::default(),
             schedule_handshake_at: Instant::now(),
             rehandshake_period,
+
+            // Initializes the hasher with random keys, ensuring we handshake with peers in a
+            // different, random order from different hosts.
+            hasher: RandomState::new(),
         }
     }
 
@@ -36,16 +43,12 @@ impl RehandshakeState {
     }
 
     pub(super) fn adjust_post_refill(&mut self) {
-        self.queue.sort_unstable();
+        // Sort by hash, and if hashes are the same, by the SocketAddr. We need to include both in
+        // the comparison key to ensure that we find duplicate entries correctly (just by hash
+        // might have different addresses interleave).
+        self.queue
+            .sort_unstable_by_key(|peer| (self.hasher.hash_one(peer), *peer));
         self.queue.dedup();
-
-        // Shuffling each time we pull a new queue means that we have p100 re-handshake time
-        // double the expected handshake period, because the entry handshaked at p0 on the
-        // first pass might end up at p100 on the second pass. We're OK with that tradeoff --
-        // the randomization avoids thundering herds against the same host, and while we could
-        // remember an order it's harder to get diffing that order with new entries right.
-        let mut rng = rand::rng();
-        self.queue.shuffle(&mut rng);
     }
 
     pub(super) fn reserve(&mut self, capacity: usize) {


### PR DESCRIPTION
### Release Summary:

* refactor(s2n-quic-dc): shrink rehandshake queue memory footprint
* fix(s2n-quic-dc): avoid new handshake queue order on every refill

### Resolved issues:

n/a

### Description of changes: 

* This cuts ~6.67MB from our reserved capacity. It's still larger than we could have if we stored IPv4 addresses packed together, but I think the new overhead is sufficient to remove the FIXME, we're ~3x worse than optimal for IPv4-only workloads now. On Linux most of the backing memory doesn't get allocated anyway.
* Handshake queue ordering is now based on a hash, not full randomness. This ensures the same peer hashes into the same slot over time, while nicely absorbing changes in the peer set. The hasher is randomly seeded.

### Call-outs:

n/a

### Testing:

Just CI for the SocketAddr changes, the handshake queue reordering change is tested in our internal test bed and produces stable results (see commit message for details).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

