### PR TITLE
fix(s2n-quic-dc): export local addr regardless of reuse_port config

### DIFF
--- a/dc/s2n-quic-dc/src/stream/environment/bach.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/bach.rs
@@ -156,7 +156,7 @@ where
 
     #[inline]
     pub fn pool_addr(&self) -> Option<SocketAddr> {
-        self.recv_pool.as_ref().and_then(|v| v.local_addr())
+        self.recv_pool.as_ref().map(|v| v.local_addr())
     }
 }
 

--- a/dc/s2n-quic-dc/src/stream/environment/bach/pool.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/bach/pool.rs
@@ -28,8 +28,7 @@ pub(super) struct Pool {
     sockets: Box<[Socket]>,
     current: AtomicUsize,
     mask: usize,
-    /// The local address if `reuse_port` was enabled
-    local_addr: Option<SocketAddr>,
+    local_addr: SocketAddr,
 }
 
 struct Socket {
@@ -132,7 +131,7 @@ impl Pool {
             sockets: sockets.into(),
             current: AtomicUsize::new(0),
             mask,
-            local_addr: Some(local_addr),
+            local_addr,
         })
     }
 
@@ -150,7 +149,7 @@ impl Pool {
         (control, stream, app_socket, worker_socket)
     }
 
-    pub fn local_addr(&self) -> Option<SocketAddr> {
+    pub fn local_addr(&self) -> SocketAddr {
         self.local_addr
     }
 

--- a/dc/s2n-quic-dc/src/stream/environment/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/tokio.rs
@@ -194,7 +194,7 @@ where
 
     #[inline]
     pub fn pool_addr(&self) -> Option<SocketAddr> {
-        self.recv_pool.as_ref().and_then(|v| v.local_addr())
+        self.recv_pool.as_ref().map(|v| v.local_addr())
     }
 }
 


### PR DESCRIPTION
### Description of changes: 

This allows the caller to know what address was selected for the socket pool in the case that a wild card was specified.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

