### PR TITLE
fix(s2n-quic-dc): fix retransmission cloning

### DIFF
--- a/dc/s2n-quic-dc/src/stream/send/tests.rs
+++ b/dc/s2n-quic-dc/src/stream/send/tests.rs
@@ -320,7 +320,6 @@ mod tcp {
     negative_suite!();
 }
 
-#[cfg(target_os = "linux")] // things are only working on linux right now
 mod udp {
     use super::*;
     const PROTOCOL: Protocol = Protocol::Udp;


### PR DESCRIPTION
### Description of changes: 

In testing I found a bug with the change in #2575 that didn't consider if one of the segments was already in the retransmit queue and ended up mutating the segment in place, which cause the last packet to override the previous value and get transmitted multiple times. This change moves the owned `Segment` into the transmission queue, which ensures the reference count is `>1`, which ensures `Arc::make_mut` does a deep clone rather than a shallow one.

### Testing:

This behavior was causing macOS send tests to fail. I've uncommented those and they now pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

