### PR TITLE
ci: Disable Github actions cache

### DIFF
--- a/.github/actions/duvet/action.yml
+++ b/.github/actions/duvet/action.yml
@@ -46,6 +46,7 @@ runs:
       with:
         crate: duvet
         version: ${{ inputs.duvet-version }}
+        use-cache: false
 
     - name: Generate Duvet report
       shell: bash

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -10,6 +10,7 @@ name: book
 
 env:
   CDN: https://dnglbrstg7yg.cloudfront.net
+  USE_CACHE: false
 
 # By default depandabot only receives read permissions. Explicitly give it write
 # permissions which is needed by the ouzi-dev/commit-status-updater task.
@@ -36,6 +37,7 @@ jobs:
       - uses: camshaft/install@v1
         with:
           crate: mdbook
+          use-cache: ${{env.USE_CACHE}}
 
       - name: Build book
         run: ./scripts/book

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ env:
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100
   S2N_UNSTABLE_CRYPTO_OPT_RX: 100
+  USE_CACHE: false
 
 # By default depandabot only receives read permissions. Explicitly give it write
 # permissions which is needed by the ouzi-dev/commit-status-updater task.
@@ -141,6 +142,7 @@ jobs:
       - uses: camshaft/install@v1
         with:
           crate: cargo-udeps
+          use-cache: ${{ env.USE_CACHE }}
 
       - name: Run cargo udeps
         run: cargo udeps --workspace --all-targets
@@ -254,6 +256,7 @@ jobs:
         uses: camshaft/install@v1
         with:
           crate: cross
+          use-cache: ${{ env.USE_CACHE }}
 
       - uses: camshaft/rust-cache@v1
         with:
@@ -660,6 +663,7 @@ jobs:
         uses: camshaft/install@v1
         with:
           crate: cargo-insta
+          use-cache: ${{ env.USE_CACHE }}
 
       - uses: camshaft/rust-cache@v1
 
@@ -732,6 +736,7 @@ jobs:
         with:
           crate: typos-cli
           bins: typos
+          use-cache: ${{ env.USE_CACHE }}
 
       - name: Run typos
         run: |
@@ -853,6 +858,7 @@ jobs:
       - uses: camshaft/install@v1
         with:
           crate: bpf-linker
+          use-cache: ${{ env.USE_CACHE }}
 
       - uses: camshaft/rust-cache@v1
 
@@ -887,6 +893,7 @@ jobs:
         with:
           crate: bindgen-cli
           bins: bindgen
+          use-cache: ${{ env.USE_CACHE }}
 
       - uses: camshaft/rust-cache@v1
 

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -22,6 +22,7 @@ env:
   WIRESHARK_VERSION: 4.4.2
   CDN: https://dnglbrstg7yg.cloudfront.net
   LOG_URL: logs/latest/SERVER_CLIENT/TEST/index.html
+  USE_CACHE: false
 
 # By default depandabot only receives read permissions. Explicitly give it write
 # permissions which is needed by the ouzi-dev/commit-status-updater task.
@@ -393,11 +394,13 @@ jobs:
         with:
           crate: inferno
           bins: inferno-collapse-perf,inferno-flamegraph
+          use-cache: ${{ env.USE_CACHE }}
 
       - name: Install ultraman
         uses: camshaft/install@v1
         with:
           crate: ultraman
+          use-cache: ${{ env.USE_CACHE }}
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
### Description of changes: 

Requests to the Github actions cache recently started returning 422. In order to unblock the CI, this PR disables cacheing in `camshaft/install@v1` until we figure out what the issue is.

### Testing:

The CI should now succeed in this PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

