### PR TITLE
ci: Fix hanging miri job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -339,9 +339,8 @@ jobs:
           cargo test --no-default-features --features "provider-tls-fips provider-tls-s2n"
 
   miri:
-    # miri needs quite a bit of memory so use a larger instance
     runs-on:
-      labels: s2n_ubuntu-20.04_8-core
+      labels: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
### Description of changes: 

The miri CI job started hanging on PRs. For example, the following job has been stuck on "Waiting for a runner to pick up this job..." for 3 hours as of this comment:
https://github.com/aws/s2n-quic/actions/runs/14202747209/job/39793296240

I think it's getting stuck because the Ubuntu 20.04 image is being deprecated: https://github.com/actions/runner-images/issues/11101.

To unblock the CI, this PR changes the miri image to `ubuntu-latest` instead. I opened an issue to investigate whether we should look into adding another custom image with increased memory for this job: https://github.com/aws/s2n-quic/issues/2585.

### Testing:

The miri CI job should succeed on this PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

