### PR TITLE
fix(s2n-quic-core): optimize Bytes read on full read

### DIFF
--- a/quic/s2n-quic-core/src/buffer/reader/storage/bytes.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/storage/bytes.rs
@@ -47,7 +47,9 @@ impl Storage for BytesMut {
     {
         let watermark = self.len().min(dest.remaining_capacity());
 
-        if Dest::SPECIALIZES_BYTES_MUT {
+        let consumes_self = watermark == self.len();
+
+        if Dest::SPECIALIZES_BYTES_MUT || consumes_self {
             let Chunk::BytesMut(chunk) = self.infallible_read_chunk(watermark) else {
                 unsafe { assume!(false) }
             };
@@ -97,7 +99,9 @@ impl Storage for Bytes {
     {
         let watermark = self.len().min(dest.remaining_capacity());
 
-        if Dest::SPECIALIZES_BYTES {
+        let consumes_self = watermark == self.len();
+
+        if Dest::SPECIALIZES_BYTES || consumes_self {
             let Chunk::Bytes(chunk) = self.infallible_read_chunk(watermark) else {
                 unsafe { assume!(false) }
             };


### PR DESCRIPTION
### Description of changes: 

This change optimizes a read to a Bytes/BytesMut when the watermark consumes the entire chunk. In this case, it doesn't matter if the caller optimizes on bytes or not - it's better to replace `self` and return the chunk to potentially avoid copies.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

