### PR TITLE
Avoid copy for unique Bytes in put_bytes

### DIFF
--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -31,7 +31,7 @@ usdt = ["dep:probe"]
 atomic-waker = { version = "1", optional = true }
 bolero-generator = { version = "0.13", default-features = false, optional = true }
 byteorder = { version = "1", default-features = false }
-bytes = { version = "1", optional = true, default-features = false }
+bytes = { version = "1.7.2", optional = true, default-features = false }
 crossbeam-utils = { version = "0.8", optional = true }
 cfg-if = "1"
 hex-literal = "0.4"

--- a/quic/s2n-quic-core/src/buffer/writer/storage/byte_queue.rs
+++ b/quic/s2n-quic-core/src/buffer/writer/storage/byte_queue.rs
@@ -58,8 +58,8 @@ macro_rules! impl_queue {
 
             #[inline]
             fn put_bytes(&mut self, bytes: Bytes) {
-                // we can't convert Bytes into BytesMut so we'll need to copy it
-                self.put_slice(&bytes);
+                // This is a zero-copy conversion if we're unique.
+                self.$push(BytesMut::from(bytes));
             }
 
             #[inline]


### PR DESCRIPTION
### Release Summary:

This change optimizes a read to a BytesMut queue when the Bytes we're pushing is uniquely owned, and so we can zero-copy convert to a BytesMut.

### Resolved issues:

n/a

### Description of changes: 

n/a

### Call-outs:

This upgrades to bytes 1.7.2 as the minimum, I don't see anything concerning in the [changelog](https://github.com/tokio-rs/bytes/blob/master/CHANGELOG.md) or any explicit pinning (not sure why I had 1.6 in my local lockfile).

### Testing:

Existing tests should cover this, no change in behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

