### PR TITLE
ci: Fix cargo-udeps install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,10 +139,12 @@ jobs:
 
       - uses: camshaft/rust-cache@v1
 
-      - uses: camshaft/install@v1
-        with:
-          crate: cargo-udeps
-          use-cache: ${{ env.USE_CACHE }}
+      # Ideally this would use the camshaft/install action to install cargo-udeps. However,
+      # the --locked flag can't currently be provided to camshaft/install. After support for this
+      # is added, camshaft/install should be used here instead:
+      # https://github.com/aws/s2n-quic/issues/2593
+      - name: Install cargo-udeps
+        run: cargo install cargo-udeps --locked
 
       - name: Run cargo udeps
         run: cargo udeps --workspace --all-targets


### PR DESCRIPTION
### Description of changes: 

`cargo-udeps` started [failing to install in the CI](https://github.com/aws/s2n-quic/actions/runs/14253308918/job/39950917819?pr=2574#step:5:359):
```
  error: failed to compile `cargo-udeps v0.1.55`, intermediate artifacts can be found at `/tmp/cargo-install6NLKp2`.
  To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
  
  Caused by:
    rustc 1.83.0-nightly is not supported by the following packages:
      cargo-credential-libsecret@0.4.12 requires rustc 1.84
      cargo-util@0.2.19 requires rustc 1.84
      cargo-util-schemas@0.7.3 requires rustc 1.84
      crates-io@0.40.9 requires rustc 1.84
    Try re-running `cargo install` with `--locked`
```

It seems some cargo-udeps dependencies started requiring a minimum of Rust 1.84. However, bumping the nightly Rust version used in the CI caused a bunch of random compilation failures in cargo-udeps dependencies. For example:
```
error[E0277]: `std::option::Option<PackageName>` doesn't implement `std::fmt::Display`
   --> /Users/vclarksa/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/cargo-0.86.0/src/cargo/util/toml/targets.rs:120:13
    |
120 |             package.name
    |             ^^^^^^^^^^^^ `std::option::Option<PackageName>` cannot be formatted with the default formatter
```

This PR updates the cargo-udeps install step to specify the `--locked` flag, which tells cargo install to use the Cargo.lock file included in cargo-udeps. This is [recommended on the cargo-udeps crate readme](https://crates.io/crates/cargo-udeps).

### Call-outs:

Unfortunately, this change means the `camshaft/install` action can't be used to cache this package, since this action doesn't support specifying cargo install flags. I opened an issue to add support for this so we can start cacheing cargo-udeps again: https://github.com/aws/s2n-quic/issues/2593

### Testing:

The `udeps` CI job should succeed on this PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

