### PR TITLE
fix: comment for rebind_before_handshake_confirmed

### DIFF
--- a/quic/s2n-quic/src/tests/connection_migration.rs
+++ b/quic/s2n-quic/src/tests/connection_migration.rs
@@ -249,8 +249,8 @@ impl Interceptor for RebindPortBeforeHandshakeConfirmed {
     }
 }
 
-/// Ensures that a datagram received from a client that changes
-/// its port before the handshake is confirmed is dropped.
+/// Ensures that a datagram is not dropped when received from a client
+/// that changes its port before the handshake is confirmed
 #[test]
 fn rebind_before_handshake_confirmed() {
     let model = Model::default();


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

Fix the wordings for the comment describing the purpose of `rebind_before_handshake_confirmed` test. The datagram should not be dropped when it is received from a client that changes its port.

### Call-outs:


### Testing:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

