### PR TITLE
ci: Re-enable Github actions `install` cacheing

### DIFF
--- a/.github/actions/duvet/action.yml
+++ b/.github/actions/duvet/action.yml
@@ -46,7 +46,6 @@ runs:
       with:
         crate: duvet
         version: ${{ inputs.duvet-version }}
-        use-cache: false
 
     - name: Generate Duvet report
       shell: bash

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -10,7 +10,6 @@ name: book
 
 env:
   CDN: https://dnglbrstg7yg.cloudfront.net
-  USE_CACHE: false
 
 # By default depandabot only receives read permissions. Explicitly give it write
 # permissions which is needed by the ouzi-dev/commit-status-updater task.
@@ -37,7 +36,6 @@ jobs:
       - uses: camshaft/install@v1
         with:
           crate: mdbook
-          use-cache: ${{env.USE_CACHE}}
 
       - name: Build book
         run: ./scripts/book

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ env:
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100
   S2N_UNSTABLE_CRYPTO_OPT_RX: 100
-  USE_CACHE: false
 
 # By default depandabot only receives read permissions. Explicitly give it write
 # permissions which is needed by the ouzi-dev/commit-status-updater task.
@@ -258,7 +257,6 @@ jobs:
         uses: camshaft/install@v1
         with:
           crate: cross
-          use-cache: ${{ env.USE_CACHE }}
 
       - uses: camshaft/rust-cache@v1
         with:
@@ -664,7 +662,6 @@ jobs:
         uses: camshaft/install@v1
         with:
           crate: cargo-insta
-          use-cache: ${{ env.USE_CACHE }}
 
       - uses: camshaft/rust-cache@v1
 
@@ -737,7 +734,6 @@ jobs:
         with:
           crate: typos-cli
           bins: typos
-          use-cache: ${{ env.USE_CACHE }}
 
       - name: Run typos
         run: |
@@ -859,7 +855,6 @@ jobs:
       - uses: camshaft/install@v1
         with:
           crate: bpf-linker
-          use-cache: ${{ env.USE_CACHE }}
 
       - uses: camshaft/rust-cache@v1
 
@@ -894,7 +889,6 @@ jobs:
         with:
           crate: bindgen-cli
           bins: bindgen
-          use-cache: ${{ env.USE_CACHE }}
 
       - uses: camshaft/rust-cache@v1
 

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -22,7 +22,6 @@ env:
   WIRESHARK_VERSION: 4.4.2
   CDN: https://dnglbrstg7yg.cloudfront.net
   LOG_URL: logs/latest/SERVER_CLIENT/TEST/index.html
-  USE_CACHE: false
 
 # By default depandabot only receives read permissions. Explicitly give it write
 # permissions which is needed by the ouzi-dev/commit-status-updater task.
@@ -394,13 +393,11 @@ jobs:
         with:
           crate: inferno
           bins: inferno-collapse-perf,inferno-flamegraph
-          use-cache: ${{ env.USE_CACHE }}
 
       - name: Install ultraman
         uses: camshaft/install@v1
         with:
           crate: ultraman
-          use-cache: ${{ env.USE_CACHE }}
 
       - uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
### Resolved issues:

Resolves https://github.com/aws/s2n-quic/issues/2583

### Description of changes: 

Cacheing was disabled in https://github.com/aws/s2n-quic/pull/2582 to workaround Github's [April 1st cacheing service deprecation brownout date](https://github.blog/changelog/2025-03-20-notification-of-upcoming-breaking-changes-in-github-actions/#decommissioned-cache-service-brownouts). Now that the `camshaft/install` action [has been updated to use the new cacheing service](https://github.com/camshaft/install/pull/1), this action should not be affected by the depreciation of the old cacheing service anymore. So, this PR re-enables `camshaft/install` cacheing in s2n-quic.

### Testing:

The CI jobs using `camshaft/install` should continue to succeed for this PR. I ran the jobs twice to ensure that the `install` action successfully retrieved from the cache on the second run:
- [first run](https://github.com/aws/s2n-quic/actions/runs/14317370737/job/40126498397?pr=2595#step:4:184): ```Caching `cargo-insta` with key cargo-insta-1.42.2-1.86.0-x86_64-unknown-linux-gnu-05f9846f893b```
- [second run](https://github.com/aws/s2n-quic/actions/runs/14317370737/job/40128090161?pr=2595#step:4:21): `Cache restored successfully`

The change to `camshaft/install` to use the proper cacheing APIs can be tested by making sure these jobs continue to succeed on the next Github brownout date, 4/8/25.

I confirmed all instances of `use-cache` were removed:
```
❯ pwd
/Users/vclarksa/w/s2n-quic-fork/.github
❯ grep -rni "use-cache" *


```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

