### PR TITLE
chore: fix comment in buffer_limit_test

### DIFF
--- a/quic/s2n-quic/src/tests/buffer_limit.rs
+++ b/quic/s2n-quic/src/tests/buffer_limit.rs
@@ -11,7 +11,7 @@ use s2n_quic_core::{crypto::tls::Error as TlsError, transport};
 // It helps to expand the Client Hello size to excced 64 KB, by filling
 // the alpn extension in Client Hello with 65310 bytes.
 static FAKE_PROTOCOL_COUNT: u16 = 4665;
-// Maximum handshake message size is 64KB in S2N-TLS.
+// Maximum handshake message size is 64KB in S2N-TLS and Rustls.
 static MAXIMUM_HANDSHAKE_MESSAGE_SIZE: usize = 65536;
 
 //= https://www.rfc-editor.org/rfc/rfc9000#section-4


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

Related to https://github.com/aws/s2n-quic/issues/332

### Description of changes: 

Rustls' limit for each handshake message's size is also 64KB. The `buffer_limit_test` will also use Rustls in CI. The comment should mention Rustls as well. This is missed in https://github.com/aws/s2n-quic/pull/2596.

### Call-outs:

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

