### PR TITLE
doc: automatically update CI artifacts

### DIFF
--- a/.github/actions/duvet/action.yml
+++ b/.github/actions/duvet/action.yml
@@ -75,7 +75,7 @@ runs:
         # Only upload to latest if the event is push to main
         if [ "${{ github.event_name }}" == "push" ]; then
           TARGET_LATEST="latest/compliance.html"
-          aws s3 cp "$REPORT_PATH" "s3://${{ inputs.aws-s3-bucket-name }}/$TARGET_LATEST" --acl private --follow-symlinks
+          aws s3 cp "s3://${{ inputs.aws-s3-bucket-name }}/$TARGET_SHA" "s3://${{ inputs.aws-s3-bucket-name }}/$TARGET_LATEST"
         fi
 
         if [ -n "${{ inputs.cdn }}" ]; then

--- a/.github/actions/duvet/action.yml
+++ b/.github/actions/duvet/action.yml
@@ -70,9 +70,13 @@ runs:
         fi
 
         TARGET_SHA="${{ github.sha }}/compliance.html"
-        TARGET_LATEST="latest/compliance.html"
         aws s3 cp "$REPORT_PATH" "s3://${{ inputs.aws-s3-bucket-name }}/$TARGET_SHA" --acl private --follow-symlinks
-        aws s3 cp "$REPORT_PATH" "s3://${{ inputs.aws-s3-bucket-name }}/$TARGET_LATEST" --acl private --follow-symlinks
+
+        # Only load to latest if the event is push to main
+        if [ "${{ github.event_name }}" == "push" ]; then
+          TARGET_LATEST="latest/compliance.html"
+          aws s3 cp "$REPORT_PATH" "s3://${{ inputs.aws-s3-bucket-name }}/$TARGET_LATEST" --acl private --follow-symlinks
+        fi
 
         if [ -n "${{ inputs.cdn }}" ]; then
           PREFIX="${{ inputs.cdn }}"

--- a/.github/actions/duvet/action.yml
+++ b/.github/actions/duvet/action.yml
@@ -69,15 +69,17 @@ runs:
           REPORT_PATH=$(dirname "${{ inputs.report-script }}")/report.html
         fi
 
-        TARGET="${{ github.sha }}/compliance.html"
-        aws s3 cp "$REPORT_PATH" "s3://${{ inputs.aws-s3-bucket-name }}/$TARGET" --acl private --follow-symlinks
+        TARGET_SHA="${{ github.sha }}/compliance.html"
+        TARGET_LATEST="latest/compliance.html"
+        aws s3 cp "$REPORT_PATH" "s3://${{ inputs.aws-s3-bucket-name }}/$TARGET_SHA" --acl private --follow-symlinks
+        aws s3 cp "$REPORT_PATH" "s3://${{ inputs.aws-s3-bucket-name }}/$TARGET_LATEST" --acl private --follow-symlinks
 
         if [ -n "${{ inputs.cdn }}" ]; then
           PREFIX="${{ inputs.cdn }}"
         else
           PREFIX="https://${{ inputs.aws-s3-bucket-name }}.s3.amazonaws.com"
         fi
-        URL="$PREFIX/$TARGET"
+        URL="$PREFIX/$TARGET_SHA"
 
         echo "::set-output name=URL::$URL"
 

--- a/.github/actions/duvet/action.yml
+++ b/.github/actions/duvet/action.yml
@@ -72,7 +72,7 @@ runs:
         TARGET_SHA="${{ github.sha }}/compliance.html"
         aws s3 cp "$REPORT_PATH" "s3://${{ inputs.aws-s3-bucket-name }}/$TARGET_SHA" --acl private --follow-symlinks
 
-        # Only load to latest if the event is push to main
+        # Only upload to latest if the event is push to main
         if [ "${{ github.event_name }}" == "push" ]; then
           TARGET_LATEST="latest/compliance.html"
           aws s3 cp "$REPORT_PATH" "s3://${{ inputs.aws-s3-bucket-name }}/$TARGET_LATEST" --acl private --follow-symlinks

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
       - main
-      - automate-latest
+      - boquan-fang/automate-doc
 
 name: book
 

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     branches:
       - main
-      - boquan-fang/automate-doc
 
 name: book
 

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -10,6 +10,7 @@ name: book
 
 env:
   CDN: https://dnglbrstg7yg.cloudfront.net
+  CI_ARTIFACTS_BUCKET: s2n-quic-ci-artifacts
 
 # By default depandabot only receives read permissions. Explicitly give it write
 # permissions which is needed by the ouzi-dev/commit-status-updater task.
@@ -58,14 +59,14 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/book"
-          aws s3 sync target/book "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync target/book "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
           # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/book"
-            aws s3 sync target/book "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+            aws s3 cp "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_LATEST" --recursive
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -62,7 +62,7 @@ jobs:
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
-          # Only load to latest if the event is push to main
+          # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/book"
             aws s3 sync target/book "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - automate-latest
 
 name: book
 
@@ -57,9 +58,11 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
-          TARGET="${{ github.sha }}/book"
-          aws s3 sync target/book "s3://s2n-quic-ci-artifacts/$TARGET" --acl private --follow-symlinks
-          URL="$CDN/$TARGET/index.html"
+          TARGET_SHA="${{ github.sha }}/book"
+          TARGET_LATEST="latest/book"
+          aws s3 sync target/book "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync target/book "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -58,11 +58,15 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/book"
-          TARGET_LATEST="latest/book"
           aws s3 sync target/book "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
-          aws s3 sync target/book "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
+
+          # Only load to latest if the event is push to main
+          if [ "${{ github.event_name }}" == "push" ]; then
+            TARGET_LATEST="latest/book"
+            aws s3 sync target/book "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
       - main
-      - automate-latest
+      - boquan-fang/automate-doc
 
 name: ci
 
@@ -183,9 +183,9 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/doc"
-          TARGET_LATEST="${{ github.sha }}/doc"
+          TARGET_LATEST="latest/doc"
           aws s3 sync target/doc "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
-          aws s3 sync target/doc "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync target/doc "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/s2n_quic/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
@@ -559,7 +559,7 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/recovery-simulations"
-          TARGET_LATESET="latest/recovery-simulations"
+          TARGET_LATEST="latest/recovery-simulations"
           aws s3 sync target/recovery-sim "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
           aws s3 sync target/recovery-sim "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/index.html"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ env:
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100
   S2N_UNSTABLE_CRYPTO_OPT_RX: 100
+  CI_ARTIFACTS_BUCKET: s2n-quic-ci-artifacts
 
 # By default depandabot only receives read permissions. Explicitly give it write
 # permissions which is needed by the ouzi-dev/commit-status-updater task.
@@ -182,14 +183,14 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/doc"
-          aws s3 sync target/doc "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync target/doc "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/s2n_quic/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
           # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/doc"
-            aws s3 sync target/doc "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+            aws s3 cp "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_LATEST" --recursive
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
@@ -407,7 +408,7 @@ jobs:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-s3-region: us-west-2
-          aws-s3-bucket-name: s2n-quic-ci-artifacts
+          aws-s3-bucket-name: ${{ env.CI_ARTIFACTS_BUCKET }}
           cdn: $CDN
 
   coverage:
@@ -448,14 +449,14 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/coverage"
-          aws s3 sync target/llvm-cov/html "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync target/llvm-cov/html "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
           # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/coverage"
-            aws s3 sync target/llvm-cov/html "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+            aws s3 cp "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_LATEST" --recursive
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
@@ -566,14 +567,14 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/recovery-simulations"
-          aws s3 sync target/recovery-sim "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync target/recovery-sim "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
           # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/recovery-simulations"
-            aws s3 sync target/recovery-sim "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+            aws s3 cp "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_LATEST" --recursive
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
@@ -617,14 +618,14 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/sim"
-          aws s3 sync target/s2n-quic-sim "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync target/s2n-quic-sim "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
           # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/sim"
-            aws s3 sync target/s2n-quic-sim "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+            aws s3 cp "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_LATEST" --recursive
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
@@ -730,14 +731,14 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/timing/index.html"
-          aws s3 cp examples/echo/target/cargo-timings/cargo-timing.html "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 cp examples/echo/target/cargo-timings/cargo-timing.html "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
           # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/timing/index.html"
-            aws s3 cp examples/echo/target/cargo-timings/cargo-timing.html "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+            aws s3 cp "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_LATEST"
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
@@ -832,14 +833,14 @@ jobs:
         working-directory: tools/memory-report
         run: |
           TARGET_SHA="${{ github.sha }}/dhat"
-          aws s3 sync target/report "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync target/report "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" --acl private --follow-symlinks
           URL="$CDN/dhat/dh_view.html?url=/$TARGET_SHA/dhat-heap.json"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
           # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/dhat"
-            aws s3 sync target/report "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+            aws s3 cp "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_LATEST" --recursive
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,7 +186,7 @@ jobs:
           URL="$CDN/$TARGET_SHA/s2n_quic/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
-          # Only load to latest if the event is push to main
+          # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/doc"
             aws s3 sync target/doc "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
@@ -452,7 +452,7 @@ jobs:
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
-          # Only load to latest if the event is push to main
+          # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/coverage"
             aws s3 sync target/llvm-cov/html "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
@@ -570,7 +570,7 @@ jobs:
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
-          # Only load to latest if the event is push to main
+          # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/recovery-simulations"
             aws s3 sync target/recovery-sim "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
@@ -621,7 +621,7 @@ jobs:
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
-          # Only load to latest if the event is push to main
+          # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/sim"
             aws s3 sync target/s2n-quic-sim "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
@@ -734,7 +734,7 @@ jobs:
           URL="$CDN/$TARGET_SHA"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
-          # Only load to latest if the event is push to main
+          # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/timing/index.html"
             aws s3 cp examples/echo/target/cargo-timings/cargo-timing.html "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
@@ -836,7 +836,7 @@ jobs:
           URL="$CDN/dhat/dh_view.html?url=/$TARGET_SHA/dhat-heap.json"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
-          # Only load to latest if the event is push to main
+          # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/dhat"
             aws s3 sync target/report "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,11 +182,15 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/doc"
-          TARGET_LATEST="latest/doc"
           aws s3 sync target/doc "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
-          aws s3 sync target/doc "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/s2n_quic/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
+
+          # Only load to latest if the event is push to main
+          if [ "${{ github.event_name }}" == "push" ]; then
+            TARGET_LATEST="latest/doc"
+            aws s3 sync target/doc "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -444,11 +448,15 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/coverage"
-          TARGET_LATEST="latest/coverage"
           aws s3 sync target/llvm-cov/html "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
-          aws s3 sync target/llvm-cov/html "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
+
+          # Only load to latest if the event is push to main
+          if [ "${{ github.event_name }}" == "push" ]; then
+            TARGET_LATEST="latest/coverage"
+            aws s3 sync target/llvm-cov/html "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -558,11 +566,15 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/recovery-simulations"
-          TARGET_LATEST="latest/recovery-simulations"
           aws s3 sync target/recovery-sim "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
-          aws s3 sync target/recovery-sim "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
+
+          # Only load to latest if the event is push to main
+          if [ "${{ github.event_name }}" == "push" ]; then
+            TARGET_LATEST="latest/recovery-simulations"
+            aws s3 sync target/recovery-sim "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -605,11 +617,15 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/sim"
-          TARGET_LATEST="latest/sim"
           aws s3 sync target/s2n-quic-sim "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
-          aws s3 sync target/s2n-quic-sim "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
+
+          # Only load to latest if the event is push to main
+          if [ "${{ github.event_name }}" == "push" ]; then
+            TARGET_LATEST="latest/sim"
+            aws s3 sync target/s2n-quic-sim "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -714,11 +730,15 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/timing/index.html"
-          TARGET_LATEST="latest/timing/index.html"
           aws s3 cp examples/echo/target/cargo-timings/cargo-timing.html "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
-          aws s3 cp examples/echo/target/cargo-timings/cargo-timing.html "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA"
           echo "URL=$URL" >> $GITHUB_OUTPUT
+
+          # Only load to latest if the event is push to main
+          if [ "${{ github.event_name }}" == "push" ]; then
+            TARGET_LATEST="latest/timing/index.html"
+            aws s3 cp examples/echo/target/cargo-timings/cargo-timing.html "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -812,11 +832,15 @@ jobs:
         working-directory: tools/memory-report
         run: |
           TARGET_SHA="${{ github.sha }}/dhat"
-          TARGET_LATEST="latest/dhat"
           aws s3 sync target/report "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
-          aws s3 sync target/report "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
           URL="$CDN/dhat/dh_view.html?url=/$TARGET_SHA/dhat-heap.json"
           echo "URL=$URL" >> $GITHUB_OUTPUT
+
+          # Only load to latest if the event is push to main
+          if [ "${{ github.event_name }}" == "push" ]; then
+            TARGET_LATEST="latest/dhat"
+            aws s3 sync target/report "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - automate-latest
 
 name: ci
 
@@ -181,9 +182,11 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
-          TARGET="${{ github.sha }}/doc"
-          aws s3 sync target/doc "s3://s2n-quic-ci-artifacts/$TARGET" --acl private --follow-symlinks
-          URL="$CDN/$TARGET/s2n_quic/index.html"
+          TARGET_SHA="${{ github.sha }}/doc"
+          TARGET_LATEST="${{ github.sha }}/doc"
+          aws s3 sync target/doc "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync target/doc "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          URL="$CDN/$TARGET_SHA/s2n_quic/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
@@ -441,9 +444,11 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
-          TARGET="${{ github.sha }}/coverage"
-          aws s3 sync target/llvm-cov/html "s3://s2n-quic-ci-artifacts/$TARGET" --acl private --follow-symlinks
-          URL="$CDN/$TARGET/index.html"
+          TARGET_SHA="${{ github.sha }}/coverage"
+          TARGET_LATEST="latest/coverage"
+          aws s3 sync target/llvm-cov/html "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync target/llvm-cov/html "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
@@ -553,9 +558,11 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
-          TARGET="${{ github.sha }}/recovery-simulations"
-          aws s3 sync target/recovery-sim "s3://s2n-quic-ci-artifacts/$TARGET" --acl private --follow-symlinks
-          URL="$CDN/$TARGET/index.html"
+          TARGET_SHA="${{ github.sha }}/recovery-simulations"
+          TARGET_LATESET="latest/recovery-simulations"
+          aws s3 sync target/recovery-sim "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync target/recovery-sim "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
@@ -598,9 +605,11 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
-          TARGET="${{ github.sha }}/sim"
-          aws s3 sync target/s2n-quic-sim "s3://s2n-quic-ci-artifacts/$TARGET" --acl private --follow-symlinks
-          URL="$CDN/$TARGET/index.html"
+          TARGET_SHA="${{ github.sha }}/sim"
+          TARGET_LATEST="latest/sim"
+          aws s3 sync target/s2n-quic-sim "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync target/s2n-quic-sim "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
@@ -705,9 +714,11 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
-          TARGET="${{ github.sha }}/timing/index.html"
-          aws s3 cp examples/echo/target/cargo-timings/cargo-timing.html "s3://s2n-quic-ci-artifacts/$TARGET" --acl private --follow-symlinks
-          URL="$CDN/$TARGET"
+          TARGET_SHA="${{ github.sha }}/timing/index.html"
+          TARGET_LATEST="latest/timing/index.html"
+          aws s3 cp examples/echo/target/cargo-timings/cargo-timing.html "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 cp examples/echo/target/cargo-timings/cargo-timing.html "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          URL="$CDN/$TARGET_SHA"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
@@ -801,9 +812,11 @@ jobs:
         id: s3
         working-directory: tools/memory-report
         run: |
-          TARGET="${{ github.sha }}/dhat"
-          aws s3 sync target/report "s3://s2n-quic-ci-artifacts/$TARGET" --acl private --follow-symlinks
-          URL="$CDN/dhat/dh_view.html?url=/$TARGET/dhat-heap.json"
+          TARGET_SHA="${{ github.sha }}/dhat"
+          TARGET_LATEST="latest/dhat"
+          aws s3 sync target/report "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync target/report "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          URL="$CDN/dhat/dh_view.html?url=/$TARGET_SHA/dhat-heap.json"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     branches:
       - main
-      - boquan-fang/automate-doc
 
 name: ci
 

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -22,6 +22,7 @@ env:
   WIRESHARK_VERSION: 4.4.2
   CDN: https://dnglbrstg7yg.cloudfront.net
   LOG_URL: logs/latest/SERVER_CLIENT/TEST/index.html
+  CI_ARTIFACTS_BUCKET: s2n-quic-ci-artifacts
 
 # By default depandabot only receives read permissions. Explicitly give it write
 # permissions which is needed by the ouzi-dev/commit-status-updater task.
@@ -229,12 +230,12 @@ jobs:
         working-directory: quic-interop-runner
         run: |
           TARGET_SHA="${{ github.sha }}/interop/logs/latest"
-          aws s3 sync results/logs "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync results/logs "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" --acl private --follow-symlinks
 
           # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/interop/logs/latest"
-            aws s3 sync results/logs "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+            aws s3 cp "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_LATEST" --recursive
           fi
 
       - uses: actions/upload-artifact@v4
@@ -328,14 +329,14 @@ jobs:
           cp .github/interop/*.html web/
           cp .github/interop/*.js web/
           TARGET_SHA="${{ github.sha }}/interop"
-          aws s3 sync web "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync web "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
           # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/interop"
-            aws s3 sync web "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+            aws s3 cp "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --recursive
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
@@ -484,14 +485,14 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/perf"
-          aws s3 sync perf-results "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync perf-results "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
           # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/perf"
-            aws s3 sync perf-results "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+            aws s3 cp "s3://${{ env.CI_ARTIFACTS_BUCKET }}/$TARGET_SHA" "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --recursive
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
     branches:
       - main
-      - boquan-fang/automate-doc
 
 name: qns
 

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -229,9 +229,13 @@ jobs:
         working-directory: quic-interop-runner
         run: |
           TARGET_SHA="${{ github.sha }}/interop/logs/latest"
-          TARGET_LATEST="latest/interop/logs/latest"
           aws s3 sync results/logs "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
-          aws s3 sync results/logs "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+
+          # Only load to latest if the event is push to main
+          if [ "${{ github.event_name }}" == "push" ]; then
+            TARGET_LATEST="latest/interop/logs/latest"
+            aws s3 sync results/logs "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          fi
 
       - uses: actions/upload-artifact@v4
         with:
@@ -324,11 +328,15 @@ jobs:
           cp .github/interop/*.html web/
           cp .github/interop/*.js web/
           TARGET_SHA="${{ github.sha }}/interop"
-          TARGET_LATEST="latest/interop"
           aws s3 sync web "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
-          aws s3 sync web "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
+
+          # Only load to latest if the event is push to main
+          if [ "${{ github.event_name }}" == "push" ]; then
+            TARGET_LATEST="latest/interop"
+            aws s3 sync web "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
@@ -476,11 +484,15 @@ jobs:
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/perf"
-          TARGET_LATEST="latest/perf"
           aws s3 sync perf-results "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
-          aws s3 sync perf-results "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
+
+          # Only load to latest if the event is push to main
+          if [ "${{ github.event_name }}" == "push" ]; then
+            TARGET_LATEST="latest/perf"
+            aws s3 sync perf-results "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -231,7 +231,7 @@ jobs:
           TARGET_SHA="${{ github.sha }}/interop/logs/latest"
           aws s3 sync results/logs "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
 
-          # Only load to latest if the event is push to main
+          # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/interop/logs/latest"
             aws s3 sync results/logs "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
@@ -332,7 +332,7 @@ jobs:
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
-          # Only load to latest if the event is push to main
+          # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/interop"
             aws s3 sync web "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
@@ -488,7 +488,7 @@ jobs:
           URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
-          # Only load to latest if the event is push to main
+          # Only upload to latest if the event is push to main
           if [ "${{ github.event_name }}" == "push" ]; then
             TARGET_LATEST="latest/perf"
             aws s3 sync perf-results "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+      - automate-latest
 
 name: qns
 
@@ -228,8 +229,10 @@ jobs:
         id: s3
         working-directory: quic-interop-runner
         run: |
-          TARGET="${{ github.sha }}/interop/logs/latest"
-          aws s3 sync results/logs "s3://s2n-quic-ci-artifacts/$TARGET" --acl private --follow-symlinks
+          TARGET_SHA="${{ github.sha }}/interop/logs/latest"
+          TARGET_LATEST="latest/interop/logs/latest"
+          aws s3 sync results/logs "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync results/logs "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
 
       - uses: actions/upload-artifact@v4
         with:
@@ -321,9 +324,11 @@ jobs:
         run: |
           cp .github/interop/*.html web/
           cp .github/interop/*.js web/
-          TARGET="${{ github.sha }}/interop"
-          aws s3 sync web "s3://s2n-quic-ci-artifacts/$TARGET" --acl private --follow-symlinks
-          URL="$CDN/$TARGET/index.html"
+          TARGET_SHA="${{ github.sha }}/interop"
+          TARGET_LATEST="latest/interop"
+          aws s3 sync web "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync web "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
@@ -471,9 +476,11 @@ jobs:
         if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
-          TARGET="${{ github.sha }}/perf"
-          aws s3 sync perf-results "s3://s2n-quic-ci-artifacts/$TARGET" --acl private --follow-symlinks
-          URL="$CDN/$TARGET/index.html"
+          TARGET_SHA="${{ github.sha }}/perf"
+          TARGET_LATEST="latest/perf"
+          aws s3 sync perf-results "s3://s2n-quic-ci-artifacts/$TARGET_SHA" --acl private --follow-symlinks
+          aws s3 sync perf-results "s3://s2n-quic-ci-artifacts/$TARGET_LATEST" --acl private --follow-symlinks
+          URL="$CDN/$TARGET_SHA/index.html"
           echo "URL=$URL" >> $GITHUB_OUTPUT
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     branches:
       - main
-      - automate-latest
+      - boquan-fang/automate-doc
 
 name: qns
 


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2302

### Description of changes: 

We want to update the Cloud Front distribution to use the most up to date CI artifact in S2N-QUIC's doc. Instead of just uploading objects to a folder with the commit hash, I also upload those objects into a new folder called `latest`. I have changed the Cloud Front Origin Path to use the `/latest` folder to locate all artifacts.

According to the [github context page](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#github-context), event_name shows the event that triggers the workflow to run. So, only when `github.event_name` is equal to `push`, a PR commit is pushed into main. We add a check for that to ensure only PR merging to main can trigger artifacts uploaded to S3. Additional event details about `push` can be found in this [doc](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#push).

### Call-outs:

* We still upload those artifacts to each commit hash, because we still want to track artifacts from each commit hash. Using latest is making the CloudFront update easier.
* We want to keep an eye on each PR that's merged in the future to see if they actually update the `latest` folder.
* A benefit of this approach is that when a report failed to generate or upload, the README.md's artifacts will just use the previous artifacts. It won't break our existing link.
* We would only upload from local to S3 once. We should then copy from existing S3 buckets to another existing S3 buckets using [`S3 cp`](https://docs.aws.amazon.com/cli/latest/reference/s3/cp.html) command.
    * I found the [S3 bucket](https://us-west-2.console.aws.amazon.com/s3/buckets/s2n-quic-ci-artifacts?region=us-west-2&bucketType=general&prefix=32e09e0f9cf95d84cb7d2451d46c5f6faf0e99a9/&showversions=false) that record the CI artifacts from [the update to main commit](https://github.com/aws/s2n-quic/pull/2606/commits/cd92943e8a936574837645040cdb51b32edcfd76). I have verified that those artifacts are successfully uploaded.

### Testing:

* We will need to merge it to see if artifacts got uploaded to S3.
    * Once this is merged, we can track if the S3 bucket `latest` folder is properly updated.
* I pushed [an empty commit](https://github.com/aws/s2n-quic/pull/2606/commits/9e66d67b5c81e5b64fae7da0f61280c62841dac3) at 04:25 11 Apr 2025 PT. We can see if the bucket got updated at the time to verify that this change will not update the bucket for each PR push.
    * I can verify that the `/latest` folder is not updated when this PR pushes another commit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

