### PR TITLE
fix(s2n-quic-dc): only actively poll RPC response

### DIFF
--- a/dc/s2n-quic-dc/src/stream/client/rpc.rs
+++ b/dc/s2n-quic-dc/src/stream/client/rpc.rs
@@ -52,7 +52,8 @@ where
     let mut reader = core::pin::pin!(reader);
 
     poll_fn(|cx| {
-        // Poll the `writer` as long as it hasn't completed or the `reader` is still being polled
+        // Poll the `writer` as long as it hasn't completed or the `reader` is still being polled.
+        // Writer polling will get deferred to a background task if the reader ends earlier than the writer.
         if !writer_finished {
             writer_finished = writer.as_mut().poll(cx)?.is_ready();
         }


### PR DESCRIPTION
### Description of changes: 

This change optimizes the stream RPC implementation where the client only "actively" polls the response to decide when to return. This is based on the assumption that if the server is able to send the entire response then it received the request, even if the local request state hasn't completely finished for whatever reason.

### Testing:

The existing RPC tests show that this maintains all of the expected behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

