### PR TITLE
fix(s2n-quic-dc): only send PTO packets when there are outstanding stream segments

### DIFF
--- a/dc/s2n-quic-dc/src/stream/tests.rs
+++ b/dc/s2n-quic-dc/src/stream/tests.rs
@@ -3,6 +3,7 @@
 
 mod accept_queue;
 mod deterministic;
+mod idle_timeout;
 mod key_update;
 mod request_response;
 mod rpc;

--- a/dc/s2n-quic-dc/src/stream/tests/idle_timeout.rs
+++ b/dc/s2n-quic-dc/src/stream/tests/idle_timeout.rs
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    stream::testing::{Client, Server},
+    testing::{ext::*, sim},
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tracing::{info_span, Instrument};
+
+#[test]
+fn other_half_keep_alive() {
+    sim(|| {
+        async move {
+            let client = Client::builder().build();
+            let mut stream = client.connect_sim("server:443").await.unwrap();
+
+            for _ in 0..120 {
+                stream.write_all(b"ping").await.unwrap();
+                1.s().sleep().await;
+            }
+            stream.shutdown().await.unwrap();
+
+            let mut response = vec![];
+            stream.read_to_end(&mut response).await.unwrap();
+
+            assert_eq!(response, b"pong!"[..]);
+        }
+        .group("client")
+        .instrument(info_span!("client"))
+        .primary()
+        .spawn();
+
+        async move {
+            let server = Server::udp().port(443).build();
+
+            while let Ok((mut stream, peer_addr)) = server.accept().await {
+                async move {
+                    let mut request = vec![];
+                    stream.read_to_end(&mut request).await.unwrap();
+
+                    stream.write_from_fin(&mut &b"pong!"[..]).await.unwrap();
+                }
+                .instrument(info_span!("stream", ?peer_addr))
+                .primary()
+                .spawn();
+            }
+        }
+        .group("server")
+        .instrument(info_span!("server"))
+        .spawn();
+    });
+}


### PR DESCRIPTION
### Description of changes: 

This change fixes a bug in the stream send state manager where it gets into a PTO feedback loop by constantly sending PTOs. This is reproduced by the test I added that shows that the sender constantly sends packets every millisecond. After the fix, no recovery packets are sent.

### Testing:

#### Before

![2025-04-17-133225_1177x1057_scrot](https://github.com/user-attachments/assets/af385309-da49-407b-bded-982bdeb13a7a)

#### After

![2025-04-17-133136_1112x564_scrot](https://github.com/user-attachments/assets/2bb49254-e1cf-4752-b4f5-4be633066fce)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

