### PR TITLE
fix(s2n-quic-dc): arm recv idle timer on init

### DIFF
--- a/dc/s2n-quic-dc/src/stream/endpoint.rs
+++ b/dc/s2n-quic-dc/src/stream/endpoint.rs
@@ -176,8 +176,14 @@ where
     let source_queue_id = sockets.source_queue_id;
 
     // construct shared reader state
-    let reader =
-        recv::shared::State::new(stream_id, &parameters, features, recv_buffer, endpoint_type);
+    let reader = recv::shared::State::new(
+        stream_id,
+        &parameters,
+        features,
+        recv_buffer,
+        endpoint_type,
+        &now,
+    );
 
     let writer = {
         let worker = sockets

--- a/dc/s2n-quic-dc/src/stream/recv/shared.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/shared.rs
@@ -89,14 +89,18 @@ pub struct State {
 
 impl State {
     #[inline]
-    pub fn new(
+    pub fn new<C>(
         stream_id: stream::Id,
         params: &dc::ApplicationParams,
         features: TransportFeatures,
         buffer: RecvBuffer,
         endpoint: endpoint::Type,
-    ) -> Self {
-        let receiver = recv::state::State::new(stream_id, params, features);
+        clock: &C,
+    ) -> Self
+    where
+        C: Clock + ?Sized,
+    {
+        let receiver = recv::state::State::new(stream_id, params, features, clock);
         let reassembler = Default::default();
         let is_owned_socket = matches!(buffer, Either::A(recv::buffer::Local { .. }));
         let inner = Inner {

--- a/dc/s2n-quic-dc/src/stream/tests/idle_timeout.rs
+++ b/dc/s2n-quic-dc/src/stream/tests/idle_timeout.rs
@@ -51,3 +51,43 @@ fn other_half_keep_alive() {
         .spawn();
     });
 }
+
+#[test]
+fn server_no_response() {
+    sim(|| {
+        async move {
+            let client = Client::builder().build();
+            let mut stream = client.connect_sim("server:443").await.unwrap();
+
+            stream.write_all(b"ping").await.unwrap();
+            stream.shutdown().await.unwrap();
+
+            let mut response = vec![];
+            stream.read_to_end(&mut response).await.unwrap_err();
+        }
+        .group("client")
+        .instrument(info_span!("client"))
+        .primary()
+        .spawn();
+
+        async move {
+            let server = Server::udp().port(443).build();
+
+            while let Ok((mut stream, peer_addr)) = server.accept().await {
+                async move {
+                    let mut request = vec![];
+                    stream.read_to_end(&mut request).await.unwrap();
+
+                    // sleep long enough to trigger the idle timer
+                    120.s().sleep().await;
+                }
+                .instrument(info_span!("stream", ?peer_addr))
+                .primary()
+                .spawn();
+            }
+        }
+        .group("server")
+        .instrument(info_span!("server"))
+        .spawn();
+    });
+}


### PR DESCRIPTION
### Description of changes: 

This change includes a fix to arm the recv idle timer on initialization. This avoids a hang where the server never sends a single packet (or the client never receives any), which means there is no timer armed and then the client hangs indefinitely.

### Testing:

I added a test to show the fix working.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

