### PR TITLE
fix(s2n-quic-dc): prioritize recovery ACK ranges over stream

### DIFF
--- a/dc/s2n-quic-dc/src/stream/recv/state.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/state.rs
@@ -760,6 +760,9 @@ impl State {
                 let intervals = self.stream_ack.packets.interval_len()
                     + self.recovery_ack.packets.interval_len();
 
+                // The value of `20` is somewhat arbitrary but doing some worst-case math the ACK ranges with
+                // 20 segments would consume about 20-25% of the packet this is a good starting point.
+                // We dont't want to go too much lower otherwise we end up spamming ACKs.
                 let mut duplicate_threshold = 20;
 
                 let mut should_duplicate = false;

--- a/dc/s2n-quic-dc/src/stream/send/state/retransmission.rs
+++ b/dc/s2n-quic-dc/src/stream/send/state/retransmission.rs
@@ -14,6 +14,14 @@ pub struct Segment<S> {
     pub included_fin: bool,
 }
 
+impl<S> Segment<S> {
+    pub fn range(&self) -> core::ops::Range<VarInt> {
+        let start = self.stream_offset;
+        let end = start + VarInt::from_u16(self.payload_len);
+        start..end
+    }
+}
+
 impl<S> PartialEq for Segment<S> {
     #[inline]
     fn eq(&self, other: &Self) -> bool {


### PR DESCRIPTION
### Description of changes: 

While testing packet loss with very large transfers, I found that receivers can get stuck and time out. After digging in as to why, it's due to how the receiver tracks packet numbers in the stream and recovery spaces. The current implementation first computes the needed space for the stream space and then the recovery. What this does in practice is starts dropping the recovery packet numbers as the ranges start to fill up. Because lost stream packets are always re-transmitted as recovery packets, this essentially means for very large transfers with quite a bit of loss that the recovery space is always cleared out and never gets any ACKs through.

This change fixes this behavior by computing the required space for recovery packets first and then the stream packets are lower priority. I was able to fuzz this implementation over night and found that after tens of thousands of runs not a single one timed out, even with 25% packet loss. Without this change those tests failed almost immediately.

Additionally, I implemented a TODO that transmits duplicate ACK packets when the number of ACK ranges is high to try and reduce the space. This brings it in line with the behavior in the ack manager for IETF QUIC.

### Testing:

I added a test to show it working, which fails without the change. It does rely on the `net-monitor` feature in bach which i haven't published yet so I've gated that behind a `cfg(todo)` for now.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

