### PR TITLE
fix(s2n-quic-transport) Ensures packet number about to be skipped is not the first packet

### DIFF
--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -166,7 +166,7 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         // necessary) and record only if a packet is transmitted.
         let mut skipped_packet_number = SkippedPacketNumber::default();
 
-        if self.recovery_manager.requires_probe() {
+        if self.recovery_manager.requires_probe() && packet_number.as_u64() != 0 {
             skipped_packet_number.pto = Some(packet_number);
             //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.4
             //# If the sender wants to elicit a faster acknowledgement on PTO, it can

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -108,7 +108,7 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
     ) -> Result<(transmission::Outcome, EncoderBuffer<'a>), PacketEncodingError<'a>> {
         let mut packet_number = self.tx_packet_numbers.next();
 
-        if self.recovery_manager.requires_probe() {
+        if self.recovery_manager.requires_probe() && packet_number.as_u64() != 0 {
             context
                 .publisher
                 .on_packet_skipped(event::builder::PacketSkipped {

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -156,7 +156,7 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
     ) -> Result<(transmission::Outcome, EncoderBuffer<'a>), PacketEncodingError<'a>> {
         let mut packet_number = self.tx_packet_numbers.next();
 
-        if self.recovery_manager.requires_probe() {
+        if self.recovery_manager.requires_probe() && packet_number.as_u64() != 0 {
             context
                 .publisher
                 .on_packet_skipped(event::builder::PacketSkipped {

--- a/quic/s2n-quic/src/tests/setup.rs
+++ b/quic/s2n-quic/src/tests/setup.rs
@@ -349,5 +349,4 @@ pub use mtls::*;
 #[cfg(feature = "s2n-quic-tls")]
 pub use resumption::*;
 
-#[cfg(not(feature = "provider-tls-fips"))]
 pub use slow_tls::SlowTlsProvider;

--- a/quic/s2n-quic/src/tests/slow_tls.rs
+++ b/quic/s2n-quic/src/tests/slow_tls.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[test]
-#[cfg(not(feature = "provider-tls-fips"))]
-fn slow_default_tls() {
+fn slow_tls() {
     use super::*;
     use crate::provider::tls::default;
     use s2n_quic_core::crypto::tls::testing::certificates::{CERT_PEM, KEY_PEM};

--- a/quic/s2n-quic/src/tests/snapshots/tests__pto__handshake_pto_timer_is_armed__events.snap
+++ b/quic/s2n-quic/src/tests/snapshots/tests__pto__handshake_pto_timer_is_armed__events.snap
@@ -181,7 +181,6 @@ measure#recovery_metrics.pto_count=1
 measure#recovery_metrics.congestion_window=12000
 measure#recovery_metrics.bytes_in_flight=[REDACTED]
 count#recovery_metrics.congestion_limited=false
-count#packet_skipped=1
 count#frame_sent=1
 count#frame_sent.packet|HANDSHAKE=1
 count#frame_sent.frame|PING=1


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves #2599

### Description of changes: 

It's technically possible for the PTO Timer to cause s2n-quic to skip the first packet number when transitioning to a new packet space. This change checks that the packet number is not zero before skipping the number, as we do not want this behavior.

### Call-outs:
The PTO module doesn't really have any knowledge of which packet number we're on. Maybe it's better to add this logic inside of the requires_probe() function. But then I would have to pass in the packet number so I really didn't think it was worth it.


### Testing:

slow_tls test now passes with the fips libcrypto.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

