### PR TITLE
fix(s2n-quic-transport): handle pto overflows in connection migration

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1066,7 +1066,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             random_generator,
             timestamp,
             &mut publisher,
-        );
+        )?;
 
         if self
             .timers

--- a/quic/s2n-quic-transport/src/space/mod.rs
+++ b/quic/s2n-quic-transport/src/space/mod.rs
@@ -353,12 +353,17 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         random_generator: &mut Config::RandomGenerator,
         timestamp: Timestamp,
         publisher: &mut Pub,
-    ) {
+    ) -> Result<(), connection::Error> {
         let path_id = path_manager.active_path_id();
         let path = path_manager.active_path();
 
         // ensure the backoff doesn't grow too quickly
-        let max_backoff = path.pto_backoff * 2;
+        let max_backoff = match path.pto_backoff.checked_mul(2) {
+            Some(value) => value,
+            None => {
+                return Err(connection::Error::immediate_close("PTO Overflows"));
+            }
+        };
 
         if let Some((space, handshake_status)) = self.initial_mut() {
             space.on_timeout(
@@ -395,6 +400,7 @@ impl<Config: endpoint::Config> PacketSpaceManager<Config> {
         }
 
         debug_assert!(path_manager.active_path().pto_backoff <= max_backoff);
+        Ok(())
     }
 
     /// Signals the connection was previously blocked by anti-amplification limits

--- a/quic/s2n-quic/src/tests/connection_migration.rs
+++ b/quic/s2n-quic/src/tests/connection_migration.rs
@@ -296,7 +296,7 @@ fn rebind_before_handshake_confirmed() {
     }
 }
 
-// Changes the port for every datagrams after the second received datagram
+// Changes the port for every datagram after the second received datagram
 #[derive(Default)]
 struct RebindPortAfterTheFirstDatagram {
     datagram_count: usize,
@@ -320,9 +320,9 @@ impl Interceptor for RebindPortAfterTheFirstDatagram {
     }
 }
 
-/// Ensures pto overflow will close the connection instead of panicking
+/// Ensures when the PTO backoff multiplier exceeds the maximum value, the connection is closed and the endpoint does not panic
 #[test]
-fn rebind_triggers_pto_overflow() {
+fn pto_backoff_exceeding_max_value_closes_connection() {
     let model = Model::default();
     let subscriber_closed = recorder::ConnectionClosed::new();
     let connection_closed_events = subscriber_closed.events();
@@ -389,11 +389,11 @@ fn rebind_triggers_pto_overflow() {
     let connection_closed_events = connection_closed_events.lock().unwrap();
     assert_eq!(connection_closed_events.len(), 1);
 
-    // The connection is closed because of PTO Overflows
+    // The connection is closed because of PTO backoff multiplier exceeded maximum value
     assert!(matches!(
         connection_closed_events[0],
         s2n_quic_core::connection::Error::ImmediateClose { reason, .. }
-        if reason == "PTO Overflows"
+        if reason == "PTO backoff multiplier exceeded maximum value"
     ));
 }
 

--- a/quic/s2n-quic/src/tests/connection_migration.rs
+++ b/quic/s2n-quic/src/tests/connection_migration.rs
@@ -296,6 +296,107 @@ fn rebind_before_handshake_confirmed() {
     }
 }
 
+// Changes the port for every datagrams after the second received datagram
+#[derive(Default)]
+struct RebindPortAfterTheFirstDatagram {
+    datagram_count: usize,
+}
+
+impl Interceptor for RebindPortAfterTheFirstDatagram {
+    fn intercept_rx_remote_address(&mut self, _subject: &Subject, addr: &mut RemoteAddress) {
+        if self.datagram_count >= 1 {
+            addr.set_port(REBIND_PORT);
+        }
+    }
+
+    fn intercept_rx_datagram<'a>(
+        &mut self,
+        _subject: &Subject,
+        _datagram: &Datagram,
+        payload: DecoderBufferMut<'a>,
+    ) -> DecoderBufferMut<'a> {
+        self.datagram_count += 1;
+        payload
+    }
+}
+
+/// Ensures pto overflow will close the connection instead of panicking
+#[test]
+fn rebind_triggers_pto_overflow() {
+    let model = Model::default();
+    let subscriber_closed = recorder::ConnectionClosed::new();
+    let connection_closed_events = subscriber_closed.events();
+
+    test(model, move |handle| {
+        let server = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(SERVER_CERTS)?
+            .with_event((tracing_events(), subscriber_closed))?
+            .with_random(Random::with_seed(456))?
+            .with_packet_interceptor(RebindPortAfterTheFirstDatagram::default())?
+            .start()?;
+
+        let client = Client::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(certificates::CERT_PEM)?
+            .with_event(tracing_events())?
+            .with_random(Random::with_seed(456))?
+            .start()?;
+
+        let server_addr = start_server(server)?;
+        let data = Data::new(1000);
+        primary::spawn(async move {
+            let connect = Connect::new(server_addr).with_server_name("localhost");
+            let mut connection = client.connect(connect).await.unwrap();
+
+            let stream = connection.open_bidirectional_stream().await.unwrap();
+
+            let (mut recv, mut send) = stream.split();
+
+            let mut send_data = data;
+            let mut recv_data = data;
+
+            // Client receive will error when PTO overflows
+            primary::spawn(async move {
+                // Use this loop to capture PtoOverflow errors
+                loop {
+                    match recv.receive().await {
+                        Ok(Some(chunk)) => {
+                            recv_data.receive(&[chunk]);
+                        }
+                        // The test will not branch into this block.
+                        // PTO will overflow while client is receiving data.
+                        // That error will be captured by the Err block.
+                        Ok(None) => {
+                            break;
+                        }
+                        Err(_) => {
+                            break;
+                        }
+                    }
+                }
+            });
+
+            while let Some(chunk) = send_data.send_one(usize::MAX) {
+                send.send(chunk).await.unwrap();
+            }
+        });
+        Ok(server_addr)
+    })
+    .unwrap();
+
+    // The connection should only be closed once
+    let connection_closed_events = connection_closed_events.lock().unwrap();
+    assert_eq!(connection_closed_events.len(), 1);
+
+    // The connection is closed because of PTO Overflows
+    assert!(matches!(
+        connection_closed_events[0],
+        s2n_quic_core::connection::Error::ImmediateClose { reason, .. }
+        if reason == "PTO Overflows"
+    ));
+}
+
 // Changes the remote address to ipv4-mapped after the first packet
 #[derive(Default)]
 struct RebindMappedAddrBeforeHandshakeConfirmed {


### PR DESCRIPTION
### Release Summary:
* Close the connection when the PTO overflows.

### Resolved issues:

### Description of changes: 

We found out that PTO would overflows if we change the port of every datagram received after the second received datagram:
```
thread 'tests::connection_migration::rebind_before_handshake_confirmed' panicked at /home/ubuntu/workspace/s2n-quic/quic/s2n-quic-transport/src/space/mod.rs:361:27:
attempt to multiply with overflow
```
https://github.com/aws/s2n-quic/blob/34f5e4b054d0fb07c767f7fe63d3c50701df4f6d/quic/s2n-quic-transport/src/space/mod.rs#L361

I have investigated the issue and this problem can't be hit in production. The PTO will overflow after about 1.8 million days, which means to hit this problem in production, the client has to continuously to run for more than 1.8 million days. That is not a particular way to configure an endpoint. However, the test shouldn't failed because of PTO overflows.

The correctly behavior is to use rust's `checked_mul()` to do the multiplication, and close the connection when PTO overflows. This PR implements such logic to error with `connection::Error::immediate_close("PTO Overflows")`. This will close the connection when PTO overflows.

### Call-outs:

* I can't use the `start_client()` function in `quic/s2n-quic/src/tests/setup.rs`, because the receive loop is using `.unwrap` to grab the data chunk. Since we intentionally generate errors, that function would panic:
https://github.com/aws/s2n-quic/blob/34f5e4b054d0fb07c767f7fe63d3c50701df4f6d/quic/s2n-quic/src/tests/setup.rs#L128-L133
Hence, I use the same logic, but rewrite the while loop with a new loop, which can handles the error.
    * As the comment suggested, the `if Ok(None) => {` block can't be reached, since before all the data are received, the PTO will overflows, and the loop will capture the error in the next block.

### Testing:

CI Test will run the new test that I introduced.
The new test changes the port address for every single datagram received after the first received datagram. We need to assert that the connection is closed and is only closed once. Furthermore, we also need to verify that the reason the connection is closed is because of the `ImmediateClose` error with a reason of `"PTO Overflows"`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

