### PR TITLE
chore: Remove wireshark ppa repository

### DIFF
--- a/dc/wireshark/generate-bindings.sh
+++ b/dc/wireshark/generate-bindings.sh
@@ -23,8 +23,8 @@ if command -v nix-shell &> /dev/null; then
 elif command -v brew &> /dev/null; then
   brew install pkg-config wireshark
 elif command -v apt-get &> /dev/null; then
-  sudo add-apt-repository ppa:wireshark-dev/stable
-  sudo apt-get update
+  sudo add-apt-repository universe
+  sudo apt update
   sudo apt-get install pkg-config wireshark-dev tshark -y
 fi
 


### PR DESCRIPTION
### Release Summary:

### Description of changes: 

quic-ci is breaking due to the following error for `dc-wireshark(ubunutu-latest)` job

```
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 libwireshark-dev : Depends: libgio-2.0-dev but it is not installable
E: Unable to correct problems, you have held broken packages.

thread 'main' panicked at xtask/src/main.rs:27:10:
called `Result::unwrap()` on an `Err` value: command exited with non-zero code `./generate-bindings.sh`: 100
stack backtrace:
   0: rust_begin_unwind
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panicking.rs:695:5
   1: core::panicking::panic_fmt
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/core/src/panicking.rs:75:14
   2: core::result::unwrap_failed
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/core/src/result.rs:1704:5
   3: core::result::Result<T,E>::unwrap
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/core/src/result.rs:1109:23
   4: xtask::Args::run
             at ./xtask/src/main.rs:21:9
   5: xtask::main
             at ./xtask/src/main.rs:298:5
   6: core::ops::function::FnOnce::call_once
             at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/core/src/ops/function.rs:250:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
Error: Process completed with exit code 101.
```
The wireshark version does not seem to be compatible with the current Ubuntu image, hence replacing the ppa repository with `ubuntu universe` repository which contains compatible version

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

