### PR TITLE
ci: run daily CI jobs and report the result to CloudWatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -963,7 +963,7 @@ jobs:
           submodules: true
       - uses: aws-actions/configure-aws-credentials@v4.1.0
         with:
-          role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
+          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
       - name: Report daily CI run to CloudWatch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -953,7 +953,7 @@ jobs:
         run: cargo xtask build
 
   scheduled-ci-status-report:
-    if: ${{ always() }} && github.event_name == 'schedule'
+    if: ${{ always() }}
     needs: [env, test, asan]
     steps:
       - name: Report daily CI run to CloudWatch
@@ -963,5 +963,7 @@ jobs:
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
         run: |
-          METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
-          aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)
+          if [ "${{ github.event_name }}" == "schedule" ]; then
+            METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
+            aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -953,10 +953,10 @@ jobs:
         run: cargo xtask build
 
   scheduled-ci-status-report:
-    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
+    runs-on: ubuntu-latest
     if: ${{ always() }}
     needs: env
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -953,7 +953,6 @@ jobs:
         run: cargo xtask build
 
   scheduled-ci-status-report:
-    if: ${{ always() }}
     needs: env
     steps:
       - name: Report daily CI run to CloudWatch
@@ -963,7 +962,4 @@ jobs:
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
         run: |
-          if [ "${{ github.event_name }}" == "schedule" ]; then
-            METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
-            aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)
-          fi
+          echo hello

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -954,7 +954,7 @@ jobs:
 
   scheduled-ci-status-report:
     if: ${{ always() }}
-    needs: [env, test, asan]
+    needs: [env, test]
     steps:
       - name: Report daily CI run to CloudWatch
         uses: aws-actions/configure-aws-credentials@v4.1.0
@@ -964,5 +964,6 @@ jobs:
           aws-region: us-west-2
         run: |
           if [ "${{ github.event_name }}" == "schedule" ]; then
-            aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value 0 --dimensions Initiator=scheduled --timestamp $(date +%s)
+            METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
+            aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    # Run daily job at 8:00 PM PT
+    - cron: '0 3 * * *'
 
 name: ci
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -955,11 +955,11 @@ jobs:
   scheduled-ci-status-report:
     needs: env
     steps:
-      - name: Report daily CI run to CloudWatch
-        uses: aws-actions/configure-aws-credentials@v4.1.0
+      - uses: aws-actions/configure-aws-credentials@v4.1.0
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
+      - name: Report daily CI run to CloudWatch
         run: |
           echo hello

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -954,6 +954,8 @@ jobs:
 
   scheduled-ci-status-report:
     runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: env
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -954,7 +954,7 @@ jobs:
 
   scheduled-ci-status-report:
     if: ${{ always() }}
-    needs: [env, test]
+    needs: env
     steps:
       - name: Report daily CI run to CloudWatch
         uses: aws-actions/configure-aws-credentials@v4.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ env:
 permissions:
   statuses: write
   id-token: write # This is required for requesting the JWT/OIDC
+  contents: read
 
 jobs:
   env:
@@ -956,8 +957,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() }}
     needs: env
-    permissions:
-      id-token: write
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -958,6 +958,9 @@ jobs:
     if: ${{ always() }}
     needs: env
     steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: aws-actions/configure-aws-credentials@v4.1.0
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -956,6 +956,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() }}
     needs: env
+    permissions:
+      id-token: write
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,6 @@ env:
 permissions:
   statuses: write
   id-token: write # This is required for requesting the JWT/OIDC
-  contents: read
 
 jobs:
   env:
@@ -955,6 +954,9 @@ jobs:
 
   scheduled-ci-status-report:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     if: ${{ always() }}
     needs: env
     steps:
@@ -963,7 +965,7 @@ jobs:
           submodules: true
       - uses: aws-actions/configure-aws-credentials@v4.1.0
         with:
-          role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
+          role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
       - name: Report daily CI run to CloudWatch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -951,3 +951,17 @@ jobs:
       - name: Run build
         working-directory: dc/wireshark
         run: cargo xtask build
+
+  scheduled-ci-status-report:
+    if: ${{ always() }} && github.event_name == 'schedule'
+    needs: [env, test, asan]
+    steps:
+      - name: Report daily CI run to CloudWatch
+        uses: aws-actions/configure-aws-credentials@v4.1.0
+        with:
+          role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHASession
+          aws-region: us-west-2
+        run: |
+          METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
+          aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -964,6 +964,5 @@ jobs:
           aws-region: us-west-2
         run: |
           if [ "${{ github.event_name }}" == "schedule" ]; then
-            METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
-            aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)
+            aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value 0 --dimensions Initiator=scheduled --timestamp $(date +%s)
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -953,7 +953,7 @@ jobs:
         run: cargo xtask build
 
   scheduled-ci-status-report:
-    needs: env
+    runs-on: ubuntu-latest
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.1.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -953,11 +953,8 @@ jobs:
         run: cargo xtask build
 
   scheduled-ci-status-report:
-    permissions:
-      id-token: write
-      contents: read
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ always() }} || github.repository == github.event.pull_request.head.repo.full_name
     needs: env
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

We decided that S2N-QUIC needs a scheduled CI job that gets run daily. The benefits of this is to test the CI with main branch every day, so that if the CI breaks (for example MSRV issue), the team will know it before a PR is cut.

I added two sections into `ci.yml`:
* I made a schedule for the CI to run at eight PM daily, when everyone is not at work. We will know the result of such run after we come back the next day.
* We will report the CI result to Cloud Watch, with 1 indicating CI failure and 0 indicating CI success.

### Call-outs:

The `scheduled-ci-status-report` should only run when the ci is triggered by `schedule`. It requires every single jobs to finish before it can be ran. Furthermore, we need to add the check for `always()`, since this job shouldn't depends on whether previous jobs are successful or not. Refer to the Github Action [guide](https://docs.github.com/en/enterprise-cloud@latest/actions/writing-workflows/choosing-what-your-workflow-does/using-jobs-in-a-workflow#example-not-requiring-successful-dependent-jobs) for such operation.

The job should check if any of those jobs in `needs` has a result of [`failure`](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#needs-context). 

### Testing:

I tested the command locally and check the result on Cloud Watch in my personal account. In the production account, we should set the Cloud Watch statistics to be maximum and period to be one day, since this job will be ran daily.

### Notes for Testing:
Although I have verified the aws Cloud Watch command works locally, this PR is not tested in production, and can not be tested by CI. We will need to merge it to main, and then monitor the github action. We should verify in the upcoming days that the CI is triggered properly at 8 PM daily and the result of the CI is properly updated to Cloud Watch.

Once that is verified, we should set up an alarm and cut ticket to our team.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

