### PR TITLE
fix(s2n-quic-dc): correctly process IPv6 on recv path

### DIFF
--- a/dc/s2n-quic-dc/src/stream/application.rs
+++ b/dc/s2n-quic-dc/src/stream/application.rs
@@ -151,6 +151,18 @@ where
     }
 
     #[inline]
+    pub fn set_read_mode(&mut self, read_mode: recv::ReadMode) -> &mut Self {
+        self.read.set_read_mode(read_mode);
+        self
+    }
+
+    #[inline]
+    pub fn set_ack_mode(&mut self, ack_mode: recv::AckMode) -> &mut Self {
+        self.read.set_ack_mode(ack_mode);
+        self
+    }
+
+    #[inline]
     pub async fn write_from(
         &mut self,
         buf: &mut impl buffer::reader::storage::Infallible,

--- a/dc/s2n-quic-dc/src/stream/client/rpc.rs
+++ b/dc/s2n-quic-dc/src/stream/client/rpc.rs
@@ -1,7 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{event, stream::application::Stream};
+use crate::{
+    event,
+    stream::{application::Stream, recv::application::ReadMode},
+};
 use s2n_quic_core::buffer::{self, writer::Storage};
 use std::{
     future::{poll_fn, Future},
@@ -19,6 +22,9 @@ where
     Res: Response,
 {
     let (mut reader, mut writer) = stream.into_split();
+
+    // prefer draining all of the packets before sending an ACK
+    reader.set_read_mode(ReadMode::UntilFull);
 
     // TODO if the request is large enough, should we spawn a task for it?
     let mut writer = async move {

--- a/dc/s2n-quic-dc/src/stream/recv/application.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/application.rs
@@ -136,6 +136,18 @@ where
     }
 
     #[inline]
+    pub fn set_read_mode(&mut self, read_mode: ReadMode) -> &mut Self {
+        self.0.read_mode = read_mode;
+        self
+    }
+
+    #[inline]
+    pub fn set_ack_mode(&mut self, ack_mode: AckMode) -> &mut Self {
+        self.0.ack_mode = ack_mode;
+        self
+    }
+
+    #[inline]
     pub async fn read_into<S>(&mut self, out_buf: &mut S) -> io::Result<usize>
     where
         S: buffer::writer::Storage,

--- a/dc/s2n-quic-dc/src/stream/socket/fd/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/socket/fd/udp.rs
@@ -115,7 +115,10 @@ fn recv_msghdr(
 
     let len = exec(&mut msg)?;
 
+    // make sure the CMSG has the correct length
     cmsg.with_msg(&msg);
+    // make sure the addr has the correct length
+    addr.update_with_msg(&msg);
 
     Ok(len)
 }


### PR DESCRIPTION
### Description of changes: 

This change fixes IPv6 address handling on the recv path for UDP streams. Before this change, we weren't updating the length of the parsed `Addr`, which was resulting in part of IPv6 addresses being interpreted as IPv4, resulting in unroutable addresses.

### Call-outs:

I've also included a change around the `ReadMode` defaults for UDP streams. Without this change, we will send an ACK for every packet we receive, which can cause quite a bit of overhead. After this change, we'll only send ACKs after we fill up the provided application buffer, which should naturally reduce it, especially for large reads.

Longer term, I plan on adding some throttling for ACKs, which should reduce the frequency independent of the application buffer sizes. But that's a larger change and this _should_ work for now under certain application behaviors.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

