### PR TITLE
deps: h3-0.0.8 (s2n-quic-h3)

### DIFF
--- a/quic/s2n-quic-h3/Cargo.toml
+++ b/quic/s2n-quic-h3/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 [dependencies]
 bytes = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false }
-h3 = "0.0.7"
+h3 = "0.0.8"
 s2n-quic = { path = "../s2n-quic" }
 tracing = { version = "0.1", optional = true }
 

--- a/quic/s2n-quic-qns/src/server/h3.rs
+++ b/quic/s2n-quic-qns/src/server/h3.rs
@@ -19,7 +19,14 @@ pub async fn handle_connection(connection: Connection, www_dir: Arc<Path>) {
         .await
         .unwrap();
 
-    while let Ok(Some((req, mut stream))) = conn.accept().await {
+    while let Ok(Some(req_resolver)) = conn.accept().await {
+        let (req, mut stream) = match req_resolver.resolve_request().await {
+            Ok(res) => res,
+            Err(err) => {
+                eprintln!("Error resolving request: {err:?}");
+                continue;
+            }
+        };
         match req.uri().path() {
             "" | "/" => {
                 tokio::spawn(async move {


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

This change supports h3 v0.0.8 that has breaking changes on its API. This was implemented by referring to h3-quinn v0.10.0, specifically by following the commit [efdc2d8bfda0d86c0efdd36867ee6183f92d54d6](https://github.com/hyperium/h3/commit/efdc2d8bfda0d86c0efdd36867ee6183f92d54d6).

### Resolved issues:

resolves #2628 (dependabot PR)

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary. If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff. -->

This change updates `quic/s2n-quic-h3/src/s2n_quic.rs` as the upstream `h3` traits changes the manner of error handling.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

I believe the change does not need to be updated at this point since it just follows the h3's API changes.

However, I am not sure if changes [L53-L58](https://github.com/aws/s2n-quic/compare/main...junkurihara:s2n-quic:deps/h3-0.0.8#diff-327d115c00ee24f279e4a904977a907c658451a5d618a3acd908d3e98e8c3c8bR53-R58) and [L74-L79](https://github.com/aws/s2n-quic/compare/main...junkurihara:s2n-quic:deps/h3-0.0.8#diff-327d115c00ee24f279e4a904977a907c658451a5d618a3acd908d3e98e8c3c8bR74-R79) (cases when a connection closes with no error) are suitable with underlying s2n-quic layer.

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

Existing tests (but there is no test in `s2n-quic-h3` as well as `h3-quinn`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

