### PR TITLE
chore: pin icu_normalizer to 1.5.0

### DIFF
--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -21,6 +21,8 @@ cfg-if = "1"
 futures = "0.3"
 http = "1.0"
 humansize = "2"
+icu_normalizer = "=1.5.0" # newer versions require rust 1.82
+icu_properties_data = "=1.5.1" # newer versions require rust 1.82
 litemap = "=0.7.4" # newer versions require rust 1.81
 lru = "0.14"
 rand = "0.9"


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

A transitive dependency of `s2n-quic-qns`, icu_normalizer, did a release yesterday and [update their MSRV to 1.82.0](https://crates.io/crates/icu_normalizer/versions). We only use it once in `s2n-quic-qns`'s url dependency, so we should pin a previous version.

This issue can be related to https://github.com/aws/s2n-quic/issues/2334.

### Call-outs:

### Testing:

CI Testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

