### PR TITLE
chore: pin idna_adapter to v1.2.0

### DIFF
--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -21,6 +21,7 @@ cfg-if = "1"
 futures = "0.3"
 http = "1.0"
 humansize = "2"
+idna_adapter = "=1.2.0" # newer versions require rust 1.82
 litemap = "=0.7.4" # newer versions require rust 1.81
 lru = "0.14"
 rand = "0.9"


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

A transitive dependency of `s2n-quic-qns`, idna_adapter, did a release today and [update their MSRV to 1.82.0](https://crates.io/crates/idna_adapter/versions). We only use it once in `s2n-quic-qns`'s url dependency, so we should pin a previous version.

### Call-outs:

This issue can be related to https://github.com/aws/s2n-quic/issues/2334.

### Testing:

CI Testing.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

