### PR TITLE
chore: restrict steps for daily ci run for scheduled jobs only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -958,13 +958,13 @@ jobs:
     needs: [env, rustfmt, clippy, udeps, doc, test, asan, fips, miri, no_std, compliance, coverage, crates, examples, recovery-simulations, sims, copyright, events, snapshots, timing, typos, kani, dhat, loom, xdp, dc-wireshark]
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.1.0
+        if: github.event_name == 'schedule'
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
       - name: Report daily CI run to CloudWatch
+        if: github.event_name == 'schedule'
         run: |
-          if [ "${{ github.event_name }}" == "schedule" ]; then
-            METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
-            aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)
-          fi
+          METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
+          aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)


### PR DESCRIPTION
### Release Summary:
### Resolved issues:
### Description of changes:
This PR is a follow up for https://github.com/aws/s2n-quic/pull/2624. This job shouldn't run the credential verification for PR cut from forked repo. Hence, add a one line check to let daily scheduled ci job to run for scheduled triggered run only.
### Call-outs:
* This issue is detected in https://github.com/aws/s2n-quic/pull/2632.
* The scheduled job will only be ran in mainline aws/s2n-quic.
* CI will pass after https://github.com/aws/s2n-quic/pull/2632 is merged.
### Testing:
With this change, the steps in `scheduled-ci-status-report` shouldn't run at all for this PR, but it should run at 8PM today for scheduled job.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.