### PR TITLE
(ci) Bumps ubuntu version in qns.yml

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   env:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.implementations.outputs.matrix }}
     steps:
@@ -72,7 +72,7 @@ jobs:
           echo "matrix=$MATRIX" >> $GITHUB_OUTPUT
 
   s2n-quic-qns:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         mode: ["debug", "release"]
@@ -108,7 +108,7 @@ jobs:
           path: s2n-quic-qns/
 
   interop:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [env, s2n-quic-qns]
     strategy:
       matrix: ${{ fromJson(needs.env.outputs.matrix) }}
@@ -249,7 +249,7 @@ jobs:
           ! grep -Rq 'The s2n-quic-qns application shut down unexpectedly' results
 
   interop-report:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [interop]
     steps:
       - uses: actions/checkout@v4
@@ -353,7 +353,7 @@ jobs:
             web/logs/latest/result.json
 
   h3spec:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [s2n-quic-qns]
     strategy:
       matrix:
@@ -375,7 +375,7 @@ jobs:
           ./scripts/h3spec
 
   perf:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [s2n-quic-qns]
     strategy:
       matrix:
@@ -453,7 +453,7 @@ jobs:
           path: target/perf/results
 
   perf-report:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [perf]
     steps:
       - uses: actions/checkout@v4
@@ -503,7 +503,7 @@ jobs:
           url: "${{ steps.s3.outputs.URL }}"
 
   attack:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [s2n-quic-qns]
     strategy:
       matrix:


### PR DESCRIPTION
### Release Summary:

### Resolved issues:


### Description of changes: 

The official interop tests are running on ubuntu-24. Test PR to see if this fixes our failing interop tests.

### Call-outs:

No idea if this will actually work.

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

