### PR TITLE
ci: Pin to older docker version

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -160,7 +160,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.7.1
+          python-version: 3.8
 
       - name: Install tshark
         run: |

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -108,7 +108,7 @@ jobs:
           path: s2n-quic-qns/
 
   interop:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     needs: [env, s2n-quic-qns]
     strategy:
       matrix: ${{ fromJson(needs.env.outputs.matrix) }}
@@ -126,6 +126,9 @@ jobs:
         with:
           name: s2n-quic-qns-release
           path: s2n-quic-qns/
+
+      - uses: docker/setup-docker-action@v4
+        with: v26.1.3
 
       - name: Setup dockerfile
         working-directory: s2n-quic-qns
@@ -160,7 +163,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.7
 
       - name: Install tshark
         run: |

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -128,7 +128,8 @@ jobs:
           path: s2n-quic-qns/
 
       - uses: docker/setup-docker-action@v4
-        with: v26.1.3
+        with: 
+          version: version=v26.1.3
 
       - name: Setup dockerfile
         working-directory: s2n-quic-qns

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -160,7 +160,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.7.1
 
       - name: Install tshark
         run: |

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -108,7 +108,7 @@ jobs:
           path: s2n-quic-qns/
 
   interop:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [env, s2n-quic-qns]
     strategy:
       matrix: ${{ fromJson(needs.env.outputs.matrix) }}

--- a/dc/s2n-quic-dc/src/path/secret/receiver/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/receiver/tests.rs
@@ -206,20 +206,11 @@ fn check_delayed_inner(seed: u64, delay: u16) {
     }
 }
 
+#[derive(Default)]
 struct Model {
     insert_order: Vec<u64>,
     oracle: HashSet<u64>,
     subject: State,
-}
-
-impl Default for Model {
-    fn default() -> Self {
-        Self {
-            oracle: Default::default(),
-            insert_order: Vec::new(),
-            subject: State::new(),
-        }
-    }
 }
 
 impl Model {

--- a/dc/s2n-quic-dc/src/stream/client/rpc.rs
+++ b/dc/s2n-quic-dc/src/stream/client/rpc.rs
@@ -44,7 +44,7 @@ where
             let storage = response.provide_storage().await?;
 
             if !storage.has_remaining_capacity() {
-                return Err(io::Error::new(io::ErrorKind::Other, "the provided response buffer failed to provide enough capacity for the peer's response"));
+                return Err(io::Error::other( "the provided response buffer failed to provide enough capacity for the peer's response"));
             }
 
             let len = reader.read_into(storage).await?;

--- a/dc/s2n-quic-dc/src/stream/environment/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/udp.rs
@@ -119,10 +119,7 @@ where
                 remote_addr = v4.to_ipv6_mapped().with_port(remote_addr.port()).into();
             }
             (IpAddress::Ipv6(_), IpAddress::Ipv4(_)) => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "IPv6 not supported on a IPv4 socket",
-                ))
+                return Err(std::io::Error::other("IPv6 not supported on a IPv4 socket"))
             }
             (IpAddress::Ipv6(_), IpAddress::Ipv6(_)) => {}
         }

--- a/dc/s2n-quic-dc/src/stream/pacer.rs
+++ b/dc/s2n-quic-dc/src/stream/pacer.rs
@@ -25,10 +25,9 @@ impl Naive {
 
         // record the time that we yielded
         let now = clock.get_time();
-        let prev_yield_window = core::mem::replace(
-            &mut self.yield_window,
-            Some(now + core::time::Duration::from_millis(1)),
-        );
+        let prev_yield_window = self
+            .yield_window
+            .replace(now + core::time::Duration::from_millis(1));
 
         // if the current time falls outside of the previous window then don't actually yield - the
         // application isn't sending at that rate

--- a/dc/s2n-quic-dc/src/stream/recv/shared.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/shared.rs
@@ -143,9 +143,10 @@ impl State {
         // increment the epoch at which we acquired the guard
         self.application_epoch.fetch_add(1, Ordering::AcqRel);
 
-        let inner = self.inner.lock().map_err(|_| {
-            io::Error::new(io::ErrorKind::Other, "shared recv state has been poisoned")
-        })?;
+        let inner = self
+            .inner
+            .lock()
+            .map_err(|_| io::Error::other("shared recv state has been poisoned"))?;
 
         let initial_state = inner.receiver.state().clone();
 
@@ -197,10 +198,7 @@ impl State {
         match self.inner.try_lock() {
             Ok(lock) => Ok(Some(lock)),
             Err(std::sync::TryLockError::WouldBlock) => Ok(None),
-            Err(_) => Err(io::Error::new(
-                io::ErrorKind::Other,
-                "shared recv state has been poisoned",
-            )),
+            Err(_) => Err(io::Error::other("shared recv state has been poisoned")),
         }
     }
 }

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp/manager.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp/manager.rs
@@ -191,7 +191,7 @@ where
             .push_back(&mut self.inner.workers, idx);
 
         // kick off the initial poll to register wakers with the socket
-        self.inner.poll_worker(idx, cx, publisher, clock);
+        let _ = self.inner.poll_worker(idx, cx, publisher, clock);
 
         true
     }

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp/manager/tests.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp/manager/tests.rs
@@ -150,7 +150,7 @@ impl Default for Harness {
 
 impl Harness {
     pub fn poll(&mut self) {
-        self.manager.poll(
+        let _ = self.manager.poll(
             &mut (),
             &publisher(&self.subscriber, &self.clock),
             &self.clock,

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
@@ -116,8 +116,8 @@ where
 
         let prev_queue_time = core::mem::replace(&mut self.queue_time, now);
         let prev_state = core::mem::replace(&mut self.state, WorkerState::Init);
-        let prev_stream = core::mem::replace(&mut self.stream, Some((stream, remote_address)));
-        let prev_ctx = core::mem::replace(&mut self.subscriber_ctx, Some(subscriber_ctx));
+        let prev_stream = self.stream.replace((stream, remote_address));
+        let prev_ctx = self.subscriber_ctx.replace(subscriber_ctx);
 
         if let Some(remote_address) = prev_stream.map(|(socket, remote_address)| {
             // If linger wasn't already set or it was set to a value other than 0, then override it

--- a/quic/s2n-quic-core/src/packet/number/sliding_window.rs
+++ b/quic/s2n-quic-core/src/packet/number/sliding_window.rs
@@ -186,9 +186,7 @@ impl SlidingWindow {
                     // Our mask is the full window since it's all getting evicted.
                     !removed
                 };
-                if let Some(prev_right_edge) =
-                    core::mem::replace(&mut self.right_edge, Some(packet_number))
-                {
+                if let Some(prev_right_edge) = self.right_edge.replace(packet_number) {
                     Ok(EvictedSet {
                         window: removed,
                         right_edge: prev_right_edge,

--- a/quic/s2n-quic-crypto/src/one_rtt.rs
+++ b/quic/s2n-quic-crypto/src/one_rtt.rs
@@ -8,7 +8,6 @@ negotiated_crypto!(OneRttKey, OneRttHeaderKey);
 
 impl crypto::OneRttKey for OneRttKey {
     #[inline]
-    #[must_use]
     fn derive_next_key(&self) -> Self {
         Self(self.0.update())
     }

--- a/quic/s2n-quic-platform/src/io/testing/network.rs
+++ b/quic/s2n-quic-platform/src/io/testing/network.rs
@@ -74,7 +74,7 @@ impl Buffers {
         let lock = self
             .inner
             .lock()
-            .map_err(|err| io::Error::new(io::ErrorKind::Other, err.to_string()))?;
+            .map_err(|err| io::Error::other(err.to_string()))?;
 
         let entries = lock.host_to_addr.get(&host).ok_or_else(|| {
             io::Error::new(
@@ -125,7 +125,7 @@ impl Buffers {
         let mut lock = self
             .inner
             .lock()
-            .map_err(|err| io::Error::new(io::ErrorKind::Other, err.to_string()))?;
+            .map_err(|err| io::Error::other(err.to_string()))?;
 
         if !lock.is_open {
             return Err(io::Error::new(
@@ -157,7 +157,7 @@ impl Buffers {
         let mut lock = self
             .inner
             .lock()
-            .map_err(|err| io::Error::new(io::ErrorKind::Other, err.to_string()))?;
+            .map_err(|err| io::Error::other(err.to_string()))?;
 
         if !lock.is_open {
             return Err(io::Error::new(

--- a/quic/s2n-quic-platform/src/io/testing/socket.rs
+++ b/quic/s2n-quic-platform/src/io/testing/socket.rs
@@ -278,7 +278,7 @@ impl tx::Socket<Message> for Socket {
 
         let res = self.0.buffers.tx_host(self.0.host, |queue| {
             count = queue.send(entries);
-            events.on_complete(count);
+            let _ = events.on_complete(count);
         });
 
         if count > 0 {
@@ -307,7 +307,7 @@ impl rx::Socket<Message> for Socket {
         let res = self.0.buffers.rx_host(self.0.host, |queue| {
             count = queue.recv(cx, entries);
             if count > 0 {
-                events.on_complete(count);
+                let _ = events.on_complete(count);
             } else {
                 events.blocked()
             }

--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -84,7 +84,7 @@ impl Io {
         let handle = if let Some(handle) = handle {
             handle
         } else {
-            Handle::try_current().map_err(|err| std::io::Error::new(io::ErrorKind::Other, err))?
+            Handle::try_current().map_err(std::io::Error::other)?
         };
 
         let guard = handle.enter();

--- a/quic/s2n-quic-platform/src/io/turmoil.rs
+++ b/quic/s2n-quic-platform/src/io/turmoil.rs
@@ -137,7 +137,7 @@ impl Io {
         let handle = if let Some(handle) = self.builder.handle.take() {
             handle
         } else {
-            Handle::try_current().map_err(|err| std::io::Error::new(io::ErrorKind::Other, err))?
+            Handle::try_current().map_err(|err| std::io::Error::other(err))?
         };
 
         let guard = handle.enter();

--- a/quic/s2n-quic-platform/src/io/turmoil.rs
+++ b/quic/s2n-quic-platform/src/io/turmoil.rs
@@ -137,7 +137,7 @@ impl Io {
         let handle = if let Some(handle) = self.builder.handle.take() {
             handle
         } else {
-            Handle::try_current().map_err(|err| std::io::Error::other(err))?
+            Handle::try_current().map_err(std::io::Error::other)?
         };
 
         let guard = handle.enter();

--- a/quic/s2n-quic-sim/src/batch.rs
+++ b/quic/s2n-quic-sim/src/batch.rs
@@ -109,8 +109,7 @@ impl FromStr for Plan {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let file = fs::read_to_string(s)?;
-        let mut plan: Self =
-            toml::from_str(&file).map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+        let mut plan: Self = toml::from_str(&file).map_err(io::Error::other)?;
 
         if plan.name.is_none() {
             plan.name = Some(

--- a/quic/s2n-quic-transport/src/sync/data_sender/transmissions.rs
+++ b/quic/s2n-quic-transport/src/sync/data_sender/transmissions.rs
@@ -424,7 +424,7 @@ impl TransmissionSlab {
         #[cfg(debug_assertions)]
         assert!(prev_entry.occupied);
 
-        let next_entry = core::mem::replace(&mut prev_entry.transmission.next, Some(next));
+        let next_entry = prev_entry.transmission.next.replace(next);
 
         #[cfg(debug_assertions)]
         assert!(self.get_mut(next).occupied);

--- a/quic/s2n-quic/src/provider/dc/confirm.rs
+++ b/quic/s2n-quic/src/provider/dc/confirm.rs
@@ -23,7 +23,7 @@ impl ConfirmComplete {
     pub async fn wait_ready(conn: &mut Connection) -> io::Result<()> {
         let mut receiver = conn
             .query_event_context_mut(|context: &mut ConfirmContext| context.sender.subscribe())
-            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+            .map_err(io::Error::other)?;
 
         loop {
             match &*receiver.borrow_and_update() {
@@ -34,10 +34,7 @@ impl ConfirmComplete {
             }
 
             if receiver.changed().await.is_err() {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "never reached terminal state",
-                ));
+                return Err(io::Error::other("never reached terminal state"));
             }
         }
     }

--- a/quic/s2n-quic/src/provider/dc/mtu_confirm.rs
+++ b/quic/s2n-quic/src/provider/dc/mtu_confirm.rs
@@ -21,7 +21,7 @@ impl MtuConfirmComplete {
     pub async fn wait_ready(conn: &mut Connection) -> io::Result<()> {
         let mut receiver = conn
             .query_event_context_mut(|context: &mut MtuConfirmContext| context.sender.subscribe())
-            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
+            .map_err(io::Error::other)?;
 
         loop {
             match &*receiver.borrow_and_update() {
@@ -31,10 +31,7 @@ impl MtuConfirmComplete {
             }
 
             if receiver.changed().await.is_err() {
-                return Err(io::Error::new(
-                    io::ErrorKind::Other,
-                    "never reached terminal state",
-                ));
+                return Err(io::Error::other("never reached terminal state"));
             }
         }
     }

--- a/tools/xdp/s2n-quic-xdp/src/syscall.rs
+++ b/tools/xdp/s2n-quic-xdp/src/syscall.rs
@@ -55,10 +55,9 @@ pub fn offsets<Fd: AsRawFd>(fd: &Fd) -> Result<MmapOffsets> {
     }
 
     // an invalid size was returned
-    Err(io::Error::new(
-        io::ErrorKind::Other,
-        format!("invalid mmap offset size: {optlen}"),
-    ))
+    Err(io::Error::other(format!(
+        "invalid mmap offset size: {optlen}"
+    )))
 }
 
 /// Returns the collected statistics for the provided AF_XDP socket
@@ -225,8 +224,7 @@ pub fn mmap(len: usize, offset: usize, fd: Option<RawFd>, huge: bool) -> Result<
         return Err(io::Error::last_os_error());
     }
 
-    let addr = NonNull::new(addr)
-        .ok_or_else(|| io::Error::new(io::ErrorKind::Other, "mmap returned null pointer"))?;
+    let addr = NonNull::new(addr).ok_or_else(|| io::Error::other("mmap returned null pointer"))?;
 
     Ok(addr)
 }


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

The newest ubuntu22/20250514 image is causing our interop tests to fail. I suspect it has to do with the docker version bump, which went from [v26 to v28](https://github.com/actions/runner-images/pull/12124). Here I am pinning our docker version to one that we know works.
I don't think this is a great long-term solution, but I would like to get our CI working again. Opened a new issue for this: https://github.com/aws/s2n-quic/issues/2640

### Call-outs:
Also fixing a new clippy lint.

### Testing:
Ci should pass.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

