### PR TITLE
ci: fix daily qns job

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -225,14 +225,14 @@ jobs:
           done
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         working-directory: quic-interop-runner
         run: |
@@ -310,8 +310,8 @@ jobs:
             results/**/result.json > \
               web/logs/latest/result.json
 
-      - name: Generate report for push to main
-        if: github.event_name == 'push'
+      - name: Generate report for push to main or daily schedule job
+        if: github.event_name == 'push' || github.event_name == 'schedule'
         run: |
           mkdir -p web/logs/latest
           python3 .github/interop/merge.py \
@@ -323,14 +323,14 @@ jobs:
               web/logs/latest/result.json
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           cp .github/interop/*.html web/
@@ -347,7 +347,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "interop / report"
           status: "success"
@@ -481,14 +481,14 @@ jobs:
           tree -H "." -T "Performance Results" --noreport --charset utf-8 > index.html
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload results
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/perf"
@@ -503,7 +503,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "perf / report"
           status: "success"


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

This PR is to fix the daily qns job enabled by https://github.com/aws/s2n-quic/pull/2636. After the schedule job is enabled, I noticed that the `interop-report` fails to run. The failed test case can be found in this [report](https://github.com/aws/s2n-quic/actions/runs/15081106179/job/42398263226). I realized the schedule job doesn't run some previous required steps, because the run is triggered by the scheduled call instead of a push to main or a pull request. Hence, I make a parity for all the jobs that are required for the push to main event and the schedule run event.

### Call-outs:

This PR can only be tested after it is merged.

### Testing:

We should merge this PR and wait until 8 PM that night. We should monitor if the daily schedule QNS job passes. If it fails, we need to investigate and figure out why that happens.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

