### PR TITLE
fix(s2n-quic-platform): register drop waker to avoid memory leaks

### DIFF
--- a/quic/s2n-quic-platform/src/socket/ring.rs
+++ b/quic/s2n-quic-platform/src/socket/ring.rs
@@ -115,7 +115,6 @@ pub fn pair<T: Message>(entries: u32, payload_len: u32) -> (Producer<T>, Consume
 pub struct Consumer<T: Message> {
     cursor: Cursor<T>,
     wakers: atomic_waker::Handle,
-    #[allow(dead_code)]
     drop_waker: atomic_waker::Handle,
     #[allow(dead_code)]
     storage: Arc<message::Storage>,
@@ -203,7 +202,6 @@ impl<T: Message> Consumer<T> {
 pub struct Producer<T: Message> {
     cursor: Cursor<T>,
     wakers: atomic_waker::Handle,
-    #[allow(dead_code)]
     drop_waker: atomic_waker::Handle,
     #[allow(dead_code)]
     storage: Arc<message::Storage>,

--- a/quic/s2n-quic-platform/src/socket/ring.rs
+++ b/quic/s2n-quic-platform/src/socket/ring.rs
@@ -133,6 +133,10 @@ impl<T: Message> Consumer<T> {
         self.cursor.acquire_consumer(watermark)
     }
 
+    pub fn register_drop_waker(&mut self, cx: &mut Context) {
+        self.drop_waker.register(cx.waker())
+    }
+
     /// Polls ready-to-consume messages from the producer
     #[inline]
     pub fn poll_acquire(&mut self, watermark: u32, cx: &mut Context) -> Poll<u32> {


### PR DESCRIPTION
### Release Summary:

Rx and Tx packet processing tasks are now properly terminated when the client endpoint is dropped, resolving a memory leak. 

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2535.

### Description of changes: 

This PR adds a `drop_waker` into the `Rx::Receiver` struct, which ensures that that the `Future` trait for `Receiver` will be called during clean up.

`poll_*` APIs  require [`either storing the provided Waker for later or immediately waking the waker to reschedule the task to be polled again`](https://github.com/aws/s2n-quic/pull/2248). Otherwise, we end up with a zombie task which doesn't make any progress and may hold onto resources indefinitely. `Rx::Receiver` is currently violating that contract, since it returns `Pending` without registering a `waker`, nor does does it immediately wake the waker. Hence, the future gets stuck and doesn't terminates the task when the Endpoint is dropped, as the caller will not be woken up to invoke `poll` again. Hence, we need to implement a `drop_waker` for `Rx::Receiver`, so that it will always have a waker associated with it. In such way, the tokio task will be terminated when the Endpoint is dropped, and its resources can be properly cleaned up.

The current code has two problems:
1. It is possible that `Future`s for `Consumer` and `Producer` have no wakers registered with them. In that way, `poll` method can not be invoked when no waker is registered with the future. Hence, the `drop` function for them can not be invoked when we want to drop them.
2. Even when the `poll` is invoked for those `Future`s, the `poll` method still returns a `Poll::Pending` which puts the `Future` to sleep again. Hence, we need to make the `poll` method to return a `Poll:Ready` when it can be fully resolved. 

This problem is causing memory builds up (leak) for our customer mentioned in https://github.com/aws/s2n-quic/issues/2535. The customer is mentioning using `heaptrack` and `htop` to detect the problem which is also how we narrow down and fix the issue.

### Call-outs:

We should also implement `drop_waker` for `Tx::Send` as well to reach parity. The Tx side might cause the same problem.

### Testing:

I ran `htop` with customized `quic_echo_client` file in a [test branch](https://github.com/boquan-fang/s2n-quic/tree/test-waker). Memory usage shwon in `htop` will stabilized rather than keep increasing over time.

Testing steps:
* Pull the code from my test branch.
* Open three terminals. In one of those terminals, run `htop`. The other two run `cargo run --bin quic_echo_server` and `cargo run --bin quic_echo_client`.
* Monitor the `hotp` outputs. You should be able to see that after a few seconds, the `Mem` section will stabilize. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

