### PR TITLE
fix: remove ouzi-dev from daily qns job

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -347,7 +347,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "interop / report"
           status: "success"
@@ -503,7 +503,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "perf / report"
           status: "success"


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

Another follow up for https://github.com/aws/s2n-quic/pull/2636, https://github.com/aws/s2n-quic/pull/2641. The daily qns run is a scheduled job which can't run `ouzi-dev/commit-status-updater@v2.0.2`.
```
Error: Error, action only works for pull_request or push events!
```

We need to take the scheduled check out of the script.

### Call-outs:

Again, such change can't be tested locally. We will have to monitor the test result every 9 PM.

### Testing:

Refer to Call-outs. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

