### PR TITLE
fix(ci): additional test that fails during cargo timing

### DIFF
--- a/codebuild/spec/cargotiming.yml
+++ b/codebuild/spec/cargotiming.yml
@@ -19,7 +19,7 @@ phases:
       - cargo build --timings --release
   post_build:
     commands:
-      - cargo test --workspace -- --skip ipv4_two_socket_test --skip ipv4_test
+      - cargo test --workspace -- --skip ipv4_two_socket_test --skip ipv4_test --skip max_total_test
 
 artifacts:
   # upload timing reports


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

none

### Description of changes: 

After merging #2525  - I'm now _occasionally_ seeing `address not available` for one of the sement tests.
Getting ready to also disable this test if it proves to be flaky.

### Call-outs:

It made it through CI prior, so this is a flaky test...

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

