### PR TITLE
chore: bump MSRV to 1.82.0

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,3 @@
-msrv = "1.75.0"
+msrv = "1.82.0"
 # // https://github.com/aws/s2n-quic/pull/2251
 too-many-arguments-threshold = 100

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 `s2n-quic` will maintain a rolling MSRV (minimum supported rust version) policy of at least 6 months. The current s2n-quic version is not guaranteed to build on Rust versions earlier than the MSRV.
 
-The current MSRV is [1.75.0][msrv-url].
+The current MSRV is [1.82.0][msrv-url].
 
 ## Security issue notifications
 
@@ -134,5 +134,5 @@ This project is licensed under the [Apache-2.0 License][license-url].
 [docs-url]: https://docs.rs/s2n-quic
 [dependencies-badge]: https://img.shields.io/librariesio/release/cargo/s2n-quic.svg
 [dependencies-url]: https://crates.io/crates/s2n-quic/dependencies
-[msrv-badge]: https://img.shields.io/badge/MSRV-1.75.0-green
-[msrv-url]: https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html
+[msrv-badge]: https://img.shields.io/badge/MSRV-1.82.0-green
+[msrv-url]: https://blog.rust-lang.org/2024/10/17/Rust-1.82.0/

--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/dc/s2n-quic-dc-benches/Cargo.toml
+++ b/dc/s2n-quic-dc-benches/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 aws-lc-rs = "1.12"
-criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
+criterion = { version = "0.6", features = ["html_reports", "async_tokio"] }
 s2n-codec = { path = "../../common/s2n-codec" }
 s2n-quic-dc = { path = "../s2n-quic-dc", features = ["testing"] }
 tokio = { version = "1", features = ["full"] }

--- a/dc/s2n-quic-dc-benches/src/crypto/encrypt.rs
+++ b/dc/s2n-quic-dc-benches/src/crypto/encrypt.rs
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use criterion::{black_box, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput};
+use std::hint::black_box;
 
 pub fn benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("crypto/encrypt");

--- a/dc/s2n-quic-dc-benches/src/crypto/hkdf.rs
+++ b/dc/s2n-quic-dc-benches/src/crypto/hkdf.rs
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use criterion::{black_box, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput};
+use std::hint::black_box;
 
 pub fn benchmarks(c: &mut Criterion) {
     psk(c);

--- a/dc/s2n-quic-dc-benches/src/crypto/hmac.rs
+++ b/dc/s2n-quic-dc-benches/src/crypto/hmac.rs
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use criterion::{black_box, Criterion, Throughput};
+use criterion::{Criterion, Throughput};
+use std::hint::black_box;
 
 pub fn benchmarks(c: &mut Criterion) {
     init(c);

--- a/dc/s2n-quic-dc-benches/src/datagram/recv.rs
+++ b/dc/s2n-quic-dc-benches/src/datagram/recv.rs
@@ -1,7 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use criterion::{black_box, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion};
+use std::hint::black_box;
 
 const PACKET: [u8; 90] = [
     64, 0, 42, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0, 4, 0, 55, 67, 102, 47, 62, 183, 50, 8, 44,

--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/dc/s2n-quic-dc/src/path/secret/map/state/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state/tests.rs
@@ -151,7 +151,7 @@ impl Model {
                     if let Invariant::ContainsId(id) = invariant {
                         if state
                             .get_by_id_untracked(id)
-                            .map_or(true, |v| v.retired_at().is_some())
+                            .is_none_or(|v| v.retired_at().is_some())
                         {
                             invalidated.push(*id);
                             return false;

--- a/dc/s2n-quic-dc/src/stream/endpoint.rs
+++ b/dc/s2n-quic-dc/src/stream/endpoint.rs
@@ -293,7 +293,7 @@ where
                 // update the waker if needed
                 if prev_waker
                     .as_ref()
-                    .map_or(true, |prev| !prev.will_wake(cx.waker()))
+                    .is_none_or(|prev| !prev.will_wake(cx.waker()))
                 {
                     prev_waker = Some(cx.waker().clone());
                     reader.update_waker(cx);
@@ -334,7 +334,7 @@ where
                 // update the waker if needed
                 if prev_waker
                     .as_ref()
-                    .map_or(true, |prev| !prev.will_wake(cx.waker()))
+                    .is_none_or(|prev| !prev.will_wake(cx.waker()))
                 {
                     prev_waker = Some(cx.waker().clone());
                     writer.update_waker(cx);

--- a/quic/s2n-quic-bench/Cargo.toml
+++ b/quic/s2n-quic-bench/Cargo.toml
@@ -12,7 +12,6 @@ publish = false
 bytes = "1"
 criterion = { version = "0.6", features = ["html_reports"] }
 crossbeam-channel = { version = "0.5" }
-half = "2.6"
 internet-checksum = "0.2"
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }

--- a/quic/s2n-quic-bench/Cargo.toml
+++ b/quic/s2n-quic-bench/Cargo.toml
@@ -10,9 +10,9 @@ publish = false
 
 [dependencies]
 bytes = "1"
-criterion = { version = "0.5", features = ["html_reports"] }
+criterion = { version = "0.6", features = ["html_reports"] }
 crossbeam-channel = { version = "0.5" }
-half = "=2.4.1" # Can be unpinned when we move to MSRV 1.81
+half = "2.6"
 internet-checksum = "0.2"
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }

--- a/quic/s2n-quic-bench/src/buffer.rs
+++ b/quic/s2n-quic-bench/src/buffer.rs
@@ -1,11 +1,12 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use criterion::{black_box, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput};
 use s2n_quic_core::{
     buffer::{reader::Storage as _, writer, Reassembler},
     varint::VarInt,
 };
+use std::hint::black_box;
 
 pub fn benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("buffer");

--- a/quic/s2n-quic-bench/src/frame.rs
+++ b/quic/s2n-quic-bench/src/frame.rs
@@ -1,9 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use criterion::{black_box, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput};
 use s2n_codec::{DecoderBufferMut, Encoder, EncoderBuffer, EncoderValue};
 use s2n_quic_core::frame::FrameMut;
+use std::hint::black_box;
 
 pub fn benchmarks(c: &mut Criterion) {
     codec(c);

--- a/quic/s2n-quic-bench/src/inet.rs
+++ b/quic/s2n-quic-bench/src/inet.rs
@@ -2,8 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use core::hash::Hasher;
-use criterion::{black_box, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput};
 use s2n_quic_core::inet::checksum::Checksum;
+use std::hint::black_box;
 
 pub fn benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("inet");

--- a/quic/s2n-quic-bench/src/packet.rs
+++ b/quic/s2n-quic-bench/src/packet.rs
@@ -1,9 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use criterion::{black_box, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput};
 use s2n_codec::DecoderBufferMut;
 use s2n_quic_core::{connection::id::ConnectionInfo, inet::SocketAddress, packet::ProtectedPacket};
+use std::hint::black_box;
 
 pub fn benchmarks(c: &mut Criterion) {
     codec(c);

--- a/quic/s2n-quic-bench/src/varint.rs
+++ b/quic/s2n-quic-bench/src/varint.rs
@@ -1,9 +1,10 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use criterion::{black_box, BenchmarkId, Criterion};
+use criterion::{BenchmarkId, Criterion};
 use s2n_codec::{DecoderBuffer, Encoder, EncoderBuffer, EncoderValue};
 use s2n_quic_core::varint::VarInt;
+use std::hint::black_box;
 
 pub fn benchmarks(c: &mut Criterion) {
     encode(c);

--- a/quic/s2n-quic-bench/src/xdp.rs
+++ b/quic/s2n-quic-bench/src/xdp.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use criterion::{black_box, BenchmarkId, Criterion, Throughput};
+use criterion::{BenchmarkId, Criterion, Throughput};
 use s2n_codec::EncoderBuffer;
 use s2n_quic_core::{
     inet::{ExplicitCongestionNotification, IpV4Address, IpV6Address},
@@ -11,6 +11,7 @@ use s2n_quic_core::{
         path,
     },
 };
+use std::hint::black_box;
 
 pub fn benchmarks(c: &mut Criterion) {
     let mut group = c.benchmark_group("xdp/encoder");

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-core/src/buffer/deque/tests.rs
+++ b/quic/s2n-quic-core/src/buffer/deque/tests.rs
@@ -53,7 +53,7 @@ impl Model {
     fn pattern(&mut self, amount: usize, skip: u8) -> impl Iterator<Item = u8> + Clone {
         let base = self.byte as usize + skip as usize;
 
-        let iter = core::iter::repeat(base as u8).take(amount);
+        let iter = std::iter::repeat_n(base as u8, amount);
 
         self.byte = (base + amount) as u8;
 

--- a/quic/s2n-quic-core/src/path/ecn.rs
+++ b/quic/s2n-quic-core/src/path/ecn.rs
@@ -404,7 +404,7 @@ impl Controller {
         ecn.using_ecn()
             && self
                 .last_acked_ecn_packet_timestamp
-                .map_or(true, |last_acked| last_acked < time_sent)
+                .is_none_or(|last_acked| last_acked < time_sent)
     }
 
     /// Set the state to Failed and arm the retest timer

--- a/quic/s2n-quic-core/src/path/mtu.rs
+++ b/quic/s2n-quic-core/src/path/mtu.rs
@@ -646,7 +646,7 @@ impl Controller {
         if sent_bytes >= self.plpmtu
             && self
                 .largest_acked_mtu_sized_packet
-                .map_or(true, |pn| packet_number > pn)
+                .is_none_or(|pn| packet_number > pn)
         {
             // Reset the black hole counter since a packet the size of the current MTU or larger
             // has been acknowledged, indicating the path can still support the current MTU
@@ -770,7 +770,7 @@ impl Controller {
                 if (self.base_plpmtu + 1..=self.plpmtu).contains(&lost_bytes)
                     && self
                         .largest_acked_mtu_sized_packet
-                        .map_or(true, |pn| packet_number > pn)
+                        .is_none_or(|pn| packet_number > pn)
                     && new_loss_burst
                 {
                     // A non-probe packet larger than the BASE_PLPMTU that was sent after the last

--- a/quic/s2n-quic-core/src/recovery/bbr/pacing.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/pacing.rs
@@ -351,8 +351,7 @@ mod tests {
         while sent_bytes < bytes_to_send {
             // Confirm the current departure time is less than 1 rtt
             assert!(pacer
-                .earliest_departure_time()
-                .map_or(true, |departure_time| departure_time < now + rtt));
+                .earliest_departure_time().is_none_or(|departure_time| departure_time < now + rtt));
             pacer.on_packet_sent(now, MINIMUM_MAX_DATAGRAM_SIZE as usize, rtt);
             sent_bytes += MINIMUM_MAX_DATAGRAM_SIZE as u64;
         }

--- a/quic/s2n-quic-core/src/recovery/bbr/pacing.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/pacing.rs
@@ -351,7 +351,8 @@ mod tests {
         while sent_bytes < bytes_to_send {
             // Confirm the current departure time is less than 1 rtt
             assert!(pacer
-                .earliest_departure_time().is_none_or(|departure_time| departure_time < now + rtt));
+                .earliest_departure_time()
+                .is_none_or(|departure_time| departure_time < now + rtt));
             pacer.on_packet_sent(now, MINIMUM_MAX_DATAGRAM_SIZE as usize, rtt);
             sent_bytes += MINIMUM_MAX_DATAGRAM_SIZE as u64;
         }

--- a/quic/s2n-quic-core/src/recovery/bbr/windowed_filter.rs
+++ b/quic/s2n-quic-core/src/recovery/bbr/windowed_filter.rs
@@ -28,13 +28,13 @@ pub(crate) struct MinFilter;
 
 impl<T: core::cmp::PartialOrd> Filter<T> for MaxFilter {
     fn supersedes(new: T, current: Option<T>) -> bool {
-        current.map_or(true, |current| new >= current)
+        current.is_none_or(|current| new >= current)
     }
 }
 
 impl<T: core::cmp::PartialOrd> Filter<T> for MinFilter {
     fn supersedes(new: T, current: Option<T>) -> bool {
-        current.map_or(true, |current| new <= current)
+        current.is_none_or(|current| new <= current)
     }
 }
 

--- a/quic/s2n-quic-core/src/recovery/cubic.rs
+++ b/quic/s2n-quic-core/src/recovery/cubic.rs
@@ -64,7 +64,7 @@ impl State {
             debug_assert!(
                 timing
                     .app_limited_time
-                    .map_or(true, |app_limited_time| timestamp >= app_limited_time),
+                    .is_none_or(|app_limited_time| timestamp >= app_limited_time),
                 "timestamp must be monotonically increasing"
             );
             debug_assert!(

--- a/quic/s2n-quic-core/src/recovery/hybrid_slow_start.rs
+++ b/quic/s2n-quic-core/src/recovery/hybrid_slow_start.rs
@@ -112,7 +112,7 @@ impl HybridSlowStart {
         // started the RTT round (or the starting packet itself) is acknowledged
         let rtt_round_is_over = self
             .rtt_round_end_time
-            .map_or(true, |end_time| time_sent >= end_time);
+            .is_none_or(|end_time| time_sent >= end_time);
 
         if rtt_round_is_over {
             // Start a new round and save the previous min RTT

--- a/quic/s2n-quic-core/src/recovery/pacing/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/pacing/tests.rs
@@ -118,8 +118,7 @@ fn test_one_rtt(slow_start: bool) {
     while sent_bytes < bytes_to_send {
         // Confirm the current departure time is less than 1 rtt
         assert!(pacer
-            .earliest_departure_time()
-            .map_or(true, |departure_time| departure_time
+            .earliest_departure_time().is_none_or(|departure_time| departure_time
                 < now + rtt.smoothed_rtt()));
         pacer.on_packet_sent(
             now,

--- a/quic/s2n-quic-core/src/recovery/pacing/tests.rs
+++ b/quic/s2n-quic-core/src/recovery/pacing/tests.rs
@@ -118,8 +118,8 @@ fn test_one_rtt(slow_start: bool) {
     while sent_bytes < bytes_to_send {
         // Confirm the current departure time is less than 1 rtt
         assert!(pacer
-            .earliest_departure_time().is_none_or(|departure_time| departure_time
-                < now + rtt.smoothed_rtt()));
+            .earliest_departure_time()
+            .is_none_or(|departure_time| departure_time < now + rtt.smoothed_rtt()));
         pacer.on_packet_sent(
             now,
             MINIMUM_MAX_DATAGRAM_SIZE as usize,

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-events/Cargo.toml
+++ b/quic/s2n-quic-events/Cargo.toml
@@ -4,7 +4,7 @@ name = "s2n-quic-events"
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0"
 # This is a commit-time crate and should not be published
 publish = false

--- a/quic/s2n-quic-h3/Cargo.toml
+++ b/quic/s2n-quic-h3/Cargo.toml
@@ -4,7 +4,7 @@ name = "s2n-quic-h3"
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0"
 # this contains an http3 implementation for testing purposes and should not be published
 publish = false

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]
@@ -49,20 +49,3 @@ tracing = { version = "0.1" }
 [package.metadata.kani]
 flags = { tests = true }
 unstable = { stubbing = true }
-
-# Remove once MSRV is 1.80.0, see https://github.com/aws/s2n-quic/issues/2334
-[lints.rust.unexpected_cfgs]
-level = "warn"
-check-cfg = [
-    'cfg(fuzz)',
-    'cfg(kani)',
-    'cfg(kani_slow)',
-    'cfg(s2n_quic_platform_cmsg)',
-    'cfg(s2n_quic_platform_socket_msg)',
-    'cfg(s2n_quic_platform_socket_mmsg)',
-    'cfg(s2n_quic_platform_mtu_disc)',
-    'cfg(s2n_quic_platform_gso)',
-    'cfg(s2n_quic_platform_gro)',
-    'cfg(s2n_quic_platform_pktinfo)',
-    'cfg(s2n_quic_platform_tos)',
-]

--- a/quic/s2n-quic-platform/build.rs
+++ b/quic/s2n-quic-platform/build.rs
@@ -115,12 +115,11 @@ fn main() -> Result<(), Error> {
         }
     }
 
-    // TODO: Uncomment once MSRV is 1.80.0, see https://github.com/aws/s2n-quic/issues/2334
-    // for name in ALL_FEATURES.iter().map(|f| f.name()) {
-    //     println!("cargo::rustc-check-cfg=cfg(s2n_quic_platform_{name})");
-    // }
-    //
-    // println!("cargo::rustc-check-cfg=cfg(fuzz, kani, kani_slow)");
+    for name in ALL_FEATURES.iter().map(|f| f.name()) {
+        println!("cargo::rustc-check-cfg=cfg(s2n_quic_platform_{name})");
+    }
+
+    println!("cargo::rustc-check-cfg=cfg(fuzz, kani, kani_slow)");
 
     Ok(())
 }

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -4,7 +4,7 @@ name = "s2n-quic-qns"
 version = "0.1.0"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0"
 publish = false
 
@@ -21,8 +21,6 @@ cfg-if = "1"
 futures = "0.3"
 http = "1.0"
 humansize = "2"
-idna_adapter = "=1.2.0" # newer versions require rust 1.82
-litemap = "=0.7.4" # newer versions require rust 1.81
 lru = "0.14"
 rand = "0.9"
 s2n-codec = { path = "../../common/s2n-codec" }
@@ -33,7 +31,6 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2"
-zerofrom = "=0.1.5" # newer versions require rust 1.81
 
 [target.'cfg(unix)'.dependencies]
 s2n-quic = { path = "../s2n-quic", features = ["provider-event-console-perf", "provider-event-tracing", "provider-tls-rustls", "provider-tls-s2n"] }

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-sim/Cargo.toml
+++ b/quic/s2n-quic-sim/Cargo.toml
@@ -6,7 +6,7 @@ description = "A simulation environment for s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0"
 publish = false
 

--- a/quic/s2n-quic-sim/src/query.rs
+++ b/quic/s2n-quic-sim/src/query.rs
@@ -34,7 +34,7 @@ pub struct Query {
 
 impl Query {
     pub fn run(&self) -> Result {
-        let input: Box<dyn io::Read> = if self.input.as_ref().map_or(true, |v| v == "-") {
+        let input: Box<dyn io::Read> = if self.input.as_ref().is_none_or(|v| v == "-") {
             let reader = io::stdin();
             Box::new(reader)
         } else {
@@ -52,7 +52,7 @@ impl Query {
         let queries = &self.query;
         let filters = &self.filter;
 
-        let header = self.header.map_or(true, |v| v.unwrap_or(true));
+        let header = self.header.is_none_or(|v| v.unwrap_or(true));
         if header {
             let seed = if with_seed {
                 Some(("seed", "id"))
@@ -95,8 +95,8 @@ impl Query {
             Ok(())
         };
 
-        let clients = self.clients.map_or(true, |v| v.unwrap_or(true));
-        let servers = self.servers.map_or(true, |v| v.unwrap_or(true));
+        let clients = self.clients.is_none_or(|v| v.unwrap_or(true));
+        let servers = self.servers.is_none_or(|v| v.unwrap_or(true));
 
         let reader = crate::stats::Stats::reader(input);
 

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic-transport/build.rs
+++ b/quic/s2n-quic-transport/build.rs
@@ -1,0 +1,7 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(s2n_quic_dump_on_panic)");
+    println!("cargo::rustc-check-cfg=cfg(feature, values(\"testing\"))");
+}

--- a/quic/s2n-quic-transport/build.rs
+++ b/quic/s2n-quic-transport/build.rs
@@ -1,7 +1,0 @@
-// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-// SPDX-License-Identifier: Apache-2.0
-
-fn main() {
-    println!("cargo::rustc-check-cfg=cfg(s2n_quic_dump_on_panic)");
-    println!("cargo::rustc-check-cfg=cfg(feature, values(\"testing\"))");
-}

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -305,8 +305,7 @@ impl<Config: endpoint::Config> Path<Config> {
         !self.at_amplification_limit()
             && self
                 .congestion_controller
-                .earliest_departure_time()
-                .map_or(true, |edt| edt.has_elapsed(timestamp))
+                .earliest_departure_time().is_none_or(|edt| edt.has_elapsed(timestamp))
     }
 
     /// Only PATH_CHALLENGE and PATH_RESPONSE frames should be transmitted here.

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -305,7 +305,8 @@ impl<Config: endpoint::Config> Path<Config> {
         !self.at_amplification_limit()
             && self
                 .congestion_controller
-                .earliest_departure_time().is_none_or(|edt| edt.has_elapsed(timestamp))
+                .earliest_departure_time()
+                .is_none_or(|edt| edt.has_elapsed(timestamp))
     }
 
     /// Only PATH_CHALLENGE and PATH_RESPONSE frames should be transmitted here.

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -520,7 +520,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             for (packet_number, acked_packet_info) in self.sent_packets.remove_range(pn_range) {
                 newly_acked_packets.push((packet_number, acked_packet_info));
 
-                if largest_newly_acked.map_or(true, |(pn, _)| packet_number > pn) {
+                if largest_newly_acked.is_none_or(|(pn, _)| packet_number > pn) {
                     largest_newly_acked = Some((packet_number, acked_packet_info));
                 }
 
@@ -652,7 +652,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             if acked_packet_info.path_id == current_path_id {
                 current_path_acked_bytes += sent_bytes;
 
-                if current_path_largest_newly_acked.map_or(true, |(pn, _)| packet_number > pn) {
+                if current_path_largest_newly_acked.is_none_or(|(pn, _)| packet_number > pn) {
                     current_path_largest_newly_acked = Some((packet_number, acked_packet_info));
                 }
             } else if sent_bytes > 0 {
@@ -961,7 +961,7 @@ impl<Config: endpoint::Config> Manager<Config> {
                 // Check that the packet was sent on this path
                 && sent_info.path_id == current_path_id;
 
-            let new_loss_burst = prev_lost_packet_number.map_or(true, |prev: PacketNumber| {
+            let new_loss_burst = prev_lost_packet_number.is_none_or(|prev: PacketNumber| {
                 packet_number.checked_distance(prev) != Some(1)
             });
 

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -961,9 +961,8 @@ impl<Config: endpoint::Config> Manager<Config> {
                 // Check that the packet was sent on this path
                 && sent_info.path_id == current_path_id;
 
-            let new_loss_burst = prev_lost_packet_number.is_none_or(|prev: PacketNumber| {
-                packet_number.checked_distance(prev) != Some(1)
-            });
+            let new_loss_burst = prev_lost_packet_number
+                .is_none_or(|prev: PacketNumber| packet_number.checked_distance(prev) != Some(1));
 
             if sent_info.transmission_mode.is_mtu_probing() {
                 //= https://www.rfc-editor.org/rfc/rfc9000#section-14.4

--- a/quic/s2n-quic-transport/src/space/application.rs
+++ b/quic/s2n-quic-transport/src/space/application.rs
@@ -596,14 +596,13 @@ impl<Config: endpoint::Config> ApplicationSpace<Config> {
         let largest_acked = self.ack_manager.largest_received_packet_number_acked();
         let packet = protected
             .unprotect(&self.header_key, largest_acked)
-            .map_err(|err| {
+            .inspect_err(|_err| {
                 publisher.on_packet_dropped(event::builder::PacketDropped {
                     reason: event::builder::PacketDropReason::UnprotectFailed {
                         space: event::builder::KeySpace::OneRtt,
                         path: path_event!(path, path_id),
                     },
                 });
-                err
             })?;
 
         let packet_number = packet.packet_number;

--- a/quic/s2n-quic-transport/src/stream/contract.rs
+++ b/quic/s2n-quic-transport/src/stream/contract.rs
@@ -144,9 +144,7 @@ pub mod tx {
             }
 
             // the request is interested in push availability
-            if self
-                .chunks
-                .as_ref().is_none_or(|chunks| chunks.is_empty())
+            if self.chunks.as_ref().is_none_or(|chunks| chunks.is_empty())
                 && !self.finish
                 && !self.flush
                 && context.is_some()

--- a/quic/s2n-quic-transport/src/stream/contract.rs
+++ b/quic/s2n-quic-transport/src/stream/contract.rs
@@ -146,8 +146,7 @@ pub mod tx {
             // the request is interested in push availability
             if self
                 .chunks
-                .as_ref()
-                .map_or(true, |chunks| chunks.is_empty())
+                .as_ref().is_none_or(|chunks| chunks.is_empty())
                 && !self.finish
                 && !self.flush
                 && context.is_some()

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -5,7 +5,7 @@ description = "A Rust implementation of the IETF QUIC protocol"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/quic/s2n-quic/src/tests/recorder.rs
+++ b/quic/s2n-quic/src/tests/recorder.rs
@@ -66,7 +66,7 @@ event_recorder!(
     SocketAddr,
     |event: &events::RecoveryMetrics, storage: &mut Vec<SocketAddr>| {
         let addr: SocketAddr = event.path.local_addr.to_string().parse().unwrap();
-        if storage.last().map_or(true, |prev| *prev != addr) {
+        if storage.last().is_none_or(|prev| *prev != addr) {
             storage.push(addr);
         }
     }

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.82.0"
 components = [ "rustc", "clippy", "rustfmt" ]

--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -5,7 +5,7 @@ description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
 edition = "2021"
-rust-version = "1.75"
+rust-version = "1.82"
 license = "Apache-2.0"
 # Exclude corpus files when publishing to crates.io
 exclude = ["corpus.tar.gz"]

--- a/tools/xdp/s2n-quic-xdp/src/ring.rs
+++ b/tools/xdp/s2n-quic-xdp/src/ring.rs
@@ -35,18 +35,14 @@ impl<T: Copy + fmt::Debug> Ring<T> {
     /// Returns the flags on the ring.
     #[inline]
     pub fn flags(&self) -> RingFlags {
-        // `as_ptr` can be removed once the MSRV hits >= 1.80.0.
-        // The flags are shared with the kernel and non-atomic, which means we cannot create a reference to them without violating aliasing rules.
-        unsafe { self.flags.as_ptr().read() }
+        unsafe { self.flags.read() }
     }
 
     /// Writes `flags` to the flags on the ring.
     #[inline]
     #[cfg(test)]
     pub fn set_flags(&mut self, flags: RingFlags) {
-        // `as_ptr` can be removed once the MSRV hits >= 1.80.0.
-        // The flags are shared with the kernel and non-atomic, which means we cannot create a reference to them without violating aliasing rules.
-        unsafe { self.flags.as_ptr().write(flags) }
+        unsafe { self.flags.write(flags) }
     }
 }
 


### PR DESCRIPTION
### Release Summary:
Bump S2N-QUIC's MSRV to 1.82.0.

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2334. resolves https://github.com/aws/s2n-quic/pull/2642.

### Description of changes: 

As shown in issue https://github.com/aws/s2n-quic/pull/2334, we have a whole bunch of updates that can be done with rustc version 1.82.0. The team has decided that we should update MSRV to 1.82.0. Our policy for deciding MSRV is:
https://github.com/aws/s2n-quic/blob/8f54b577991df0780dbd7bc7e38af547fbf8b0b9/README.md?plain=1#L112
Rustc v1.82.0 is release on 17 October 2024, which was more than six months away from now.

This PR includes MSRV bumps for every crates in S2N-QUIC, unpinning some dependencies versions, and apply clippy requirements in Rustc v1.82.0.

One of our dependency S2N-TLS updates its MSRV to 1.82.0 very recently: https://github.com/aws/s2n-tls/pull/5295. We should achieve parity.

### Call-outs:

One requirement that we still can't unpin with Rustc v1.82.0 is [`hex_literal`](https://crates.io/crates/hex-literal/versions). The latest version of that requires Rustc v1.85.0. I will create a separate issue to track that and all future pins: https://github.com/aws/s2n-quic/issues/2655.

### Testing:

This change will be tested by the CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

