### PR TITLE
ci(GithubAction): only run aws credential on upstream s2n-quic

### DIFF
--- a/.github/actions/duvet/action.yml
+++ b/.github/actions/duvet/action.yml
@@ -52,14 +52,14 @@ runs:
       run: ${{ inputs.report-script }} ${{ github.sha }}
 
     - uses: aws-actions/configure-aws-credentials@v4.0.2
-      if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+      if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
       with:
         role-to-assume: ${{ inputs.role-to-assume}}
         role-session-name: ${{ inputs.role-session-name}}
         aws-region: ${{ inputs.aws-s3-region }}
 
     - name: Upload to S3
-      if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+      if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
       id: s3
       shell: bash
       run: |
@@ -88,7 +88,7 @@ runs:
         echo "::set-output name=URL::$URL"
 
     - uses: ouzi-dev/commit-status-updater@v1.1.2
-      if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+      if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
       with:
         name: "compliance / report"
         status: "success"

--- a/.github/actions/duvet/action.yml
+++ b/.github/actions/duvet/action.yml
@@ -52,14 +52,14 @@ runs:
       run: ${{ inputs.report-script }} ${{ github.sha }}
 
     - uses: aws-actions/configure-aws-credentials@v4.0.2
-      if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+      if: github.repository == 'aws/s2n-quic'
       with:
         role-to-assume: ${{ inputs.role-to-assume}}
         role-session-name: ${{ inputs.role-session-name}}
         aws-region: ${{ inputs.aws-s3-region }}
 
     - name: Upload to S3
-      if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+      if: github.repository == 'aws/s2n-quic'
       id: s3
       shell: bash
       run: |
@@ -88,7 +88,7 @@ runs:
         echo "::set-output name=URL::$URL"
 
     - uses: ouzi-dev/commit-status-updater@v1.1.2
-      if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+      if: github.repository == 'aws/s2n-quic'
       with:
         name: "compliance / report"
         status: "success"

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -48,14 +48,14 @@ jobs:
           folder: target/book
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/book"
@@ -70,7 +70,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "book / url"
           status: "success"

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -48,14 +48,14 @@ jobs:
           folder: target/book
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/book"
@@ -70,7 +70,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           name: "book / url"
           status: "success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -958,13 +958,13 @@ jobs:
     needs: [env, rustfmt, clippy, udeps, doc, test, asan, fips, miri, no_std, compliance, coverage, crates, examples, recovery-simulations, sims, copyright, events, snapshots, timing, typos, kani, dhat, loom, xdp, dc-wireshark]
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' && github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
       - name: Report daily CI run to CloudWatch
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' && github.repository == 'aws/s2n-quic'
         run: |
           METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
           aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,14 +175,14 @@ jobs:
           RUSTDOCFLAGS: --cfg docsrs
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/doc"
@@ -197,7 +197,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "doc / report"
           status: "success"
@@ -441,14 +441,14 @@ jobs:
         run: cargo llvm-cov --html --no-fail-fast --workspace --exclude s2n-quic-qns --exclude s2n-quic-events --all-features
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload results
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/coverage"
@@ -463,7 +463,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "coverage / report"
           status: "success"
@@ -559,14 +559,14 @@ jobs:
           ./scripts/recovery-sim
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/recovery-simulations"
@@ -581,7 +581,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "recovery-simulations / report"
           status: "success"
@@ -610,14 +610,14 @@ jobs:
           ./scripts/sim
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/sim"
@@ -632,7 +632,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "sims / report"
           status: "success"
@@ -723,14 +723,14 @@ jobs:
           cargo build --timings --release --workspace
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/timing/index.html"
@@ -745,7 +745,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "timing / report"
           status: "success"
@@ -824,14 +824,14 @@ jobs:
           mv dhat-heap.json target/report/
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         working-directory: tools/memory-report
         run: |
@@ -847,7 +847,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "dhat / report"
           status: "success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,14 +175,14 @@ jobs:
           RUSTDOCFLAGS: --cfg docsrs
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/doc"
@@ -197,7 +197,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           name: "doc / report"
           status: "success"
@@ -441,14 +441,14 @@ jobs:
         run: cargo llvm-cov --html --no-fail-fast --workspace --exclude s2n-quic-qns --exclude s2n-quic-events --all-features
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload results
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/coverage"
@@ -463,7 +463,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           name: "coverage / report"
           status: "success"
@@ -559,14 +559,14 @@ jobs:
           ./scripts/recovery-sim
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/recovery-simulations"
@@ -581,7 +581,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           name: "recovery-simulations / report"
           status: "success"
@@ -610,14 +610,14 @@ jobs:
           ./scripts/sim
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/sim"
@@ -632,7 +632,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           name: "sims / report"
           status: "success"
@@ -723,14 +723,14 @@ jobs:
           cargo build --timings --release --workspace
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/timing/index.html"
@@ -745,7 +745,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           name: "timing / report"
           status: "success"
@@ -824,14 +824,14 @@ jobs:
           mv dhat-heap.json target/report/
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         id: s3
         working-directory: tools/memory-report
         run: |
@@ -847,7 +847,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           name: "dhat / report"
           status: "success"
@@ -958,13 +958,13 @@ jobs:
     needs: [env, rustfmt, clippy, udeps, doc, test, asan, fips, miri, no_std, compliance, coverage, crates, examples, recovery-simulations, sims, copyright, events, snapshots, timing, typos, kani, dhat, loom, xdp, dc-wireshark]
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'schedule' && github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
       - name: Report daily CI run to CloudWatch
-        if: github.event_name == 'schedule' && github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic'
         run: |
           METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
           aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -225,14 +225,18 @@ jobs:
           done
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
+        if: |
+          ((github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'aws/s2n-quic') ||
+          github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
+        if: |
+          ((github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'aws/s2n-quic') ||
+          github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         working-directory: quic-interop-runner
         run: |
@@ -323,14 +327,18 @@ jobs:
               web/logs/latest/result.json
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
+        if: |
+          ((github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'aws/s2n-quic') ||
+          github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
+        if: |
+          ((github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'aws/s2n-quic') ||
+          github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           cp .github/interop/*.html web/
@@ -347,7 +355,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "interop / report"
           status: "success"
@@ -481,14 +489,18 @@ jobs:
           tree -H "." -T "Performance Results" --noreport --charset utf-8 > index.html
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
+        if: |
+          ((github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'aws/s2n-quic') ||
+          github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload results
-        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
+        if: |
+          ((github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'aws/s2n-quic') ||
+          github.repository == github.event.pull_request.head.repo.full_name
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/perf"
@@ -503,7 +515,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           name: "perf / report"
           status: "success"

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -225,18 +225,14 @@ jobs:
           done
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: |
-          ((github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'aws/s2n-quic') ||
-          github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: |
-          ((github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'aws/s2n-quic') ||
-          github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         id: s3
         working-directory: quic-interop-runner
         run: |
@@ -327,18 +323,14 @@ jobs:
               web/logs/latest/result.json
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: |
-          ((github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'aws/s2n-quic') ||
-          github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: |
-          ((github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'aws/s2n-quic') ||
-          github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         id: s3
         run: |
           cp .github/interop/*.html web/
@@ -355,7 +347,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           name: "interop / report"
           status: "success"
@@ -489,18 +481,14 @@ jobs:
           tree -H "." -T "Performance Results" --noreport --charset utf-8 > index.html
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: |
-          ((github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'aws/s2n-quic') ||
-          github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload results
-        if: |
-          ((github.event_name == 'push' || github.event_name == 'schedule') && github.repository == 'aws/s2n-quic') ||
-          github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         id: s3
         run: |
           TARGET_SHA="${{ github.sha }}/perf"
@@ -515,7 +503,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           name: "perf / report"
           status: "success"
@@ -570,13 +558,13 @@ jobs:
     needs: [env, s2n-quic-qns, interop, interop-report, h3spec, perf, perf-report, attack]
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'schedule' && github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
       - name: Report daily qns run to CloudWatch
-        if: github.event_name == 'schedule' && github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic'
         run: |
           METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
           aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -570,13 +570,13 @@ jobs:
     needs: [env, s2n-quic-qns, interop, interop-report, h3spec, perf, perf-report, attack]
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' && github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
       - name: Report daily qns run to CloudWatch
-        if: github.event_name == 'schedule'
+        if: github.event_name == 'schedule' && github.repository == 'aws/s2n-quic'
         run: |
           METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
           aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,14 +47,14 @@ jobs:
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCEcrRole
           role-session-name: S2nQuicGHAECRSession
           aws-region: us-east-1   # Required for ECR
 
       - name: Login to Amazon ECR Public
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v2
         with:
@@ -62,7 +62,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3.4.0
-        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -70,6 +70,7 @@ jobs:
 
       - name: Build and push image
         uses: docker/build-push-action@v6
+        if: github.repository == 'aws/s2n-quic'
         with:
           tags: ${{ steps.tags.outputs.tags }}
           file: quic/s2n-quic-qns/etc/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,14 +47,14 @@ jobs:
           echo "tags=${TAGS}" >> $GITHUB_OUTPUT
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCEcrRole
           role-session-name: S2nQuicGHAECRSession
           aws-region: us-east-1   # Required for ECR
 
       - name: Login to Amazon ECR Public
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v2
         with:
@@ -62,7 +62,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3.4.0
-        if: github.event_name == 'push' || github.repository == github.event.pull_request.head.repo.full_name
+        if: (github.event_name == 'push' && github.repository == 'aws/s2n-quic') || github.repository == github.event.pull_request.head.repo.full_name
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/tshark.yml
+++ b/.github/workflows/tshark.yml
@@ -52,13 +52,17 @@ jobs:
             cp /usr/local/bin/tshark /usr/local/bin/editcap /host-dir/
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.repository == github.event.pull_request.head.repo.full_name
+        if: |
+          ((github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.repository == 'aws/s2n-quic') ||
+          github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' || github.repository == github.event.pull_request.head.repo.full_name
+        if: |
+          ((github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.repository == 'aws/s2n-quic') ||
+          github.repository == github.event.pull_request.head.repo.full_name
         run: |
           aws s3 sync target/tshark "s3://s2n-quic-ci-artifacts/tshark" --acl private --follow-symlinks

--- a/.github/workflows/tshark.yml
+++ b/.github/workflows/tshark.yml
@@ -52,17 +52,13 @@ jobs:
             cp /usr/local/bin/tshark /usr/local/bin/editcap /host-dir/
 
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: |
-          ((github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.repository == 'aws/s2n-quic') ||
-          github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         with:
           role-to-assume: arn:aws:iam::024603541914:role/GitHubOIDCRole
           role-session-name: S2nQuicGHAS3Session
           aws-region: us-west-2
 
       - name: Upload to S3
-        if: |
-          ((github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.repository == 'aws/s2n-quic') ||
-          github.repository == github.event.pull_request.head.repo.full_name
+        if: github.repository == 'aws/s2n-quic'
         run: |
           aws s3 sync target/tshark "s3://s2n-quic-ci-artifacts/tshark" --acl private --follow-symlinks


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

related to https://github.com/aws/s2n-quic/issues/2651.

### Description of changes: 

We want to add logic to ensure that only `push` or `schedule` event to mainline s2n-quic will trigger AWS action to run. I believe that we only need to check if the `github.repository` is `aws/s2n-quic`.

The following conversation has more details: https://github.com/boquan-fang/s2n-quic/actions/runs/15501459732, https://github.com/boquan-fang/s2n-quic/actions/runs/15501459733.

### Call-outs:

We need to merge this PR into upstream. Pull down the code to local repo and then sync up with a forked s2n-quic repo to see if those jobs are not ran.

### Testing:

We need two parts of testing:
1. This PR is cut on upstream s2n-quic, so we should verify that every aws action are successfully ran.
2. After this PR is merged, as mentioned in the `Call-outs` section, we should verify that a forked s2n-quic repo doesn't run those aws actions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

