### PR TITLE
ci(udeps): use nightly v1.85.0 toolchain to fix udeps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-10-09
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-12-17
   CDN: https://dnglbrstg7yg.cloudfront.net
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

S2N-QUIC daily CI run detected a compilation issue with `udeps`: https://github.com/aws/s2n-quic/actions/runs/15432791547/job/43483440426. `udeps` did a release yesterday (16 hours ago) which requires rustc v1.85.0 nightly toolchain, while our current CI is using rustc v1.83.0. Hence, I need to update the nightly toolchain that we use to fix the issue.

Error snapshot:
```
error: failed to compile `cargo-udeps v0.1.56`, intermediate artifacts can be found at `/tmp/cargo-installi3Qmt7`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  rustc 1.83.0-nightly is not supported by the following packages:
    cargo@0.88.0 requires rustc 1.85
    cargo@0.88.0 requires rustc 1.85
    cargo@0.88.0 requires rustc 1.85
    cargo-credential-libsecret@0.4.13 requires rustc 1.85
    cargo-util@0.2.20 requires rustc 1.85
    cargo-util-schemas@0.8.1 requires rustc 1.85
    crates-io@0.40.10 requires rustc 1.85
```

### Call-outs:

### Testing:

This will be tested by our CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

