### PR TITLE
fix(dc/wireshark): Provide Rust edition to bindgen

### DIFF
--- a/dc/wireshark/generate-bindings.sh
+++ b/dc/wireshark/generate-bindings.sh
@@ -80,12 +80,14 @@ OPTIONS=(
 mkdir -p src/wireshark_sys/
 
 RUST_TARGET=$(rustc -vV | grep release: | awk '{ print $2 }')
+RUST_EDITION=$(cat ../../.rustfmt.toml | grep edition | awk '{ print $3 }' | tr -d '"')
 
 # This list is filtered to roughly what our current usage requires.
 # It's possible there's a better way to do this -- some of the Wireshark
 # headers end up pulling in C++ so we do need some filtering.
 bindgen \
   --rust-target $RUST_TARGET \
+  --rust-edition $RUST_EDITION \
   --raw-line '// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.' \
   --raw-line '// SPDX-License-Identifier: Apache-2.0' \
   ${OPTIONS[@]} \
@@ -95,6 +97,7 @@ bindgen \
 
 bindgen \
   --rust-target $RUST_TARGET \
+  --rust-edition $RUST_EDITION \
   --raw-line '// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.' \
   --raw-line '// SPDX-License-Identifier: Apache-2.0' \
   ${OPTIONS[@]} \


### PR DESCRIPTION
### Description of changes: 

A [new version of bindgen was released](https://github.com/rust-lang/rust-bindgen/releases/tag/v0.72.0), which [adds an `--edition` argument](https://github.com/rust-lang/rust-bindgen/blob/6e13d4fe95baafc27e18b7bf3bffb8f8399e327f/bindgen/lib.rs#L1027-L1031) to the rustfmt command that runs on the generated code.

 s2n-quic [runs rustfmt with the 2018 edition](https://github.com/aws/s2n-quic/blob/a1c0626f5cacc2e7d1caa87c7b5097ab5c90e657/.rustfmt.toml#L1). By default, bindgen [uses the latest edition](https://github.com/rust-lang/rust-bindgen/blame/6e13d4fe95baafc27e18b7bf3bffb8f8399e327f/bindgen/lib.rs#L1030).

This caused our rustfmt to fail when checking the code generated by bindgen:
https://github.com/aws/s2n-quic/actions/runs/15526083389/job/43752623889#step:7:29

This PR runs bindgen with the Rust edition specified in [our rustfmt config](https://github.com/aws/s2n-quic/blob/a1c0626f5cacc2e7d1caa87c7b5097ab5c90e657/.rustfmt.toml#L1), ensuring bindgen's rustfmt and our rustfmt agree.


### Testing:

The dc-wireshark CI jobs should succeed on this PR.

All the auth failures are unrelated to this change. They also fail in an unrelated test PR: https://github.com/aws/s2n-quic/pull/2662

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

