### PR TITLE
fix(ci): only report schedule CI result and run commit status update only on pull_request or push event

### DIFF
--- a/.github/actions/duvet/action.yml
+++ b/.github/actions/duvet/action.yml
@@ -87,8 +87,8 @@ runs:
 
         echo "::set-output name=URL::$URL"
 
-    - uses: ouzi-dev/commit-status-updater@v1.1.2
-      if: github.repository == 'aws/s2n-quic'
+    - uses: ouzi-dev/commit-status-updater@v2.0.2
+      if: github.repository == 'aws/s2n-quic' && (github.event_name == 'push' || github.event_name == 'pull_request')
       with:
         name: "compliance / report"
         status: "success"

--- a/.github/workflows/book.yml
+++ b/.github/workflows/book.yml
@@ -70,7 +70,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic' && (github.event_name == 'push' || github.event_name == 'pull_request')
         with:
           name: "book / url"
           status: "success"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -958,13 +958,13 @@ jobs:
     needs: [env, rustfmt, clippy, udeps, doc, test, asan, fips, miri, no_std, compliance, coverage, crates, examples, recovery-simulations, sims, copyright, events, snapshots, timing, typos, kani, dhat, loom, xdp, dc-wireshark]
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
       - name: Report daily CI run to CloudWatch
-        if: github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
         run: |
           METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
           aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -954,17 +954,15 @@ jobs:
 
   scheduled-ci-status-report:
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ always() }} && github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
     needs: [env, rustfmt, clippy, udeps, doc, test, asan, fips, miri, no_std, compliance, coverage, crates, examples, recovery-simulations, sims, copyright, events, snapshots, timing, typos, kani, dhat, loom, xdp, dc-wireshark]
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
       - name: Report daily CI run to CloudWatch
-        if: github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
         run: |
           METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
           aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic' && (github.event_name == 'push' || github.event_name == 'pull_request')
         with:
           name: "doc / report"
           status: "success"
@@ -463,7 +463,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic' && (github.event_name == 'push' || github.event_name == 'pull_request')
         with:
           name: "coverage / report"
           status: "success"
@@ -581,7 +581,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic' && (github.event_name == 'push' || github.event_name == 'pull_request')
         with:
           name: "recovery-simulations / report"
           status: "success"
@@ -632,7 +632,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic' && (github.event_name == 'push' || github.event_name == 'pull_request')
         with:
           name: "sims / report"
           status: "success"
@@ -745,7 +745,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic' && (github.event_name == 'push' || github.event_name == 'pull_request')
         with:
           name: "timing / report"
           status: "success"
@@ -847,7 +847,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic' && (github.event_name == 'push' || github.event_name == 'pull_request')
         with:
           name: "dhat / report"
           status: "success"
@@ -954,15 +954,17 @@ jobs:
 
   scheduled-ci-status-report:
     runs-on: ubuntu-latest
-    if: ${{ always() }} && github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
+    if: ${{ always() }}
     needs: [env, rustfmt, clippy, udeps, doc, test, asan, fips, miri, no_std, compliance, coverage, crates, examples, recovery-simulations, sims, copyright, events, snapshots, timing, typos, kani, dhat, loom, xdp, dc-wireshark]
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.2.1
+        if: github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
       - name: Report daily CI run to CloudWatch
+        if: github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
         run: |
           METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
           aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -347,7 +347,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic' && (github.event_name == 'push' || github.event_name == 'pull_request')
         with:
           name: "interop / report"
           status: "success"
@@ -503,7 +503,7 @@ jobs:
           fi
 
       - uses: ouzi-dev/commit-status-updater@v2.0.2
-        if: github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic' && (github.event_name == 'push' || github.event_name == 'pull_request')
         with:
           name: "perf / report"
           status: "success"
@@ -554,15 +554,17 @@ jobs:
 
   scheduled-qns-status-report:
     runs-on: ubuntu-latest
-    if: ${{ always() }} && github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
+    if: ${{ always() }}
     needs: [env, s2n-quic-qns, interop, interop-report, h3spec, perf, perf-report, attack]
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.2.1
+        if: github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
       - name: Report daily qns run to CloudWatch
+        if: github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
         run: |
           METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
           aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -554,17 +554,15 @@ jobs:
 
   scheduled-qns-status-report:
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ always() }} && github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
     needs: [env, s2n-quic-qns, interop, interop-report, h3spec, perf, perf-report, attack]
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
       - name: Report daily qns run to CloudWatch
-        if: github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
         run: |
           METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
           aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -558,13 +558,13 @@ jobs:
     needs: [env, s2n-quic-qns, interop, interop-report, h3spec, perf, perf-report, attack]
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.2.1
-        if: github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
       - name: Report daily qns run to CloudWatch
-        if: github.repository == 'aws/s2n-quic'
+        if: github.repository == 'aws/s2n-quic' && github.event_name == 'schedule'
         run: |
           METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
           aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

related to https://github.com/aws/s2n-quic/pull/2656, related to https://github.com/aws/s2n-quic/issues/2651

### Description of changes: 

After the mentioned PR is merged, I noticed that the status report for scheduled job is ran after each PR. It should only run when the github event is a `schedule` and it is running on upstream s2n-quic. This PR try to fix that issue.

Furthermore, we can only run `ouzi-dev/commit-status-updater` for github event of either `push` and `pull_request`, so we need to add that logic to this PR.

### Call-outs:

We need to watch github action closely to see if there are any behavior errors relate to https://github.com/aws/s2n-quic/pull/2656.

### Testing:

We should check that the CI for this PR will not report status to the CloudWatch metrics since it is not a scheduled job.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

