### PR TITLE
fix(ci): skip max_total_test for cargotiming job

### DIFF
--- a/codebuild/spec/cargotiming.yml
+++ b/codebuild/spec/cargotiming.yml
@@ -19,11 +19,10 @@ phases:
       - cargo build --timings --release
   post_build:
     commands:
-      - cargo test --workspace -- --skip ipv4_two_socket_test --skip ipv4_test
+      - cargo test --workspace -- --skip ipv4_two_socket_test --skip ipv4_test --skip max_total_test
 
 artifacts:
   # upload timing reports
   files:
     - '**/*'
   base-directory: target/cargo-timings
-


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

The current [`cargotiming`](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/003495580562/projects/CargoTiming/build/CargoTiming%3Ab8674570-bb37-404d-b6e0-1f0189666a05/?region=us-west-2) job is always failing because of the `max_total_test`:
```
failures:
2102 |  
2103 | ---- msg::segment::max_total_test stdout ----
2104 | thread 'msg::segment::max_total_test' panicked at dc/s2n-quic-dc/src/msg/segment.rs:63:54:
2105 | called `Result::unwrap()` on an `Err` value: Os { code: 99, kind: AddrNotAvailable, message: "Cannot assign requested address" }
2106 | note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
2107 |  
```

The reason is CodeBuild doesn't allow a bind to ipv4 localhost which is found by https://github.com/aws/s2n-quic/pull/2525. However, the previous PR forgot to skip `max_total_test` which also directly bind to ipv4 localhost address. Hence, this PR will skip such test.

### Call-outs:

We should figure out why we can't bind to ipv4 localhost in CodeBuild.

### Testing:

CI should pass, and we need to run this in CodeBuild to see whether it works. The link to the Cargotiming job run base on this PR: 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

