### PR TITLE
s2n-quic-transport(feat): Adds packet storage feature

### DIFF
--- a/quic/s2n-quic-core/src/packet/handshake.rs
+++ b/quic/s2n-quic-core/src/packet/handshake.rs
@@ -65,6 +65,10 @@ pub type EncryptedHandshake<'a> =
 pub type CleartextHandshake<'a> = Handshake<&'a [u8], &'a [u8], PacketNumber, DecoderBufferMut<'a>>;
 
 impl<'a> ProtectedHandshake<'a> {
+    pub fn get_wire_bytes(&self) -> Vec<u8> {
+        self.payload.buffer.encode_to_vec()
+    }
+
     #[inline]
     pub(crate) fn decode(
         _tag: Tag,

--- a/quic/s2n-quic-core/src/packet/short.rs
+++ b/quic/s2n-quic-core/src/packet/short.rs
@@ -194,6 +194,10 @@ impl<'a> ProtectedShort<'a> {
             .get_checked_range(&self.destination_connection_id)
             .into_less_safe_slice()
     }
+
+    pub fn get_wire_bytes(&self) -> Vec<u8> {
+        self.payload.buffer.encode_to_vec()
+    }
 }
 
 impl<'a> EncryptedShort<'a> {

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -138,6 +138,8 @@ impl connection::Trait for TestConnection {
         _datagram: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
         _conn_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
+        _random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
+        _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
     ) -> Result<(), connection::Error> {
         Ok(())
     }

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -115,6 +115,8 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         datagram: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
         conn_limits: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
+        random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
+        packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
     ) -> Result<(), connection::Error>;
 
     // Packet handling

--- a/quic/s2n-quic-transport/src/connection/mod.rs
+++ b/quic/s2n-quic-transport/src/connection/mod.rs
@@ -89,4 +89,6 @@ pub struct Parameters<'a, Cfg: endpoint::Config> {
     pub event_subscriber: &'a mut Cfg::EventSubscriber,
     /// The connection limits provider
     pub limits_endpoint: &'a mut Cfg::ConnectionLimits,
+    pub random_endpoint: &'a mut Cfg::RandomGenerator,
+    pub interceptor_endpoint: &'a mut Cfg::PacketInterceptor,
 }

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -316,6 +316,8 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             dc_endpoint: endpoint_context.dc,
             open_registry: None,
             limits_endpoint: endpoint_context.connection_limits,
+            random_endpoint: endpoint_context.random_generator,
+            interceptor_endpoint: endpoint_context.packet_interceptor,
         };
 
         let mut connection = <Config as endpoint::Config>::Connection::new(connection_parameters)?;

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -27,10 +27,12 @@ use s2n_quic_core::{
         id::{ConnectionInfo, Generator},
         InitialId, LocalId, PeerId,
     },
-    crypto::{tls, tls::Endpoint as _, CryptoSuite, InitialKey},
+    crypto::{
+        tls::{self, Endpoint as _},
+        CryptoSuite, InitialKey,
+    },
     datagram::{Endpoint as DatagramEndpoint, PreConnectionInfo},
-    dc,
-    dc::Endpoint as _,
+    dc::{self, Endpoint as _},
     endpoint::{limits::Outcome, Limiter as _},
     event::{
         self, supervisor, ConnectionPublisher, EndpointPublisher as _, IntoEvent, Subscriber as _,
@@ -38,8 +40,7 @@ use s2n_quic_core::{
     inet::{datagram, DatagramInfo},
     io::{rx, tx},
     packet::{initial::ProtectedInitial, interceptor::Interceptor, ProtectedPacket},
-    path,
-    path::{mtu, Handle as _},
+    path::{self, mtu, Handle as _},
     random::Generator as _,
     stateless_reset::token::{Generator as _, LEN as StatelessResetTokenLen},
     time::{Clock, Timestamp},
@@ -215,6 +216,8 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
                     endpoint_context.datagram,
                     endpoint_context.dc,
                     endpoint_context.connection_limits,
+                    endpoint_context.random_generator,
+                    endpoint_context.packet_interceptor,
                 ) {
                     conn.close(
                         error,
@@ -1232,6 +1235,8 @@ impl<Cfg: Config> Endpoint<Cfg> {
             dc_endpoint: endpoint_context.dc,
             open_registry,
             limits_endpoint: endpoint_context.connection_limits,
+            random_endpoint: endpoint_context.random_generator,
+            interceptor_endpoint: endpoint_context.packet_interceptor,
         };
         let connection = <Cfg as crate::endpoint::Config>::Connection::new(connection_parameters)?;
         self.connections

--- a/quic/s2n-quic/src/tests/slow_tls.rs
+++ b/quic/s2n-quic/src/tests/slow_tls.rs
@@ -36,6 +36,7 @@ fn slow_tls() {
         let client = Client::builder()
             .with_io(handle.builder().build().unwrap())?
             .with_tls(slow_client)?
+            .with_event((tracing_events(), MyEvents))?
             .start()?;
         let addr = start_server(server)?;
         start_client(client, addr, Data::new(1000))?;
@@ -43,4 +44,37 @@ fn slow_tls() {
         Ok(addr)
     })
     .unwrap();
+
+    struct MyEvents;
+    struct MyContext;
+    impl events::Subscriber for MyEvents {
+        type ConnectionContext = MyContext;
+
+        fn create_connection_context(
+            &mut self,
+            _meta: &events::ConnectionMeta,
+            _info: &events::ConnectionInfo,
+        ) -> Self::ConnectionContext {
+            Self::ConnectionContext {}
+        }
+        fn on_transport_parameters_received(
+            &mut self,
+            _context: &mut Self::ConnectionContext,
+            meta: &s2n_quic_core::event::api::ConnectionMeta,
+            _event: &s2n_quic_core::event::api::TransportParametersReceived,
+        ) {
+            // Slow TLS implementation has no affect on when transport parameters are received
+            assert_eq!(meta.timestamp.to_string(), "0:00:00.100000");
+        }
+
+        fn on_connection_closed(
+            &mut self,
+            _context: &mut Self::ConnectionContext,
+            meta: &s2n_quic_core::event::api::ConnectionMeta,
+            _event: &s2n_quic_core::event::api::ConnectionClosed,
+        ) {
+            // Slow TLS implementation has no affect on when the connection is shut down
+            assert_eq!(meta.timestamp.to_string(), "0:00:00.200000");
+        }
+    }
 }


### PR DESCRIPTION
### Release Summary:
s2n-quic now buffers packets it cannot decrypt until the keys to decrypt them are generated. This potentially allocates more memory per connection but it also combats packet loss and should complete the handshake faster under certain circumstances.

### Resolved issues:

resolves #2601

### Description of changes: 

s2n-quic will currently throw out packets it can't decrypt. We want to buffer at least one per packet space so that if the TLS library returns pending we store the packet until we can decrypt it.

### Call-outs:

There's some very obvious problems with this code. 
1. Probably the biggest one is that I am not using the endpoint's connection_id_validator and instead just implemented a fake one that works. To be honest, not really sure what the best thing to do here is. I could use some thoughts/opinions about this. 
2. Should this feature be configurable? I wonder if the extra memory allocation is actually better than the packet loss/retransmission time.
### Testing:

Includes changes to the slow_tls test to assert that with this feature we are as fast as a normal TLS handshake since we are now buffering packets that were previously dropped.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

