### PR TITLE
build(deps): revert update of prost requirement from 0.13 to 0.14

### DIFF
--- a/quic/s2n-quic-sim/Cargo.toml
+++ b/quic/s2n-quic-sim/Cargo.toml
@@ -17,7 +17,7 @@ bolero-generator = "0.13.0"
 indicatif = { version = "0.17", features = ["rayon"] }
 jiff = "0.2"
 once_cell = "1"
-prost = "0.14"
+prost = "0.13"
 rand = "0.9"
 rayon = "1"
 s2n-quic = { path = "../s2n-quic", features = ["unstable-provider-io-testing", "provider-event-tracing"] }


### PR DESCRIPTION
### Description of changes: 

This reverts commit c6e694e99cc4e81d1863b8b3bb5a23311f24e40f as version 0.14 of prost has been yanked. See
https://github.com/tokio-rs/prost/issues/1296.

### Testing:

Tested in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

