### PR TITLE
feat(s2n-quic-dc): Expose dc::HandshakingPath publicly

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map.rs
@@ -9,7 +9,6 @@ use crate::{
     stream::TransportFeatures,
 };
 use core::fmt;
-pub use entry::ApplicationData;
 use s2n_quic_core::{dc, time};
 use std::{net::SocketAddr, sync::Arc};
 
@@ -32,7 +31,10 @@ mod event_tests;
 pub use entry::Entry;
 use store::Store;
 
-pub use entry::{ApplicationPair, Bidirectional, ControlPair};
+pub use entry::{
+    ApplicationData, ApplicationDataError, ApplicationPair, Bidirectional, ControlPair,
+};
+pub use handshake::HandshakingPath;
 pub use peer::Peer;
 
 pub(crate) use size_of::SizeOf;
@@ -299,7 +301,7 @@ impl Map {
         cb: Box<
             dyn Fn(
                     &dyn s2n_quic_core::crypto::tls::TlsSession,
-                ) -> Result<Option<ApplicationData>, &'static str>
+                ) -> Result<Option<ApplicationData>, ApplicationDataError>
                 + Send
                 + Sync,
         >,

--- a/dc/s2n-quic-dc/src/path/secret/map/entry.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/entry.rs
@@ -33,6 +33,14 @@ mod tests;
 
 pub type ApplicationData = Arc<dyn Any + Send + Sync>;
 
+#[derive(Debug, thiserror::Error)]
+#[error("{inner}")]
+pub struct ApplicationDataError {
+    pub msg: &'static str,
+    #[source]
+    pub inner: Box<dyn std::error::Error + Send + Sync>,
+}
+
 #[derive(Debug)]
 pub struct Entry {
     creation_time: Instant,

--- a/dc/s2n-quic-dc/src/path/secret/map/peer.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/peer.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{dc, seal, Bidirectional, Credentials, Entry, Map, TransportFeatures};
+use super::{dc, seal, Bidirectional, Credentials, Entry, Id, Map, TransportFeatures};
 use std::sync::Arc;
 
 pub struct Peer {
@@ -28,6 +28,11 @@ impl Peer {
         let keys = self.entry.bidi_local(features);
 
         (keys, self.entry.parameters())
+    }
+
+    #[inline]
+    pub fn id(&self) -> &Id {
+        self.entry.id()
     }
 
     #[inline]

--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -1,7 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{cleaner::Cleaner, entry::ApplicationData, stateless_reset, Entry, Store};
+use super::{
+    cleaner::Cleaner, stateless_reset, ApplicationData, ApplicationDataError, Entry, Store,
+};
 use crate::{
     credentials::{Credentials, Id},
     crypto,
@@ -221,7 +223,7 @@ where
             Box<
                 dyn Fn(
                         &dyn s2n_quic_core::crypto::tls::TlsSession,
-                    ) -> Result<Option<ApplicationData>, &'static str>
+                    ) -> Result<Option<ApplicationData>, ApplicationDataError>
                     + Send
                     + Sync,
             >,
@@ -678,7 +680,7 @@ where
         cb: Box<
             dyn Fn(
                     &dyn s2n_quic_core::crypto::tls::TlsSession,
-                ) -> Result<Option<ApplicationData>, &'static str>
+                ) -> Result<Option<ApplicationData>, ApplicationDataError>
                 + Send
                 + Sync,
         >,
@@ -894,7 +896,7 @@ where
     fn application_data(
         &self,
         session: &dyn s2n_quic_core::crypto::tls::TlsSession,
-    ) -> Result<Option<ApplicationData>, &'static str> {
+    ) -> Result<Option<ApplicationData>, ApplicationDataError> {
         if let Some(ctxt) = &*self
             .mk_application_data
             .read()

--- a/dc/s2n-quic-dc/src/path/secret/map/store.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/store.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{entry::ApplicationData, Entry};
+use super::{ApplicationData, ApplicationDataError, Entry};
 use crate::{
     credentials::{Credentials, Id},
     packet::{secret_control as control, Packet, WireVersion},
@@ -108,7 +108,7 @@ pub trait Store: 'static + Send + Sync {
         cb: Box<
             dyn Fn(
                     &dyn s2n_quic_core::crypto::tls::TlsSession,
-                ) -> Result<Option<ApplicationData>, &'static str>
+                ) -> Result<Option<ApplicationData>, ApplicationDataError>
                 + Send
                 + Sync,
         >,
@@ -117,5 +117,5 @@ pub trait Store: 'static + Send + Sync {
     fn application_data(
         &self,
         session: &dyn s2n_quic_core::crypto::tls::TlsSession,
-    ) -> Result<Option<ApplicationData>, &'static str>;
+    ) -> Result<Option<ApplicationData>, ApplicationDataError>;
 }


### PR DESCRIPTION
### Release Summary:

* feat(s2n-quic-dc): Expose HandshakingPath to access entry/error after handshake completes

### Resolved issues:

n/a

### Description of changes: 

This refactors the HandshakingPath to allow consumers of the DcPathCreated event to store a copy of the path locally, allowing subsequent access after various events are handled (e.g., to pull out the path secret ID for logging).

This also adjusts error propagation out of the HandshakingPath to preserve more detail about errors, again propagating that into the HandshakingPath for consumers to access if desired. This also avoids panics in a few cases in favor of failing just the one handshake.
### Call-outs:

n/a

### Testing:

Just refactoring (mostly exposing more types), no particular tests added.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

