### PR TITLE
fix(s2n-quic-dc): detect truncated streams

### DIFF
--- a/dc/s2n-quic-dc/src/stream/recv/buffer/local/test.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/buffer/local/test.rs
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::stream::{recv, recv::buffer::Dispatch};
+use std::net::{IpAddr, Ipv4Addr};
+
+// Checks that a stream which saw EOF mid-packet will not expect more data to come in and returns an error.
+#[test]
+fn check_truncation() {
+    let mut local = super::Local::new(super::msg::recv::Message::new(9000), None);
+    let mut dispatch = NoopDispatch;
+
+    // Populate the receive buffer enough that we can start parsing...
+    let packet = vec![0b0101_0000];
+    local.recv_buffer.test_recv(
+        (IpAddr::from(Ipv4Addr::LOCALHOST), 1).into(),
+        Default::default(),
+        packet,
+    );
+
+    // OK, maybe more bytes will come in.
+    local.dispatch_buffer_stream(&mut dispatch).unwrap();
+
+    // Then we indicate that no more bytes are coming, at which point dispatch indicates an error
+    // has happened.
+    local.saw_fin = true;
+    let err = local.dispatch_buffer_stream(&mut dispatch).unwrap_err();
+
+    assert!(matches!(err.kind(), recv::error::Kind::Decode));
+}
+
+struct NoopDispatch;
+
+impl Dispatch for NoopDispatch {
+    fn on_packet(
+        &mut self,
+        _remote_addr: &s2n_quic_core::inet::SocketAddress,
+        _ecn: s2n_quic_core::inet::ExplicitCongestionNotification,
+        _packet: crate::packet::Packet,
+    ) -> Result<(), crate::stream::recv::Error> {
+        // should never actually parse a packet
+        unreachable!()
+    }
+}


### PR DESCRIPTION
### Release Summary:

* fix(s2n-quic-dc): properly detect truncated streams

### Resolved issues:

n/a

### Description of changes: 

Previously we ignored the return from poll_read on the underlying TcpStream (poll_fill_once calls into that), which meant that a truncated stream caused effectively a busy loop trying to parse the last packet to be sent on the stream.

### Call-outs:

This fixes a known case but doesn't fix the class of bug definitively -- there may be other poll_read's hiding whose output is ignored. Unfortunately I'm not sure we have any good tooling for catching that, but I'll attempt to manually audit soon.

### Testing:

See added unit test.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

