### PR TITLE
Expose inner context on metrics Subscriber

### DIFF
--- a/dc/s2n-quic-dc/src/event/generated/metrics.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics.rs
@@ -46,6 +46,14 @@ pub struct Context<R: Recorder> {
     stream_read_socket_errored: AtomicU64,
     connection_closed: AtomicU64,
 }
+impl<R: Recorder> Context<R> {
+    pub fn inner(&self) -> &R {
+        &self.recorder
+    }
+    pub fn inner_mut(&mut self) -> &mut R {
+        &mut self.recorder
+    }
+}
 impl<S: event::Subscriber> event::Subscriber for Subscriber<S>
 where
     S::ConnectionContext: Recorder,

--- a/quic/s2n-quic-core/src/event/generated/metrics.rs
+++ b/quic/s2n-quic-core/src/event/generated/metrics.rs
@@ -74,6 +74,14 @@ pub struct Context<R: Recorder> {
     dc_path_created: u64,
     connection_closed: u64,
 }
+impl<R: Recorder> Context<R> {
+    pub fn inner(&self) -> &R {
+        &self.recorder
+    }
+    pub fn inner_mut(&mut self) -> &mut R {
+        &mut self.recorder
+    }
+}
 impl<S: event::Subscriber> event::Subscriber for Subscriber<S>
 where
     S::ConnectionContext: Recorder,

--- a/quic/s2n-quic-events/src/output/metrics.rs
+++ b/quic/s2n-quic-events/src/output/metrics.rs
@@ -94,6 +94,16 @@ pub fn emit(output: &Output, files: &[File]) -> TokenStream {
             #fields
         }
 
+        impl<R: Recorder> Context<R> {
+            pub fn inner(&self) -> &R {
+                &self.recorder
+            }
+
+            pub fn inner_mut(&mut self) -> &mut R {
+                &mut self.recorder
+            }
+        }
+
         impl<S: event::Subscriber> event::Subscriber for Subscriber<S>
             where S::ConnectionContext: Recorder {
             type ConnectionContext = Context<S::ConnectionContext>;


### PR DESCRIPTION
### Release Summary:

n/a -- only affects s2n-quic-core API

### Resolved issues:

n/a

### Description of changes: 

This lets applications wrapping their own Subscriber access the context via query_event_context on Connection.

### Call-outs:

n/a

### Testing:

No particular testing, but just exposing the inner field, so pretty straightforward. This is all unstable API anyway.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

