### PR TITLE
fix(s2n-quic-dc): avoid memory leak in worker waker

### DIFF
--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -34,7 +34,6 @@ bitflags = "2"
 bolero-generator = { version = "0.13", default-features = false, optional = true }
 bytes = "1"
 crossbeam-channel = "0.5"
-crossbeam-epoch = "0.9"
 crossbeam-queue = { version = "0.3" }
 dashmap = "6"
 event-listener-strategy = "0.5"

--- a/dc/s2n-quic-dc/src/task/waker/worker.rs
+++ b/dc/s2n-quic-dc/src/task/waker/worker.rs
@@ -42,7 +42,7 @@ impl Waker {
         // we only need to `wake_by_ref` if the worker is sleeping
         ensure!(matches!(state.status, Status::Sleeping));
 
-        // clone the waker out of the lock to avoid deadlocks
+        // wake the waker outside of the lock to avoid deadlocks
         let waker = state.waker.clone();
         drop(state);
         waker.wake();
@@ -50,7 +50,7 @@ impl Waker {
 
     #[inline]
     pub fn wake_forced(&self) {
-        // clone the waker out of the lock to avoid deadlocks
+        // wake the waker outside of the lock to avoid deadlocks
         let waker = self.state.lock().unwrap().waker.clone();
         waker.wake();
     }

--- a/dc/s2n-quic-dc/src/task/waker/worker.rs
+++ b/dc/s2n-quic-dc/src/task/waker/worker.rs
@@ -1,26 +1,30 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use core::{
-    sync::atomic::{AtomicU8, Ordering},
-    task,
-};
-use crossbeam_epoch::{pin, Atomic};
-use s2n_quic_core::{ensure, state::is};
+use core::task;
+use s2n_quic_core::{ensure, state::is, task::waker::noop};
+use std::sync::Mutex;
 
 /// An atomic waker that doesn't change often
 #[derive(Debug)]
 pub struct Waker {
-    waker: Atomic<task::Waker>,
-    has_woken: AtomicU8,
+    state: Mutex<State>,
+}
+
+#[derive(Debug)]
+struct State {
+    waker: task::Waker,
+    status: Status,
 }
 
 impl Default for Waker {
     #[inline]
     fn default() -> Self {
         Self {
-            waker: Atomic::null(),
-            has_woken: AtomicU8::new(Status::Sleeping.as_u8()),
+            state: Mutex::new(State {
+                waker: noop(),
+                status: Status::Sleeping,
+            }),
         }
     }
 }
@@ -28,44 +32,33 @@ impl Default for Waker {
 impl Waker {
     #[inline]
     pub fn update(&self, waker: &task::Waker) {
-        let pin = crossbeam_epoch::pin();
-
-        let waker = crossbeam_epoch::Owned::new(waker.clone()).into_shared(&pin);
-        let prev = self.waker.swap(waker, Ordering::AcqRel, &pin);
-
-        ensure!(!prev.is_null());
-
-        unsafe {
-            pin.defer_unchecked(move || {
-                drop(prev.try_into_owned());
-            })
-        }
+        self.state.lock().unwrap().waker = waker.clone();
     }
 
     #[inline]
     pub fn wake(&self) {
-        let status = self.swap_status(Status::PendingWork, Ordering::Acquire);
+        let state = self.state.lock().unwrap();
 
         // we only need to `wake_by_ref` if the worker is sleeping
-        ensure!(matches!(status, Status::Sleeping));
+        ensure!(matches!(state.status, Status::Sleeping));
 
-        self.wake_forced();
+        // clone the waker out of the lock to avoid deadlocks
+        let waker = state.waker.clone();
+        drop(state);
+        waker.wake();
     }
 
     #[inline]
     pub fn wake_forced(&self) {
-        let guard = crossbeam_epoch::pin();
-        let waker = self.waker.load(Ordering::Acquire, &guard);
-        let Some(waker) = (unsafe { waker.as_ref() }) else {
-            return;
-        };
-        waker.wake_by_ref();
+        // clone the waker out of the lock to avoid deadlocks
+        let waker = self.state.lock().unwrap().waker.clone();
+        waker.wake();
     }
 
     /// Called when the worker wakes
     #[inline]
     pub fn on_worker_wake(&self) {
-        self.swap_status(Status::Working, Ordering::Release);
+        self.swap_status(Status::Working);
     }
 
     /// Called before the worker sleeps
@@ -73,12 +66,13 @@ impl Waker {
     /// Returns the previous [`Status`]
     #[inline]
     pub fn on_worker_sleep(&self) -> Status {
-        self.swap_status(Status::Sleeping, Ordering::Release)
+        self.swap_status(Status::Sleeping)
     }
 
     #[inline]
-    fn swap_status(&self, status: Status, ordering: Ordering) -> Status {
-        Status::from_u8(self.has_woken.swap(status.as_u8(), ordering))
+    fn swap_status(&self, status: Status) -> Status {
+        let mut state = self.state.lock().unwrap();
+        core::mem::replace(&mut state.status, status)
     }
 }
 
@@ -93,39 +87,4 @@ impl Status {
     is!(is_sleeping, Sleeping);
     is!(is_pending_work, PendingWork);
     is!(is_working, Working);
-
-    #[inline]
-    fn as_u8(self) -> u8 {
-        match self {
-            Self::Sleeping => 0,
-            Self::PendingWork => 1,
-            Self::Working => 2,
-        }
-    }
-
-    #[inline]
-    fn from_u8(v: u8) -> Self {
-        match v {
-            1 => Self::PendingWork,
-            2 => Self::Working,
-            _ => Self::Sleeping,
-        }
-    }
-}
-
-impl Drop for Waker {
-    #[inline]
-    fn drop(&mut self) {
-        let pin = pin();
-        let waker = crossbeam_epoch::Shared::null();
-        let prev = self.waker.swap(waker, Ordering::AcqRel, &pin);
-
-        ensure!(!prev.is_null());
-
-        unsafe {
-            pin.defer_unchecked(move || {
-                drop(prev.try_into_owned());
-            })
-        }
-    }
 }


### PR DESCRIPTION
### Description of changes: 

Our usage of the crossbeam-epoch `Atomic` seems to be incorrect and leaks Wakers. I don't really think our current usage really justifies the complicated (unsafe) interface so i've just replaced it with a Mutex.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

