### PR TITLE
test(s2n-quic): server handle conn migration with zero-length cid

### DIFF
--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -85,6 +85,7 @@ zeroize = { version = "1", optional = true, default-features = false }
 
 [dev-dependencies]
 bolero = { version = "0.13" }
+quiche = "0.24"
 s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "probe-tracing", "testing"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["testing"] }
 s2n-quic-transport = { path = "../s2n-quic-transport", features = ["unstable_resumption", "unstable-provider-dc"] }

--- a/quic/s2n-quic/src/tests.rs
+++ b/quic/s2n-quic/src/tests.rs
@@ -43,6 +43,7 @@ mod pto;
 mod self_test;
 mod skip_packets;
 mod tls_context;
+mod zero_length_cid_client_connection_migration;
 
 // TODO: https://github.com/aws/s2n-quic/issues/1726
 //

--- a/quic/s2n-quic/src/tests/recorder.rs
+++ b/quic/s2n-quic/src/tests/recorder.rs
@@ -129,6 +129,34 @@ event_recorder!(
     }
 );
 
+event_recorder!(
+    InitialCryptoFrameReceived,
+    FrameReceived,
+    on_frame_received,
+    Vec<u8>,
+    |event: &events::FrameReceived, storage: &mut Vec<Vec<u8>>| {
+        if matches!(event.frame, s2n_quic_core::event::api::Frame::Crypto { .. })
+            && matches!(
+                event.packet_header,
+                s2n_quic_core::event::api::PacketHeader::Initial { .. }
+            )
+        {
+            storage.push(event.path.remote_cid.bytes.to_vec());
+        }
+    }
+);
+
+event_recorder!(
+    PathChallengeUpdated,
+    PathChallengeUpdated,
+    on_path_challenge_updated,
+    s2n_quic_core::event::api::PathChallengeStatus,
+    |event: &events::PathChallengeUpdated,
+     storage: &mut Vec<s2n_quic_core::event::api::PathChallengeStatus>| {
+        storage.push(event.path_challenge_status.clone());
+    }
+);
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PacketDropReason {
     ConnectionError,

--- a/quic/s2n-quic/src/tests/setup.rs
+++ b/quic/s2n-quic/src/tests/setup.rs
@@ -11,10 +11,18 @@ use crate::{
     Client, Server,
 };
 use rand::{Rng, RngCore};
-use s2n_quic_core::{crypto::tls::testing::certificates, havoc, stream::testing::Data};
+use s2n_quic_core::{
+    crypto::tls::testing::certificates, havoc, inet::ExplicitCongestionNotification::*,
+    stream::testing::Data,
+};
+use s2n_quic_platform::io::testing::Socket;
 use std::net::SocketAddr;
+use zerocopy::IntoBytes;
 
 pub static SERVER_CERTS: (&str, &str) = (certificates::CERT_PEM, certificates::KEY_PEM);
+
+const QUICHE_MAX_DATAGRAM_SIZE: usize = 1350;
+const QUICHE_STREAM_ID: u64 = 0;
 
 pub fn tracing_events() -> event::tracing::Subscriber {
     use std::sync::Once;
@@ -135,6 +143,145 @@ pub fn start_client(client: Client, server_addr: SocketAddr, data: Data) -> Resu
         while let Some(chunk) = send_data.send_one(usize::MAX) {
             tracing::debug!("client sending {} chunk", chunk.len());
             send.send(chunk).await.unwrap();
+        }
+    });
+
+    Ok(())
+}
+
+pub fn start_quiche_client(
+    mut client_conn: quiche::Connection,
+    socket: Socket,
+    migrated_socket: Socket,
+    server_addr: SocketAddr,
+) -> Result {
+    let mut out = [0; QUICHE_MAX_DATAGRAM_SIZE];
+    let mut buf = [0; QUICHE_MAX_DATAGRAM_SIZE];
+    let application_data = "Test Migration";
+
+    primary::spawn(async move {
+        client_conn.timeout();
+
+        // Write Initial handshake packets
+        let (write, send_info) = client_conn.send(&mut out).expect("Initial send failed");
+        socket
+            .send_to(send_info.to, NotEct, out[..write].to_vec())
+            .unwrap();
+
+        let mut path_probed = false;
+        let mut req_sent = false;
+        loop {
+            // We need to check if there is a timeout event at the beginning of
+            // each loop to make sure that the connection will close properly when
+            // the test is done.
+            client_conn.on_timeout();
+            // Quiche doesn't handle IO. So we need to handle events happen
+            // on both the original socket and the migrated socket
+            let sockets = vec![&socket, &migrated_socket];
+            for active_socket in sockets {
+                let local_addr = active_socket.local_addr().unwrap();
+                match active_socket.try_recv_from() {
+                    Ok(Some((from, _ecn, payload))) => {
+                        // Quiche conn.recv requires a mutable payload array
+                        let mut payload_copy = payload.clone();
+
+                        // Feed received data from IO Socket to Quiche
+                        let _read = match client_conn.recv(
+                            &mut payload_copy,
+                            quiche::RecvInfo {
+                                from,
+                                to: active_socket.local_addr().unwrap(),
+                            },
+                        ) {
+                            Ok(v) => v,
+                            Err(quiche::Error::Done) => 0,
+                            Err(e) => {
+                                panic!("quiche client receive error: {:?}", e);
+                            }
+                        };
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        panic!("quiche client socket recv error: {:?}", e);
+                    }
+                }
+
+                for peer_addr in client_conn.paths_iter(local_addr) {
+                    loop {
+                        let (write, send_info) = match client_conn.send_on_path(
+                            &mut out,
+                            Some(local_addr),
+                            Some(peer_addr),
+                        ) {
+                            Ok(v) => v,
+                            Err(quiche::Error::Done) => {
+                                break;
+                            }
+                            Err(e) => {
+                                panic!("quiche client send error: {:?}", e)
+                            }
+                        };
+
+                        active_socket
+                            .send_to(send_info.to, NotEct, out[..write].to_vec())
+                            .unwrap();
+                    }
+
+                    // Send application data using the migrated address
+                    // This can only be done once the connection migration is completed
+                    if local_addr == migrated_socket.local_addr().unwrap()
+                        && client_conn
+                            .is_path_validated(local_addr, peer_addr)
+                            .unwrap()
+                        && !req_sent
+                    {
+                        client_conn
+                            .stream_send(QUICHE_STREAM_ID, application_data.as_bytes(), true)
+                            .unwrap();
+                        req_sent = true;
+                    }
+                }
+
+                for stream_id in client_conn.readable() {
+                    while let Ok((read, _)) = client_conn.stream_recv(stream_id, &mut buf) {
+                        let stream_buf = &buf[..read];
+                        // The data that the Quiche client received should be the same that it sent
+                        if stream_buf.as_bytes() == application_data.as_bytes() {
+                            // The test is done once the client recieves the data. Hence, close the connection
+                            client_conn.close(false, 0x00, b"test finished").unwrap();
+                        } else {
+                            panic!("No string recieved!");
+                        }
+                    }
+                }
+            }
+
+            // Exit the test once the connection is closed
+            if client_conn.is_closed() {
+                break;
+            }
+
+            while let Some(qe) = client_conn.path_event_next() {
+                match qe {
+                    quiche::PathEvent::Validated(local_addr, peer_addr) => {
+                        client_conn.migrate(local_addr, peer_addr).unwrap();
+                    }
+                    _ => {}
+                }
+            }
+
+            // Perform connection migration after the connection is established
+            // and the server provides spare CIDs
+            if client_conn.is_established() && client_conn.available_dcids() > 0 {
+                if !path_probed {
+                    let new_addr = migrated_socket.local_addr().unwrap();
+                    client_conn.probe_path(new_addr, server_addr).unwrap();
+                    path_probed = true;
+                }
+            }
+
+            // Sleep a bit to avoid busy-waiting
+            crate::provider::io::testing::time::delay(std::time::Duration::from_millis(10)).await;
         }
     });
 

--- a/quic/s2n-quic/src/tests/zero_length_cid_client_connection_migration.rs
+++ b/quic/s2n-quic/src/tests/zero_length_cid_client_connection_migration.rs
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::provider::{
+    limits,
+    tls::default::{self as tls},
+};
+
+#[test]
+fn zero_length_cid_client_connection_migration_test() {
+    let model = Model::default();
+
+    // Create event subscribers to track frame received events
+    let initial_cid_subscriber = recorder::InitialCryptoFrameReceived::new();
+    let initial_cid_event = initial_cid_subscriber.events();
+    let path_challenge_subscriber = recorder::PathChallengeUpdated::new();
+    let path_challenge_event = path_challenge_subscriber.events();
+
+    test(model, |handle| {
+        // Set up a s2n-quic server
+        let server = tls::Server::builder()
+            .with_application_protocols(["h3"].iter())
+            .unwrap()
+            .with_certificate(certificates::CERT_PEM, certificates::KEY_PEM)
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let server = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(server)?
+            .with_event((
+                tracing_events(),
+                (initial_cid_subscriber, path_challenge_subscriber),
+            ))?
+            .with_random(Random::with_seed(456))?
+            .with_limits(limits::Limits::new().with_max_active_connection_ids(3)?)?
+            .start()?;
+
+        let server_addr = start_server(server)?;
+
+        // Set up a Cloudflare Quiche client
+        let mut client_config = quiche::Config::new(quiche::PROTOCOL_VERSION).unwrap();
+        client_config
+            .set_application_protos(quiche::h3::APPLICATION_PROTOCOL)
+            .unwrap();
+        client_config.verify_peer(false);
+        client_config.set_initial_max_data(10_000_000);
+        client_config.set_initial_max_stream_data_bidi_local(1_000_000);
+        client_config.set_initial_max_stream_data_bidi_remote(1_000_000);
+        client_config.set_disable_active_migration(false);
+        client_config.set_active_connection_id_limit(5);
+
+        // create a zero-length Source CID
+        let scid = quiche::ConnectionId::default();
+
+        let socket = handle.builder().build()?.socket();
+        let migrated_socket = handle.builder().build()?.socket();
+
+        // Create a QUIC connection and initiate handshake.
+        let conn = quiche::connect(
+            Some(&"localhost"),
+            &scid,
+            socket.local_addr().unwrap(),
+            server_addr,
+            &mut client_config,
+        )
+        .unwrap();
+
+        // Check if the client is using zero-length CID
+        assert_eq!(conn.source_id().len(), 0);
+
+        start_quiche_client(conn, socket, migrated_socket, server_addr).unwrap();
+
+        Ok(())
+    })
+    .unwrap();
+
+    let initial_cid_vec = initial_cid_event.lock().unwrap();
+    // The server should only perform one handshake with a successful
+    // connection mgiration. Hence, it should only receive one Initial packet
+    // with Crypto frame
+    assert_eq!(initial_cid_vec.len(), 1);
+    // Verify if the client's original CID is zero-length
+    assert_eq!(initial_cid_vec[0].len(), 0);
+
+    // Verify if the new path is validated
+    let path_challenge_statuses = path_challenge_event.lock().unwrap();
+    let path_validated = path_challenge_statuses
+        .iter()
+        .any(|status| matches!(status, events::PathChallengeStatus::Validated { .. }));
+    assert!(path_validated);
+}


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2378.

### Description of changes: 

I added a test to verify that S2N-QUIC can handle a client migration which uses a zero-length CID.

I add [Cloudflare Quiche](https://github.com/cloudflare/quiche) as one of our test dependencies to our integration tests. The test uses Quiche as a client which uses a zero-length CID. It would migrate to the a new path once the Quiche client establish a connection with a S2N-QUIC server. Once the migration is completed, it would send a Stream data, "Test Migration", from the new address to the server, and once the client received the message back from the server, it would close the connection. 

I added two event recorder to the `recorders.rs`: one to track the `Initial` packet which contains the `Crypto` frame, another to track all `PATH_CHALLENGE` status. On a successful test, there should only be one `Inital` packet with `Crypto` frame (because the server and client should only do one full handshake if the migration is successful), and the new path will be validated (the `PATH_CHALLENGE` sent to the old path will be abandoned per RFC requirements).

### Call-outs:

* We believe that https://github.com/aws/s2n-quic/pull/2516 enables this feature. I did more testings and confirmed this.
    * I reverted that change in [my personal branch](https://github.com/aws/s2n-quic/compare/main...boquan-fang:s2n-quic:revert-change-with-quiche#diff-624883fcffa16cac8a9464469c0ccf46a52d0635c067a24a375b2c018b753ca3R92). I ran the same test, and the migration failed with a reason of [`InsufficientConnectionIds`](https://github.com/boquan-fang/s2n-quic/blob/da0dfe6917cd284de4b5e28e4f268587d37f5ac5/quic/s2n-quic/src/tests/reverted_migration.log#L92C190-L92C215). This was the previous behavior that when a s2n-quic endpoint receives a `PATH_CHALLENGE` from another endpoint with zero-length CID: the s2n-quic endpoint will drop the datagram. Commits after that PR are able to handle such connection migration.
* Due to scheduling reason, I am planning to put the migrating all S2N-QUIC integration tests to a separate crate on hold. This issue is tracked by https://github.com/aws/s2n-quic/issues/2694.

### Testing:

This PR is to add a test. The CI will runs it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

