### PR TITLE
ci(fix): pin nightly-1.86.0 for udeps fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2024-12-17
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2025-01-31
   CDN: https://dnglbrstg7yg.cloudfront.net
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

I detected a CI failure on `udeps` for s2n-quic's CI:
```
Caused by:
  rustc 1.85.0-nightly is not supported by the following packages:
    cargo@0.89.0 requires rustc 1.86
    cargo@0.89.0 requires rustc 1.86
    cargo@0.89.0 requires rustc 1.86
    cargo-credential-libsecret@0.4.14 requires rustc 1.86
    cargo-util@0.2.21 requires rustc 1.86
    cargo-util-schemas@0.8.2 requires rustc 1.86
    crates-io@0.40.11 requires rustc 1.86
```
`Udeps` did a [release](https://crates.io/crates/cargo-udeps/0.1.57) at around 9:00 PM on July 5th, which bumps its required nightly version to 1.86. Hence, we need to pin that specific nightly version in our CI to make the test pass.

`nightly-1.86.0` is `nightly-2025-01-31`:
```
rust version 1.86.0-nightly (854f22563 2025-01-31)
```

### Call-outs:

The daily scheduled CI run should capture this problem today: https://github.com/aws/s2n-quic/actions/runs/16106868336/job/45443734421.

### Testing:

`udeps` run in CI should pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

