### PR TITLE
build(deps): update socket2 to v0.6.0

### DIFF
--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -27,7 +27,7 @@ futures = { version = "0.3", default-features = false, features = ["async-await"
 lazy_static = { version = "1", optional = true }
 s2n-quic-core = { version = "=0.61.0", path = "../s2n-quic-core", default-features = false }
 s2n-quic-xdp = { version = "=0.61.0", path = "../../tools/xdp/s2n-quic-xdp", optional = true }
-socket2 = { version = "0.5", features = ["all"], optional = true }
+socket2 = { version = "0.6", features = ["all"], optional = true }
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt", "time"], optional = true }
 tracing = { version = "0.1", optional = true }
 turmoil = { version = "0.6.0", optional = true }

--- a/quic/s2n-quic-platform/src/socket/options.rs
+++ b/quic/s2n-quic-platform/src/socket/options.rs
@@ -87,7 +87,7 @@ impl Options {
 
         let socket = socket2::Socket::new(domain, ty, Some(protocol))?;
 
-        socket.set_nodelay(!self.delay)?;
+        socket.set_tcp_nodelay(!self.delay)?;
 
         self.build_common(&socket)?;
 


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves https://github.com/aws/s2n-quic/pull/2699

### Description of changes: 

`socket2` did a release two days ago: https://crates.io/crates/socket2. There were a couple of breaking changes for method name changes. This PR update `socket2` to v0.6.0 and to update the method name of `set_nodelay()` to [`set_tcp_nodelay()`](https://docs.rs/socket2/0.6.0/socket2/struct.Socket.html#method.set_tcp_nodelay).

### Call-outs:

### Testing:

CI test should pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

