### PR TITLE
fix(ci): install cmake to compile quiche on cargotiming job

### DIFF
--- a/codebuild/spec/cargotiming.yml
+++ b/codebuild/spec/cargotiming.yml
@@ -14,6 +14,7 @@ phases:
       - echo "Installing Rust ..."
       - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - . $HOME/.cargo/env
+      # cmake is a dependency of quiche, which is one of our test dependencies
       - yum update -y && yum install -y cmake
   build:
     commands:

--- a/codebuild/spec/cargotiming.yml
+++ b/codebuild/spec/cargotiming.yml
@@ -14,6 +14,7 @@ phases:
       - echo "Installing Rust ..."
       - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - . $HOME/.cargo/env
+      - yum update -y && yum install -y cmake
   build:
     commands:
       - cargo build --timings --release


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

related to https://github.com/aws/s2n-quic/pull/2697

### Description of changes: 

In [this PR](https://github.com/aws/s2n-quic/pull/2697), we introduced CloudFlare Quiche as a dev dependency. Our `CargoTiming` job is running on a EC2 fleet which doesn't have `cmake` installed. However, CloudFlare Quiche needs `cmake` to compile its TLS provider `BoringSSL`. Hence, we need to install `cmake` for the `CargoTiming` job.

### Call-outs:

### Testing:

I put this script into `Codebuild`, and manually kick off a `CargoTiming` job. Quiche finished compiling. The build can be found in this [link](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/003495580562/projects/CargoTiming/build/CargoTiming%3Aed753aaf-d178-48ea-b1ad-7202365b63a4/log?region=us-west-2).

Before this PR:
```
Compiling quiche v0.24.4


--- stderr
--
thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cmake-0.1.54/src/lib.rs:1119:5:
 
failed to execute command: No such file or directory (os error 2)
is `cmake` not installed?
```

After this PR:
```

Compiling s2n-tls-sys v0.3.22
--
Compiling openssl-sys v0.9.109
Compiling libmimalloc-sys v0.1.43
Compiling quiche v0.24.4
Compiling clap v4.5.41
Compiling matchers v0.1.0
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

