### PR TITLE
CI Fix Negative Test PR

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -608,7 +608,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             parameters.mtu_config,
             parameters.limits.anti_amplification_multiplier(),
         );
-
+        // Should cause a panic
+        assert_eq!(1, 0);
         let path_manager = path::Manager::new(initial_path, parameters.peer_id_registry);
 
         let mut publisher =

--- a/quic/s2n-quic/src/tests/connection_limits.rs
+++ b/quic/s2n-quic/src/tests/connection_limits.rs
@@ -31,6 +31,7 @@ fn connection_limits() {
 
     let model = Model::default();
     // Benign assertion that should not cause CI failure
+    // Extra comment
     assert_eq!(1, 1);
     test(model, |handle| {
         let server = Server::builder()

--- a/quic/s2n-quic/src/tests/connection_limits.rs
+++ b/quic/s2n-quic/src/tests/connection_limits.rs
@@ -31,6 +31,7 @@ fn connection_limits() {
 
     let model = Model::default();
     // Benign assertion that should not cause CI failure
+    // :)
     assert_eq!(1, 1);
     test(model, |handle| {
         let server = Server::builder()

--- a/quic/s2n-quic/src/tests/connection_limits.rs
+++ b/quic/s2n-quic/src/tests/connection_limits.rs
@@ -30,6 +30,8 @@ fn connection_limits() {
     }
 
     let model = Model::default();
+    // Benign assertion that should not cause CI failure
+    assert_eq!(1, 1);
     test(model, |handle| {
         let server = Server::builder()
             .with_io(handle.builder().build()?)?

--- a/quic/s2n-quic/src/tests/connection_limits.rs
+++ b/quic/s2n-quic/src/tests/connection_limits.rs
@@ -31,7 +31,7 @@ fn connection_limits() {
 
     let model = Model::default();
     // Benign assertion that should not cause CI failure
-    //
+    // :)
     assert_eq!(1, 1);
     test(model, |handle| {
         let server = Server::builder()

--- a/quic/s2n-quic/src/tests/connection_limits.rs
+++ b/quic/s2n-quic/src/tests/connection_limits.rs
@@ -31,6 +31,7 @@ fn connection_limits() {
 
     let model = Model::default();
     // Benign assertion that should not cause CI failure
+    //
     assert_eq!(1, 1);
     test(model, |handle| {
         let server = Server::builder()

--- a/quic/s2n-quic/src/tests/connection_limits.rs
+++ b/quic/s2n-quic/src/tests/connection_limits.rs
@@ -31,7 +31,6 @@ fn connection_limits() {
 
     let model = Model::default();
     // Benign assertion that should not cause CI failure
-    // Extra comment
     assert_eq!(1, 1);
     test(model, |handle| {
         let server = Server::builder()

--- a/quic/s2n-quic/src/tests/connection_limits.rs
+++ b/quic/s2n-quic/src/tests/connection_limits.rs
@@ -30,8 +30,6 @@ fn connection_limits() {
     }
 
     let model = Model::default();
-    // Benign assertion that should not cause CI failure
-    assert_eq!(1, 1);
     test(model, |handle| {
         let server = Server::builder()
             .with_io(handle.builder().build()?)?

--- a/quic/s2n-quic/src/tests/connection_limits.rs
+++ b/quic/s2n-quic/src/tests/connection_limits.rs
@@ -31,7 +31,6 @@ fn connection_limits() {
 
     let model = Model::default();
     // Benign assertion that should not cause CI failure
-    // :)
     assert_eq!(1, 1);
     test(model, |handle| {
         let server = Server::builder()


### PR DESCRIPTION
### Description of changes: 
This creates a panic in s2n-quic and should cause the quic attack test to fail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

