### PR TITLE
ci: Adds github action to trigger codebuild job for quic-attack

### DIFF
--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -1,0 +1,36 @@
+
+name: Codebuild
+
+on:
+  push:
+    branches: [main]
+  pull_request_target:
+    branches: [main, ci_fix]
+  workflow_dispatch:
+
+jobs:
+  codebuild-trigger:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      event_name: ${{ github.event_name }}
+      source_pr: pr/${{ github.event.pull_request.number }}
+      source_sha: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get credentials
+        uses: aws-actions/configure-aws-credentials@v4.2.1
+        with:
+          role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
+          role-session-name: ${{ github.run_id }}
+          aws-region: us-west-2
+      - name: Start Codebuild
+        run: |
+          if [[ "$event_name" == "pull_request_target" ]]; then
+            source=$source_pr
+          else
+            source=$source_sha
+          fi
+          ./codebuild/bin/start_codebuild.sh $source

--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -5,8 +5,7 @@ on:
   push:
     branches: [main]
   pull_request_target:
-    branches: [main, ci_fix]
-  workflow_dispatch:
+    branches: [main]
 
 jobs:
   codebuild-trigger:

--- a/codebuild/bin/start_codebuild.sh
+++ b/codebuild/bin/start_codebuild.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+BUILDS=(
+    "quic-attack"
+)
+usage() {
+    echo "start_codebuild.sh <source_version> <repo>"
+    echo "    example: start_codebuild.sh pr/1111"
+    echo "    example: start_codebuild.sh 1234abcd"
+    echo "    example: start_codebuild.sh test_branch lrstewart/s2n"
+}
+
+if [ "$#" -lt "1" ]; then
+    usage
+    exit 1
+fi
+SOURCE_VERSION=$1
+REPO=${2:-aws/s2n-quic}
+
+start_build() {
+    NAME=$1
+    REGION=${2:-"us-west-2"}  
+    START_COMMAND="start-build"
+
+        aws --region $REGION codebuild $START_COMMAND \
+        --project-name $NAME \
+        --source-location-override https://github.com/$REPO \
+        --source-version $SOURCE_VERSION | jq -re "(.buildBatch.id // .build.id)"
+}
+
+for args in "${BUILDS[@]}"; do
+    start_build $args
+done
+echo "All builds successfully started."
+


### PR DESCRIPTION
### Release Summary:
### Resolved issues:

### Description of changes: 

Adds a new github action that invokes a script to use the aws CLI tool to trigger a codebuild job.
### Call-outs:

I didn't add this to our ci.yml file. It feels different to me because it's codebuild? But it is also a github action.
Also note that quic-attack will not run on this PR, unless I manually kick it off, as the github action will not run until it is merged. 

### Testing:
 I have a [commit that passes the CI run](https://github.com/aws/s2n-quic/pull/2703) and [a commit that deliberately causes a panic](https://github.com/aws/s2n-quic/pull/2706) to prove that this action is working.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

