### PR TITLE
feat(s2n-quic-dc): Add cleaner duration metrics

### DIFF
--- a/dc/s2n-quic-dc/events/map.rs
+++ b/dc/s2n-quic-dc/events/map.rs
@@ -425,4 +425,12 @@ struct PathSecretMapCleanerCycled {
     /// The number of handshake requests that were retired in the cycle
     #[measure("handshake_requests.retired")]
     handshake_requests_retired: usize,
+
+    /// How long we kept the handshake lock held (this blocks completing handshakes).
+    #[measure("handshake_lock_duration", Duration)]
+    handshake_lock_duration: core::time::Duration,
+
+    /// Total duration of a cycle.
+    #[measure("total_duration", Duration)]
+    duration: core::time::Duration,
 }

--- a/dc/s2n-quic-dc/src/event/generated.rs
+++ b/dc/s2n-quic-dc/src/event/generated.rs
@@ -1806,6 +1806,10 @@ pub mod api {
         pub handshake_requests: usize,
         #[doc = " The number of handshake requests that were retired in the cycle"]
         pub handshake_requests_retired: usize,
+        #[doc = " How long we kept the handshake lock held (this blocks completing handshakes)."]
+        pub handshake_lock_duration: core::time::Duration,
+        #[doc = " Total duration of a cycle."]
+        pub duration: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
     impl crate::event::snapshot::Fmt for PathSecretMapCleanerCycled {
@@ -1843,6 +1847,8 @@ pub mod api {
                 "handshake_requests_retired",
                 &self.handshake_requests_retired,
             );
+            fmt.field("handshake_lock_duration", &self.handshake_lock_duration);
+            fmt.field("duration", &self.duration);
             fmt.finish()
         }
     }
@@ -2831,8 +2837,10 @@ pub mod tracing {
                 address_entries_initial_utilization,
                 handshake_requests,
                 handshake_requests_retired,
+                handshake_lock_duration,
+                duration,
             } = event;
-            tracing :: event ! (target : "path_secret_map_cleaner_cycled" , parent : parent , tracing :: Level :: DEBUG , { id_entries = tracing :: field :: debug (id_entries) , id_entries_retired = tracing :: field :: debug (id_entries_retired) , id_entries_active = tracing :: field :: debug (id_entries_active) , id_entries_active_utilization = tracing :: field :: debug (id_entries_active_utilization) , id_entries_utilization = tracing :: field :: debug (id_entries_utilization) , id_entries_initial_utilization = tracing :: field :: debug (id_entries_initial_utilization) , address_entries = tracing :: field :: debug (address_entries) , address_entries_active = tracing :: field :: debug (address_entries_active) , address_entries_active_utilization = tracing :: field :: debug (address_entries_active_utilization) , address_entries_retired = tracing :: field :: debug (address_entries_retired) , address_entries_utilization = tracing :: field :: debug (address_entries_utilization) , address_entries_initial_utilization = tracing :: field :: debug (address_entries_initial_utilization) , handshake_requests = tracing :: field :: debug (handshake_requests) , handshake_requests_retired = tracing :: field :: debug (handshake_requests_retired) });
+            tracing :: event ! (target : "path_secret_map_cleaner_cycled" , parent : parent , tracing :: Level :: DEBUG , { id_entries = tracing :: field :: debug (id_entries) , id_entries_retired = tracing :: field :: debug (id_entries_retired) , id_entries_active = tracing :: field :: debug (id_entries_active) , id_entries_active_utilization = tracing :: field :: debug (id_entries_active_utilization) , id_entries_utilization = tracing :: field :: debug (id_entries_utilization) , id_entries_initial_utilization = tracing :: field :: debug (id_entries_initial_utilization) , address_entries = tracing :: field :: debug (address_entries) , address_entries_active = tracing :: field :: debug (address_entries_active) , address_entries_active_utilization = tracing :: field :: debug (address_entries_active_utilization) , address_entries_retired = tracing :: field :: debug (address_entries_retired) , address_entries_utilization = tracing :: field :: debug (address_entries_utilization) , address_entries_initial_utilization = tracing :: field :: debug (address_entries_initial_utilization) , handshake_requests = tracing :: field :: debug (handshake_requests) , handshake_requests_retired = tracing :: field :: debug (handshake_requests_retired) , handshake_lock_duration = tracing :: field :: debug (handshake_lock_duration) , duration = tracing :: field :: debug (duration) });
         }
     }
 }
@@ -4539,6 +4547,10 @@ pub mod builder {
         pub handshake_requests: usize,
         #[doc = " The number of handshake requests that were retired in the cycle"]
         pub handshake_requests_retired: usize,
+        #[doc = " How long we kept the handshake lock held (this blocks completing handshakes)."]
+        pub handshake_lock_duration: core::time::Duration,
+        #[doc = " Total duration of a cycle."]
+        pub duration: core::time::Duration,
     }
     impl IntoEvent<api::PathSecretMapCleanerCycled> for PathSecretMapCleanerCycled {
         #[inline]
@@ -4558,6 +4570,8 @@ pub mod builder {
                 address_entries_initial_utilization,
                 handshake_requests,
                 handshake_requests_retired,
+                handshake_lock_duration,
+                duration,
             } = self;
             api::PathSecretMapCleanerCycled {
                 id_entries: id_entries.into_event(),
@@ -4575,6 +4589,8 @@ pub mod builder {
                     .into_event(),
                 handshake_requests: handshake_requests.into_event(),
                 handshake_requests_retired: handshake_requests_retired.into_event(),
+                handshake_lock_duration: handshake_lock_duration.into_event(),
+                duration: duration.into_event(),
             }
         }
     }

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -13,7 +13,7 @@ use crate::event::{
     },
 };
 use core::sync::atomic::{AtomicU64, Ordering};
-static INFO: &[Info; 228usize] = &[
+static INFO: &[Info; 230usize] = &[
     info::Builder {
         id: 0usize,
         name: Str::new("acceptor_tcp_started\0"),
@@ -1382,6 +1382,18 @@ static INFO: &[Info; 228usize] = &[
         units: Units::None,
     }
     .build(),
+    info::Builder {
+        id: 228usize,
+        name: Str::new("path_secret_map_cleaner_cycled.handshake_lock_duration\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
+        id: 229usize,
+        name: Str::new("path_secret_map_cleaner_cycled.total_duration\0"),
+        units: Units::Duration,
+    }
+    .build(),
 ];
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -1420,7 +1432,7 @@ pub struct Subscriber<R: Registry> {
     #[allow(dead_code)]
     nominal_counter_offsets: Box<[usize; 32usize]>,
     #[allow(dead_code)]
-    measures: Box<[R::Measure; 87usize]>,
+    measures: Box<[R::Measure; 89usize]>,
     #[allow(dead_code)]
     gauges: Box<[R::Gauge; 0usize]>,
     #[allow(dead_code)]
@@ -1451,7 +1463,7 @@ impl<R: Registry> Subscriber<R> {
         let mut bool_counters = Vec::with_capacity(14usize);
         let mut nominal_counters = Vec::with_capacity(32usize);
         let mut nominal_counter_offsets = Vec::with_capacity(32usize);
-        let mut measures = Vec::with_capacity(87usize);
+        let mut measures = Vec::with_capacity(89usize);
         let mut gauges = Vec::with_capacity(0usize);
         let mut timers = Vec::with_capacity(18usize);
         let mut nominal_timers = Vec::with_capacity(0usize);
@@ -1990,6 +2002,8 @@ impl<R: Registry> Subscriber<R> {
         measures.push(registry.register_measure(&INFO[225usize]));
         measures.push(registry.register_measure(&INFO[226usize]));
         measures.push(registry.register_measure(&INFO[227usize]));
+        measures.push(registry.register_measure(&INFO[228usize]));
+        measures.push(registry.register_measure(&INFO[229usize]));
         timers.push(registry.register_timer(&INFO[5usize]));
         timers.push(registry.register_timer(&INFO[15usize]));
         timers.push(registry.register_timer(&INFO[21usize]));
@@ -2467,6 +2481,8 @@ impl<R: Registry> Subscriber<R> {
                 84usize => (&INFO[225usize], entry),
                 85usize => (&INFO[226usize], entry),
                 86usize => (&INFO[227usize], entry),
+                87usize => (&INFO[228usize], entry),
+                88usize => (&INFO[229usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -3707,6 +3723,8 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
         self.measure(225usize, 84usize, event.address_entries_initial_utilization);
         self.measure(226usize, 85usize, event.handshake_requests);
         self.measure(227usize, 86usize, event.handshake_requests_retired);
+        self.measure(228usize, 87usize, event.handshake_lock_duration);
+        self.measure(229usize, 88usize, event.duration);
         let _ = event;
         let _ = meta;
     }

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -669,6 +669,8 @@ mod measure {
                 }
                 226usize => Self(path_secret_map_cleaner_cycled__handshake_requests),
                 227usize => Self(path_secret_map_cleaner_cycled__handshake_requests__retired),
+                228usize => Self(path_secret_map_cleaner_cycled__handshake_lock_duration),
+                229usize => Self(path_secret_map_cleaner_cycled__total_duration),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }
@@ -854,6 +856,10 @@ mod measure {
             fn path_secret_map_cleaner_cycled__handshake_requests(value: u64);
             # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__handshake_requests__retired]
             fn path_secret_map_cleaner_cycled__handshake_requests__retired(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__handshake_lock_duration]
+            fn path_secret_map_cleaner_cycled__handshake_lock_duration(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__total_duration]
+            fn path_secret_map_cleaner_cycled__total_duration(value: u64);
         }
     );
 }

--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -213,7 +213,7 @@ where
 
     init_time: Timestamp,
 
-    clock: C,
+    pub(super) clock: C,
 
     subscriber: S,
 


### PR DESCRIPTION


### Release Summary:

* feat(s2n-quic-dc): This tracks the cleaner cycle time. The cleaner holds a lock also taken during handshakes, so long cycle times can interfere with the event loop and slow down our ability to handshake.

### Resolved issues:

n/a

### Description of changes: 

Just adds a few new metrics to the dcQUIC path secret map cleaner.

### Call-outs:

n/a

### Testing:

We don't have tests (at least that I can see) but the metrics are pretty obvious and fit into the existing framework. I'm not sure a test would add any real value here.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

