### PR TITLE
doc(README): add minimun supported kernel version section

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,9 +113,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 The current MSRV is [1.82.0][msrv-url].
 
-## Minimum Supported Kernel Version
+## Supported Operating Systems
 
-`s2n-quic` requires Linux kernel version 5.0 or later. Earlier kernel versions are not supported as they lack the Generic Segmentation Offload (GSO) capabilities required by `s2n-quic`.
+`s2n-quic` can be built on Linux, MacOS, and Windows. `s2n-quic` requires Linux kernel version 5.0 or later. Earlier Linux kernel versions are not supported as they lack the Generic Segmentation Offload (GSO) capabilities required by `s2n-quic`.
 
 ## Security issue notifications
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
 The current MSRV is [1.82.0][msrv-url].
 
+## Minimum Supported Kernel Version
+
+`s2n-quic` requires Linux kernel version 5.0 or later. Earlier kernel versions are not supported as they lack the Generic Segmentation Offload (GSO) capabilities required by `s2n-quic`.
+
 ## Security issue notifications
 
 If you discover a potential security issue in s2n-quic we ask that you notify


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2261

### Description of changes: 

This PR adds a section to document that S2N-QUIC requires kernel version 5.0 or later, since it needs GSO support that older version doesn't have. This PR specifically address https://github.com/aws/s2n-quic/issues/2261#issuecomment-2223459594.

### Call-outs:

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

