### PR TITLE
Account for CPU time spent on handshakes in bach sims

### DIFF
--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["corpus.tar.gz"]
 default = ["alloc", "std"]
 alloc = ["atomic-waker", "bytes", "crossbeam-utils", "s2n-codec/alloc"]
 std = ["alloc", "once_cell"]
-testing = ["std", "generator", "s2n-codec/testing", "checked-counters", "insta", "futures-test"]
+testing = ["std", "generator", "s2n-codec/testing", "checked-counters", "insta", "futures-test", "bach"]
 generator = ["bolero-generator"]
 checked-counters = []
 branch-tracing = ["tracing"]
@@ -47,6 +47,7 @@ tracing = { version = "0.1", default-features = false, optional = true }
 zerocopy = { version = "0.8", features = ["derive"] }
 futures-test = { version = "0.3", optional = true } # For testing Waker interactions
 once_cell = { version = "1", optional = true }
+bach = { version = "0.1.0", optional = true }
 
 [dev-dependencies]
 bolero = "0.13"

--- a/quic/s2n-quic-core/src/io/rx.rs
+++ b/quic/s2n-quic-core/src/io/rx.rs
@@ -12,7 +12,7 @@ pub trait Rx: Sized {
     // TODO make this generic over lifetime
     // See https://github.com/aws/s2n-quic/issues/1742
     type Queue: Queue<Handle = Self::PathHandle>;
-    type Error;
+    type Error: Send;
 
     /// Returns a future that yields after a packet is ready to be received
     #[inline]

--- a/quic/s2n-quic-core/src/io/tx.rs
+++ b/quic/s2n-quic-core/src/io/tx.rs
@@ -15,7 +15,7 @@ pub trait Tx: Sized {
     // TODO make this generic over lifetime
     // See https://github.com/aws/s2n-quic/issues/1742
     type Queue: Queue<Handle = Self::PathHandle>;
-    type Error;
+    type Error: Send;
 
     /// Returns a future that yields after a packet is ready to be transmitted
     #[inline]


### PR DESCRIPTION
### Release Summary:

n/a, purely internal

### Resolved issues:

n/a

### Description of changes: 

This adds internal sleeps during the s2n-quic event loop which account for CPU time spent doing work. That time is not otherwise tracked during s2n-quic-sim simulations, which makes it hard to simulate handshake workloads -- at least where concurrency etc. are involved.

### Call-outs:

Requesting review from @camshaft to discuss whether this seems like an OK way to communicate this to bach, or if we should be trying to add some kind of advance_time to bach's simulated time. Tokio has sort of a similar function (https://docs.rs/tokio/latest/tokio/time/fn.advance.html) but I'm not sure how much bach's executor cares about the differences vs sleep noted in The Tokio docs.

If bach did offer such an API, ideally it would be a non-async function so we could call it directly from the innards of s2n-quic.

As-is this can't land since we need some way to detect which time to use -- these sleeps should be no-ops unless we're in a bach context. I'm not sure what the best way to achieve that is, maybe there's a bach-set thread local we could check.

### Testing:

Ran s2n-quic-sim locally successfully, where even a zero-latency network now take some time during handshakes (this is sort of a bad graph since it's really just a single datapoint...):

<img width="694" height="709" alt="image" src="https://github.com/user-attachments/assets/39126a2e-7e70-404a-a1ac-4d6bf6ad88c8" />

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

