### PR TITLE
refactor(s2n-quic-sim): avoid JS precision loss rounding s2n-quic-sim seeds

### DIFF
--- a/quic/s2n-quic-sim/src/report.rs
+++ b/quic/s2n-quic-sim/src/report.rs
@@ -62,7 +62,9 @@ impl Report {
                 Entry::Vacant(entry) => {
                     entry.insert(next_id);
 
-                    seed_hist.push((seed, vec![], vec![]));
+                    // Keep seeds as strings in JS, because otherwise some seeds lose precision (JS
+                    // has everything as floats and so >2^53 gets rounded).
+                    seed_hist.push((seed.to_string(), vec![], vec![]));
 
                     next_id
                 }
@@ -176,7 +178,7 @@ impl Report {
         let groups_per_line = seed_hist_size / group_width;
 
         let command = format!(
-            "{:?} + (isNumber({s}) ? (' --seed ' + {s}) : '')",
+            "{:?} + (isString({s}) ? (' --seed ' + {s}) : '')",
             args.join(" "),
             s = "sig$seed_hist.seed"
         );


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

n/a

### Description of changes: 

Keep seeds (random u64s) as strings in JS, because otherwise some seeds lose precision (JS stores everything as floats and so >2^53 gets rounded).

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

Ran s2n-quic-sim and verified the rendered large seeds are the same as in the JSON file (which isn't lossy).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

