### PR TITLE
fix(s2n-quic-dc): fix emitting ABORTED metric for successful connects

### DIFF
--- a/dc/s2n-quic-dc/src/stream/client/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/client/tokio.rs
@@ -135,6 +135,13 @@ where
             }
         }
     }
+
+    // Clear the guard, we were successful. This stops emitting a metric indicating we dropped
+    // before the stream was connected.
+    if error.is_none() {
+        guard.reason = None;
+    }
+
     env.endpoint_publisher()
         .on_stream_connect(event::builder::StreamConnect {
             error: error.is_some(),


### PR DESCRIPTION
### Release Summary:

* fix(s2n-quic-dc): Fix incorrectly emitted error metrics for successful connects

### Resolved issues:

n/a

### Description of changes: 

The drop guard was supposed to be disarmed if we didn't experience an error, but this was missed when adding it initially. This change fixes that.

### Call-outs:

n/a

### Testing:

Change is fairly clear -- only affects metrics/events in any case. I don't think a test makes sense at this time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

