### PR TITLE
feat(s2n-quic-core) TLS offloading

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [
     "common/s2n-*",
     "quic/s2n-*",
-    "dc/s2n-*",
+    "dc/s2n-*", "examples/tls-offloading",
 ]
 default-members = [
     "common/s2n-*",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [
     "common/s2n-*",
     "quic/s2n-*",
-    "dc/s2n-*", "examples/tls-offloading",
+    "dc/s2n-*",
 ]
 default-members = [
     "common/s2n-*",

--- a/examples/tls-offloading/Cargo.toml
+++ b/examples/tls-offloading/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "tls-offloading"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+s2n-quic = { version = "1", path = "../../quic/s2n-quic", features = ["unstable-offload-tls"]}
+tokio = { version = "1", features = ["full"] }

--- a/examples/tls-offloading/README.md
+++ b/examples/tls-offloading/README.md
@@ -1,0 +1,25 @@
+# TLS offload
+
+s2n-quic is single-threaded by default. This can cause performance issues in the instance where many clients try to connect to a single s2n-quic server at the same time. Each incoming Client Hello will cause the s2n-quic server event loop to be blocked while the TLS provider completes the expensive cryptographic operations necessary to process the Client Hello. This has the potential to slow down all existing connections in favor of new ones. The TLS offloading feature attempts to alleviate this problem by moving each TLS connection to a separate async task, which can then be spawned by the runtime the user provides.
+
+To do this, implement the `offload::Executor` trait with the runtime of your choice. In this example, we use the `tokio::spawn` function as our executor: 
+```
+struct TokioExecutor;
+impl Executor for TokioExecutor {
+    fn spawn(&self, task: impl core::future::Future<Output = ()> + Send + 'static) {
+        tokio::spawn(task);
+    }
+}
+```
+
+# Warning
+The default offloading feature as-is may result in packet loss in the handshake, depending on how packets arrive to the offload endpoint. This packet loss will slow down the handshake, as QUIC has to detect the loss and the peer has to resend the lost packets. We have an upcoming feature that will combat this packet loss and will probably be required to achieve the fastest handshakes possible with s2n-quic: https://github.com/aws/s2n-quic/pull/2668. However, it is still in the PR process.
+
+# Set-up
+
+Currently offloading is disabled by default as it is still in development. It can be enabled by adding this line to your Cargo.toml file:
+
+```toml
+[dependencies]
+s2n-quic = { version = "1", features = ["unstable-offload-tls"]}
+```

--- a/examples/tls-offloading/src/bin/client.rs
+++ b/examples/tls-offloading/src/bin/client.rs
@@ -6,7 +6,7 @@ use s2n_quic::{
     client::Connect,
     provider::tls::{
         default,
-        offload::{Executor, OffloadBuilder},
+        offload::{Executor, ExporterHandler, OffloadBuilder, TlsSession},
     },
 };
 use std::{error::Error, net::SocketAddr};
@@ -23,6 +23,22 @@ impl Executor for TokioExecutor {
         tokio::spawn(task);
     }
 }
+struct Exporter;
+impl ExporterHandler for Exporter {
+    fn on_tls_handshake_failed(
+        &self,
+        _session: &impl TlsSession,
+    ) -> Option<Box<dyn std::any::Any + Send>> {
+        None
+    }
+
+    fn on_tls_exporter_ready(
+        &self,
+        _session: &impl TlsSession,
+    ) -> Option<Box<dyn std::any::Any + Send>> {
+        None
+    }
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -32,6 +48,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let tls_endpoint = OffloadBuilder::new()
         .with_endpoint(tls)
         .with_executor(TokioExecutor)
+        .with_exporter(Exporter)
         .build();
 
     let client = Client::builder()

--- a/examples/tls-offloading/src/bin/client.rs
+++ b/examples/tls-offloading/src/bin/client.rs
@@ -6,7 +6,7 @@ use s2n_quic::{
     client::Connect,
     provider::tls::{
         default,
-        offload::{Executor, ExporterHandler, OffloadBuilder, TlsSession},
+        offload::{Executor, OffloadBuilder},
     },
 };
 use std::{error::Error, net::SocketAddr};
@@ -23,22 +23,6 @@ impl Executor for TokioExecutor {
         tokio::spawn(task);
     }
 }
-struct Exporter;
-impl ExporterHandler for Exporter {
-    fn on_tls_handshake_failed(
-        &self,
-        _session: &impl TlsSession,
-    ) -> Option<Box<dyn std::any::Any + Send>> {
-        None
-    }
-
-    fn on_tls_exporter_ready(
-        &self,
-        _session: &impl TlsSession,
-    ) -> Option<Box<dyn std::any::Any + Send>> {
-        None
-    }
-}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -48,7 +32,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let tls_endpoint = OffloadBuilder::new()
         .with_endpoint(tls)
         .with_executor(TokioExecutor)
-        .with_exporter(Exporter)
         .build();
 
     let client = Client::builder()

--- a/examples/tls-offloading/src/bin/client.rs
+++ b/examples/tls-offloading/src/bin/client.rs
@@ -6,7 +6,7 @@ use s2n_quic::{
     client::Connect,
     provider::tls::{
         default,
-        offload::{Executor, Offload},
+        offload::{Executor, OffloadBuilder},
     },
 };
 use std::{error::Error, net::SocketAddr};
@@ -29,10 +29,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let tls = default::Client::builder()
         .with_certificate(CERT_PEM)?
         .build()?;
-    let tls = Offload(tls, TokioExecutor);
+    let tls_endpoint = OffloadBuilder::new()
+        .with_endpoint(tls)
+        .with_executor(TokioExecutor)
+        .build();
 
     let client = Client::builder()
-        .with_tls(tls)?
+        .with_tls(tls_endpoint)?
         .with_io("0.0.0.0:0")?
         .start()?;
 

--- a/examples/tls-offloading/src/bin/client.rs
+++ b/examples/tls-offloading/src/bin/client.rs
@@ -1,0 +1,61 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_quic::{
+    Client,
+    client::Connect,
+    provider::tls::{
+        default,
+        offload::{Executor, Offload},
+    },
+};
+use std::{error::Error, net::SocketAddr};
+
+/// NOTE: this certificate is to be used for demonstration purposes only!
+pub static CERT_PEM: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../quic/s2n-quic-core/certs/cert.pem"
+));
+
+struct TokioExecutor;
+impl Executor for TokioExecutor {
+    fn spawn(&self, task: impl core::future::Future<Output = ()> + Send + 'static) {
+        tokio::spawn(task);
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let tls = default::Client::builder()
+        .with_certificate(CERT_PEM)?
+        .build()?;
+    let tls = Offload(tls, TokioExecutor);
+
+    let client = Client::builder()
+        .with_tls(tls)?
+        .with_io("0.0.0.0:0")?
+        .start()?;
+
+    let addr: SocketAddr = "127.0.0.1:4433".parse()?;
+    let connect = Connect::new(addr).with_server_name("localhost");
+    let mut connection = client.connect(connect).await?;
+
+    // ensure the connection doesn't time out with inactivity
+    connection.keep_alive(true)?;
+
+    // open a new stream and split the receiving and sending sides
+    let stream = connection.open_bidirectional_stream().await?;
+    let (mut receive_stream, mut send_stream) = stream.split();
+
+    // spawn a task that copies responses from the server to stdout
+    tokio::spawn(async move {
+        let mut stdout = tokio::io::stdout();
+        let _ = tokio::io::copy(&mut receive_stream, &mut stdout).await;
+    });
+
+    // copy data from stdin and send it to the server
+    let mut stdin = tokio::io::stdin();
+    tokio::io::copy(&mut stdin, &mut send_stream).await?;
+
+    Ok(())
+}

--- a/examples/tls-offloading/src/bin/server.rs
+++ b/examples/tls-offloading/src/bin/server.rs
@@ -5,7 +5,7 @@ use s2n_quic::{
     Server,
     provider::tls::{
         default,
-        offload::{Executor, Offload},
+        offload::{Executor, OffloadBuilder},
     },
 };
 use std::error::Error;
@@ -33,10 +33,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let tls = default::Server::builder()
         .with_certificate(CERT_PEM, KEY_PEM)?
         .build()?;
-    let tls = Offload(tls, TokioExecutor);
+
+    let tls_endpoint = OffloadBuilder::new()
+        .with_endpoint(tls)
+        .with_executor(TokioExecutor)
+        .build();
 
     let mut server = Server::builder()
-        .with_tls(tls)?
+        .with_tls(tls_endpoint)?
         .with_io("127.0.0.1:4433")?
         .start()?;
 

--- a/examples/tls-offloading/src/bin/server.rs
+++ b/examples/tls-offloading/src/bin/server.rs
@@ -1,0 +1,63 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_quic::{
+    Server,
+    provider::tls::{
+        default,
+        offload::{Executor, Offload},
+    },
+};
+use std::error::Error;
+
+/// NOTE: this certificate is to be used for demonstration purposes only!
+pub static CERT_PEM: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../quic/s2n-quic-core/certs/cert.pem"
+));
+/// NOTE: this certificate is to be used for demonstration purposes only!
+pub static KEY_PEM: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../quic/s2n-quic-core/certs/key.pem"
+));
+
+struct TokioExecutor;
+impl Executor for TokioExecutor {
+    fn spawn(&self, task: impl core::future::Future<Output = ()> + Send + 'static) {
+        tokio::spawn(task);
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let tls = default::Server::builder()
+        .with_certificate(CERT_PEM, KEY_PEM)?
+        .build()?;
+    let tls = Offload(tls, TokioExecutor);
+
+    let mut server = Server::builder()
+        .with_tls(tls)?
+        .with_io("127.0.0.1:4433")?
+        .start()?;
+
+    while let Some(mut connection) = server.accept().await {
+        // spawn a new task for the connection
+        tokio::spawn(async move {
+            eprintln!("Connection accepted from {:?}", connection.remote_addr());
+
+            while let Ok(Some(mut stream)) = connection.accept_bidirectional_stream().await {
+                // spawn a new task for the stream
+                tokio::spawn(async move {
+                    eprintln!("Stream opened from {:?}", stream.connection().remote_addr());
+
+                    // echo any data back to the stream
+                    while let Ok(Some(data)) = stream.receive().await {
+                        stream.send(data).await.expect("stream should be open");
+                    }
+                });
+            }
+        });
+    }
+
+    Ok(())
+}

--- a/examples/tls-offloading/src/bin/server.rs
+++ b/examples/tls-offloading/src/bin/server.rs
@@ -5,7 +5,7 @@ use s2n_quic::{
     Server,
     provider::tls::{
         default,
-        offload::{Executor, ExporterHandler, OffloadBuilder, TlsSession},
+        offload::{Executor, OffloadBuilder},
     },
 };
 use std::error::Error;
@@ -27,22 +27,6 @@ impl Executor for TokioExecutor {
         tokio::spawn(task);
     }
 }
-struct Exporter;
-impl ExporterHandler for Exporter {
-    fn on_tls_handshake_failed(
-        &self,
-        _session: &impl TlsSession,
-    ) -> Option<Box<dyn std::any::Any + Send>> {
-        None
-    }
-
-    fn on_tls_exporter_ready(
-        &self,
-        _session: &impl TlsSession,
-    ) -> Option<Box<dyn std::any::Any + Send>> {
-        None
-    }
-}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
@@ -53,7 +37,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let tls_endpoint = OffloadBuilder::new()
         .with_endpoint(tls)
         .with_executor(TokioExecutor)
-        .with_exporter(Exporter)
         .build();
 
     let mut server = Server::builder()

--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -20,6 +20,9 @@ pub mod null;
 #[cfg(feature = "alloc")]
 pub mod slow_tls;
 
+#[cfg(feature = "alloc")]
+pub mod offload;
+
 /// Holds all application parameters which are exchanged within the TLS handshake.
 #[derive(Debug)]
 pub struct ApplicationParameters<'a> {

--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -20,7 +20,7 @@ pub mod null;
 #[cfg(feature = "alloc")]
 pub mod slow_tls;
 
-#[cfg(feature = "alloc")]
+#[cfg(feature = "std")]
 pub mod offload;
 
 /// Holds all application parameters which are exchanged within the TLS handshake.

--- a/quic/s2n-quic-core/src/crypto/tls/offload.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/offload.rs
@@ -9,7 +9,7 @@ use crate::{
     sync::spsc::{channel, Receiver, Sender},
     transport,
 };
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 use core::{
     any::Any,
     future::Future,
@@ -466,7 +466,7 @@ impl<'a, S: CryptoSuite> tls::Context<S> for RemoteContext<'a, Msg<S>> {
 
     fn on_tls_handshake_failed(
         &mut self,
-        session: &impl tls::TlsSession,
+        _session: &impl tls::TlsSession,
     ) -> Result<(), crate::transport::Error> {
         // Not sure what we can do here
         Ok(())

--- a/quic/s2n-quic-core/src/crypto/tls/offload.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/offload.rs
@@ -124,7 +124,7 @@ impl<S: tls::Session + 'static> OffloadSession<S> {
                         }
                         Poll::Ready(res)
                     } else {
-                        // For whatever reason the QUIC thread decided to drop this channel. In this case
+                        // For whatever reason the QUIC side decided to drop this channel. In this case
                         // we complete the future without erroring.
                         Poll::Ready(Poll::Ready(Ok(())))
                     }
@@ -220,7 +220,7 @@ impl<S: tls::Session> tls::Session for OffloadSession<S> {
                     }
                 }
                 Err(_) => {
-                    // For whatever reason the TLS thread was cancelled. We cannot continue the handshake.
+                    // For whatever reason the TLS task was cancelled. We cannot continue the handshake.
                     return Poll::Ready(Err(transport::Error::from(tls::Error::HANDSHAKE_FAILURE)));
                 }
             }
@@ -251,7 +251,7 @@ impl<S: tls::Session> tls::Session for OffloadSession<S> {
                     let _ = slice.push(Response::TlsWakeup);
                 }
                 Err(_) => {
-                    // For whatever reason the TLS thread was cancelled. We cannot continue the handshake.
+                    // For whatever reason the TLS task was cancelled. We cannot continue the handshake.
                     return Poll::Ready(Err(transport::Error::from(tls::Error::HANDSHAKE_FAILURE)));
                 }
             }

--- a/quic/s2n-quic-core/src/crypto/tls/offload.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/offload.rs
@@ -220,7 +220,7 @@ impl<S: tls::Session> tls::Session for OffloadSession<S> {
                     }
                 }
                 Err(_) => {
-                    // The TLS thread was cancelled for some reason if we can't read from the channel
+                    // For whatever reason the TLS thread was cancelled. We cannot continue the handshake.
                     return Poll::Ready(Err(transport::Error::from(tls::Error::HANDSHAKE_FAILURE)));
                 }
             }
@@ -251,7 +251,7 @@ impl<S: tls::Session> tls::Session for OffloadSession<S> {
                     let _ = slice.push(Response::TlsWakeup);
                 }
                 Err(_) => {
-                    // The TLS thread was cancelled for some reason if we can't write to the channel
+                    // For whatever reason the TLS thread was cancelled. We cannot continue the handshake.
                     return Poll::Ready(Err(transport::Error::from(tls::Error::HANDSHAKE_FAILURE)));
                 }
             }

--- a/quic/s2n-quic-core/src/crypto/tls/offload.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/offload.rs
@@ -1,0 +1,534 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+use crate::{
+    application,
+    crypto::{
+        tls::{self, NamedGroup},
+        CryptoSuite,
+    },
+    sync::spsc::{channel, Receiver, Sender},
+    transport,
+};
+use alloc::boxed::Box;
+use core::{
+    any::Any,
+    future::Future,
+    task::{Context, Poll},
+};
+
+pub trait Executor {
+    fn spawn(&self, task: impl Future<Output = ()> + Send + 'static);
+}
+
+pub struct OffloadEndpoint<E: tls::Endpoint, X: Executor> {
+    inner: E,
+    executor: X,
+}
+
+impl<E: tls::Endpoint, X: Executor> OffloadEndpoint<E, X> {
+    pub fn new(inner: E, executor: X) -> Self {
+        Self { inner, executor }
+    }
+}
+
+impl<E: tls::Endpoint, X: Executor + Send + 'static> tls::Endpoint for OffloadEndpoint<E, X> {
+    type Session = OffloadSession<<E as tls::Endpoint>::Session>;
+
+    fn new_server_session<Params: s2n_codec::EncoderValue>(
+        &mut self,
+        transport_parameters: &Params,
+    ) -> Self::Session {
+        OffloadSession::new(
+            self.inner.new_server_session(transport_parameters),
+            &self.executor,
+        )
+    }
+
+    fn new_client_session<Params: s2n_codec::EncoderValue>(
+        &mut self,
+        transport_parameters: &Params,
+        server_name: application::ServerName,
+    ) -> Self::Session {
+        OffloadSession::new(
+            self.inner
+                .new_client_session(transport_parameters, server_name),
+            &self.executor,
+        )
+    }
+
+    fn max_tag_length(&self) -> usize {
+        self.inner.max_tag_length()
+    }
+}
+
+#[derive(Debug)]
+pub struct OffloadSession<S: tls::Session> {
+    recv_from_tls: Receiver<Msg<S>>,
+    send_to_tls: Sender<Msg<S>>,
+}
+impl<S: tls::Session + 'static> OffloadSession<S> {
+    fn new(mut inner: S, executor: &impl Executor) -> Self {
+        let (mut send_to_quic, recv_from_tls): (Sender<Msg<S>>, Receiver<Msg<S>>) = channel(10);
+        let (send_to_tls, mut recv_from_quic): (Sender<Msg<S>>, Receiver<Msg<S>>) = channel(10);
+
+        let future = async move {
+            loop {
+                if (recv_from_quic.acquire().await).is_err() {
+                    break;
+                }
+
+                let res = core::future::poll_fn(|ctx| {
+                    let mut slice = recv_from_quic.slice();
+                    let mut context = RemoteContext {
+                        send_to_quic: &mut send_to_quic,
+                        waker: ctx.waker().clone(),
+                        initial_data: Vec::default(),
+                        handshake_data: Vec::default(),
+                        application_data: Vec::default(),
+                        can_send_initial: false,
+                        can_send_handshake: false,
+                        can_send_application: false,
+                    };
+                    while let Some(msg) = slice.pop() {
+                        match msg {
+                            Msg::ResponseInitial(data) => {
+                                context.initial_data.push(data);
+                            }
+                            Msg::ResponseHandshake(data) => context.handshake_data.push(data),
+                            Msg::ResponseApplication(data) => context.application_data.push(data),
+                            Msg::CanSendHandshake(bool) => context.can_send_handshake = bool,
+                            Msg::CanSendInitial(bool) => context.can_send_initial = bool,
+                            Msg::CanSendApplication(bool) => context.can_send_application = bool,
+                            _ => (),
+                        }
+                    }
+                    let res = inner.poll(&mut context);
+
+                    // If the TLS implementation is complete, either there was an error or the handshake has finished
+                    if let Poll::Ready(res) = res {
+                        if let Poll::Ready(Ok(mut slice)) = send_to_quic.poll_slice(ctx) {
+                            match res {
+                                Ok(()) => {
+                                    let _ = slice.push(Msg::TlsDone);
+                                }
+
+                                Err(e) => {
+                                    let _ = slice.push(Msg::TlsError(e));
+                                }
+                            }
+                        }
+                    }
+                    Poll::Ready(res)
+                })
+                .await;
+
+                match res {
+                    Poll::Ready(_) => {
+                        return;
+                    }
+                    Poll::Pending => (),
+                }
+            }
+        };
+        executor.spawn(future);
+
+        Self {
+            recv_from_tls,
+            send_to_tls,
+        }
+    }
+}
+
+impl<S: tls::Session> tls::Session for OffloadSession<S> {
+    #[inline]
+    fn poll<W>(&mut self, context: &mut W) -> Poll<Result<(), transport::Error>>
+    where
+        W: tls::Context<Self>,
+    {
+        let cloned_waker = &context.waker().clone();
+        let mut ctx = core::task::Context::from_waker(cloned_waker);
+
+        if let Poll::Ready(Ok(mut slice)) = self.recv_from_tls.poll_slice(&mut ctx) {
+            while let Some(msg) = slice.pop() {
+                match msg {
+                    Msg::HandshakeKeys(key, header_key) => {
+                        context.on_handshake_keys(key, header_key)?;
+                    }
+                    Msg::ServerName(server_name) => context.on_server_name(server_name)?,
+                    Msg::SendInitial(bytes) => context.send_initial(bytes),
+                    Msg::ClientParams(client_params, mut server_params) => context
+                        .on_client_application_params(
+                            tls::ApplicationParameters {
+                                transport_parameters: &client_params,
+                            },
+                            &mut server_params,
+                        )?,
+                    Msg::ApplicationProtocol(bytes) => {
+                        context.on_application_protocol(bytes)?;
+                    }
+                    Msg::KeyExchangeGroup(named_group) => {
+                        context.on_key_exchange_group(named_group)?;
+                    }
+                    Msg::OneRttKeys(key, header_key, transport_parameters) => context
+                        .on_one_rtt_keys(
+                            key,
+                            header_key,
+                            tls::ApplicationParameters {
+                                transport_parameters: &transport_parameters,
+                            },
+                        )?,
+                    Msg::SendHandshake(bytes) => {
+                        context.send_handshake(bytes);
+                    }
+                    Msg::HandshakeComplete => {
+                        context.on_handshake_complete()?;
+                    }
+                    Msg::TlsDone => {
+                        return Poll::Ready(Ok(()));
+                    }
+                    Msg::ZeroRtt(key, header_key, transport_parameters) => {
+                        context.on_zero_rtt_keys(
+                            key,
+                            header_key,
+                            tls::ApplicationParameters {
+                                transport_parameters: &transport_parameters,
+                            },
+                        )?;
+                    }
+                    Msg::TlsContext(ctx) => {
+                        context.on_tls_context(ctx);
+                    }
+                    Msg::SendApplication(transmission) => {
+                        context.send_application(transmission);
+                    }
+                    Msg::TlsError(e) => return Poll::Ready(Err(e)),
+                    // No other messages are sent from the TLS side
+                    _ => (),
+                }
+            }
+        };
+
+        // Send any TLS data to the TLS side. Note that we have to schedule a wakeup on the quic endpoint each time
+        // we pass data to the TLS side. This is because TLS may generate some data that needs to be sent
+        // in response to the data quic provides (for example, reading the client hello causes the TLS side
+        // to produce a server hello, which will then need to be sent).
+        if let Poll::Ready(Ok(mut slice)) = self.send_to_tls.poll_slice(&mut ctx) {
+            if let Some(resp) = context.receive_initial(None) {
+                context.waker().wake_by_ref();
+                let _ = slice.push(Msg::ResponseInitial(resp));
+            }
+
+            if let Some(resp) = context.receive_handshake(None) {
+                context.waker().wake_by_ref();
+                let _ = slice.push(Msg::ResponseHandshake(resp));
+            }
+
+            if let Some(resp) = context.receive_application(None) {
+                context.waker().wake_by_ref();
+                let _ = slice.push(Msg::ResponseApplication(resp));
+            }
+
+            let _ = slice.push(Msg::CanSendInitial(context.can_send_initial()));
+            let _ = slice.push(Msg::CanSendHandshake(context.can_send_handshake()));
+            let _ = slice.push(Msg::CanSendApplication(context.can_send_application()));
+        }
+
+        Poll::Pending
+    }
+}
+
+impl<S: tls::Session> CryptoSuite for OffloadSession<S> {
+    type HandshakeKey = <S as CryptoSuite>::HandshakeKey;
+    type HandshakeHeaderKey = <S as CryptoSuite>::HandshakeHeaderKey;
+    type InitialKey = <S as CryptoSuite>::InitialKey;
+    type InitialHeaderKey = <S as CryptoSuite>::InitialHeaderKey;
+    type ZeroRttKey = <S as CryptoSuite>::ZeroRttKey;
+    type ZeroRttHeaderKey = <S as CryptoSuite>::ZeroRttHeaderKey;
+    type OneRttKey = <S as CryptoSuite>::OneRttKey;
+    type OneRttHeaderKey = <S as CryptoSuite>::OneRttHeaderKey;
+    type RetryKey = <S as CryptoSuite>::RetryKey;
+}
+
+#[derive(Debug)]
+struct RemoteContext<'a, Msg> {
+    send_to_quic: &'a mut Sender<Msg>,
+    waker: core::task::Waker,
+    initial_data: Vec<bytes::Bytes>,
+    handshake_data: Vec<bytes::Bytes>,
+    application_data: Vec<bytes::Bytes>,
+    can_send_initial: bool,
+    can_send_handshake: bool,
+    can_send_application: bool,
+}
+
+impl<'a, S: CryptoSuite> tls::Context<S> for RemoteContext<'a, Msg<S>> {
+    fn on_client_application_params(
+        &mut self,
+        client_params: tls::ApplicationParameters,
+        server_params: &mut alloc::vec::Vec<u8>,
+    ) -> Result<(), crate::transport::Error> {
+        let mut cx = Context::from_waker(&self.waker);
+        if let Poll::Ready(Ok(mut slice)) = self.send_to_quic.poll_slice(&mut cx) {
+            let _ = slice.push(Msg::ClientParams(
+                client_params.transport_parameters.to_vec(),
+                server_params.to_vec(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn on_handshake_keys(
+        &mut self,
+        key: <S as CryptoSuite>::HandshakeKey,
+        header_key: <S as CryptoSuite>::HandshakeHeaderKey,
+    ) -> Result<(), crate::transport::Error> {
+        let mut cx = Context::from_waker(&self.waker);
+        if let Poll::Ready(Ok(mut slice)) = self.send_to_quic.poll_slice(&mut cx) {
+            let _ = slice.push(Msg::HandshakeKeys(key, header_key));
+        }
+        Ok(())
+    }
+
+    fn on_zero_rtt_keys(
+        &mut self,
+        key: <S as CryptoSuite>::ZeroRttKey,
+        header_key: <S as CryptoSuite>::ZeroRttHeaderKey,
+        application_parameters: tls::ApplicationParameters,
+    ) -> Result<(), crate::transport::Error> {
+        let mut cx = Context::from_waker(&self.waker);
+        if let Poll::Ready(Ok(mut slice)) = self.send_to_quic.poll_slice(&mut cx) {
+            let _ = slice.push(Msg::ZeroRtt(
+                key,
+                header_key,
+                application_parameters.transport_parameters.to_vec(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn on_one_rtt_keys(
+        &mut self,
+        key: <S as CryptoSuite>::OneRttKey,
+        header_key: <S as CryptoSuite>::OneRttHeaderKey,
+        application_parameters: tls::ApplicationParameters,
+    ) -> Result<(), crate::transport::Error> {
+        let mut cx = Context::from_waker(&self.waker);
+        if let Poll::Ready(Ok(mut slice)) = self.send_to_quic.poll_slice(&mut cx) {
+            let _ = slice.push(Msg::OneRttKeys(
+                key,
+                header_key,
+                application_parameters.transport_parameters.to_vec(),
+            ));
+        }
+        Ok(())
+    }
+
+    fn on_server_name(
+        &mut self,
+        server_name: crate::application::ServerName,
+    ) -> Result<(), crate::transport::Error> {
+        let mut cx = Context::from_waker(&self.waker);
+        if let Poll::Ready(Ok(mut slice)) = self.send_to_quic.poll_slice(&mut cx) {
+            let _ = slice.push(Msg::ServerName(server_name));
+        }
+        Ok(())
+    }
+
+    fn on_application_protocol(
+        &mut self,
+        application_protocol: bytes::Bytes,
+    ) -> Result<(), crate::transport::Error> {
+        let mut cx = Context::from_waker(&self.waker);
+        if let Poll::Ready(Ok(mut slice)) = self.send_to_quic.poll_slice(&mut cx) {
+            let _ = slice.push(Msg::ApplicationProtocol(application_protocol));
+        }
+        Ok(())
+    }
+
+    fn on_key_exchange_group(
+        &mut self,
+        named_group: tls::NamedGroup,
+    ) -> Result<(), crate::transport::Error> {
+        let mut cx = Context::from_waker(&self.waker);
+        if let Poll::Ready(Ok(mut slice)) = self.send_to_quic.poll_slice(&mut cx) {
+            let _ = slice.push(Msg::KeyExchangeGroup(named_group));
+        }
+        Ok(())
+    }
+
+    fn on_handshake_complete(&mut self) -> Result<(), crate::transport::Error> {
+        let mut cx = Context::from_waker(&self.waker);
+        if let Poll::Ready(Ok(mut slice)) = self.send_to_quic.poll_slice(&mut cx) {
+            let _ = slice.push(Msg::HandshakeComplete);
+        }
+
+        Ok(())
+    }
+
+    fn on_tls_context(&mut self, context: Box<dyn Any + Send>) {
+        let mut cx = Context::from_waker(&self.waker);
+        if let Poll::Ready(Ok(mut slice)) = self.send_to_quic.poll_slice(&mut cx) {
+            let _ = slice.push(Msg::TlsContext(context));
+        }
+    }
+
+    fn on_tls_exporter_ready(
+        &mut self,
+        _session: &impl tls::TlsSession,
+    ) -> Result<(), crate::transport::Error> {
+        // Not sure what we can do here
+        Ok(())
+    }
+
+    fn receive_initial(&mut self, max_len: Option<usize>) -> Option<bytes::Bytes> {
+        if let Some(max_len) = max_len {
+            if !self.initial_data.is_empty() {
+                let mut bytes = self.initial_data.remove(0);
+                if bytes.len() > max_len {
+                    let remainder = bytes.split_off(max_len);
+                    self.initial_data.insert(0, remainder);
+                }
+
+                return Some(bytes);
+            }
+        }
+
+        None
+    }
+
+    fn receive_handshake(&mut self, max_len: Option<usize>) -> Option<bytes::Bytes> {
+        if let Some(max_len) = max_len {
+            if !self.handshake_data.is_empty() {
+                let mut bytes = self.handshake_data.remove(0);
+                if bytes.len() > max_len {
+                    let remainder = bytes.split_off(max_len);
+                    self.handshake_data.insert(0, remainder);
+                }
+
+                return Some(bytes);
+            }
+        }
+        None
+    }
+
+    fn receive_application(&mut self, max_len: Option<usize>) -> Option<bytes::Bytes> {
+        if let Some(max_len) = max_len {
+            if !self.application_data.is_empty() {
+                let mut bytes = self.application_data.remove(0);
+                if bytes.len() > max_len {
+                    let remainder = bytes.split_off(max_len);
+                    self.application_data.insert(0, remainder);
+                }
+
+                return Some(bytes);
+            }
+        }
+
+        None
+    }
+
+    fn can_send_initial(&self) -> bool {
+        self.can_send_initial
+    }
+
+    fn send_initial(&mut self, transmission: bytes::Bytes) {
+        let mut cx = Context::from_waker(&self.waker);
+        if let Poll::Ready(Ok(mut slice)) = self.send_to_quic.poll_slice(&mut cx) {
+            let _ = slice.push(Msg::SendInitial(transmission));
+        }
+    }
+
+    fn can_send_handshake(&self) -> bool {
+        self.can_send_handshake
+    }
+
+    fn send_handshake(&mut self, transmission: bytes::Bytes) {
+        let mut cx = Context::from_waker(&self.waker);
+        if let Poll::Ready(Ok(mut slice)) = self.send_to_quic.poll_slice(&mut cx) {
+            let _ = slice.push(Msg::SendHandshake(transmission));
+        }
+    }
+
+    fn can_send_application(&self) -> bool {
+        self.can_send_application
+    }
+
+    fn send_application(&mut self, transmission: bytes::Bytes) {
+        let mut cx = Context::from_waker(&self.waker);
+        if let Poll::Ready(Ok(mut slice)) = self.send_to_quic.poll_slice(&mut cx) {
+            let _ = slice.push(Msg::SendApplication(transmission));
+        }
+    }
+
+    fn waker(&self) -> &core::task::Waker {
+        &self.waker
+    }
+
+    fn on_tls_handshake_failed(
+        &mut self,
+        session: &impl tls::TlsSession,
+    ) -> Result<(), crate::transport::Error> {
+        todo!()
+    }
+}
+
+enum Msg<S: CryptoSuite> {
+    ZeroRtt(
+        <S as CryptoSuite>::ZeroRttKey,
+        <S as CryptoSuite>::ZeroRttHeaderKey,
+        Vec<u8>,
+    ),
+    ServerName(crate::application::ServerName),
+    SendInitial(bytes::Bytes),
+    ResponseInitial(bytes::Bytes),
+    ClientParams(Vec<u8>, Vec<u8>),
+    HandshakeKeys(
+        <S as CryptoSuite>::HandshakeKey,
+        <S as CryptoSuite>::HandshakeHeaderKey,
+    ),
+    SendHandshake(bytes::Bytes),
+    ApplicationProtocol(bytes::Bytes),
+    KeyExchangeGroup(NamedGroup),
+    OneRttKeys(
+        <S as CryptoSuite>::OneRttKey,
+        <S as CryptoSuite>::OneRttHeaderKey,
+        Vec<u8>,
+    ),
+    ResponseHandshake(bytes::Bytes),
+    HandshakeComplete,
+    TlsDone,
+    TlsContext(Box<dyn Any + Send>),
+    ResponseApplication(bytes::Bytes),
+    SendApplication(bytes::Bytes),
+    TlsError(transport::Error),
+    CanSendInitial(bool),
+    CanSendHandshake(bool),
+    CanSendApplication(bool),
+}
+
+impl<S: CryptoSuite> alloc::fmt::Debug for Msg<S> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Msg::ServerName(_) => write!(f, "ServerName"),
+            Msg::SendInitial(_) => write!(f, "SendInitial"),
+            Msg::ResponseInitial(_) => write!(f, "ResponseInitial"),
+            Msg::ClientParams(_, _) => write!(f, "ClientParams"),
+            Msg::HandshakeKeys(_, _) => write!(f, "HandshakeKeys"),
+            Msg::SendHandshake(_) => write!(f, "SendHandshake"),
+            Msg::ApplicationProtocol(_) => write!(f, "ApplicationProtocol"),
+            Msg::KeyExchangeGroup(_) => write!(f, "KeyExchangeGroup"),
+            Msg::OneRttKeys(_, _, _) => write!(f, "OneRttKeys"),
+            Msg::ResponseHandshake(_) => write!(f, "ResponseHandshake"),
+            Msg::HandshakeComplete => write!(f, "HandshakeComplete"),
+            Msg::TlsDone => write!(f, "TlsDone"),
+            Msg::ZeroRtt(_, _, _) => write!(f, "ZeroRtt"),
+            Msg::TlsContext(_) => write!(f, "TlsContext"),
+            Msg::ResponseApplication(_) => write!(f, "ResponseApplication"),
+            Msg::SendApplication(_) => write!(f, "SendApplication"),
+            Msg::TlsError(_) => write!(f, "TlsError"),
+            Msg::CanSendInitial(_) => write!(f, "CanSendInitial"),
+            Msg::CanSendHandshake(_) => write!(f, "CanSendHandshake"),
+            Msg::CanSendApplication(_) => write!(f, "CanSendApplication"),
+        }
+    }
+}

--- a/quic/s2n-quic-core/src/crypto/tls/offload.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/offload.rs
@@ -125,8 +125,8 @@ impl<S: tls::Session + 'static> OffloadSession<S> {
                                 error: None,
                             };
 
-                            match recv_from_quic.poll_slice(ctx) {
-                                Poll::Ready(res) => match res {
+                            while let Poll::Ready(res) = recv_from_quic.poll_slice(ctx) {
+                                match res {
                                     Ok(mut recv_slice) => {
                                         while let Some(response) = recv_slice.pop() {
                                             match response {
@@ -148,8 +148,7 @@ impl<S: tls::Session + 'static> OffloadSession<S> {
                                         // we complete the future.
                                         return Poll::Ready(());
                                     }
-                                },
-                                Poll::Pending => return Poll::Pending,
+                                }
                             }
 
                             let res = inner.poll(&mut context);

--- a/quic/s2n-quic-core/src/crypto/tls/offload.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/offload.rs
@@ -10,11 +10,7 @@ use crate::{
     transport,
 };
 use alloc::{boxed::Box, collections::vec_deque::VecDeque};
-use core::{
-    any::Any,
-    future::Future,
-    task::{Context, Poll},
-};
+use core::{any::Any, future::Future, task::Poll};
 
 pub trait Executor {
     fn spawn(&self, task: impl Future<Output = ()> + Send + 'static);
@@ -131,9 +127,10 @@ impl<S: tls::Session + 'static> OffloadSession<S> {
                             }
                         }
                         return Poll::Ready(res);
+                    } else {
+                        // Can't get a send_slice from the channel
+                        return Poll::Ready(Poll::Pending);
                     }
-
-                    Poll::Pending
                 })
                 .await;
 

--- a/quic/s2n-quic-core/src/crypto/tls/offload.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/offload.rs
@@ -468,7 +468,8 @@ impl<'a, S: CryptoSuite> tls::Context<S> for RemoteContext<'a, Msg<S>> {
         &mut self,
         session: &impl tls::TlsSession,
     ) -> Result<(), crate::transport::Error> {
-        todo!()
+        // Not sure what we can do here
+        Ok(())
     }
 }
 

--- a/quic/s2n-quic-core/src/crypto/tls/offload.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/offload.rs
@@ -380,59 +380,54 @@ impl<'a, S: CryptoSuite> tls::Context<S> for RemoteContext<'a, Msg<S>> {
         &mut self,
         _session: &impl TlsSession,
     ) -> Result<(), crate::transport::Error> {
-        // let mut cx = Context::from_waker(&self.waker);
-        // if let Poll::Ready(Ok(mut slice)) = self.send_to_quic.poll_slice(&mut cx) {
-        //     let res = Msg::TlsExporter;
-        //     let _ = slice.push(res);
-        // }
+        // TODO
 
         Ok(())
     }
 
     fn receive_initial(&mut self, max_len: Option<usize>) -> Option<bytes::Bytes> {
-        if let Some(max_len) = max_len {
-            if !self.initial_data.is_empty() {
-                let mut bytes = self.initial_data.remove(0);
+        if !self.initial_data.is_empty() {
+            let mut bytes = self.initial_data.remove(0);
+
+            if let Some(max_len) = max_len {
                 if bytes.len() > max_len {
                     let remainder = bytes.split_off(max_len);
                     self.initial_data.insert(0, remainder);
                 }
-
-                return Some(bytes);
             }
+            return Some(bytes);
         }
 
         None
     }
 
     fn receive_handshake(&mut self, max_len: Option<usize>) -> Option<bytes::Bytes> {
-        if let Some(max_len) = max_len {
-            if !self.handshake_data.is_empty() {
-                let mut bytes = self.handshake_data.remove(0);
+        if !self.handshake_data.is_empty() {
+            let mut bytes = self.handshake_data.remove(0);
+
+            if let Some(max_len) = max_len {
                 if bytes.len() > max_len {
                     let remainder = bytes.split_off(max_len);
                     self.handshake_data.insert(0, remainder);
                 }
-
-                return Some(bytes);
             }
+            return Some(bytes);
         }
         None
     }
 
     fn receive_application(&mut self, max_len: Option<usize>) -> Option<bytes::Bytes> {
-        if let Some(max_len) = max_len {
-            if !self.application_data.is_empty() {
-                let mut bytes = self.application_data.remove(0);
+        if !self.application_data.is_empty() {
+            let mut bytes = self.application_data.remove(0);
+
+            if let Some(max_len) = max_len {
                 if bytes.len() > max_len {
                     let remainder = bytes.split_off(max_len);
                     self.application_data.insert(0, remainder);
                 }
-
-                return Some(bytes);
             }
+            return Some(bytes);
         }
-
         None
     }
 

--- a/quic/s2n-quic-core/src/crypto/tls/offload.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/offload.rs
@@ -66,6 +66,7 @@ pub struct OffloadSession<S: tls::Session> {
     recv_from_tls: Receiver<Msg<S>>,
     send_to_tls: Sender<Msg<S>>,
 }
+
 impl<S: tls::Session + 'static> OffloadSession<S> {
     fn new(mut inner: S, executor: &impl Executor) -> Self {
         let (mut send_to_quic, recv_from_tls): (Sender<Msg<S>>, Receiver<Msg<S>>) = channel(10);

--- a/quic/s2n-quic-core/src/sync/spsc/recv.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/recv.rs
@@ -8,6 +8,7 @@ use core::{
     task::{Context, Poll},
 };
 
+#[derive(Debug)]
 pub struct Receiver<T>(pub(super) State<T>);
 
 impl<T> Receiver<T> {

--- a/quic/s2n-quic-core/src/sync/spsc/send.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/send.rs
@@ -8,6 +8,7 @@ use core::{
     task::{Context, Poll},
 };
 
+#[derive(Debug)]
 pub struct Sender<T>(pub(super) State<T>);
 
 impl<T> Sender<T> {

--- a/quic/s2n-quic-core/src/sync/spsc/send.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/send.rs
@@ -82,6 +82,7 @@ impl<T> Drop for Sender<T> {
     }
 }
 
+#[derive(Debug)]
 pub struct SendSlice<'a, T>(&'a mut State<T>, Cursor);
 
 impl<T> SendSlice<'_, T> {

--- a/quic/s2n-quic-tests/Cargo.toml
+++ b/quic/s2n-quic-tests/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 publish = false
 
 [dependencies]
+bach = "0.1.0"
 bytes = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std"] }
 rand = "0.9"

--- a/quic/s2n-quic-tests/Cargo.toml
+++ b/quic/s2n-quic-tests/Cargo.toml
@@ -32,4 +32,4 @@ zerocopy = { version = "0.8", features = ["derive"] }
 quiche = "0.24"
 
 [target.'cfg(unix)'.dependencies]
-s2n-quic = { path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-s2n", "unstable-provider-io-testing", "unstable-provider-dc", "unstable-provider-packet-interceptor", "unstable-provider-random"] }
+s2n-quic = { path = "../s2n-quic", features = ["provider-event-tracing", "provider-tls-s2n", "unstable-provider-io-testing", "unstable-provider-dc", "unstable-provider-packet-interceptor", "unstable-provider-random", "unstable-offload-tls", "unstable_client_hello"] }

--- a/quic/s2n-quic-tests/Cargo.toml
+++ b/quic/s2n-quic-tests/Cargo.toml
@@ -18,7 +18,7 @@ rand = "0.9"
 rand_chacha = "0.9"
 s2n-codec = { path = "../../common/s2n-codec" }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "probe-tracing", "testing"] }
-s2n-quic = { path = "../s2n-quic", features = ["provider-event-tracing", "unstable-provider-io-testing", "unstable-provider-dc", "unstable-provider-packet-interceptor", "unstable-provider-random"] }
+s2n-quic = { path = "../s2n-quic", features = ["provider-event-tracing", "unstable-provider-io-testing", "unstable-provider-dc", "unstable-provider-packet-interceptor", "unstable-provider-random", "unstable-offload-tls"] }
 s2n-quic-platform = { path = "../s2n-quic-platform", features = ["tokio-runtime"] }
 s2n-quic-transport = { path = "../s2n-quic-transport", features = ["unstable_resumption", "unstable-provider-dc"] }
 tokio = { version = "1", features = ["full"] }

--- a/quic/s2n-quic-tests/src/tests.rs
+++ b/quic/s2n-quic-tests/src/tests.rs
@@ -39,6 +39,8 @@ mod issue_1717;
 mod issue_954;
 mod mtu;
 mod no_tls;
+#[cfg(feature = "unstable-offload-tls")]
+mod offload;
 mod platform_events;
 mod pto;
 mod resumption;

--- a/quic/s2n-quic-tests/src/tests.rs
+++ b/quic/s2n-quic-tests/src/tests.rs
@@ -39,7 +39,6 @@ mod issue_1717;
 mod issue_954;
 mod mtu;
 mod no_tls;
-#[cfg(feature = "unstable-offload-tls")]
 mod offload;
 mod platform_events;
 mod pto;

--- a/quic/s2n-quic-tests/src/tests/offload.rs
+++ b/quic/s2n-quic-tests/src/tests/offload.rs
@@ -53,7 +53,7 @@ fn tls() {
         let client_endpoint = OffloadBuilder::new()
             .with_endpoint(client_endpoint)
             .with_executor(BachExecutor)
-            .with_exporter(Exporter)
+            //.with_exporter(Exporter)
             .build();
 
         let server = Server::builder()

--- a/quic/s2n-quic-tests/src/tests/offload.rs
+++ b/quic/s2n-quic-tests/src/tests/offload.rs
@@ -3,7 +3,7 @@
 use super::*;
 use s2n_quic::provider::tls::{
     default,
-    offload::{Executor, Offload},
+    offload::{Executor, Offload, OffloadBuilder},
 };
 struct BachExecutor;
 impl Executor for BachExecutor {
@@ -26,8 +26,16 @@ fn tls() {
             .unwrap()
             .build()
             .unwrap();
-        let server_endpoint = Offload(server_endpoint, BachExecutor);
-        let client_endpoint = Offload(client_endpoint, BachExecutor);
+
+        let server_endpoint = OffloadBuilder::new()
+            .with_endpoint(server_endpoint)
+            .with_executor(BachExecutor)
+            .build();
+        let client_endpoint = OffloadBuilder::new()
+            .with_endpoint(client_endpoint)
+            .with_executor(BachExecutor)
+            .build();
+
         let server = Server::builder()
             .with_io(handle.builder().build()?)?
             .with_event(tracing_events())?
@@ -55,8 +63,14 @@ fn mtls() {
         let server_endpoint = build_server_mtls_provider(certificates::MTLS_CA_CERT)?;
         let client_endpoint = build_client_mtls_provider(certificates::MTLS_CA_CERT)?;
 
-        let server_endpoint = Offload(server_endpoint, BachExecutor);
-        let client_endpoint = Offload(client_endpoint, BachExecutor);
+        let server_endpoint = OffloadBuilder::new()
+            .with_endpoint(server_endpoint)
+            .with_executor(BachExecutor)
+            .build();
+        let client_endpoint = OffloadBuilder::new()
+            .with_endpoint(client_endpoint)
+            .with_executor(BachExecutor)
+            .build();
 
         let server = Server::builder()
             .with_io(handle.builder().build()?)?
@@ -151,8 +165,14 @@ fn async_client_hello() {
             .build()
             .unwrap();
 
-        let server_endpoint = Offload(server_endpoint, BachExecutor);
-        let client_endpoint = Offload(client_endpoint, BachExecutor);
+        let server_endpoint = OffloadBuilder::new()
+            .with_endpoint(server_endpoint)
+            .with_executor(BachExecutor)
+            .build();
+        let client_endpoint = OffloadBuilder::new()
+            .with_endpoint(client_endpoint)
+            .with_executor(BachExecutor)
+            .build();
 
         let server = Server::builder()
             .with_io(handle.builder().build()?)?

--- a/quic/s2n-quic-tests/src/tests/offload.rs
+++ b/quic/s2n-quic-tests/src/tests/offload.rs
@@ -21,11 +21,15 @@ fn tls() {
 
     test(model, |handle| {
         let server_endpoint = default::Server::builder()
-            .with_certificate(certificates::CERT_PEM, certificates::KEY_PEM)?
-            .build()?;
+            .with_certificate(certificates::CERT_PEM, certificates::KEY_PEM)
+            .unwrap()
+            .build()
+            .unwrap();
         let client_endpoint = default::Client::builder()
-            .with_certificate(certificates::CERT_PEM)?
-            .build()?;
+            .with_certificate(certificates::CERT_PEM)
+            .unwrap()
+            .build()
+            .unwrap();
         let server_endpoint = Offload(server_endpoint, BachExecutor);
         let client_endpoint = Offload(client_endpoint, BachExecutor);
         let server = Server::builder()
@@ -48,6 +52,7 @@ fn tls() {
 }
 
 #[test]
+#[cfg(unix)]
 fn mtls() {
     struct BachExecutor;
     impl Executor for BachExecutor {
@@ -153,12 +158,16 @@ fn async_client_hello() {
         let client_hello_handler = MyCallbackHandler::new(3);
 
         let server_endpoint = default::Server::builder()
-            .with_certificate(certificates::CERT_PEM, certificates::KEY_PEM)?
-            .with_client_hello_handler(client_hello_handler)?
+            .with_certificate(certificates::CERT_PEM, certificates::KEY_PEM)
+            .unwrap()
+            .with_client_hello_handler(client_hello_handler)
+            .unwrap()
             .build()?;
         let client_endpoint = default::Client::builder()
-            .with_certificate(certificates::CERT_PEM)?
-            .build()?;
+            .with_certificate(certificates::CERT_PEM)
+            .unwrap()
+            .build()
+            .unwrap();
 
         let server_endpoint = Offload(server_endpoint, BachExecutor);
         let client_endpoint = Offload(client_endpoint, BachExecutor);

--- a/quic/s2n-quic-tests/src/tests/offload.rs
+++ b/quic/s2n-quic-tests/src/tests/offload.rs
@@ -12,6 +12,7 @@ impl Executor for BachExecutor {
     }
 }
 
+#[derive(Clone)]
 struct Exporter;
 impl ExporterHandler for Exporter {
     fn on_tls_handshake_failed(

--- a/quic/s2n-quic-tests/src/tests/offload.rs
+++ b/quic/s2n-quic-tests/src/tests/offload.rs
@@ -1,24 +1,20 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
-
 use super::*;
-
 use s2n_quic::provider::tls::{
     default,
     offload::{Executor, Offload},
 };
+struct BachExecutor;
+impl Executor for BachExecutor {
+    fn spawn(&self, task: impl core::future::Future<Output = ()> + Send + 'static) {
+        bach::spawn(task);
+    }
+}
 
 #[test]
 fn tls() {
-    struct BachExecutor;
-    impl Executor for BachExecutor {
-        fn spawn(&self, task: impl core::future::Future<Output = ()> + Send + 'static) {
-            bach::spawn(task);
-        }
-    }
-
     let model = Model::default();
-
     test(model, |handle| {
         let server_endpoint = default::Server::builder()
             .with_certificate(certificates::CERT_PEM, certificates::KEY_PEM)
@@ -54,13 +50,6 @@ fn tls() {
 #[test]
 #[cfg(unix)]
 fn mtls() {
-    struct BachExecutor;
-    impl Executor for BachExecutor {
-        fn spawn(&self, task: impl core::future::Future<Output = ()> + Send + 'static) {
-            bach::spawn(task);
-        }
-    }
-
     let model = Model::default();
     test(model, |handle| {
         let server_endpoint = build_server_mtls_provider(certificates::MTLS_CA_CERT)?;
@@ -98,13 +87,6 @@ fn async_client_hello() {
         sync::atomic::{AtomicBool, AtomicU8, Ordering},
         task::Poll,
     };
-
-    struct BachExecutor;
-    impl Executor for BachExecutor {
-        fn spawn(&self, task: impl core::future::Future<Output = ()> + Send + 'static) {
-            bach::spawn(task);
-        }
-    }
 
     let model = Model::default();
 

--- a/quic/s2n-quic-tests/src/tests/offload.rs
+++ b/quic/s2n-quic-tests/src/tests/offload.rs
@@ -53,7 +53,7 @@ fn tls() {
         let client_endpoint = OffloadBuilder::new()
             .with_endpoint(client_endpoint)
             .with_executor(BachExecutor)
-            //.with_exporter(Exporter)
+            .with_exporter(Exporter)
             .build();
 
         let server = Server::builder()

--- a/quic/s2n-quic-tests/src/tests/offload.rs
+++ b/quic/s2n-quic-tests/src/tests/offload.rs
@@ -3,7 +3,7 @@
 use super::*;
 use s2n_quic::provider::tls::{
     default,
-    offload::{Executor, Offload, OffloadBuilder},
+    offload::{Executor, OffloadBuilder},
 };
 struct BachExecutor;
 impl Executor for BachExecutor {

--- a/quic/s2n-quic-tests/src/tests/offload.rs
+++ b/quic/s2n-quic-tests/src/tests/offload.rs
@@ -65,12 +65,19 @@ fn failed_tls_handshake() {
     let model = Model::default();
     test(model, |handle| {
         let server_endpoint = default::Server::builder()
-            .with_certificate(certificates::CERT_PEM, certificates::KEY_PEM)
+            .with_certificate(
+                certificates::UNTRUSTED_CERT_PEM,
+                certificates::UNTRUSTED_KEY_PEM,
+            )
             .unwrap()
             .build()
             .unwrap();
-        // Client has no ability to trust server, which will lead to a cert untrusted error
-        let client_endpoint = default::Client::builder().build().unwrap();
+
+        let client_endpoint = default::Client::builder()
+            .with_certificate(certificates::CERT_PEM)
+            .unwrap()
+            .build()
+            .unwrap();
 
         let server_endpoint = OffloadBuilder::new()
             .with_endpoint(server_endpoint)

--- a/quic/s2n-quic-tests/src/tests/offload.rs
+++ b/quic/s2n-quic-tests/src/tests/offload.rs
@@ -1,0 +1,185 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+
+use crate::provider::tls::{default, offload::Offload};
+use s2n_quic_core::crypto::tls::{
+    offload::Executor,
+    testing::certificates::{CERT_PEM, KEY_PEM},
+};
+
+#[test]
+fn tls() {
+    struct BachExecutor;
+    impl Executor for BachExecutor {
+        fn spawn(&self, task: impl core::future::Future<Output = ()> + Send + 'static) {
+            bach::spawn(task);
+        }
+    }
+
+    let model = Model::default();
+
+    test(model, |handle| {
+        let server_endpoint = default::Server::builder()
+            .with_certificate(CERT_PEM, KEY_PEM)?
+            .build()?;
+        let client_endpoint = default::Client::builder()
+            .with_certificate(CERT_PEM)?
+            .build()?;
+        let server_endpoint = Offload(server_endpoint, BachExecutor);
+        let client_endpoint = Offload(client_endpoint, BachExecutor);
+        let server = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_event(tracing_events())?
+            .with_tls(server_endpoint)?
+            .start()?;
+
+        let client = Client::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(client_endpoint)?
+            .with_event(tracing_events())?
+            .start()?;
+        let addr = start_server(server)?;
+        start_client(client, addr, Data::new(1000))?;
+
+        Ok(addr)
+    })
+    .unwrap();
+}
+
+#[test]
+fn mtls() {
+    struct BachExecutor;
+    impl Executor for BachExecutor {
+        fn spawn(&self, task: impl core::future::Future<Output = ()> + Send + 'static) {
+            bach::spawn(task);
+        }
+    }
+
+    let model = Model::default();
+    test(model, |handle| {
+        let server_endpoint = build_server_mtls_provider(certificates::MTLS_CA_CERT)?;
+        let client_endpoint = build_client_mtls_provider(certificates::MTLS_CA_CERT)?;
+
+        let server_endpoint = Offload(server_endpoint, BachExecutor);
+        let client_endpoint = Offload(client_endpoint, BachExecutor);
+
+        let server = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_event(tracing_events())?
+            .with_tls(server_endpoint)?
+            .start()?;
+
+        let client = Client::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(client_endpoint)?
+            .with_event(tracing_events())?
+            .start()?;
+        let addr = start_server(server)?;
+        start_client(client, addr, Data::new(1000))?;
+
+        Ok(addr)
+    })
+    .unwrap();
+}
+
+#[test]
+#[cfg(feature = "s2n-quic-tls")]
+#[cfg(feature = "unstable_client_hello")]
+fn async_client_hello() {
+    use crate::provider::tls::s2n_tls::{
+        self, callbacks::ClientHelloCallback, connection::Connection, error::Error,
+    };
+    use std::{
+        sync::atomic::{AtomicBool, AtomicU8, Ordering},
+        task::Poll,
+    };
+
+    struct BachExecutor;
+    impl Executor for BachExecutor {
+        fn spawn(&self, task: impl core::future::Future<Output = ()> + Send + 'static) {
+            bach::spawn(task);
+        }
+    }
+
+    let model = Model::default();
+
+    pub struct MyCallbackHandler {
+        done: Arc<AtomicBool>,
+        wait_counter: Arc<AtomicU8>,
+    }
+    struct MyConnectionFuture {
+        done: Arc<AtomicBool>,
+        wait_counter: Arc<AtomicU8>,
+    }
+
+    impl MyCallbackHandler {
+        fn new(wait_counter: u8) -> Self {
+            MyCallbackHandler {
+                done: Arc::new(AtomicBool::new(false)),
+                wait_counter: Arc::new(AtomicU8::new(wait_counter)),
+            }
+        }
+    }
+
+    impl ClientHelloCallback for MyCallbackHandler {
+        fn on_client_hello(
+            &self,
+            _connection: &mut Connection,
+        ) -> Result<Option<std::pin::Pin<Box<dyn s2n_tls::callbacks::ConnectionFuture>>>, Error>
+        {
+            let fut = MyConnectionFuture {
+                done: self.done.clone(),
+                wait_counter: self.wait_counter.clone(),
+            };
+            Ok(Some(Box::pin(fut)))
+        }
+    }
+
+    impl s2n_tls::callbacks::ConnectionFuture for MyConnectionFuture {
+        fn poll(
+            self: std::pin::Pin<&mut Self>,
+            _connection: &mut Connection,
+            _ctx: &mut core::task::Context,
+        ) -> Poll<Result<(), Error>> {
+            if self.wait_counter.fetch_sub(1, Ordering::SeqCst) == 0 {
+                self.done.store(true, Ordering::SeqCst);
+                return Poll::Ready(Ok(()));
+            }
+
+            Poll::Pending
+        }
+    }
+    test(model, |handle| {
+        let client_hello_handler = MyCallbackHandler::new(3);
+
+        let server_endpoint = default::Server::builder()
+            .with_certificate(CERT_PEM, KEY_PEM)?
+            .with_client_hello_handler(client_hello_handler)?
+            .build()?;
+        let client_endpoint = default::Client::builder()
+            .with_certificate(CERT_PEM)?
+            .build()?;
+
+        let server_endpoint = Offload(server_endpoint, BachExecutor);
+        let client_endpoint = Offload(client_endpoint, BachExecutor);
+
+        let server = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_event(tracing_events())?
+            .with_tls(server_endpoint)?
+            .start()?;
+
+        let client = Client::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(client_endpoint)?
+            .with_event(tracing_events())?
+            .start()?;
+        let addr = start_server(server)?;
+        start_client(client, addr, Data::new(1000))?;
+
+        Ok(addr)
+    })
+    .unwrap();
+}

--- a/quic/s2n-quic-tests/src/tests/offload.rs
+++ b/quic/s2n-quic-tests/src/tests/offload.rs
@@ -3,10 +3,9 @@
 
 use super::*;
 
-use crate::provider::tls::{default, offload::Offload};
-use s2n_quic_core::crypto::tls::{
-    offload::Executor,
-    testing::certificates::{CERT_PEM, KEY_PEM},
+use s2n_quic::provider::tls::{
+    default,
+    offload::{Executor, Offload},
 };
 
 #[test]
@@ -22,10 +21,10 @@ fn tls() {
 
     test(model, |handle| {
         let server_endpoint = default::Server::builder()
-            .with_certificate(CERT_PEM, KEY_PEM)?
+            .with_certificate(certificates::CERT_PEM, certificates::KEY_PEM)?
             .build()?;
         let client_endpoint = default::Client::builder()
-            .with_certificate(CERT_PEM)?
+            .with_certificate(certificates::CERT_PEM)?
             .build()?;
         let server_endpoint = Offload(server_endpoint, BachExecutor);
         let client_endpoint = Offload(client_endpoint, BachExecutor);
@@ -85,10 +84,9 @@ fn mtls() {
 }
 
 #[test]
-#[cfg(feature = "s2n-quic-tls")]
-#[cfg(feature = "unstable_client_hello")]
+#[cfg(unix)]
 fn async_client_hello() {
-    use crate::provider::tls::s2n_tls::{
+    use s2n_quic::provider::tls::s2n_tls::{
         self, callbacks::ClientHelloCallback, connection::Connection, error::Error,
     };
     use std::{
@@ -155,11 +153,11 @@ fn async_client_hello() {
         let client_hello_handler = MyCallbackHandler::new(3);
 
         let server_endpoint = default::Server::builder()
-            .with_certificate(CERT_PEM, KEY_PEM)?
+            .with_certificate(certificates::CERT_PEM, certificates::KEY_PEM)?
             .with_client_hello_handler(client_hello_handler)?
             .build()?;
         let client_endpoint = default::Client::builder()
-            .with_certificate(CERT_PEM)?
+            .with_certificate(certificates::CERT_PEM)?
             .build()?;
 
         let server_endpoint = Offload(server_endpoint, BachExecutor);

--- a/quic/s2n-quic-tests/src/tests/offload.rs
+++ b/quic/s2n-quic-tests/src/tests/offload.rs
@@ -3,12 +3,29 @@
 use super::*;
 use s2n_quic::provider::tls::{
     default,
-    offload::{Executor, OffloadBuilder},
+    offload::{Executor, ExporterHandler, OffloadBuilder},
 };
 struct BachExecutor;
 impl Executor for BachExecutor {
     fn spawn(&self, task: impl core::future::Future<Output = ()> + Send + 'static) {
         bach::spawn(task);
+    }
+}
+
+struct Exporter;
+impl ExporterHandler for Exporter {
+    fn on_tls_handshake_failed(
+        &self,
+        _session: &impl s2n_quic_core::crypto::tls::TlsSession,
+    ) -> Option<Box<dyn std::any::Any + Send>> {
+        None
+    }
+
+    fn on_tls_exporter_ready(
+        &self,
+        _session: &impl s2n_quic_core::crypto::tls::TlsSession,
+    ) -> Option<Box<dyn std::any::Any + Send>> {
+        None
     }
 }
 
@@ -30,10 +47,12 @@ fn tls() {
         let server_endpoint = OffloadBuilder::new()
             .with_endpoint(server_endpoint)
             .with_executor(BachExecutor)
+            .with_exporter(Exporter)
             .build();
         let client_endpoint = OffloadBuilder::new()
             .with_endpoint(client_endpoint)
             .with_executor(BachExecutor)
+            .with_exporter(Exporter)
             .build();
 
         let server = Server::builder()
@@ -82,10 +101,12 @@ fn failed_tls_handshake() {
         let server_endpoint = OffloadBuilder::new()
             .with_endpoint(server_endpoint)
             .with_executor(BachExecutor)
+            .with_exporter(Exporter)
             .build();
         let client_endpoint = OffloadBuilder::new()
             .with_endpoint(client_endpoint)
             .with_executor(BachExecutor)
+            .with_exporter(Exporter)
             .build();
 
         let server = Server::builder()
@@ -128,98 +149,12 @@ fn mtls() {
         let server_endpoint = OffloadBuilder::new()
             .with_endpoint(server_endpoint)
             .with_executor(BachExecutor)
+            .with_exporter(Exporter)
             .build();
         let client_endpoint = OffloadBuilder::new()
             .with_endpoint(client_endpoint)
             .with_executor(BachExecutor)
-            .build();
-
-        let server = Server::builder()
-            .with_io(handle.builder().build()?)?
-            .with_event(tracing_events())?
-            .with_tls(server_endpoint)?
-            .start()?;
-
-        let client = Client::builder()
-            .with_io(handle.builder().build()?)?
-            .with_tls(client_endpoint)?
-            .with_event(tracing_events())?
-            .start()?;
-        let addr = start_server(server)?;
-        start_client(client, addr, Data::new(1000))?;
-
-        Ok(addr)
-    })
-    .unwrap();
-}
-
-#[test]
-#[cfg(unix)]
-fn async_client_hello() {
-    use s2n_quic::provider::tls::s2n_tls::{
-        self, callbacks::ClientHelloCallback, connection::Connection, error::Error,
-    };
-    use std::task::Poll;
-
-    let model = Model::default();
-
-    struct MyCallbackHandler;
-    struct MyConnectionFuture {
-        output: Option<bach::task::JoinHandle<()>>,
-    }
-
-    impl ClientHelloCallback for MyCallbackHandler {
-        fn on_client_hello(
-            &self,
-            _connection: &mut Connection,
-        ) -> Result<Option<std::pin::Pin<Box<dyn s2n_tls::callbacks::ConnectionFuture>>>, Error>
-        {
-            let fut = MyConnectionFuture { output: None };
-            Ok(Some(Box::pin(fut)))
-        }
-    }
-
-    impl s2n_tls::callbacks::ConnectionFuture for MyConnectionFuture {
-        fn poll(
-            mut self: std::pin::Pin<&mut Self>,
-            _connection: &mut Connection,
-            _ctx: &mut core::task::Context,
-        ) -> Poll<Result<(), Error>> {
-            if let Some(handle) = &self.output {
-                if handle.is_finished() {
-                    return Poll::Ready(Ok(()));
-                }
-            } else {
-                let future = async move {
-                    let timer = bach::time::sleep(Duration::from_secs(3));
-                    timer.await;
-                };
-                self.output = Some(bach::spawn(future));
-            }
-
-            Poll::Pending
-        }
-    }
-    test(model, |handle| {
-        let server_endpoint = default::Server::builder()
-            .with_certificate(certificates::CERT_PEM, certificates::KEY_PEM)
-            .unwrap()
-            .with_client_hello_handler(MyCallbackHandler)
-            .unwrap()
-            .build()?;
-        let client_endpoint = default::Client::builder()
-            .with_certificate(certificates::CERT_PEM)
-            .unwrap()
-            .build()
-            .unwrap();
-
-        let server_endpoint = OffloadBuilder::new()
-            .with_endpoint(server_endpoint)
-            .with_executor(BachExecutor)
-            .build();
-        let client_endpoint = OffloadBuilder::new()
-            .with_endpoint(client_endpoint)
-            .with_executor(BachExecutor)
+            .with_exporter(Exporter)
             .build();
 
         let server = Server::builder()

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -61,6 +61,8 @@ unstable-congestion-controller = ["s2n-quic-core/unstable-congestion-controller"
 unstable-limits = ["s2n-quic-core/unstable-limits"]
 # The feature enables the close formatter provider
 unstable-provider-connection-close-formatter = []
+# This feature enables the use of the offloaded TLS feature
+unstable-offload-tls = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }

--- a/quic/s2n-quic/src/provider/tls.rs
+++ b/quic/s2n-quic/src/provider/tls.rs
@@ -313,7 +313,8 @@ pub mod s2n_tls {
 #[cfg(feature = "unstable-offload-tls")]
 pub mod offload {
     use super::Provider;
-    use s2n_quic_core::crypto::tls::offload::{Executor, OffloadEndpoint};
+    pub use s2n_quic_core::crypto::tls::offload::Executor;
+    use s2n_quic_core::crypto::tls::offload::OffloadEndpoint;
 
     pub struct Offload<E, X>(pub E, pub X);
 

--- a/quic/s2n-quic/src/provider/tls.rs
+++ b/quic/s2n-quic/src/provider/tls.rs
@@ -315,6 +315,7 @@ pub mod offload {
     use super::Provider;
     use s2n_quic_core::crypto::tls::offload::OffloadEndpoint;
     pub use s2n_quic_core::crypto::tls::offload::{Executor, ExporterHandler};
+    pub use s2n_quic_core::crypto::tls::TlsSession;
     use std::sync::Arc;
 
     pub struct Offload<E, X, H> {

--- a/quic/s2n-quic/src/provider/tls.rs
+++ b/quic/s2n-quic/src/provider/tls.rs
@@ -314,8 +314,10 @@ pub mod s2n_tls {
 pub mod offload {
     use super::Provider;
     use s2n_quic_core::crypto::tls::offload::OffloadEndpoint;
-    pub use s2n_quic_core::crypto::tls::offload::{Executor, ExporterHandler};
-    pub use s2n_quic_core::crypto::tls::TlsSession;
+    pub use s2n_quic_core::crypto::tls::{
+        offload::{Executor, ExporterHandler},
+        TlsSession,
+    };
     use std::sync::Arc;
 
     pub struct Offload<E, X, H> {

--- a/quic/s2n-quic/src/provider/tls.rs
+++ b/quic/s2n-quic/src/provider/tls.rs
@@ -344,6 +344,12 @@ pub mod offload {
         }
     }
 
+    impl Default for OffloadBuilder<(), (), ()> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
+
     impl<X, H> OffloadBuilder<(), X, H> {
         pub fn with_endpoint<E: Endpoint>(self, endpoint: E) -> OffloadBuilder<E, X, H> {
             OffloadBuilder::<E, X, H> {

--- a/quic/s2n-quic/src/provider/tls.rs
+++ b/quic/s2n-quic/src/provider/tls.rs
@@ -324,6 +324,11 @@ pub mod offload {
         endpoint: Option<E>,
         executor: Option<X>,
     }
+    impl<E, X> Default for OffloadBuilder<E, X> {
+        fn default() -> Self {
+            Self::new()
+        }
+    }
     impl<E, X> OffloadBuilder<E, X> {
         pub fn new() -> Self {
             OffloadBuilder {
@@ -340,11 +345,10 @@ pub mod offload {
             self
         }
         pub fn build(self) -> Offload<E, X> {
-            let offload = Offload {
+            Offload {
                 endpoint: self.endpoint.expect("Please provide an endpoint"),
                 executor: self.executor.expect("Please provide an executor"),
-            };
-            offload
+            }
         }
     }
 


### PR DESCRIPTION
### Release Summary:
Adds unstable feature to move s2n-tls operations out of the main event loop.
### Resolved issues:

resolves #2598
### Description of changes: 

Adds a new TLS provider that spawns an asynchronous task which will complete the TLS handshake.
I am closing #2688 in favor of this PR.

### Call-outs:


### Testing:

New integ tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

