### PR TITLE
ci: temporarily disable neqo

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -14,10 +14,7 @@
       "client",
       "server"
     ],
-    "neqo": [
-      "client",
-      "server"
-    ],
+    "neqo": [],
     "ngtcp2": [
       "client",
       "server"
@@ -60,10 +57,7 @@
     "mvfst": [
       "server"
     ],
-    "neqo": [
-      "client",
-      "server"
-    ],
+    "neqo": [],
     "ngtcp2": [
       "client",
       "server"
@@ -106,10 +100,7 @@
     "mvfst": [
       "client"
     ],
-    "neqo": [
-      "client",
-      "server"
-    ],
+    "neqo": [],
     "ngtcp2": [
       "client",
       "server"
@@ -150,10 +141,7 @@
     "mvfst": [
       "server"
     ],
-    "neqo": [
-      "client",
-      "server"
-    ],
+    "neqo": [],
     "ngtcp2": [
       "client",
       "server"
@@ -190,9 +178,7 @@
     "lsquic": [],
     "msquic": [],
     "mvfst": [],
-    "neqo": [
-      "client"
-    ],
+    "neqo": [],
     "ngtcp2": [
       "client"
     ],
@@ -221,10 +207,7 @@
       "client",
       "server"
     ],
-    "neqo": [
-      "client",
-      "server"
-    ],
+    "neqo": [],
     "ngtcp2": [
       "client",
       "server"
@@ -263,10 +246,7 @@
     ],
     "msquic": [],
     "mvfst": [],
-    "neqo": [
-      "client",
-      "server"
-    ],
+    "neqo": [],
     "ngtcp2": [
       "client",
       "server"
@@ -305,10 +285,7 @@
     ],
     "msquic": [],
     "mvfst": [],
-    "neqo": [
-      "client",
-      "server"
-    ],
+    "neqo": [],
     "ngtcp2": [
       "client",
       "server"
@@ -341,9 +318,7 @@
     "lsquic": [],
     "msquic": [],
     "mvfst": [],
-    "neqo": [
-      "client"
-    ],
+    "neqo": [],
     "ngtcp2": [
       "client"
     ],
@@ -397,9 +372,7 @@
     ],
     "msquic": [],
     "mvfst": [],
-    "neqo": [
-      "client"
-    ],
+    "neqo": [],
     "ngtcp2": [
       "client",
       "server"
@@ -459,10 +432,7 @@
     ],
     "msquic": [],
     "mvfst": [],
-    "neqo": [
-      "client",
-      "server"
-    ],
+    "neqo": [],
     "ngtcp2": [
       "client",
       "server"
@@ -522,10 +492,7 @@
     ],
     "msquic": [],
     "mvfst": [],
-    "neqo": [
-      "client",
-      "server"
-    ],
+    "neqo": [],
     "ngtcp2": [
       "client",
       "server"
@@ -562,9 +529,7 @@
     ],
     "msquic": [],
     "mvfst": [],
-    "neqo": [
-      "client"
-    ],
+    "neqo": [],
     "ngtcp2": [],
     "picoquic": [
       "client"
@@ -646,10 +611,7 @@
     "mvfst": [
       "server"
     ],
-    "neqo": [
-      "client",
-      "server"
-    ],
+    "neqo": [],
     "ngtcp2": [
       "client",
       "server"


### PR DESCRIPTION
### Description of changes: 

Our intero-report [failed on all the neqo tests](https://github.com/aws/s2n-quic/actions/runs/16460832209/job/46582202373). We suspect this is caused by [some bug](https://github.com/mozilla/neqo/issues/2807) in `neqo`. The official report on QUIC Interop Runner also recorded similar results: https://interop.seemann.io/?run=2025-07-23T08:43. When neqo runs at the server side, most of the interop tests failed with different QUIC implementations.

We could temporarily remove `neqo` from the interop tests to unblock CI.

### Call-outs:

This PR should be reverted after `neqo` fixes the bug.

### Testing:

CI should pass


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

