### PR TITLE
fix(s2n-quic-dc): include ipv6 header length in MAX_TOTAL_IPV6 payload length

### DIFF
--- a/dc/s2n-quic-dc/src/msg/segment.rs
+++ b/dc/s2n-quic-dc/src/msg/segment.rs
@@ -46,6 +46,7 @@ const MAX_TOTAL_IPV4: u16 = if cfg!(target_os = "linux") {
 
 /// The maximum payload allowed in sendmsg calls using IPv6+UDP
 const MAX_TOTAL_IPV6: u16 = if cfg!(target_os = "linux") {
+    // The IPV6_HEADER_LEN is required in this calculation to accommodate older kernels (such as kernel 5.10)
     u16::MAX - IPV6_HEADER_LEN - UDP_HEADER_LEN
 } else {
     9001 - IPV6_HEADER_LEN - UDP_HEADER_LEN

--- a/dc/s2n-quic-dc/src/msg/segment.rs
+++ b/dc/s2n-quic-dc/src/msg/segment.rs
@@ -46,8 +46,7 @@ const MAX_TOTAL_IPV4: u16 = if cfg!(target_os = "linux") {
 
 /// The maximum payload allowed in sendmsg calls using IPv6+UDP
 const MAX_TOTAL_IPV6: u16 = if cfg!(target_os = "linux") {
-    // IPv6 doesn't include the IP header size in the calculation
-    u16::MAX - UDP_HEADER_LEN
+    u16::MAX - IPV6_HEADER_LEN - UDP_HEADER_LEN
 } else {
     9001 - IPV6_HEADER_LEN - UDP_HEADER_LEN
 };


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

We should include a 40 bytes `IPV6_HEADER_LEN` in the calculation for the max payload size that can be sent for IPV6.

I was testing this code on AL2 X86_64 Kernel 5.10 machine, and the max_total_test is consistently failing. I test the limit by changing the constant definition of `MAX_TOTAL_IPV6`, and found out that the maximum amount that can be sent with IPV6 is `u16::MAX - IPV6_HEADER_LEN - UDP_HEADER_LEN`, the current calculation doesn't include `IPV6_HEADER_LEN`.

### Call-outs:

This problem only happens on AL2 X86_64 Kernel 5.10 machine, and we are not aware of any other platforms that will make this fail.

The next step for this PR is to investigate issue https://github.com/aws/s2n-quic/issues/2728.

### Testing:

I ran the code on AL2 X86_64 Kernel 5.10 machine, and it succeeded:
```
(25-07-25 20:53:59) <0> [~/workspace/s2n-quic/dc/s2n-quic-dc/src]  
machine % uname -r
5.10.238-215.956.amzn2int.x86_64

(25-07-25 20:54:01) <0> [~/workspace/s2n-quic/dc/s2n-quic-dc/src]  
machine % cargo test max_total_test
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.11s
     Running unittests src/lib.rs (/workplace/bqfang/s2n-quic/target/debug/deps/s2n_quic_dc-456121e1fd155bb6)

running 1 test
test msg::segment::max_total_test ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 328 filtered out; finished in 0.00s
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

