### PR TITLE
fix(typo): fix a typo in codebuild.yml

### DIFF
--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -61,5 +61,5 @@ jobs:
             echo "Review the latest version of the PR to ensure that the code is safe to execute."
             echo "Note the full SHA of the commit that you are reviewing."
             echo "Run: ./codebuild/bin/start_codebuild.sh <full sha>"
-            ehco "Warning: use the full SHA, NOT the PR number. The PR could be updated after your review."
+            echo "Warning: use the full SHA, NOT the PR number. The PR could be updated after your review."
           fi


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

We found a typo in the codebuild.yml file:
https://github.com/aws/s2n-quic/blob/4938450468d9b68c1098634ecf4213dcafe2d091/.github/workflows/codebuild.yml#L64

It should be `echo` not `ehco`.

### Call-outs:

### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

