### PR TITLE
fix: clippy lint updates for rust version 1.89.0

### DIFF
--- a/common/s2n-codec/src/decoder/checked_range.rs
+++ b/common/s2n-codec/src/decoder/checked_range.rs
@@ -87,7 +87,7 @@ impl CheckedRange {
 }
 
 impl fmt::Debug for CheckedRange {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}..{}", self.start, self.end)
     }
 }

--- a/common/s2n-codec/src/decoder/mod.rs
+++ b/common/s2n-codec/src/decoder/mod.rs
@@ -191,10 +191,10 @@ macro_rules! impl_buffer {
                 // TODO add doctest
 
                 #[inline]
-                pub fn skip_into_range(
+                pub fn skip_into_range<'b>(
                     self,
                     count: usize,
-                    original_buffer: &crate::DecoderBufferMut,
+                    original_buffer: &'b crate::DecoderBufferMut<'b>,
                 ) -> $result<'a, crate::CheckedRange> {
                     let start = original_buffer.len() - self.len();
                     let (slice, buffer) = self.decode_slice(count)?;
@@ -212,9 +212,9 @@ macro_rules! impl_buffer {
                 // TODO add doctest
 
                 #[inline]
-                pub fn skip_into_range_with_len_prefix<Length: $value<'a> + core::convert::TryInto<usize>>(
+                pub fn skip_into_range_with_len_prefix<'b, Length: $value<'a> + core::convert::TryInto<usize>>(
                     self,
-                    original_buffer: &crate::DecoderBufferMut,
+                    original_buffer: &'b crate::DecoderBufferMut<'b>,
                 ) -> $result<'a, crate::CheckedRange> {
                     let (len, buffer) = self.decode::<Length>()?;
                     let len = len.try_into().map_err(|_| DecoderError::LengthCapacityExceeded)?;
@@ -227,7 +227,7 @@ macro_rules! impl_buffer {
                 // TODO add doctest
 
                 #[inline]
-                pub fn get_checked_range(&self, range: &crate::CheckedRange) -> DecoderBuffer {
+                pub fn get_checked_range(&self, range: &crate::CheckedRange) -> DecoderBuffer<'_> {
                     range.get(self.bytes).into()
                 }
             }
@@ -286,7 +286,7 @@ macro_rules! impl_buffer {
             pub fn peek_range(
                 &self,
                 range: core::ops::Range<usize>,
-            ) -> Result<crate::DecoderBuffer, DecoderError> {
+            ) -> Result<crate::DecoderBuffer<'_>, DecoderError> {
                 let end = range.end;
                 self.bytes
                     .get(range)
@@ -423,7 +423,7 @@ pub enum DecoderError {
 
 use core::fmt;
 impl fmt::Display for DecoderError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // https://github.com/model-checking/kani/issues/1767#issuecomment-1275449305
         if cfg!(kani) {
             return Ok(());

--- a/common/s2n-codec/src/unaligned.rs
+++ b/common/s2n-codec/src/unaligned.rs
@@ -203,7 +203,7 @@ impl From<core::num::TryFromIntError> for TryFromIntError {
 }
 
 impl core::fmt::Display for TryFromIntError {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "TryFromIntError")
     }
 }

--- a/common/s2n-codec/src/zerocopy.rs
+++ b/common/s2n-codec/src/zerocopy.rs
@@ -266,13 +266,13 @@ macro_rules! zerocopy_network_integer {
         }
 
         impl fmt::Debug for $name {
-            fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(formatter, "{}", self.get())
             }
         }
 
         impl fmt::Display for $name {
-            fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                 write!(formatter, "{}", self.get())
             }
         }

--- a/dc/s2n-quic-dc-benches/src/datagram/recv.rs
+++ b/dc/s2n-quic-dc-benches/src/datagram/recv.rs
@@ -28,7 +28,7 @@ macro_rules! impl_recv {
             #[allow(dead_code)]
             pub fn parse(
                 buffer: &mut [u8],
-            ) -> Option<s2n_quic_dc::packet::datagram::decoder::Packet> {
+            ) -> Option<s2n_quic_dc::packet::datagram::decoder::Packet<'_>> {
                 let buffer = s2n_codec::DecoderBufferMut::new(buffer);
                 let (packet, _buffer) = s2n_quic_dc::packet::datagram::decoder::Packet::decode(
                     buffer,

--- a/dc/s2n-quic-dc/src/msg/send.rs
+++ b/dc/s2n-quic-dc/src/msg/send.rs
@@ -325,7 +325,7 @@ impl Message {
     }
 
     #[inline]
-    pub fn drain(&mut self) -> Drain {
+    pub fn drain(&mut self) -> Drain<'_> {
         Drain {
             message: self,
             index: 0,

--- a/dc/s2n-quic-dc/src/packet/control/decoder.rs
+++ b/dc/s2n-quic-dc/src/packet/control/decoder.rs
@@ -130,7 +130,7 @@ impl Packet<'_> {
     }
 
     #[inline]
-    pub fn control_frames_mut(&mut self) -> ControlFramesMut {
+    pub fn control_frames_mut(&mut self) -> ControlFramesMut<'_> {
         ControlFramesMut {
             buffer: self.control_data.get_mut(self.header),
         }

--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -400,7 +400,7 @@ where
         self.ids = Default::default();
     }
 
-    pub(super) fn subscriber(&self) -> event::EndpointPublisherSubscriber<S> {
+    pub(super) fn subscriber(&self) -> event::EndpointPublisherSubscriber<'_, S> {
         use event::IntoEvent as _;
 
         let timestamp = self.clock.get_time().into_event();

--- a/dc/s2n-quic-dc/src/stream/environment.rs
+++ b/dc/s2n-quic-dc/src/stream/environment.rs
@@ -36,7 +36,7 @@ pub trait Environment {
 
     /// Creates an endpoint publisher with the environment's subscriber
     #[inline]
-    fn endpoint_publisher(&self) -> event::EndpointPublisherSubscriber<Self::Subscriber> {
+    fn endpoint_publisher(&self) -> event::EndpointPublisherSubscriber<'_, Self::Subscriber> {
         use s2n_quic_core::time::Clock as _;
 
         self.endpoint_publisher_with_time(self.clock().get_time())
@@ -46,7 +46,7 @@ pub trait Environment {
     fn endpoint_publisher_with_time(
         &self,
         timestamp: Timestamp,
-    ) -> event::EndpointPublisherSubscriber<Self::Subscriber> {
+    ) -> event::EndpointPublisherSubscriber<'_, Self::Subscriber> {
         use s2n_quic_core::event::IntoEvent;
 
         let timestamp = timestamp.into_event();

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/queue.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/queue.rs
@@ -299,7 +299,7 @@ impl<T> Queue<T> {
     }
 
     #[inline]
-    fn lock(&self) -> Result<std::sync::MutexGuard<Inner<T>>, Closed> {
+    fn lock(&self) -> Result<std::sync::MutexGuard<'_, Inner<T>>, Closed> {
         self.inner.lock().map_err(|_| Closed)
     }
 }

--- a/dc/s2n-quic-dc/src/stream/recv/shared.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/shared.rs
@@ -208,7 +208,7 @@ impl State {
     }
 
     #[inline]
-    pub fn worker_try_lock(&self) -> io::Result<Option<MutexGuard<Inner>>> {
+    pub fn worker_try_lock(&self) -> io::Result<Option<MutexGuard<'_, Inner>>> {
         match self.inner.try_lock() {
             Ok(lock) => Ok(Some(lock)),
             Err(std::sync::TryLockError::WouldBlock) => Ok(None),

--- a/dc/s2n-quic-dc/src/stream/shared.rs
+++ b/dc/s2n-quic-dc/src/stream/shared.rs
@@ -207,7 +207,7 @@ where
     }
 
     #[inline]
-    pub fn publisher(&self) -> event::ConnectionPublisherSubscriber<Sub> {
+    pub fn publisher(&self) -> event::ConnectionPublisherSubscriber<'_, Sub> {
         self.publisher_with_timestamp(self.clock.get_time())
     }
 
@@ -215,7 +215,7 @@ where
     pub fn publisher_with_timestamp(
         &self,
         timestamp: Timestamp,
-    ) -> event::ConnectionPublisherSubscriber<Sub> {
+    ) -> event::ConnectionPublisherSubscriber<'_, Sub> {
         self.subscriber.publisher(timestamp)
     }
 
@@ -223,7 +223,7 @@ where
     pub fn endpoint_publisher(
         &self,
         timestamp: Timestamp,
-    ) -> event::EndpointPublisherSubscriber<Sub> {
+    ) -> event::EndpointPublisherSubscriber<'_, Sub> {
         self.subscriber.endpoint_publisher(timestamp)
     }
 }
@@ -241,7 +241,7 @@ where
     Sub: event::Subscriber,
 {
     #[inline]
-    pub fn publisher(&self, timestamp: Timestamp) -> event::ConnectionPublisherSubscriber<Sub> {
+    pub fn publisher(&self, timestamp: Timestamp) -> event::ConnectionPublisherSubscriber<'_, Sub> {
         event::ConnectionPublisherSubscriber::new(
             event::builder::ConnectionMeta {
                 id: 0, // TODO
@@ -257,7 +257,7 @@ where
     pub fn endpoint_publisher(
         &self,
         timestamp: Timestamp,
-    ) -> event::EndpointPublisherSubscriber<Sub> {
+    ) -> event::EndpointPublisherSubscriber<'_, Sub> {
         event::EndpointPublisherSubscriber::new(
             event::builder::EndpointMeta {
                 timestamp: timestamp.into_event(),

--- a/dc/s2n-quic-dc/src/stream/socket/handle.rs
+++ b/dc/s2n-quic-dc/src/stream/socket/handle.rs
@@ -29,12 +29,12 @@ pub trait Socket: 'static + Send + Sync {
     fn features(&self) -> TransportFeatures;
 
     /// Returns the amount of buffered data on the socket
-    fn poll_peek_len(&self, cx: &mut Context) -> Poll<io::Result<usize>>;
+    fn poll_peek_len(&self, cx: &mut Context<'_>) -> Poll<io::Result<usize>>;
 
     #[inline]
     fn poll_recv_buffer(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         msg: &mut msg::recv::Message,
     ) -> Poll<io::Result<usize>> {
         #[cfg(debug_assertions)]
@@ -51,10 +51,10 @@ pub trait Socket: 'static + Send + Sync {
     /// Receives data on the socket
     fn poll_recv(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         addr: &mut Addr,
         cmsg: &mut cmsg::Receiver,
-        buffer: &mut [IoSliceMut],
+        buffer: &mut [IoSliceMut<'_>],
     ) -> Poll<io::Result<usize>>;
 
     #[inline]
@@ -67,13 +67,13 @@ pub trait Socket: 'static + Send + Sync {
         &self,
         addr: &Addr,
         ecn: ExplicitCongestionNotification,
-        buffer: &[IoSlice],
+        buffer: &[IoSlice<'_>],
     ) -> io::Result<usize>;
 
     #[inline]
     fn poll_send_buffer(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         msg: &mut msg::send::Message,
     ) -> Poll<io::Result<usize>> {
         msg.poll_send_with(|addr, ecn, iov| self.poll_send(cx, addr, ecn, iov))
@@ -82,10 +82,10 @@ pub trait Socket: 'static + Send + Sync {
     /// Sends data on the socket
     fn poll_send(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         addr: &Addr,
         ecn: ExplicitCongestionNotification,
-        buffer: &[IoSlice],
+        buffer: &[IoSlice<'_>],
     ) -> Poll<io::Result<usize>>;
 
     /// Shuts down the sender half of the socket, if a concept exists
@@ -133,17 +133,17 @@ macro_rules! impl_box {
             }
 
             #[inline(always)]
-            fn poll_peek_len(&self, cx: &mut Context) -> Poll<io::Result<usize>> {
+            fn poll_peek_len(&self, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
                 (**self).poll_peek_len(cx)
             }
 
             #[inline(always)]
             fn poll_recv(
                 &self,
-                cx: &mut Context,
+                cx: &mut Context<'_>,
                 addr: &mut Addr,
                 cmsg: &mut cmsg::Receiver,
-                buffer: &mut [IoSliceMut],
+                buffer: &mut [IoSliceMut<'_>],
             ) -> Poll<io::Result<usize>> {
                 (**self).poll_recv(cx, addr, cmsg, buffer)
             }
@@ -153,7 +153,7 @@ macro_rules! impl_box {
                 &self,
                 addr: &Addr,
                 ecn: ExplicitCongestionNotification,
-                buffer: &[IoSlice],
+                buffer: &[IoSlice<'_>],
             ) -> io::Result<usize> {
                 (**self).try_send(addr, ecn, buffer)
             }
@@ -161,10 +161,10 @@ macro_rules! impl_box {
             #[inline(always)]
             fn poll_send(
                 &self,
-                cx: &mut Context,
+                cx: &mut Context<'_>,
                 addr: &Addr,
                 ecn: ExplicitCongestionNotification,
-                buffer: &[IoSlice],
+                buffer: &[IoSlice<'_>],
             ) -> Poll<io::Result<usize>> {
                 (**self).poll_send(cx, addr, ecn, buffer)
             }

--- a/dc/s2n-quic-dc/src/stream/socket/send_only.rs
+++ b/dc/s2n-quic-dc/src/stream/socket/send_only.rs
@@ -33,17 +33,17 @@ where
     }
 
     #[inline]
-    fn poll_peek_len(&self, _cx: &mut Context) -> Poll<io::Result<usize>> {
+    fn poll_peek_len(&self, _cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         unimplemented!()
     }
 
     #[inline]
     fn poll_recv(
         &self,
-        _cx: &mut Context,
+        _cx: &mut Context<'_>,
         _addr: &mut Addr,
         _cmsg: &mut cmsg::Receiver,
-        _buffer: &mut [IoSliceMut],
+        _buffer: &mut [IoSliceMut<'_>],
     ) -> Poll<io::Result<usize>> {
         unimplemented!()
     }
@@ -53,7 +53,7 @@ where
         &self,
         addr: &Addr,
         ecn: ExplicitCongestionNotification,
-        buffer: &[IoSlice],
+        buffer: &[IoSlice<'_>],
     ) -> io::Result<usize> {
         // no point in sending empty packets
         ensure!(!buffer.is_empty(), Ok(0));
@@ -86,10 +86,10 @@ where
     #[inline]
     fn poll_send(
         &self,
-        _cx: &mut Context,
+        _cx: &mut Context<'_>,
         addr: &Addr,
         ecn: ExplicitCongestionNotification,
-        buffer: &[IoSlice],
+        buffer: &[IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
         self.try_send(addr, ecn, buffer).into()
     }

--- a/dc/s2n-quic-dc/src/stream/socket/tokio/tcp.rs
+++ b/dc/s2n-quic-dc/src/stream/socket/tokio/tcp.rs
@@ -31,7 +31,7 @@ impl Socket for TcpStream {
     }
 
     #[inline]
-    fn poll_peek_len(&self, cx: &mut Context) -> Poll<io::Result<usize>> {
+    fn poll_peek_len(&self, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         loop {
             ready!(self.poll_read_ready(cx))?;
 
@@ -55,10 +55,10 @@ impl Socket for TcpStream {
     #[inline]
     fn poll_recv(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         _addr: &mut Addr,
         cmsg: &mut cmsg::Receiver,
-        buffer: &mut [IoSliceMut],
+        buffer: &mut [IoSliceMut<'_>],
     ) -> Poll<io::Result<usize>> {
         loop {
             ready!(self.poll_read_ready(cx))?;
@@ -95,7 +95,7 @@ impl Socket for TcpStream {
         &self,
         _addr: &Addr,
         _ecn: ExplicitCongestionNotification,
-        buffer: &[IoSlice],
+        buffer: &[IoSlice<'_>],
     ) -> io::Result<usize> {
         loop {
             match tcp::send(self, buffer) {
@@ -111,10 +111,10 @@ impl Socket for TcpStream {
     #[inline]
     fn poll_send(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         _addr: &Addr,
         _ecn: ExplicitCongestionNotification,
-        buffer: &[IoSlice],
+        buffer: &[IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
         loop {
             ready!(self.poll_write_ready(cx))?;

--- a/dc/s2n-quic-dc/src/stream/socket/tokio/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/socket/tokio/udp.rs
@@ -34,7 +34,7 @@ where
     }
 
     #[inline]
-    fn poll_peek_len(&self, cx: &mut Context) -> Poll<io::Result<usize>> {
+    fn poll_peek_len(&self, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         loop {
             let mut socket = ready!(self.poll_read_ready(cx))?;
 
@@ -59,10 +59,10 @@ where
     #[inline]
     fn poll_recv(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         addr: &mut Addr,
         cmsg: &mut cmsg::Receiver,
-        buffer: &mut [IoSliceMut],
+        buffer: &mut [IoSliceMut<'_>],
     ) -> Poll<io::Result<usize>> {
         // no point in receiving empty packets
         ensure!(!buffer.is_empty(), Ok(0).into());
@@ -103,7 +103,7 @@ where
         &self,
         addr: &Addr,
         ecn: ExplicitCongestionNotification,
-        buffer: &[IoSlice],
+        buffer: &[IoSlice<'_>],
     ) -> io::Result<usize> {
         // no point in sending empty packets
         ensure!(!buffer.is_empty(), Ok(0));
@@ -132,10 +132,10 @@ where
     #[inline]
     fn poll_send(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         addr: &Addr,
         ecn: ExplicitCongestionNotification,
-        buffer: &[IoSlice],
+        buffer: &[IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
         // no point in sending empty packets
         ensure!(!buffer.is_empty(), Ok(0).into());

--- a/dc/s2n-quic-dc/src/stream/socket/tracing.rs
+++ b/dc/s2n-quic-dc/src/stream/socket/tracing.rs
@@ -31,7 +31,7 @@ impl<S: Socket> Socket for Tracing<S> {
     }
 
     #[inline(always)]
-    fn poll_peek_len(&self, cx: &mut Context) -> Poll<io::Result<usize>> {
+    fn poll_peek_len(&self, cx: &mut Context<'_>) -> Poll<io::Result<usize>> {
         let result = self.0.poll_peek_len(cx);
 
         trace!(
@@ -47,10 +47,10 @@ impl<S: Socket> Socket for Tracing<S> {
     #[inline(always)]
     fn poll_recv(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         addr: &mut Addr,
         cmsg: &mut cmsg::Receiver,
-        buffer: &mut [IoSliceMut],
+        buffer: &mut [IoSliceMut<'_>],
     ) -> Poll<io::Result<usize>> {
         let result = self.0.poll_recv(cx, addr, cmsg, buffer);
 
@@ -90,7 +90,7 @@ impl<S: Socket> Socket for Tracing<S> {
         &self,
         addr: &Addr,
         ecn: ExplicitCongestionNotification,
-        buffer: &[IoSlice],
+        buffer: &[IoSlice<'_>],
     ) -> io::Result<usize> {
         let result = self.0.try_send(addr, ecn, buffer);
 
@@ -115,10 +115,10 @@ impl<S: Socket> Socket for Tracing<S> {
     #[inline(always)]
     fn poll_send(
         &self,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         addr: &Addr,
         ecn: ExplicitCongestionNotification,
-        buffer: &[IoSlice],
+        buffer: &[IoSlice<'_>],
     ) -> Poll<io::Result<usize>> {
         let result = self.0.poll_send(cx, addr, ecn, buffer);
 

--- a/dc/s2n-quic-dc/src/task/waker/set.rs
+++ b/dc/s2n-quic-dc/src/task/waker/set.rs
@@ -20,7 +20,7 @@ pub struct Set {
 impl Set {
     /// Called at the beginning of the `poll` function for the owner of [`Set`]
     #[inline]
-    pub fn poll_start(&mut self, cx: &task::Context) {
+    pub fn poll_start(&mut self, cx: &task::Context<'_>) {
         let new_waker = cx.waker();
 
         let root_task_requires_update = if let Some(waker) = self.local_root.as_ref() {

--- a/quic/s2n-quic-core/src/application/server_name.rs
+++ b/quic/s2n-quic-core/src/application/server_name.rs
@@ -60,7 +60,7 @@ impl From<alloc::string::String> for ServerName {
 }
 
 impl core::fmt::Debug for ServerName {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         self.as_str().fmt(f)
     }
 }

--- a/quic/s2n-quic-core/src/buffer/deque.rs
+++ b/quic/s2n-quic-core/src/buffer/deque.rs
@@ -19,7 +19,7 @@ pub struct Deque {
 }
 
 impl fmt::Debug for Deque {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Deque")
             .field("len", &self.len())
             .field("capacity", &self.capacity())
@@ -217,7 +217,7 @@ impl Deque {
 pub struct FillError(());
 
 impl fmt::Display for FillError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "the buffer does not have enough capacity for the provided fill amount"

--- a/quic/s2n-quic-core/src/buffer/error.rs
+++ b/quic/s2n-quic-core/src/buffer/error.rs
@@ -34,7 +34,7 @@ impl Error {
 impl<E: std::error::Error> std::error::Error for Error<E> {}
 
 impl<E: core::fmt::Display> core::fmt::Display for Error<E> {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::OutOfRange => write!(f, "write extends out of the maximum possible offset"),
             Self::InvalidFin => write!(

--- a/quic/s2n-quic-core/src/buffer/reader.rs
+++ b/quic/s2n-quic-core/src/buffer/reader.rs
@@ -70,7 +70,7 @@ pub trait Reader: Storage {
 
     /// Limits the maximum offset that the caller can read from the reader
     #[inline]
-    fn with_max_data(&mut self, max_data: VarInt) -> Limit<Self> {
+    fn with_max_data(&mut self, max_data: VarInt) -> Limit<'_, Self> {
         let max_buffered_len = max_data.saturating_sub(self.current_offset());
         let max_buffered_len = max_buffered_len.as_u64().min(self.buffered_len() as u64) as usize;
         self.with_read_limit(max_buffered_len)
@@ -78,13 +78,13 @@ pub trait Reader: Storage {
 
     /// Limits the maximum amount of data that the caller can read from the reader
     #[inline]
-    fn with_read_limit(&mut self, max_buffered_len: usize) -> Limit<Self> {
+    fn with_read_limit(&mut self, max_buffered_len: usize) -> Limit<'_, Self> {
         Limit::new(self, max_buffered_len)
     }
 
     /// Return an empty view onto the reader, with no change in current offset
     #[inline]
-    fn with_empty_buffer(&self) -> Empty<Self> {
+    fn with_empty_buffer(&self) -> Empty<'_, Self> {
         Empty::new(self)
     }
 
@@ -95,7 +95,7 @@ pub trait Reader: Storage {
     /// `debug_assertions` must be enabled for these checks to be performed. Otherwise, the reader
     /// methods will simply be forwarded to `Self`.
     #[inline]
-    fn with_checks(&mut self) -> Checked<Self> {
+    fn with_checks(&mut self) -> Checked<'_, Self> {
         Checked::new(self)
     }
 }

--- a/quic/s2n-quic-core/src/buffer/reader/complete.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/complete.rs
@@ -53,14 +53,14 @@ where
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         let chunk = self.storage.read_chunk(watermark)?;
         self.current_offset += chunk.len();
         Ok(chunk)
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/empty.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/empty.rs
@@ -29,12 +29,12 @@ impl<R: Reader + ?Sized> Storage for Empty<'_, R> {
     }
 
     #[inline(always)]
-    fn read_chunk(&mut self, _watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, _watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         Ok(Chunk::empty())
     }
 
     #[inline(always)]
-    fn partial_copy_into<Dest>(&mut self, _dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, _dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/incremental.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/incremental.rs
@@ -97,14 +97,14 @@ impl<C: Storage> Storage for WithStorage<'_, C> {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         let chunk = self.storage.read_chunk(watermark)?;
         self.incremental.current_offset += chunk.len();
         Ok(chunk)
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/limit.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/limit.rs
@@ -35,7 +35,7 @@ impl<R: Reader + ?Sized> Storage for Limit<'_, R> {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         let watermark = self.len.min(watermark);
         let chunk = self.reader.read_chunk(watermark)?;
         unsafe {
@@ -46,7 +46,7 @@ impl<R: Reader + ?Sized> Storage for Limit<'_, R> {
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/storage.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/storage.rs
@@ -66,13 +66,13 @@ pub trait Storage {
     ///
     /// The returned `Chunk` from `partial_copy_into` will always be empty.
     #[inline]
-    fn full_copy(&mut self) -> FullCopy<Self> {
+    fn full_copy(&mut self) -> FullCopy<'_, Self> {
         FullCopy::new(self)
     }
 
     /// Tracks the number of bytes read from the storage
     #[inline]
-    fn track_read(&mut self) -> Tracked<Self> {
+    fn track_read(&mut self) -> Tracked<'_, Self> {
         Tracked::new(self)
     }
 }

--- a/quic/s2n-quic-core/src/buffer/reader/storage/buf.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/storage/buf.rs
@@ -56,7 +56,7 @@ where
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         self.commit_pending();
         let chunk = self.buf.chunk();
         let len = chunk.len().min(watermark);
@@ -65,7 +65,7 @@ where
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/storage/bytes.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/storage/bytes.rs
@@ -19,7 +19,7 @@ impl Storage for BytesMut {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         let len = self.len().min(watermark);
 
         ensure!(len > 0, Ok(Self::new().into()));
@@ -33,7 +33,7 @@ impl Storage for BytesMut {
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {
@@ -79,13 +79,13 @@ impl Storage for Bytes {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         let len = self.len().min(watermark);
         Ok(self.split_to(len).into())
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/storage/chunk.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/storage/chunk.rs
@@ -79,7 +79,7 @@ impl Storage for Chunk<'_> {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         match self {
             Self::Slice(v) => v.read_chunk(watermark),
             Self::Bytes(v) => v.read_chunk(watermark),
@@ -88,7 +88,7 @@ impl Storage for Chunk<'_> {
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/storage/full_copy.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/storage/full_copy.rs
@@ -31,12 +31,12 @@ impl<S: Storage + ?Sized> Storage for FullCopy<'_, S> {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         self.0.read_chunk(watermark)
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/storage/io_slice.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/storage/io_slice.rs
@@ -212,7 +212,7 @@ where
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         Ok(match self.read_chunk_control_flow(watermark) {
             ControlFlow::Continue(chunk) => chunk,
             ControlFlow::Break(chunk) => chunk,
@@ -220,7 +220,7 @@ where
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/storage/slice.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/storage/slice.rs
@@ -32,7 +32,7 @@ macro_rules! impl_slice {
             }
 
             #[inline]
-            fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+            fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
                 ensure!(!self.is_empty(), Ok(Chunk::empty()));
                 let len = self.len().min(watermark);
                 // use `take` to work around borrowing rules
@@ -50,7 +50,7 @@ macro_rules! impl_slice {
             }
 
             #[inline]
-            fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+            fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
             where
                 Dest: writer::Storage + ?Sized,
             {

--- a/quic/s2n-quic-core/src/buffer/reassembler/reader.rs
+++ b/quic/s2n-quic-core/src/buffer/reassembler/reader.rs
@@ -28,7 +28,7 @@ impl Storage for Reassembler {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         let Some(slot) = self.slots.front_mut() else {
             return Ok(BytesMut::new().into());
         };
@@ -66,7 +66,7 @@ impl Storage for Reassembler {
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reassembler/request.rs
+++ b/quic/s2n-quic-core/src/buffer/reassembler/request.rs
@@ -15,7 +15,7 @@ pub struct Request<'a> {
 }
 
 impl fmt::Debug for Request<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Request")
             .field("offset", &self.offset)
             .field("len", &self.data.len())
@@ -73,7 +73,7 @@ impl reader::Storage for Request<'_> {
     fn partial_copy_into<Dest>(
         &mut self,
         dest: &mut Dest,
-    ) -> Result<reader::storage::Chunk, Self::Error>
+    ) -> Result<reader::storage::Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/writer/storage.rs
+++ b/quic/s2n-quic-core/src/buffer/writer/storage.rs
@@ -78,7 +78,7 @@ pub trait Storage {
 
     /// Writes a reader [`Chunk`] into the storage
     #[inline]
-    fn put_chunk(&mut self, chunk: Chunk) {
+    fn put_chunk(&mut self, chunk: Chunk<'_>) {
         match chunk {
             Chunk::Slice(v) => self.put_slice(v),
             Chunk::Bytes(v) => self.put_bytes(v),
@@ -88,13 +88,13 @@ pub trait Storage {
 
     /// Limits the number of bytes that can be written to the storage
     #[inline]
-    fn with_write_limit(&mut self, max_len: usize) -> Limit<Self> {
+    fn with_write_limit(&mut self, max_len: usize) -> Limit<'_, Self> {
         Limit::new(self, max_len)
     }
 
     /// Tracks the number of bytes written to the storage
     #[inline]
-    fn track_write(&mut self) -> Tracked<Self> {
+    fn track_write(&mut self) -> Tracked<'_, Self> {
         Tracked::new(self)
     }
 
@@ -103,7 +103,7 @@ pub trait Storage {
     /// This can be used for very low latency scenarios where processing the single read is more
     /// important than filling the entire storage with as much data as possible.
     #[inline]
-    fn write_once(&mut self) -> WriteOnce<Self> {
+    fn write_once(&mut self) -> WriteOnce<'_, Self> {
         WriteOnce::new(self)
     }
 }

--- a/quic/s2n-quic-core/src/buffer/writer/storage/limit.rs
+++ b/quic/s2n-quic-core/src/buffer/writer/storage/limit.rs
@@ -89,7 +89,7 @@ impl<S: Storage + ?Sized> Storage for Limit<'_, S> {
     }
 
     #[inline]
-    fn put_chunk(&mut self, chunk: Chunk) {
+    fn put_chunk(&mut self, chunk: Chunk<'_>) {
         let len = chunk.len();
         debug_assert!(len <= self.remaining_capacity);
         self.storage.put_chunk(chunk);

--- a/quic/s2n-quic-core/src/buffer/writer/storage/tracked.rs
+++ b/quic/s2n-quic-core/src/buffer/writer/storage/tracked.rs
@@ -73,7 +73,7 @@ impl<S: Storage + ?Sized> Storage for Tracked<'_, S> {
     }
 
     #[inline]
-    fn put_chunk(&mut self, chunk: Chunk) {
+    fn put_chunk(&mut self, chunk: Chunk<'_>) {
         let len = chunk.len();
         self.storage.put_chunk(chunk);
         self.written += len;

--- a/quic/s2n-quic-core/src/buffer/writer/storage/write_once.rs
+++ b/quic/s2n-quic-core/src/buffer/writer/storage/write_once.rs
@@ -74,7 +74,7 @@ impl<S: Storage + ?Sized> Storage for WriteOnce<'_, S> {
     }
 
     #[inline]
-    fn put_chunk(&mut self, chunk: Chunk) {
+    fn put_chunk(&mut self, chunk: Chunk<'_>) {
         let did_write = !chunk.is_empty();
         self.storage.put_chunk(chunk);
         self.did_write |= did_write;

--- a/quic/s2n-quic-core/src/connection/close.rs
+++ b/quic/s2n-quic-core/src/connection/close.rs
@@ -10,29 +10,32 @@ pub use crate::{frame::ConnectionClose, inet::SocketAddress};
 /// to peers. This includes removing `reason` fields and making error codes more general.
 pub trait Formatter: 'static + Send {
     /// Formats a transport error for use in 1-RTT (application data) packets
-    fn format_transport_error(&self, context: &Context, error: transport::Error)
-        -> ConnectionClose;
+    fn format_transport_error(
+        &self,
+        context: &Context<'_>,
+        error: transport::Error,
+    ) -> ConnectionClose<'static>;
 
     /// Formats an application error for use in 1-RTT (application data) packets
     fn format_application_error(
         &self,
-        context: &Context,
+        context: &Context<'_>,
         error: application::Error,
-    ) -> ConnectionClose;
+    ) -> ConnectionClose<'static>;
 
     /// Formats a transport error for use in early (initial, handshake) packets
     fn format_early_transport_error(
         &self,
-        context: &Context,
+        context: &Context<'_>,
         error: transport::Error,
-    ) -> ConnectionClose;
+    ) -> ConnectionClose<'static>;
 
     /// Formats an application error for use in early (initial, handshake) packets
     fn format_early_application_error(
         &self,
-        context: &Context,
+        context: &Context<'_>,
         error: application::Error,
-    ) -> ConnectionClose;
+    ) -> ConnectionClose<'static>;
 }
 
 #[non_exhaustive]
@@ -57,33 +60,33 @@ pub struct Development;
 impl Formatter for Development {
     fn format_transport_error(
         &self,
-        _context: &Context,
+        _context: &Context<'_>,
         error: transport::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'static> {
         error.into()
     }
 
     fn format_application_error(
         &self,
-        _context: &Context,
+        _context: &Context<'_>,
         error: application::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'static> {
         error.into()
     }
 
     fn format_early_transport_error(
         &self,
-        _context: &Context,
+        _context: &Context<'_>,
         error: transport::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'static> {
         error.into()
     }
 
     fn format_early_application_error(
         &self,
-        _context: &Context,
+        _context: &Context<'_>,
         error: application::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'static> {
         error.into()
     }
 }
@@ -102,9 +105,9 @@ pub struct Production;
 impl Formatter for Production {
     fn format_transport_error(
         &self,
-        _context: &Context,
+        _context: &Context<'_>,
         error: transport::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'static> {
         // rewrite internal errors as PROTOCOL_VIOLATION
         if error.code == transport::Error::INTERNAL_ERROR.code {
             return transport::Error::PROTOCOL_VIOLATION.into();
@@ -126,25 +129,25 @@ impl Formatter for Production {
 
     fn format_application_error(
         &self,
-        _context: &Context,
+        _context: &Context<'_>,
         error: application::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'static> {
         error.into()
     }
 
     fn format_early_transport_error(
         &self,
-        context: &Context,
+        context: &Context<'_>,
         error: transport::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'static> {
         Self.format_transport_error(context, error)
     }
 
     fn format_early_application_error(
         &self,
-        _context: &Context,
+        _context: &Context<'_>,
         _error: application::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'static> {
         //= https://www.rfc-editor.org/rfc/rfc9000#section-10.2.3
         //# Sending a CONNECTION_CLOSE of type 0x1d in an Initial or Handshake
         //# packet could expose application state or be used to alter application

--- a/quic/s2n-quic-core/src/connection/error.rs
+++ b/quic/s2n-quic-core/src/connection/error.rs
@@ -105,7 +105,7 @@ pub enum Error {
 impl std::error::Error for Error {}
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Closed { initiator, .. } => write!(
                 f,
@@ -402,7 +402,7 @@ impl Error {
 pub fn as_frame<'a, F: connection::close::Formatter>(
     error: Error,
     formatter: &'a F,
-    context: &'a connection::close::Context<'a>,
+    context: &'a connection::close::Context<'_>,
 ) -> Option<(ConnectionClose<'a>, ConnectionClose<'a>)> {
     match error {
         Error::Closed { initiator, .. } => {
@@ -500,7 +500,7 @@ impl From<transport::Error> for Error {
 
 impl From<ConnectionClose<'_>> for Error {
     #[track_caller]
-    fn from(error: ConnectionClose) -> Self {
+    fn from(error: ConnectionClose<'_>) -> Self {
         if let Some(frame_type) = error.frame_type {
             let error = transport::Error {
                 code: transport::error::Code::new(error.error_code),

--- a/quic/s2n-quic-core/src/connection/id.rs
+++ b/quic/s2n-quic-core/src/connection/id.rs
@@ -309,7 +309,7 @@ impl Error {
 }
 
 impl core::fmt::Display for Error {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.message())
     }
 }
@@ -358,12 +358,12 @@ pub trait Validator {
     /// data after the connection ID.
     ///
     /// Returns the length of the connection id if successful, otherwise `None` is returned.
-    fn validate(&self, connection_info: &ConnectionInfo, buffer: &[u8]) -> Option<usize>;
+    fn validate(&self, connection_info: &ConnectionInfo<'_>, buffer: &[u8]) -> Option<usize>;
 }
 
 impl Validator for usize {
     #[inline]
-    fn validate(&self, _connection_info: &ConnectionInfo, buffer: &[u8]) -> Option<usize> {
+    fn validate(&self, _connection_info: &ConnectionInfo<'_>, buffer: &[u8]) -> Option<usize> {
         if buffer.len() >= *self {
             Some(*self)
         } else {
@@ -383,7 +383,7 @@ pub trait Generator {
     ///
     /// Each call to `generate` should produce a unique Connection ID,
     /// otherwise the endpoint may terminate.
-    fn generate(&mut self, connection_info: &ConnectionInfo) -> LocalId;
+    fn generate(&mut self, connection_info: &ConnectionInfo<'_>) -> LocalId;
 
     /// The maximum amount of time each generated connection ID should be
     /// used for. By default there is no maximum, though connection IDs
@@ -485,13 +485,13 @@ pub mod testing {
     pub struct Format(u64);
 
     impl Validator for Format {
-        fn validate(&self, _connection_info: &ConnectionInfo, _buffer: &[u8]) -> Option<usize> {
+        fn validate(&self, _connection_info: &ConnectionInfo<'_>, _buffer: &[u8]) -> Option<usize> {
             Some(core::mem::size_of::<u64>())
         }
     }
 
     impl Generator for Format {
-        fn generate(&mut self, _connection_info: &ConnectionInfo) -> LocalId {
+        fn generate(&mut self, _connection_info: &ConnectionInfo<'_>) -> LocalId {
             let id = (&self.0.to_be_bytes()[..]).try_into().unwrap();
             self.0 += 1;
             id

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -440,13 +440,13 @@ impl<'a> UpdatableLimits<'a> {
 
 /// Creates limits for a given connection
 pub trait Limiter: 'static + Send {
-    fn on_connection(&mut self, info: &ConnectionInfo) -> Limits;
+    fn on_connection(&mut self, info: &ConnectionInfo<'_>) -> Limits;
 
     /// Provides another opportunity to change connection limits with information
     /// from the handshake
     #[inline]
     #[cfg(feature = "alloc")]
-    fn on_post_handshake(&mut self, info: &HandshakeInfo, limits: &mut UpdatableLimits) {
+    fn on_post_handshake(&mut self, info: &HandshakeInfo<'_>, limits: &mut UpdatableLimits<'_>) {
         let _ = info;
         let _ = limits;
     }
@@ -454,11 +454,11 @@ pub trait Limiter: 'static + Send {
 
 /// Implement Limiter for a Limits struct
 impl Limiter for Limits {
-    fn on_connection(&mut self, _into: &ConnectionInfo) -> Limits {
+    fn on_connection(&mut self, _into: &ConnectionInfo<'_>) -> Limits {
         *self
     }
     #[cfg(feature = "alloc")]
-    fn on_post_handshake(&mut self, _info: &HandshakeInfo, _limits: &mut UpdatableLimits) {}
+    fn on_post_handshake(&mut self, _info: &HandshakeInfo<'_>, _limits: &mut UpdatableLimits<'_>) {}
 }
 
 #[cfg(test)]

--- a/quic/s2n-quic-core/src/crypto/header_crypto.rs
+++ b/quic/s2n-quic-core/src/crypto/header_crypto.rs
@@ -13,7 +13,7 @@ pub trait HeaderKey: Send {
     /// used for opening a packet.
     ///
     /// The sample size is determined by the key function.
-    fn opening_header_protection_mask(&self, ciphertext_sample: &[u8]) -> HeaderProtectionMask;
+    fn opening_header_protection_mask(&self, ciphertext_sample: &'_ [u8]) -> HeaderProtectionMask;
 
     /// Returns the sample size needed for the header protection
     /// buffer
@@ -23,7 +23,7 @@ pub trait HeaderKey: Send {
     /// used for sealing a packet.
     ///
     /// The sample size is determined by the key function.
-    fn sealing_header_protection_mask(&self, ciphertext_sample: &[u8]) -> HeaderProtectionMask;
+    fn sealing_header_protection_mask(&self, ciphertext_sample: &'_ [u8]) -> HeaderProtectionMask;
 
     /// Returns the sample size needed for the header protection
     /// buffer
@@ -77,10 +77,10 @@ fn xor_mask(payload: &mut [u8], mask: &[u8]) {
 }
 
 #[inline]
-pub(crate) fn apply_header_protection(
+pub(crate) fn apply_header_protection<'a>(
     mask: HeaderProtectionMask,
-    payload: EncryptedPayload,
-) -> ProtectedPayload {
+    payload: EncryptedPayload<'a>,
+) -> ProtectedPayload<'a> {
     let header_len = payload.header_len;
     let packet_number_len = payload.packet_number_len;
     let payload = payload.buffer.into_less_safe_slice();
@@ -95,11 +95,11 @@ pub(crate) fn apply_header_protection(
 }
 
 #[inline]
-pub(crate) fn remove_header_protection(
+pub(crate) fn remove_header_protection<'a>(
     space: PacketNumberSpace,
     mask: HeaderProtectionMask,
-    payload: ProtectedPayload,
-) -> Result<(TruncatedPacketNumber, EncryptedPayload), DecoderError> {
+    payload: ProtectedPayload<'a>,
+) -> Result<(TruncatedPacketNumber, EncryptedPayload<'a>), DecoderError> {
     let header_len = payload.header_len;
     let payload = payload.buffer.into_less_safe_slice();
 

--- a/quic/s2n-quic-core/src/crypto/key.rs
+++ b/quic/s2n-quic-core/src/crypto/key.rs
@@ -15,11 +15,11 @@ pub trait Key: Send {
     ) -> Result<(), packet_protection::Error>;
 
     /// Encrypt a payload
-    fn encrypt(
+    fn encrypt<'a>(
         &mut self,
         packet_number: u64,
         header: &[u8],
-        payload: &mut scatter::Buffer,
+        payload: &mut scatter::Buffer<'a>,
     ) -> Result<(), packet_protection::Error>;
 
     /// Length of the appended tag
@@ -87,11 +87,11 @@ pub mod testing {
         }
 
         /// Encrypt a payload
-        fn encrypt(
+        fn encrypt<'a>(
             &mut self,
             _packet_number: u64,
             _header: &[u8],
-            payload: &mut scatter::Buffer,
+            payload: &mut scatter::Buffer<'a>,
         ) -> Result<(), packet_protection::Error> {
             // copy any bytes into the final slice
             payload.flatten();
@@ -158,7 +158,7 @@ pub mod testing {
     }
 
     impl CryptoHeaderKey for HeaderKey {
-        fn opening_header_protection_mask(&self, _sample: &[u8]) -> HeaderProtectionMask {
+        fn opening_header_protection_mask(&self, _sample: &'_ [u8]) -> HeaderProtectionMask {
             [0; 5]
         }
 
@@ -166,7 +166,7 @@ pub mod testing {
             0
         }
 
-        fn sealing_header_protection_mask(&self, _sample: &[u8]) -> HeaderProtectionMask {
+        fn sealing_header_protection_mask(&self, _sample: &'_ [u8]) -> HeaderProtectionMask {
             [0; 5]
         }
 

--- a/quic/s2n-quic-core/src/crypto/packet_protection.rs
+++ b/quic/s2n-quic-core/src/crypto/packet_protection.rs
@@ -38,7 +38,7 @@ impl Error {
 }
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         if !self.reason.is_empty() {
             self.reason.fmt(f)
         } else {

--- a/quic/s2n-quic-core/src/crypto/payload.rs
+++ b/quic/s2n-quic-core/src/crypto/payload.rs
@@ -48,7 +48,7 @@ impl<'a> ProtectedPayload<'a> {
     }
 
     /// Reads data from a `CheckedRange`
-    pub fn get_checked_range(&self, range: &CheckedRange) -> DecoderBuffer {
+    pub fn get_checked_range<'b>(&'b self, range: &CheckedRange) -> DecoderBuffer<'b> {
         self.buffer.get_checked_range(range)
     }
 
@@ -125,7 +125,7 @@ impl<'a> EncryptedPayload<'a> {
     }
 
     /// Reads data from a `CheckedRange`
-    pub fn get_checked_range(&self, range: &CheckedRange) -> DecoderBuffer {
+    pub fn get_checked_range<'b>(&'b self, range: &CheckedRange) -> DecoderBuffer<'b> {
         self.buffer.get_checked_range(range)
     }
 
@@ -148,11 +148,11 @@ impl<'a> EncryptedPayload<'a> {
     }
 }
 
-fn header_protection_sample(
-    buffer: DecoderBuffer,
+fn header_protection_sample<'a>(
+    buffer: DecoderBuffer<'a>,
     header_len: usize,
     sample_len: usize,
-) -> Result<&[u8], DecoderError> {
+) -> Result<&'a [u8], DecoderError> {
     let buffer = buffer.skip(header_len)?;
 
     //= https://www.rfc-editor.org/rfc/rfc9001#section-5.4.2

--- a/quic/s2n-quic-core/src/crypto/tls/testing.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/testing.rs
@@ -414,7 +414,7 @@ impl<C: CryptoSuite, State: Debug, Params> fmt::Debug for Context<C, State, Para
 where
     for<'a> Params: DecoderValue<'a>,
 {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Context")
             .field("initial", &self.initial)
             .field("handshake", &self.handshake)
@@ -508,12 +508,12 @@ where
         assert!(self.transport_parameters.is_some());
     }
 
-    fn on_application_params(
+    fn on_application_params<'a>(
         &mut self,
-        params: tls::ApplicationParameters,
+        params: tls::ApplicationParameters<'a>,
     ) -> Result<(), transport::Error> {
         // make sure the parameters parse correctly
-        let buffer = DecoderBuffer::new(params.transport_parameters);
+        let buffer = DecoderBuffer::<'_>::new(params.transport_parameters);
         let _ = buffer
             .decode::<Params>()
             .map_err(|_| transport::Error::FRAME_ENCODING_ERROR)?;
@@ -556,7 +556,7 @@ impl<K: Key, Hk: HeaderKey> Default for Space<K, Hk> {
 }
 
 impl<K: Key, Hk: HeaderKey> fmt::Debug for Space<K, Hk> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Space")
             .field("crypto", &self.crypto.is_some())
             .field("rx", &self.rx)
@@ -668,9 +668,9 @@ impl<C: CryptoSuite, State: Debug, Params> tls::Context<C> for Context<C, State,
 where
     for<'a> Params: DecoderValue<'a>,
 {
-    fn on_client_application_params(
+    fn on_client_application_params<'a>(
         &mut self,
-        _client_params: ApplicationParameters,
+        _client_params: ApplicationParameters<'a>,
         _server_params: &mut Vec<u8>,
     ) -> Result<(), transport::Error> {
         self.log("client application params");
@@ -691,11 +691,11 @@ where
         Ok(())
     }
 
-    fn on_zero_rtt_keys(
+    fn on_zero_rtt_keys<'a>(
         &mut self,
         key: C::ZeroRttKey,
         header_key: C::ZeroRttHeaderKey,
-        params: tls::ApplicationParameters,
+        params: tls::ApplicationParameters<'a>,
     ) -> Result<(), transport::Error> {
         assert!(
             self.zero_rtt_crypto.is_none(),
@@ -707,11 +707,11 @@ where
         Ok(())
     }
 
-    fn on_one_rtt_keys(
+    fn on_one_rtt_keys<'a>(
         &mut self,
         key: C::OneRttKey,
         header_key: C::OneRttHeaderKey,
-        params: tls::ApplicationParameters,
+        params: tls::ApplicationParameters<'a>,
     ) -> Result<(), transport::Error> {
         assert!(
             self.application.crypto.is_none(),

--- a/quic/s2n-quic-core/src/event/snapshot.rs
+++ b/quic/s2n-quic-core/src/event/snapshot.rs
@@ -81,7 +81,7 @@ impl Location {
 pub trait Fmt {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result;
 
-    fn to_snapshot(&self) -> ToSnapshot<Self> {
+    fn to_snapshot(&self) -> ToSnapshot<'_, Self> {
         ToSnapshot(self)
     }
 }

--- a/quic/s2n-quic-core/src/interval_set/mod.rs
+++ b/quic/s2n-quic-core/src/interval_set/mod.rs
@@ -501,7 +501,7 @@ impl<T: IntervalBound> IntervalSet<T> {
     /// assert_eq!(vec![0, 1, 2, 3, 4, 10, 11, 12, 13, 14], items);
     /// ```
     #[inline]
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             iter: self.intervals.iter(),
             head: None,
@@ -704,7 +704,7 @@ impl<T: Copy> IntervalSet<T> {
     /// assert_eq!(set.intervals().collect::<Vec<_>>(), vec![0..=10]);
     /// ```
     #[inline]
-    pub fn intervals(&self) -> IntervalIter<T> {
+    pub fn intervals(&self) -> IntervalIter<'_, T> {
         IntervalIter {
             iter: self.intervals.iter(),
         }
@@ -721,7 +721,7 @@ impl<T: Copy> IntervalSet<T> {
     /// assert_eq!(set.ranges().collect::<Vec<_>>(), vec![0..11]);
     /// ```
     #[inline]
-    pub fn ranges(&self) -> RangeIter<T> {
+    pub fn ranges(&self) -> RangeIter<'_, T> {
         RangeIter {
             iter: self.intervals.iter(),
         }
@@ -738,7 +738,7 @@ impl<T: Copy> IntervalSet<T> {
     /// assert_eq!(set.inclusive_ranges().collect::<Vec<_>>(), vec![0..=10]);
     /// ```
     #[inline]
-    pub fn inclusive_ranges(&self) -> RangeInclusiveIter<T> {
+    pub fn inclusive_ranges(&self) -> RangeInclusiveIter<'_, T> {
         RangeInclusiveIter {
             iter: self.intervals.iter(),
         }

--- a/quic/s2n-quic-core/src/io/rx.rs
+++ b/quic/s2n-quic-core/src/io/rx.rs
@@ -16,7 +16,7 @@ pub trait Rx: Sized {
 
     /// Returns a future that yields after a packet is ready to be received
     #[inline]
-    fn ready(&mut self) -> RxReady<Self> {
+    fn ready(&mut self) -> RxReady<'_, Self> {
         RxReady(self)
     }
 

--- a/quic/s2n-quic-core/src/io/tx.rs
+++ b/quic/s2n-quic-core/src/io/tx.rs
@@ -19,7 +19,7 @@ pub trait Tx: Sized {
 
     /// Returns a future that yields after a packet is ready to be transmitted
     #[inline]
-    fn ready(&mut self) -> TxReady<Self> {
+    fn ready(&mut self) -> TxReady<'_, Self> {
         TxReady(self)
     }
 

--- a/quic/s2n-quic-core/src/packet/number/map.rs
+++ b/quic/s2n-quic-core/src/packet/number/map.rs
@@ -221,7 +221,7 @@ impl<V> Map<V> {
 
     /// Removes a range of packets from the map and returns their value
     #[inline]
-    pub fn remove_range(&mut self, range: PacketNumberRange) -> RemoveIter<V> {
+    pub fn remove_range(&mut self, range: PacketNumberRange) -> RemoveIter<'_, V> {
         RemoveIter::new(self, range)
     }
 
@@ -233,7 +233,7 @@ impl<V> Map<V> {
 
     /// Gets an iterator over the sent packet entries, sorted by PacketNumber
     #[inline]
-    pub fn iter(&self) -> Iter<V> {
+    pub fn iter(&self) -> Iter<'_, V> {
         Iter::new(self)
     }
 

--- a/quic/s2n-quic-core/src/packet/retry.rs
+++ b/quic/s2n-quic-core/src/packet/retry.rs
@@ -287,7 +287,7 @@ impl<'a> Retry<'a> {
     }
 
     #[inline]
-    fn pseudo_packet(&self, odcid: &'a [u8]) -> PseudoRetry {
+    fn pseudo_packet(&self, odcid: &'a [u8]) -> PseudoRetry<'_> {
         PseudoRetry {
             original_destination_connection_id: odcid,
             tag: self.tag,

--- a/quic/s2n-quic-core/src/packet/version_negotiation.rs
+++ b/quic/s2n-quic-core/src/packet/version_negotiation.rs
@@ -65,8 +65,8 @@ impl<'a> ProtectedVersionNegotiation<'a> {
     pub fn decode(
         tag: Tag,
         _version: Version,
-        buffer: DecoderBufferMut,
-    ) -> DecoderBufferMutResult<VersionNegotiation<&[u8]>> {
+        buffer: DecoderBufferMut<'_>,
+    ) -> DecoderBufferMutResult<'_, VersionNegotiation<'_, &[u8]>> {
         let buffer = buffer
             .skip(size_of::<Tag>() + size_of::<Version>())
             .expect("tag and version already verified");

--- a/quic/s2n-quic-core/src/stream/testing.rs
+++ b/quic/s2n-quic-core/src/stream/testing.rs
@@ -201,7 +201,7 @@ impl reader::Storage for Data {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<reader::storage::Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<reader::storage::Chunk<'_>, Self::Error> {
         if let Some(chunk) = self.send_one(watermark) {
             return Ok(chunk.into());
         }
@@ -213,7 +213,7 @@ impl reader::Storage for Data {
     fn partial_copy_into<Dest: writer::Storage + ?Sized>(
         &mut self,
         dest: &mut Dest,
-    ) -> Result<reader::storage::Chunk, Self::Error> {
+    ) -> Result<reader::storage::Chunk<'_>, Self::Error> {
         while let Some(chunk) = self.send_one(dest.remaining_capacity()) {
             // if the chunk matches the destination then return it instead of copying
             if chunk.len() == dest.remaining_capacity() || self.is_finished() {

--- a/quic/s2n-quic-core/src/sync/spsc/recv.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/recv.rs
@@ -36,7 +36,7 @@ impl<T> Receiver<T> {
     ///
     /// Callers should call [`Self::acquire`] or [`Self::poll_slice`] before calling this method.
     #[inline]
-    pub fn slice(&mut self) -> RecvSlice<T> {
+    pub fn slice(&mut self) -> RecvSlice<'_, T> {
         let cursor = self.0.cursor;
         RecvSlice(&mut self.0, cursor)
     }
@@ -48,7 +48,7 @@ impl<T> Receiver<T> {
     }
 
     #[inline]
-    pub fn poll_slice(&mut self, cx: &mut Context) -> Poll<Result<RecvSlice<T>>> {
+    pub fn poll_slice(&mut self, cx: &mut Context) -> Poll<Result<RecvSlice<'_, T>>> {
         macro_rules! acquire_filled {
             () => {
                 match self.0.acquire_filled() {
@@ -80,7 +80,7 @@ impl<T> Receiver<T> {
     }
 
     #[inline]
-    pub fn try_slice(&mut self) -> Result<Option<RecvSlice<T>>> {
+    pub fn try_slice(&mut self) -> Result<Option<RecvSlice<'_, T>>> {
         Ok(if self.0.acquire_filled()? {
             let cursor = self.0.cursor;
             Some(RecvSlice(&mut self.0, cursor))

--- a/quic/s2n-quic-core/src/sync/spsc/send.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/send.rs
@@ -21,7 +21,7 @@ impl<T> Sender<T> {
     ///
     /// Callers should call [`Self::acquire`] or [`Self::poll_slice`] before calling this method.
     #[inline]
-    pub fn slice(&mut self) -> SendSlice<T> {
+    pub fn slice(&mut self) -> SendSlice<'_, T> {
         let cursor = self.0.cursor;
         SendSlice(&mut self.0, cursor)
     }
@@ -33,7 +33,7 @@ impl<T> Sender<T> {
     }
 
     #[inline]
-    pub fn poll_slice(&mut self, cx: &mut Context) -> Poll<Result<SendSlice<T>>> {
+    pub fn poll_slice(&mut self, cx: &mut Context) -> Poll<Result<SendSlice<'_, T>>> {
         macro_rules! acquire_capacity {
             () => {
                 match self.0.acquire_capacity() {
@@ -65,7 +65,7 @@ impl<T> Sender<T> {
     }
 
     #[inline]
-    pub fn try_slice(&mut self) -> Result<Option<SendSlice<T>>> {
+    pub fn try_slice(&mut self) -> Result<Option<SendSlice<'_, T>>> {
         Ok(if self.0.acquire_capacity()? {
             let cursor = self.0.cursor;
             Some(SendSlice(&mut self.0, cursor))

--- a/quic/s2n-quic-core/src/sync/spsc/state.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/state.rs
@@ -382,7 +382,7 @@ impl<T> State<T> {
 
     /// Returns the channel slots as two pairs of filled and unfilled slices
     #[inline]
-    pub fn as_pairs(&self) -> (Pair<T>, Pair<T>) {
+    pub fn as_pairs(&self) -> (Pair<'_, T>, Pair<'_, T>) {
         let data = self.data();
         self.data_to_pairs(data)
     }

--- a/quic/s2n-quic-core/src/sync/spsc/tests.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/tests.rs
@@ -37,7 +37,7 @@ impl Default for WakeState {
 }
 
 impl WakeState {
-    fn context(&self) -> Context {
+    fn context(&self) -> Context<'_> {
         Context::from_waker(&self.waker)
     }
 

--- a/quic/s2n-quic-core/src/task/waker/contract.rs
+++ b/quic/s2n-quic-core/src/task/waker/contract.rs
@@ -47,7 +47,7 @@ impl Contract {
 
     /// Returns a new [`Context`] to be checked
     #[inline]
-    pub fn context(&self) -> Context {
+    pub fn context(&self) -> Context<'_> {
         Context::from_waker(&self.waker)
     }
 

--- a/quic/s2n-quic-core/src/time/clock.rs
+++ b/quic/s2n-quic-core/src/time/clock.rs
@@ -29,7 +29,7 @@ pub trait ClockWithTimer: Clock {
 
 pub trait Timer {
     #[inline]
-    fn ready(&mut self) -> TimerReady<Self> {
+    fn ready(&mut self) -> TimerReady<'_, Self> {
         TimerReady(self)
     }
 

--- a/quic/s2n-quic-core/src/transmission/writer/testing.rs
+++ b/quic/s2n-quic-core/src/transmission/writer/testing.rs
@@ -31,7 +31,7 @@ pub struct WrittenFrame {
 impl WrittenFrame {
     /// Deserializes a written frame into a quic_frame::Frame type.
     /// panics if deserialization fails.
-    pub fn as_frame(&mut self) -> FrameMut {
+    pub fn as_frame(&mut self) -> FrameMut<'_> {
         let buffer = DecoderBufferMut::new(&mut self.data[..]);
         let (frame, remaining) = buffer
             .decode::<FrameMut>()

--- a/quic/s2n-quic-crypto/src/header_key.rs
+++ b/quic/s2n-quic-crypto/src/header_key.rs
@@ -9,7 +9,7 @@ pub struct HeaderKey(pub(crate) aead::quic::HeaderProtectionKey);
 
 impl crypto::HeaderKey for HeaderKey {
     #[inline]
-    fn opening_header_protection_mask(&self, sample: &[u8]) -> HeaderProtectionMask {
+    fn opening_header_protection_mask(&self, sample: &'_ [u8]) -> HeaderProtectionMask {
         self.header_protection_mask(sample)
     }
 
@@ -19,7 +19,7 @@ impl crypto::HeaderKey for HeaderKey {
     }
 
     #[inline]
-    fn sealing_header_protection_mask(&self, sample: &[u8]) -> HeaderProtectionMask {
+    fn sealing_header_protection_mask(&self, sample: &'_ [u8]) -> HeaderProtectionMask {
         self.header_protection_mask(sample)
     }
 
@@ -76,7 +76,7 @@ pub struct HeaderKeyPair {
 
 impl crypto::HeaderKey for HeaderKeyPair {
     #[inline]
-    fn opening_header_protection_mask(&self, sample: &[u8]) -> HeaderProtectionMask {
+    fn opening_header_protection_mask(&self, sample: &'_ [u8]) -> HeaderProtectionMask {
         self.opener.opening_header_protection_mask(sample)
     }
 
@@ -86,7 +86,7 @@ impl crypto::HeaderKey for HeaderKeyPair {
     }
 
     #[inline]
-    fn sealing_header_protection_mask(&self, sample: &[u8]) -> HeaderProtectionMask {
+    fn sealing_header_protection_mask(&self, sample: &'_ [u8]) -> HeaderProtectionMask {
         self.sealer.sealing_header_protection_mask(sample)
     }
 
@@ -105,7 +105,7 @@ macro_rules! header_key {
             #[inline]
             fn opening_header_protection_mask(
                 &self,
-                sample: &[u8],
+                sample: &'_ [u8],
             ) -> s2n_quic_core::crypto::HeaderProtectionMask {
                 self.0.opening_header_protection_mask(sample)
             }
@@ -118,7 +118,7 @@ macro_rules! header_key {
             #[inline]
             fn sealing_header_protection_mask(
                 &self,
-                sample: &[u8],
+                sample: &'_ [u8],
             ) -> s2n_quic_core::crypto::HeaderProtectionMask {
                 self.0.sealing_header_protection_mask(sample)
             }

--- a/quic/s2n-quic-platform/src/io/testing/message.rs
+++ b/quic/s2n-quic-platform/src/io/testing/message.rs
@@ -90,7 +90,7 @@ impl MessageTrait for Message {
     fn rx_read(
         &mut self,
         _local_address: &path::LocalAddress,
-    ) -> Option<message::RxMessage<Self::Handle>> {
+    ) -> Option<message::RxMessage<'_, Self::Handle>> {
         let path = self.handle;
         let header = datagram::Header {
             path,

--- a/quic/s2n-quic-platform/src/message.rs
+++ b/quic/s2n-quic-platform/src/message.rs
@@ -122,7 +122,10 @@ pub trait Message: 'static + Copy {
     unsafe fn reset(&mut self, mtu: usize);
 
     /// Reads the message as an RX packet
-    fn rx_read(&mut self, local_address: &path::LocalAddress) -> Option<RxMessage<Self::Handle>>;
+    fn rx_read(
+        &mut self,
+        local_address: &path::LocalAddress,
+    ) -> Option<RxMessage<'_, Self::Handle>>;
 
     /// Writes the message into the TX packet
     fn tx_write<M: tx::Message<Handle = Self::Handle>>(

--- a/quic/s2n-quic-platform/src/message/cmsg/storage.rs
+++ b/quic/s2n-quic-platform/src/message/cmsg/storage.rs
@@ -14,7 +14,7 @@ pub struct Storage<const L: usize>([u8; L]);
 
 impl<const L: usize> Storage<L> {
     #[inline]
-    pub fn encoder(&mut self) -> Encoder<L> {
+    pub fn encoder(&mut self) -> Encoder<'_, L> {
         Encoder {
             storage: self,
             cursor: 0,
@@ -22,7 +22,7 @@ impl<const L: usize> Storage<L> {
     }
 
     #[inline]
-    pub fn iter(&self) -> super::decode::Iter {
+    pub fn iter(&self) -> super::decode::Iter<'_> {
         super::decode::Iter::new(self)
     }
 }
@@ -78,7 +78,7 @@ impl<'a, const L: usize> Encoder<'a, L> {
     }
 
     #[inline]
-    pub fn iter(&self) -> super::decode::Iter {
+    pub fn iter(&self) -> super::decode::Iter<'_> {
         unsafe {
             // SAFETY: bytes are aligned with Storage type
             super::decode::Iter::from_bytes(self)

--- a/quic/s2n-quic-platform/src/message/mmsg.rs
+++ b/quic/s2n-quic-platform/src/message/mmsg.rs
@@ -64,7 +64,7 @@ impl MessageTrait for mmsghdr {
     fn rx_read(
         &mut self,
         local_address: &path::LocalAddress,
-    ) -> Option<super::RxMessage<Self::Handle>> {
+    ) -> Option<super::RxMessage<'_, Self::Handle>> {
         unsafe {
             // We need to replicate the `msg_len` field to the inner type before delegating
             // Safety: The `msg_len` is associated with the same buffer as the `msg_hdr`

--- a/quic/s2n-quic-platform/src/message/msg.rs
+++ b/quic/s2n-quic-platform/src/message/msg.rs
@@ -128,7 +128,7 @@ impl MessageTrait for msghdr {
     fn rx_read(
         &mut self,
         local_address: &path::LocalAddress,
-    ) -> Option<super::RxMessage<Self::Handle>> {
+    ) -> Option<super::RxMessage<'_, Self::Handle>> {
         if cfg!(test) {
             assert_eq!(
                 self.msg_flags & libc::MSG_CTRUNC,

--- a/quic/s2n-quic-platform/src/message/simple.rs
+++ b/quic/s2n-quic-platform/src/message/simple.rs
@@ -76,7 +76,7 @@ impl MessageTrait for Message {
     fn rx_read(
         &mut self,
         local_address: &path::LocalAddress,
-    ) -> Option<super::RxMessage<Self::Handle>> {
+    ) -> Option<super::RxMessage<'_, Self::Handle>> {
         let path = path::Tuple {
             remote_address: self.address.into(),
             local_address: *local_address,

--- a/quic/s2n-quic-rustls/src/session.rs
+++ b/quic/s2n-quic-rustls/src/session.rs
@@ -130,7 +130,7 @@ impl Session {
         Ok(())
     }
 
-    fn application_parameters(&self) -> Result<tls::ApplicationParameters, transport::Error> {
+    fn application_parameters(&self) -> Result<tls::ApplicationParameters<'_>, transport::Error> {
         //= https://www.rfc-editor.org/rfc/rfc9001#section-8.2
         //# endpoints that
         //# receive ClientHello or EncryptedExtensions messages without the

--- a/quic/s2n-quic-transport/src/ack/tests/environment.rs
+++ b/quic/s2n-quic-transport/src/ack/tests/environment.rs
@@ -38,7 +38,7 @@ impl TestEnvironment {
         }
     }
 
-    pub fn context(&mut self) -> MockWriteContext {
+    pub fn context(&mut self) -> MockWriteContext<'_> {
         MockWriteContext::new(
             self.current_time,
             &mut self.sent_frames,

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -53,7 +53,7 @@ pub trait Config: 'static + Send + Sized + core::fmt::Debug {
     const ENDPOINT_TYPE: endpoint::Type;
 
     /// Returns the context for the endpoint configuration
-    fn context(&mut self) -> Context<Self>;
+    fn context(&mut self) -> Context<'_, Self>;
 }
 
 #[derive(Debug)]

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -1293,7 +1293,7 @@ pub mod testing {
         type DatagramEndpoint = s2n_quic_core::datagram::Disabled;
         type DcEndpoint = s2n_quic_core::dc::testing::MockDcEndpoint;
 
-        fn context(&mut self) -> super::Context<Self> {
+        fn context(&mut self) -> super::Context<'_, Self> {
             todo!()
         }
 
@@ -1325,7 +1325,7 @@ pub mod testing {
         type DatagramEndpoint = s2n_quic_core::datagram::Disabled;
         type DcEndpoint = s2n_quic_core::dc::testing::MockDcEndpoint;
 
-        fn context(&mut self) -> super::Context<Self> {
+        fn context(&mut self) -> super::Context<'_, Self> {
             todo!()
         }
 

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -223,7 +223,7 @@ impl<Config: endpoint::Config> Manager<Config> {
 
     /// Returns an iterator over all paths pending path_challenge or path_response
     /// transmission.
-    pub fn paths_pending_validation(&mut self) -> PathsPendingValidation<Config> {
+    pub fn paths_pending_validation(&mut self) -> PathsPendingValidation<'_, Config> {
         PathsPendingValidation::new(self)
     }
 

--- a/quic/s2n-quic-transport/src/stream/api.rs
+++ b/quic/s2n-quic-transport/src/stream/api.rs
@@ -43,7 +43,7 @@ impl State {
         self.connection.poll_request(id, request, context)
     }
 
-    fn request(&mut self) -> Request {
+    fn request(&mut self) -> Request<'_, '_> {
         Request {
             state: self,
             request: ops::Request::default(),
@@ -331,18 +331,18 @@ impl Stream {
         &self.0.connection
     }
 
-    pub fn request(&mut self) -> Request {
+    pub fn request(&mut self) -> Request<'_, '_> {
         self.0.request()
     }
 
-    pub fn tx_request(&mut self) -> Result<TxRequest, StreamError> {
+    pub fn tx_request(&mut self) -> Result<TxRequest<'_, '_>, StreamError> {
         Ok(TxRequest {
             state: &mut self.0,
             request: ops::Request::default(),
         })
     }
 
-    pub fn rx_request(&mut self) -> Result<RxRequest, StreamError> {
+    pub fn rx_request(&mut self) -> Result<RxRequest<'_, '_>, StreamError> {
         Ok(RxRequest {
             state: &mut self.0,
             request: ops::Request::default(),
@@ -396,7 +396,7 @@ impl SendStream {
         &self.0.connection
     }
 
-    pub fn tx_request(&mut self) -> Result<TxRequest, StreamError> {
+    pub fn tx_request(&mut self) -> Result<TxRequest<'_, '_>, StreamError> {
         Ok(TxRequest {
             state: &mut self.0,
             request: ops::Request::default(),
@@ -440,7 +440,7 @@ impl ReceiveStream {
         &self.0.connection
     }
 
-    pub fn rx_request(&mut self) -> Result<RxRequest, StreamError> {
+    pub fn rx_request(&mut self) -> Result<RxRequest<'_, '_>, StreamError> {
         Ok(RxRequest {
             state: &mut self.0,
             request: ops::Request::default(),

--- a/quic/s2n-quic-transport/src/sync/data_sender/buffer.rs
+++ b/quic/s2n-quic-transport/src/sync/data_sender/buffer.rs
@@ -137,7 +137,7 @@ impl Buffer {
 
     /// Returns a Viewer for the buffer
     #[inline]
-    pub fn viewer(&self) -> Viewer {
+    pub fn viewer(&self) -> Viewer<'_> {
         Viewer {
             buffer: self,
             offset: *self.head,

--- a/quic/s2n-quic-transport/src/sync/data_sender/transmissions.rs
+++ b/quic/s2n-quic-transport/src/sync/data_sender/transmissions.rs
@@ -294,7 +294,7 @@ impl Set {
     }
 
     #[inline]
-    pub fn remove_range(&mut self, range: PacketNumberRange) -> SetRemoveIter {
+    pub fn remove_range(&mut self, range: PacketNumberRange) -> SetRemoveIter<'_> {
         SetRemoveIter {
             inner: self.packets.remove_range(range),
             next: None,

--- a/quic/s2n-quic/src/client/providers.rs
+++ b/quic/s2n-quic/src/client/providers.rs
@@ -331,7 +331,7 @@ impl<
 
     const ENDPOINT_TYPE: endpoint::Type = endpoint::Type::Client;
 
-    fn context(&mut self) -> endpoint::Context<Self> {
+    fn context(&mut self) -> endpoint::Context<'_, Self> {
         endpoint::Context {
             congestion_controller: &mut self.congestion_controller,
             connection_close_formatter: &mut self.connection_close_formatter,

--- a/quic/s2n-quic/src/server/providers.rs
+++ b/quic/s2n-quic/src/server/providers.rs
@@ -301,7 +301,7 @@ impl<
 
     const ENDPOINT_TYPE: endpoint::Type = endpoint::Type::Server;
 
-    fn context(&mut self) -> endpoint::Context<Self> {
+    fn context(&mut self) -> endpoint::Context<'_, Self> {
         endpoint::Context {
             congestion_controller: &mut self.congestion_controller,
             connection_close_formatter: &mut self.connection_close_formatter,

--- a/quic/s2n-quic/src/stream/receive.rs
+++ b/quic/s2n-quic/src/stream/receive.rs
@@ -212,7 +212,7 @@ macro_rules! impl_receive_stream_api {
         #[inline]
         pub(crate) fn rx_request(
             &mut self,
-        ) -> $crate::stream::Result<s2n_quic_transport::stream::RxRequest> {
+        ) -> $crate::stream::Result<s2n_quic_transport::stream::RxRequest<'_, '_>> {
             macro_rules! $dispatch {
                 () => {
                     Err($crate::stream::Error::non_readable())


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

Rust version 1.89.0 is released and there are additional clippy lints associated with it. The [scheduled CI run](https://github.com/aws/s2n-quic/actions/runs/16821209011/job/47648305069) captured this problem and I am cutting this PR to fix it.

### Call-outs:

### Testing:

CI test. The clippy job should pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

