### PR TITLE
fix: clippy lint updates for rust version 1.89.0

### DIFF
--- a/common/s2n-codec/src/decoder/mod.rs
+++ b/common/s2n-codec/src/decoder/mod.rs
@@ -227,7 +227,7 @@ macro_rules! impl_buffer {
                 // TODO add doctest
 
                 #[inline]
-                pub fn get_checked_range(&self, range: &crate::CheckedRange) -> DecoderBuffer {
+                pub fn get_checked_range(&self, range: &crate::CheckedRange) -> DecoderBuffer<'_> {
                     range.get(self.bytes).into()
                 }
             }
@@ -286,7 +286,7 @@ macro_rules! impl_buffer {
             pub fn peek_range(
                 &self,
                 range: core::ops::Range<usize>,
-            ) -> Result<crate::DecoderBuffer, DecoderError> {
+            ) -> Result<crate::DecoderBuffer<'_>, DecoderError> {
                 let end = range.end;
                 self.bytes
                     .get(range)

--- a/quic/s2n-quic-core/src/buffer/reader.rs
+++ b/quic/s2n-quic-core/src/buffer/reader.rs
@@ -70,7 +70,7 @@ pub trait Reader: Storage {
 
     /// Limits the maximum offset that the caller can read from the reader
     #[inline]
-    fn with_max_data(&mut self, max_data: VarInt) -> Limit<Self> {
+    fn with_max_data(&mut self, max_data: VarInt) -> Limit<'_, Self> {
         let max_buffered_len = max_data.saturating_sub(self.current_offset());
         let max_buffered_len = max_buffered_len.as_u64().min(self.buffered_len() as u64) as usize;
         self.with_read_limit(max_buffered_len)
@@ -78,13 +78,13 @@ pub trait Reader: Storage {
 
     /// Limits the maximum amount of data that the caller can read from the reader
     #[inline]
-    fn with_read_limit(&mut self, max_buffered_len: usize) -> Limit<Self> {
+    fn with_read_limit(&mut self, max_buffered_len: usize) -> Limit<'_, Self> {
         Limit::new(self, max_buffered_len)
     }
 
     /// Return an empty view onto the reader, with no change in current offset
     #[inline]
-    fn with_empty_buffer(&self) -> Empty<Self> {
+    fn with_empty_buffer(&self) -> Empty<'_, Self> {
         Empty::new(self)
     }
 
@@ -95,7 +95,7 @@ pub trait Reader: Storage {
     /// `debug_assertions` must be enabled for these checks to be performed. Otherwise, the reader
     /// methods will simply be forwarded to `Self`.
     #[inline]
-    fn with_checks(&mut self) -> Checked<Self> {
+    fn with_checks(&mut self) -> Checked<'_, Self> {
         Checked::new(self)
     }
 }

--- a/quic/s2n-quic-core/src/buffer/reader/complete.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/complete.rs
@@ -53,14 +53,14 @@ where
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         let chunk = self.storage.read_chunk(watermark)?;
         self.current_offset += chunk.len();
         Ok(chunk)
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/empty.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/empty.rs
@@ -29,12 +29,12 @@ impl<R: Reader + ?Sized> Storage for Empty<'_, R> {
     }
 
     #[inline(always)]
-    fn read_chunk(&mut self, _watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, _watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         Ok(Chunk::empty())
     }
 
     #[inline(always)]
-    fn partial_copy_into<Dest>(&mut self, _dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, _dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/incremental.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/incremental.rs
@@ -97,14 +97,14 @@ impl<C: Storage> Storage for WithStorage<'_, C> {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         let chunk = self.storage.read_chunk(watermark)?;
         self.incremental.current_offset += chunk.len();
         Ok(chunk)
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/limit.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/limit.rs
@@ -35,7 +35,7 @@ impl<R: Reader + ?Sized> Storage for Limit<'_, R> {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         let watermark = self.len.min(watermark);
         let chunk = self.reader.read_chunk(watermark)?;
         unsafe {
@@ -46,7 +46,7 @@ impl<R: Reader + ?Sized> Storage for Limit<'_, R> {
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/storage.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/storage.rs
@@ -66,13 +66,13 @@ pub trait Storage {
     ///
     /// The returned `Chunk` from `partial_copy_into` will always be empty.
     #[inline]
-    fn full_copy(&mut self) -> FullCopy<Self> {
+    fn full_copy(&mut self) -> FullCopy<'_, Self> {
         FullCopy::new(self)
     }
 
     /// Tracks the number of bytes read from the storage
     #[inline]
-    fn track_read(&mut self) -> Tracked<Self> {
+    fn track_read(&mut self) -> Tracked<'_, Self> {
         Tracked::new(self)
     }
 }

--- a/quic/s2n-quic-core/src/buffer/reader/storage/buf.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/storage/buf.rs
@@ -56,7 +56,7 @@ where
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         self.commit_pending();
         let chunk = self.buf.chunk();
         let len = chunk.len().min(watermark);
@@ -65,7 +65,7 @@ where
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/storage/bytes.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/storage/bytes.rs
@@ -19,7 +19,7 @@ impl Storage for BytesMut {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         let len = self.len().min(watermark);
 
         ensure!(len > 0, Ok(Self::new().into()));
@@ -33,7 +33,7 @@ impl Storage for BytesMut {
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {
@@ -79,13 +79,13 @@ impl Storage for Bytes {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         let len = self.len().min(watermark);
         Ok(self.split_to(len).into())
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/storage/chunk.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/storage/chunk.rs
@@ -79,7 +79,7 @@ impl Storage for Chunk<'_> {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         match self {
             Self::Slice(v) => v.read_chunk(watermark),
             Self::Bytes(v) => v.read_chunk(watermark),
@@ -88,7 +88,7 @@ impl Storage for Chunk<'_> {
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/storage/full_copy.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/storage/full_copy.rs
@@ -31,12 +31,12 @@ impl<S: Storage + ?Sized> Storage for FullCopy<'_, S> {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         self.0.read_chunk(watermark)
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/storage/io_slice.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/storage/io_slice.rs
@@ -212,7 +212,7 @@ where
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         Ok(match self.read_chunk_control_flow(watermark) {
             ControlFlow::Continue(chunk) => chunk,
             ControlFlow::Break(chunk) => chunk,
@@ -220,7 +220,7 @@ where
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reader/storage/slice.rs
+++ b/quic/s2n-quic-core/src/buffer/reader/storage/slice.rs
@@ -32,7 +32,7 @@ macro_rules! impl_slice {
             }
 
             #[inline]
-            fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+            fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
                 ensure!(!self.is_empty(), Ok(Chunk::empty()));
                 let len = self.len().min(watermark);
                 // use `take` to work around borrowing rules
@@ -50,7 +50,7 @@ macro_rules! impl_slice {
             }
 
             #[inline]
-            fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+            fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
             where
                 Dest: writer::Storage + ?Sized,
             {

--- a/quic/s2n-quic-core/src/buffer/reassembler/reader.rs
+++ b/quic/s2n-quic-core/src/buffer/reassembler/reader.rs
@@ -28,7 +28,7 @@ impl Storage for Reassembler {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<Chunk<'_>, Self::Error> {
         let Some(slot) = self.slots.front_mut() else {
             return Ok(BytesMut::new().into());
         };
@@ -66,7 +66,7 @@ impl Storage for Reassembler {
     }
 
     #[inline]
-    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk, Self::Error>
+    fn partial_copy_into<Dest>(&mut self, dest: &mut Dest) -> Result<Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/reassembler/request.rs
+++ b/quic/s2n-quic-core/src/buffer/reassembler/request.rs
@@ -73,7 +73,7 @@ impl reader::Storage for Request<'_> {
     fn partial_copy_into<Dest>(
         &mut self,
         dest: &mut Dest,
-    ) -> Result<reader::storage::Chunk, Self::Error>
+    ) -> Result<reader::storage::Chunk<'_>, Self::Error>
     where
         Dest: writer::Storage + ?Sized,
     {

--- a/quic/s2n-quic-core/src/buffer/writer/storage.rs
+++ b/quic/s2n-quic-core/src/buffer/writer/storage.rs
@@ -88,13 +88,13 @@ pub trait Storage {
 
     /// Limits the number of bytes that can be written to the storage
     #[inline]
-    fn with_write_limit(&mut self, max_len: usize) -> Limit<Self> {
+    fn with_write_limit(&mut self, max_len: usize) -> Limit<'_, Self> {
         Limit::new(self, max_len)
     }
 
     /// Tracks the number of bytes written to the storage
     #[inline]
-    fn track_write(&mut self) -> Tracked<Self> {
+    fn track_write(&mut self) -> Tracked<'_, Self> {
         Tracked::new(self)
     }
 
@@ -103,7 +103,7 @@ pub trait Storage {
     /// This can be used for very low latency scenarios where processing the single read is more
     /// important than filling the entire storage with as much data as possible.
     #[inline]
-    fn write_once(&mut self) -> WriteOnce<Self> {
+    fn write_once(&mut self) -> WriteOnce<'_, Self> {
         WriteOnce::new(self)
     }
 }

--- a/quic/s2n-quic-core/src/connection/close.rs
+++ b/quic/s2n-quic-core/src/connection/close.rs
@@ -11,28 +11,28 @@ pub use crate::{frame::ConnectionClose, inet::SocketAddress};
 pub trait Formatter: 'static + Send {
     /// Formats a transport error for use in 1-RTT (application data) packets
     fn format_transport_error(&self, context: &Context, error: transport::Error)
-        -> ConnectionClose;
+        -> ConnectionClose<'_>;
 
     /// Formats an application error for use in 1-RTT (application data) packets
     fn format_application_error(
         &self,
         context: &Context,
         error: application::Error,
-    ) -> ConnectionClose;
+    ) -> ConnectionClose<'_>;
 
     /// Formats a transport error for use in early (initial, handshake) packets
     fn format_early_transport_error(
         &self,
         context: &Context,
         error: transport::Error,
-    ) -> ConnectionClose;
+    ) -> ConnectionClose<'_>;
 
     /// Formats an application error for use in early (initial, handshake) packets
     fn format_early_application_error(
         &self,
         context: &Context,
         error: application::Error,
-    ) -> ConnectionClose;
+    ) -> ConnectionClose<'_>;
 }
 
 #[non_exhaustive]
@@ -59,7 +59,7 @@ impl Formatter for Development {
         &self,
         _context: &Context,
         error: transport::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'_> {
         error.into()
     }
 
@@ -67,7 +67,7 @@ impl Formatter for Development {
         &self,
         _context: &Context,
         error: application::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'_> {
         error.into()
     }
 
@@ -75,7 +75,7 @@ impl Formatter for Development {
         &self,
         _context: &Context,
         error: transport::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'_> {
         error.into()
     }
 
@@ -83,7 +83,7 @@ impl Formatter for Development {
         &self,
         _context: &Context,
         error: application::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'_> {
         error.into()
     }
 }
@@ -104,7 +104,7 @@ impl Formatter for Production {
         &self,
         _context: &Context,
         error: transport::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'_> {
         // rewrite internal errors as PROTOCOL_VIOLATION
         if error.code == transport::Error::INTERNAL_ERROR.code {
             return transport::Error::PROTOCOL_VIOLATION.into();
@@ -128,7 +128,7 @@ impl Formatter for Production {
         &self,
         _context: &Context,
         error: application::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'_> {
         error.into()
     }
 
@@ -136,7 +136,7 @@ impl Formatter for Production {
         &self,
         context: &Context,
         error: transport::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'_> {
         Self.format_transport_error(context, error)
     }
 
@@ -144,7 +144,7 @@ impl Formatter for Production {
         &self,
         _context: &Context,
         _error: application::Error,
-    ) -> ConnectionClose {
+    ) -> ConnectionClose<'_> {
         //= https://www.rfc-editor.org/rfc/rfc9000#section-10.2.3
         //# Sending a CONNECTION_CLOSE of type 0x1d in an Initial or Handshake
         //# packet could expose application state or be used to alter application

--- a/quic/s2n-quic-core/src/crypto/payload.rs
+++ b/quic/s2n-quic-core/src/crypto/payload.rs
@@ -48,7 +48,7 @@ impl<'a> ProtectedPayload<'a> {
     }
 
     /// Reads data from a `CheckedRange`
-    pub fn get_checked_range(&self, range: &CheckedRange) -> DecoderBuffer {
+    pub fn get_checked_range(&self, range: &CheckedRange) -> DecoderBuffer<'_> {
         self.buffer.get_checked_range(range)
     }
 
@@ -125,7 +125,7 @@ impl<'a> EncryptedPayload<'a> {
     }
 
     /// Reads data from a `CheckedRange`
-    pub fn get_checked_range(&self, range: &CheckedRange) -> DecoderBuffer {
+    pub fn get_checked_range(&self, range: &CheckedRange) -> DecoderBuffer<'_> {
         self.buffer.get_checked_range(range)
     }
 
@@ -149,7 +149,7 @@ impl<'a> EncryptedPayload<'a> {
 }
 
 fn header_protection_sample(
-    buffer: DecoderBuffer,
+    buffer: DecoderBuffer<'_>,
     header_len: usize,
     sample_len: usize,
 ) -> Result<&[u8], DecoderError> {

--- a/quic/s2n-quic-core/src/event/snapshot.rs
+++ b/quic/s2n-quic-core/src/event/snapshot.rs
@@ -81,7 +81,7 @@ impl Location {
 pub trait Fmt {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result;
 
-    fn to_snapshot(&self) -> ToSnapshot<Self> {
+    fn to_snapshot(&self) -> ToSnapshot<'_, Self> {
         ToSnapshot(self)
     }
 }

--- a/quic/s2n-quic-core/src/interval_set/mod.rs
+++ b/quic/s2n-quic-core/src/interval_set/mod.rs
@@ -501,7 +501,7 @@ impl<T: IntervalBound> IntervalSet<T> {
     /// assert_eq!(vec![0, 1, 2, 3, 4, 10, 11, 12, 13, 14], items);
     /// ```
     #[inline]
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         Iter {
             iter: self.intervals.iter(),
             head: None,
@@ -704,7 +704,7 @@ impl<T: Copy> IntervalSet<T> {
     /// assert_eq!(set.intervals().collect::<Vec<_>>(), vec![0..=10]);
     /// ```
     #[inline]
-    pub fn intervals(&self) -> IntervalIter<T> {
+    pub fn intervals(&self) -> IntervalIter<'_, T> {
         IntervalIter {
             iter: self.intervals.iter(),
         }
@@ -721,7 +721,7 @@ impl<T: Copy> IntervalSet<T> {
     /// assert_eq!(set.ranges().collect::<Vec<_>>(), vec![0..11]);
     /// ```
     #[inline]
-    pub fn ranges(&self) -> RangeIter<T> {
+    pub fn ranges(&self) -> RangeIter<'_, T> {
         RangeIter {
             iter: self.intervals.iter(),
         }
@@ -738,7 +738,7 @@ impl<T: Copy> IntervalSet<T> {
     /// assert_eq!(set.inclusive_ranges().collect::<Vec<_>>(), vec![0..=10]);
     /// ```
     #[inline]
-    pub fn inclusive_ranges(&self) -> RangeInclusiveIter<T> {
+    pub fn inclusive_ranges(&self) -> RangeInclusiveIter<'_, T> {
         RangeInclusiveIter {
             iter: self.intervals.iter(),
         }

--- a/quic/s2n-quic-core/src/io/rx.rs
+++ b/quic/s2n-quic-core/src/io/rx.rs
@@ -16,7 +16,7 @@ pub trait Rx: Sized {
 
     /// Returns a future that yields after a packet is ready to be received
     #[inline]
-    fn ready(&mut self) -> RxReady<Self> {
+    fn ready(&mut self) -> RxReady<'_, Self> {
         RxReady(self)
     }
 

--- a/quic/s2n-quic-core/src/io/tx.rs
+++ b/quic/s2n-quic-core/src/io/tx.rs
@@ -19,7 +19,7 @@ pub trait Tx: Sized {
 
     /// Returns a future that yields after a packet is ready to be transmitted
     #[inline]
-    fn ready(&mut self) -> TxReady<Self> {
+    fn ready(&mut self) -> TxReady<'_, Self> {
         TxReady(self)
     }
 

--- a/quic/s2n-quic-core/src/packet/number/map.rs
+++ b/quic/s2n-quic-core/src/packet/number/map.rs
@@ -221,7 +221,7 @@ impl<V> Map<V> {
 
     /// Removes a range of packets from the map and returns their value
     #[inline]
-    pub fn remove_range(&mut self, range: PacketNumberRange) -> RemoveIter<V> {
+    pub fn remove_range(&mut self, range: PacketNumberRange) -> RemoveIter<'_, V> {
         RemoveIter::new(self, range)
     }
 
@@ -233,7 +233,7 @@ impl<V> Map<V> {
 
     /// Gets an iterator over the sent packet entries, sorted by PacketNumber
     #[inline]
-    pub fn iter(&self) -> Iter<V> {
+    pub fn iter(&self) -> Iter<'_, V> {
         Iter::new(self)
     }
 

--- a/quic/s2n-quic-core/src/packet/retry.rs
+++ b/quic/s2n-quic-core/src/packet/retry.rs
@@ -287,7 +287,7 @@ impl<'a> Retry<'a> {
     }
 
     #[inline]
-    fn pseudo_packet(&self, odcid: &'a [u8]) -> PseudoRetry {
+    fn pseudo_packet(&self, odcid: &'a [u8]) -> PseudoRetry<'_> {
         PseudoRetry {
             original_destination_connection_id: odcid,
             tag: self.tag,

--- a/quic/s2n-quic-core/src/packet/version_negotiation.rs
+++ b/quic/s2n-quic-core/src/packet/version_negotiation.rs
@@ -65,8 +65,8 @@ impl<'a> ProtectedVersionNegotiation<'a> {
     pub fn decode(
         tag: Tag,
         _version: Version,
-        buffer: DecoderBufferMut,
-    ) -> DecoderBufferMutResult<VersionNegotiation<&[u8]>> {
+        buffer: DecoderBufferMut<'_>,
+    ) -> DecoderBufferMutResult<'_, VersionNegotiation<'_, &[u8]>> {
         let buffer = buffer
             .skip(size_of::<Tag>() + size_of::<Version>())
             .expect("tag and version already verified");

--- a/quic/s2n-quic-core/src/stream/testing.rs
+++ b/quic/s2n-quic-core/src/stream/testing.rs
@@ -201,7 +201,7 @@ impl reader::Storage for Data {
     }
 
     #[inline]
-    fn read_chunk(&mut self, watermark: usize) -> Result<reader::storage::Chunk, Self::Error> {
+    fn read_chunk(&mut self, watermark: usize) -> Result<reader::storage::Chunk<'_>, Self::Error> {
         if let Some(chunk) = self.send_one(watermark) {
             return Ok(chunk.into());
         }
@@ -213,7 +213,7 @@ impl reader::Storage for Data {
     fn partial_copy_into<Dest: writer::Storage + ?Sized>(
         &mut self,
         dest: &mut Dest,
-    ) -> Result<reader::storage::Chunk, Self::Error> {
+    ) -> Result<reader::storage::Chunk<'_>, Self::Error> {
         while let Some(chunk) = self.send_one(dest.remaining_capacity()) {
             // if the chunk matches the destination then return it instead of copying
             if chunk.len() == dest.remaining_capacity() || self.is_finished() {

--- a/quic/s2n-quic-core/src/sync/spsc/recv.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/recv.rs
@@ -36,7 +36,7 @@ impl<T> Receiver<T> {
     ///
     /// Callers should call [`Self::acquire`] or [`Self::poll_slice`] before calling this method.
     #[inline]
-    pub fn slice(&mut self) -> RecvSlice<T> {
+    pub fn slice(&mut self) -> RecvSlice<'_, T> {
         let cursor = self.0.cursor;
         RecvSlice(&mut self.0, cursor)
     }
@@ -48,7 +48,7 @@ impl<T> Receiver<T> {
     }
 
     #[inline]
-    pub fn poll_slice(&mut self, cx: &mut Context) -> Poll<Result<RecvSlice<T>>> {
+    pub fn poll_slice(&mut self, cx: &mut Context) -> Poll<Result<RecvSlice<'_, T>>> {
         macro_rules! acquire_filled {
             () => {
                 match self.0.acquire_filled() {
@@ -80,7 +80,7 @@ impl<T> Receiver<T> {
     }
 
     #[inline]
-    pub fn try_slice(&mut self) -> Result<Option<RecvSlice<T>>> {
+    pub fn try_slice(&mut self) -> Result<Option<RecvSlice<'_, T>>> {
         Ok(if self.0.acquire_filled()? {
             let cursor = self.0.cursor;
             Some(RecvSlice(&mut self.0, cursor))

--- a/quic/s2n-quic-core/src/sync/spsc/send.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/send.rs
@@ -21,7 +21,7 @@ impl<T> Sender<T> {
     ///
     /// Callers should call [`Self::acquire`] or [`Self::poll_slice`] before calling this method.
     #[inline]
-    pub fn slice(&mut self) -> SendSlice<T> {
+    pub fn slice(&mut self) -> SendSlice<'_, T> {
         let cursor = self.0.cursor;
         SendSlice(&mut self.0, cursor)
     }
@@ -33,7 +33,7 @@ impl<T> Sender<T> {
     }
 
     #[inline]
-    pub fn poll_slice(&mut self, cx: &mut Context) -> Poll<Result<SendSlice<T>>> {
+    pub fn poll_slice(&mut self, cx: &mut Context) -> Poll<Result<SendSlice<'_, T>>> {
         macro_rules! acquire_capacity {
             () => {
                 match self.0.acquire_capacity() {
@@ -65,7 +65,7 @@ impl<T> Sender<T> {
     }
 
     #[inline]
-    pub fn try_slice(&mut self) -> Result<Option<SendSlice<T>>> {
+    pub fn try_slice(&mut self) -> Result<Option<SendSlice<'_, T>>> {
         Ok(if self.0.acquire_capacity()? {
             let cursor = self.0.cursor;
             Some(SendSlice(&mut self.0, cursor))

--- a/quic/s2n-quic-core/src/sync/spsc/state.rs
+++ b/quic/s2n-quic-core/src/sync/spsc/state.rs
@@ -382,7 +382,7 @@ impl<T> State<T> {
 
     /// Returns the channel slots as two pairs of filled and unfilled slices
     #[inline]
-    pub fn as_pairs(&self) -> (Pair<T>, Pair<T>) {
+    pub fn as_pairs(&self) -> (Pair<'_, T>, Pair<'_, T>) {
         let data = self.data();
         self.data_to_pairs(data)
     }

--- a/quic/s2n-quic-core/src/task/waker/contract.rs
+++ b/quic/s2n-quic-core/src/task/waker/contract.rs
@@ -47,7 +47,7 @@ impl Contract {
 
     /// Returns a new [`Context`] to be checked
     #[inline]
-    pub fn context(&self) -> Context {
+    pub fn context(&self) -> Context<'_> {
         Context::from_waker(&self.waker)
     }
 

--- a/quic/s2n-quic-core/src/time/clock.rs
+++ b/quic/s2n-quic-core/src/time/clock.rs
@@ -29,7 +29,7 @@ pub trait ClockWithTimer: Clock {
 
 pub trait Timer {
     #[inline]
-    fn ready(&mut self) -> TimerReady<Self> {
+    fn ready(&mut self) -> TimerReady<'_, Self> {
         TimerReady(self)
     }
 

--- a/quic/s2n-quic-core/src/transmission/writer/testing.rs
+++ b/quic/s2n-quic-core/src/transmission/writer/testing.rs
@@ -31,7 +31,7 @@ pub struct WrittenFrame {
 impl WrittenFrame {
     /// Deserializes a written frame into a quic_frame::Frame type.
     /// panics if deserialization fails.
-    pub fn as_frame(&mut self) -> FrameMut {
+    pub fn as_frame(&mut self) -> FrameMut<'_> {
         let buffer = DecoderBufferMut::new(&mut self.data[..]);
         let (frame, remaining) = buffer
             .decode::<FrameMut>()

--- a/quic/s2n-quic-platform/src/io/testing/message.rs
+++ b/quic/s2n-quic-platform/src/io/testing/message.rs
@@ -90,7 +90,7 @@ impl MessageTrait for Message {
     fn rx_read(
         &mut self,
         _local_address: &path::LocalAddress,
-    ) -> Option<message::RxMessage<Self::Handle>> {
+    ) -> Option<message::RxMessage<'_, Self::Handle>> {
         let path = self.handle;
         let header = datagram::Header {
             path,

--- a/quic/s2n-quic-platform/src/message.rs
+++ b/quic/s2n-quic-platform/src/message.rs
@@ -122,7 +122,7 @@ pub trait Message: 'static + Copy {
     unsafe fn reset(&mut self, mtu: usize);
 
     /// Reads the message as an RX packet
-    fn rx_read(&mut self, local_address: &path::LocalAddress) -> Option<RxMessage<Self::Handle>>;
+    fn rx_read(&mut self, local_address: &path::LocalAddress) -> Option<RxMessage<'_, Self::Handle>>;
 
     /// Writes the message into the TX packet
     fn tx_write<M: tx::Message<Handle = Self::Handle>>(

--- a/quic/s2n-quic-platform/src/message/cmsg/storage.rs
+++ b/quic/s2n-quic-platform/src/message/cmsg/storage.rs
@@ -14,7 +14,7 @@ pub struct Storage<const L: usize>([u8; L]);
 
 impl<const L: usize> Storage<L> {
     #[inline]
-    pub fn encoder(&mut self) -> Encoder<L> {
+    pub fn encoder(&mut self) -> Encoder<'_, L> {
         Encoder {
             storage: self,
             cursor: 0,
@@ -22,7 +22,7 @@ impl<const L: usize> Storage<L> {
     }
 
     #[inline]
-    pub fn iter(&self) -> super::decode::Iter {
+    pub fn iter(&self) -> super::decode::Iter<'_> {
         super::decode::Iter::new(self)
     }
 }
@@ -78,7 +78,7 @@ impl<'a, const L: usize> Encoder<'a, L> {
     }
 
     #[inline]
-    pub fn iter(&self) -> super::decode::Iter {
+    pub fn iter(&self) -> super::decode::Iter<'_> {
         unsafe {
             // SAFETY: bytes are aligned with Storage type
             super::decode::Iter::from_bytes(self)

--- a/quic/s2n-quic-platform/src/message/mmsg.rs
+++ b/quic/s2n-quic-platform/src/message/mmsg.rs
@@ -64,7 +64,7 @@ impl MessageTrait for mmsghdr {
     fn rx_read(
         &mut self,
         local_address: &path::LocalAddress,
-    ) -> Option<super::RxMessage<Self::Handle>> {
+    ) -> Option<super::RxMessage<'_, Self::Handle>> {
         unsafe {
             // We need to replicate the `msg_len` field to the inner type before delegating
             // Safety: The `msg_len` is associated with the same buffer as the `msg_hdr`

--- a/quic/s2n-quic-platform/src/message/msg.rs
+++ b/quic/s2n-quic-platform/src/message/msg.rs
@@ -128,7 +128,7 @@ impl MessageTrait for msghdr {
     fn rx_read(
         &mut self,
         local_address: &path::LocalAddress,
-    ) -> Option<super::RxMessage<Self::Handle>> {
+    ) -> Option<super::RxMessage<'_, Self::Handle>> {
         if cfg!(test) {
             assert_eq!(
                 self.msg_flags & libc::MSG_CTRUNC,

--- a/quic/s2n-quic-platform/src/message/simple.rs
+++ b/quic/s2n-quic-platform/src/message/simple.rs
@@ -76,7 +76,7 @@ impl MessageTrait for Message {
     fn rx_read(
         &mut self,
         local_address: &path::LocalAddress,
-    ) -> Option<super::RxMessage<Self::Handle>> {
+    ) -> Option<super::RxMessage<'_, Self::Handle>> {
         let path = path::Tuple {
             remote_address: self.address.into(),
             local_address: *local_address,

--- a/quic/s2n-quic-rustls/src/session.rs
+++ b/quic/s2n-quic-rustls/src/session.rs
@@ -130,7 +130,7 @@ impl Session {
         Ok(())
     }
 
-    fn application_parameters(&self) -> Result<tls::ApplicationParameters, transport::Error> {
+    fn application_parameters(&self) -> Result<tls::ApplicationParameters<'_>, transport::Error> {
         //= https://www.rfc-editor.org/rfc/rfc9001#section-8.2
         //# endpoints that
         //# receive ClientHello or EncryptedExtensions messages without the

--- a/quic/s2n-quic-transport/src/contexts/testing.rs
+++ b/quic/s2n-quic-transport/src/contexts/testing.rs
@@ -32,7 +32,7 @@ pub struct WrittenFrame {
 impl WrittenFrame {
     /// Deserializes a written frame into a quic_frame::Frame type.
     /// panics if deserialization fails.
-    pub fn as_frame(&mut self) -> FrameMut {
+    pub fn as_frame(&mut self) -> FrameMut<'_> {
         let buffer = DecoderBufferMut::new(&mut self.data[..]);
         let (frame, remaining) = buffer
             .decode::<FrameMut>()

--- a/quic/s2n-quic-transport/src/endpoint/config.rs
+++ b/quic/s2n-quic-transport/src/endpoint/config.rs
@@ -53,7 +53,7 @@ pub trait Config: 'static + Send + Sized + core::fmt::Debug {
     const ENDPOINT_TYPE: endpoint::Type;
 
     /// Returns the context for the endpoint configuration
-    fn context(&mut self) -> Context<Self>;
+    fn context(&mut self) -> Context<'_, Self>;
 }
 
 #[derive(Debug)]

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -223,7 +223,7 @@ impl<Config: endpoint::Config> Manager<Config> {
 
     /// Returns an iterator over all paths pending path_challenge or path_response
     /// transmission.
-    pub fn paths_pending_validation(&mut self) -> PathsPendingValidation<Config> {
+    pub fn paths_pending_validation(&mut self) -> PathsPendingValidation<'_, Config> {
         PathsPendingValidation::new(self)
     }
 

--- a/quic/s2n-quic-transport/src/stream/api.rs
+++ b/quic/s2n-quic-transport/src/stream/api.rs
@@ -43,7 +43,7 @@ impl State {
         self.connection.poll_request(id, request, context)
     }
 
-    fn request(&mut self) -> Request {
+    fn request(&mut self) -> Request<'_, '_> {
         Request {
             state: self,
             request: ops::Request::default(),
@@ -331,18 +331,18 @@ impl Stream {
         &self.0.connection
     }
 
-    pub fn request(&mut self) -> Request {
+    pub fn request(&mut self) -> Request<'_, '_> {
         self.0.request()
     }
 
-    pub fn tx_request(&mut self) -> Result<TxRequest, StreamError> {
+    pub fn tx_request(&mut self) -> Result<TxRequest<'_, '_>, StreamError> {
         Ok(TxRequest {
             state: &mut self.0,
             request: ops::Request::default(),
         })
     }
 
-    pub fn rx_request(&mut self) -> Result<RxRequest, StreamError> {
+    pub fn rx_request(&mut self) -> Result<RxRequest<'_, '_>, StreamError> {
         Ok(RxRequest {
             state: &mut self.0,
             request: ops::Request::default(),
@@ -396,7 +396,7 @@ impl SendStream {
         &self.0.connection
     }
 
-    pub fn tx_request(&mut self) -> Result<TxRequest, StreamError> {
+    pub fn tx_request(&mut self) -> Result<TxRequest<'_, '_>, StreamError> {
         Ok(TxRequest {
             state: &mut self.0,
             request: ops::Request::default(),
@@ -440,7 +440,7 @@ impl ReceiveStream {
         &self.0.connection
     }
 
-    pub fn rx_request(&mut self) -> Result<RxRequest, StreamError> {
+    pub fn rx_request(&mut self) -> Result<RxRequest<'_, '_>, StreamError> {
         Ok(RxRequest {
             state: &mut self.0,
             request: ops::Request::default(),

--- a/quic/s2n-quic-transport/src/sync/data_sender/buffer.rs
+++ b/quic/s2n-quic-transport/src/sync/data_sender/buffer.rs
@@ -137,7 +137,7 @@ impl Buffer {
 
     /// Returns a Viewer for the buffer
     #[inline]
-    pub fn viewer(&self) -> Viewer {
+    pub fn viewer(&self) -> Viewer<'_> {
         Viewer {
             buffer: self,
             offset: *self.head,

--- a/quic/s2n-quic-transport/src/sync/data_sender/transmissions.rs
+++ b/quic/s2n-quic-transport/src/sync/data_sender/transmissions.rs
@@ -294,7 +294,7 @@ impl Set {
     }
 
     #[inline]
-    pub fn remove_range(&mut self, range: PacketNumberRange) -> SetRemoveIter {
+    pub fn remove_range(&mut self, range: PacketNumberRange) -> SetRemoveIter<'_> {
         SetRemoveIter {
             inner: self.packets.remove_range(range),
             next: None,

--- a/quic/s2n-quic/src/client/providers.rs
+++ b/quic/s2n-quic/src/client/providers.rs
@@ -331,7 +331,7 @@ impl<
 
     const ENDPOINT_TYPE: endpoint::Type = endpoint::Type::Client;
 
-    fn context(&mut self) -> endpoint::Context<Self> {
+    fn context(&mut self) -> endpoint::Context<'_, Self> {
         endpoint::Context {
             congestion_controller: &mut self.congestion_controller,
             connection_close_formatter: &mut self.connection_close_formatter,

--- a/quic/s2n-quic/src/server/providers.rs
+++ b/quic/s2n-quic/src/server/providers.rs
@@ -301,7 +301,7 @@ impl<
 
     const ENDPOINT_TYPE: endpoint::Type = endpoint::Type::Server;
 
-    fn context(&mut self) -> endpoint::Context<Self> {
+    fn context(&mut self) -> endpoint::Context<'_, Self> {
         endpoint::Context {
             congestion_controller: &mut self.congestion_controller,
             connection_close_formatter: &mut self.connection_close_formatter,

--- a/quic/s2n-quic/src/stream/receive.rs
+++ b/quic/s2n-quic/src/stream/receive.rs
@@ -212,7 +212,7 @@ macro_rules! impl_receive_stream_api {
         #[inline]
         pub(crate) fn rx_request(
             &mut self,
-        ) -> $crate::stream::Result<s2n_quic_transport::stream::RxRequest> {
+        ) -> $crate::stream::Result<s2n_quic_transport::stream::RxRequest<'_, '_>> {
             macro_rules! $dispatch {
                 () => {
                     Err($crate::stream::Error::non_readable())


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

resolves #ISSUE-NUMBER1, resolves #ISSUE-NUMBER2, etc.

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary. If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff. -->

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

