### PR TITLE
Box ControlPair to reduce copy overhead

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map/entry.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/entry.rs
@@ -219,7 +219,7 @@ impl Entry {
         let control = if features.is_reliable() {
             None
         } else {
-            Some(ControlPair::new(&self.secret, key_id, initiator))
+            Some(Box::new(ControlPair::new(&self.secret, key_id, initiator)))
         };
 
         Bidirectional {
@@ -253,7 +253,7 @@ impl Entry {
         let control = if features.is_reliable() {
             None
         } else {
-            Some(ControlPair::new(&self.secret, key_id, initiator))
+            Some(Box::new(ControlPair::new(&self.secret, key_id, initiator)))
         };
 
         Bidirectional {
@@ -331,7 +331,7 @@ impl receiver::Error {
 pub struct Bidirectional {
     pub credentials: Credentials,
     pub application: ApplicationPair,
-    pub control: Option<ControlPair>,
+    pub control: Option<Box<ControlPair>>,
 }
 
 pub struct ApplicationPair {


### PR DESCRIPTION
### Release Summary:

* opt(s2n-quic-dc): optimize credential creation for TCP streams

### Resolved issues:

n/a

### Description of changes: 

ControlPair is 2.5kb large (2 copies of the full HMAC state). That's maybe possible to shrink directly, but since we pass ControlPair around by value it's good to add some indirection to avoid copying the large value. The ControlPair is also not created at all in the TCP stream case, so this is a pure win there.

Not measured independently (currently that's a bit slow to do) but doesn't appear that this makes any meaningful end-to-end performance difference. Seems like a clear win for the TCP case though.

### Call-outs:

n/a

### Testing:

Existing tests cover the changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

