### PR TITLE
feat(s2n-quic): configurable PTO jitter

### DIFF
--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -39,7 +39,6 @@ const MAX_KEEP_ALIVE_PERIOD_DEFAULT: Duration = Duration::from_secs(30);
 pub const ANTI_AMPLIFICATION_MULTIPLIER: u8 = 3;
 
 pub const DEFAULT_STREAM_BATCH_SIZE: u8 = 1;
-pub const DEFAULT_PTO_JITTER_PERCENTAGE: u8 = 0;
 
 // Maximum allowed PTO jitter percentage. Limited to 50% to prevent PTO timers
 // from becoming too short (which could cause premature timeouts) or too long

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -42,7 +42,7 @@ pub const DEFAULT_STREAM_BATCH_SIZE: u8 = 1;
 
 // Maximum allowed PTO jitter percentage. Limited to 50% to prevent PTO timers
 // from becoming too short (which could cause premature timeouts) or too long
-// (which could significantly delay loss recovery).
+// (which could delay loss recovery).
 pub const MAX_PTO_JITTER_PERCENTAGE: u8 = 50;
 pub const DEFAULT_PTO_JITTER_PERCENTAGE: u8 = 0;
 
@@ -344,16 +344,6 @@ impl Limits {
     /// Valid range: 0-50%
     /// - 0%: No jitter (default)
     /// - 1-50%: Applies random jitter within ±percentage of base PTO
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use s2n_quic_core::connection::Limits;
-    /// // Configure 25% PTO jitter
-    /// let limits = Limits::new()
-    ///     .with_pto_jitter_percentage(25)
-    ///     .unwrap();
-    /// ```
     pub fn with_pto_jitter_percentage(mut self, value: u8) -> Result<Self, ValidationError> {
         ensure!(
             value <= MAX_PTO_JITTER_PERCENTAGE,
@@ -365,10 +355,8 @@ impl Limits {
         Ok(self)
     }
 
-    /// Gets the configured PTO jitter percentage
-    ///
-    /// Returns the percentage of jitter applied to PTO calculations.
-    /// A value of 0 means no jitter is applied (default behavior).
+    #[doc(hidden)]
+    #[inline]
     pub fn pto_jitter_percentage(&self) -> u8 {
         self.pto_jitter_percentage
     }

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -39,6 +39,13 @@ const MAX_KEEP_ALIVE_PERIOD_DEFAULT: Duration = Duration::from_secs(30);
 pub const ANTI_AMPLIFICATION_MULTIPLIER: u8 = 3;
 
 pub const DEFAULT_STREAM_BATCH_SIZE: u8 = 1;
+pub const DEFAULT_PTO_JITTER_PERCENTAGE: u8 = 0;
+
+// Maximum allowed PTO jitter percentage. Limited to 50% to prevent PTO timers
+// from becoming too short (which could cause premature timeouts) or too long
+// (which could significantly delay loss recovery).
+pub const MAX_PTO_JITTER_PERCENTAGE: u8 = 50;
+pub const DEFAULT_PTO_JITTER_PERCENTAGE: u8 = 0;
 
 #[non_exhaustive]
 #[derive(Debug)]
@@ -104,6 +111,7 @@ pub struct Limits {
     pub(crate) migration_support: MigrationSupport,
     pub(crate) anti_amplification_multiplier: u8,
     pub(crate) stream_batch_size: u8,
+    pub(crate) pto_jitter_percentage: u8,
 }
 
 impl Default for Limits {
@@ -151,6 +159,7 @@ impl Limits {
             migration_support: MigrationSupport::RECOMMENDED,
             anti_amplification_multiplier: ANTI_AMPLIFICATION_MULTIPLIER,
             stream_batch_size: DEFAULT_STREAM_BATCH_SIZE,
+            pto_jitter_percentage: DEFAULT_PTO_JITTER_PERCENTAGE,
         }
     }
 
@@ -326,6 +335,44 @@ impl Limits {
         u8
     );
 
+    /// Sets the PTO jitter percentage (default: 0)
+    ///
+    /// Adds random jitter to Probe Timeout (PTO) calculations to prevent synchronized
+    /// timeouts across multiple connections. The jitter is applied as a percentage
+    /// of the base PTO period, with values between -X% and +X% where X is the
+    /// configured percentage.
+    ///
+    /// Valid range: 0-50%
+    /// - 0%: No jitter (default)
+    /// - 1-50%: Applies random jitter within ±percentage of base PTO
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use s2n_quic_core::connection::Limits;
+    /// let limits = Limits::new()
+    ///     .with_pto_jitter_percentage(25)
+    ///     .unwrap();
+    /// ```
+    pub fn with_pto_jitter_percentage(mut self, value: u8) -> Result<Self, ValidationError> {
+        ensure!(
+            value <= MAX_PTO_JITTER_PERCENTAGE,
+            Err(ValidationError(
+                "PTO jitter percentage must be between 0 and 50"
+            ))
+        );
+        self.pto_jitter_percentage = value;
+        Ok(self)
+    }
+
+    /// Gets the configured PTO jitter percentage
+    ///
+    /// Returns the percentage of jitter applied to PTO calculations.
+    /// A value of 0 means no jitter is applied.
+    pub fn pto_jitter_percentage(&self) -> u8 {
+        self.pto_jitter_percentage
+    }
+
     // internal APIs
 
     #[doc(hidden)]
@@ -491,5 +538,99 @@ mod tests {
         let new_size = 10;
         updatable_limits.with_stream_batch_size(new_size);
         assert_eq!(limits.stream_batch_size, new_size);
+    }
+
+    #[test]
+    fn pto_jitter_percentage_default() {
+        let limits = Limits::new();
+        assert_eq!(
+            limits.pto_jitter_percentage(),
+            DEFAULT_PTO_JITTER_PERCENTAGE
+        );
+
+        let limits = Limits::default();
+        assert_eq!(
+            limits.pto_jitter_percentage(),
+            DEFAULT_PTO_JITTER_PERCENTAGE
+        );
+    }
+
+    #[test]
+    fn pto_jitter_percentage_valid_values() {
+        let limits = Limits::new();
+
+        // Test valid values (0-MAX_PTO_JITTER_PERCENTAGE)
+        for value in 0..=MAX_PTO_JITTER_PERCENTAGE {
+            let result = limits.with_pto_jitter_percentage(value);
+            assert!(result.is_ok(), "Value {} should be valid", value);
+            let limits = result.unwrap();
+            assert_eq!(limits.pto_jitter_percentage(), value);
+        }
+    }
+
+    #[test]
+    fn pto_jitter_percentage_invalid_values() {
+        let limits = Limits::new();
+
+        // Test invalid values (> MAX_PTO_JITTER_PERCENTAGE)
+        for value in (MAX_PTO_JITTER_PERCENTAGE + 1)..=255 {
+            let result = limits.with_pto_jitter_percentage(value);
+            assert!(result.is_err(), "Value {} should be invalid", value);
+
+            if let Err(ValidationError(msg)) = result {
+                assert_eq!(msg, "PTO jitter percentage must be between 0 and 50");
+            } else {
+                panic!("Expected ValidationError for value {}", value);
+            }
+        }
+    }
+
+    #[test]
+    fn pto_jitter_percentage_edge_cases() {
+        let limits = Limits::new();
+
+        // Test boundary values
+        let result = limits.with_pto_jitter_percentage(0);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().pto_jitter_percentage(), 0);
+
+        let result = limits.with_pto_jitter_percentage(MAX_PTO_JITTER_PERCENTAGE);
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap().pto_jitter_percentage(),
+            MAX_PTO_JITTER_PERCENTAGE
+        );
+
+        let result = limits.with_pto_jitter_percentage(MAX_PTO_JITTER_PERCENTAGE + 1);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn pto_jitter_percentage_chaining() {
+        // Test that the setter can be chained with other setters
+        let result = Limits::new()
+            .with_pto_jitter_percentage(25)
+            .and_then(|l| l.with_stream_batch_size(5));
+
+        assert!(result.is_ok());
+        let limits = result.unwrap();
+        assert_eq!(limits.pto_jitter_percentage(), 25);
+        assert_eq!(limits.stream_batch_size(), 5);
+    }
+
+    #[test]
+    fn pto_jitter_percentage_getter() {
+        let mut limits = Limits::new();
+
+        // Test initial value
+        assert_eq!(limits.pto_jitter_percentage(), 0);
+
+        // Test after setting value
+        limits = limits.with_pto_jitter_percentage(30).unwrap();
+        assert_eq!(limits.pto_jitter_percentage(), 30);
+
+        // Test that getter returns the correct value
+        limits = limits.with_pto_jitter_percentage(15).unwrap();
+        assert_eq!(limits.pto_jitter_percentage(), 15);
     }
 }

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -349,6 +349,7 @@ impl Limits {
     ///
     /// ```
     /// # use s2n_quic_core::connection::Limits;
+    /// // Configure 25% PTO jitter
     /// let limits = Limits::new()
     ///     .with_pto_jitter_percentage(25)
     ///     .unwrap();
@@ -367,7 +368,7 @@ impl Limits {
     /// Gets the configured PTO jitter percentage
     ///
     /// Returns the percentage of jitter applied to PTO calculations.
-    /// A value of 0 means no jitter is applied.
+    /// A value of 0 means no jitter is applied (default behavior).
     pub fn pto_jitter_percentage(&self) -> u8 {
         self.pto_jitter_percentage
     }

--- a/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
+++ b/quic/s2n-quic-core/src/recovery/rtt_estimator.rs
@@ -455,6 +455,10 @@ fn calculate_jitter_amount(
     let max_jitter_micros = (base_pto_micros * jitter_percentage as u64) / 100;
 
     // Use gen_range_biased to generate value in range [0, 2 * max_jitter]
+    // The very slight amount of bias this method will impose towards the lower
+    // range of values will result in a slight bias towards lower PTO values,
+    // but are not significant enough to impact this feature or reveal any
+    // sensitive inputs.
     let jitter_range = 2 * max_jitter_micros as usize;
     let random_value = random::gen_range_biased(random_generator, 0..=jitter_range);
 

--- a/quic/s2n-quic-qns/src/limits.rs
+++ b/quic/s2n-quic-qns/src/limits.rs
@@ -45,6 +45,8 @@ impl Limits {
             .with_max_handshake_duration(Duration::from_secs(self.max_handshake_duration))
             .unwrap()
             .with_max_idle_timeout(Duration::from_secs(self.max_idle_timeout))
+            .unwrap()
+            .with_pto_jitter_percentage(33)
             .unwrap();
 
         if let Some(size) = self.stream_send_buffer_size {

--- a/quic/s2n-quic-qns/src/limits.rs
+++ b/quic/s2n-quic-qns/src/limits.rs
@@ -45,8 +45,6 @@ impl Limits {
             .with_max_handshake_duration(Duration::from_secs(self.max_handshake_duration))
             .unwrap()
             .with_max_idle_timeout(Duration::from_secs(self.max_idle_timeout))
-            .unwrap()
-            .with_pto_jitter_percentage(33)
             .unwrap();
 
         if let Some(size) = self.stream_send_buffer_size {

--- a/quic/s2n-quic-tests/src/tests/pto.rs
+++ b/quic/s2n-quic-tests/src/tests/pto.rs
@@ -3,13 +3,15 @@
 
 use super::*;
 use s2n_codec::encoder::scatter;
+use s2n_quic::provider::limits::Limits;
 use s2n_quic_core::{
     event::{
-        api::{PacketHeader, Subject},
+        api::{ConnectionMeta, PacketHeader, Subject},
         metrics::aggregate,
     },
     packet::interceptor::{Interceptor, Packet},
 };
+use std::net::ToSocketAddrs;
 
 /// This test ensures the PTO timer in the Handshake space is armed even
 /// when the client does not otherwise receive or send any handshake
@@ -91,6 +93,99 @@ fn handshake_pto_timer_is_armed() {
     assert_eq!(expected_handshake_packet_count, handshake_packets_sent);
 }
 
+/// Test that configuring PTO jitter results in PTOs sent at different timestamps
+#[test]
+fn pto_jitter() {
+    let model = Model::default();
+    let pto_subscriber = recorder::Pto::new();
+    let pto_subscriber_jitter = recorder::Pto::new();
+    let datagram_sent_subscriber = DatagramSentTime::new();
+    let datagram_sent_subscriber_jitter = DatagramSentTime::new();
+    let pto_events = pto_subscriber.events();
+    let pto_events_jitter = pto_subscriber_jitter.events();
+    let datagram_sent_events = datagram_sent_subscriber.events();
+    let datagram_sent_events_jitter = datagram_sent_subscriber_jitter.events();
+
+    // Test 2 clients, one with jitter, one without
+    test(model.clone(), |handle| {
+        let addr = "127.0.0.1:443".to_socket_addrs()?.next().unwrap();
+
+        // Allow the handshake to go on for longer to allow for more PTO probes to be sent
+        let limits = Limits::new().with_max_handshake_duration(Duration::from_secs(70))?;
+        let client_no_jitter = Client::builder()
+            .with_io(handle.builder().build().unwrap())?
+            .with_tls(certificates::CERT_PEM)?
+            .with_limits(limits)?
+            .with_event(((tracing_events(), pto_subscriber), datagram_sent_subscriber))?
+            .start()?;
+
+        primary::spawn(async move {
+            let connect = Connect::new(addr).with_server_name("localhost");
+            assert!(client_no_jitter.connect(connect).await.is_err());
+        });
+
+        // Configure 50% jitter
+        let limits = Limits::new()
+            .with_pto_jitter_percentage(50)?
+            .with_max_handshake_duration(Duration::from_secs(70))?;
+        let client_with_jitter = Client::builder()
+            .with_io(handle.builder().build().unwrap())?
+            .with_tls(certificates::CERT_PEM)?
+            .with_limits(limits)?
+            .with_event((
+                (tracing_events(), pto_subscriber_jitter),
+                datagram_sent_subscriber_jitter,
+            ))?
+            .with_random(Random::with_seed(123))?
+            .start()?;
+
+        primary::spawn(async move {
+            let connect = Connect::new(addr).with_server_name("localhost");
+            assert!(client_with_jitter.connect(connect).await.is_err());
+        });
+
+        Ok(addr)
+    })
+    .unwrap();
+
+    let pto_count = *pto_events.lock().unwrap().iter().max().unwrap_or(&0) as usize;
+    let pto_count_jitter = *pto_events_jitter.lock().unwrap().iter().max().unwrap_or(&0) as usize;
+    let datagram_sent_events = datagram_sent_events.lock().unwrap();
+    let datagram_sent_events_jitter = datagram_sent_events_jitter.lock().unwrap();
+
+    const EXPECTED_PTO_COUNT: usize = 6;
+
+    // Assert that the clients sent some PTOs
+    assert_eq!(pto_count, EXPECTED_PTO_COUNT);
+    assert_eq!(pto_count_jitter, EXPECTED_PTO_COUNT);
+
+    // Each client should send 1 initial datagram + 3 PTOs (each consisting of 2 datagrams)
+    assert_eq!(datagram_sent_events.len(), 1 + EXPECTED_PTO_COUNT * 2);
+    assert_eq!(
+        datagram_sent_events_jitter.len(),
+        1 + EXPECTED_PTO_COUNT * 2
+    );
+
+    for pto_count in 1..=EXPECTED_PTO_COUNT {
+        let default_pto_base = Duration::from_millis(999);
+        let expected_pto = default_pto_base * (2_u32.pow(pto_count as u32) - 1);
+        let first_pto_datagram = datagram_sent_events[pto_count * 2 - 1];
+        let second_pto_datagram = datagram_sent_events[pto_count * 2];
+        let first_pto_datagram_jitter = datagram_sent_events_jitter[pto_count * 2 - 1];
+        let second_pto_datagram_jitter = datagram_sent_events_jitter[pto_count * 2];
+
+        // 2 PTO datagrams are sent at the same time
+        assert_eq!(first_pto_datagram, second_pto_datagram);
+        assert_eq!(first_pto_datagram_jitter, second_pto_datagram_jitter);
+
+        // Without jitter the PTO is sent at the expected time
+        assert_eq!(expected_pto, first_pto_datagram);
+
+        // With jitter the PTO is sent at a different time
+        assert_ne!(expected_pto, first_pto_datagram_jitter);
+    }
+}
+
 /// Drops all outgoing handshake packets
 struct DropHandshakeTx;
 
@@ -105,5 +200,44 @@ impl Interceptor for DropHandshakeTx {
         if packet.number.space().is_handshake() {
             payload.clear();
         }
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct DatagramSentTime {
+    pub events: Arc<Mutex<Vec<Duration>>>,
+}
+
+impl DatagramSentTime {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn events(&self) -> Arc<Mutex<Vec<Duration>>> {
+        self.events.clone()
+    }
+}
+impl events::Subscriber for DatagramSentTime {
+    type ConnectionContext = DatagramSentTime;
+
+    fn create_connection_context(
+        &mut self,
+        _meta: &events::ConnectionMeta,
+        _info: &events::ConnectionInfo,
+    ) -> Self::ConnectionContext {
+        self.clone()
+    }
+
+    fn on_datagram_sent(
+        &mut self,
+        context: &mut Self::ConnectionContext,
+        meta: &ConnectionMeta,
+        _event: &events::DatagramSent,
+    ) {
+        context
+            .events
+            .lock()
+            .unwrap()
+            .push(meta.timestamp.duration_since_start().clone());
     }
 }

--- a/quic/s2n-quic-tests/src/tests/pto.rs
+++ b/quic/s2n-quic-tests/src/tests/pto.rs
@@ -253,6 +253,6 @@ impl events::Subscriber for DatagramSentTime {
             .events
             .lock()
             .unwrap()
-            .push(meta.timestamp.duration_since_start().clone());
+            .push(meta.timestamp.duration_since_start());
     }
 }

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -83,6 +83,7 @@ impl connection::Trait for TestConnection {
         _error: connection::Error,
         _close_formatter: &<Self::Config as endpoint::Config>::ConnectionCloseFormatter,
         _packet_buffer: &mut endpoint::PacketBuffer,
+        _random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         timestamp: Timestamp,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
@@ -110,6 +111,7 @@ impl connection::Trait for TestConnection {
     fn on_transmit<Tx: tx::Queue>(
         &mut self,
         _queue: &mut Tx,
+        _random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         _timestamp: Timestamp,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
@@ -138,6 +140,7 @@ impl connection::Trait for TestConnection {
         _datagram: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
         _conn_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
+        _random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
     ) -> Result<(), connection::Error> {
         Ok(())
     }
@@ -249,6 +252,7 @@ impl connection::Trait for TestConnection {
         _congestion_controller_endpoint: &mut <Self::Config as endpoint::Config>::CongestionControllerEndpoint,
         _path_migration: &mut <Self::Config as endpoint::Config>::PathMigrationValidator,
         _mtu: &mut mtu::Manager<<Self::Config as endpoint::Config>::Mtu>,
+        _random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         _subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) -> Result<path::Id, DatagramDropReason> {
         todo!()

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -33,7 +33,8 @@ use core::{
     time::Duration,
 };
 use s2n_quic_core::{
-    application::{self, ServerName},
+    application,
+    application::ServerName,
     connection::{error::Error, id::Generator as _, InitialId, PeerId},
     crypto::{tls, CryptoSuite},
     datagram::{Receiver, Sender},

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -65,6 +65,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         error: connection::Error,
         close_formatter: &<Self::Config as endpoint::Config>::ConnectionCloseFormatter,
         packet_buffer: &mut endpoint::PacketBuffer,
+        random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         timestamp: Timestamp,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
@@ -88,6 +89,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
     fn on_transmit<Tx>(
         &mut self,
         queue: &mut Tx,
+        random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         timestamp: Timestamp,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
         packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
@@ -115,6 +117,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         datagram: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
         conn_limits: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
+        random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
     ) -> Result<(), connection::Error>;
 
     // Packet handling
@@ -213,6 +216,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         congestion_controller_endpoint: &mut <Self::Config as endpoint::Config>::CongestionControllerEndpoint,
         migration_validator: &mut <Self::Config as endpoint::Config>::PathMigrationValidator,
         mtu: &mut mtu::Manager<<Self::Config as endpoint::Config>::Mtu>,
+        random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
         subscriber: &mut <Self::Config as endpoint::Config>::EventSubscriber,
     ) -> Result<path::Id, DatagramDropReason>;
 

--- a/quic/s2n-quic-transport/src/connection/mod.rs
+++ b/quic/s2n-quic-transport/src/connection/mod.rs
@@ -89,4 +89,6 @@ pub struct Parameters<'a, Cfg: endpoint::Config> {
     pub event_subscriber: &'a mut Cfg::EventSubscriber,
     /// The connection limits provider
     pub limits_endpoint: &'a mut Cfg::ConnectionLimits,
+    /// The random generator
+    pub random_generator: &'a mut Cfg::RandomGenerator,
 }

--- a/quic/s2n-quic-transport/src/connection/transmission.rs
+++ b/quic/s2n-quic-transport/src/connection/transmission.rs
@@ -28,6 +28,7 @@ pub struct ConnectionTransmissionContext<'a, 'sub, Config: endpoint::Config> {
     pub ecn: ExplicitCongestionNotification,
     pub min_packet_len: Option<usize>,
     pub transmission_mode: transmission::Mode,
+    pub random_generator: &'a mut Config::RandomGenerator,
     pub publisher: &'a mut event::ConnectionPublisherSubscriber<'sub, Config::EventSubscriber>,
     pub packet_interceptor: &'a mut Config::PacketInterceptor,
 }
@@ -299,6 +300,7 @@ impl<Config: endpoint::Config> tx::Message for ConnectionTransmission<'_, '_, Co
                 if Config::ENDPOINT_TYPE.is_client() {
                     space_manager.discard_initial(
                         self.context.path_manager,
+                        self.context.random_generator,
                         self.context.timestamp,
                         self.context.publisher,
                     );

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -316,6 +316,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             dc_endpoint: endpoint_context.dc,
             open_registry: None,
             limits_endpoint: endpoint_context.connection_limits,
+            random_generator: endpoint_context.random_generator,
         };
 
         let mut connection = <Config as endpoint::Config>::Connection::new(connection_parameters)?;
@@ -329,6 +330,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                     endpoint_context.congestion_controller,
                     endpoint_context.path_migration,
                     endpoint_context.mtu,
+                    endpoint_context.random_generator,
                     endpoint_context.event_subscriber,
                 );
 

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -142,6 +142,7 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
             // ignore the transmission error and just query the queue capacity instead
             let _ = connection.on_transmit(
                 queue,
+                endpoint_context.random_generator,
                 timestamp,
                 endpoint_context.event_subscriber,
                 endpoint_context.packet_interceptor,
@@ -215,11 +216,13 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
                     endpoint_context.datagram,
                     endpoint_context.dc,
                     endpoint_context.connection_limits,
+                    endpoint_context.random_generator,
                 ) {
                     conn.close(
                         error,
                         endpoint_context.connection_close_formatter,
                         close_packet_buffer,
+                        endpoint_context.random_generator,
                         timestamp,
                         endpoint_context.event_subscriber,
                         endpoint_context.packet_interceptor,
@@ -572,6 +575,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                         endpoint_context.congestion_controller,
                         endpoint_context.path_migration,
                         endpoint_context.mtu,
+                        endpoint_context.random_generator,
                         endpoint_context.event_subscriber,
                     )
                     .map_err(|datagram_drop_reason| {
@@ -618,6 +622,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                         err,
                         endpoint_context.connection_close_formatter,
                         close_packet_buffer,
+                        endpoint_context.random_generator,
                         datagram.timestamp,
                         endpoint_context.event_subscriber,
                         endpoint_context.packet_interceptor,
@@ -645,6 +650,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                         err,
                         endpoint_context.connection_close_formatter,
                         close_packet_buffer,
+                        endpoint_context.random_generator,
                         datagram.timestamp,
                         endpoint_context.event_subscriber,
                         endpoint_context.packet_interceptor,
@@ -905,6 +911,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                 connection::Error::stateless_reset(),
                 endpoint_context.connection_close_formatter,
                 close_packet_buffer,
+                endpoint_context.random_generator,
                 timestamp,
                 endpoint_context.event_subscriber,
                 endpoint_context.packet_interceptor,
@@ -932,6 +939,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                         error,
                         endpoint_context.connection_close_formatter,
                         close_packet_buffer,
+                        endpoint_context.random_generator,
                         timestamp,
                         endpoint_context.event_subscriber,
                         endpoint_context.packet_interceptor,
@@ -1255,6 +1263,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
             dc_endpoint: endpoint_context.dc,
             open_registry,
             limits_endpoint: endpoint_context.connection_limits,
+            random_generator: endpoint_context.random_generator,
         };
         let connection = <Cfg as crate::endpoint::Config>::Connection::new(connection_parameters)?;
         self.connections

--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -469,6 +469,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             true,
             mtu_config,
             limits.anti_amplification_multiplier(),
+            limits.pto_jitter_percentage(),
         );
 
         let amplification_outcome = path.on_bytes_received(datagram.payload_len);

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -63,6 +63,7 @@ fn get_path_by_address_test() {
         false,
         mtu_config,
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // Default to no jitter for tests
     );
 
     let second_conn_id = connection::PeerId::try_from_bytes(&[5, 4, 3, 2, 1]).unwrap();
@@ -75,6 +76,7 @@ fn get_path_by_address_test() {
         false,
         mtu_config,
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // Default to no jitter for tests
     );
 
     let mut manager = manager_server(first_path.clone());
@@ -1976,6 +1978,7 @@ pub fn helper_path(peer_id: connection::PeerId) -> ServerPath {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // Default to no jitter for tests
     )
 }
 

--- a/quic/s2n-quic-transport/src/path/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/path/manager/tests.rs
@@ -63,7 +63,7 @@ fn get_path_by_address_test() {
         false,
         mtu_config,
         ANTI_AMPLIFICATION_MULTIPLIER,
-        0, // Default to no jitter for tests
+        0, // pto_jitter_percentage
     );
 
     let second_conn_id = connection::PeerId::try_from_bytes(&[5, 4, 3, 2, 1]).unwrap();
@@ -76,7 +76,7 @@ fn get_path_by_address_test() {
         false,
         mtu_config,
         ANTI_AMPLIFICATION_MULTIPLIER,
-        0, // Default to no jitter for tests
+        0, // pto_jitter_percentage
     );
 
     let mut manager = manager_server(first_path.clone());
@@ -109,6 +109,7 @@ fn test_invalid_path_fallback() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     // simulate receiving a handshake packet to force path validation
     first_path.on_handshake_packet();
@@ -126,6 +127,7 @@ fn test_invalid_path_fallback() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     second_path.set_challenge(challenge);
 
@@ -510,6 +512,7 @@ fn silently_return_when_there_is_no_valid_path() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     first_path.set_challenge(challenge);
     let mut manager = manager_server(first_path);
@@ -718,6 +721,7 @@ fn test_adding_new_path() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     let mut manager = manager_server(first_path);
 
@@ -782,6 +786,7 @@ fn do_not_add_new_path_if_handshake_not_confirmed() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     let mut manager = manager_server(first_path);
 
@@ -845,6 +850,7 @@ fn do_not_add_new_path_if_client() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     let mut manager = manager_client(first_path);
     let mut publisher = Publisher::snapshot();
@@ -901,6 +907,7 @@ fn switch_destination_connection_id_after_first_server_response() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     let mut manager = manager_client(zero_path);
     assert_eq!(manager[zero_path_id].peer_connection_id, initial_cid);
@@ -940,6 +947,7 @@ fn limit_number_of_connection_migrations() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     let mut manager = manager_server(first_path);
     let mut total_paths = 1;
@@ -1003,6 +1011,7 @@ fn active_connection_migration_disabled() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     let mut manager = manager_server(first_path);
     // Give the path manager some new CIDs so it's able to use one for an active migration.
@@ -1129,6 +1138,7 @@ fn connection_migration_challenge_behavior() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     let mut manager = manager_server(first_path);
 
@@ -1225,6 +1235,7 @@ fn connection_migration_use_max_ack_delay_from_active_path() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     let mut manager = manager_server(first_path);
 
@@ -1306,6 +1317,7 @@ fn connection_migration_new_path_abandon_timer() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     let mut manager = manager_server(first_path);
 
@@ -1429,6 +1441,7 @@ fn stop_using_a_retired_connection_id() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     let mut manager = manager_server(first_path);
 
@@ -1526,6 +1539,7 @@ fn pending_paths_should_return_paths_pending_validation() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     let expected_response_data = [0; 8];
     third_path.on_path_challenge(&expected_response_data);
@@ -1592,6 +1606,7 @@ fn temporary_until_authenticated() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     let mut manager = manager_server(first_path);
 
@@ -1978,7 +1993,7 @@ pub fn helper_path(peer_id: connection::PeerId) -> ServerPath {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
-        0, // Default to no jitter for tests
+        0, // pto_jitter_percentage
     )
 }
 

--- a/quic/s2n-quic-transport/src/path/mod.rs
+++ b/quic/s2n-quic-transport/src/path/mod.rs
@@ -1310,10 +1310,13 @@ mod tests {
 }
     #[test]
     fn pto_period_with_jitter_configuration() {
-        use s2n_quic_core::packet::number::PacketNumberSpace;
+        use s2n_quic_core::{
+            connection::limits::ANTI_AMPLIFICATION_MULTIPLIER,
+            packet::number::PacketNumberSpace,
+        };
         
         // Test with zero jitter (should match original behavior)
-        let path_no_jitter = Path::new(
+        let path_no_jitter: Path<endpoint::testing::Server> = Path::new(
             Default::default(),
             connection::PeerId::try_from_bytes(&[]).unwrap(),
             connection::LocalId::TEST_ID,
@@ -1330,7 +1333,7 @@ mod tests {
         let pto_no_jitter_with_method = path_no_jitter.pto_period_with_jitter(PacketNumberSpace::ApplicationData, &mut rng);
         
         // Test with jitter enabled
-        let path_with_jitter = Path::new(
+        let path_with_jitter: Path<endpoint::testing::Server> = Path::new(
             Default::default(),
             connection::PeerId::try_from_bytes(&[]).unwrap(),
             connection::LocalId::TEST_ID,

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -176,6 +176,7 @@ impl<Config: endpoint::Config> Manager<Config> {
                     context.active_path(),
                     timestamp,
                     context.is_handshake_confirmed(),
+                    random_generator,
                 );
             }
         } else {
@@ -198,6 +199,7 @@ impl<Config: endpoint::Config> Manager<Config> {
                     context.active_path(),
                     timestamp,
                     context.is_handshake_confirmed(),
+                    random_generator,
                 );
             }
         }
@@ -279,11 +281,12 @@ impl<Config: endpoint::Config> Manager<Config> {
         active_path: &Path<Config>,
         now: Timestamp,
         is_handshake_confirmed: bool,
+        random_generator: &mut Config::RandomGenerator,
     ) {
         debug_assert!(active_path.is_active());
         if self.pto_update_pending {
             // Update the PTO timer once per transmission burst to reduce CPU cost
-            self.update_pto_timer(active_path, now, is_handshake_confirmed);
+            self.update_pto_timer(active_path, now, is_handshake_confirmed, random_generator);
             debug_assert!(!self.pto_update_pending);
         }
         self.check_consistency(active_path, is_handshake_confirmed);
@@ -295,6 +298,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         active_path: &Path<Config>,
         now: Timestamp,
         is_handshake_confirmed: bool,
+        random_generator: &mut Config::RandomGenerator,
     ) {
         self.pto_update_pending = false;
 
@@ -360,7 +364,7 @@ impl<Config: endpoint::Config> Manager<Config> {
             };
 
             self.pto
-                .update(pto_base_timestamp, active_path.pto_period(self.space));
+                .update(pto_base_timestamp, active_path.pto_period_with_jitter(self.space, random_generator));
         })();
 
         self.check_consistency(active_path, is_handshake_confirmed);
@@ -693,7 +697,7 @@ impl<Config: endpoint::Config> Manager<Config> {
         // be restarted. This behavior is preferred, as detect_and_remove_lost_packets() will
         // cancel the loss timer, and there may still be ack eliciting packets pending that
         // require a PTO timer for recovery.
-        self.update_pto_timer(context.active_path(), timestamp, is_handshake_confirmed);
+        self.update_pto_timer(context.active_path(), timestamp, is_handshake_confirmed, random_generator);
 
         debug_assert!(
             !newly_acked_packets.is_empty(),

--- a/quic/s2n-quic-transport/src/recovery/manager.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager.rs
@@ -363,8 +363,10 @@ impl<Config: endpoint::Config> Manager<Config> {
                 now
             };
 
-            self.pto
-                .update(pto_base_timestamp, active_path.pto_period_with_jitter(self.space, random_generator));
+            self.pto.update(
+                pto_base_timestamp,
+                active_path.pto_period_with_jitter(self.space, random_generator),
+            );
         })();
 
         self.check_consistency(active_path, is_handshake_confirmed);
@@ -697,7 +699,12 @@ impl<Config: endpoint::Config> Manager<Config> {
         // be restarted. This behavior is preferred, as detect_and_remove_lost_packets() will
         // cancel the loss timer, and there may still be ack eliciting packets pending that
         // require a PTO timer for recovery.
-        self.update_pto_timer(context.active_path(), timestamp, is_handshake_confirmed, random_generator);
+        self.update_pto_timer(
+            context.active_path(),
+            timestamp,
+            is_handshake_confirmed,
+            random_generator,
+        );
 
         debug_assert!(
             !newly_acked_packets.is_empty(),

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -3458,14 +3458,24 @@ fn on_transmit_burst_complete() {
     context.path_mut().on_peer_validated();
 
     assert!(manager.pto_update_pending);
-    manager.on_transmit_burst_complete(path_manager.active_path(), now, is_handshake_confirmed, random);
+    manager.on_transmit_burst_complete(
+        path_manager.active_path(),
+        now,
+        is_handshake_confirmed,
+        random,
+    );
     assert!(manager.pto.is_armed());
     assert!(!manager.pto_update_pending);
 
     // Cancel the PTO timer to validate it isn't re-armed when not needed
     manager.pto.cancel();
     manager.sent_packets.clear();
-    manager.on_transmit_burst_complete(path_manager.active_path(), now, is_handshake_confirmed, random);
+    manager.on_transmit_burst_complete(
+        path_manager.active_path(),
+        now,
+        is_handshake_confirmed,
+        random,
+    );
     assert!(!manager.pto.is_armed());
 }
 

--- a/quic/s2n-quic-transport/src/recovery/manager/tests.rs
+++ b/quic/s2n-quic-transport/src/recovery/manager/tests.rs
@@ -63,6 +63,7 @@ fn one_second_pto_when_no_previous_rtt_available() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
 
     manager
@@ -445,6 +446,7 @@ fn on_ack_frame() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     context.path_manager.activate_path_for_test(path_id);
     context.path_mut().pto_backoff = 2;
@@ -541,7 +543,7 @@ fn on_invalid_ack_frame() {
             &mut publisher,
         );
     }
-    manager.on_transmit_burst_complete(context.active_path(), time_sent, true);
+    manager.on_transmit_burst_complete(context.active_path(), time_sent, true, random);
 
     // Ack packet 2, arming the loss timer for packet 1
     let ack_receive_time = time_sent + Duration::from_millis(10);
@@ -2146,6 +2148,7 @@ fn detect_and_remove_lost_packets_early_mtu_probe() {
             .build()
             .unwrap(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
 
     let mut path_manager = path::Manager::new(path, registry);
@@ -2761,6 +2764,7 @@ fn update_pto_timer() {
     let ecn = ExplicitCongestionNotification::default();
     let mut context = MockContext::new(&mut path_manager);
     let mut publisher = Publisher::snapshot();
+    let random = &mut random::testing::Generator::default();
 
     context.path_mut().rtt_estimator.update_rtt(
         Duration::from_millis(0),
@@ -2783,7 +2787,7 @@ fn update_pto_timer() {
     // Arm the PTO so we can verify it is cancelled
     manager.pto.update(now, Duration::from_secs(10));
     manager.pto_update_pending = true;
-    manager.update_pto_timer(context.path(), now, is_handshake_confirmed);
+    manager.update_pto_timer(context.path(), now, is_handshake_confirmed, random);
 
     //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.2.1
     //= type=test
@@ -2801,7 +2805,7 @@ fn update_pto_timer() {
     // simulate receiving a handshake packet to force path validation
     context.path_mut().on_handshake_packet();
     context.path_mut().on_peer_validated();
-    manager.update_pto_timer(context.path(), now, is_handshake_confirmed);
+    manager.update_pto_timer(context.path(), now, is_handshake_confirmed, random);
 
     // Since the path is peer validated and sent packets is empty, PTO is cancelled
     assert!(!manager.pto.is_armed());
@@ -2820,6 +2824,7 @@ fn update_pto_timer() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     context.path_manager.activate_path_for_test(path_id);
     // simulate receiving a handshake packet to force path validation
@@ -2827,7 +2832,7 @@ fn update_pto_timer() {
     context.path_mut().pto_backoff = 2;
     manager.pto_update_pending = true;
     let is_handshake_confirmed = false;
-    manager.update_pto_timer(context.path(), now, is_handshake_confirmed);
+    manager.update_pto_timer(context.path(), now, is_handshake_confirmed, random);
 
     //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.1
     //= type=test
@@ -2839,7 +2844,7 @@ fn update_pto_timer() {
     // Set is handshake confirmed back to true
     let is_handshake_confirmed = true;
     manager.pto_update_pending = true;
-    manager.update_pto_timer(context.path(), now, is_handshake_confirmed);
+    manager.update_pto_timer(context.path(), now, is_handshake_confirmed, random);
 
     // Now the PTO is armed
     assert!(manager.pto.is_armed());
@@ -2873,7 +2878,7 @@ fn update_pto_timer() {
         space,
     );
     manager.pto_update_pending = true;
-    manager.update_pto_timer(context.path(), now, is_handshake_confirmed);
+    manager.update_pto_timer(context.path(), now, is_handshake_confirmed, random);
 
     //= https://www.rfc-editor.org/rfc/rfc9002#section-6.2.1
     //# When an ack-eliciting packet is transmitted, the sender schedules a
@@ -2904,6 +2909,7 @@ fn pto_armed_if_handshake_not_confirmed() {
     let now = time::now() + Duration::from_secs(10);
     let is_handshake_confirmed = false;
     let mut path_manager = helper_generate_path_manager(Duration::from_millis(10));
+    let random = &mut random::testing::Generator::default();
     let path_id = unsafe { path::Id::new(0) };
     path_manager[path_id] = Path::new(
         Default::default(),
@@ -2914,13 +2920,14 @@ fn pto_armed_if_handshake_not_confirmed() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
     path_manager.activate_path_for_test(path_id);
 
     // simulate receiving a handshake packet to force path validation
     path_manager[path_id].on_handshake_packet();
 
-    manager.update_pto_timer(&path_manager[path_id], now, is_handshake_confirmed);
+    manager.update_pto_timer(&path_manager[path_id], now, is_handshake_confirmed, random);
 
     assert!(manager.pto.is_armed());
 }
@@ -2943,6 +2950,7 @@ fn pto_must_be_at_least_k_granularity() {
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
 
     // Update RTT with the smallest possible sample
@@ -3008,7 +3016,7 @@ fn on_timeout() {
         &mut context,
         &mut publisher,
     );
-    manager.on_transmit_burst_complete(context.path(), now, true);
+    manager.on_transmit_burst_complete(context.path(), now, true, random);
 
     // Loss timer is armed and expired, on_packet_loss is called
     manager.loss_timer.set(now - Duration::from_secs(1));
@@ -3141,7 +3149,7 @@ fn on_timeout_packet_lost() {
         &mut context,
         &mut publisher,
     );
-    manager.on_transmit_burst_complete(context.path(), now - Duration::from_secs(5), true);
+    manager.on_transmit_burst_complete(context.path(), now - Duration::from_secs(5), true, random);
 
     assert!(manager.pto.is_armed());
 
@@ -3220,7 +3228,7 @@ fn new_client_space() {
 
     // No PTO update was pending, nothing happens
     assert!(!manager.pto_update_pending);
-    manager.on_transmit_burst_complete(context.path(), now, false);
+    manager.on_transmit_burst_complete(context.path(), now, false, random);
     assert!(!manager.pto_update_pending);
 }
 
@@ -3426,6 +3434,7 @@ fn on_transmit_burst_complete() {
     let ecn = ExplicitCongestionNotification::default();
     let mut context = MockContext::new(&mut path_manager);
     let mut publisher = Publisher::snapshot();
+    let random = &mut random::testing::Generator::default();
 
     // Send an ack-eliciting packet to trigger a PTO timer update
     manager.on_packet_sent(
@@ -3449,14 +3458,14 @@ fn on_transmit_burst_complete() {
     context.path_mut().on_peer_validated();
 
     assert!(manager.pto_update_pending);
-    manager.on_transmit_burst_complete(path_manager.active_path(), now, is_handshake_confirmed);
+    manager.on_transmit_burst_complete(path_manager.active_path(), now, is_handshake_confirmed, random);
     assert!(manager.pto.is_armed());
     assert!(!manager.pto_update_pending);
 
     // Cancel the PTO timer to validate it isn't re-armed when not needed
     manager.pto.cancel();
     manager.sent_packets.clear();
-    manager.on_transmit_burst_complete(path_manager.active_path(), now, is_handshake_confirmed);
+    manager.on_transmit_burst_complete(path_manager.active_path(), now, is_handshake_confirmed, random);
     assert!(!manager.pto.is_armed());
 }
 
@@ -3578,6 +3587,7 @@ fn helper_generate_path_manager_with_first_addr(
         true,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
 
     path::Manager::new(path, registry)
@@ -3603,6 +3613,7 @@ fn helper_generate_client_path_manager(
         false,
         mtu::Config::default(),
         ANTI_AMPLIFICATION_MULTIPLIER,
+        0, // pto_jitter_percentage
     );
 
     path::Manager::new(path, registry)

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -196,11 +196,13 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
         active_path: &Path<Config>,
         timestamp: Timestamp,
         is_handshake_confirmed: bool,
+        random_generator: &mut Config::RandomGenerator,
     ) {
         self.recovery_manager.on_transmit_burst_complete(
             active_path,
             timestamp,
             is_handshake_confirmed,
+            random_generator,
         );
     }
 
@@ -303,11 +305,13 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
         path_manager: &path::Manager<Config>,
         now: Timestamp,
         is_handshake_confirmed: bool,
+        random_generator: &mut Config::RandomGenerator,
     ) {
         self.recovery_manager.update_pto_timer(
             path_manager.active_path(),
             now,
             is_handshake_confirmed,
+            random_generator,
         );
     }
 
@@ -515,6 +519,7 @@ impl<Config: endpoint::Config> PacketSpace<Config> for HandshakeSpace<Config> {
         path_manager: &path::Manager<Config>,
         timestamp: Timestamp,
         is_handshake_confirmed: bool,
+        random_generator: &mut Config::RandomGenerator,
     ) {
         debug_assert!(
             Config::ENDPOINT_TYPE.is_server(),
@@ -526,7 +531,12 @@ impl<Config: endpoint::Config> PacketSpace<Config> for HandshakeSpace<Config> {
         //# datagram unblocks it, even if none of the packets in the datagram are
         //# successfully processed.  In such a case, the PTO timer will need to
         //# be re-armed.
-        self.update_pto_timer(path_manager, timestamp, is_handshake_confirmed);
+        self.update_pto_timer(
+            path_manager,
+            timestamp,
+            is_handshake_confirmed,
+            random_generator,
+        );
     }
 
     fn handle_crypto_frame<Pub: event::ConnectionPublisher>(

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -245,11 +245,13 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
         active_path: &Path<Config>,
         timestamp: Timestamp,
         is_handshake_confirmed: bool,
+        random_generator: &mut Config::RandomGenerator,
     ) {
         self.recovery_manager.on_transmit_burst_complete(
             active_path,
             timestamp,
             is_handshake_confirmed,
+            random_generator,
         );
     }
 
@@ -643,6 +645,7 @@ impl<Config: endpoint::Config> PacketSpace<Config> for InitialSpace<Config> {
         path_manager: &path::Manager<Config>,
         timestamp: Timestamp,
         is_handshake_confirmed: bool,
+        random_generator: &mut Config::RandomGenerator,
     ) {
         debug_assert!(
             Config::ENDPOINT_TYPE.is_server(),
@@ -658,6 +661,7 @@ impl<Config: endpoint::Config> PacketSpace<Config> for InitialSpace<Config> {
             path_manager.active_path(),
             timestamp,
             is_handshake_confirmed,
+            random_generator,
         );
     }
 

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -69,6 +69,7 @@ pub struct SessionContext<'a, Config: endpoint::Config, Pub: event::ConnectionPu
     pub dc: &'a mut Config::DcEndpoint,
     pub limits_endpoint: &'a mut Config::ConnectionLimits,
     pub tls_context: &'a mut Option<Box<dyn Any + Send>>,
+    pub random_generator: &'a mut Config::RandomGenerator,
 }
 
 impl<Config: endpoint::Config, Pub: event::ConnectionPublisher> SessionContext<'_, Config, Pub> {
@@ -615,6 +616,7 @@ impl<Config: endpoint::Config, Pub: event::ConnectionPublisher>
                 application.on_handshake_confirmed(
                     self.path_manager.active_path(),
                     self.local_id_registry,
+                    self.random_generator,
                     self.now,
                 );
             }


### PR DESCRIPTION
### Release Summary: 

Adds configurable percentage-based random jitter to Probe Timeout (PTO) calculations to prevent synchronized timeouts across multiple connections and reduce network congestion. Users can now configure jitter between 0-50% of the base PTO period, with 0% maintaining current RFC 9002 compliant behavior.

### Resolved issues: 

resolves #2730

### Description of changes: 

This PR implements configurable PTO jitter for s2n-quic's loss recovery mechanism. Currently, PTO calculations follow RFC 9002 exactly: `PTO = smoothed_rtt + max(4*rttvar, kGranularity) + max_ack_delay`. This can lead to synchronized timeouts when multiple connections start simultaneously, causing network congestion. The changes add: 

- New `pto_jitter_percentage` field to the `Limits` configuration struct (0-50% range, default 0%) 
- Modified `RttEstimator::pto_period()` method to apply symmetric jitter (±X%) to the base PTO calculation 
- Jitter calculation using existing cryptographically secure random number generator 
- Validation to ensure jittered PTO values never fall below RFC 9002's minimum requirements 
- Integration across all packet number spaces (Initial, Handshake, Application) When jitter is enabled, the final PTO becomes: `final_pto = base_pto * (1 + random_jitter_factor)` where the jitter factor is randomly generated within the configured percentage range. 

### Testing: 

- **Unit tests**: Verify jitter calculations are within expected ranges, 0% jitter maintains current behavior, and RFC compliance is preserved 
- **Integration tests**: End-to-end testing through the `Limits` API in `s2n-quic-tests` to ensure real connections work correctly with jitter enabled 
- **Property-based tests**: Validate arithmetic safety, bounds checking, and distribution properties - 
- **Validation tests**: Confirm configuration validation rejects invalid values (>50%) with clear error messages
- **Simulation tests**: Demonstrate jitter effectiveness in reducing synchronized timeouts using `s2n-quic-sim` with multiple concurrent clients. From the before and after results below, without jitter, many connections exceed the 10 second maximum handshake time, especially as client concurrency increases.

Without Jitter:
<img width="443" height="462" alt="Screenshot 2025-08-14 at 8 25 58 PM" src="https://github.com/user-attachments/assets/da589a7d-adb6-4699-9cb3-7dfd0cc4d536" />

With Jitter (33%):
<img width="447" height="457" alt="Screenshot 2025-08-14 at 8 26 26 PM" src="https://github.com/user-attachments/assets/da1ccfa1-78f2-4a33-ad8d-97a112e873f2" />


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.