### PR TITLE
ci: reduce false alarms for ActionCIFailure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -944,13 +944,14 @@ jobs:
     needs: [env, rustfmt, clippy, udeps, doc, test, asan, fips, miri, no_std, compliance, coverage, crates, examples, recovery-simulations, sims, copyright, events, snapshots, timing, typos, kani, dhat, loom, xdp, dc-wireshark]
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.3.1
-        if: github.event_name == 'schedule'
+        if: github.event_name != 'pull_request'
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
       - name: Report daily CI run to CloudWatch
-        if: github.event_name == 'schedule'
+        if: github.event_name != 'pull_request'
         run: |
           METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
-          aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)
+          aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFailure" \
+            --value $METRIC_VALUE --dimensions Initiator=${{github.event_name}} --timestamp $(date +%s)

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -555,16 +555,37 @@ jobs:
   scheduled-qns-status-report:
     runs-on: ubuntu-latest
     if: ${{ always() }}
-    needs: [env, s2n-quic-qns, interop, interop-report, h3spec, perf, perf-report, attack]
+    needs: [env, s2n-quic-qns, interop, h3spec, perf, perf-report, attack]
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.3.1
-        if: github.event_name == 'schedule'
+        if: github.event_name != 'pull_request'
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
       - name: Report daily qns run to CloudWatch
-        if: github.event_name == 'schedule'
+        if: github.event_name != 'pull_request'
         run: |
           METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
-          aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFaliure" --value $METRIC_VALUE --dimensions Initiator=scheduled --timestamp $(date +%s)
+          aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFailure" \
+            --value $METRIC_VALUE --dimensions Initiator=${{github.event_name}} --timestamp $(date +%s)
+
+  # Some tests may be flaky and require less strict alarming.
+  # Report those tests separately until the flakiness has been resolved.
+  qns-status-report-flaky:
+    runs-on: ubuntu-latest
+    if: ${{ always() }}
+    needs: [interop-report]
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4.3.1
+        if: github.event_name != 'pull_request'
+        with:
+          role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
+          role-session-name: S2nQuicGHASession
+          aws-region: us-west-2
+      - name: Report potentially flaky qns job runs to CloudWatch
+        if: github.event_name != 'pull_request'
+        run: |
+          METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
+          aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFailureFlaky" \
+            --value $METRIC_VALUE --dimensions Initiator=${{github.event_name}} --timestamp $(date +%s)


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

I'm attempting to clean up the ActionCIFailure metric/alarm a little. To do that I'm:
1. Splitting out the currently flaky jobs into a separate metric. We can allow more consecutive failures for that metric.
2. Expanding the metrics task to also run on merge to main. The extra data points will likely primarily be useful for the flaky jobs (we can hit x consecutive failures faster) but could be useful for the non-flaky ones too.

And since I'm touching the alarm anyway, I also:
1. Fixed the spelling of ActionCIFaliure. It made me sad :smiling_face_with_tear: 
3. Made the "Initiator" exactly match the github event. That saves us some translation logic, but the current "scheduled" will change to "schedule"

### Call-outs:
As a followup, I'll need to update the alarm we have on "ActionCIFaliure".

### Testing:

Testing something that doesn't run on PRs is a little tricky. I made an "lrstewart/ci" branch, then merged this change + a commit that added "lrstewart/ci" to the allowed push branches into that new branch. The CI ran on that commit, including the old reporting tasks and the new reporting task: [https://github.com/aws/s2n-quic/actions/runs/17086416387/job/48452234875]. I also checked Cloudwatch and the correctly spelled "ActionCIFailure" and the new "ActionCIFailureFlaky" metrics are being reported as "0" with Initiator=push.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

