### PR TITLE
ci: add interop retries

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -6,11 +6,8 @@ on:
     branches:
       - main
   schedule:
-    # Run the daily job three times, to account for flakiness
-    # The jobs start running at 8 PM PST / 3 AM UTC
+    # Run the daily job at 8 PM PST / 3 AM UTC
     - cron: '0 3 * * *'
-    - cron: '0 4 * * *'
-    - cron: '0 5 * * *'
 
 name: qns
 
@@ -555,10 +552,29 @@ jobs:
           # `timeout` exits with `124` if the time limit was reached
           [[ "$EXIT_CODE" == "124" ]] || exit $EXIT_CODE
 
+  retry-failures:
+    runs-on: ubuntu-latest
+    needs: [interop-report]
+    if: failure() && fromJSON(github.run_attempt) < 3 && github.event_name != 'pull_request'
+    permissions:
+      actions: write
+    env:
+      GH_REPO: ${{ github.repository }}
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Run retry.yml
+        run: |
+          # You cannot rerun an in-progress workflow, so you cannot rerun a workflow
+          # from inside that same workflow. Instead, start a new workflow.
+          # The new workflow will wait for this run to complete, then retry.
+          gh workflow run retry.yml \
+            -r ${{ github.head_ref || github.ref_name }} \
+            -F run_id=${{ github.run_id }}
+
   qns-status-report:
     runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: [env, s2n-quic-qns, interop, h3spec, perf, perf-report, attack]
+    if: always() && needs.retry-failures.result == 'skipped'
+    needs: [retry-failures, env, s2n-quic-qns, interop, interop-report, h3spec, perf, perf-report, attack]
     steps:
       - uses: aws-actions/configure-aws-credentials@v4.3.1
         if: github.event_name != 'pull_request'
@@ -571,24 +587,4 @@ jobs:
         run: |
           METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
           aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFailure" \
-            --value $METRIC_VALUE --dimensions Initiator=${{github.event_name}} --timestamp $(date +%s)
-
-  # Some tests may be flaky and require less strict alarming.
-  # Report those tests separately until the flakiness has been resolved.
-  qns-status-report-flaky:
-    runs-on: ubuntu-latest
-    if: ${{ always() }}
-    needs: [interop-report]
-    steps:
-      - uses: aws-actions/configure-aws-credentials@v4.3.1
-        if: github.event_name != 'pull_request'
-        with:
-          role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
-          role-session-name: S2nQuicGHASession
-          aws-region: us-west-2
-      - name: Report potentially flaky qns job runs to CloudWatch
-        if: github.event_name != 'pull_request'
-        run: |
-          METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
-          aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFailureFlaky" \
             --value $METRIC_VALUE --dimensions Initiator=${{github.event_name}} --timestamp $(date +%s)

--- a/.github/workflows/retry.yml
+++ b/.github/workflows/retry.yml
@@ -1,0 +1,22 @@
+# You cannot rerun an in-progress workflow, so you cannot rerun a workflow
+# from inside that same workflow. Instead, this workflow should be used.
+# It waits for the previous workflow complete, then reruns it.
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        required: true
+jobs:
+  retry:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: rerun ${{ inputs.run_id }}
+        env:
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh run watch ${{ inputs.run_id }}
+          gh run rerun ${{ inputs.run_id }}


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

As an alternative to https://github.com/aws/s2n-quic/commit/f217c8551739a23fe6485eeddd8571ae6a7eaed7, we could instead retry the interop tests when they fail. As long as we have remaining attempts, we will not report the failure via qns-status-report.

I modeled this solution off of https://github.com/orgs/community/discussions/67654#discussioncomment-8038649.

### Call-outs:

Currently, I'm retrying the entire "qns" workflow. I could probably limit the retry to just the interop tests by introducing a new "interop-trigger" job that "interop" depends on, and then rerun just that job. HOWEVER, Github counts "attempts" per workflow, NOT per job. So by retrying a subset of jobs, the counter we rely on to check for retries goes up for all jobs anyway. I think that could be confusing? Retrying the entire workflow seemed more straightforward and clear.

### Testing:

How was this change tested? With difficulty.

#### Running the workflow at all

You can't use "gh workflow run" on workflows that don't exist on the default branch yet, meaning workflows that haven't been committed to main. So this change can't actually be tested as-is. Here's an issue about that problem: www.github.com/cli/cli/issues/9781

I worked around this by hijacking the tshark workflow, which already exists on main and even has a single workflow_dispatch input (the workflow_dispatch inputs of your spec also have to match what's on main). I overwrote the tshark workflow with my new retry workflow, and then tested with that. Comparing the two files:
```
<       run_id:
---
>       version:
16c12
<       - name: rerun ${{ inputs.run_id }}
---
>       - name: rerun ${{ inputs.version }}
21,22c17,18
<           gh run watch ${{ inputs.run_id }}
<           gh run rerun ${{ inputs.run_id }}
\ No newline at end of file
---
>           gh run watch ${{ inputs.version }}
>           gh run rerun ${{ inputs.version }}
```

#### Failure testing

Here's the PR I opened to test: https://github.com/aws/s2n-quic/pull/2762 

I made a few other changes to 1) let me test with a PR and 2) ensure the interop tests fail. See the "enable testing" commit: https://github.com/aws/s2n-quic/pull/2762/commits/6cb209a4bba0836cacaef782c70dd85a8b1df4af.

Note that qns has 3 attempts: https://github.com/aws/s2n-quic/actions/runs/17124819438/job/48579132466 Those were automatically triggered. "qns-status-report" was also skipped on all but the last attempt.

#### Success Testing
I then modified my forced failure to succeed on the second attempt. See the "enable testing success" commit: https://github.com/aws/s2n-quic/pull/2762/commits/b902d1a412eccacffe52fdae36529799528f0876

Note that qns then has only 2 attempts, and succeeds on the second attempt: https://github.com/aws/s2n-quic/actions/runs/17133219460/job/48602891524?pr=2762 The first attempt skipped qns-status-report.

#### Accidental Real Failure testing
While I was doing "Success Testing", the handshakeloss interop test also failed for real :) https://github.com/aws/s2n-quic/actions/runs/17133219460/job/48607253793?pr=2762 That attempt was supposed to succeed, but it instead failed and a third attempt was made.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
