### PR TITLE
refactor(s2n-quic-dc): increase fuzz_test's timeout

### DIFF
--- a/dc/s2n-quic-dc/src/stream/tests/request_response.rs
+++ b/dc/s2n-quic-dc/src/stream/tests/request_response.rs
@@ -309,7 +309,7 @@ impl Harness {
     async fn run_with(self, client: testing::Client, server: testing::Server) {
         let (run_handle, run_watch) = testing::drop_handle::new();
         let task = self.run_with_drop_handle(client, server, run_watch);
-        let duration = Duration::from_secs(180);
+        let duration = Duration::from_secs(250);
         timeout(duration, task).await.unwrap();
         drop(run_handle);
     }

--- a/dc/s2n-quic-dc/src/testing.rs
+++ b/dc/s2n-quic-dc/src/testing.rs
@@ -48,6 +48,8 @@ pub async fn timeout<F>(duration: Duration, f: F) -> Result<F::Output, bach::tim
 where
     F: core::future::Future,
 {
+    tracing::error!("runtime exceeded timeout of {} seconds", duration.as_secs());
+
     if bach::is_active() {
         bach::time::timeout(duration, f).await
     } else {


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

We detected flakiness in the `s2n-quic-dc`'s `fuzz_test` in https://github.com/aws/s2n-quic/pull/2770. The link to the error can be found here: https://github.com/aws/s2n-quic/actions/runs/17136590871/job/48613985390?pr=2770#step:11:2326.
```
test stream::tests::request_response::udp::fuzz_test ...	run time: 234.090669871s | iterations/s: 0.29 | rng inputs: 67 | exit reason: test failure
```

We have previously increased the runtime from 120 seconds to 180 seconds to reduce flakiness in case some random inputs results in long runtime: https://github.com/aws/s2n-quic/pull/2689. However, that seems to be not enough. This PR will increase the timeout to 250 seconds which should solve the failure (failed in 234 seconds). I also added a message in the `timeout` function to specifically call out the timeout failure.

### Call-outs:

### Testing:

CI.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

