### PR TITLE
fix(s2n-quic-dc): adjust trait bounds for providers

### DIFF
--- a/dc/s2n-quic-dc/src/event.rs
+++ b/dc/s2n-quic-dc/src/event.rs
@@ -47,7 +47,7 @@ pub mod metrics {
 }
 
 pub mod disabled {
-    #[derive(Debug, Default)]
+    #[derive(Clone, Debug, Default)]
     pub struct Subscriber(());
 
     impl super::Subscriber for Subscriber {

--- a/dc/s2n-quic-dc/src/psk/client.rs
+++ b/dc/s2n-quic-dc/src/psk/client.rs
@@ -54,7 +54,7 @@ fn make_runtime() -> (Arc<Runtime>, DropGuard) {
 
 impl State {
     fn new_runtime<
-        Provider: Prov + Clone + Send + Sync + 'static,
+        Provider: Prov + Send + Sync + 'static,
         Subscriber: Sub + Send + Sync + 'static,
         Event: s2n_quic::provider::event::Subscriber,
     >(
@@ -91,7 +91,7 @@ impl Provider {
     }
 
     pub fn new<
-        Provider: Prov + Clone + Send + Sync + 'static,
+        Provider: Prov + Send + Sync + 'static,
         Subscriber: Sub + Send + Sync + 'static,
         Event: s2n_quic::provider::event::Subscriber,
     >(

--- a/dc/s2n-quic-dc/src/psk/client/builder.rs
+++ b/dc/s2n-quic-dc/src/psk/client/builder.rs
@@ -93,7 +93,7 @@ impl<Event: s2n_quic::provider::event::Subscriber> Builder<Event> {
     ///
     /// Typically the address provided can use an ephemeral port.
     pub fn start<
-        TlsProvider: Prov + Clone + Send + Sync + 'static,
+        TlsProvider: Prov + Send + Sync + 'static,
         Subscriber: Sub + Send + Sync + 'static,
     >(
         self,

--- a/dc/s2n-quic-dc/src/psk/io.rs
+++ b/dc/s2n-quic-dc/src/psk/io.rs
@@ -44,7 +44,7 @@ pub struct Server {
 
 impl Server {
     pub fn bind<
-        Provider: Prov + Clone + Send + Sync + 'static,
+        Provider: Prov + Send + Sync + 'static,
         Subscriber: Sub + Send + Sync + 'static,
         Event: s2n_quic::provider::event::Subscriber,
     >(
@@ -89,7 +89,7 @@ impl Server {
 }
 
 pub(super) async fn server<
-    Provider: Prov + Clone + Send + Sync + 'static,
+    Provider: Prov + Send + Sync + 'static,
     Subscriber: Sub + Send + Sync + 'static,
     Event: s2n_quic::provider::event::Subscriber,
 >(
@@ -164,7 +164,7 @@ impl Client {
     }
 
     pub fn bind<
-        Provider: Prov + Clone + Send + Sync + 'static,
+        Provider: Prov + Send + Sync + 'static,
         Subscriber: Sub + Send + Sync + 'static,
         Event: s2n_quic::provider::event::Subscriber,
     >(

--- a/dc/s2n-quic-dc/src/psk/server.rs
+++ b/dc/s2n-quic-dc/src/psk/server.rs
@@ -19,7 +19,7 @@ pub struct Provider {
 
 impl Provider {
     pub fn setup<
-        Provider: Prov + Clone + Send + Sync + 'static,
+        Provider: Prov + Send + Sync + 'static,
         Subscriber: Sub + Send + Sync + 'static,
         Event: s2n_quic::provider::event::Subscriber,
     >(

--- a/dc/s2n-quic-dc/src/psk/server/builder.rs
+++ b/dc/s2n-quic-dc/src/psk/server/builder.rs
@@ -88,8 +88,8 @@ impl<Event: s2n_quic::provider::event::Subscriber> Builder<Event> {
 
     /// Starts the server listening to the given address.
     pub async fn start<
-        TlsProvider: Prov + Clone + Send + Sync + 'static,
-        Subscriber: Sub + Default + Clone + Send + Sync + 'static,
+        TlsProvider: Prov + Send + Sync + 'static,
+        Subscriber: Sub + Send + Sync + 'static,
     >(
         self,
         bind: SocketAddr,
@@ -110,8 +110,8 @@ impl<Event: s2n_quic::provider::event::Subscriber> Builder<Event> {
 
     /// Starts the server listening to the given address, blocking until the server has been bound to the address.
     pub fn start_blocking<
-        TlsProvider: Prov + Clone + Send + Sync + 'static,
-        Subscriber: Sub + Default + Clone + Send + Sync + 'static,
+        TlsProvider: Prov + Send + Sync + 'static,
+        Subscriber: Sub + Send + Sync + 'static,
     >(
         self,
         bind: SocketAddr,

--- a/dc/s2n-quic-dc/src/stream/client/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/client/tokio.rs
@@ -40,6 +40,24 @@ pub trait Handshake: Clone {
     fn map(&self) -> &secret::Map;
 }
 
+impl Handshake for crate::psk::client::Provider {
+    async fn handshake_with_entry(
+        &self,
+        remote_handshake_addr: SocketAddr,
+    ) -> std::io::Result<(secret::map::Peer, secret::HandshakeKind)> {
+        self.handshake_with_entry(remote_handshake_addr, |_conn, _duration| {})
+            .await
+    }
+
+    fn local_addr(&self) -> std::io::Result<SocketAddr> {
+        self.local_addr()
+    }
+
+    fn map(&self) -> &secret::Map {
+        self.map()
+    }
+}
+
 #[derive(Clone)]
 pub struct Client<H: Handshake + Clone, S: event::Subscriber + Clone> {
     env: Environment<S>,

--- a/dc/s2n-quic-dc/src/stream/server/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio.rs
@@ -32,6 +32,16 @@ pub trait Handshake: Clone {
     fn map(&self) -> &secret::Map;
 }
 
+impl Handshake for crate::psk::server::Provider {
+    fn local_addr(&self) -> SocketAddr {
+        self.local_addr()
+    }
+
+    fn map(&self) -> &secret::Map {
+        self.map()
+    }
+}
+
 #[derive(Clone)]
 pub struct Server<H: Handshake + Clone, S: event::Subscriber + Clone> {
     streams: accept::Receiver<S>,

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use core::{future::poll_fn, task::Poll};
 use s2n_quic_core::{inet::SocketAddress, time::Clock};
-use std::{net::TcpListener, os::fd::AsRawFd, time::Duration};
+use std::{net::TcpListener, time::Duration};
 use tokio::io::unix::AsyncFd;
 use tracing::debug;
 
@@ -62,6 +62,8 @@ where
 
         #[cfg(target_os = "linux")]
         {
+            use std::os::fd::AsRawFd;
+
             let res = unsafe {
                 libc::setsockopt(
                     acceptor.socket.get_ref().as_raw_fd(),


### PR DESCRIPTION
### Description of changes: 

This change makes a couple of adjustments for s2n-quic-dc endpoint builders:

* Removes `Clone` and `Default` bounds for TLS and event providers - they aren't needed and a lot of impls don't include those.
* Implements the `Handshake` traits for the client and server `Provider` structs. This makes it more convenient when the application doesn't need the callback.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

