### PR TITLE
refactor(s2n-quic-dc): configurable server_name option

### DIFF
--- a/dc/s2n-quic-dc/src/psk/client.rs
+++ b/dc/s2n-quic-dc/src/psk/client.rs
@@ -5,6 +5,7 @@ use super::io::{self, HandshakeFailed};
 use crate::path::secret;
 use s2n_quic::{
     provider::{event::Subscriber as Sub, tls::Provider as Prov},
+    server::Name,
     Connection,
 };
 use std::{net::SocketAddr, sync::Arc, time::Duration};
@@ -101,6 +102,7 @@ impl Provider {
         subscriber: Subscriber,
         query_event_callback: fn(&mut Connection, Duration),
         builder: Builder<Event>,
+        server_name: Name,
     ) -> io::Result<Self> {
         let state = State::new_runtime(
             addr,
@@ -117,11 +119,13 @@ impl Provider {
             if let Some(state) = weak.upgrade() {
                 let runtime = state.runtime.as_ref().map(|v| &v.0).unwrap();
                 let client = state.client.clone();
+                let server_name = server_name.clone();
                 // Drop the JoinHandle -- we're not actually going to block on the join handle's
                 // result. The future will keep running in the background.
                 runtime.spawn(async move {
-                    if let Err(HandshakeFailed { .. }) =
-                        client.connect(peer, query_event_callback).await
+                    if let Err(HandshakeFailed { .. }) = client
+                        .connect(peer, query_event_callback, server_name)
+                        .await
                     {
                         // failure has already been logged, no further action required.
                     }
@@ -140,9 +144,10 @@ impl Provider {
         &self,
         peer: SocketAddr,
         query_event_callback: fn(&mut Connection, Duration),
+        server_name: Name,
     ) -> std::io::Result<HandshakeKind> {
         let (_peer, kind) = self
-            .handshake_with_entry(peer, query_event_callback)
+            .handshake_with_entry(peer, query_event_callback, server_name)
             .await?;
         Ok(kind)
     }
@@ -156,11 +161,12 @@ impl Provider {
         &self,
         peer: SocketAddr,
         query_event_callback: fn(&mut Connection, Duration),
+        server_name: Name,
     ) -> std::io::Result<(secret::map::Peer, HandshakeKind)> {
         // Unconditionally request a background handshake. This schedules any re-handshaking
         // needed.
         if self.state.runtime.is_some() {
-            let _ = self.background_handshake_with(peer, query_event_callback);
+            let _ = self.background_handshake_with(peer, query_event_callback, server_name.clone());
         }
 
         if let Some(peer) = self.state.map.get_tracked(peer) {
@@ -170,10 +176,18 @@ impl Provider {
         let state = self.state.clone();
         if let Some((runtime, _)) = self.state.runtime.as_ref() {
             runtime
-                .spawn(async move { state.client.connect(peer, query_event_callback).await })
+                .spawn(async move {
+                    state
+                        .client
+                        .connect(peer, query_event_callback, server_name)
+                        .await
+                })
                 .await??;
         } else {
-            state.client.connect(peer, query_event_callback).await?;
+            state
+                .client
+                .connect(peer, query_event_callback, server_name)
+                .await?;
         }
 
         // already recorded a metric above in get_tracked.
@@ -193,6 +207,7 @@ impl Provider {
         &self,
         peer: SocketAddr,
         query_event_callback: fn(&mut Connection, Duration),
+        server_name: Name,
     ) -> std::io::Result<HandshakeKind> {
         if self.state.map.contains(&peer) {
             return Ok(HandshakeKind::Cached);
@@ -200,11 +215,13 @@ impl Provider {
 
         let client = self.state.client.clone();
         if let Some((runtime, _)) = self.state.runtime.as_ref() {
+            let server_name = server_name.clone();
             // Drop the JoinHandle -- we're not actually going to block on the join handle's
             // result. The future will keep running in the background.
             runtime.spawn(async move {
-                if let Err(HandshakeFailed { .. }) =
-                    client.connect(peer, query_event_callback).await
+                if let Err(HandshakeFailed { .. }) = client
+                    .connect(peer, query_event_callback, server_name)
+                    .await
                 {
                     // error already logged
                 }
@@ -229,18 +246,22 @@ impl Provider {
         &self,
         peer: SocketAddr,
         query_event_callback: fn(&mut Connection, Duration),
+        server_name: Name,
     ) -> std::io::Result<HandshakeKind> {
         // Unconditionally request a background handshake. This schedules any re-handshaking
         // needed.
         if self.state.runtime.is_some() {
-            let _ = self.background_handshake_with(peer, query_event_callback);
+            let _ = self.background_handshake_with(peer, query_event_callback, server_name.clone());
         }
 
         if self.state.map.contains(&peer) {
             return Ok(HandshakeKind::Cached);
         }
 
-        let fut = self.state.client.connect(peer, query_event_callback);
+        let fut = self
+            .state
+            .client
+            .connect(peer, query_event_callback, server_name);
         if let Some((runtime, _)) = self.state.runtime.as_ref() {
             runtime.block_on(fut)?
         } else {
@@ -260,11 +281,17 @@ impl Provider {
         &self,
         peer: SocketAddr,
         query_event_callback: fn(&mut Connection, Duration),
+        server_name: Name,
     ) -> std::io::Result<secret::map::Peer> {
         let state = self.state.clone();
         if let Some((runtime, _)) = self.state.runtime.as_ref() {
             runtime
-                .spawn(async move { state.client.connect(peer, query_event_callback).await })
+                .spawn(async move {
+                    state
+                        .client
+                        .connect(peer, query_event_callback, server_name)
+                        .await
+                })
                 .await??;
         } else {
             return Err(std::io::Error::new(

--- a/dc/s2n-quic-dc/src/psk/client/builder.rs
+++ b/dc/s2n-quic-dc/src/psk/client/builder.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use s2n_quic::{
     provider::{event::Subscriber as Sub, tls::Provider as Prov},
+    server::Name,
     Connection,
 };
 use std::{net::SocketAddr, time::Duration};
@@ -102,6 +103,7 @@ impl<Event: s2n_quic::provider::event::Subscriber> Builder<Event> {
         tls_materials_provider: TlsProvider,
         subscriber: Subscriber,
         query_event_callback: fn(&mut Connection, Duration),
+        server_name: Name,
     ) -> Result<Provider> {
         Provider::new::<TlsProvider, Subscriber, Event>(
             addr,
@@ -110,6 +112,7 @@ impl<Event: s2n_quic::provider::event::Subscriber> Builder<Event> {
             subscriber,
             query_event_callback,
             self,
+            server_name,
         )
     }
 }


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

Instead of asking dcQUIC endpoints to always use "anyhostname" as the server name, I add a parameter to allow users to add their own SNI.

### Call-outs:

### Testing:

I test it with our system.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

