### PR TITLE
ci(clippy): create a clippy bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,6 @@ env:
 permissions:
   statuses: write
   id-token: write # This is required for requesting the JWT/OIDC
-  # clippy bot requires write permission for contents and pull-requests
-  contents: write
-  pull-requests: write
 
 jobs:
   env:
@@ -104,6 +101,11 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     needs: env
+    # clippy bot requires write permission for contents and pull-requests when creating PRs.
+    # create-pull-request action mandates this in https://github.com/marketplace/actions/create-pull-request#token
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v5
         with:
@@ -140,10 +142,10 @@ jobs:
         with:
           title: 'chore: clippy lint updates'
           body: |
-            ## Description of Change:
-            Apply new clippy lints requirements to the s2n-quic codebase.
+            ### Description of changes: 
+            Fixes new Clippy lints in the latest Rust release. For details on the new lints, see the [Rust Blog](https://blog.rust-lang.org/releases/latest).
 
-            ## Testing:
+            ### Testing:
             CI clippy test should pass.
 
   udeps:


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2643

### Description of changes: 

Enabling a automated clippy bot that will fix clippy lints update for the team. The bot will run at 8 PM PST daily, and it would run clippy fix for us and cut a PR to fix potential failure if it detects anything.

### Call-outs:

* This clippy bot will not fix everything. `cargo clippy --fix` can't fix warnings that clippy lints emit. We notice this when we attempt to handle rust 1.89.0 clippy lints: https://github.com/aws/s2n-quic/pull/2750, and https://github.com/aws/s2n-quic/pull/2748. However, it will handle most of clippy lints update for us.
* We might encounter permission issue when trying to create a PR. If so, we should follow these steps: 
https://github.com/peter-evans/create-pull-request?tab=readme-ov-file#workflow-permissions
> For repositories belonging to an organization, this setting can be managed by admins in organization settings under Actions > General > Workflow permissions.

### Testing:

1. Run success for a `pull_request` event: I cut this PR against `aws/main`. The clippy run can be found in https://github.com/aws/s2n-quic/actions/runs/17275974370/job/49032630470?pr=2782.
2. A push event, which shouldn't trigger any fixes. I tweak the clippy job setting to use beta version of rust, which should trigger some errors. I push those code to my forked main branch, which should fail, but shouldn't create PR to fix those errors: https://github.com/boquan-fang/s2n-quic/actions/runs/17276014437/job/49032775536.
3. A actual clippy bot run should cut a PR to fix those errors (a schedule event trigger is hard to test, so I change the event trigger to be `workflow_dispatch`): https://github.com/boquan-fang/s2n-quic/actions/runs/17276038882/job/49033973148.

### Verify Clippy Bot Cutting PR:

In the actual [clippy job run](https://github.com/boquan-fang/s2n-quic/actions/runs/17274348947/job/49027130922), we see the following logs which show that clippy bot is trying to fix new lints update:
```
Fixed quic/s2n-quic-tests/src/lib.rs (1 fix)
Fixed quic/s2n-quic-qns/src/tls.rs (1 fix)
```
The clippy bot cuts a PR on my forked repo: https://github.com/boquan-fang/s2n-quic/pull/1.

Although I have done testing on forked repo, we need to keep track of how it actually runs on upstream s2n-quic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

