### PR TITLE
test(s2n-quic-dc): cap fuzz_test request size if that is too large

### DIFF
--- a/dc/s2n-quic-dc/src/stream/tests/request_response.rs
+++ b/dc/s2n-quic-dc/src/stream/tests/request_response.rs
@@ -425,15 +425,27 @@ impl Harness {
     }
 }
 
-// Filter requests that are too large compared to client's or server's max_read_len
-// Timeout will happen if the request size is 100 times larger than client's or server's max_read_len
-fn filter_large_requests(
+/// Cap request sizes that are too large compared to client or server max_read_len
+///
+/// This helper function caps request sizes to 100 times the minimum max_read_len
+/// of the client or server if they exceed this limit. This prevents timeouts that
+/// can occur when processing excessively large requests.
+fn cap_large_requests(
     client: &Client,
     server: &Server,
     mut requests: Vec<Request>,
 ) -> Vec<Request> {
     let min_max_read_len = client.max_read_len.min(server.max_read_len);
-    requests.retain(|request| request.request_size <= min_max_read_len * 100);
+
+    // Set maximum request sizes to be 100 times the minimum of client or server max_read_len
+    let max_request_size = min_max_read_len * 100;
+
+    // Cap request sizes to max_request_size if they exceed it
+    for request in &mut requests {
+        if request.request_size > max_request_size {
+            request.request_size = max_request_size;
+        }
+    }
 
     requests
 }
@@ -474,13 +486,13 @@ impl Runtime {
     }
 
     fn run_with(&self, client: Client, server: Server, requests: Vec<Request>) {
-        // Filter out requests that are too large compared to client or server max_read_len
-        let filtered_requests = filter_large_requests(&client, &server, requests);
+        // Cap request sizes that are too large compared to client or server max_read_len
+        let capped_requests = cap_large_requests(&client, &server, requests);
 
         let harness = Harness {
             client,
             server,
-            requests: filtered_requests,
+            requests: capped_requests,
             protocol: self.protocol,
         };
         let client = self.client.clone();


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

Related to https://github.com/aws/s2n-quic/pull/2773.

### Description of changes: 

This PR is another approach to address the `fuzz_test` timeout in `s2n-quic-dc` (refer to https://github.com/aws/s2n-quic/pull/2773 for the previous approach). I added a helper function to filter out requests size that is 100 times larger than the minimum of client's or server's `max_read_len`.

### Call-outs:

* We can have further discussion about whether 100 times is the right amount. Should we make it larger?
* I tried to put a limit on the input generation. However, I think limiting input generation might loss lots of coverage. Also, it is not trivial to do. Inputs for this fuzz_test are generated completely independent from each other:

https://github.com/aws/s2n-quic/blob/a1e763c1be088efc04c5ce1bfe8d670558048b9f/dc/s2n-quic-dc/src/stream/tests/request_response.rs#L54-L62

https://github.com/aws/s2n-quic/blob/a1e763c1be088efc04c5ce1bfe8d670558048b9f/dc/s2n-quic-dc/src/stream/tests/request_response.rs#L74-L85

https://github.com/aws/s2n-quic/blob/a1e763c1be088efc04c5ce1bfe8d670558048b9f/dc/s2n-quic-dc/src/stream/tests/request_response.rs#L117-L126

It is not easier to put such limit during input generation. Hence, I believe filtering out request size that are too large is the right way.

### Testing:

CI tests, and we shouldn't encounter this test timeout for the same reason again.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

