### PR TITLE
ci: Fixes typo in metrics feature

### DIFF
--- a/dc/s2n-quic-dc/events/acceptor.rs
+++ b/dc/s2n-quic-dc/events/acceptor.rs
@@ -240,7 +240,7 @@ struct AcceptorUdpPacketReceived<'a> {
     is_zero_offset: bool,
 
     /// If the packet is a retransmission
-    #[bool_counter("is_retransmisson")]
+    #[bool_counter("is_retransmission")]
     is_retransmission: bool,
 
     /// If the packet includes the final bytes of the stream

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -226,7 +226,7 @@ static INFO: &[Info; 238usize] = &[
     .build(),
     info::Builder {
         id: 35usize,
-        name: Str::new("acceptor_udp_packet_received.is_retransmisson\0"),
+        name: Str::new("acceptor_udp_packet_received.is_retransmission\0"),
         units: Units::None,
     }
     .build(),

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -277,7 +277,7 @@ mod counter {
                     19usize => Self(acceptor_tcp_packet_received__is_fin),
                     20usize => Self(acceptor_tcp_packet_received__is_fin_known),
                     34usize => Self(acceptor_udp_packet_received__is_zero_offset),
-                    35usize => Self(acceptor_udp_packet_received__is_retransmisson),
+                    35usize => Self(acceptor_udp_packet_received__is_retransmission),
                     36usize => Self(acceptor_udp_packet_received__is_fin),
                     37usize => Self(acceptor_udp_packet_received__is_fin_known),
                     84usize => Self(stream_write_shutdown__background),
@@ -306,8 +306,8 @@ mod counter {
                 fn acceptor_tcp_packet_received__is_fin_known(value: bool);
                 # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_zero_offset]
                 fn acceptor_udp_packet_received__is_zero_offset(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_retransmisson]
-                fn acceptor_udp_packet_received__is_retransmisson(value: bool);
+                # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_retransmission]
+                fn acceptor_udp_packet_received__is_retransmission(value: bool);
                 # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_fin]
                 fn acceptor_udp_packet_received__is_fin(value: bool);
                 # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_fin_known]


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

N/A

### Description of changes: 

Fixes a typo. Technically this is a breaking change since it touches a metric name, however, we do not believe anyone has consumed this metric yet as it is for the dc quic crate.

### Call-outs:

N/A

### Testing:

CI should pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

