### PR TITLE
test(s2n-events): Generate test events system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -669,23 +669,17 @@ jobs:
         with:
           submodules: true
 
-      # nightly features are used for formatting
-      - name: Install rust nightly toolchain
-        id: nightly-toolchain
+      - name: Install rust toolchain
+        id: toolchain
         run: |
-          rustup toolchain install nightly --component rustfmt
-
-      - name: Install rust stable toolchain
-        id: stable-toolchain
-        run: |
-          rustup toolchain install stable
-          rustup override set stable
+          rustup toolchain install ${{ env.RUST_NIGHTLY_TOOLCHAIN }} --profile minimal --component rustfmt
+          rustup override set ${{ env.RUST_NIGHTLY_TOOLCHAIN }}
 
       - uses: camshaft/rust-cache@v1
 
       - name: format
         working-directory: ./tools/s2n-events
-        run: cargo +nightly fmt -- --check
+        run: cargo fmt -- --check
 
       - name: generate test events
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -687,6 +687,15 @@ jobs:
         working-directory: ./tools/s2n-events
         run: cargo +nightly fmt -- --check
 
+      - name: generate test events
+        run: |
+          cargo run --manifest-path ./tools/s2n-events/Cargo.toml
+
+      - name: ensure test events are up to date
+        run: |
+          # If this fails you need to run `cargo run --manifest-path ./tools/s2n-events/Cargo.toml`
+          git diff --exit-code
+
       - name: test
         working-directory: ./tools/s2n-events
         run: cargo test

--- a/tools/s2n-events/Cargo.toml
+++ b/tools/s2n-events/Cargo.toml
@@ -9,6 +9,9 @@ license = "Apache-2.0"
 # This is a commit-time crate and should not be published
 publish = false
 
+[features]
+testing = []
+
 [dependencies]
 glob = "0.3"
 heck = "0.5"
@@ -18,3 +21,7 @@ syn = { version = "2", features = ["full", "extra-traits"] }
 
 [workspace]
 members = ["."]
+
+[dev-dependencies]
+s2n-quic-core = { path = "../../quic/s2n-quic-core", features = ["testing"] }
+tracing = { version = "0.1" }

--- a/tools/s2n-events/src/bin/generate_test_events.rs
+++ b/tools/s2n-events/src/bin/generate_test_events.rs
@@ -1,0 +1,97 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use proc_macro2::TokenStream;
+use quote::quote;
+use s2n_events::{parser, validation, Output, Result};
+
+struct EventInfo<'a> {
+    input_path: &'a str,
+    output_path: &'a str,
+    crate_name: &'a str,
+    s2n_quic_core_path: TokenStream,
+    builder: TokenStream,
+    tracing_subscriber_def: TokenStream,
+}
+
+impl EventInfo<'_> {
+    fn test_c_ffi_events() -> Self {
+        let tracing_subscriber_def = quote!(
+        /// Emits events with [`tracing`](https://docs.rs/tracing)
+        #[derive(Clone, Debug)]
+        pub struct Subscriber {
+            root: tracing::Span,
+        }
+
+        impl Default for Subscriber {
+            fn default() -> Self {
+                let root = tracing::span!(target: "c_ffi_events_test", tracing::Level::DEBUG, "c_ffi_events_test");
+
+                Self {
+                    root,
+                }
+            }
+        }
+
+        impl Subscriber {
+            fn parent<M: crate::event::Meta>(&self, _meta: &M) -> Option<tracing::Id> {
+                self.root.id()
+            }
+        }
+        );
+
+        EventInfo {
+            crate_name: "c_ffi_events",
+            input_path: concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/tests/c_ffi_events/events/**/*.rs"
+            ),
+            output_path: concat!(env!("CARGO_MANIFEST_DIR"), "/tests/c_ffi_events/event"),
+            s2n_quic_core_path: quote!(s2n_quic_core),
+            builder: quote! {
+                pub use s2n_quic_core::event::builder::SocketAddress;
+            },
+            tracing_subscriber_def,
+        }
+    }
+}
+
+fn main() -> Result<()> {
+    let event_paths = [EventInfo::test_c_ffi_events()];
+
+    for event_info in event_paths {
+        let mut files = vec![];
+
+        let input_path = event_info.input_path;
+
+        for path in glob::glob(input_path)? {
+            let path = path?;
+            eprintln!("loading {}", path.canonicalize().unwrap().display());
+            let file = std::fs::read_to_string(&path)?;
+            files.push(parser::parse(&file, path).unwrap());
+        }
+
+        // make sure events are in a deterministic order
+        files.sort_by(|a, b| a.path.as_os_str().cmp(b.path.as_os_str()));
+
+        // validate the events
+        validation::validate(&files);
+
+        let root = std::path::Path::new(event_info.output_path);
+        let _ = std::fs::create_dir_all(root);
+        let root = root.canonicalize()?;
+
+        let mut output = Output {
+            s2n_quic_core_path: event_info.s2n_quic_core_path,
+            builders: event_info.builder,
+            tracing_subscriber_def: event_info.tracing_subscriber_def,
+            crate_name: event_info.crate_name,
+            root,
+            ..Default::default()
+        };
+
+        output.generate(&files);
+    }
+
+    Ok(())
+}

--- a/tools/s2n-events/tests/c_ffi_events/event.rs
+++ b/tools/s2n-events/tests/c_ffi_events/event.rs
@@ -1,0 +1,44 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub use s2n_quic_core::event::{Event, IntoEvent, Timestamp};
+
+#[cfg(any(test, feature = "testing"))]
+use s2n_quic_core::event::snapshot;
+
+pub trait Meta: core::fmt::Debug {
+    fn subject(&self) -> api::Subject;
+}
+
+impl Meta for api::ConnectionMeta {
+    fn subject(&self) -> api::Subject {
+        builder::Subject::Connection { id: self.id }.into_event()
+    }
+}
+
+impl Meta for api::EndpointMeta {
+    fn subject(&self) -> api::Subject {
+        builder::Subject::Endpoint {}.into_event()
+    }
+}
+
+mod generated;
+pub use generated::*;
+pub use s2n_quic_core::time::Duration;
+
+pub mod metrics {
+    pub use crate::event::generated::metrics::*;
+    pub use s2n_quic_core::event::metrics::Recorder;
+
+    pub mod aggregate {
+        pub use crate::event::generated::metrics::aggregate::*;
+        pub use s2n_quic_core::event::metrics::aggregate::{
+            info, AsVariant, BoolRecorder, Info, Metric, NominalRecorder, Recorder, Registry, Units,
+        };
+
+        pub mod probe {
+            pub use crate::event::generated::metrics::probe::*;
+            pub use s2n_quic_core::event::metrics::aggregate::probe::dynamic;
+        }
+    }
+}

--- a/tools/s2n-events/tests/c_ffi_events/event/generated.rs
+++ b/tools/s2n-events/tests/c_ffi_events/event/generated.rs
@@ -1,0 +1,1004 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// DO NOT MODIFY THIS FILE
+// This file was generated with the `s2n-events` crate and any required
+// changes should be made there.
+
+#![allow(clippy::needless_lifetimes)]
+use super::*;
+pub(crate) mod metrics;
+pub mod api {
+    #![doc = r" This module contains events that are emitted to the [`Subscriber`](crate::event::Subscriber)"]
+    use super::*;
+    #[allow(unused_imports)]
+    use crate::event::metrics::aggregate;
+    pub use traits::Subscriber;
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub struct ConnectionMeta {
+        pub id: u64,
+        pub timestamp: Timestamp,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl crate::event::snapshot::Fmt for ConnectionMeta {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("ConnectionMeta");
+            fmt.field("id", &self.id);
+            fmt.field("timestamp", &self.timestamp);
+            fmt.finish()
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub struct EndpointMeta {}
+    #[cfg(any(test, feature = "testing"))]
+    impl crate::event::snapshot::Fmt for EndpointMeta {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("EndpointMeta");
+            fmt.finish()
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub struct ConnectionInfo {}
+    #[cfg(any(test, feature = "testing"))]
+    impl crate::event::snapshot::Fmt for ConnectionInfo {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("ConnectionInfo");
+            fmt.finish()
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub enum Subject {
+        #[non_exhaustive]
+        Endpoint {},
+        #[non_exhaustive]
+        Connection { id: u64 },
+    }
+    impl aggregate::AsVariant for Subject {
+        const VARIANTS: &'static [aggregate::info::Variant] = &[
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("ENDPOINT\0"),
+                id: 0usize,
+            }
+            .build(),
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("CONNECTION\0"),
+                id: 1usize,
+            }
+            .build(),
+        ];
+        #[inline]
+        fn variant_idx(&self) -> usize {
+            match self {
+                Self::Endpoint { .. } => 0usize,
+                Self::Connection { .. } => 1usize,
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub struct ByteArrayEvent<'a> {
+        pub data: &'a [u8],
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for ByteArrayEvent<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("ByteArrayEvent");
+            fmt.field("data", &self.data);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for ByteArrayEvent<'a> {
+        const NAME: &'static str = "byte_array_event";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub struct EnumEvent {
+        pub value: TestEnum,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl crate::event::snapshot::Fmt for EnumEvent {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("EnumEvent");
+            fmt.field("value", &self.value);
+            fmt.finish()
+        }
+    }
+    impl Event for EnumEvent {
+        const NAME: &'static str = "enum_event";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub enum TestEnum {
+        #[non_exhaustive]
+        TestValue1 {},
+        #[non_exhaustive]
+        TestValue2 {},
+    }
+    impl aggregate::AsVariant for TestEnum {
+        const VARIANTS: &'static [aggregate::info::Variant] = &[
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("TEST_VALUE1\0"),
+                id: 0usize,
+            }
+            .build(),
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("TEST_VALUE2\0"),
+                id: 1usize,
+            }
+            .build(),
+        ];
+        #[inline]
+        fn variant_idx(&self) -> usize {
+            match self {
+                Self::TestValue1 { .. } => 0usize,
+                Self::TestValue2 { .. } => 1usize,
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub struct CountEvent {
+        pub count: u32,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl crate::event::snapshot::Fmt for CountEvent {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("CountEvent");
+            fmt.field("count", &self.count);
+            fmt.finish()
+        }
+    }
+    impl Event for CountEvent {
+        const NAME: &'static str = "count_event";
+    }
+}
+pub mod tracing {
+    #![doc = r" This module contains event integration with [`tracing`](https://docs.rs/tracing)"]
+    use super::api;
+    #[doc = r" Emits events with [`tracing`](https://docs.rs/tracing)"]
+    #[derive(Clone, Debug)]
+    pub struct Subscriber {
+        root: tracing::Span,
+    }
+    impl Default for Subscriber {
+        fn default() -> Self {
+            let root = tracing :: span ! (target : "c_ffi_events_test" , tracing :: Level :: DEBUG , "c_ffi_events_test");
+            Self { root }
+        }
+    }
+    impl Subscriber {
+        fn parent<M: crate::event::Meta>(&self, _meta: &M) -> Option<tracing::Id> {
+            self.root.id()
+        }
+    }
+    impl super::Subscriber for Subscriber {
+        type ConnectionContext = tracing::Span;
+        fn create_connection_context(
+            &mut self,
+            meta: &api::ConnectionMeta,
+            _info: &api::ConnectionInfo,
+        ) -> Self::ConnectionContext {
+            let parent = self.parent(meta);
+            tracing :: span ! (target : "c_ffi_events" , parent : parent , tracing :: Level :: DEBUG , "conn" , id = meta . id)
+        }
+        #[inline]
+        fn on_byte_array_event(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            _meta: &api::ConnectionMeta,
+            event: &api::ByteArrayEvent,
+        ) {
+            let id = context.id();
+            let api::ByteArrayEvent { data } = event;
+            tracing :: event ! (target : "byte_array_event" , parent : id , tracing :: Level :: DEBUG , { data = tracing :: field :: debug (data) });
+        }
+        #[inline]
+        fn on_enum_event(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            _meta: &api::ConnectionMeta,
+            event: &api::EnumEvent,
+        ) {
+            let id = context.id();
+            let api::EnumEvent { value } = event;
+            tracing :: event ! (target : "enum_event" , parent : id , tracing :: Level :: DEBUG , { value = tracing :: field :: debug (value) });
+        }
+        #[inline]
+        fn on_count_event(&mut self, meta: &api::EndpointMeta, event: &api::CountEvent) {
+            let parent = self.parent(meta);
+            let api::CountEvent { count } = event;
+            tracing :: event ! (target : "count_event" , parent : parent , tracing :: Level :: DEBUG , { count = tracing :: field :: debug (count) });
+        }
+    }
+}
+pub mod builder {
+    use super::*;
+    pub use s2n_quic_core::event::builder::SocketAddress;
+    #[derive(Clone, Debug)]
+    pub struct ConnectionMeta {
+        pub id: u64,
+        pub timestamp: Timestamp,
+    }
+    impl IntoEvent<api::ConnectionMeta> for ConnectionMeta {
+        #[inline]
+        fn into_event(self) -> api::ConnectionMeta {
+            let ConnectionMeta { id, timestamp } = self;
+            api::ConnectionMeta {
+                id: id.into_event(),
+                timestamp: timestamp.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct EndpointMeta {}
+    impl IntoEvent<api::EndpointMeta> for EndpointMeta {
+        #[inline]
+        fn into_event(self) -> api::EndpointMeta {
+            let EndpointMeta {} = self;
+            api::EndpointMeta {}
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct ConnectionInfo {}
+    impl IntoEvent<api::ConnectionInfo> for ConnectionInfo {
+        #[inline]
+        fn into_event(self) -> api::ConnectionInfo {
+            let ConnectionInfo {} = self;
+            api::ConnectionInfo {}
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub enum Subject {
+        Endpoint,
+        Connection { id: u64 },
+    }
+    impl IntoEvent<api::Subject> for Subject {
+        #[inline]
+        fn into_event(self) -> api::Subject {
+            use api::Subject::*;
+            match self {
+                Self::Endpoint => Endpoint {},
+                Self::Connection { id } => Connection {
+                    id: id.into_event(),
+                },
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct ByteArrayEvent<'a> {
+        pub data: &'a [u8],
+    }
+    impl<'a> IntoEvent<api::ByteArrayEvent<'a>> for ByteArrayEvent<'a> {
+        #[inline]
+        fn into_event(self) -> api::ByteArrayEvent<'a> {
+            let ByteArrayEvent { data } = self;
+            api::ByteArrayEvent {
+                data: data.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct EnumEvent {
+        pub value: TestEnum,
+    }
+    impl IntoEvent<api::EnumEvent> for EnumEvent {
+        #[inline]
+        fn into_event(self) -> api::EnumEvent {
+            let EnumEvent { value } = self;
+            api::EnumEvent {
+                value: value.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub enum TestEnum {
+        TestValue1,
+        TestValue2,
+    }
+    impl IntoEvent<api::TestEnum> for TestEnum {
+        #[inline]
+        fn into_event(self) -> api::TestEnum {
+            use api::TestEnum::*;
+            match self {
+                Self::TestValue1 => TestValue1 {},
+                Self::TestValue2 => TestValue2 {},
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct CountEvent {
+        pub count: u32,
+    }
+    impl IntoEvent<api::CountEvent> for CountEvent {
+        #[inline]
+        fn into_event(self) -> api::CountEvent {
+            let CountEvent { count } = self;
+            api::CountEvent {
+                count: count.into_event(),
+            }
+        }
+    }
+}
+pub mod supervisor {
+    #![doc = r" This module contains the `supervisor::Outcome` and `supervisor::Context` for use"]
+    #![doc = r" when implementing [`Subscriber::supervisor_timeout`](crate::event::Subscriber::supervisor_timeout) and"]
+    #![doc = r" [`Subscriber::on_supervisor_timeout`](crate::event::Subscriber::on_supervisor_timeout)"]
+    #![doc = r" on a Subscriber."]
+    use crate::{
+        application,
+        event::{builder::SocketAddress, IntoEvent},
+    };
+    #[non_exhaustive]
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub enum Outcome {
+        #[doc = r" Allow the connection to remain open"]
+        Continue,
+        #[doc = r" Close the connection and notify the peer"]
+        Close { error_code: application::Error },
+        #[doc = r" Close the connection without notifying the peer"]
+        ImmediateClose { reason: &'static str },
+    }
+    impl Default for Outcome {
+        fn default() -> Self {
+            Self::Continue
+        }
+    }
+    #[non_exhaustive]
+    #[derive(Debug)]
+    pub struct Context<'a> {
+        #[doc = r" Number of handshakes that have begun but not completed"]
+        pub inflight_handshakes: usize,
+        #[doc = r" Number of open connections"]
+        pub connection_count: usize,
+        #[doc = r" The address of the peer"]
+        pub remote_address: SocketAddress<'a>,
+        #[doc = r" True if the connection is in the handshake state, false otherwise"]
+        pub is_handshaking: bool,
+    }
+    impl<'a> Context<'a> {
+        pub fn new(
+            inflight_handshakes: usize,
+            connection_count: usize,
+            remote_address: &'a crate::inet::SocketAddress,
+            is_handshaking: bool,
+        ) -> Self {
+            Self {
+                inflight_handshakes,
+                connection_count,
+                remote_address: remote_address.into_event(),
+                is_handshaking,
+            }
+        }
+    }
+}
+pub use traits::*;
+mod traits {
+    use super::*;
+    use crate::event::Meta;
+    use core::fmt;
+    use s2n_quic_core::query;
+    #[doc = r" Allows for events to be subscribed to"]
+    pub trait Subscriber: 'static + Send {
+        #[doc = r" An application provided type associated with each connection."]
+        #[doc = r""]
+        #[doc = r" The context provides a mechanism for applications to provide a custom type"]
+        #[doc = r" and update it on each event, e.g. computing statistics. Each event"]
+        #[doc = r" invocation (e.g. [`Subscriber::on_packet_sent`]) also provides mutable"]
+        #[doc = r" access to the context `&mut ConnectionContext` and allows for updating the"]
+        #[doc = r" context."]
+        #[doc = r""]
+        #[doc = r" ```no_run"]
+        #[doc = r" # mod s2n_quic { pub mod provider { pub mod event {"]
+        #[doc = r" #     pub use s2n_quic_core::event::{api as events, api::ConnectionInfo, api::ConnectionMeta, Subscriber};"]
+        #[doc = r" # }}}"]
+        #[doc = r" use s2n_quic::provider::event::{"]
+        #[doc = r"     ConnectionInfo, ConnectionMeta, Subscriber, events::PacketSent"]
+        #[doc = r" };"]
+        #[doc = r""]
+        #[doc = r" pub struct MyEventSubscriber;"]
+        #[doc = r""]
+        #[doc = r" pub struct MyEventContext {"]
+        #[doc = r"     packet_sent: u64,"]
+        #[doc = r" }"]
+        #[doc = r""]
+        #[doc = r" impl Subscriber for MyEventSubscriber {"]
+        #[doc = r"     type ConnectionContext = MyEventContext;"]
+        #[doc = r""]
+        #[doc = r"     fn create_connection_context("]
+        #[doc = r"         &mut self, _meta: &ConnectionMeta,"]
+        #[doc = r"         _info: &ConnectionInfo,"]
+        #[doc = r"     ) -> Self::ConnectionContext {"]
+        #[doc = r"         MyEventContext { packet_sent: 0 }"]
+        #[doc = r"     }"]
+        #[doc = r""]
+        #[doc = r"     fn on_packet_sent("]
+        #[doc = r"         &mut self,"]
+        #[doc = r"         context: &mut Self::ConnectionContext,"]
+        #[doc = r"         _meta: &ConnectionMeta,"]
+        #[doc = r"         _event: &PacketSent,"]
+        #[doc = r"     ) {"]
+        #[doc = r"         context.packet_sent += 1;"]
+        #[doc = r"     }"]
+        #[doc = r" }"]
+        #[doc = r"  ```"]
+        type ConnectionContext: 'static + Send;
+        #[doc = r" Creates a context to be passed to each connection-related event"]
+        fn create_connection_context(
+            &mut self,
+            meta: &api::ConnectionMeta,
+            info: &api::ConnectionInfo,
+        ) -> Self::ConnectionContext;
+        #[doc = r" The period at which `on_supervisor_timeout` is called"]
+        #[doc = r""]
+        #[doc = r" If multiple `event::Subscriber`s are composed together, the minimum `supervisor_timeout`"]
+        #[doc = r" across all `event::Subscriber`s will be used."]
+        #[doc = r""]
+        #[doc = r" If the `supervisor_timeout()` is `None` across all `event::Subscriber`s, connection supervision"]
+        #[doc = r" will cease for the remaining lifetime of the connection and `on_supervisor_timeout` will no longer"]
+        #[doc = r" be called."]
+        #[doc = r""]
+        #[doc = r" It is recommended to avoid setting this value less than ~100ms, as short durations"]
+        #[doc = r" may lead to higher CPU utilization."]
+        #[allow(unused_variables)]
+        fn supervisor_timeout(
+            &mut self,
+            conn_context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            context: &supervisor::Context,
+        ) -> Option<Duration> {
+            None
+        }
+        #[doc = r" Called for each `supervisor_timeout` to determine any action to take on the connection based on the `supervisor::Outcome`"]
+        #[doc = r""]
+        #[doc = r" If multiple `event::Subscriber`s are composed together, the minimum `supervisor_timeout`"]
+        #[doc = r" across all `event::Subscriber`s will be used, and thus `on_supervisor_timeout` may be called"]
+        #[doc = r" earlier than the `supervisor_timeout` for a given `event::Subscriber` implementation."]
+        #[allow(unused_variables)]
+        fn on_supervisor_timeout(
+            &mut self,
+            conn_context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            context: &supervisor::Context,
+        ) -> supervisor::Outcome {
+            supervisor::Outcome::default()
+        }
+        #[doc = "Called when the `ByteArrayEvent` event is triggered"]
+        #[inline]
+        fn on_byte_array_event(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &api::ByteArrayEvent,
+        ) {
+            let _ = context;
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `EnumEvent` event is triggered"]
+        #[inline]
+        fn on_enum_event(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &api::EnumEvent,
+        ) {
+            let _ = context;
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `CountEvent` event is triggered"]
+        #[inline]
+        fn on_count_event(&mut self, meta: &api::EndpointMeta, event: &api::CountEvent) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = r" Called for each event that relates to the endpoint and all connections"]
+        #[inline]
+        fn on_event<M: Meta, E: Event>(&mut self, meta: &M, event: &E) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = r" Called for each event that relates to a connection"]
+        #[inline]
+        fn on_connection_event<E: Event>(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &E,
+        ) {
+            let _ = context;
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = r" Used for querying the `Subscriber::ConnectionContext` on a Subscriber"]
+        #[inline]
+        fn query(
+            context: &Self::ConnectionContext,
+            query: &mut dyn query::Query,
+        ) -> query::ControlFlow {
+            query.execute(context)
+        }
+        #[doc = r" Used for querying and mutating the `Subscriber::ConnectionContext` on a Subscriber"]
+        #[inline]
+        fn query_mut(
+            context: &mut Self::ConnectionContext,
+            query: &mut dyn query::QueryMut,
+        ) -> query::ControlFlow {
+            query.execute_mut(context)
+        }
+    }
+    #[doc = r" Subscriber is implemented for a 2-element tuple to make it easy to compose multiple"]
+    #[doc = r" subscribers."]
+    impl<A, B> Subscriber for (A, B)
+    where
+        A: Subscriber,
+        B: Subscriber,
+    {
+        type ConnectionContext = (A::ConnectionContext, B::ConnectionContext);
+        #[inline]
+        fn create_connection_context(
+            &mut self,
+            meta: &api::ConnectionMeta,
+            info: &api::ConnectionInfo,
+        ) -> Self::ConnectionContext {
+            (
+                self.0.create_connection_context(meta, info),
+                self.1.create_connection_context(meta, info),
+            )
+        }
+        #[inline]
+        fn supervisor_timeout(
+            &mut self,
+            conn_context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            context: &supervisor::Context,
+        ) -> Option<Duration> {
+            let timeout_a = self
+                .0
+                .supervisor_timeout(&mut conn_context.0, meta, context);
+            let timeout_b = self
+                .1
+                .supervisor_timeout(&mut conn_context.1, meta, context);
+            match (timeout_a, timeout_b) {
+                (None, None) => None,
+                (None, Some(timeout)) | (Some(timeout), None) => Some(timeout),
+                (Some(a), Some(b)) => Some(a.min(b)),
+            }
+        }
+        #[inline]
+        fn on_supervisor_timeout(
+            &mut self,
+            conn_context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            context: &supervisor::Context,
+        ) -> supervisor::Outcome {
+            let outcome_a = self
+                .0
+                .on_supervisor_timeout(&mut conn_context.0, meta, context);
+            let outcome_b = self
+                .1
+                .on_supervisor_timeout(&mut conn_context.1, meta, context);
+            match (outcome_a, outcome_b) {
+                (supervisor::Outcome::ImmediateClose { reason }, _)
+                | (_, supervisor::Outcome::ImmediateClose { reason }) => {
+                    supervisor::Outcome::ImmediateClose { reason }
+                }
+                (supervisor::Outcome::Close { error_code }, _)
+                | (_, supervisor::Outcome::Close { error_code }) => {
+                    supervisor::Outcome::Close { error_code }
+                }
+                _ => supervisor::Outcome::Continue,
+            }
+        }
+        #[inline]
+        fn on_byte_array_event(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &api::ByteArrayEvent,
+        ) {
+            (self.0).on_byte_array_event(&mut context.0, meta, event);
+            (self.1).on_byte_array_event(&mut context.1, meta, event);
+        }
+        #[inline]
+        fn on_enum_event(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &api::EnumEvent,
+        ) {
+            (self.0).on_enum_event(&mut context.0, meta, event);
+            (self.1).on_enum_event(&mut context.1, meta, event);
+        }
+        #[inline]
+        fn on_count_event(&mut self, meta: &api::EndpointMeta, event: &api::CountEvent) {
+            (self.0).on_count_event(meta, event);
+            (self.1).on_count_event(meta, event);
+        }
+        #[inline]
+        fn on_event<M: Meta, E: Event>(&mut self, meta: &M, event: &E) {
+            self.0.on_event(meta, event);
+            self.1.on_event(meta, event);
+        }
+        #[inline]
+        fn on_connection_event<E: Event>(
+            &mut self,
+            context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &E,
+        ) {
+            self.0.on_connection_event(&mut context.0, meta, event);
+            self.1.on_connection_event(&mut context.1, meta, event);
+        }
+        #[inline]
+        fn query(
+            context: &Self::ConnectionContext,
+            query: &mut dyn query::Query,
+        ) -> query::ControlFlow {
+            query
+                .execute(context)
+                .and_then(|| A::query(&context.0, query))
+                .and_then(|| B::query(&context.1, query))
+        }
+        #[inline]
+        fn query_mut(
+            context: &mut Self::ConnectionContext,
+            query: &mut dyn query::QueryMut,
+        ) -> query::ControlFlow {
+            query
+                .execute_mut(context)
+                .and_then(|| A::query_mut(&mut context.0, query))
+                .and_then(|| B::query_mut(&mut context.1, query))
+        }
+    }
+    pub trait EndpointPublisher {
+        #[doc = "Publishes a `CountEvent` event to the publisher's subscriber"]
+        fn on_count_event(&mut self, event: builder::CountEvent);
+        #[doc = r" Returns the QUIC version, if any"]
+        fn quic_version(&self) -> Option<u32>;
+    }
+    pub struct EndpointPublisherSubscriber<'a, Sub: Subscriber> {
+        meta: api::EndpointMeta,
+        quic_version: Option<u32>,
+        subscriber: &'a mut Sub,
+    }
+    impl<'a, Sub: Subscriber> fmt::Debug for EndpointPublisherSubscriber<'a, Sub> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.debug_struct("ConnectionPublisherSubscriber")
+                .field("meta", &self.meta)
+                .field("quic_version", &self.quic_version)
+                .finish()
+        }
+    }
+    impl<'a, Sub: Subscriber> EndpointPublisherSubscriber<'a, Sub> {
+        #[inline]
+        pub fn new(
+            meta: builder::EndpointMeta,
+            quic_version: Option<u32>,
+            subscriber: &'a mut Sub,
+        ) -> Self {
+            Self {
+                meta: meta.into_event(),
+                quic_version,
+                subscriber,
+            }
+        }
+    }
+    impl<'a, Sub: Subscriber> EndpointPublisher for EndpointPublisherSubscriber<'a, Sub> {
+        #[inline]
+        fn on_count_event(&mut self, event: builder::CountEvent) {
+            let event = event.into_event();
+            self.subscriber.on_count_event(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn quic_version(&self) -> Option<u32> {
+            self.quic_version
+        }
+    }
+    pub trait ConnectionPublisher {
+        #[doc = "Publishes a `ByteArrayEvent` event to the publisher's subscriber"]
+        fn on_byte_array_event(&mut self, event: builder::ByteArrayEvent);
+        #[doc = "Publishes a `EnumEvent` event to the publisher's subscriber"]
+        fn on_enum_event(&mut self, event: builder::EnumEvent);
+        #[doc = r" Returns the QUIC version negotiated for the current connection, if any"]
+        fn quic_version(&self) -> u32;
+        #[doc = r" Returns the [`Subject`] for the current publisher"]
+        fn subject(&self) -> api::Subject;
+    }
+    pub struct ConnectionPublisherSubscriber<'a, Sub: Subscriber> {
+        meta: api::ConnectionMeta,
+        quic_version: u32,
+        subscriber: &'a mut Sub,
+        context: &'a mut Sub::ConnectionContext,
+    }
+    impl<'a, Sub: Subscriber> fmt::Debug for ConnectionPublisherSubscriber<'a, Sub> {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.debug_struct("ConnectionPublisherSubscriber")
+                .field("meta", &self.meta)
+                .field("quic_version", &self.quic_version)
+                .finish()
+        }
+    }
+    impl<'a, Sub: Subscriber> ConnectionPublisherSubscriber<'a, Sub> {
+        #[inline]
+        pub fn new(
+            meta: builder::ConnectionMeta,
+            quic_version: u32,
+            subscriber: &'a mut Sub,
+            context: &'a mut Sub::ConnectionContext,
+        ) -> Self {
+            Self {
+                meta: meta.into_event(),
+                quic_version,
+                subscriber,
+                context,
+            }
+        }
+    }
+    impl<'a, Sub: Subscriber> ConnectionPublisher for ConnectionPublisherSubscriber<'a, Sub> {
+        #[inline]
+        fn on_byte_array_event(&mut self, event: builder::ByteArrayEvent) {
+            let event = event.into_event();
+            self.subscriber
+                .on_byte_array_event(self.context, &self.meta, &event);
+            self.subscriber
+                .on_connection_event(self.context, &self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_enum_event(&mut self, event: builder::EnumEvent) {
+            let event = event.into_event();
+            self.subscriber
+                .on_enum_event(self.context, &self.meta, &event);
+            self.subscriber
+                .on_connection_event(self.context, &self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn quic_version(&self) -> u32 {
+            self.quic_version
+        }
+        #[inline]
+        fn subject(&self) -> api::Subject {
+            self.meta.subject()
+        }
+    }
+}
+#[cfg(any(test, feature = "testing"))]
+pub mod testing {
+    use super::*;
+    use crate::event::snapshot::Location;
+    pub mod endpoint {
+        use super::*;
+        pub struct Subscriber {
+            location: Option<Location>,
+            output: Vec<String>,
+            pub count_event: u64,
+        }
+        impl Drop for Subscriber {
+            fn drop(&mut self) {
+                if std::thread::panicking() {
+                    return;
+                }
+                if let Some(location) = self.location.as_ref() {
+                    location.snapshot_log(&self.output);
+                }
+            }
+        }
+        impl Subscriber {
+            #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+            #[track_caller]
+            pub fn snapshot() -> Self {
+                let mut sub = Self::no_snapshot();
+                sub.location = Location::from_thread_name();
+                sub
+            }
+            #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+            #[track_caller]
+            pub fn named_snapshot<Name: core::fmt::Display>(name: Name) -> Self {
+                let mut sub = Self::no_snapshot();
+                sub.location = Some(Location::new(name));
+                sub
+            }
+            #[doc = r" Creates a subscriber with snapshot assertions disabled"]
+            pub fn no_snapshot() -> Self {
+                Self {
+                    location: None,
+                    output: Default::default(),
+                    count_event: 0,
+                }
+            }
+        }
+        impl super::super::Subscriber for Subscriber {
+            type ConnectionContext = ();
+            fn create_connection_context(
+                &mut self,
+                _meta: &api::ConnectionMeta,
+                _info: &api::ConnectionInfo,
+            ) -> Self::ConnectionContext {
+            }
+            fn on_count_event(&mut self, meta: &api::EndpointMeta, event: &api::CountEvent) {
+                self.count_event += 1;
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.push(out);
+            }
+        }
+    }
+    #[derive(Debug)]
+    pub struct Subscriber {
+        location: Option<Location>,
+        output: Vec<String>,
+        pub byte_array_event: u64,
+        pub enum_event: u64,
+        pub count_event: u64,
+    }
+    impl Drop for Subscriber {
+        fn drop(&mut self) {
+            if std::thread::panicking() {
+                return;
+            }
+            if let Some(location) = self.location.as_ref() {
+                location.snapshot_log(&self.output);
+            }
+        }
+    }
+    impl Subscriber {
+        #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+        #[track_caller]
+        pub fn snapshot() -> Self {
+            let mut sub = Self::no_snapshot();
+            sub.location = Location::from_thread_name();
+            sub
+        }
+        #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+        #[track_caller]
+        pub fn named_snapshot<Name: core::fmt::Display>(name: Name) -> Self {
+            let mut sub = Self::no_snapshot();
+            sub.location = Some(Location::new(name));
+            sub
+        }
+        #[doc = r" Creates a subscriber with snapshot assertions disabled"]
+        pub fn no_snapshot() -> Self {
+            Self {
+                location: None,
+                output: Default::default(),
+                byte_array_event: 0,
+                enum_event: 0,
+                count_event: 0,
+            }
+        }
+    }
+    impl super::Subscriber for Subscriber {
+        type ConnectionContext = ();
+        fn create_connection_context(
+            &mut self,
+            _meta: &api::ConnectionMeta,
+            _info: &api::ConnectionInfo,
+        ) -> Self::ConnectionContext {
+        }
+        fn on_byte_array_event(
+            &mut self,
+            _context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &api::ByteArrayEvent,
+        ) {
+            self.byte_array_event += 1;
+            if self.location.is_some() {
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.push(out);
+            }
+        }
+        fn on_enum_event(
+            &mut self,
+            _context: &mut Self::ConnectionContext,
+            meta: &api::ConnectionMeta,
+            event: &api::EnumEvent,
+        ) {
+            self.enum_event += 1;
+            if self.location.is_some() {
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.push(out);
+            }
+        }
+        fn on_count_event(&mut self, meta: &api::EndpointMeta, event: &api::CountEvent) {
+            self.count_event += 1;
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.push(out);
+        }
+    }
+    #[derive(Debug)]
+    pub struct Publisher {
+        location: Option<Location>,
+        output: Vec<String>,
+        pub byte_array_event: u64,
+        pub enum_event: u64,
+        pub count_event: u64,
+    }
+    impl Publisher {
+        #[doc = r" Creates a publisher with snapshot assertions enabled"]
+        #[track_caller]
+        pub fn snapshot() -> Self {
+            let mut sub = Self::no_snapshot();
+            sub.location = Location::from_thread_name();
+            sub
+        }
+        #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+        #[track_caller]
+        pub fn named_snapshot<Name: core::fmt::Display>(name: Name) -> Self {
+            let mut sub = Self::no_snapshot();
+            sub.location = Some(Location::new(name));
+            sub
+        }
+        #[doc = r" Creates a publisher with snapshot assertions disabled"]
+        pub fn no_snapshot() -> Self {
+            Self {
+                location: None,
+                output: Default::default(),
+                byte_array_event: 0,
+                enum_event: 0,
+                count_event: 0,
+            }
+        }
+    }
+    impl super::EndpointPublisher for Publisher {
+        fn on_count_event(&mut self, event: builder::CountEvent) {
+            self.count_event += 1;
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.push(out);
+        }
+        fn quic_version(&self) -> Option<u32> {
+            Some(1)
+        }
+    }
+    impl super::ConnectionPublisher for Publisher {
+        fn on_byte_array_event(&mut self, event: builder::ByteArrayEvent) {
+            self.byte_array_event += 1;
+            let event = event.into_event();
+            if self.location.is_some() {
+                let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+                let out = format!("{event:?}");
+                self.output.push(out);
+            }
+        }
+        fn on_enum_event(&mut self, event: builder::EnumEvent) {
+            self.enum_event += 1;
+            let event = event.into_event();
+            if self.location.is_some() {
+                let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+                let out = format!("{event:?}");
+                self.output.push(out);
+            }
+        }
+        fn quic_version(&self) -> u32 {
+            1
+        }
+        fn subject(&self) -> api::Subject {
+            builder::Subject::Connection { id: 0 }.into_event()
+        }
+    }
+    impl Drop for Publisher {
+        fn drop(&mut self) {
+            if std::thread::panicking() {
+                return;
+            }
+            if let Some(location) = self.location.as_ref() {
+                location.snapshot_log(&self.output);
+            }
+        }
+    }
+}

--- a/tools/s2n-events/tests/c_ffi_events/event/generated/metrics.rs
+++ b/tools/s2n-events/tests/c_ffi_events/event/generated/metrics.rs
@@ -1,0 +1,85 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// DO NOT MODIFY THIS FILE
+// This file was generated with the `s2n-events` crate and any required
+// changes should be made there.
+
+use crate::event::{self, api, metrics::Recorder};
+pub(crate) mod aggregate;
+pub(crate) mod probe;
+#[derive(Debug)]
+pub struct Subscriber<S: event::Subscriber>
+where
+    S::ConnectionContext: Recorder,
+{
+    subscriber: S,
+}
+impl<S: event::Subscriber> Subscriber<S>
+where
+    S::ConnectionContext: Recorder,
+{
+    pub fn new(subscriber: S) -> Self {
+        Self { subscriber }
+    }
+}
+pub struct Context<R: Recorder> {
+    recorder: R,
+    byte_array_event: u64,
+    enum_event: u64,
+}
+impl<R: Recorder> Context<R> {
+    pub fn inner(&self) -> &R {
+        &self.recorder
+    }
+    pub fn inner_mut(&mut self) -> &mut R {
+        &mut self.recorder
+    }
+}
+impl<S: event::Subscriber> event::Subscriber for Subscriber<S>
+where
+    S::ConnectionContext: Recorder,
+{
+    type ConnectionContext = Context<S::ConnectionContext>;
+    fn create_connection_context(
+        &mut self,
+        meta: &api::ConnectionMeta,
+        info: &api::ConnectionInfo,
+    ) -> Self::ConnectionContext {
+        Context {
+            recorder: self.subscriber.create_connection_context(meta, info),
+            byte_array_event: 0,
+            enum_event: 0,
+        }
+    }
+    #[inline]
+    fn on_byte_array_event(
+        &mut self,
+        context: &mut Self::ConnectionContext,
+        meta: &api::ConnectionMeta,
+        event: &api::ByteArrayEvent,
+    ) {
+        context.byte_array_event += 1;
+        self.subscriber
+            .on_byte_array_event(&mut context.recorder, meta, event);
+    }
+    #[inline]
+    fn on_enum_event(
+        &mut self,
+        context: &mut Self::ConnectionContext,
+        meta: &api::ConnectionMeta,
+        event: &api::EnumEvent,
+    ) {
+        context.enum_event += 1;
+        self.subscriber
+            .on_enum_event(&mut context.recorder, meta, event);
+    }
+}
+impl<R: Recorder> Drop for Context<R> {
+    fn drop(&mut self) {
+        self.recorder
+            .increment_counter("byte_array_event", self.byte_array_event as _);
+        self.recorder
+            .increment_counter("enum_event", self.enum_event as _);
+    }
+}

--- a/tools/s2n-events/tests/c_ffi_events/event/generated/metrics/aggregate.rs
+++ b/tools/s2n-events/tests/c_ffi_events/event/generated/metrics/aggregate.rs
@@ -1,0 +1,295 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// DO NOT MODIFY THIS FILE
+// This file was generated with the `s2n-events` crate and any required
+// changes should be made there.
+
+use crate::event::{
+    self, api,
+    metrics::aggregate::{
+        info::{self, Str},
+        AsVariant, BoolRecorder, Info, Metric, NominalRecorder, Recorder, Registry, Units,
+    },
+};
+static INFO: &[Info; 4usize] = &[
+    info::Builder {
+        id: 0usize,
+        name: Str::new("byte_array_event\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 1usize,
+        name: Str::new("enum_event\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 2usize,
+        name: Str::new("enum_event.value\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 3usize,
+        name: Str::new("count_event\0"),
+        units: Units::None,
+    }
+    .build(),
+];
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct ConnectionContext {
+    start_time: crate::event::Timestamp,
+}
+pub struct Subscriber<R: Registry> {
+    #[allow(dead_code)]
+    counters: Box<[R::Counter; 3usize]>,
+    #[allow(dead_code)]
+    bool_counters: Box<[R::BoolCounter; 0usize]>,
+    #[allow(dead_code)]
+    nominal_counters: Box<[R::NominalCounter]>,
+    #[allow(dead_code)]
+    nominal_counter_offsets: Box<[usize; 1usize]>,
+    #[allow(dead_code)]
+    measures: Box<[R::Measure; 0usize]>,
+    #[allow(dead_code)]
+    gauges: Box<[R::Gauge; 0usize]>,
+    #[allow(dead_code)]
+    timers: Box<[R::Timer; 0usize]>,
+    #[allow(dead_code)]
+    nominal_timers: Box<[R::NominalTimer]>,
+    #[allow(dead_code)]
+    nominal_timer_offsets: Box<[usize; 0usize]>,
+    #[allow(dead_code)]
+    registry: R,
+}
+impl<R: Registry + Default> Default for Subscriber<R> {
+    fn default() -> Self {
+        Self::new(R::default())
+    }
+}
+impl<R: Registry> Subscriber<R> {
+    #[doc = r" Creates a new subscriber with the given registry"]
+    #[doc = r""]
+    #[doc = r" # Note"]
+    #[doc = r""]
+    #[doc = r" All of the recorders are registered on initialization and cached for the lifetime"]
+    #[doc = r" of the subscriber."]
+    #[allow(unused_mut)]
+    #[inline]
+    pub fn new(registry: R) -> Self {
+        let mut counters = Vec::with_capacity(3usize);
+        let mut bool_counters = Vec::with_capacity(0usize);
+        let mut nominal_counters = Vec::with_capacity(1usize);
+        let mut nominal_counter_offsets = Vec::with_capacity(1usize);
+        let mut measures = Vec::with_capacity(0usize);
+        let mut gauges = Vec::with_capacity(0usize);
+        let mut timers = Vec::with_capacity(0usize);
+        let mut nominal_timers = Vec::with_capacity(0usize);
+        let mut nominal_timer_offsets = Vec::with_capacity(0usize);
+        counters.push(registry.register_counter(&INFO[0usize]));
+        counters.push(registry.register_counter(&INFO[1usize]));
+        counters.push(registry.register_counter(&INFO[3usize]));
+        {
+            #[allow(unused_imports)]
+            use api::*;
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <TestEnum as AsVariant>::VARIANTS.iter() {
+                    nominal_counters
+                        .push(registry.register_nominal_counter(&INFO[2usize], variant));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+        }
+        {
+            #[allow(unused_imports)]
+            use api::*;
+        }
+        Self {
+            counters: counters
+                .try_into()
+                .unwrap_or_else(|_| panic!("invalid len")),
+            bool_counters: bool_counters
+                .try_into()
+                .unwrap_or_else(|_| panic!("invalid len")),
+            nominal_counters: nominal_counters.into(),
+            nominal_counter_offsets: nominal_counter_offsets
+                .try_into()
+                .unwrap_or_else(|_| panic!("invalid len")),
+            measures: measures
+                .try_into()
+                .unwrap_or_else(|_| panic!("invalid len")),
+            gauges: gauges.try_into().unwrap_or_else(|_| panic!("invalid len")),
+            timers: timers.try_into().unwrap_or_else(|_| panic!("invalid len")),
+            nominal_timers: nominal_timers.into(),
+            nominal_timer_offsets: nominal_timer_offsets
+                .try_into()
+                .unwrap_or_else(|_| panic!("invalid len")),
+            registry,
+        }
+    }
+    #[doc = r" Returns all of the registered counters"]
+    #[inline]
+    pub fn counters(&self) -> impl Iterator<Item = (&'static Info, &R::Counter)> + '_ {
+        self.counters
+            .iter()
+            .enumerate()
+            .map(|(idx, entry)| match idx {
+                0usize => (&INFO[0usize], entry),
+                1usize => (&INFO[1usize], entry),
+                2usize => (&INFO[3usize], entry),
+                _ => unsafe { core::hint::unreachable_unchecked() },
+            })
+    }
+    #[allow(dead_code)]
+    #[inline(always)]
+    fn count<T: Metric>(&self, info: usize, id: usize, value: T) {
+        let info = &INFO[info];
+        let counter = &self.counters[id];
+        counter.record(info, value);
+    }
+    #[doc = r" Returns all of the registered bool counters"]
+    #[inline]
+    pub fn bool_counters(&self) -> impl Iterator<Item = (&'static Info, &R::BoolCounter)> + '_ {
+        core::iter::empty()
+    }
+    #[allow(dead_code)]
+    #[inline(always)]
+    fn count_bool(&self, info: usize, id: usize, value: bool) {
+        let info = &INFO[info];
+        let counter = &self.bool_counters[id];
+        counter.record(info, value);
+    }
+    #[doc = r" Returns all of the registered nominal counters"]
+    #[inline]
+    pub fn nominal_counters(
+        &self,
+    ) -> impl Iterator<Item = (&'static Info, &[R::NominalCounter], &[info::Variant])> + '_ {
+        use api::*;
+        self.nominal_counter_offsets
+            .iter()
+            .enumerate()
+            .map(|(idx, entry)| match idx {
+                0usize => {
+                    let offset = *entry;
+                    let variants = <TestEnum as AsVariant>::VARIANTS;
+                    let entries = &self.nominal_counters[offset..offset + variants.len()];
+                    (&INFO[2usize], entries, variants)
+                }
+                _ => unsafe { core::hint::unreachable_unchecked() },
+            })
+    }
+    #[allow(dead_code)]
+    #[inline(always)]
+    fn count_nominal<T: AsVariant>(&self, info: usize, id: usize, value: &T) {
+        let info = &INFO[info];
+        let idx = self.nominal_counter_offsets[id] + value.variant_idx();
+        let counter = &self.nominal_counters[idx];
+        counter.record(info, value.as_variant(), 1usize);
+    }
+    #[doc = r" Returns all of the registered measures"]
+    #[inline]
+    pub fn measures(&self) -> impl Iterator<Item = (&'static Info, &R::Measure)> + '_ {
+        core::iter::empty()
+    }
+    #[allow(dead_code)]
+    #[inline(always)]
+    fn measure<T: Metric>(&self, info: usize, id: usize, value: T) {
+        let info = &INFO[info];
+        let measure = &self.measures[id];
+        measure.record(info, value);
+    }
+    #[doc = r" Returns all of the registered gauges"]
+    #[inline]
+    pub fn gauges(&self) -> impl Iterator<Item = (&'static Info, &R::Gauge)> + '_ {
+        core::iter::empty()
+    }
+    #[allow(dead_code)]
+    #[inline(always)]
+    fn gauge<T: Metric>(&self, info: usize, id: usize, value: T) {
+        let info = &INFO[info];
+        let gauge = &self.gauges[id];
+        gauge.record(info, value);
+    }
+    #[doc = r" Returns all of the registered timers"]
+    #[inline]
+    pub fn timers(&self) -> impl Iterator<Item = (&'static Info, &R::Timer)> + '_ {
+        core::iter::empty()
+    }
+    #[allow(dead_code)]
+    #[inline(always)]
+    fn time(&self, info: usize, id: usize, value: core::time::Duration) {
+        let info = &INFO[info];
+        let timer = &self.timers[id];
+        timer.record(info, value);
+    }
+    #[allow(dead_code)]
+    #[inline(always)]
+    fn time_nominal<T: AsVariant>(
+        &self,
+        info: usize,
+        id: usize,
+        value: &T,
+        duration: core::time::Duration,
+    ) {
+        let info = &INFO[info];
+        let idx = self.nominal_timer_offsets[id] + value.variant_idx();
+        let counter = &self.nominal_timers[idx];
+        counter.record(info, value.as_variant(), duration);
+    }
+}
+impl<R: Registry> event::Subscriber for Subscriber<R> {
+    type ConnectionContext = ConnectionContext;
+    fn create_connection_context(
+        &mut self,
+        meta: &api::ConnectionMeta,
+        _info: &api::ConnectionInfo,
+    ) -> Self::ConnectionContext {
+        Self::ConnectionContext {
+            start_time: meta.timestamp,
+        }
+    }
+    #[inline]
+    fn on_byte_array_event(
+        &mut self,
+        context: &mut Self::ConnectionContext,
+        meta: &api::ConnectionMeta,
+        event: &api::ByteArrayEvent,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(0usize, 0usize, 1usize);
+        let _ = context;
+        let _ = meta;
+        let _ = event;
+    }
+    #[inline]
+    fn on_enum_event(
+        &mut self,
+        context: &mut Self::ConnectionContext,
+        meta: &api::ConnectionMeta,
+        event: &api::EnumEvent,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(1usize, 1usize, 1usize);
+        self.count_nominal(2usize, 0usize, &event.value);
+        let _ = context;
+        let _ = meta;
+        let _ = event;
+    }
+    #[inline]
+    fn on_count_event(&mut self, meta: &api::EndpointMeta, event: &api::CountEvent) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(3usize, 2usize, 1usize);
+        let _ = event;
+        let _ = meta;
+    }
+}

--- a/tools/s2n-events/tests/c_ffi_events/event/generated/metrics/probe.rs
+++ b/tools/s2n-events/tests/c_ffi_events/event/generated/metrics/probe.rs
@@ -1,0 +1,203 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// DO NOT MODIFY THIS FILE
+// This file was generated with the `s2n-events` crate and any required
+// changes should be made there.
+
+use crate::event::metrics::aggregate::{
+    self, info, BoolRecorder, Info, NominalRecorder, Recorder as MetricRecorder,
+};
+use s2n_quic_core::probe::define;
+mod counter {
+    #![allow(non_snake_case)]
+    use super::*;
+    use crate::event::metrics::aggregate::Metric;
+    pub struct Recorder(fn(u64));
+    impl Recorder {
+        pub(crate) fn new(info: &'static Info) -> Self {
+            match info.id {
+                0usize => Self(byte_array_event),
+                1usize => Self(enum_event),
+                3usize => Self(count_event),
+                _ => unreachable!("invalid info: {info:?}"),
+            }
+        }
+    }
+    impl MetricRecorder for Recorder {
+        fn record<T: Metric>(&self, _info: &'static Info, value: T) {
+            (self.0)(value.as_u64());
+        }
+    }
+    define!(
+        extern "probe" {
+            # [link_name = c_ffi_events__event__counter__byte_array_event]
+            fn byte_array_event(value: u64);
+            # [link_name = c_ffi_events__event__counter__enum_event]
+            fn enum_event(value: u64);
+            # [link_name = c_ffi_events__event__counter__count_event]
+            fn count_event(value: u64);
+        }
+    );
+    pub mod bool {
+        #![allow(non_snake_case)]
+        use super::*;
+        pub struct Recorder(fn(bool));
+        impl Recorder {
+            pub(crate) fn new(info: &'static Info) -> Self {
+                unreachable!("invalid info: {info:?}")
+            }
+        }
+        impl BoolRecorder for Recorder {
+            fn record(&self, _info: &'static Info, value: bool) {
+                (self.0)(value);
+            }
+        }
+    }
+    pub mod nominal {
+        #![allow(non_snake_case)]
+        use super::*;
+        use crate::event::metrics::aggregate::Metric;
+        pub struct Recorder(fn(u64, u64, &info::Str));
+        impl Recorder {
+            pub(crate) fn new(info: &'static Info, _variant: &'static info::Variant) -> Self {
+                match info.id {
+                    2usize => Self(enum_event__value),
+                    _ => unreachable!("invalid info: {info:?}"),
+                }
+            }
+        }
+        impl NominalRecorder for Recorder {
+            fn record<T: Metric>(
+                &self,
+                _info: &'static Info,
+                variant: &'static info::Variant,
+                value: T,
+            ) {
+                (self.0)(value.as_u64(), variant.id as _, variant.name);
+            }
+        }
+        define!(
+            extern "probe" {
+                # [link_name = c_ffi_events__event__counter__nominal__enum_event__value]
+                fn enum_event__value(value: u64, variant: u64, variant_name: &info::Str);
+            }
+        );
+    }
+}
+mod measure {
+    #![allow(non_snake_case)]
+    use super::*;
+    use crate::event::metrics::aggregate::Metric;
+    pub struct Recorder(fn(u64));
+    impl Recorder {
+        pub(crate) fn new(info: &'static Info) -> Self {
+            unreachable!("invalid info: {info:?}")
+        }
+    }
+    impl MetricRecorder for Recorder {
+        fn record<T: Metric>(&self, _info: &'static Info, value: T) {
+            (self.0)(value.as_u64());
+        }
+    }
+}
+mod gauge {
+    #![allow(non_snake_case)]
+    use super::*;
+    use crate::event::metrics::aggregate::Metric;
+    pub struct Recorder(fn(u64));
+    impl Recorder {
+        pub(crate) fn new(info: &'static Info) -> Self {
+            unreachable!("invalid info: {info:?}")
+        }
+    }
+    impl MetricRecorder for Recorder {
+        fn record<T: Metric>(&self, _info: &'static Info, value: T) {
+            (self.0)(value.as_u64());
+        }
+    }
+}
+mod timer {
+    #![allow(non_snake_case)]
+    use super::*;
+    use crate::event::metrics::aggregate::Metric;
+    pub struct Recorder(fn(core::time::Duration));
+    impl Recorder {
+        pub(crate) fn new(info: &'static Info) -> Self {
+            unreachable!("invalid info: {info:?}")
+        }
+    }
+    impl MetricRecorder for Recorder {
+        fn record<T: Metric>(&self, _info: &'static Info, value: T) {
+            (self.0)(value.as_duration());
+        }
+    }
+    pub mod nominal {
+        #![allow(non_snake_case)]
+        use super::*;
+        use crate::event::metrics::aggregate::Metric;
+        pub struct Recorder(fn(core::time::Duration, u64, &info::Str));
+        impl Recorder {
+            pub(crate) fn new(info: &'static Info, _variant: &'static info::Variant) -> Self {
+                unreachable!("invalid info: {info:?}")
+            }
+        }
+        impl NominalRecorder for Recorder {
+            fn record<T: Metric>(
+                &self,
+                _info: &'static Info,
+                variant: &'static info::Variant,
+                value: T,
+            ) {
+                (self.0)(value.as_duration(), variant.id as _, variant.name);
+            }
+        }
+    }
+}
+#[derive(Default)]
+pub struct Registry(());
+impl aggregate::Registry for Registry {
+    type Counter = counter::Recorder;
+    type BoolCounter = counter::bool::Recorder;
+    type NominalCounter = counter::nominal::Recorder;
+    type Measure = measure::Recorder;
+    type Gauge = gauge::Recorder;
+    type Timer = timer::Recorder;
+    type NominalTimer = timer::nominal::Recorder;
+    #[inline]
+    fn register_counter(&self, info: &'static Info) -> Self::Counter {
+        counter::Recorder::new(info)
+    }
+    #[inline]
+    fn register_bool_counter(&self, info: &'static Info) -> Self::BoolCounter {
+        counter::bool::Recorder::new(info)
+    }
+    #[inline]
+    fn register_nominal_counter(
+        &self,
+        info: &'static Info,
+        variant: &'static info::Variant,
+    ) -> Self::NominalCounter {
+        counter::nominal::Recorder::new(info, variant)
+    }
+    #[inline]
+    fn register_measure(&self, info: &'static Info) -> Self::Measure {
+        measure::Recorder::new(info)
+    }
+    #[inline]
+    fn register_gauge(&self, info: &'static Info) -> Self::Gauge {
+        gauge::Recorder::new(info)
+    }
+    #[inline]
+    fn register_timer(&self, info: &'static Info) -> Self::Timer {
+        timer::Recorder::new(info)
+    }
+    #[inline]
+    fn register_nominal_timer(
+        &self,
+        info: &'static Info,
+        variant: &'static info::Variant,
+    ) -> Self::NominalTimer {
+        timer::nominal::Recorder::new(info, variant)
+    }
+}

--- a/tools/s2n-events/tests/c_ffi_events/events/common.rs
+++ b/tools/s2n-events/tests/c_ffi_events/events/common.rs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+enum Subject {
+    Endpoint,
+    Connection {
+        id: u64,
+    },
+}
+
+struct ConnectionMeta {
+    id: u64,
+    timestamp: Timestamp,
+}
+
+struct EndpointMeta {}
+
+struct ConnectionInfo {}

--- a/tools/s2n-events/tests/c_ffi_events/events/connection.rs
+++ b/tools/s2n-events/tests/c_ffi_events/events/connection.rs
@@ -1,0 +1,18 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[event("byte_array_event")]
+struct ByteArrayEvent<'a> {
+    data: &'a [u8],
+}
+
+enum TestEnum {
+    TestValue1,
+    TestValue2,
+}
+
+#[event("enum_event")]
+struct EnumEvent {
+    #[nominal_counter("value")]
+    value: TestEnum,
+}

--- a/tools/s2n-events/tests/c_ffi_events/events/endpoint.rs
+++ b/tools/s2n-events/tests/c_ffi_events/events/endpoint.rs
@@ -1,0 +1,8 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[event("count_event")]
+#[subject(endpoint)]
+struct CountEvent {
+    count: u32,
+}

--- a/tools/s2n-events/tests/c_ffi_events/mod.rs
+++ b/tools/s2n-events/tests/c_ffi_events/mod.rs
@@ -1,0 +1,4 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod event;

--- a/tools/s2n-events/tests/test_c_ffi_events.rs
+++ b/tools/s2n-events/tests/test_c_ffi_events.rs
@@ -1,0 +1,57 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+mod c_ffi_events;
+
+pub use c_ffi_events::event;
+use c_ffi_events::event::ConnectionPublisher;
+use s2n_quic_core::{
+    application,
+    event::IntoEvent,
+    inet,
+    time::{testing::Clock as MockClock, Clock},
+};
+
+#[test]
+fn publish_byte_array_event() {
+    struct MySubscriber {
+        received_data: Vec<u8>,
+    }
+
+    impl event::Subscriber for MySubscriber {
+        type ConnectionContext = ();
+
+        fn create_connection_context(
+            &mut self,
+            _meta: &event::api::ConnectionMeta,
+            _info: &event::api::ConnectionInfo,
+        ) -> Self::ConnectionContext {
+        }
+
+        fn on_byte_array_event(
+            &mut self,
+            _context: &mut Self::ConnectionContext,
+            _meta: &event::api::ConnectionMeta,
+            event: &event::api::ByteArrayEvent,
+        ) {
+            self.received_data.extend_from_slice(event.data);
+        }
+    }
+
+    let mut subscriber = MySubscriber {
+        received_data: Vec::new(),
+    };
+
+    let timestamp = MockClock::default().get_time().into_event();
+    let mut context = ();
+    let mut publisher = event::ConnectionPublisherSubscriber::new(
+        event::builder::ConnectionMeta { id: 0, timestamp },
+        0,
+        &mut subscriber,
+        &mut context,
+    );
+
+    publisher.on_byte_array_event(event::builder::ByteArrayEvent { data: &[1, 2, 3] });
+
+    assert_eq!(subscriber.received_data, vec![1, 2, 3]);
+}


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2765

### Description of changes: 

A new events system with a few test events is generated in order to test upcoming code generation changes to s2n-events (see https://github.com/aws/s2n-quic/issues/2764). 

Committing this test events system will also allow reviewers to observe how future changes to s2n-events affect the resulting generated code, as many of the planned changes will not affect the existing s2n-quic/s2n-quic-dc events systems.

### Call-outs:

The primary functionality I intend to test with this new events system is the C FFI stuff for https://github.com/aws/s2n-quic/issues/2767, so I named the events system `c_ffi_events`. I'm open to other names for it though.

A lot of the changes in this PR are just committing the generated events system (tests/c_ffi_events/event/*). The contents of the generated files shouldn't need to be reviewed.

### Testing:

A simple publish/subscribe test was added to make sure the current events system is building/working as expected. I [confirmed that this is running in CI](https://github.com/aws/s2n-quic/actions/runs/17592250779/job/49975614115?pr=2795#step:9:130).

A new test was added to the CI to ensure that the test events system remains up to date with any changes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

