### PR TITLE
docs(s2n-events): Fix event-generator readme path

### DIFF
--- a/tools/event-generator/README.md
+++ b/tools/event-generator/README.md
@@ -1,4 +1,4 @@
 
-# generate-events
+# event-generator
 
 This crate generates the events systems for s2n-quic/s2n-quic-dc using `s2n-events`. See the [s2n-events](../s2n-events) crate for more details.


### PR DESCRIPTION
### Description of changes: 

https://github.com/aws/s2n-quic/pull/2797 created a readme in tools/generate-events, which isn't the correct directory of the event generator. The correct directory is tools/event-generator. This PR fixes the path.

The generate-events directory existed in my local environment because of a previous PR revision, and I accidentally created the readme there.

### Call-outs:

None

### Testing:

Documentation change.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

