### PR TITLE
refactor(s2n-events): Move OutputMode into OutputConfig

### DIFF
--- a/tools/event-generator/src/main.rs
+++ b/tools/event-generator/src/main.rs
@@ -3,13 +3,13 @@
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use s2n_events::{Output, OutputMode, Result, parser, validation};
+use s2n_events::{Output, OutputConfig, OutputMode, Result, parser, validation};
 
 struct EventInfo<'a> {
     input_path: &'a str,
     output_path: &'a str,
     crate_name: &'a str,
-    output_mode: OutputMode,
+    output_config: OutputConfig,
     s2n_quic_core_path: TokenStream,
     api: TokenStream,
     builder: TokenStream,
@@ -61,7 +61,9 @@ impl EventInfo<'_> {
                 env!("CARGO_MANIFEST_DIR"),
                 "/../../quic/s2n-quic-core/src/event"
             ),
-            output_mode: OutputMode::Mut,
+            output_config: OutputConfig {
+                mode: OutputMode::Mut,
+            },
             s2n_quic_core_path: quote!(crate),
             api: quote!(),
             builder: quote!(),
@@ -108,7 +110,9 @@ impl EventInfo<'_> {
                 env!("CARGO_MANIFEST_DIR"),
                 "/../../dc/s2n-quic-dc/src/event"
             ),
-            output_mode: OutputMode::Ref,
+            output_config: OutputConfig {
+                mode: OutputMode::Ref,
+            },
             s2n_quic_core_path: quote!(s2n_quic_core),
             api: quote! {
                 pub use s2n_quic_core::event::api::{
@@ -157,7 +161,7 @@ fn main() -> Result<()> {
         let root = root.canonicalize()?;
 
         let mut output = Output {
-            mode: event_info.output_mode,
+            config: event_info.output_config,
             s2n_quic_core_path: event_info.s2n_quic_core_path,
             api: event_info.api,
             builders: event_info.builder,

--- a/tools/event-generator/src/main.rs
+++ b/tools/event-generator/src/main.rs
@@ -3,13 +3,13 @@
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use s2n_events::{Output, OutputConfig, OutputMode, Result, parser, validation};
+use s2n_events::{Output, GenerateConfig, OutputMode, Result, parser, validation};
 
 struct EventInfo<'a> {
     input_path: &'a str,
     output_path: &'a str,
     crate_name: &'a str,
-    output_config: OutputConfig,
+    generate_config: GenerateConfig,
     s2n_quic_core_path: TokenStream,
     api: TokenStream,
     builder: TokenStream,
@@ -61,7 +61,7 @@ impl EventInfo<'_> {
                 env!("CARGO_MANIFEST_DIR"),
                 "/../../quic/s2n-quic-core/src/event"
             ),
-            output_config: OutputConfig {
+            generate_config: GenerateConfig {
                 mode: OutputMode::Mut,
             },
             s2n_quic_core_path: quote!(crate),
@@ -110,7 +110,7 @@ impl EventInfo<'_> {
                 env!("CARGO_MANIFEST_DIR"),
                 "/../../dc/s2n-quic-dc/src/event"
             ),
-            output_config: OutputConfig {
+            generate_config: GenerateConfig {
                 mode: OutputMode::Ref,
             },
             s2n_quic_core_path: quote!(s2n_quic_core),
@@ -161,7 +161,7 @@ fn main() -> Result<()> {
         let root = root.canonicalize()?;
 
         let mut output = Output {
-            config: event_info.output_config,
+            config: event_info.generate_config,
             s2n_quic_core_path: event_info.s2n_quic_core_path,
             api: event_info.api,
             builders: event_info.builder,

--- a/tools/event-generator/src/main.rs
+++ b/tools/event-generator/src/main.rs
@@ -3,7 +3,7 @@
 
 use proc_macro2::TokenStream;
 use quote::quote;
-use s2n_events::{Output, GenerateConfig, OutputMode, Result, parser, validation};
+use s2n_events::{GenerateConfig, Output, OutputMode, Result, parser, validation};
 
 struct EventInfo<'a> {
     input_path: &'a str,

--- a/tools/s2n-events/src/generate_config.rs
+++ b/tools/s2n-events/src/generate_config.rs
@@ -30,11 +30,11 @@ impl OutputMode {
 }
 
 #[derive(Debug, Default)]
-pub struct OutputConfig {
+pub struct GenerateConfig {
     pub mode: OutputMode,
 }
 
-impl OutputConfig {
+impl GenerateConfig {
     pub fn counter_type(&self) -> TokenStream {
         match self.mode {
             OutputMode::Ref => quote!(AtomicU64),

--- a/tools/s2n-events/src/lib.rs
+++ b/tools/s2n-events/src/lib.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod output;
-mod output_mode;
+mod output_config;
 
 pub mod parser;
 pub mod validation;
 
 pub use output::Output;
-pub use output_mode::OutputMode;
+pub use output_config::{OutputConfig, OutputMode};
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 pub type Result<T, E = Error> = core::result::Result<T, E>;

--- a/tools/s2n-events/src/lib.rs
+++ b/tools/s2n-events/src/lib.rs
@@ -1,14 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-mod output;
 mod generate_config;
+mod output;
 
 pub mod parser;
 pub mod validation;
 
-pub use output::Output;
 pub use generate_config::{GenerateConfig, OutputMode};
+pub use output::Output;
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 pub type Result<T, E = Error> = core::result::Result<T, E>;

--- a/tools/s2n-events/src/lib.rs
+++ b/tools/s2n-events/src/lib.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod output;
-mod output_config;
+mod generate_config;
 
 pub mod parser;
 pub mod validation;
 
 pub use output::Output;
-pub use output_config::{OutputConfig, OutputMode};
+pub use generate_config::{GenerateConfig, OutputMode};
 
 pub type Error = Box<dyn std::error::Error + Send + Sync>;
 pub type Result<T, E = Error> = core::result::Result<T, E>;

--- a/tools/s2n-events/src/output.rs
+++ b/tools/s2n-events/src/output.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{parser::File, OutputConfig};
+use crate::{parser::File, GenerateConfig};
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use std::path::{Path, PathBuf};
@@ -31,7 +31,7 @@ pub struct Output {
     pub endpoint_publisher_testing: TokenStream,
     pub connection_publisher_testing: TokenStream,
     pub extra: TokenStream,
-    pub config: OutputConfig,
+    pub config: GenerateConfig,
     pub crate_name: &'static str,
     pub s2n_quic_core_path: TokenStream,
     pub top_level: TokenStream,

--- a/tools/s2n-events/src/output.rs
+++ b/tools/s2n-events/src/output.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{parser::File, OutputMode};
+use crate::{parser::File, OutputConfig};
 use proc_macro2::TokenStream;
 use quote::{quote, ToTokens};
 use std::path::{Path, PathBuf};
@@ -31,7 +31,7 @@ pub struct Output {
     pub endpoint_publisher_testing: TokenStream,
     pub connection_publisher_testing: TokenStream,
     pub extra: TokenStream,
-    pub mode: OutputMode,
+    pub config: OutputConfig,
     pub crate_name: &'static str,
     pub s2n_quic_core_path: TokenStream,
     pub top_level: TokenStream,
@@ -110,7 +110,7 @@ impl ToTokens for Output {
             endpoint_publisher_testing,
             connection_publisher_testing,
             extra,
-            mode,
+            config: _,
             s2n_quic_core_path,
             top_level,
             feature_alloc: _,
@@ -118,18 +118,19 @@ impl ToTokens for Output {
             root: _,
         } = self;
 
-        let imports = self.mode.imports();
-        let mutex = self.mode.mutex();
-        let testing_output_type = self.mode.testing_output_type();
-        let lock = self.mode.lock();
-        let supervisor = self.mode.supervisor();
-        let supervisor_timeout = self.mode.supervisor_timeout();
-        let supervisor_timeout_tuple = self.mode.supervisor_timeout_tuple();
-        let query_mut = self.mode.query_mut();
-        let query_mut_tuple = self.mode.query_mut_tuple();
-        let trait_constraints = self.mode.trait_constraints();
+        let mode = &self.config.mode;
+        let imports = self.config.imports();
+        let mutex = self.config.mutex();
+        let testing_output_type = self.config.testing_output_type();
+        let lock = self.config.lock();
+        let supervisor = self.config.supervisor();
+        let supervisor_timeout = self.config.supervisor_timeout();
+        let supervisor_timeout_tuple = self.config.supervisor_timeout_tuple();
+        let query_mut = self.config.query_mut();
+        let query_mut_tuple = self.config.query_mut_tuple();
+        let trait_constraints = self.config.trait_constraints();
 
-        let ref_subscriber = self.mode.ref_subscriber(quote!(
+        let ref_subscriber = self.config.ref_subscriber(quote!(
             type ConnectionContext = T::ConnectionContext;
 
             #[inline]

--- a/tools/s2n-events/src/output/metrics.rs
+++ b/tools/s2n-events/src/output/metrics.rs
@@ -17,14 +17,14 @@ pub fn emit(output: &Output, files: &[File]) -> TokenStream {
             s.attrs.subject.is_connection()
         });
 
-    let mode = &output.mode;
+    let mode = &output.config.mode;
 
-    let imports = output.mode.imports();
-    let receiver = output.mode.receiver();
-    let counter_increment = output.mode.counter_increment();
-    let counter_type = output.mode.counter_type();
-    let counter_init = output.mode.counter_init();
-    let counter_load = output.mode.counter_load();
+    let imports = output.config.imports();
+    let receiver = mode.receiver();
+    let counter_increment = output.config.counter_increment();
+    let counter_type = output.config.counter_type();
+    let counter_init = output.config.counter_init();
+    let counter_load = output.config.counter_load();
 
     let mut fields = quote!();
     let mut init = quote!();

--- a/tools/s2n-events/src/output/metrics/aggregate.rs
+++ b/tools/s2n-events/src/output/metrics/aggregate.rs
@@ -20,13 +20,13 @@ pub fn emit(output: &Output, files: &[File]) -> TokenStream {
         .filter(|s| s.attrs.event_name.is_some())
         .filter(|s| s.attrs.allow_deprecated.is_empty());
 
-    let mode = &output.mode;
-    let counter_type = &output.mode.counter_type();
-    let counter_increment = &output.mode.counter_increment();
-    let counter_init = &output.mode.counter_init();
-    let counter_load = &output.mode.counter_load();
+    let mode = &output.config.mode;
+    let counter_type = &output.config.counter_type();
+    let counter_increment = &output.config.counter_increment();
+    let counter_init = &output.config.counter_init();
+    let counter_load = &output.config.counter_load();
 
-    let receiver = output.mode.receiver();
+    let receiver = mode.receiver();
     let s2n_quic_core_path = &output.s2n_quic_core_path;
 
     let mut subscriber = quote!();
@@ -241,7 +241,7 @@ pub fn emit(output: &Output, files: &[File]) -> TokenStream {
                 let ctx_name = Ident::new(&format!("ctr_{id}"), Span::call_site());
 
                 let value = quote!(event.#field_name.as_u64());
-                let counter_increment = output.mode.counter_increment_by(value);
+                let counter_increment = output.config.counter_increment_by(value);
 
                 context_fields.extend(quote!(
                     #ctx_name: #counter_type,
@@ -333,7 +333,7 @@ pub fn emit(output: &Output, files: &[File]) -> TokenStream {
     let nominal_timers_probes = nominal_timers.probe();
     let nominal_timers_len = nominal_timers.len;
     let info_len = info.len;
-    let mut imports = output.mode.imports();
+    let mut imports = output.config.imports();
 
     if !output.feature_alloc.is_empty() {
         imports.extend(quote!(

--- a/tools/s2n-events/src/output_config.rs
+++ b/tools/s2n-events/src/output_config.rs
@@ -27,51 +27,58 @@ impl OutputMode {
             OutputMode::Mut => quote!(mut),
         }
     }
+}
 
+#[derive(Debug, Default)]
+pub struct OutputConfig {
+    pub mode: OutputMode,
+}
+
+impl OutputConfig {
     pub fn counter_type(&self) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!(AtomicU64),
             OutputMode::Mut => quote!(u64),
         }
     }
 
     pub fn counter_init(&self) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!(AtomicU64::new(0)),
             OutputMode::Mut => quote!(0),
         }
     }
 
     pub fn counter_increment(&self) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!(.fetch_add(1, Ordering::Relaxed)),
             OutputMode::Mut => quote!(+= 1),
         }
     }
 
     pub fn counter_increment_by(&self, value: TokenStream) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!(.fetch_add(#value, Ordering::Relaxed)),
             OutputMode::Mut => quote!(+= #value),
         }
     }
 
     pub fn counter_load(&self) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!(.load(Ordering::Relaxed)),
             OutputMode::Mut => quote!(),
         }
     }
 
     pub fn lock(&self) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!(.lock().unwrap()),
             OutputMode::Mut => quote!(),
         }
     }
 
     pub fn imports(&self) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!(
                 use core::sync::atomic::{AtomicU64, Ordering};
             ),
@@ -80,7 +87,7 @@ impl OutputMode {
     }
 
     pub fn mutex(&self) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!(
                 use std::sync::Mutex;
             ),
@@ -89,21 +96,21 @@ impl OutputMode {
     }
 
     pub fn testing_output_type(&self) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!(Mutex<Vec<String>>),
             OutputMode::Mut => quote!(Vec<String>),
         }
     }
 
     pub fn trait_constraints(&self) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!('static + Send + Sync),
             OutputMode::Mut => quote!('static + Send),
         }
     }
 
     pub fn query_mut(&self) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!(),
             OutputMode::Mut => quote!(
                 /// Used for querying and mutating the `Subscriber::ConnectionContext` on a Subscriber
@@ -119,7 +126,7 @@ impl OutputMode {
     }
 
     pub fn query_mut_tuple(&self) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!(),
             OutputMode::Mut => quote!(
                 #[inline]
@@ -137,7 +144,7 @@ impl OutputMode {
     }
 
     pub fn supervisor(&self) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!(),
             OutputMode::Mut => quote!(
                 pub mod supervisor {
@@ -207,7 +214,7 @@ impl OutputMode {
     }
 
     pub fn supervisor_timeout(&self) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!(),
             OutputMode::Mut => quote!(
                 /// The period at which `on_supervisor_timeout` is called
@@ -250,7 +257,7 @@ impl OutputMode {
     }
 
     pub fn supervisor_timeout_tuple(&self) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!(),
             OutputMode::Mut => quote!(
                 #[inline]
@@ -303,7 +310,7 @@ impl OutputMode {
     }
 
     pub fn ref_subscriber(&self, inner: TokenStream) -> TokenStream {
-        match self {
+        match self.mode {
             OutputMode::Ref => quote!(
                 impl<T: Subscriber> Subscriber for std::sync::Arc<T> {
                     #inner

--- a/tools/s2n-events/src/parser.rs
+++ b/tools/s2n-events/src/parser.rs
@@ -190,8 +190,8 @@ impl Struct {
             let publisher_doc =
                 format!("Publishes a `{ident_str}` event to the publisher's subscriber");
 
-            let counter_type = output.mode.counter_type();
-            let counter_init = output.mode.counter_init();
+            let counter_type = output.config.counter_type();
+            let counter_init = output.config.counter_init();
 
             // add a counter for testing structs
             output.testing_fields.extend(quote!(
@@ -201,9 +201,9 @@ impl Struct {
                 #counter: #counter_init,
             ));
 
-            let receiver = output.mode.receiver();
-            let counter_increment = output.mode.counter_increment();
-            let lock = output.mode.lock();
+            let receiver = output.config.mode.receiver();
+            let counter_increment = output.config.counter_increment();
+            let lock = output.config.lock();
 
             match attrs.subject {
                 Subject::Endpoint => {
@@ -227,7 +227,7 @@ impl Struct {
                         }
                     ));
 
-                    if output.mode.is_ref() {
+                    if output.config.mode.is_ref() {
                         output.ref_subscriber.extend(quote!(
                             #[inline]
                             #allow_deprecated
@@ -329,7 +329,7 @@ impl Struct {
                         }
                     ));
 
-                    if output.mode.is_ref() {
+                    if output.config.mode.is_ref() {
                         output.ref_subscriber.extend(quote!(
                             #[inline]
                             #allow_deprecated


### PR DESCRIPTION
### Resolved issues:

Part of https://github.com/aws/s2n-quic/issues/2767

### Description of changes:

The s2n-events code generation is configurable with the `OutputMode` enum, which allows the s2n-quic and s2n-quic-dc event systems to be generated slightly differently. For example, the s2n-quic `Subscriber` trait [is defined to be 'static + Send](https://github.com/aws/s2n-quic/blob/fdf958632f475569705e5d6f81ae34ad62f0215b/quic/s2n-quic-core/src/event/generated.rs#L6968), while the s2n-quic-dc `Subscriber` trait is [defined to be 'static + Send + Sync](https://github.com/aws/s2n-quic/blob/fdf958632f475569705e5d6f81ae34ad62f0215b/dc/s2n-quic-dc/src/event/generated.rs#L4722). This is implemented by [trait_constraints()](https://github.com/aws/s2n-quic/blob/fdf958632f475569705e5d6f81ae34ad62f0215b/tools/s2n-events/src/output_mode.rs#L98-L103) in `OutputMode`, which returns a trait constraints quote depending on the configured mode, which [is used in the `output` module](https://github.com/aws/s2n-quic/blob/fdf958632f475569705e5d6f81ae34ad62f0215b/tools/s2n-events/src/output.rs#L222-L223) to create the final generated code quote.

I intend to use this same strategy to add an option for generating the C FFI publisher, and maybe for configuring other stuff in the future. To support additional configuration options, this PR moves `OutputMode` into an outer `OutputConfig` struct. For now, an `OutputMode` is the only thing that can be configured on the `OutputConfig`, but we can later add additional configuration options to this struct to use more than just the `OutputMode` to influence what the `OutputConfig` quote functions return.

### Testing:

This is a refactor change, and should not impact any generated code.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

