### PR TITLE
build(CI): install cross from the latest commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,9 +285,7 @@ jobs:
 
       - name: Install cross
         if: ${{ matrix.target != 'native' }}
-        uses: camshaft/install@v1
-        with:
-          crate: cross
+        run: cargo install cross --git https://github.com/cross-rs/cross
 
       - uses: camshaft/rust-cache@v1
         with:


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

We noticed that our CI job: [ci / test (stable, ubuntu-latest, aarch64-unknown-linux-gnu](https://github.com/aws/s2n-quic/actions/runs/17685105146/job/50268092076?pr=2800) is failing since it failed to install the latest version of `aws-lc-sys`. We are recommended to install `cross` from their repo with their latest commit to fix the issue. This PR will install `cross` from source instead of using `camshaft/install@v1`.

### Call-outs:

* We should audit all of our usage of `camshaft/install@v1` and see if all of them are necessary. It would be better if we just use the official repo.
* We should pay attention to how much time that installing from `cross` would take.
    * Install `cross` from source should take less than 1 minute, so this should be fine. 
* QNS failures are not related to this PR.

### Testing:

The `ci / test (stable, ubuntu-latest, aarch64-unknown-linux-gnu` should succeed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

