### PR TITLE
platform: ring buffer reset in producer instead of consumer

### DIFF
--- a/quic/s2n-quic-platform/src/io/tokio.rs
+++ b/quic/s2n-quic-platform/src/io/tokio.rs
@@ -191,6 +191,8 @@ impl Io {
                 entries.next_power_of_two()
             };
 
+            let max_mtu = MaxMtu::try_from(payload_len as u16).expect("payload cannot have 0-len");
+
             let mut consumers = vec![];
 
             let rx_socket_count = parse_env("S2N_QUIC_UNSTABLE_RX_SOCKET_COUNT").unwrap_or(1);
@@ -210,6 +212,7 @@ impl Io {
                         producer,
                         rx_cooldown,
                         stats_sender.clone(),
+                        max_mtu,
                     ));
                     break;
                 } else {
@@ -219,14 +222,14 @@ impl Io {
                         producer,
                         rx_cooldown.clone(),
                         stats_sender.clone(),
+                        max_mtu,
                     ));
                 }
             }
 
             // construct the RX side for the endpoint event loop
-            let max_mtu = MaxMtu::try_from(payload_len as u16).unwrap();
             let addr: inet::SocketAddress = rx_addr.into();
-            socket::io::rx::Rx::new(consumers, max_mtu, addr.into())
+            socket::io::rx::Rx::new(consumers, addr.into())
         };
 
         let tx = {

--- a/quic/s2n-quic-platform/src/io/tokio/task.rs
+++ b/quic/s2n-quic-platform/src/io/tokio/task.rs
@@ -28,15 +28,16 @@ macro_rules! libc_msg {
                 message::$message::Message,
                 socket::{ring, stats},
             };
-            use s2n_quic_core::task::cooldown::Cooldown;
+            use s2n_quic_core::{path::MaxMtu, task::cooldown::Cooldown};
 
             pub async fn rx<S: Into<std::net::UdpSocket>>(
                 socket: S,
                 producer: ring::Producer<Message>,
                 cooldown: Cooldown,
                 stats: stats::Sender,
+                max_mtu: MaxMtu,
             ) -> std::io::Result<()> {
-                unix::rx(socket, producer, cooldown, stats).await
+                unix::rx(socket, producer, cooldown, stats, max_mtu).await
             }
 
             pub async fn tx<S: Into<std::net::UdpSocket>>(

--- a/quic/s2n-quic-platform/src/io/turmoil.rs
+++ b/quic/s2n-quic-platform/src/io/turmoil.rs
@@ -90,7 +90,7 @@ impl Io {
             let (producer, consumer) = ring::pair(entries, payload_len);
             consumers.push(consumer);
 
-            let rx = rx::Rx::new(consumers, mtu_config.max_mtu(), local_addr.into());
+            let rx = rx::Rx::new(consumers, local_addr.into());
 
             (rx, producer)
         };

--- a/quic/s2n-quic-platform/src/syscall.rs
+++ b/quic/s2n-quic-platform/src/syscall.rs
@@ -63,6 +63,7 @@ pub trait UnixMessage: crate::message::Message {
         entries: &mut [Self],
         events: &mut E,
         stats: &stats::Sender,
+        max_mtu: s2n_quic_core::path::MaxMtu,
     );
 }
 

--- a/quic/s2n-quic-platform/src/syscall/mmsg.rs
+++ b/quic/s2n-quic-platform/src/syscall/mmsg.rs
@@ -4,6 +4,7 @@
 use super::{SocketEvents, SocketType, UnixMessage};
 use crate::socket::stats;
 use libc::mmsghdr;
+use s2n_quic_core::path::MaxMtu;
 use std::os::unix::io::{AsRawFd, RawFd};
 
 impl UnixMessage for mmsghdr {
@@ -24,7 +25,11 @@ impl UnixMessage for mmsghdr {
         entries: &mut [Self],
         events: &mut E,
         stats: &stats::Sender,
+        max_mtu: MaxMtu,
     ) {
+        // we don't need max mtu to reset message len for mmsg
+        let _max_mtu = max_mtu;
+
         recv(&fd, ty, entries, events, stats)
     }
 }

--- a/quic/s2n-quic-tests/src/tests/mtu.rs
+++ b/quic/s2n-quic-tests/src/tests/mtu.rs
@@ -99,7 +99,7 @@ fn mtu_updates<S: tls::Provider, C: tls::Provider>(
             .start()?;
         let addr = start_server(server)?;
         // we need a large payload to allow for multiple rounds of MTU probing
-        start_client(client, addr, Data::new(20_000_000))?;
+        start_client(client, addr, Data::new(90_000_000))?;
         Ok(addr)
     })
     .unwrap();


### PR DESCRIPTION
This PR supersedes [#2786](https://github.com/aws/s2n-quic/pull/2786) and addresses [#2220](https://github.com/aws/s2n-quic/issues/2220)

The platform ring buffer uses two memory regions for socket I/O. Currently, buffer resets are performed by the consumer and assumed to propagate across both regions. This assumption is incorrect: synchronization only occurs on producer release, meaning resets done by the consumer are not visible.

As a result, the producer can reuse buffers that are not properly reset.
* Windows: This leads to recv failures (`WSAEMSGSIZE`) because smaller-than-expected buffers are reused, making the library effectively unusable.
* Testing backend: No immediate failure occurs, but MTU discovery behavior changes. With this fix, the test runs faster, so the payload size for MTU probing has been increased.
* Unix (msg/mmsg): Not directly affected, since buffer lengths are handled via pointers, but the assumption was still present in the shared code.

Instead of synchronizing ring buffer regions on consumer release (as done in the [other fix](https://github.com/aws/s2n-quic/pull/2786), this patch ensures that every receive operation resets its buffers with the configured MaxMtu. This eliminates reliance on consumer-side side effects and ensures correctness across all backends.

Compared to #2786, this solution avoids extra synchronization logic between ring regions and fixes the root cause at the I/O boundary where buffers are reused. It ensures consistent behavior across platforms while reducing assumptions about the ring buffer’s internal structure.

### Comparisons with #2786 
Pros:
* Avoids extra synchronization logic in the consumer.
* Aligns better with architectural design: the consumer should only consume and not produce data or side effects. The previous assumption was the root cause of subtle bugs and was difficult to detect.
* Lower risk of performance regressions compared to adding sync operations.

Cons:
* Requires broader refactoring, primarily to propagate MaxMtu down into lower layers.
* Slightly higher risk of missing an implementation detail, since changes touch several trait definitions. That said, the compiler will generally enforce correctness by surfacing missing impls.

