### PR TITLE
test(s2n-quic-dc): add s2n-quic-dc tests for checking size and endpoint creation without tokio runtime

### DIFF
--- a/dc/s2n-quic-dc/src/stream/testing.rs
+++ b/dc/s2n-quic-dc/src/stream/testing.rs
@@ -30,9 +30,24 @@ thread_local! {
     static SERVERS: RefCell<HashMap<SocketAddr, server::Handle>> = Default::default();
 }
 
+pub mod read {
+    use crate::stream::recv::application as recv;
+
+    pub use recv::{AckMode, ReadMode};
+    pub type Reader = recv::Reader<super::Subscriber>;
+}
+
+pub mod write {
+    use crate::stream::send::application as send;
+
+    pub type Writer = send::Writer<super::Subscriber>;
+}
+
 pub type Subscriber = (Arc<event::testing::Subscriber>, event::tracing::Subscriber);
 
 pub type Stream = application::Stream<Subscriber>;
+pub use read::Reader;
+pub use write::Writer;
 
 const DEFAULT_POOLED: bool = true;
 

--- a/dc/s2n-quic-dc/src/stream/tests.rs
+++ b/dc/s2n-quic-dc/src/stream/tests.rs
@@ -1,6 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::{testing, Protocol};
+
 mod accept_queue;
 mod behavior;
 /// A set of tests ensuring we support a large number of peers.
@@ -12,3 +14,37 @@ mod key_update;
 mod request_response;
 mod restart;
 mod rpc;
+
+/// Shows an endpoint doesn't need an application tokio runtime to be created
+#[test]
+fn runtime_free_context_test() {
+    let _ = testing::dcquic::Context::new_sync(Protocol::Udp, "127.0.0.1:0".parse().unwrap());
+}
+
+mod sizes {
+    use core::mem::size_of;
+
+    #[test]
+    fn stream_test() {
+        assert_eq!(
+            size_of::<crate::stream::testing::Stream>(),
+            size_of::<Box<()>>() * 2
+        );
+    }
+
+    #[test]
+    fn reader_test() {
+        assert_eq!(
+            size_of::<crate::stream::testing::Reader>(),
+            size_of::<Box<()>>()
+        );
+    }
+
+    #[test]
+    fn writer_test() {
+        assert_eq!(
+            size_of::<crate::stream::testing::Writer>(),
+            size_of::<Box<()>>()
+        );
+    }
+}


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

related to https://github.com/aws/s2n-quic/pull/2772

### Description of changes: 

Implement four more tests for s2n-quic-dc's tokio stream tests. Show that a dcQUIC endpoint doesn't need tokio runtime supoort to be created. Also test the size for reader and write if a Subscriber is provided.

### Call-outs:

### Testing:

These tests should be ran on CI.
```
test stream::tests::runtime_free_context_test ... ok
test stream::tests::sizes::reader_test ... ok
test stream::tests::sizes::stream_test ... ok
test stream::tests::sizes::writer_test ... ok
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

