### PR TITLE
fix(s2n-events): Fix warning when no nominal counters are defined

### DIFF
--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -2240,6 +2240,7 @@ impl<R: Registry> Subscriber<R> {
     pub fn nominal_counters(
         &self,
     ) -> impl Iterator<Item = (&'static Info, &[R::NominalCounter], &[info::Variant])> + '_ {
+        #[allow(unused_imports)]
         use api::*;
         self.nominal_counter_offsets
             .iter()

--- a/quic/s2n-quic-core/src/event/generated/metrics/aggregate.rs
+++ b/quic/s2n-quic-core/src/event/generated/metrics/aggregate.rs
@@ -1680,6 +1680,7 @@ impl<R: Registry> Subscriber<R> {
     pub fn nominal_counters(
         &self,
     ) -> impl Iterator<Item = (&'static Info, &[R::NominalCounter], &[info::Variant])> + '_ {
+        #[allow(unused_imports)]
         use api::*;
         self.nominal_counter_offsets
             .iter()

--- a/tools/s2n-events/src/output/metrics/aggregate.rs
+++ b/tools/s2n-events/src/output/metrics/aggregate.rs
@@ -470,6 +470,7 @@ pub fn emit(output: &Output, files: &[File]) -> TokenStream {
             /// Returns all of the registered nominal counters
             #[inline]
             pub fn nominal_counters(&self) -> impl Iterator<Item = (&'static Info, &[R::NominalCounter], &[info::Variant])> + '_ {
+                #[allow(unused_imports)]
                 use api::*;
                 #nominal_counters
             }

--- a/tools/s2n-events/tests/c_ffi_events/event/generated/metrics/aggregate.rs
+++ b/tools/s2n-events/tests/c_ffi_events/event/generated/metrics/aggregate.rs
@@ -12,7 +12,7 @@ use crate::event::{
         AsVariant, BoolRecorder, Info, Metric, NominalRecorder, Recorder, Registry, Units,
     },
 };
-static INFO: &[Info; 4usize] = &[
+static INFO: &[Info; 3usize] = &[
     info::Builder {
         id: 0usize,
         name: Str::new("byte_array_event\0"),
@@ -27,12 +27,6 @@ static INFO: &[Info; 4usize] = &[
     .build(),
     info::Builder {
         id: 2usize,
-        name: Str::new("enum_event.value\0"),
-        units: Units::None,
-    }
-    .build(),
-    info::Builder {
-        id: 3usize,
         name: Str::new("count_event\0"),
         units: Units::None,
     }
@@ -51,7 +45,7 @@ pub struct Subscriber<R: Registry> {
     #[allow(dead_code)]
     nominal_counters: Box<[R::NominalCounter]>,
     #[allow(dead_code)]
-    nominal_counter_offsets: Box<[usize; 1usize]>,
+    nominal_counter_offsets: Box<[usize; 0usize]>,
     #[allow(dead_code)]
     measures: Box<[R::Measure; 0usize]>,
     #[allow(dead_code)]
@@ -82,8 +76,8 @@ impl<R: Registry> Subscriber<R> {
     pub fn new(registry: R) -> Self {
         let mut counters = Vec::with_capacity(3usize);
         let mut bool_counters = Vec::with_capacity(0usize);
-        let mut nominal_counters = Vec::with_capacity(1usize);
-        let mut nominal_counter_offsets = Vec::with_capacity(1usize);
+        let mut nominal_counters = Vec::with_capacity(0usize);
+        let mut nominal_counter_offsets = Vec::with_capacity(0usize);
         let mut measures = Vec::with_capacity(0usize);
         let mut gauges = Vec::with_capacity(0usize);
         let mut timers = Vec::with_capacity(0usize);
@@ -91,21 +85,10 @@ impl<R: Registry> Subscriber<R> {
         let mut nominal_timer_offsets = Vec::with_capacity(0usize);
         counters.push(registry.register_counter(&INFO[0usize]));
         counters.push(registry.register_counter(&INFO[1usize]));
-        counters.push(registry.register_counter(&INFO[3usize]));
+        counters.push(registry.register_counter(&INFO[2usize]));
         {
             #[allow(unused_imports)]
             use api::*;
-            {
-                let offset = nominal_counters.len();
-                let mut count = 0;
-                for variant in <TestEnum as AsVariant>::VARIANTS.iter() {
-                    nominal_counters
-                        .push(registry.register_nominal_counter(&INFO[2usize], variant));
-                    count += 1;
-                }
-                debug_assert_ne!(count, 0, "field type needs at least one variant");
-                nominal_counter_offsets.push(offset);
-            }
         }
         {
             #[allow(unused_imports)]
@@ -143,7 +126,7 @@ impl<R: Registry> Subscriber<R> {
             .map(|(idx, entry)| match idx {
                 0usize => (&INFO[0usize], entry),
                 1usize => (&INFO[1usize], entry),
-                2usize => (&INFO[3usize], entry),
+                2usize => (&INFO[2usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -172,18 +155,7 @@ impl<R: Registry> Subscriber<R> {
         &self,
     ) -> impl Iterator<Item = (&'static Info, &[R::NominalCounter], &[info::Variant])> + '_ {
         use api::*;
-        self.nominal_counter_offsets
-            .iter()
-            .enumerate()
-            .map(|(idx, entry)| match idx {
-                0usize => {
-                    let offset = *entry;
-                    let variants = <TestEnum as AsVariant>::VARIANTS;
-                    let entries = &self.nominal_counters[offset..offset + variants.len()];
-                    (&INFO[2usize], entries, variants)
-                }
-                _ => unsafe { core::hint::unreachable_unchecked() },
-            })
+        core::iter::empty()
     }
     #[allow(dead_code)]
     #[inline(always)]
@@ -279,7 +251,6 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
         #[allow(unused_imports)]
         use api::*;
         self.count(1usize, 1usize, 1usize);
-        self.count_nominal(2usize, 0usize, &event.value);
         let _ = context;
         let _ = meta;
         let _ = event;
@@ -288,7 +259,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
     fn on_count_event(&mut self, meta: &api::EndpointMeta, event: &api::CountEvent) {
         #[allow(unused_imports)]
         use api::*;
-        self.count(3usize, 2usize, 1usize);
+        self.count(2usize, 2usize, 1usize);
         let _ = event;
         let _ = meta;
     }

--- a/tools/s2n-events/tests/c_ffi_events/event/generated/metrics/aggregate.rs
+++ b/tools/s2n-events/tests/c_ffi_events/event/generated/metrics/aggregate.rs
@@ -154,6 +154,7 @@ impl<R: Registry> Subscriber<R> {
     pub fn nominal_counters(
         &self,
     ) -> impl Iterator<Item = (&'static Info, &[R::NominalCounter], &[info::Variant])> + '_ {
+        #[allow(unused_imports)]
         use api::*;
         core::iter::empty()
     }

--- a/tools/s2n-events/tests/c_ffi_events/event/generated/metrics/probe.rs
+++ b/tools/s2n-events/tests/c_ffi_events/event/generated/metrics/probe.rs
@@ -19,7 +19,7 @@ mod counter {
             match info.id {
                 0usize => Self(byte_array_event),
                 1usize => Self(enum_event),
-                3usize => Self(count_event),
+                2usize => Self(count_event),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }
@@ -61,10 +61,7 @@ mod counter {
         pub struct Recorder(fn(u64, u64, &info::Str));
         impl Recorder {
             pub(crate) fn new(info: &'static Info, _variant: &'static info::Variant) -> Self {
-                match info.id {
-                    2usize => Self(enum_event__value),
-                    _ => unreachable!("invalid info: {info:?}"),
-                }
+                unreachable!("invalid info: {info:?}")
             }
         }
         impl NominalRecorder for Recorder {
@@ -77,12 +74,6 @@ mod counter {
                 (self.0)(value.as_u64(), variant.id as _, variant.name);
             }
         }
-        define!(
-            extern "probe" {
-                # [link_name = c_ffi_events__event__counter__nominal__enum_event__value]
-                fn enum_event__value(value: u64, variant: u64, variant_name: &info::Str);
-            }
-        );
     }
 }
 mod measure {

--- a/tools/s2n-events/tests/c_ffi_events/events/connection.rs
+++ b/tools/s2n-events/tests/c_ffi_events/events/connection.rs
@@ -13,6 +13,5 @@ enum TestEnum {
 
 #[event("enum_event")]
 struct EnumEvent {
-    #[nominal_counter("value")]
     value: TestEnum,
 }


### PR DESCRIPTION
### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary. If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff. -->

An events system generated by s2n-events will currently [emit a warning](https://github.com/aws/s2n-quic/actions/runs/17778433907/job/50531874815?pr=2811#step:5:2439) when the events system defines no nominal counter metrics. This is because `api` is imported in `nominal_counters()` but is unused, since there are no nominal counter definitions.

This PR ignores the unused_imports warning on this import, [similar to other instances where an import is declared but may be unused](https://github.com/aws/s2n-quic/blob/1d4aa38795acf27e3f4e925e4a9d89c6772fc6e1/tools/s2n-events/src/output/metrics/aggregate.rs#L763-L765).

### Call outs:

The manual change is made in src/output/metrics/aggregate.rs (and the event struct update in events/connection.rs). The remaining changes are the resulting code generation.

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

This PR removes the only nominal counter metric in the test events system. The clippy job which fails on warnings should no longer fail on this PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

