### PR TITLE
refactor(s2n-quic-tests): add test annotation to endpoint_limits_close_test

### DIFF
--- a/quic/s2n-quic-tests/src/tests/endpoint_limits.rs
+++ b/quic/s2n-quic-tests/src/tests/endpoint_limits.rs
@@ -52,6 +52,11 @@ impl connection_id::Validator for MaxSizeIdFormat {
     }
 }
 
+//= https://www.rfc-editor.org/rfc/rfc9000#section-5.2.2
+//= type=test
+//# If a server refuses to accept a new connection, it SHOULD send an
+//# Initial packet containing a CONNECTION_CLOSE frame with error code
+//# CONNECTION_REFUSED.
 // This test verifies that the server sends a CONNECTION_CLOSE frame with
 // error code CONNECTION_REFUSED when the server's limiter returns Outcome::close().
 #[test]


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

related to https://github.com/aws/s2n-quic/pull/2792, https://github.com/aws/s2n-quic/issues/270

### Description of changes: 

I noticed that I didn't add the compliance test annotation to the `endpoint_limits_close_test` for RFC section 5.2.2. Hence, the [compliance report](https://dnglbrstg7yg.cloudfront.net/5ed195518443a229f93024ec51b63c3a04533d20/compliance.html#/spec/https%3A%2F%2Fwww.rfc-editor.org%2Frfc%2Frfc9000) is showing `missing test` for 5.2.2.

This PR add the test annotation so that it adds that annotation.

### Call-outs:

### Testing:

We should see section 5.2.2 as complete in the compliance report.

https://dnglbrstg7yg.cloudfront.net/04c39cc0176b2350f83bc0cd432f694b27d8b05a/compliance.html#/spec/https%3A%2F%2Fwww.rfc-editor.org%2Frfc%2Frfc9000/section-5.2.2#A2072

That section is shown as `Complete` now.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

