### PR TITLE
chore: Fix new clippy finding

### DIFF
--- a/quic/s2n-quic-qns/src/tls.rs
+++ b/quic/s2n-quic-qns/src/tls.rs
@@ -251,7 +251,7 @@ pub mod s2n_tls {
         fn initialize_connection(
             &self,
             connection: &mut Connection,
-        ) -> Result<Option<Pin<Box<(dyn ConnectionFuture)>>>, Error> {
+        ) -> Result<Option<Pin<Box<dyn ConnectionFuture>>>, Error> {
             if let Some(ticket) = (*self.ticket_storage)
                 .lock()
                 .unwrap()

--- a/quic/s2n-quic-tests/src/lib.rs
+++ b/quic/s2n-quic-tests/src/lib.rs
@@ -308,7 +308,7 @@ pub mod resumption {
         fn initialize_connection(
             &self,
             connection: &mut Connection,
-        ) -> Result<Option<Pin<Box<(dyn ConnectionFuture)>>>, Error> {
+        ) -> Result<Option<Pin<Box<dyn ConnectionFuture>>>, Error> {
             if let Some(ticket) = (*self.ticket_storage).lock().unwrap().pop_back().as_deref() {
                 connection.set_session_ticket(ticket)?;
             }


### PR DESCRIPTION
### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary. If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff. -->

The clippy CI job failed on https://github.com/aws/s2n-quic/pull/2818 after discovering [a new finding](https://github.com/aws/s2n-quic/actions/runs/17832916733/job/50702500335?pr=2818#step:5:662). This PR fixes the new clippy errors:
```
error: unnecessary parentheses around type
   --> quic/s2n-quic-qns/src/tls.rs:254:36
    |
254 |         ) -> Result<Option<Pin<Box<(dyn ConnectionFuture)>>>, Error> {
    |                                    ^                    ^
    |
    = note: `-D unused-parens` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(unused_parens)]`
```


### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

None

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

The clippy job should succeed on this PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

