### PR TITLE
refactor(clippy-bot): configure the commit message of clippy PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,8 @@ jobs:
         if: steps.should_fix.outputs.SHOULD_FIX == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          commit-message: |
+            chore: clippy lint updates
           title: 'chore: clippy lint updates'
           body: |
             ### Description of changes: 


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

related to https://github.com/aws/s2n-quic/pull/2822

### Description of changes: 

S2N-QUIC Clippy bot can automatically cut PRs to fix clippy updates. However, the PR's commit message is using a default message, while we want the message to be conventional commit message. Hence, I add the option to configure the actual commit message to be `chore: clippy lint updates`.

I previously thought the commit message in main is going to use the PR title, but turns out it is using the first commit message.

### Call-outs:

### Testing:

Workflow running on my forked which shows the logic runs correctly: https://github.com/boquan-fang/s2n-quic/actions/runs/17850394959/job/50757691653

The new PR cut has the right commit message: https://github.com/boquan-fang/s2n-quic/pull/3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

