### PR TITLE
refactor(ci): update nightly toolchain version for udeps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ env:
   RUST_BACKTRACE: 1
   # Pin the nightly toolchain to prevent breakage.
   # This should be occasionally updated.
-  RUST_NIGHTLY_TOOLCHAIN: nightly-2025-01-31
+  RUST_NIGHTLY_TOOLCHAIN: nightly-2025-03-31
   CDN: https://dnglbrstg7yg.cloudfront.net
   # enable unstable features for testing
   S2N_UNSTABLE_CRYPTO_OPT_TX: 100


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

Our daily CI run detects `udeps` failure in https://github.com/aws/s2n-quic/actions/runs/17919636533/job/50950891477.
```
error: failed to compile `cargo-udeps v0.1.59`, intermediate artifacts can be found at `/tmp/cargo-installHaX4sJ`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.

Caused by:
  rustc 1.86.0-nightly is not supported by the following packages:
    cargo@0.91.0 requires rustc 1.88
    cargo@0.91.0 requires rustc 1.88
    cargo@0.91.0 requires rustc 1.88
    cargo-credential-libsecret@0.5.1 requires rustc 1.88
    cargo-util@0.2.23 requires rustc 1.88
    cargo-util-schemas@0.10.0 requires rustc 1.88
    crates-io@0.40.13 requires rustc 1.88
```

This PR updates the nightly toolchain version to 1.88.0 to fix the issue.

### Call-outs:


### Testing:

Test the toolchain version on my local machine:
```
nightly-2025-04-01-x86_64-unknown-linux-gnu installed - rustc 1.88.0-nightly (0b45675cf 2025-03-31)
```

CI should pass with `udeps`: https://github.com/aws/s2n-quic/actions/runs/17921929531/job/50958821699?pr=2826


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

