### PR TITLE
feat(s2n-events): Support defining associated C types for events

### DIFF
--- a/tools/s2n-events/src/generate_config.rs
+++ b/tools/s2n-events/src/generate_config.rs
@@ -333,6 +333,37 @@ impl GenerateConfig {
             OutputMode::Mut => quote!(),
         }
     }
+
+    pub fn c_ffi(
+        &self,
+        inner: &TokenStream,
+        connection_meta_c_type: &TokenStream,
+        connection_info_c_type: &TokenStream,
+    ) -> TokenStream {
+        if !self.c_api {
+            return quote!();
+        }
+
+        assert!(
+            !connection_meta_c_type.is_empty(),
+            "An associated C type must be specified for ConnectionMeta with the #[c_type()] \
+            attribute."
+        );
+        assert!(
+            !connection_info_c_type.is_empty(),
+            "An associated C type must be specified for ConnectionInfo with the #[c_type()] \
+            attribute."
+        );
+
+        quote!(
+            pub mod c_ffi {
+                #[allow(unused_imports)]
+                use std::ffi::*;
+
+                #inner
+            }
+        )
+    }
 }
 
 impl ToTokens for OutputMode {

--- a/tools/s2n-events/src/output.rs
+++ b/tools/s2n-events/src/output.rs
@@ -36,6 +36,9 @@ pub struct Output {
     pub s2n_quic_core_path: TokenStream,
     pub top_level: TokenStream,
     pub feature_alloc: TokenStream,
+    pub c_ffi: TokenStream,
+    pub connection_meta_c_type: TokenStream,
+    pub connection_info_c_type: TokenStream,
     pub root: PathBuf,
 }
 
@@ -115,6 +118,9 @@ impl ToTokens for Output {
             top_level,
             feature_alloc: _,
             crate_name,
+            c_ffi,
+            connection_meta_c_type,
+            connection_info_c_type,
             root: _,
         } = self;
 
@@ -129,6 +135,9 @@ impl ToTokens for Output {
         let query_mut = self.config.query_mut();
         let query_mut_tuple = self.config.query_mut_tuple();
         let trait_constraints = self.config.trait_constraints();
+        let c_ffi = self
+            .config
+            .c_ffi(c_ffi, connection_meta_c_type, connection_info_c_type);
 
         let ref_subscriber = self.config.ref_subscriber(quote!(
             type ConnectionContext = T::ConnectionContext;
@@ -461,6 +470,8 @@ impl ToTokens for Output {
                     }
                 }
             }
+
+            #c_ffi
 
             #[cfg(any(test, feature = "testing"))]
             pub mod testing {

--- a/tools/s2n-events/tests/c_ffi_events/events/common.rs
+++ b/tools/s2n-events/tests/c_ffi_events/events/common.rs
@@ -8,11 +8,42 @@ enum Subject {
     },
 }
 
+#[c_type(s2n_event_connection_meta)]
 struct ConnectionMeta {
     id: u64,
     timestamp: Timestamp,
 }
 
+#[repr(C)]
+#[allow(non_camel_case_types)]
+struct s2n_event_connection_meta {
+    timestamp: u64,
+}
+
+impl IntoEvent<builder::ConnectionMeta> for &c_ffi::s2n_event_connection_meta {
+    fn into_event(self) -> builder::ConnectionMeta {
+        let duration = Duration::from_nanos(self.timestamp);
+        let timestamp = unsafe {
+            s2n_quic_core::time::Timestamp::from_duration(duration).into_event()
+        };
+        builder::ConnectionMeta {
+            id: 0,
+            timestamp,
+        }
+    }
+}
+
 struct EndpointMeta {}
 
+#[c_type(s2n_event_connection_info)]
 struct ConnectionInfo {}
+
+#[repr(C)]
+#[allow(non_camel_case_types)]
+struct s2n_event_connection_info {}
+
+impl IntoEvent<builder::ConnectionInfo> for &c_ffi::s2n_event_connection_info {
+    fn into_event(self) -> builder::ConnectionInfo {
+        builder::ConnectionInfo {}
+    }
+}

--- a/tools/s2n-events/tests/c_ffi_events/events/connection.rs
+++ b/tools/s2n-events/tests/c_ffi_events/events/connection.rs
@@ -2,16 +2,66 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #[event("byte_array_event")]
+#[c_type(s2n_byte_array_event)]
 struct ByteArrayEvent<'a> {
     data: &'a [u8],
 }
 
+#[repr(C)]
+#[allow(non_camel_case_types)]
+struct s2n_byte_array_event {
+    data: *const u8,
+    len: u32,
+}
+
+impl<'a> IntoEvent<builder::ByteArrayEvent<'a>> for &c_ffi::s2n_byte_array_event {
+    fn into_event(self) -> builder::ByteArrayEvent<'a> {
+        let data = unsafe {
+            std::slice::from_raw_parts(self.data, self.len.try_into().unwrap())
+        };
+        builder::ByteArrayEvent { data }
+    }
+}
+
+#[builder_derive(derive(PartialEq))]
 enum TestEnum {
     TestValue1,
     TestValue2,
 }
 
 #[event("enum_event")]
+#[c_type(s2n_enum_event)]
 struct EnumEvent {
     value: TestEnum,
+}
+
+#[repr(C)]
+#[allow(non_camel_case_types)]
+enum s2n_test_enum {
+    S2N_TEST_VALUE_1,
+    S2N_TEST_VALUE_2,
+}
+
+impl IntoEvent<builder::TestEnum> for c_ffi::s2n_test_enum {
+    fn into_event(self) -> builder::TestEnum {
+        match self {
+            Self::S2N_TEST_VALUE_1 => builder::TestEnum::TestValue1,
+            Self::S2N_TEST_VALUE_2 => builder::TestEnum::TestValue2,
+        }
+    }
+}
+
+#[repr(C)]
+#[allow(non_camel_case_types)]
+struct s2n_enum_event {
+    value: s2n_test_enum,
+}
+
+impl IntoEvent<builder::EnumEvent> for &c_ffi::s2n_enum_event {
+    fn into_event(self) -> builder::EnumEvent {
+        let value = self.value.clone();
+        builder::EnumEvent {
+            value: value.into_event(),
+        }
+    }
 }


### PR DESCRIPTION
### Resolved issues:

Part of https://github.com/aws/s2n-quic/issues/2767

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary. If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff. -->

This PR allows C types to be defined and associated with events. This will allow the future C APIs that publish events to be provided with the defined C types as arguments.

For an event to be published, the s2n-events publisher must be provided with information that's specific to each event. For example, for an `ApplicationProtocolInformation` event, the publisher must be provided with the array of bytes associated with the received ALPN. This is handled by a ["builder" event struct](https://github.com/aws/s2n-quic/blob/9b89de7f8fb98dbc501fe53784e74b27ca3434a0/quic/s2n-quic-core/src/event/generated.rs#L5641-L5645) that's generated according to how the event is defined by the user.

The C API for s2n-events will allow s2n-tls to invoke the s2n-events publisher, so s2n-tls will also need to provide the publisher with information that's specific to each event. My plan is to use a similar event struct which contains the event-specific data that will be passed to the `on_event` API for that event in the publisher. Unfortunately, it will be difficult to automatically generate the C argument struct for this purpose since the Rust and C structs will generally be different. For example, consider the `ApplicationProtocolInformation` event, which needs an array of bytes as input. In Rust, this is handled with a single `&'a [u8]` field. In C, this needs to be handled with a `data: *const u8` field and a `len: u32` field.

Rather than try to do this conversion as part of the code generation, this PR adds a way for the developer to specify a C-specific struct for each event. The developer can choose the representation of the event data that makes the most sense for C, and then implement `IntoEvent` on the C struct to convert it into the Rust "builder" struct so the event can be published.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

This PR only adds support for associating C types with events. These C types will be used when generating the C API for the publisher interface, but this will be done in a separate PR.

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

New tests were added to make sure the `IntoEvent` implementations to convert C structs to the Rust event structs are correct.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

