### PR TITLE
fix(s2n-quic-dc): send connection close frames with pruned streams

### DIFF
--- a/dc/s2n-quic-dc/src/packet/control/decoder.rs
+++ b/dc/s2n-quic-dc/src/packet/control/decoder.rs
@@ -279,6 +279,13 @@ pub struct ControlFramesMut<'a> {
     buffer: &'a mut [u8],
 }
 
+impl<'a> ControlFramesMut<'a> {
+    #[inline]
+    pub(crate) fn new(buffer: &'a mut [u8]) -> Self {
+        Self { buffer }
+    }
+}
+
 impl<'a> Iterator for ControlFramesMut<'a> {
     type Item = Result<FrameMut<'a>, s2n_codec::DecoderError>;
 

--- a/dc/s2n-quic-dc/src/packet/stream/decoder.rs
+++ b/dc/s2n-quic-dc/src/packet/stream/decoder.rs
@@ -5,6 +5,7 @@ use crate::{
     credentials::Credentials,
     crypto,
     packet::{
+        control::decoder::ControlFramesMut,
         stream::{self, RelativeRetransmissionOffset, Tag},
         WireVersion,
     },
@@ -200,6 +201,11 @@ impl Packet<'_> {
     #[inline]
     pub fn control_data(&self) -> &[u8] {
         self.control_data.get(self.header)
+    }
+
+    #[inline]
+    pub fn control_frames_mut(&mut self) -> ControlFramesMut<'_> {
+        ControlFramesMut::new(self.control_data.get_mut(self.header))
     }
 
     #[inline]

--- a/dc/s2n-quic-dc/src/psk/server/builder.rs
+++ b/dc/s2n-quic-dc/src/psk/server/builder.rs
@@ -18,6 +18,7 @@ pub struct Builder<
     #[allow(dead_code)]
     pub(crate) event_subscriber: Event,
     pub(crate) data_window: u64,
+    pub(crate) initial_data_window: Option<u64>,
     pub(crate) mtu: u16,
     pub(crate) max_idle_timeout: Duration,
     pub(crate) pto_jitter_percentage: u8,
@@ -28,6 +29,7 @@ impl Default for Builder<s2n_quic::provider::event::default::Subscriber> {
         Self {
             event_subscriber: Default::default(),
             data_window: DEFAULT_MAX_DATA,
+            initial_data_window: None,
             mtu: DEFAULT_MTU,
             max_idle_timeout: DEFAULT_IDLE_TIMEOUT,
             pto_jitter_percentage: DEFAULT_PTO_JITTER_PERCENTAGE,
@@ -44,6 +46,7 @@ impl<Event: s2n_quic::provider::event::Subscriber> Builder<Event> {
         Builder {
             event_subscriber,
             data_window: self.data_window,
+            initial_data_window: self.initial_data_window,
             mtu: self.mtu,
             max_idle_timeout: self.max_idle_timeout,
             pto_jitter_percentage: self.pto_jitter_percentage,
@@ -53,6 +56,15 @@ impl<Event: s2n_quic::provider::event::Subscriber> Builder<Event> {
     /// Sets the data window to use for flow control
     pub fn with_data_window(mut self, data_window: u64) -> Self {
         self.data_window = data_window;
+        self
+    }
+
+    /// Sets the initial amount of data that the peer is allowed to send before the application
+    /// accepts the stream
+    ///
+    /// This defaults to 10x the MTU if not set.
+    pub fn with_initial_data_window(mut self, initial_data_window: u64) -> Self {
+        self.initial_data_window = Some(initial_data_window);
         self
     }
 

--- a/dc/s2n-quic-dc/src/socket/recv/router.rs
+++ b/dc/s2n-quic-dc/src/socket/recv/router.rs
@@ -13,6 +13,12 @@ use s2n_quic_core::{
     varint::VarInt,
 };
 
+// Use `debug` logging for unhandled packets in non-test builds to reduce noise
+#[cfg(not(test))]
+use tracing::debug as warn;
+#[cfg(test)]
+use tracing::warn;
+
 mod with_map;
 mod zero_router;
 
@@ -139,7 +145,7 @@ pub trait Router {
         credentials: Credentials,
         segment: descriptor::Filled,
     ) {
-        tracing::warn!(
+        warn!(
             unhandled_packet = "control",
             ?tag,
             ?id,
@@ -168,7 +174,7 @@ pub trait Router {
         credentials: Credentials,
         segment: descriptor::Filled,
     ) {
-        tracing::warn!(
+        warn!(
             unhandled_packet = "stream",
             ?tag,
             ?id,
@@ -196,7 +202,7 @@ pub trait Router {
         credentials: Credentials,
         segment: descriptor::Filled,
     ) {
-        tracing::warn!(
+        warn!(
             unhandled_packet = "datagram",
             ?tag,
             ?credentials,
@@ -221,7 +227,7 @@ pub trait Router {
         credentials: credentials::Id,
         segment: descriptor::Filled,
     ) {
-        tracing::warn!(
+        warn!(
             unhandled_packet = "stale_key",
             ?queue_id,
             ?credentials,
@@ -246,7 +252,7 @@ pub trait Router {
         credentials: credentials::Id,
         segment: descriptor::Filled,
     ) {
-        tracing::warn!(
+        warn!(
             unhandled_packet = "replay_detected",
             ?queue_id,
             ?credentials,
@@ -270,7 +276,7 @@ pub trait Router {
         credentials: credentials::Id,
         segment: descriptor::Filled,
     ) {
-        tracing::warn!(
+        warn!(
             unhandled_packet = "unknown_path_secret",
             ?queue_id,
             ?credentials,
@@ -281,7 +287,7 @@ pub trait Router {
 
     #[inline]
     fn on_unhandled_packet(&mut self, remote_address: SocketAddress, packet: packet::Packet) {
-        tracing::warn!(unhandled_packet = ?packet, ?remote_address)
+        warn!(unhandled_packet = ?packet, ?remote_address)
     }
 
     #[inline]
@@ -291,7 +297,7 @@ pub trait Router {
         remote_address: SocketAddress,
         segment: descriptor::Filled,
     ) {
-        tracing::warn!(
+        warn!(
             ?error,
             ?remote_address,
             packet_len = segment.len(),

--- a/dc/s2n-quic-dc/src/stream/application.rs
+++ b/dc/s2n-quic-dc/src/stream/application.rs
@@ -99,7 +99,8 @@ where
                 reason,
             });
 
-        // TODO emit event
+        self.shared.receiver.on_prune();
+        self.shared.sender.on_prune();
     }
 }
 
@@ -171,11 +172,27 @@ where
     }
 
     #[inline]
+    pub async fn write_all_from(
+        &mut self,
+        buf: &mut impl buffer::reader::storage::Infallible,
+    ) -> io::Result<usize> {
+        self.write.write_all_from(buf).await
+    }
+
+    #[inline]
     pub async fn write_from_fin(
         &mut self,
         buf: &mut impl buffer::reader::storage::Infallible,
     ) -> io::Result<usize> {
         self.write.write_from_fin(buf).await
+    }
+
+    #[inline]
+    pub async fn write_all_from_fin(
+        &mut self,
+        buf: &mut impl buffer::reader::storage::Infallible,
+    ) -> io::Result<usize> {
+        self.write.write_all_from_fin(buf).await
     }
 
     #[inline]

--- a/dc/s2n-quic-dc/src/stream/endpoint.rs
+++ b/dc/s2n-quic-dc/src/stream/endpoint.rs
@@ -289,7 +289,7 @@ where
         let shared = shared.clone();
 
         let task = async move {
-            let mut reader = recv::worker::Worker::new(socket, shared, endpoint_type);
+            let mut reader = recv::worker::Worker::new(socket, shared, endpoint_type, &parameters);
 
             let mut prev_waker: Option<core::task::Waker> = None;
             core::future::poll_fn(|cx| {

--- a/dc/s2n-quic-dc/src/stream/environment/bach.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/bach.rs
@@ -14,6 +14,7 @@ use crate::{
 use bach::ext::*;
 use s2n_quic_platform::features;
 use std::{io, net::SocketAddr, sync::Arc};
+use tracing::{info_span, Instrument};
 
 mod pool;
 pub mod udp;
@@ -188,8 +189,9 @@ where
     }
 
     #[inline]
+    #[track_caller]
     fn spawn_reader<F: 'static + Send + std::future::Future<Output = ()>>(&self, f: F) {
-        self.rt.spawn(f.primary());
+        self.rt.spawn(f.instrument(info_span!("reader")).primary());
     }
 
     #[inline]
@@ -198,7 +200,8 @@ where
     }
 
     #[inline]
+    #[track_caller]
     fn spawn_writer<F: 'static + Send + std::future::Future<Output = ()>>(&self, f: F) {
-        self.rt.spawn(f.primary());
+        self.rt.spawn(f.instrument(info_span!("writer")).primary());
     }
 }

--- a/dc/s2n-quic-dc/src/stream/recv/shared.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/shared.rs
@@ -9,7 +9,7 @@ use crate::{
     packet::{stream, Packet},
     stream::{
         recv::{self, buffer::Buffer as _},
-        shared::{self, handshake, ArcShared},
+        shared::{self, handshake, AcceptState, ArcShared, ShutdownKind},
         socket::{self, Socket},
         Actor, TransportFeatures,
     },
@@ -22,7 +22,13 @@ use core::{
     task::{Context, Poll},
 };
 use s2n_quic_core::{
-    buffer, dc, endpoint, ensure, inet::SocketAddress, ready, stream::state, time::Clock,
+    buffer, dc,
+    endpoint::{self, Location},
+    ensure,
+    inet::SocketAddress,
+    ready,
+    stream::state,
+    time::Clock,
     varint::VarInt,
 };
 use std::{
@@ -47,12 +53,13 @@ pub enum AckMode {
 
 pub enum ApplicationState {
     Open,
-    Closed { is_panicking: bool },
+    Closed { shutdown_kind: ShutdownKind },
 }
 
 impl ApplicationState {
     const IS_CLOSED_MASK: u8 = 1;
     const IS_PANICKING_MASK: u8 = 1 << 1;
+    const IS_PRUNED_MASK: u8 = 1 << 2;
 
     #[inline]
     fn load(shared: &AtomicU8) -> Self {
@@ -61,17 +68,29 @@ impl ApplicationState {
             return Self::Open;
         }
 
-        let is_panicking = value & Self::IS_PANICKING_MASK != 0;
+        let shutdown_kind = if (value & Self::IS_PRUNED_MASK) != 0 {
+            ShutdownKind::Pruned
+        } else if (value & Self::IS_PANICKING_MASK) != 0 {
+            ShutdownKind::Panicking
+        } else {
+            ShutdownKind::Normal
+        };
 
-        Self::Closed { is_panicking }
+        Self::Closed { shutdown_kind }
     }
 
     #[inline]
-    fn close(shared: &AtomicU8, is_panicking: bool) {
+    fn close(shared: &AtomicU8, kind: ShutdownKind) {
         let mut value = Self::IS_CLOSED_MASK;
 
-        if is_panicking {
-            value |= Self::IS_PANICKING_MASK;
+        match kind {
+            ShutdownKind::Normal => {}
+            ShutdownKind::Panicking => {
+                value |= Self::IS_PANICKING_MASK;
+            }
+            ShutdownKind::Pruned => {
+                value |= Self::IS_PRUNED_MASK;
+            }
         }
 
         shared.store(value, Ordering::Release);
@@ -164,16 +183,26 @@ impl State {
     }
 
     #[inline]
-    pub fn shutdown(&self, is_panicking: bool) {
-        ApplicationState::close(&self.application_state, is_panicking);
+    pub fn shutdown(&self, shutdown_kind: ShutdownKind) {
+        ApplicationState::close(&self.application_state, shutdown_kind);
         self.worker_waker.wake();
     }
 
+    pub fn on_prune(&self) {
+        self.notify_error(
+            recv::error::Kind::ApplicationError {
+                error: ShutdownKind::PRUNED_CODE.into(),
+            }
+            .err(),
+            Location::Local,
+        );
+    }
+
     #[inline]
-    pub fn notify_error(&self, error: recv::Error) {
+    pub fn notify_error(&self, error: recv::Error, source: Location) {
         let waker = {
             let mut inner = self.inner.lock().unwrap();
-            inner.receiver.on_error(error);
+            inner.receiver.on_error(error, source);
             inner.application_waker.take()
         };
         self.worker_waker.wake();
@@ -318,7 +347,7 @@ where
 
         // shut down the worker if we're in a terminal state
         if current_state.is_terminal() {
-            self.shared.receiver.shutdown(false);
+            self.shared.receiver.shutdown(ShutdownKind::Normal);
         }
     }
 }
@@ -415,6 +444,7 @@ impl Inner {
         out_buf: &mut impl buffer::writer::Storage,
         shared: &ArcShared<Sub>,
         features: TransportFeatures,
+        accept_state: AcceptState,
     ) -> bool
     where
         Sub: event::Subscriber,
@@ -424,7 +454,7 @@ impl Inner {
 
         // try copying data out of the reassembler into the application buffer
         self.receiver
-            .on_read_buffer(&mut self.reassembler, out_buf, clock);
+            .on_read_buffer(&mut self.reassembler, out_buf, accept_state, clock);
 
         // check if we have any packets to process
         if !self.buffer.is_empty() {
@@ -443,6 +473,7 @@ impl Inner {
                         control_opener,
                         clock,
                         shared,
+                        accept_state,
                     );
 
                     self.buffer.process(features, &mut router)
@@ -459,6 +490,7 @@ impl Inner {
                         control_opener,
                         clock,
                         shared,
+                        accept_state,
                     );
 
                     self.buffer.process(features, &mut router)
@@ -466,12 +498,12 @@ impl Inner {
             };
 
             if let Err(err) = res {
-                self.receiver.on_error(err);
+                self.receiver.on_error(err, Location::Local);
             }
 
             // if we processed packets then we may have data to copy out
             self.receiver
-                .on_read_buffer(&mut self.reassembler, out_buf, clock);
+                .on_read_buffer(&mut self.reassembler, out_buf, accept_state, clock);
         }
 
         // we only check for timeouts on unreliable transports
@@ -501,6 +533,7 @@ where
     out_buf: &'a mut Buf,
     shared: &'a ArcShared<Sub>,
     clock: &'a Clk,
+    accept_state: AcceptState,
 }
 
 impl<'a, Buf, Crypt, Clk, Sub> PacketDispatch<'a, Buf, Crypt, Clk, Sub, true>
@@ -519,6 +552,7 @@ where
         control_opener: &'a Crypt,
         clock: &'a Clk,
         shared: &'a ArcShared<Sub>,
+        accept_state: AcceptState,
     ) -> Self {
         Self {
             any_valid_packets: false,
@@ -530,6 +564,7 @@ where
             shared,
             clock,
             handshake,
+            accept_state,
         }
     }
 }
@@ -550,6 +585,7 @@ where
         control_opener: &'a Crypt,
         clock: &'a Clk,
         shared: &'a ArcShared<Sub>,
+        accept_state: AcceptState,
     ) -> Self {
         Self {
             any_valid_packets: false,
@@ -561,6 +597,7 @@ where
             shared,
             clock,
             handshake,
+            accept_state,
         }
     }
 }
@@ -596,12 +633,20 @@ where
 
                 let _ = self.shared.crypto.open_with(
                     |opener| {
+                        let accept_state = if IS_STREAM {
+                            // Streaming transport handles accept state internally
+                            AcceptState::Accepted
+                        } else {
+                            self.accept_state
+                        };
+
                         self.receiver.on_stream_packet(
                             opener,
                             self.control_opener,
                             self.shared.credentials(),
                             &mut packet,
                             ecn,
+                            accept_state,
                             self.clock,
                             self.out_buf,
                             &self.shared.subscriber,

--- a/dc/s2n-quic-dc/src/stream/shared.rs
+++ b/dc/s2n-quic-dc/src/stream/shared.rs
@@ -36,6 +36,32 @@ pub enum Half {
     Write,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum ShutdownKind {
+    Normal,
+    Panicking,
+    Pruned,
+}
+
+impl ShutdownKind {
+    pub const PRUNED_CODE: u8 = 0x02;
+
+    pub fn error_code(&self) -> Option<u8> {
+        match self {
+            ShutdownKind::Normal => None,
+            ShutdownKind::Panicking => Some(0x01),
+            ShutdownKind::Pruned => Some(Self::PRUNED_CODE),
+        }
+    }
+}
+
+/// The state of whether the stream has been accepted by the application
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AcceptState {
+    Waiting,
+    Accepted,
+}
+
 pub type ArcShared<Sub> = Arc<Shared<Sub, dyn Clock>>;
 
 pub struct Shared<Subscriber, Clk>

--- a/dc/s2n-quic-dc/src/stream/tests/accept_queue.rs
+++ b/dc/s2n-quic-dc/src/stream/tests/accept_queue.rs
@@ -3,11 +3,21 @@
 
 use crate::{
     stream::testing::{Client, Server},
-    testing::init_tracing,
+    testing::{ext::*, init_tracing, sim},
 };
-use std::{io, time::Duration};
+use bach::time::Instant;
+use s2n_quic_core::stream::testing::Data;
+use std::{
+    io,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+    vec,
+};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tracing::{info_span, Instrument};
+use tracing::{info, info_span, Instrument};
 
 async fn check_stream(client: &Client, server: &Server) -> io::Result<()> {
     tokio::try_join!(
@@ -178,4 +188,95 @@ async fn graceful_surpassing_concurrency() {
     assert_eq!(errors + ok, concurrent * 2);
     assert_eq!(errors, concurrent);
     assert_eq!(ok, concurrent);
+}
+
+#[test]
+fn backlog_rejection() {
+    let backlog = 2;
+    let timed_out = Arc::new(AtomicUsize::new(0));
+    let refused = Arc::new(AtomicUsize::new(0));
+    sim(|| {
+        for idx in 0..(backlog * 2) {
+            let timed_out = timed_out.clone();
+            let refused = refused.clone();
+            async move {
+                let client = Client::builder().build();
+                let mut stream = client.connect_sim("server:443").await.unwrap();
+
+                // Alternate between small and large payloads to try and trigger different failure modes
+                let small_len = 100;
+                let large_len = u32::MAX as u64;
+                let payload_len = if idx % 2 == 0 { small_len } else { large_len };
+                let is_small = payload_len == small_len;
+                let mut payload = Data::new(payload_len);
+
+                let start = Instant::now();
+
+                let write_res = stream.write_all_from_fin(&mut payload).await;
+
+                info!(res = ?write_res, payload_len, "write");
+
+                let write_err = if is_small {
+                    // The small payloads shouldn't block on the stream getting accepted
+                    write_res.unwrap();
+                    None
+                } else {
+                    Some(write_res.unwrap_err())
+                };
+
+                let mut response = vec![];
+                let read_res = stream.read_to_end(&mut response).await;
+
+                info!(res = ?read_res, payload_len, "read");
+                let read_err = read_res.unwrap_err();
+
+                if let Some(write_err) = write_err {
+                    assert_eq!(
+                        read_err.kind(),
+                        write_err.kind(),
+                        "read error ({:?}) should match write error ({:?}); payload_len: {payload_len}",
+                        read_err.kind(),
+                        write_err.kind(),
+                    );
+                }
+
+                let elapsed = start.elapsed();
+
+                match read_err.kind() {
+                    io::ErrorKind::ConnectionRefused => {
+                        assert!(elapsed < 1.s(), "connection refused should be fast");
+                        refused.fetch_add(1, Ordering::Relaxed);
+                    }
+                    io::ErrorKind::TimedOut => {
+                        timed_out.fetch_add(1, Ordering::Relaxed);
+                    }
+                    _ => {
+                        panic!("unexpected error kind: {read_err:?}");
+                    }
+                }
+            }
+            .group(format!("client-{idx}"))
+            .instrument(info_span!("client", client = idx))
+            .primary()
+            .spawn();
+        }
+
+        async move {
+            let server = Server::udp().port(443).backlog(backlog).build();
+
+            60.s().sleep().await;
+
+            drop(server);
+        }
+        .group("server")
+        .instrument(info_span!("server"))
+        .spawn();
+    });
+
+    let timed_out = timed_out.load(Ordering::Relaxed);
+    let refused = refused.load(Ordering::Relaxed);
+    assert_eq!(
+        timed_out, refused,
+        "timed_out: {timed_out} == refused: {refused}"
+    );
 }

--- a/dc/s2n-quic-dc/src/stream/tests/behavior.rs
+++ b/dc/s2n-quic-dc/src/stream/tests/behavior.rs
@@ -28,7 +28,6 @@ mod dcquic_tcp {
 }
 
 #[path = "behavior"]
-#[cfg(not(target_os = "macos"))] // TODO fix macos
 mod dcquic_udp {
     use super::testing::dcquic::udp::*;
 

--- a/dc/s2n-quic-dc/src/stream/tests/rpc.rs
+++ b/dc/s2n-quic-dc/src/stream/tests/rpc.rs
@@ -282,7 +282,7 @@ fn large_transfer() {
         Harness {
             num_clients: 1,
             num_requests: 1,
-            req_size: 1_000_000_000,
+            req_size: 100_000_000,
             res_size: 10,
             server_pause: 1,
             server_include_fin: true,

--- a/quic/s2n-quic-core/src/dc/testing.rs
+++ b/quic/s2n-quic-core/src/dc/testing.rs
@@ -98,7 +98,7 @@ impl dc::Path for MockDcPath {
 #[allow(clippy::declare_interior_mutable_const)]
 pub const TEST_APPLICATION_PARAMS: ApplicationParams = ApplicationParams {
     max_datagram_size: AtomicU16::new(1472),
-    remote_max_data: VarInt::from_u32(1u32 << 25),
+    remote_max_data: VarInt::from_u32(1472 * 10),
     local_send_max_data: VarInt::from_u32(1u32 << 25),
     local_recv_max_data: VarInt::from_u32(1u32 << 25),
     max_idle_timeout: NonZeroU32::new(Duration::from_secs(30).as_millis() as _),


### PR DESCRIPTION
### Description of changes: 

This change implements notifications on streams being dropped in the accept queue. The current implementation does not send anything when this happens and the client times out.

The other thing I noticed while implementing this change is that the flow window negotiated to the client is very large, meaning while the recv worker is processing packets while it's waiting in the accept queue it's also increasing the flow window. If the stream never gets accepted by the application then this is wasted work. As part of this change, I've clamped the initial window to 10x the MTU by default, with a configurable separate limit on the server builder. Once the server accepts the stream, it's able to increase the window to the larger value and notify the client.

### Testing:

I've implemented a test harness showing all of these changes working, both with small and large streams.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

