### PR TITLE
ci: Temporarily remove xquic from required interop tests

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -39,9 +39,7 @@
       "client",
       "server"
     ],
-    "xquic": [
-      "server"
-    ]
+    "xquic": []
   },
   "handshake": {
     "aioquic": [
@@ -82,9 +80,7 @@
       "client",
       "server"
     ],
-    "xquic": [
-      "server"
-    ]
+    "xquic": []
   },
   "transfer": {
     "aioquic": [
@@ -166,9 +162,7 @@
       "client",
       "server"
     ],
-    "xquic": [
-      "server"
-    ]
+    "xquic": []
   },
   "chacha20": {
     "aioquic": [


### PR DESCRIPTION
### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary. If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff. -->

The xquic interop tests [recently started failing with s2n-quic](https://github.com/aws/s2n-quic/actions/runs/18101631284/job/51514843000#step:12:24). Looking at the [interop runner report](https://interop.seemann.io/?run=2025-09-29T08:39), it appears that xquic is failing with other QUIC implementations as well. So, this is believed to be an issue with xquic rather than s2n-quic.

This PR temporarily removes xquic from the required interop tests until this issue is resolved in xquic. An issue has been opened to the xquic maintainers: https://github.com/alibaba/xquic/issues/506

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

None

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

The interop report job should succeed on this PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

