### PR TITLE
fix(s2n-quic-dc): resolve restart test flakiness on MacOS GithubAction Image

### DIFF
--- a/dc/s2n-quic-dc/src/stream/tests/restart.rs
+++ b/dc/s2n-quic-dc/src/stream/tests/restart.rs
@@ -98,7 +98,7 @@ impl Harness {
     }
 
     async fn run_one(&self, bidirectional: bool, sleep_before_shutdown: bool) {
-        tracing::info!(bidirectional, sleep_before_shutdown);
+        tracing::debug!(bidirectional, sleep_before_shutdown);
         let context = Context::bind(self.protocol, "127.0.0.1:0".parse().unwrap()).await;
 
         check_stream(&context, bidirectional, sleep_before_shutdown)
@@ -117,7 +117,7 @@ impl Harness {
 
         // This might fail, we don't care. At least two streams should fail before we
         // manage to successfully establish after dropping state.
-        tracing::info!(
+        tracing::debug!(
             "initial: {:?}",
             tokio::time::timeout(
                 Duration::from_secs(2),
@@ -132,7 +132,7 @@ impl Harness {
 
         // This should enqueue a recovery handshake. This used to be something we'd *wait* for, but
         // now we just do that in the background; this should still fail.
-        tracing::info!(
+        tracing::debug!(
             "recovery handshake: {:?}",
             tokio::time::timeout(
                 Duration::from_secs(2),


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

related to https://github.com/aws/s2n-quic/issues/2812

### Description of changes: 

Attempt to resolve the restart flakiness on Github Action's MacOS image.

### Call-outs:


### Testing:

CI test which includes MacOS image on Github Action.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

