### PR TITLE
chore(ci): allow triage users to start quic-attack

### DIFF
--- a/.github/workflows/codebuild.yml
+++ b/.github/workflows/codebuild.yml
@@ -52,10 +52,10 @@ jobs:
         run: |
           permission=$(jq -r '.permission' <<< '${{ steps.get_permission.outputs.data }}')
           echo "$pr_author has permission '$permission'".
-          if [[ "$permission" == "admin" || "$permission" == "write" ]]; then
+          if [[ "$permission" == "admin" || "$permission" == "write" || "$permission" == "triage" ]]; then
             ./codebuild/bin/start_codebuild.sh $source_pr
           else
-            echo "$pr_author does not have write permissions."
+            echo "$pr_author does not have triage permissions."
             echo "A maintainer will need to manually run the Codebuild jobs."
             echo ""
             echo "Review the latest version of the PR to ensure that the code is safe to execute."


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

none

### Description of changes: 

Extend the permissions check on quic-attack to traige users.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

