### PR TITLE
tests: exercise ring with testing message

### DIFF
--- a/quic/s2n-quic-platform/src/io/testing/message.rs
+++ b/quic/s2n-quic-platform/src/io/testing/message.rs
@@ -94,7 +94,7 @@ impl MessageTrait for Message {
         let path = self.handle;
         let header = datagram::Header {
             path,
-            ecn: Default::default(),
+            ecn: self.ecn,
         };
         let payload = self.payload_mut();
 
@@ -123,6 +123,7 @@ impl MessageTrait for Message {
         }
 
         self.handle = *message.path_handle();
+        self.ecn = message.ecn();
 
         Ok(len)
     }

--- a/quic/s2n-quic-platform/src/socket/ring.rs
+++ b/quic/s2n-quic-platform/src/socket/ring.rs
@@ -506,6 +506,7 @@ mod tests {
     }
 
     replication_test!(simple_replication, crate::message::simple::Message);
+    replication_test!(testing_replication, crate::io::testing::message::Message);
     #[cfg(s2n_quic_platform_socket_msg)]
     replication_test!(msg_replication, crate::message::msg::Message);
     #[cfg(s2n_quic_platform_socket_mmsg)]
@@ -572,6 +573,7 @@ mod tests {
     }
 
     send_recv_test!(simple_send_recv, crate::message::simple::Message);
+    send_recv_test!(testing_send_recv, crate::io::testing::message::Message);
     #[cfg(s2n_quic_platform_socket_msg)]
     send_recv_test!(msg_send_recv, crate::message::msg::Message);
     #[cfg(s2n_quic_platform_socket_mmsg)]
@@ -618,6 +620,10 @@ mod tests {
     }
 
     consumer_modifications_test!(simple_rx_modifications, crate::message::simple::Message);
+    consumer_modifications_test!(
+        testing_rx_modifications,
+        crate::io::testing::message::Message
+    );
     #[cfg(s2n_quic_platform_socket_msg)]
     consumer_modifications_test!(msg_rx_modifications, crate::message::msg::Message);
     #[cfg(s2n_quic_platform_socket_mmsg)]


### PR DESCRIPTION
## Summary
- extend the ring buffer unit tests to run against the shared testing message for all scenarios
- teach the testing message to round-trip ECN values so the new send/recv check passes

## Testing
- 
running 12 tests
test socket::ring::tests::msg_rx_modifications ... ok
test socket::ring::tests::msg_replication ... ok
test socket::ring::tests::simple_rx_modifications ... ok
test socket::ring::tests::mmsg_rx_modifications ... ok
test socket::ring::tests::mmsg_replication ... ok
test socket::ring::tests::mmsg_send_recv ... ok
test socket::ring::tests::simple_replication ... ok
test socket::ring::tests::msg_send_recv ... ok
test socket::ring::tests::simple_send_recv ... ok
test socket::ring::tests::testing_replication ... ok
test socket::ring::tests::testing_send_recv ... ok
test socket::ring::tests::testing_rx_modifications ... ok

test result: ok. 12 passed; 0 failed; 0 ignored; 0 measured; 14 filtered out; finished in 2.03s

Fixes #2809