### PR TITLE
feat(s2n-quic-dc): throttle repeated successful handshakes

### DIFF
--- a/dc/s2n-quic-dc/src/psk/client/builder.rs
+++ b/dc/s2n-quic-dc/src/psk/client/builder.rs
@@ -25,6 +25,7 @@ pub struct Builder<
     pub(crate) mtu: u16,
     pub(crate) max_idle_timeout: Duration,
     pub(crate) pto_jitter_percentage: u8,
+    pub(crate) success_jitter: Duration,
 }
 
 impl Default for Builder<s2n_quic::provider::event::default::Subscriber> {
@@ -35,6 +36,7 @@ impl Default for Builder<s2n_quic::provider::event::default::Subscriber> {
             mtu: DEFAULT_MTU,
             max_idle_timeout: DEFAULT_IDLE_TIMEOUT,
             pto_jitter_percentage: DEFAULT_PTO_JITTER_PERCENTAGE,
+            success_jitter: Duration::from_secs(60),
         }
     }
 }
@@ -51,6 +53,7 @@ impl<Event: s2n_quic::provider::event::Subscriber> Builder<Event> {
             mtu: self.mtu,
             max_idle_timeout: self.max_idle_timeout,
             pto_jitter_percentage: self.pto_jitter_percentage,
+            success_jitter: self.success_jitter,
         }
     }
 
@@ -87,6 +90,17 @@ impl<Event: s2n_quic::provider::event::Subscriber> Builder<Event> {
     /// - 1-50%: Applies random jitter within ±percentage of base PTO
     pub fn with_pto_jitter_percentage(mut self, pto_jitter_percentage: u8) -> Self {
         self.pto_jitter_percentage = pto_jitter_percentage;
+        self
+    }
+
+    /// Sets the period we wait before attempting new handshakes with the same peer (by IP:port),
+    /// after a successfully completed handshake.
+    ///
+    /// This is the upper bound, the jitter is randomized between 1 second and the upper bound.
+    ///
+    /// This defaults to 1 minute.
+    pub fn with_success_jitter(mut self, period: Duration) -> Self {
+        self.success_jitter = period;
         self
     }
 

--- a/dc/s2n-quic-dc/src/testing.rs
+++ b/dc/s2n-quic-dc/src/testing.rs
@@ -241,6 +241,14 @@ impl Pair {
             client = client.with_mtu(mtu);
         }
 
+        // Don't wait after previous handshake before trying another one.
+        //
+        // Primarily this is needed for restart tests, which expect to recover immediately. In
+        // production we don't expect to have *just* handshaked with a peer that's restarting (or
+        // at least that's uncommon) and peers rarely undergo e.g. deployment in less than 1
+        // minute. So not generally an issue there.
+        client = client.with_success_jitter(Duration::ZERO);
+
         client
     }
 


### PR DESCRIPTION
### Release Summary:

* feat(s2n-quic-dc): throttle repeated successful handshakes

### Resolved issues:

n/a

### Description of changes: 

This mirrors prior work for *failing* handshakes by adding a throttle on outgoing, successful handshakes to a given peer. This is particularly relevant for workloads that happen to trigger replay detection relatively often, which would otherwise cause us to repeatedly handshake with the peer.

It remains generally a good idea for us to switch to new secret material in case of e.g. spurious bitflips in memory or other issues that have broken the old entry in some way, so retaining the handshake-on-possible-replay makes sense, but doing so at a high rate increases CPU utilization for little benefit.

### Call-outs:

n/a

### Testing:

No particular testing added. This is exercise by most of our existing tests since the code is hit by anything that handshakes; I don't think we need additional, dedicated test coverage for it.

The stream tests are updated to disable this jitter as it breaks restart tests. As noted in comments, I think the tradeoff is reasonable, but open to other thoughts there (or other defaults instead of 1 minute).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

