### PR TITLE
chore: fix group in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @s2n-core
+* @aws/s2n-core


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

N/A

### Description of changes: 

The org is required for teams.

### Callouts

For the TLS project, we reverted a similar change in https://github.com/aws/s2n-tls/pull/3571 due to getting the group permissions levels sorted.

### Testing:

When you browse the`.github/CODEOWNERS` file, GitHub shows an `Unknown owner` error pop-up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

