### PR TITLE
chore: scope permissions down for one GHA

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -23,9 +23,14 @@ on:
     # run every morning at 10am Pacific Time
     - cron: "0 17 * * *"
 
+permissions:
+  contents: read  # This is required for actions/checkout
+
 jobs:
   audit:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # Required for GITHUB_TOKEN usage
     steps:
       - uses: actions/checkout@v5
         with:


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

- https://github.com/aws/s2n-quic/security/code-scanning/1
- https://github.com/aws/s2n-quic/security/code-scanning/2


### Description of changes: 

Scope down permissions on one of the GitHub Action files.

### Testing:

How is this change tested (unit tests, fuzz tests, etc.)? This action only runs on a schedule or pushes to main.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

