### PR TITLE
ci(dhat): upload dhat artifacts regardless of steps outcome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -873,7 +873,9 @@ jobs:
         run: ./target/release/memory-report server &
 
       - name: Run client
+        id: run-client
         working-directory: tools/memory-report
+        continue-on-error: true
         run: ./target/release/memory-report client > report.tsv
 
       - name: Prepare artifacts
@@ -912,6 +914,12 @@ jobs:
           name: "dhat / report"
           status: "success"
           url: "${{ steps.s3.outputs.URL }}"
+          
+      - name: Check run client status
+        if: steps.run-client.outcome != 'success'
+        run: |
+          echo "Run client step failed"
+          exit 1
 
   loom:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2817.

### Description of changes: 

This PR adds the option `continue-on-erro: true` for the `Run client` step in our CI. In this way, regardless of the outcome from the `run-client` step, dhat artifacts should always be prepared and uploaded to S3. The entire dhat job should fail if the `Run client` step fails.

### Call-outs:

N/A

### Testing:

I opened another PR in https://github.com/aws/s2n-quic/pull/2851.

That PR has the exact code change with one more line:
```
      - name: Run client
        id: run-client
        working-directory: tools/memory-report
        continue-on-error: true
        run: |
          ./target/release/memory-report client > report.tsv
          exit 1
```

It intentionally failed the `Run client` job to test the code change:
1. The `dhat` artifacts should be uploaded to S3, and I have verified that in https://us-west-2.console.aws.amazon.com/s3/buckets/s2n-quic-ci-artifacts?region=us-west-2&bucketType=general&prefix=6a381411776129df99150a810595564dd4449815/dhat/&showversions=false. The artifacts are successfully uploaded.
2. The job should fail and the last step `Check run client status` should fail the entire job. I have verified that happened:
https://github.com/aws/s2n-quic/actions/runs/18474446048/job/52635728821?pr=2851.

Hence, that should prove that this change works.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

