### PR TITLE
Expose static server name constructor

### DIFF
--- a/quic/s2n-quic-core/src/application/server_name.rs
+++ b/quic/s2n-quic-core/src/application/server_name.rs
@@ -28,12 +28,16 @@ pub struct ServerName(Bytes);
 
 /// A static value for localhost
 #[allow(dead_code)] // this is used by conditional modules so don't warn
-pub(crate) static LOCALHOST: ServerName = ServerName(Bytes::from_static(b"localhost"));
+pub(crate) static LOCALHOST: ServerName = ServerName::from_static("localhost");
 
 impl ServerName {
     #[inline]
     pub fn into_bytes(self) -> Bytes {
         self.0
+    }
+
+    pub const fn from_static(s: &'static str) -> Self {
+        ServerName(Bytes::from_static(s.as_bytes()))
     }
 
     #[inline]


### PR DESCRIPTION


### Release Summary:

* feat(s2n-quic): Allow creating server names in const contexts

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2777

### Description of changes: 

This allows const construction of server names and allows cloning those to be near-free (Bytes::from_static does not require reference counting).

### Call-outs:

n/a

### Testing:

n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

