### PR TITLE
chore: add xquic back to CI

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -601,8 +601,7 @@
       "client",
       "server"
     ],
-    "kwik": [
-    ],
+    "kwik": [],
     "lsquic": [
       "client",
       "server"


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2835. related to https://github.com/alibaba/xquic/issues/506.

### Description of changes: 

xquic has fixed their problems with the interop runner. We should add xquic back to our CI.

### Call-outs:

### Testing:

Interop test should pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

