### PR TITLE
feat(s2n-quic-dc): Add events measuring write lock latency

### DIFF
--- a/dc/s2n-quic-dc/events/map.rs
+++ b/dc/s2n-quic-dc/events/map.rs
@@ -434,3 +434,21 @@ struct PathSecretMapCleanerCycled {
     #[measure("total_duration", Duration)]
     duration: core::time::Duration,
 }
+
+#[event("path_secret_map:id_cache_write_lock")]
+#[subject(endpoint)]
+struct PathSecretMapIdWriteLock {
+    #[measure("acquire", Duration)]
+    acquire: core::time::Duration,
+    #[measure("duration", Duration)]
+    duration: core::time::Duration,
+}
+
+#[event("path_secret_map:address_cache_write_lock")]
+#[subject(endpoint)]
+struct PathSecretMapAddressWriteLock {
+    #[measure("acquire", Duration)]
+    acquire: core::time::Duration,
+    #[measure("duration", Duration)]
+    duration: core::time::Duration,
+}

--- a/dc/s2n-quic-dc/src/event/generated.rs
+++ b/dc/s2n-quic-dc/src/event/generated.rs
@@ -2255,6 +2255,42 @@ pub mod api {
     impl Event for PathSecretMapCleanerCycled {
         const NAME: &'static str = "path_secret_map:cleaner_cycled";
     }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub struct PathSecretMapIdWriteLock {
+        pub acquire: core::time::Duration,
+        pub duration: core::time::Duration,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl crate::event::snapshot::Fmt for PathSecretMapIdWriteLock {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("PathSecretMapIdWriteLock");
+            fmt.field("acquire", &self.acquire);
+            fmt.field("duration", &self.duration);
+            fmt.finish()
+        }
+    }
+    impl Event for PathSecretMapIdWriteLock {
+        const NAME: &'static str = "path_secret_map:id_cache_write_lock";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
+    pub struct PathSecretMapAddressWriteLock {
+        pub acquire: core::time::Duration,
+        pub duration: core::time::Duration,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl crate::event::snapshot::Fmt for PathSecretMapAddressWriteLock {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("PathSecretMapAddressWriteLock");
+            fmt.field("acquire", &self.acquire);
+            fmt.field("duration", &self.duration);
+            fmt.finish()
+        }
+    }
+    impl Event for PathSecretMapAddressWriteLock {
+        const NAME: &'static str = "path_secret_map:address_cache_write_lock";
+    }
     impl IntoEvent<builder::AcceptorPacketDropReason> for s2n_codec::DecoderError {
         fn into_event(self) -> builder::AcceptorPacketDropReason {
             use builder::AcceptorPacketDropReason as Reason;
@@ -3472,6 +3508,26 @@ pub mod tracing {
                 duration,
             } = event;
             tracing :: event ! (target : "path_secret_map_cleaner_cycled" , parent : parent , tracing :: Level :: DEBUG , { id_entries = tracing :: field :: debug (id_entries) , id_entries_retired = tracing :: field :: debug (id_entries_retired) , id_entries_active = tracing :: field :: debug (id_entries_active) , id_entries_active_utilization = tracing :: field :: debug (id_entries_active_utilization) , id_entries_utilization = tracing :: field :: debug (id_entries_utilization) , id_entries_initial_utilization = tracing :: field :: debug (id_entries_initial_utilization) , address_entries = tracing :: field :: debug (address_entries) , address_entries_active = tracing :: field :: debug (address_entries_active) , address_entries_active_utilization = tracing :: field :: debug (address_entries_active_utilization) , address_entries_retired = tracing :: field :: debug (address_entries_retired) , address_entries_utilization = tracing :: field :: debug (address_entries_utilization) , address_entries_initial_utilization = tracing :: field :: debug (address_entries_initial_utilization) , handshake_requests = tracing :: field :: debug (handshake_requests) , handshake_requests_retired = tracing :: field :: debug (handshake_requests_retired) , handshake_lock_duration = tracing :: field :: debug (handshake_lock_duration) , duration = tracing :: field :: debug (duration) });
+        }
+        #[inline]
+        fn on_path_secret_map_id_write_lock(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapIdWriteLock,
+        ) {
+            let parent = self.parent(meta);
+            let api::PathSecretMapIdWriteLock { acquire, duration } = event;
+            tracing :: event ! (target : "path_secret_map_id_write_lock" , parent : parent , tracing :: Level :: DEBUG , { acquire = tracing :: field :: debug (acquire) , duration = tracing :: field :: debug (duration) });
+        }
+        #[inline]
+        fn on_path_secret_map_address_write_lock(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapAddressWriteLock,
+        ) {
+            let parent = self.parent(meta);
+            let api::PathSecretMapAddressWriteLock { acquire, duration } = event;
+            tracing :: event ! (target : "path_secret_map_address_write_lock" , parent : parent , tracing :: Level :: DEBUG , { acquire = tracing :: field :: debug (acquire) , duration = tracing :: field :: debug (duration) });
         }
     }
 }
@@ -5645,6 +5701,36 @@ pub mod builder {
             }
         }
     }
+    #[derive(Clone, Debug)]
+    pub struct PathSecretMapIdWriteLock {
+        pub acquire: core::time::Duration,
+        pub duration: core::time::Duration,
+    }
+    impl IntoEvent<api::PathSecretMapIdWriteLock> for PathSecretMapIdWriteLock {
+        #[inline]
+        fn into_event(self) -> api::PathSecretMapIdWriteLock {
+            let PathSecretMapIdWriteLock { acquire, duration } = self;
+            api::PathSecretMapIdWriteLock {
+                acquire: acquire.into_event(),
+                duration: duration.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub struct PathSecretMapAddressWriteLock {
+        pub acquire: core::time::Duration,
+        pub duration: core::time::Duration,
+    }
+    impl IntoEvent<api::PathSecretMapAddressWriteLock> for PathSecretMapAddressWriteLock {
+        #[inline]
+        fn into_event(self) -> api::PathSecretMapAddressWriteLock {
+            let PathSecretMapAddressWriteLock { acquire, duration } = self;
+            api::PathSecretMapAddressWriteLock {
+                acquire: acquire.into_event(),
+                duration: duration.into_event(),
+            }
+        }
+    }
 }
 pub use traits::*;
 mod traits {
@@ -6625,6 +6711,26 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
+        #[doc = "Called when the `PathSecretMapIdWriteLock` event is triggered"]
+        #[inline]
+        fn on_path_secret_map_id_write_lock(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapIdWriteLock,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
+        #[doc = "Called when the `PathSecretMapAddressWriteLock` event is triggered"]
+        #[inline]
+        fn on_path_secret_map_address_write_lock(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapAddressWriteLock,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
         #[doc = r" Called for each event that relates to the endpoint and all connections"]
         #[inline]
         fn on_event<M: Meta, E: Event>(&self, meta: &M, event: &E) {
@@ -7413,6 +7519,23 @@ mod traits {
             event: &api::PathSecretMapCleanerCycled,
         ) {
             self.as_ref().on_path_secret_map_cleaner_cycled(meta, event);
+        }
+        #[inline]
+        fn on_path_secret_map_id_write_lock(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapIdWriteLock,
+        ) {
+            self.as_ref().on_path_secret_map_id_write_lock(meta, event);
+        }
+        #[inline]
+        fn on_path_secret_map_address_write_lock(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapAddressWriteLock,
+        ) {
+            self.as_ref()
+                .on_path_secret_map_address_write_lock(meta, event);
         }
         #[inline]
         fn on_event<M: Meta, E: Event>(&self, meta: &M, event: &E) {
@@ -8251,6 +8374,24 @@ mod traits {
             (self.1).on_path_secret_map_cleaner_cycled(meta, event);
         }
         #[inline]
+        fn on_path_secret_map_id_write_lock(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapIdWriteLock,
+        ) {
+            (self.0).on_path_secret_map_id_write_lock(meta, event);
+            (self.1).on_path_secret_map_id_write_lock(meta, event);
+        }
+        #[inline]
+        fn on_path_secret_map_address_write_lock(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapAddressWriteLock,
+        ) {
+            (self.0).on_path_secret_map_address_write_lock(meta, event);
+            (self.1).on_path_secret_map_address_write_lock(meta, event);
+        }
+        #[inline]
         fn on_event<M: Meta, E: Event>(&self, meta: &M, event: &E) {
             self.0.on_event(meta, event);
             self.1.on_event(meta, event);
@@ -8423,6 +8564,13 @@ mod traits {
         );
         #[doc = "Publishes a `PathSecretMapCleanerCycled` event to the publisher's subscriber"]
         fn on_path_secret_map_cleaner_cycled(&self, event: builder::PathSecretMapCleanerCycled);
+        #[doc = "Publishes a `PathSecretMapIdWriteLock` event to the publisher's subscriber"]
+        fn on_path_secret_map_id_write_lock(&self, event: builder::PathSecretMapIdWriteLock);
+        #[doc = "Publishes a `PathSecretMapAddressWriteLock` event to the publisher's subscriber"]
+        fn on_path_secret_map_address_write_lock(
+            &self,
+            event: builder::PathSecretMapAddressWriteLock,
+        );
         #[doc = r" Returns the QUIC version, if any"]
         fn quic_version(&self) -> Option<u32>;
     }
@@ -8863,6 +9011,23 @@ mod traits {
             let event = event.into_event();
             self.subscriber
                 .on_path_secret_map_cleaner_cycled(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_path_secret_map_id_write_lock(&self, event: builder::PathSecretMapIdWriteLock) {
+            let event = event.into_event();
+            self.subscriber
+                .on_path_secret_map_id_write_lock(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_path_secret_map_address_write_lock(
+            &self,
+            event: builder::PathSecretMapAddressWriteLock,
+        ) {
+            let event = event.into_event();
+            self.subscriber
+                .on_path_secret_map_address_write_lock(&self.meta, &event);
             self.subscriber.on_event(&self.meta, &event);
         }
         #[inline]
@@ -9350,6 +9515,8 @@ pub mod testing {
             pub path_secret_map_id_cache_accessed: AtomicU64,
             pub path_secret_map_id_cache_accessed_hit: AtomicU64,
             pub path_secret_map_cleaner_cycled: AtomicU64,
+            pub path_secret_map_id_write_lock: AtomicU64,
+            pub path_secret_map_address_write_lock: AtomicU64,
         }
         impl Drop for Subscriber {
             fn drop(&mut self) {
@@ -9436,6 +9603,8 @@ pub mod testing {
                     path_secret_map_id_cache_accessed: AtomicU64::new(0),
                     path_secret_map_id_cache_accessed_hit: AtomicU64::new(0),
                     path_secret_map_cleaner_cycled: AtomicU64::new(0),
+                    path_secret_map_id_write_lock: AtomicU64::new(0),
+                    path_secret_map_address_write_lock: AtomicU64::new(0),
                 }
             }
         }
@@ -10088,6 +10257,30 @@ pub mod testing {
                 let out = format!("{meta:?} {event:?}");
                 self.output.lock().unwrap().push(out);
             }
+            fn on_path_secret_map_id_write_lock(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::PathSecretMapIdWriteLock,
+            ) {
+                self.path_secret_map_id_write_lock
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_path_secret_map_address_write_lock(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::PathSecretMapAddressWriteLock,
+            ) {
+                self.path_secret_map_address_write_lock
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
         }
     }
     #[derive(Debug)]
@@ -10181,6 +10374,8 @@ pub mod testing {
         pub path_secret_map_id_cache_accessed: AtomicU64,
         pub path_secret_map_id_cache_accessed_hit: AtomicU64,
         pub path_secret_map_cleaner_cycled: AtomicU64,
+        pub path_secret_map_id_write_lock: AtomicU64,
+        pub path_secret_map_address_write_lock: AtomicU64,
     }
     impl Drop for Subscriber {
         fn drop(&mut self) {
@@ -10299,6 +10494,8 @@ pub mod testing {
                 path_secret_map_id_cache_accessed: AtomicU64::new(0),
                 path_secret_map_id_cache_accessed_hit: AtomicU64::new(0),
                 path_secret_map_cleaner_cycled: AtomicU64::new(0),
+                path_secret_map_id_write_lock: AtomicU64::new(0),
+                path_secret_map_address_write_lock: AtomicU64::new(0),
             }
         }
     }
@@ -11409,6 +11606,30 @@ pub mod testing {
             let out = format!("{meta:?} {event:?}");
             self.output.lock().unwrap().push(out);
         }
+        fn on_path_secret_map_id_write_lock(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapIdWriteLock,
+        ) {
+            self.path_secret_map_id_write_lock
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_path_secret_map_address_write_lock(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapAddressWriteLock,
+        ) {
+            self.path_secret_map_address_write_lock
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
     }
     #[derive(Debug)]
     pub struct Publisher {
@@ -11501,6 +11722,8 @@ pub mod testing {
         pub path_secret_map_id_cache_accessed: AtomicU64,
         pub path_secret_map_id_cache_accessed_hit: AtomicU64,
         pub path_secret_map_cleaner_cycled: AtomicU64,
+        pub path_secret_map_id_write_lock: AtomicU64,
+        pub path_secret_map_address_write_lock: AtomicU64,
     }
     impl Publisher {
         #[doc = r" Creates a publisher with snapshot assertions enabled"]
@@ -11609,6 +11832,8 @@ pub mod testing {
                 path_secret_map_id_cache_accessed: AtomicU64::new(0),
                 path_secret_map_id_cache_accessed_hit: AtomicU64::new(0),
                 path_secret_map_cleaner_cycled: AtomicU64::new(0),
+                path_secret_map_id_write_lock: AtomicU64::new(0),
+                path_secret_map_address_write_lock: AtomicU64::new(0),
             }
         }
     }
@@ -12072,6 +12297,25 @@ pub mod testing {
         }
         fn on_path_secret_map_cleaner_cycled(&self, event: builder::PathSecretMapCleanerCycled) {
             self.path_secret_map_cleaner_cycled
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_path_secret_map_id_write_lock(&self, event: builder::PathSecretMapIdWriteLock) {
+            self.path_secret_map_id_write_lock
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_path_secret_map_address_write_lock(
+            &self,
+            event: builder::PathSecretMapAddressWriteLock,
+        ) {
+            self.path_secret_map_address_write_lock
                 .fetch_add(1, Ordering::Relaxed);
             let event = event.into_event();
             let event = crate::event::snapshot::Fmt::to_snapshot(&event);

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -13,7 +13,7 @@ use crate::event::{
     },
 };
 use core::sync::atomic::{AtomicU64, Ordering};
-static INFO: &[Info; 292usize] = &[
+static INFO: &[Info; 298usize] = &[
     info::Builder {
         id: 0usize,
         name: Str::new("acceptor_tcp_started\0"),
@@ -1766,6 +1766,42 @@ static INFO: &[Info; 292usize] = &[
         units: Units::Duration,
     }
     .build(),
+    info::Builder {
+        id: 292usize,
+        name: Str::new("path_secret_map_id_write_lock\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 293usize,
+        name: Str::new("path_secret_map_id_write_lock.acquire\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
+        id: 294usize,
+        name: Str::new("path_secret_map_id_write_lock.duration\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
+        id: 295usize,
+        name: Str::new("path_secret_map_address_write_lock\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: 296usize,
+        name: Str::new("path_secret_map_address_write_lock.acquire\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
+        id: 297usize,
+        name: Str::new("path_secret_map_address_write_lock.duration\0"),
+        units: Units::Duration,
+    }
+    .build(),
 ];
 #[derive(Debug)]
 #[allow(dead_code)]
@@ -1803,7 +1839,7 @@ pub struct ConnectionContext {
 }
 pub struct Subscriber<R: Registry> {
     #[allow(dead_code)]
-    counters: Box<[R::Counter; 99usize]>,
+    counters: Box<[R::Counter; 101usize]>,
     #[allow(dead_code)]
     bool_counters: Box<[R::BoolCounter; 21usize]>,
     #[allow(dead_code)]
@@ -1811,7 +1847,7 @@ pub struct Subscriber<R: Registry> {
     #[allow(dead_code)]
     nominal_counter_offsets: Box<[usize; 32usize]>,
     #[allow(dead_code)]
-    measures: Box<[R::Measure; 120usize]>,
+    measures: Box<[R::Measure; 124usize]>,
     #[allow(dead_code)]
     gauges: Box<[R::Gauge; 0usize]>,
     #[allow(dead_code)]
@@ -1838,11 +1874,11 @@ impl<R: Registry> Subscriber<R> {
     #[allow(unused_mut)]
     #[inline]
     pub fn new(registry: R) -> Self {
-        let mut counters = Vec::with_capacity(99usize);
+        let mut counters = Vec::with_capacity(101usize);
         let mut bool_counters = Vec::with_capacity(21usize);
         let mut nominal_counters = Vec::with_capacity(32usize);
         let mut nominal_counter_offsets = Vec::with_capacity(32usize);
-        let mut measures = Vec::with_capacity(120usize);
+        let mut measures = Vec::with_capacity(124usize);
         let mut gauges = Vec::with_capacity(0usize);
         let mut timers = Vec::with_capacity(20usize);
         let mut nominal_timers = Vec::with_capacity(0usize);
@@ -1946,6 +1982,8 @@ impl<R: Registry> Subscriber<R> {
         counters.push(registry.register_counter(&INFO[271usize]));
         counters.push(registry.register_counter(&INFO[273usize]));
         counters.push(registry.register_counter(&INFO[275usize]));
+        counters.push(registry.register_counter(&INFO[292usize]));
+        counters.push(registry.register_counter(&INFO[295usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[19usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[20usize]));
         bool_counters.push(registry.register_bool_counter(&INFO[42usize]));
@@ -2443,6 +2481,10 @@ impl<R: Registry> Subscriber<R> {
         measures.push(registry.register_measure(&INFO[289usize]));
         measures.push(registry.register_measure(&INFO[290usize]));
         measures.push(registry.register_measure(&INFO[291usize]));
+        measures.push(registry.register_measure(&INFO[293usize]));
+        measures.push(registry.register_measure(&INFO[294usize]));
+        measures.push(registry.register_measure(&INFO[296usize]));
+        measures.push(registry.register_measure(&INFO[297usize]));
         timers.push(registry.register_timer(&INFO[5usize]));
         timers.push(registry.register_timer(&INFO[15usize]));
         timers.push(registry.register_timer(&INFO[21usize]));
@@ -2596,6 +2638,8 @@ impl<R: Registry> Subscriber<R> {
                 96usize => (&INFO[271usize], entry),
                 97usize => (&INFO[273usize], entry),
                 98usize => (&INFO[275usize], entry),
+                99usize => (&INFO[292usize], entry),
+                100usize => (&INFO[295usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -2985,6 +3029,10 @@ impl<R: Registry> Subscriber<R> {
                 117usize => (&INFO[289usize], entry),
                 118usize => (&INFO[290usize], entry),
                 119usize => (&INFO[291usize], entry),
+                120usize => (&INFO[293usize], entry),
+                121usize => (&INFO[294usize], entry),
+                122usize => (&INFO[296usize], entry),
+                123usize => (&INFO[297usize], entry),
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
     }
@@ -4512,6 +4560,34 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
         self.measure(289usize, 117usize, event.handshake_requests_retired);
         self.measure(290usize, 118usize, event.handshake_lock_duration);
         self.measure(291usize, 119usize, event.duration);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_path_secret_map_id_write_lock(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::PathSecretMapIdWriteLock,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(292usize, 99usize, 1usize);
+        self.measure(293usize, 120usize, event.acquire);
+        self.measure(294usize, 121usize, event.duration);
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_path_secret_map_address_write_lock(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::PathSecretMapAddressWriteLock,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(295usize, 100usize, 1usize);
+        self.measure(296usize, 122usize, event.acquire);
+        self.measure(297usize, 123usize, event.duration);
         let _ = event;
         let _ = meta;
     }

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -116,6 +116,8 @@ mod counter {
                 271usize => Self(path_secret_map_id_cache_accessed),
                 273usize => Self(path_secret_map_id_cache_accessed_hit),
                 275usize => Self(path_secret_map_cleaner_cycled),
+                292usize => Self(path_secret_map_id_write_lock),
+                295usize => Self(path_secret_map_address_write_lock),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }
@@ -325,6 +327,10 @@ mod counter {
             fn path_secret_map_id_cache_accessed_hit(value: u64);
             # [link_name = s2n_quic_dc__event__counter__path_secret_map_cleaner_cycled]
             fn path_secret_map_cleaner_cycled(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__path_secret_map_id_write_lock]
+            fn path_secret_map_id_write_lock(value: u64);
+            # [link_name = s2n_quic_dc__event__counter__path_secret_map_address_write_lock]
+            fn path_secret_map_address_write_lock(value: u64);
         }
     );
     pub mod bool {
@@ -789,6 +795,10 @@ mod measure {
                 289usize => Self(path_secret_map_cleaner_cycled__handshake_requests__retired),
                 290usize => Self(path_secret_map_cleaner_cycled__handshake_lock_duration),
                 291usize => Self(path_secret_map_cleaner_cycled__total_duration),
+                293usize => Self(path_secret_map_id_write_lock__acquire),
+                294usize => Self(path_secret_map_id_write_lock__duration),
+                296usize => Self(path_secret_map_address_write_lock__acquire),
+                297usize => Self(path_secret_map_address_write_lock__duration),
                 _ => unreachable!("invalid info: {info:?}"),
             }
         }
@@ -1040,6 +1050,14 @@ mod measure {
             fn path_secret_map_cleaner_cycled__handshake_lock_duration(value: u64);
             # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__total_duration]
             fn path_secret_map_cleaner_cycled__total_duration(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__path_secret_map_id_write_lock__acquire]
+            fn path_secret_map_id_write_lock__acquire(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__path_secret_map_id_write_lock__duration]
+            fn path_secret_map_id_write_lock__duration(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__path_secret_map_address_write_lock__acquire]
+            fn path_secret_map_address_write_lock__acquire(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__path_secret_map_address_write_lock__duration]
+            fn path_secret_map_address_write_lock__duration(value: u64);
         }
     );
 }

--- a/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
@@ -154,7 +154,11 @@ impl Cleaner {
             // Avoid double counting by making sure we have unique peer IPs.
             // We clear/take the accessed bit regardless of whether we're going to count it to
             // preserve the property that every cleaner run snapshots last ~minute.
-            if entry.take_accessed_addr() && state.cleaner_peer_seen.insert(entry.clone()).is_none()
+            if entry.take_accessed_addr()
+                && state
+                    .cleaner_peer_seen
+                    .insert_no_events(entry.clone())
+                    .is_none()
             {
                 address_entries_active += 1;
             }

--- a/dc/s2n-quic-dc/src/path/secret/map/snapshots/path__secret__map__event_tests__control_packets__events.snap
+++ b/dc/s2n-quic-dc/src/path/secret/map/snapshots/path__secret__map__event_tests__control_packets__events.snap
@@ -4,9 +4,13 @@ input_file: dc/s2n-quic-dc/src/path/secret/map/event_tests.rs
 ---
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapInitialized { capacity: 10 }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapInitialized { capacity: 10 }
+EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapIdWriteLock { acquire: 1µs, duration: 1µs }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapEntryInserted { peer_address: 127.0.0.1:5678, credential_id: "[HIDDEN]" }
+EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapAddressWriteLock { acquire: 1µs, duration: 1µs }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapEntryReady { peer_address: 127.0.0.1:5678, credential_id: "[HIDDEN]" }
+EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapIdWriteLock { acquire: 1µs, duration: 1µs }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapEntryInserted { peer_address: 127.0.0.1:1234, credential_id: "[HIDDEN]" }
+EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapAddressWriteLock { acquire: 1µs, duration: 1µs }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapEntryReady { peer_address: 127.0.0.1:1234, credential_id: "[HIDDEN]" }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } UnknownPathSecretPacketReceived { peer_address: 127.0.0.1:5678, credential_id: "[HIDDEN]" }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } UnknownPathSecretPacketDropped { peer_address: 127.0.0.1:5678, credential_id: "[HIDDEN]" }

--- a/dc/s2n-quic-dc/src/path/secret/map/snapshots/path__secret__map__event_tests__insert_one__events.snap
+++ b/dc/s2n-quic-dc/src/path/secret/map/snapshots/path__secret__map__event_tests__insert_one__events.snap
@@ -3,6 +3,8 @@ source: quic/s2n-quic-core/src/event/snapshot.rs
 input_file: dc/s2n-quic-dc/src/path/secret/map/event_tests.rs
 ---
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapInitialized { capacity: 10 }
+EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapIdWriteLock { acquire: 1µs, duration: 1µs }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapEntryInserted { peer_address: 127.0.0.1:4567, credential_id: "[HIDDEN]" }
+EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapAddressWriteLock { acquire: 1µs, duration: 1µs }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapEntryReady { peer_address: 127.0.0.1:4567, credential_id: "[HIDDEN]" }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapUninitialized { capacity: 10, entries: 1, lifetime: 1µs }


### PR DESCRIPTION
### Release Summary:

* feat(s2n-quic-dc): Add events measuring write lock latency

### Resolved issues:

n/a

### Description of changes: 

This instruments acquire + total duration of write locks on the path secret ID and address maps. These metrics should help us determine whether these locks are impeding the *read* path (which is of higher performance concern) without incurring as high an overhead as instrumenting the read path directly would take.

parking_lot's RwLock will block new readers as soon as a write lock is requested, so the total duration of the write lock is how long a reader might wait for (plus any scheduling delay from sleeping and waking). The acquire latency will indirectly tell us whether that latency is due to (for some reason) slow readers or not.

If we find that locks are taking a long time to acquire, we can look at replacing our global locks: sharding the table and/or replacing it entirely with something that has per-slot locking. TBD on specifics for that if we find it's warranted. In general, we expect that the durations measured here will typically be quite small -- our critical sections should all be very fast, but this will help confirm that.

### Call-outs:

n/a

### Testing:

Just new metrics. Existing tests confirm we don't break the map functionality (most of the changes are just code movement).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

