### PR TITLE
ci: Add a conv. commit lint action+config

### DIFF
--- a/.github/config/commitlint.config.js
+++ b/.github/config/commitlint.config.js
@@ -1,0 +1,21 @@
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+   // refer to https://commitlint.js.org/reference/rules-configuration.html#rules-configuration for rule configurations
+   rules: {
+    'subject-case': [0],
+    'body-max-line-length': [0],
+    'footer-max-line-length': [0],
+    'type-enum': [2, 'always', [
+      'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test',
+      'opt', 'internal', 'tests'
+    ]]
+  },
+  parserPreset: {
+    parserOpts: {
+      issuePrefixes: ['#']
+    }
+  },
+  ignores: [
+    (message) => message.includes('Co-authored-by:')
+  ]
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -835,6 +835,15 @@ jobs:
           cat /tmp/typos.json
           ! grep -q '[^[:space:]]' /tmp/typos.json
 
+  commit-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: true
+      - uses: ahmadnassri/action-commit-lint@v2
+        with:
+          config: ./.github/config/commitlint.config.js
   kani:
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Description of changes: 

GitHub Action to check the last commit for compliance with conventional commits.

### Call-outs:

I've added a few types from the commit history to the config that aren't common: `opt` and `internal`.

Aiming for parity of the config with the https://github.com/aws/s2n-tls project.

### Testing:

In this PR's history, you can see a force push that failed when I removed the `ci:` prefix from the commit.

local:
```
npm install --save-dev @commitlint/config-conventional @commitlint/cli
cd .github
#Check the last commit
npx commitlint -g ./config/commitlint.config.js --last
# Check between these sha's:
npx commitlint -g ./config/commitlint.config.js --from f51926a63f8b0053186900582e68c916cb4965b5 --to 1e12360a5f9d4045f7beed5cac0e361939c7350e 
⧗   input: Expose TLS error to Subscribers using on_tls_handshake_failed (#2855)
✖   subject may not be empty [subject-empty]
✖   type may not be empty [type-empty]

✖   found 2 problems, 0 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint

⧗   input: Expose static server name constructor (#2865)
✖   subject may not be empty [subject-empty]
✖   type may not be empty [type-empty]

✖   found 2 problems, 0 warnings
ⓘ   Get help: https://github.com/conventional-changelog/commitlint/#what-is-commitlint

```
No output means the commit passed, but from the above output you can see that there are a few past commits that would have failed this check.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

