### PR TITLE
fix(ci): copyright check improvement

### DIFF
--- a/tools/xdp/s2n-quic-xdp/src/if_xdp.rs
+++ b/tools/xdp/s2n-quic-xdp/src/if_xdp.rs
@@ -1,5 +1,6 @@
 // Copyright Intel Corporation
 // SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note
+// Modifications copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::Result;


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2889.

### Description of changes: 

Instead of checking for the word `Copyright` in our CI, we should check the phrase `Copyright Amazon.com, Inc. or its affiliates.` to ensure all files contain Amazon's copyright statement.

### Call-outs:

I add the [`-i`](https://man7.org/linux/man-pages/man1/grep.1.html) option to the command, because case distinction shouldn't affect this check. In fact, we do have at least one file that is using `copyright Amazon.com, Inc. or its affiliates`:
https://github.com/aws/s2n-quic/blob/cf77e2b466d837db0be875109ac009589c9364d8/tools/xdp/s2n-quic-xdp/src/if_xdp.rs#L3

### Testing:

Local test: I removed the Amazon copy right statement in `if_xdp.rs`. The file would still have the word `Copyright` at the top, but this test will error:
```
EC2:path to 2n-quic$ ./scripts/copyright_check 
Copyright Check Failed: /home/ubuntu/workspace/s2n-quic/tools/xdp/s2n-quic-xdp/src/if_xdp.rs
FAILED Copyright Check
```

Github test: I remove that line on this PR to show that copy right will fail. I then revert the commit to pass the test.
Negative test: for commit: https://github.com/aws/s2n-quic/pull/2890/commits/2ebfdb4e4ff600f7f86bfe78a178299fbcd79725, the copyright test failed: https://github.com/aws/s2n-quic/actions/runs/19242825789/job/55009419600?pr=2890.

Positive test: I revert the negative test commit. The new commit is https://github.com/aws/s2n-quic/pull/2890/commits/31cefd6f099eaebec495a08d2c0e16a5d4b2ef62, the copyright test passed: https://github.com/aws/s2n-quic/actions/runs/19242880178/job/55009601767?pr=2890.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

