### PR TITLE
ci: skip validate-pr-title when merged to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -844,12 +844,13 @@ jobs:
       - uses: actions/checkout@v5
       - name: PR Conventional Commit Validation
         id: cc_check
+        if: github.event_name == 'pull_request_target'
         uses: ytanikin/pr-conventional-commits@1.4.2
         with:
           task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert","build"]'
           add_label: 'false'
       - name: Failure case
-        if: steps.cc_check.outcome != 'success'
+        if: github.event_name == 'pull_request_target' && steps.cc_check.outcome != 'success'
         run: |
           echo "Make sure the PR title/commit follows https://www.conventionalcommits.org/"
           exit 1


### PR DESCRIPTION
### Description of changes: 

Currently, the validate-pr-title job [failed on the main branch](https://github.com/aws/s2n-quic/actions/runs/19280236818/job/55129556784) even if it succeeded on PR. This PR adds an `if` statement to each step in the job; thus it's not executed when PRs are merged to main. Similar change has [succeeded in s2n-tls](https://github.com/aws/s2n-tls/actions/runs/19282552571/job/55136598977).

### Testing:

CI should pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

