### PR TITLE
chore(xdp): pin aya-obj to prevent clippy breakage

### DIFF
--- a/tools/xdp/Cargo.toml
+++ b/tools/xdp/Cargo.toml
@@ -3,6 +3,8 @@ members = ["s2n-quic-xdp", "tester", "xtask"]
 resolver = "2"
 
 [workspace.dependencies]
-aya-obj = "=0.2.1" # new version requires MSRV 1.87.0 https://crates.io/crates/aya-obj/versions
+aya = "=0.13.1" # new version requires MSRV 1.87.0
+aya-log = "=0.2.0" # new version requires MSRV 1.87.0
+aya-log-common = "=0.1.14" # new version requires MSRV 1.87.0
 bolero = "0.13"
 bolero-generator = { version = "0.13", default-features = false }

--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["corpus.tar.gz"]
 default = ["tokio"]
 
 [dependencies]
-aya = { version = "0.13", default-features = false }
+aya = { workspace = true }
 bitflags = "2"
 errno = "0.3"
 libc = "0.2"

--- a/tools/xdp/tester/Cargo.toml
+++ b/tools/xdp/tester/Cargo.toml
@@ -5,8 +5,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aya = { version = "0.13", features = ["async_tokio"] }
-aya-log = "0.2.1"
+aya = { workspace = true, features = ["async_tokio"] }
+aya-log = { workspace = true }
+aya-log-common = { workspace = true }
 clap = { version = "4.1", features = ["derive"] }
 anyhow = "1.0.68"
 env_logger = "0.11"


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

related to https://github.com/aws/s2n-quic/issues/2888

### Description of changes: 

I noticed a clippy breakage by the most recently merged commit: https://github.com/aws/s2n-quic/actions/runs/19439029952/job/55617414515. Our transitive dependency in xdp crate, `aya-obj`, did a release two hours ago, which bumps their MSRV to 1.87.0, while our MSRV is at 1.84.0.

### Call-outs:

We should unpin this dependency once our MSRV is bumped to 1.88.0.

### Testing:

CI should pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

