### PR TITLE
ci: exclude dc for timing

### DIFF
--- a/codebuild/spec/cargotiming.yml
+++ b/codebuild/spec/cargotiming.yml
@@ -18,13 +18,14 @@ phases:
       - yum update -y && yum install -y cmake
   build:
     commands:
-      - cargo build --timings --release
+      - cargo build --timings --release --workspace --exclude s2n-quic-dc-metrics
   post_build:
     commands:
-      - cargo test --workspace
+      - cargo test --timings --workspace --exclude s2n-quic-dc-metrics
 
 artifacts:
   # upload timing reports
   files:
     - '**/*'
   base-directory: target/cargo-timings
+


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

n/a

### Description of changes: 

We split the [MSRV for s2n-quic-dc](https://github.com/aws/s2n-quic/pull/2884), so exclude it from the build/test timing metric.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

Ad-hoc [test](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/003495580562/projects/CargoTiming/build/CargoTiming%3A7835b012-dccc-436e-96fb-adeea19e4a68/?region=us-west-2) passed. This runs on a schedule, so PR won't catch the failures.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

