### PR TITLE
chore(xdp): pin aya to prevent clippy/MSRV breakage

### DIFF
--- a/tools/xdp/Cargo.toml
+++ b/tools/xdp/Cargo.toml
@@ -3,5 +3,8 @@ members = ["s2n-quic-xdp", "tester", "xtask"]
 resolver = "2"
 
 [workspace.dependencies]
+aya-obj = "=0.2.1" # new version requires MSRV 1.87.0 https://crates.io/crates/aya-obj/versions
+aya-log = "=0.2.1" # v0.2.2+ requires MSRV 1.87.0, v0.2.1 is compatible with aya 0.13
+aya-log-common = "=0.1.15" # v0.1.16+ requires MSRV 1.87.0, v0.1.15 is compatible with aya-log 0.2.1
 bolero = "0.13"
 bolero-generator = { version = "0.13", default-features = false }

--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -15,6 +15,7 @@ default = ["tokio"]
 
 [dependencies]
 aya = { version = "0.13", default-features = false }
+aya-obj = { workspace = true }
 bitflags = "2"
 errno = "0.3"
 libc = "0.2"

--- a/tools/xdp/tester/Cargo.toml
+++ b/tools/xdp/tester/Cargo.toml
@@ -6,7 +6,8 @@ publish = false
 
 [dependencies]
 aya = { version = "0.13", features = ["async_tokio"] }
-aya-log = "0.2.1"
+aya-log = { workspace = true }
+aya-log-common = { workspace = true }
 clap = { version = "4.1", features = ["derive"] }
 anyhow = "1.0.68"
 env_logger = "0.11"


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

none

### Description of changes: 

Pins some aya-* transitive dependencies that needed newer MSRV and feature flags.
Example [ci failure](https://github.com/aws/s2n-quic/actions/runs/19470795192)

### Call-outs:

Between the time it broke and getting this ready, [aya 0.13.2](https://crates.io/crates/aya/0.13.2) was yanked.

### Testing:

CI


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

