### PR TITLE
Revert "chore(xdp): pin aya to prevent clippy/MSRV breakage (#2897)"

### DIFF
--- a/tools/xdp/Cargo.toml
+++ b/tools/xdp/Cargo.toml
@@ -3,8 +3,5 @@ members = ["s2n-quic-xdp", "tester", "xtask"]
 resolver = "2"
 
 [workspace.dependencies]
-aya-obj = "=0.2.1" # new version requires MSRV 1.87.0 https://crates.io/crates/aya-obj/versions
-aya-log = "=0.2.1" # v0.2.2+ requires MSRV 1.87.0, v0.2.1 is compatible with aya 0.13
-aya-log-common = "=0.1.15" # v0.1.16+ requires MSRV 1.87.0, v0.1.15 is compatible with aya-log 0.2.1
 bolero = "0.13"
 bolero-generator = { version = "0.13", default-features = false }

--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -15,7 +15,6 @@ default = ["tokio"]
 
 [dependencies]
 aya = { version = "0.13", default-features = false }
-aya-obj = { workspace = true }
 bitflags = "2"
 errno = "0.3"
 libc = "0.2"

--- a/tools/xdp/tester/Cargo.toml
+++ b/tools/xdp/tester/Cargo.toml
@@ -6,8 +6,7 @@ publish = false
 
 [dependencies]
 aya = { version = "0.13", features = ["async_tokio"] }
-aya-log = { workspace = true }
-aya-log-common = { workspace = true }
+aya-log = "0.2.1"
 clap = { version = "4.1", features = ["derive"] }
 anyhow = "1.0.68"
 env_logger = "0.11"


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

related to https://github.com/aws/s2n-quic/pull/2897, resolves https://github.com/aws/s2n-quic/pull/2899, resolves https://github.com/aws/s2n-quic/pull/2898.

### Description of changes: 

This reverts commit 291d555ecdfe3664552da2e3460a08a85102ad56.

`aya-obj` version 0.2.2 was yanked, so we no longer need to pin `aya-obj` version 0.2.1.

### Call-outs:

### Testing:

CI should pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

