### PR TITLE
ci: exculde dc from cargo timing job

### DIFF
--- a/codebuild/spec/cargotiming.yml
+++ b/codebuild/spec/cargotiming.yml
@@ -21,7 +21,7 @@ phases:
       - cargo build --timings --release
   post_build:
     commands:
-      - cargo test --workspace
+      - cargo test
 
 artifacts:
   # upload timing reports


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

Fixes failing cargo timing job. rust-toolchain sets msrv to 1.84 while dc-quic requires 1.88

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary. If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff. -->

dc-quic wasn't intended to be included in the timing job. This PR excludes dc-quic from it

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

https://github.com/aws/s2n-quic/pull/2896 can be closed after this is merged

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->
Ad-hoc test passed on codebuild. This runs on a schedule, so PR won't catch the failures.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

