### PR TITLE
refactor(build): make cargotiming to build and test for workspace

### DIFF
--- a/codebuild/spec/cargotiming.yml
+++ b/codebuild/spec/cargotiming.yml
@@ -14,14 +14,15 @@ phases:
       - echo "Installing Rust ..."
       - curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
       - . $HOME/.cargo/env
+      - rustup override set stable
       # cmake is a dependency of quiche, which is one of our test dependencies
       - yum update -y && yum install -y cmake
   build:
     commands:
-      - cargo build --workspace --timings --release --exclude s2n-quic-dc-metrics
+      - cargo build --workspace --timings --release
   post_build:
     commands:
-      - cargo test --workspace --exclude s2n-quic-dc-metrics
+      - cargo test --workspace
 
 artifacts:
   # upload timing reports


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

related to https://github.com/aws/s2n-quic/pull/2903 and https://github.com/aws/s2n-quic/pull/2896.

### Description of changes: 

We have recently introduced `s2n-quic-dc-metrics` crate which has a different MSRV than the other s2n-quic's crate. The cargotiming job seems to always use 1.84.0 as its rust version which caused compiling issue with the `s2n-quic-dc-metrics` crate. Hence, I am adding forcing the job to use the stable rust toolchain, so that it can run build and tests on all crates in the s2n-quic repository.

### Call-outs:

I am also adding the flag `--workspace` for the build phase, since we also want to measure build time to build dcQUIC.

### Testing:

I have ran the job on Codebuild and it is passing.

```
[Instance] <Time Stamp> Running command cargo build --workspace --timings --release
...
Compiling s2n-quic-dc-metrics v0.69.0
...
Compiling s2n-quic-dc v0.69.0
...
Compiling s2n-quic-dc-benches v0.1.0
...
[Instance] <Time Stamp> Running command cargo test --workspace
...

Running unittests src/lib.rs (target/debug/deps/s2n_quic_dc_metrics-60d8936f8de0643f)
--
 
running 22 tests
test appender::test::flush_on_drop ... ok
test appender::test::test_configured_rotation ... ok
test appender::test::test_reuse ... ok
test appender::test::test_rotation ... ok
test appender::test::test_time_rollback ... ok
test rseq::tests::check_per_cpu ... ok
test summary::bucket::tests::idx_to_upper_bound ... ok
test summary::bucket::tests::idx_to_lower_bound ... ok
test summary::bucket::tests::sizes ... ok
test rseq::tests::test_thread_ctor_dtor ... ok
test summary::bucket::tests::total_buckets ... ok
test summary::bucket::tests::value_to_idx ... ok
test summary::test::config ... ok
test test::counters_for_enum_counts ... ok
test summary::test::maximum ... ok
test counter::basic ... ok
test rseq::tests::test_send_event_local ... ok
test summary::test::count_correct ... ok
test rseq::tests::check_send_slow_branches ... ok
test summary::test::visits_all_buckets ... ok
test rseq::tests::test_send_event_overflow ... ok
test rseq::tests::check_send_branches ... ok
 
test result: ok. 22 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s


```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

