### PR TITLE
chore(ci): add logic to track CI runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,10 +6,10 @@ on:
     branches:
       - main
   schedule:
-    # Run daily job at 8:00 AM PT.
+    # Run daily job at 8:00 AM and 8:00 PM PT.
     # The workflow is run in the morning to allow for the clippy job to resolve lints from new Rust
     # versions in a timely manner.
-    - cron: '0 15 * * *'
+    - cron: '0 3,15 * * *'
   workflow_dispatch:
 
 name: ci
@@ -46,7 +46,12 @@ jobs:
       examples: ${{ steps.definitions.outputs.examples }}
       crates: ${{ steps.definitions.outputs.crates }}
       workspaces:  ${{ steps.definitions.outputs.workspaces }}
+      start-time: ${{ steps.start-time.outputs.time }}
     steps:
+      - name: Record workflow start time
+        id: start-time
+        run: echo "time=$(date +%s)" >> $GITHUB_OUTPUT
+
       - uses: actions/checkout@v6
       # examples is populated by
       # find all child folders in the examples directory
@@ -1039,14 +1044,44 @@ jobs:
     needs: [env, rustfmt, clippy, udeps, doc, test, asan, fips, miri, no_std, compliance, coverage, crates, examples, recovery-simulations, sims, copyright, s2n-events, generate-events, snapshots, timing, typos, kani, dhat, loom, xdp, dc-wireshark]
     steps:
       - uses: aws-actions/configure-aws-credentials@v5.1.1
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
+
       - name: Report daily CI run to CloudWatch
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
         run: |
           METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
           aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFailure" \
             --value $METRIC_VALUE --dimensions Initiator=${{github.event_name}} --timestamp $(date +%s)
+
+      - name: Calculate workflow duration
+        run: |
+          START_TIME=${{ needs.env.outputs.start-time }}
+          END_TIME=$(date +%s)
+          DURATION_SECONDS=$((END_TIME - START_TIME))
+          DURATION_MINUTES=$(echo "scale=2; $DURATION_SECONDS / 60" | bc)
+          CI_STATUS="${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}"
+          
+          echo "Workflow duration: $DURATION_MINUTES minutes"
+          echo "CI Status: $CI_STATUS"
+          echo "Event type: ${{ github.event_name }}"
+          
+          # Save for next step
+          echo "DURATION_MINUTES=$DURATION_MINUTES" >> $GITHUB_ENV
+          echo "CI_STATUS=$CI_STATUS" >> $GITHUB_ENV
+          echo "END_TIME=$END_TIME" >> $GITHUB_ENV
+
+      - name: Report workflow duration to CloudWatch
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
+        run: |
+          aws cloudwatch put-metric-data \
+            --namespace "Github" \
+            --metric-name "ActionCIDuration" \
+            --value $DURATION_MINUTES \
+            --dimensions Status=$CI_STATUS \
+            --timestamp $END_TIME
+          
+          echo "Successfully reported workflow duration to CloudWatch"

--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -6,8 +6,8 @@ on:
     branches:
       - main
   schedule:
-    # Run the daily job at 8 AM PST / 3 PM UTC
-    - cron: '0 15 * * *'
+    # Run the daily job at 8 AM PST and 8 PM PST
+    - cron: '0 3,15 * * *'
 
 name: qns
 
@@ -42,7 +42,12 @@ jobs:
     runs-on: ubuntu-22.04
     outputs:
       matrix: ${{ steps.implementations.outputs.matrix }}
+      start-time: ${{ steps.start-time.outputs.time }}
     steps:
+      - name: Record workflow start time
+        id: start-time
+        run: echo "time=$(date +%s)" >> $GITHUB_OUTPUT
+
       - uses: actions/checkout@v6
         with:
           path: s2n-quic
@@ -577,14 +582,44 @@ jobs:
     needs: [retry-failures, env, s2n-quic-qns, interop, interop-report, h3spec, perf, perf-report, attack]
     steps:
       - uses: aws-actions/configure-aws-credentials@v5.1.1
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
         with:
           role-to-assume: arn:aws:iam::003495580562:role/GitHubOIDCRole
           role-session-name: S2nQuicGHASession
           aws-region: us-west-2
+
       - name: Report daily qns run to CloudWatch
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
         run: |
           METRIC_VALUE=${{ contains(needs.*.result, 'failure') && '1' || '0' }}
           aws cloudwatch put-metric-data --namespace "Github" --metric-name "ActionCIFailure" \
             --value $METRIC_VALUE --dimensions Initiator=${{github.event_name}} --timestamp $(date +%s)
+
+      - name: Calculate workflow duration
+        run: |
+          START_TIME=${{ needs.env.outputs.start-time }}
+          END_TIME=$(date +%s)
+          DURATION_SECONDS=$((END_TIME - START_TIME))
+          DURATION_MINUTES=$(echo "scale=2; $DURATION_SECONDS / 60" | bc)
+          CI_STATUS="${{ contains(needs.*.result, 'failure') && 'failure' || 'success' }}"
+          
+          echo "Workflow duration: $DURATION_MINUTES minutes"
+          echo "CI Status: $CI_STATUS"
+          echo "Event type: ${{ github.event_name }}"
+          
+          # Save for next step
+          echo "DURATION_MINUTES=$DURATION_MINUTES" >> $GITHUB_ENV
+          echo "CI_STATUS=$CI_STATUS" >> $GITHUB_ENV
+          echo "END_TIME=$END_TIME" >> $GITHUB_ENV
+
+      - name: Report workflow duration to CloudWatch
+        if: github.event_name == 'push' || github.event_name == 'schedule' || github.repository == github.event.pull_request.head.repo.full_name
+        run: |
+          aws cloudwatch put-metric-data \
+            --namespace "Github" \
+            --metric-name "ActionQNSDuration" \
+            --value $DURATION_MINUTES \
+            --dimensions Status=$CI_STATUS \
+            --timestamp $END_TIME
+          
+          echo "Successfully reported workflow duration to CloudWatch"


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

related to https://github.com/aws/s2n-quic/issues/2910.

### Description of changes: 

Record CI runtime and upload it to AWS CloudWatch to generate dashboard metrics.

#### Implementation Details

1. We will calculate the runtime by recording the start time and end time in `env` and `ci/qns-status-report` jobs. With those two data points, we should be able to calculate the actual runtime for the workflow.
2. We track CI/QNS runtime per workflow and upload them to AWS CloudWatch. The implementation logic is built upon the existing daily CI run framework. The first PR for that implementation is https://github.com/aws/s2n-quic/pull/2624.
    a. We will keep using `Github` as the namespace. The metric name will be `ActionCIDuration`. We will then further differentiate the status by whether the CI/QNS succeeds or not.
3. We only collect data from merge to main, schedule CI run, and PR cut from a branch in mainline aws/s2n-quic.
    a. Only these events would successfully connect to our AWS account. PR cut from a branch in s2n-quic's fork can't connect to our account.

### Call-outs:

I would like to increase the frequency of daily CI run. It's normal that no PRs are cut to this repo in one day. In that case, the daily CI run should provide datapoints for CI runtime. I would like to run the CI at least twice per day to collect data.

### Testing:

Local testing and this PR run is also testing it.

My review should go to our AWS account and look for the metrics.

Successfully upload data point to the AWS CloudWatch:

<img width="2301" height="512" alt="Screenshot 2025-12-10 at 2 24 35 PM" src="https://github.com/user-attachments/assets/54f249ed-aa42-46cc-b253-06c7cc4fbf9d" />


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

