### PR TITLE
refactor(s2n-quic-core): use core::net::SocketAddr

### DIFF
--- a/quic/s2n-quic-core/events/common.rs
+++ b/quic/s2n-quic-core/events/common.rs
@@ -221,11 +221,10 @@ impl<'a> IntoEvent<builder::SocketAddress<'a>> for &'a crate::inet::SocketAddres
     }
 }
 
-#[cfg(feature = "std")]
-impl From<SocketAddress<'_>> for std::net::SocketAddr {
+impl From<SocketAddress<'_>> for core::net::SocketAddr {
     #[inline]
     fn from(address: SocketAddress) -> Self {
-        use std::net;
+        use core::net;
         match address {
             SocketAddress::IpV4 { ip, port } => {
                 let ip = net::IpAddr::V4(net::Ipv4Addr::from(*ip));
@@ -239,11 +238,10 @@ impl From<SocketAddress<'_>> for std::net::SocketAddr {
     }
 }
 
-#[cfg(feature = "std")]
-impl From<&SocketAddress<'_>> for std::net::SocketAddr {
+impl From<&SocketAddress<'_>> for core::net::SocketAddr {
     #[inline]
     fn from(address: &SocketAddress) -> Self {
-        use std::net;
+        use core::net;
         match address {
             SocketAddress::IpV4 { ip, port } => {
                 let ip = net::IpAddr::V4(net::Ipv4Addr::from(**ip));

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -3279,11 +3279,10 @@ pub mod api {
             }
         }
     }
-    #[cfg(feature = "std")]
-    impl From<SocketAddress<'_>> for std::net::SocketAddr {
+    impl From<SocketAddress<'_>> for core::net::SocketAddr {
         #[inline]
         fn from(address: SocketAddress) -> Self {
-            use std::net;
+            use core::net;
             match address {
                 SocketAddress::IpV4 { ip, port } => {
                     let ip = net::IpAddr::V4(net::Ipv4Addr::from(*ip));
@@ -3296,11 +3295,10 @@ pub mod api {
             }
         }
     }
-    #[cfg(feature = "std")]
-    impl From<&SocketAddress<'_>> for std::net::SocketAddr {
+    impl From<&SocketAddress<'_>> for core::net::SocketAddr {
         #[inline]
         fn from(address: &SocketAddress) -> Self {
-            use std::net;
+            use core::net;
             match address {
                 SocketAddress::IpV4 { ip, port } => {
                     let ip = net::IpAddr::V4(net::Ipv4Addr::from(**ip));

--- a/quic/s2n-quic-core/src/inet/ipv4.rs
+++ b/quic/s2n-quic-core/src/inet/ipv4.rs
@@ -7,7 +7,7 @@ use crate::inet::{
     unspecified::Unspecified,
     ExplicitCongestionNotification,
 };
-use core::{fmt, mem::size_of};
+use core::{fmt, mem::size_of, net};
 use s2n_codec::zerocopy::U16;
 
 //= https://www.rfc-editor.org/rfc/rfc791#section-2.3
@@ -295,6 +295,68 @@ impl Unspecified for SocketAddressV4 {
     #[inline]
     fn is_unspecified(&self) -> bool {
         Self::UNSPECIFIED.eq(self)
+    }
+}
+
+impl From<net::Ipv4Addr> for IpV4Address {
+    fn from(address: net::Ipv4Addr) -> Self {
+        (&address).into()
+    }
+}
+
+impl From<&net::Ipv4Addr> for IpV4Address {
+    fn from(address: &net::Ipv4Addr) -> Self {
+        address.octets().into()
+    }
+}
+
+impl From<IpV4Address> for net::Ipv4Addr {
+    fn from(address: IpV4Address) -> Self {
+        address.octets.into()
+    }
+}
+
+impl From<net::SocketAddrV4> for SocketAddressV4 {
+    fn from(address: net::SocketAddrV4) -> Self {
+        let ip = address.ip().into();
+        let port = address.port().into();
+        Self { ip, port }
+    }
+}
+
+impl From<(net::Ipv4Addr, u16)> for SocketAddressV4 {
+    fn from((ip, port): (net::Ipv4Addr, u16)) -> Self {
+        Self::new(ip, port)
+    }
+}
+
+impl From<SocketAddressV4> for net::SocketAddrV4 {
+    fn from(address: SocketAddressV4) -> Self {
+        let ip = address.ip.into();
+        let port = address.port.into();
+        Self::new(ip, port)
+    }
+}
+
+impl From<&SocketAddressV4> for net::SocketAddrV4 {
+    fn from(address: &SocketAddressV4) -> Self {
+        let ip = address.ip.into();
+        let port = address.port.into();
+        Self::new(ip, port)
+    }
+}
+
+impl From<SocketAddressV4> for net::SocketAddr {
+    fn from(address: SocketAddressV4) -> Self {
+        let addr: net::SocketAddrV4 = address.into();
+        addr.into()
+    }
+}
+
+impl From<&SocketAddressV4> for net::SocketAddr {
+    fn from(address: &SocketAddressV4) -> Self {
+        let addr: net::SocketAddrV4 = address.into();
+        addr.into()
     }
 }
 
@@ -672,68 +734,6 @@ impl fmt::Debug for FlagFragment {
 mod std_conversion {
     use super::*;
     use std::net;
-
-    impl From<net::Ipv4Addr> for IpV4Address {
-        fn from(address: net::Ipv4Addr) -> Self {
-            (&address).into()
-        }
-    }
-
-    impl From<&net::Ipv4Addr> for IpV4Address {
-        fn from(address: &net::Ipv4Addr) -> Self {
-            address.octets().into()
-        }
-    }
-
-    impl From<IpV4Address> for net::Ipv4Addr {
-        fn from(address: IpV4Address) -> Self {
-            address.octets.into()
-        }
-    }
-
-    impl From<net::SocketAddrV4> for SocketAddressV4 {
-        fn from(address: net::SocketAddrV4) -> Self {
-            let ip = address.ip().into();
-            let port = address.port().into();
-            Self { ip, port }
-        }
-    }
-
-    impl From<(net::Ipv4Addr, u16)> for SocketAddressV4 {
-        fn from((ip, port): (net::Ipv4Addr, u16)) -> Self {
-            Self::new(ip, port)
-        }
-    }
-
-    impl From<SocketAddressV4> for net::SocketAddrV4 {
-        fn from(address: SocketAddressV4) -> Self {
-            let ip = address.ip.into();
-            let port = address.port.into();
-            Self::new(ip, port)
-        }
-    }
-
-    impl From<&SocketAddressV4> for net::SocketAddrV4 {
-        fn from(address: &SocketAddressV4) -> Self {
-            let ip = address.ip.into();
-            let port = address.port.into();
-            Self::new(ip, port)
-        }
-    }
-
-    impl From<SocketAddressV4> for net::SocketAddr {
-        fn from(address: SocketAddressV4) -> Self {
-            let addr: net::SocketAddrV4 = address.into();
-            addr.into()
-        }
-    }
-
-    impl From<&SocketAddressV4> for net::SocketAddr {
-        fn from(address: &SocketAddressV4) -> Self {
-            let addr: net::SocketAddrV4 = address.into();
-            addr.into()
-        }
-    }
 
     impl net::ToSocketAddrs for SocketAddressV4 {
         type Iter = std::iter::Once<net::SocketAddr>;

--- a/quic/s2n-quic-core/src/path/mod.rs
+++ b/quic/s2n-quic-core/src/path/mod.rs
@@ -145,6 +145,13 @@ macro_rules! impl_addr {
             }
         }
 
+        impl From<$name> for core::net::SocketAddr {
+            #[inline]
+            fn from(value: $name) -> Self {
+                value.0.into()
+            }
+        }
+
         impl core::ops::Deref for $name {
             type Target = SocketAddress;
 


### PR DESCRIPTION
### Description of changes: 

Since Rust 1.77 `std::net::SocketAddr` and related types have been [available](https://doc.rust-lang.org/stable/core/net/index.html) in `core::net`. This means we no longer need to gate some of the conversion methods we had for converting between our own socket address representations and the `net::SocketAddr` types behind and `std` feature flag. 

I've also added a `From` impl for `LocalAddress` and `RemoteAddress`, as that may be useful in #2906

### Call-outs:

`std::net::ToSocketAddrs` remains in `std` so we can't remove the entire `std_conversion` mod

### Testing:

Existing tests pass and ./scripts/test_no_std script passes


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

