### PR TITLE
refactor(s2n-quic-platform): use portable_atomic to support 32bit system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,6 +271,12 @@ jobs:
             exclude: --exclude s2n-quic-dc --exclude s2n-quic-dc-benches --exclude s2n-quic-dc-metrics
           - rust: stable
             os: ubuntu-latest
+            target: armv5te-unknown-linux-musleabi
+            # s2n-quic-dc and s2n-quic-dc-benches depends on seize which takes dependency on core::sync::atomic::AtomicU64.
+            # That dependency is not supported on armv5te-unknown-linux-musleabi.
+            exclude: --exclude s2n-quic-dc --exclude s2n-quic-dc-benches
+          - rust: stable
+            os: ubuntu-latest
             target: x86_64-unknown-linux-musl
             args: --features aws-lc-bindgen
           # test with different platform features

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -25,6 +25,7 @@ bolero-generator = { version = "0.13", default-features = false, optional = true
 cfg-if = "1"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 lazy_static = { version = "1", optional = true }
+portable-atomic = "1"
 s2n-quic-core = { version = "=0.71.0", path = "../s2n-quic-core", default-features = false }
 s2n-quic-xdp = { version = "=0.71.0", path = "../../tools/xdp/s2n-quic-xdp", optional = true }
 socket2 = { version = "0.6", features = ["all"], optional = true }

--- a/quic/s2n-quic-platform/src/socket/stats.rs
+++ b/quic/s2n-quic-platform/src/socket/stats.rs
@@ -1,11 +1,8 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use core::{
-    fmt,
-    sync::atomic::{AtomicU64, Ordering},
-    task::Poll,
-};
+use core::{fmt, task::Poll};
+use portable_atomic::{AtomicU64, Ordering};
 use s2n_quic_core::{
     event::{self, EndpointPublisher},
     io::event_loop,


### PR DESCRIPTION
### Release Summary:

Use `protable_atomic` crate to support 32-bit systems. This is specifically to allow s2n-quic to run on `armv5te-unknown-linux-musleabi`.

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2923.

### Description of changes: 

Replace the `core::sync::atomic::AtomicU64` in s2n-quic-platform socket/stat.rs with [`portable_atomic` crate](https://crates.io/crates/portable-atomic). There is no change in behavior.

### Call-outs:

One of our dependency in s2n-quic-dc is depending on seize which also takes dependency on core::...::AtomicU64:
```
Machine:path_to_s2n_quic$ cargo tree --workspace -i seize
seize v0.3.3
└── flurry v0.5.2
    └── s2n-quic-dc v0.71.0 (/home/ubuntu/workspace/s2n-quic/dc/s2n-quic-dc)
        └── s2n-quic-dc-benches v0.1.0 (/home/ubuntu/workspace/s2n-quic/dc/s2n-quic-dc-benches)
```
Hence, our test would skip s2n-quic-dc and s2n-quic-dc-benches crate just like other tests that doesn't support s2n-quic-dc.

### Testing:

I add the test on `armv5te-unknown-linux-musleabi` in our system. This test should pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

