### PR TITLE
fix(s2n-quic-core): MtuProbingCompleteSupport transport parameter encoding

### DIFF
--- a/quic/s2n-quic-core/src/transport/parameters/mod.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/mod.rs
@@ -1211,13 +1211,9 @@ impl<'a> IntoEvent<&'a [u32]> for &'a DcSupportedVersions {
 /// This is a DC-specific transport parameter
 #[derive(Clone, Copy, Debug, PartialEq, Default)]
 pub enum MtuProbingCompleteSupport {
-    #[default]
     Enabled,
+    #[default]
     Disabled,
-}
-
-impl MtuProbingCompleteSupport {
-    pub const RECOMMENDED: Self = Self::Enabled;
 }
 
 impl TransportParameter for MtuProbingCompleteSupport {
@@ -1226,11 +1222,11 @@ impl TransportParameter for MtuProbingCompleteSupport {
     const ID: TransportParameterId = TransportParameterId::from_u32(0xdc0001);
 
     fn from_codec_value(_value: ()) -> Self {
-        MtuProbingCompleteSupport::Disabled
+        MtuProbingCompleteSupport::Enabled
     }
 
     fn try_into_codec_value(&self) -> Option<&()> {
-        if let MtuProbingCompleteSupport::Disabled = self {
+        if let MtuProbingCompleteSupport::Enabled = self {
             Some(&())
         } else {
             None

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__ClientTransportParameters__default.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__ClientTransportParameters__default.snap
@@ -1,5 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/tests.rs
+assertion_line: 52
 expression: default_value
 ---
 TransportParameters {
@@ -76,5 +77,5 @@ TransportParameters {
             0,
         ],
     },
-    mtu_probing_complete_support: Enabled,
+    mtu_probing_complete_support: Disabled,
 }

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__ServerTransportParameters__default.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__ServerTransportParameters__default.snap
@@ -1,5 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/tests.rs
+assertion_line: 47
 expression: default_value
 ---
 TransportParameters {
@@ -76,5 +77,5 @@ TransportParameters {
             0,
         ],
     },
-    mtu_probing_complete_support: Enabled,
+    mtu_probing_complete_support: Disabled,
 }

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__client_snapshot_test.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__client_snapshot_test.snap
@@ -1,5 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/tests.rs
+assertion_line: 139
 expression: encoded_output
 ---
 [
@@ -54,4 +55,9 @@ expression: encoded_output
     2,
     3,
     4,
+    128,
+    220,
+    0,
+    1,
+    0,
 ]

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__load_client_limits.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__load_client_limits.snap
@@ -1,5 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/tests.rs
+assertion_line: 161
 expression: params
 ---
 TransportParameters {
@@ -76,5 +77,5 @@ TransportParameters {
             0,
         ],
     },
-    mtu_probing_complete_support: Enabled,
+    mtu_probing_complete_support: Disabled,
 }

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__load_server_limits.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__load_server_limits.snap
@@ -1,5 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/tests.rs
+assertion_line: 151
 expression: params
 ---
 TransportParameters {
@@ -76,5 +77,5 @@ TransportParameters {
             0,
         ],
     },
-    mtu_probing_complete_support: Enabled,
+    mtu_probing_complete_support: Disabled,
 }

--- a/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__server_snapshot_test.snap
+++ b/quic/s2n-quic-core/src/transport/parameters/snapshots/s2n_quic_core__transport__parameters__tests__server_snapshot_test.snap
@@ -1,5 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/transport/parameters/tests.rs
+assertion_line: 97
 expression: encoded_output
 ---
 [
@@ -132,4 +133,9 @@ expression: encoded_output
     0,
     1,
     3,
+    128,
+    220,
+    0,
+    1,
+    0,
 ]

--- a/quic/s2n-quic-core/src/transport/parameters/tests.rs
+++ b/quic/s2n-quic-core/src/transport/parameters/tests.rs
@@ -336,3 +336,35 @@ fn dc_selected_version() {
         .selected_version()
         .is_err());
 }
+
+#[test]
+fn mtu_probing_complete_support_encoding() {
+    let id_bytes = MtuProbingCompleteSupport::ID.encode_to_vec();
+    let mut params = ClientTransportParameters::default();
+
+    // When Enabled, the parameter SHOULD be encoded
+    {
+        params.mtu_probing_complete_support = MtuProbingCompleteSupport::Enabled;
+        let encoded = params.encode_to_vec();
+
+        assert!(
+            encoded
+                .windows(id_bytes.len())
+                .any(|window| window == id_bytes.as_slice()),
+            "MtuProbingCompleteSupport parameter should be encoded when Enabled"
+        );
+    }
+
+    // When Disabled, the parameter should NOT be encoded
+    {
+        params.mtu_probing_complete_support = MtuProbingCompleteSupport::Disabled;
+        let encoded = params.encode_to_vec();
+
+        assert!(
+            !encoded
+                .windows(id_bytes.len())
+                .any(|window| window == id_bytes.as_slice()),
+            "MtuProbingCompleteSupport parameter should NOT be encoded when Disabled"
+        );
+    }
+}

--- a/quic/s2n-quic-tests/src/tests/snapshots/tests__dc__dc_not_secret_control_packet__events.snap
+++ b/quic/s2n-quic-tests/src/tests/snapshots/tests__dc__dc_not_secret_control_packet__events.snap
@@ -1,5 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/event/snapshot.rs
+assertion_line: 59
 input_file: quic/s2n-quic-tests/src/tests/dc.rs
 ---
 === client ===

--- a/quic/s2n-quic-tests/src/tests/snapshots/tests__dc__dc_secret_control_packet__events.snap
+++ b/quic/s2n-quic-tests/src/tests/snapshots/tests__dc__dc_secret_control_packet__events.snap
@@ -1,5 +1,6 @@
 ---
 source: quic/s2n-quic-core/src/event/snapshot.rs
+assertion_line: 59
 input_file: quic/s2n-quic-tests/src/tests/dc.rs
 ---
 === client ===

--- a/quic/s2n-quic-transport/src/space/session_context.rs
+++ b/quic/s2n-quic-transport/src/space/session_context.rs
@@ -41,7 +41,7 @@ use s2n_quic_core::{
         parameters::{
             ActiveConnectionIdLimit, ClientTransportParameters, DatagramLimits,
             DcSupportedVersions, InitialFlowControlLimits, InitialSourceConnectionId, MaxAckDelay,
-            ServerTransportParameters, TransportParameter as _,
+            MtuProbingCompleteSupport, ServerTransportParameters, TransportParameter as _,
         },
         Error,
     },
@@ -747,6 +747,10 @@ impl<Config: endpoint::Config, Pub: event::ConnectionPublisher>
             if let Some(selected_version) = dc::select_version(client_params.dc_supported_versions)
             {
                 DcSupportedVersions::for_server(selected_version).append_to_buffer(server_params)
+            }
+
+            if self.dc.mtu_probing_complete_support() {
+                MtuProbingCompleteSupport::Enabled.append_to_buffer(server_params);
             }
         }
 


### PR DESCRIPTION
### Release Summary:

Fix MtuProbingCompleteSupport transport parameter encoding.

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2927.

### Description of changes: 

`MtuProbingCompleteSupport` transport parameter should be disabled by default and can only be enabled if an endpoint has dc enabled. The logic for encoding was inverted with its current code. dcQUIC should encode the `MtuProbingCompleteSupport` transport parameter if it is enabled so that it can be sent on the wire.

In addition to that, I noticed that the server won't send this transport parameter currently, so I add such logic in `quic/s2n-quic-transport/src/space/session_context.rs`.

### Call-outs:

Review the snapshot changes now. All endpoints that doesn't have dc enabled should have the MtuprobingCompleteSupport transport parameter disabled.

### Testing:

I add a unit test for the `MtuProbingCompleteSupport` transport parameter. The test would verify if `MtuProbingCompleteSupport` is enabled, then the parameter will be encoded, and otherwise, it would not.

Additional verifications are also added to two integration tests for this feature: `mtu_probing_complete_frame_exchange_test` and `mtu_probing_complete_server_only_test`. Those two tests would verify that if the transport parameters are properly received from its peer.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

