### PR TITLE
chore(s2n-quic-dc): allow usage of deprecated set_linger method in tokio

### DIFF
--- a/dc/s2n-quic-dc/src/stream/client/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/client/tokio.rs
@@ -530,6 +530,7 @@ where
     let _ = socket.set_nodelay(true);
 
     if linger.is_some() {
+        #[allow(deprecated)]
         let _ = socket.set_linger(linger);
     }
 

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp/lazy.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp/lazy.rs
@@ -34,6 +34,7 @@ impl LazyBoundStream {
 
     pub fn set_linger(&self, linger: Option<Duration>) -> io::Result<()> {
         match self {
+            #[allow(deprecated)]
             LazyBoundStream::Tokio(s) => s.set_linger(linger),
             LazyBoundStream::Std(s) => {
                 // Once it stabilizes we can switch to the std function


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

The `set_linger()` function was deprecated in the latest tokio release: https://docs.rs/tokio/latest/tokio/net/struct.TcpSocket.html#method.set_linger.
Seems like there is no replacement for this method and tokio just decide not to support this method anymore.

For dcQUIC purpose, we still need to use this method, and hence, I am adding the allow deprecated flag to the affected code.

### Call-outs:

We should file an issue to see if we can track down a reproducer for whatever caused tokio to deprecate it and whether it applies even with set_linger(0).

### Testing:

CI, specifically clippy, should pass now.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

