### PR TITLE
ci(QNS): Revert "temporarily disable neqo (#2724)"

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -398,7 +398,7 @@
     "msquic": [],
     "mvfst": [],
     "neqo": [
-      "client"
+      "server"
     ],
     "ngtcp2": [
       "client",


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/2738.

### Description of changes: 

This reverts commit 10c973d5d789bed680c4a80c260d8d9ad58f479d.

I am monitoring the s2n-quic's interop runner report: https://dnglbrstg7yg.cloudfront.net/latest/interop/index.html. The current report is showing the neqo interop test with s2n-quic is currently passing. I went back a couple days of QNS scheduled run result, and s2n-quic@neqo interop test has always been passing. Hence, I believe it would be okay to re-enable neqo tests in s2n-quic's interop runner.

### Call-outs:

I am noticing that previously we required neqo to run as client, but that is currently failing. However, currently neqo running as server (s2n-quic running as client) is passing. This behavior can match the main interop runner. I want to add this test first, so that we can get the test coverage, and we can investigate the root cause later.

### Testing:

We should check the interop runner result for the CI run of this PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

