### PR TITLE
fix(s2n-quic-core): one more effort to acquire credits in worker

### DIFF
--- a/quic/s2n-quic-core/src/sync/worker.rs
+++ b/quic/s2n-quic-core/src/sync/worker.rs
@@ -59,12 +59,14 @@ impl Receiver {
         // if we didn't get any credits then register the waker
         state.receiver.register(cx.waker());
 
-        // make one last effort to acquire credits in case a sender submitted some while we were
+        // make one more effort to acquire credits in case a sender submitted some while we were
         // registering the waker
         acquire!();
 
         // If we're the only ones with a handle to the state then we're done
         if state.senders.load(Ordering::Acquire) == 0 {
+            // One last check in case the sender submitted work before dropping
+            acquire!();
             return Poll::Ready(None);
         }
 


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

The daily CI job noticed a rare miri test failure with respect to s2n-quic-core's worker using loom tests. After some investigation, I believe the `poll_acquire` function is not capturing every credits that the sender is going to send.

The run can be found in https://github.com/aws/s2n-quic/actions/runs/20961630742/attempts/1. The error message that we should pay attention to is:
```
thread '<unnamed>' (4242) panicked at quic/s2n-quic-core/src/sync/worker.rs:175:21:
assertion `left == right` failed
  left: 792
 right: 800
```
This indicates the total amount of credits that were received by the receiver is exactly either bytes less than the amount the sender has sent. Eight bytes is also exactly one batch of the amount that is supposed to be sent. That should indicates the receiver missed exactly one batch of data.

After going through the source code for Receiver's `poll_acquire()` method,  I believe the send might be able to send data after the second acquire that the receiver called, and hence the receiver will miss the last batch of data that the sender submit. 
https://github.com/aws/s2n-quic/blob/d2f6bfaf5f5ad168223a0b5f9ba27e60435bd219/quic/s2n-quic-core/src/sync/worker.rs#L56-L69
Hence, I believe the `poll_acquire` function should do one more acquire call before exit the future with `Poll::Ready(None)`.

### Call-outs:

### Testing:

CI should pass and we shouldn't see the same problems again in our daily CI run.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

