### PR TITLE
chore(s2n-quic-tests): use ConnectionInfo from s2n_quic

### DIFF
--- a/quic/s2n-quic-tests/src/tests/ch_callback_connection_info.rs
+++ b/quic/s2n-quic-tests/src/tests/ch_callback_connection_info.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::*;
-use s2n_quic_core::crypto::tls::ConnectionInfo;
+use s2n_quic::provider::tls::ConnectionInfo;
 use s2n_tls::{
     callbacks::{ClientHelloCallback, ConnectionFuture},
     error::Error as S2nError,


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

related to https://github.com/aws/s2n-quic/pull/2906.

### Description of changes: 

The test in this PR is supposed to serve as a example for how to use `s2n-tls`' client hello callback to access connection info at a very early stage of the connection. The ConnectionInfo struct lives in s2n-quic-core crate but was re-exported to s2n-quic crate.
https://github.com/aws/s2n-quic/blob/373567548d39fb56b8f312257163f45ad2c29cdd/quic/s2n-quic/src/provider/tls.rs#L9

Hence, our customer should directly use it from s2n-quic crate instead of s2n-quic-core crate. This test should reflect that change to make it clear.

### Call-outs:

### Testing:

CI should pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

