### PR TITLE
fix(s2n-quic-dc): limit background handshake concurrency

### DIFF
--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -75,7 +75,7 @@ s2n-quic-core = { path = "../../quic/s2n-quic-core", features = ["testing"] }
 s2n-quic-platform = { path = "../../quic/s2n-quic-platform", features = [
     "testing",
 ] }
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["full", "test-util"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [lints.rust.unexpected_cfgs]

--- a/dc/s2n-quic-dc/events/map.rs
+++ b/dc/s2n-quic-dc/events/map.rs
@@ -422,9 +422,11 @@ struct PathSecretMapCleanerCycled {
     #[measure("handshake_requests")]
     handshake_requests: usize,
 
-    /// The number of handshake requests that were retired in the cycle
-    #[measure("handshake_requests.retired")]
-    handshake_requests_retired: usize,
+    /// The number of handshake requests that were skipped in the cycle due to running out of time
+    /// (other background handshakes took too long to complete, and so were postponed to the next
+    /// cleaner cycle).
+    #[measure("handshake_requests.skipped")]
+    handshake_requests_skipped: usize,
 
     /// How long we kept the handshake lock held (this blocks completing handshakes).
     #[measure("handshake_lock_duration", Duration)]

--- a/dc/s2n-quic-dc/src/event/generated.rs
+++ b/dc/s2n-quic-dc/src/event/generated.rs
@@ -2326,8 +2326,10 @@ pub mod api {
         pub address_entries_initial_utilization: f32,
         #[doc = " The number of handshake requests that are pending after the cleaning cycle"]
         pub handshake_requests: usize,
-        #[doc = " The number of handshake requests that were retired in the cycle"]
-        pub handshake_requests_retired: usize,
+        #[doc = " The number of handshake requests that were skipped in the cycle due to running out of time"]
+        #[doc = " (other background handshakes took too long to complete, and so were postponed to the next"]
+        #[doc = " cleaner cycle)."]
+        pub handshake_requests_skipped: usize,
         #[doc = " How long we kept the handshake lock held (this blocks completing handshakes)."]
         pub handshake_lock_duration: core::time::Duration,
         #[doc = " Total duration of a cycle."]
@@ -2366,8 +2368,8 @@ pub mod api {
             );
             fmt.field("handshake_requests", &self.handshake_requests);
             fmt.field(
-                "handshake_requests_retired",
-                &self.handshake_requests_retired,
+                "handshake_requests_skipped",
+                &self.handshake_requests_skipped,
             );
             fmt.field("handshake_lock_duration", &self.handshake_lock_duration);
             fmt.field("duration", &self.duration);
@@ -3635,11 +3637,11 @@ pub mod tracing {
                 address_entries_utilization,
                 address_entries_initial_utilization,
                 handshake_requests,
-                handshake_requests_retired,
+                handshake_requests_skipped,
                 handshake_lock_duration,
                 duration,
             } = event;
-            tracing :: event ! (target : "path_secret_map_cleaner_cycled" , parent : parent , tracing :: Level :: DEBUG , { id_entries = tracing :: field :: debug (id_entries) , id_entries_retired = tracing :: field :: debug (id_entries_retired) , id_entries_active = tracing :: field :: debug (id_entries_active) , id_entries_active_utilization = tracing :: field :: debug (id_entries_active_utilization) , id_entries_utilization = tracing :: field :: debug (id_entries_utilization) , id_entries_initial_utilization = tracing :: field :: debug (id_entries_initial_utilization) , address_entries = tracing :: field :: debug (address_entries) , address_entries_active = tracing :: field :: debug (address_entries_active) , address_entries_active_utilization = tracing :: field :: debug (address_entries_active_utilization) , address_entries_retired = tracing :: field :: debug (address_entries_retired) , address_entries_utilization = tracing :: field :: debug (address_entries_utilization) , address_entries_initial_utilization = tracing :: field :: debug (address_entries_initial_utilization) , handshake_requests = tracing :: field :: debug (handshake_requests) , handshake_requests_retired = tracing :: field :: debug (handshake_requests_retired) , handshake_lock_duration = tracing :: field :: debug (handshake_lock_duration) , duration = tracing :: field :: debug (duration) });
+            tracing :: event ! (target : "path_secret_map_cleaner_cycled" , parent : parent , tracing :: Level :: DEBUG , { id_entries = tracing :: field :: debug (id_entries) , id_entries_retired = tracing :: field :: debug (id_entries_retired) , id_entries_active = tracing :: field :: debug (id_entries_active) , id_entries_active_utilization = tracing :: field :: debug (id_entries_active_utilization) , id_entries_utilization = tracing :: field :: debug (id_entries_utilization) , id_entries_initial_utilization = tracing :: field :: debug (id_entries_initial_utilization) , address_entries = tracing :: field :: debug (address_entries) , address_entries_active = tracing :: field :: debug (address_entries_active) , address_entries_active_utilization = tracing :: field :: debug (address_entries_active_utilization) , address_entries_retired = tracing :: field :: debug (address_entries_retired) , address_entries_utilization = tracing :: field :: debug (address_entries_utilization) , address_entries_initial_utilization = tracing :: field :: debug (address_entries_initial_utilization) , handshake_requests = tracing :: field :: debug (handshake_requests) , handshake_requests_skipped = tracing :: field :: debug (handshake_requests_skipped) , handshake_lock_duration = tracing :: field :: debug (handshake_lock_duration) , duration = tracing :: field :: debug (duration) });
         }
         #[inline]
         fn on_path_secret_map_id_write_lock(
@@ -5847,8 +5849,10 @@ pub mod builder {
         pub address_entries_initial_utilization: f32,
         #[doc = " The number of handshake requests that are pending after the cleaning cycle"]
         pub handshake_requests: usize,
-        #[doc = " The number of handshake requests that were retired in the cycle"]
-        pub handshake_requests_retired: usize,
+        #[doc = " The number of handshake requests that were skipped in the cycle due to running out of time"]
+        #[doc = " (other background handshakes took too long to complete, and so were postponed to the next"]
+        #[doc = " cleaner cycle)."]
+        pub handshake_requests_skipped: usize,
         #[doc = " How long we kept the handshake lock held (this blocks completing handshakes)."]
         pub handshake_lock_duration: core::time::Duration,
         #[doc = " Total duration of a cycle."]
@@ -5871,7 +5875,7 @@ pub mod builder {
                 address_entries_utilization,
                 address_entries_initial_utilization,
                 handshake_requests,
-                handshake_requests_retired,
+                handshake_requests_skipped,
                 handshake_lock_duration,
                 duration,
             } = self;
@@ -5890,7 +5894,7 @@ pub mod builder {
                 address_entries_initial_utilization: address_entries_initial_utilization
                     .into_event(),
                 handshake_requests: handshake_requests.into_event(),
-                handshake_requests_retired: handshake_requests_retired.into_event(),
+                handshake_requests_skipped: handshake_requests_skipped.into_event(),
                 handshake_lock_duration: handshake_lock_duration.into_event(),
                 duration: duration.into_event(),
             }

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -1774,7 +1774,7 @@ static INFO: &[Info; 302usize] = &[
     .build(),
     info::Builder {
         id: 293usize,
-        name: Str::new("path_secret_map_cleaner_cycled.handshake_requests.retired\0"),
+        name: Str::new("path_secret_map_cleaner_cycled.handshake_requests.skipped\0"),
         units: Units::None,
     }
     .build(),
@@ -4630,7 +4630,7 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
             event.address_entries_initial_utilization,
         );
         self.measure(292usize, 116usize, event.handshake_requests);
-        self.measure(293usize, 117usize, event.handshake_requests_retired);
+        self.measure(293usize, 117usize, event.handshake_requests_skipped);
         self.measure(294usize, 118usize, event.handshake_lock_duration);
         self.measure(295usize, 119usize, event.duration);
         let _ = event;

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -809,7 +809,7 @@ mod measure {
                     Self(path_secret_map_cleaner_cycled__entries__address__utilization__initial)
                 }
                 292usize => Self(path_secret_map_cleaner_cycled__handshake_requests),
-                293usize => Self(path_secret_map_cleaner_cycled__handshake_requests__retired),
+                293usize => Self(path_secret_map_cleaner_cycled__handshake_requests__skipped),
                 294usize => Self(path_secret_map_cleaner_cycled__handshake_lock_duration),
                 295usize => Self(path_secret_map_cleaner_cycled__total_duration),
                 297usize => Self(path_secret_map_id_write_lock__acquire),
@@ -1061,8 +1061,8 @@ mod measure {
             fn path_secret_map_cleaner_cycled__entries__address__utilization__initial(value: u64);
             # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__handshake_requests]
             fn path_secret_map_cleaner_cycled__handshake_requests(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__handshake_requests__retired]
-            fn path_secret_map_cleaner_cycled__handshake_requests__retired(value: u64);
+            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__handshake_requests__skipped]
+            fn path_secret_map_cleaner_cycled__handshake_requests__skipped(value: u64);
             # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__handshake_lock_duration]
             fn path_secret_map_cleaner_cycled__handshake_lock_duration(value: u64);
             # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__total_duration]

--- a/dc/s2n-quic-dc/src/path/secret/map.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map.rs
@@ -16,6 +16,7 @@ use crate::{
 use core::fmt;
 use s2n_quic_core::{dc, time, varint::VarInt};
 use std::{net::SocketAddr, sync::Arc};
+use tokio::task::JoinHandle;
 
 mod cleaner;
 mod entry;
@@ -121,7 +122,7 @@ impl Map {
 
     pub fn register_request_handshake(
         &self,
-        cb: Box<dyn Fn(SocketAddr, HandshakeReason) + Send + Sync>,
+        cb: Box<dyn Fn(SocketAddr, HandshakeReason) -> Option<JoinHandle<()>> + Send + Sync>,
     ) {
         self.store.register_request_handshake(cb);
     }

--- a/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
@@ -202,10 +202,11 @@ impl Cleaner {
         }
 
         let mut handshake_requests = 0;
-        rehandshake.next_rehandshake_batch(state.peers.len(), |peer| {
-            handshake_requests += 1;
-            state.request_handshake(peer, crate::psk::io::HandshakeReason::Periodic);
-        });
+        let handshake_requests_skipped =
+            rehandshake.next_rehandshake_batch(state.peers.len(), |peer| {
+                handshake_requests += 1;
+                state.request_handshake(peer, crate::psk::io::HandshakeReason::Periodic)
+            });
 
         drop(rehandshake);
 
@@ -227,7 +228,7 @@ impl Cleaner {
                 address_entries_initial_utilization: utilization(address_entries_initial),
                 address_entries_retired,
                 handshake_requests,
-                handshake_requests_retired: 0,
+                handshake_requests_skipped,
                 handshake_lock_duration,
                 duration: state.clock.get_time().saturating_duration_since(start),
             },

--- a/dc/s2n-quic-dc/src/path/secret/map/rehandshake.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/rehandshake.rs
@@ -3,11 +3,10 @@
 
 use s2n_quic_core::inet::{SocketAddress, SocketAddressV6};
 use std::{
-    collections::hash_map::RandomState,
-    hash::BuildHasher,
-    net::SocketAddr,
-    time::{Duration, Instant},
+    collections::hash_map::RandomState, hash::BuildHasher, mem::ManuallyDrop, net::SocketAddr,
+    sync::Arc, time::Duration,
 };
+use tokio::{runtime::Runtime, sync::Semaphore, task::JoinHandle, time::Instant};
 
 pub(super) struct RehandshakeState {
     queue: Vec<SocketAddressV6>,
@@ -18,19 +17,43 @@ pub(super) struct RehandshakeState {
     rehandshake_period: Duration,
 
     hasher: RandomState,
+    runtime: ManuallyDrop<Runtime>,
+    semaphore: Arc<Semaphore>,
 }
 
 impl RehandshakeState {
     pub(super) fn new(rehandshake_period: Duration) -> Self {
+        Self::new_with_runtime(rehandshake_period, false)
+    }
+
+    #[cfg(test)]
+    fn new_with_paused_time(rehandshake_period: Duration) -> Self {
+        Self::new_with_runtime(rehandshake_period, true)
+    }
+
+    fn new_with_runtime(rehandshake_period: Duration, start_paused: bool) -> Self {
+        let mut builder = tokio::runtime::Builder::new_current_thread();
+        builder.enable_all();
+        if start_paused {
+            #[cfg(test)]
+            builder.start_paused(true);
+        }
+        let runtime = builder.build().unwrap();
+        let _guard = runtime.enter();
+        let now = Instant::now();
         Self {
             queue: Default::default(),
             handshake_at: Default::default(),
-            schedule_handshake_at: Instant::now(),
+            schedule_handshake_at: now,
             rehandshake_period,
 
             // Initializes the hasher with random keys, ensuring we handshake with peers in a
             // different, random order from different hosts.
             hasher: RandomState::new(),
+            // This is arbitrarily chosen, and should be less than the permits granted to
+            // handshakes in the handshake client (currently limited to 5).
+            semaphore: Arc::new(Semaphore::new(2)),
+            runtime: ManuallyDrop::new(runtime),
         }
     }
 
@@ -55,11 +78,19 @@ impl RehandshakeState {
         self.queue.reserve(capacity);
     }
 
+    /// Returns the number of handshake requests skipped due to handshakes taking too long.
     pub(super) fn next_rehandshake_batch(
         &mut self,
         peer_count: usize,
-        mut request_handshake: impl FnMut(SocketAddr),
-    ) {
+        mut request_handshake: impl FnMut(SocketAddr) -> Option<JoinHandle<()>>,
+    ) -> usize {
+        let _guard = self.runtime.enter();
+        let start = Instant::now();
+
+        // Reduce the batch deadline to give time for our p100 handshake duration, which we expect
+        // to be approximately 10 seconds.
+        let batch_deadline = start + Duration::from_secs(50);
+
         // Get the number of handshakes we should run during each minute.
         let mut to_select =
             (60.0 * peer_count as f64 / self.rehandshake_period.as_secs() as f64).trunc() as usize;
@@ -71,35 +102,76 @@ impl RehandshakeState {
             (self.rehandshake_period.as_secs() as f64 / peer_count as f64).ceil() as u64;
 
         // Schedule when we're going to add the one handshake.
-        if self.handshake_at.is_none()
-            && max_delay > 0
-            && self.schedule_handshake_at <= Instant::now()
-        {
+        if self.handshake_at.is_none() && max_delay > 0 && self.schedule_handshake_at <= start {
             max_delay = max_delay.clamp(0, self.rehandshake_period.as_secs());
             let delta = rand::random_range(0..max_delay);
-            self.handshake_at = Some(Instant::now() + Duration::from_secs(delta));
-            self.schedule_handshake_at = Instant::now() + Duration::from_secs(max_delay);
+            self.handshake_at = Some(start + Duration::from_secs(delta));
+            self.schedule_handshake_at = start + Duration::from_secs(max_delay);
         }
 
         // If the time when we should add the single handshake, then add it.
-        if self.handshake_at.is_some_and(|t| t <= Instant::now()) {
+        if self.handshake_at.is_some_and(|t| t <= start) {
             to_select += 1;
             self.handshake_at = None;
         }
 
-        for idx in 0..to_select {
+        let mut handles = Vec::new();
+        let mut last_spawn = start;
+
+        while to_select > 0 {
+            // Check if we've exceeded the batch deadline
+            let now = Instant::now();
+            if now >= batch_deadline {
+                break;
+            }
+
+            to_select -= 1;
+
             let Some(entry) = self.queue.pop() else {
+                to_select = 0;
                 break;
             };
 
-            request_handshake(entry.unmap().into());
+            // Pace handshakes by waiting 100ms since the last spawn. If a handshake is slow this
+            // is a no-op but otherwise this effectively limits concurrency to 1.
+            let pace_until = last_spawn + Duration::from_millis(100);
+            self.runtime.block_on(tokio::time::sleep_until(pace_until));
+            last_spawn = Instant::now();
 
-            if idx % 5 == 0 && idx != 0 {
-                // Since we handshake in bursts of 5, this still allows 60*1000/10*5 = 30k
-                // handshakes/minute, which is orders of magnitude more than we should ever have.
-                // At 500k peers with a 24 hour handshake period means ~348 handshakes/minute.
-                std::thread::sleep(Duration::from_millis(10));
+            // Wait for a slot if we're at capacity
+            let permit = self
+                .runtime
+                .block_on(self.semaphore.clone().acquire_owned())
+                .unwrap();
+
+            if let Some(handle) = request_handshake(entry.unmap().into()) {
+                let wrapped = self.runtime.spawn(async move {
+                    handle.await.expect("propagate panic");
+                    drop(permit);
+                });
+                handles.push(wrapped);
+            } else {
+                drop(permit);
             }
+        }
+
+        // Wait for all tasks to complete
+        for handle in handles {
+            self.runtime.block_on(handle).expect("propagate panic");
+        }
+
+        to_select
+    }
+}
+
+impl Drop for RehandshakeState {
+    fn drop(&mut self) {
+        // SAFETY: This runs in Drop and no further usage of the ManuallyDrop occurs.
+        unsafe {
+            ManuallyDrop::take(&mut self.runtime).shutdown_background();
         }
     }
 }
+
+#[cfg(test)]
+mod test;

--- a/dc/s2n-quic-dc/src/path/secret/map/rehandshake/test.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/rehandshake/test.rs
@@ -1,0 +1,205 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use std::{
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+#[test]
+fn test_limits_concurrency() {
+    // Use a short rehandshake period so we schedule multiple handshakes per minute
+    let mut state = RehandshakeState::new_with_paused_time(Duration::from_secs(60));
+
+    // Add 10 peers
+    for i in 0..10 {
+        state.push(SocketAddr::from(([127, 0, 0, 1], 4000 + i)));
+    }
+    state.adjust_post_refill();
+
+    let concurrent = Arc::new(AtomicUsize::new(0));
+    let max_concurrent = Arc::new(AtomicUsize::new(0));
+    let handle = state.runtime.handle().clone();
+
+    state.next_rehandshake_batch(10, |_addr| {
+        let concurrent = concurrent.clone();
+        let max_concurrent = max_concurrent.clone();
+
+        Some(handle.spawn(async move {
+            let current = concurrent.fetch_add(1, Ordering::Relaxed) + 1;
+            max_concurrent.fetch_max(current, Ordering::Relaxed);
+
+            // Simulate handshake taking 5 seconds
+            tokio::time::sleep(Duration::from_secs(5)).await;
+
+            concurrent.fetch_sub(1, Ordering::Relaxed);
+        }))
+    });
+
+    // Semaphore is set to 2, so max concurrent should be 2, despite pacing.
+    assert_eq!(max_concurrent.load(Ordering::Relaxed), 2);
+}
+
+#[test]
+fn test_limits_concurrency_for_fast_handshakes() {
+    // Use a short rehandshake period so we schedule multiple handshakes per minute
+    let mut state = RehandshakeState::new_with_paused_time(Duration::from_secs(60));
+
+    // Add 10 peers
+    for i in 0..10 {
+        state.push(SocketAddr::from(([127, 0, 0, 1], 4000 + i)));
+    }
+    state.adjust_post_refill();
+
+    let concurrent = Arc::new(AtomicUsize::new(0));
+    let max_concurrent = Arc::new(AtomicUsize::new(0));
+    let handle = state.runtime.handle().clone();
+
+    state.next_rehandshake_batch(10, |_addr| {
+        let concurrent = concurrent.clone();
+        let max_concurrent = max_concurrent.clone();
+
+        Some(handle.spawn(async move {
+            let current = concurrent.fetch_add(1, Ordering::Relaxed) + 1;
+            max_concurrent.fetch_max(current, Ordering::Relaxed);
+
+            // Simulate handshake taking 1ms
+            tokio::time::sleep(Duration::from_millis(1)).await;
+
+            concurrent.fetch_sub(1, Ordering::Relaxed);
+        }))
+    });
+
+    // Semaphore is set to 2. However we only expect one handshake at a time because pacing is
+    // configured at 10ms, and all handshakes complete fast enough that it's respected.
+    assert_eq!(max_concurrent.load(Ordering::Relaxed), 1);
+}
+
+#[test]
+fn test_waits_for_completion() {
+    // Use a short rehandshake period so we schedule multiple handshakes per minute
+    let mut state = RehandshakeState::new_with_paused_time(Duration::from_secs(60));
+
+    for i in 0..5 {
+        state.push(SocketAddr::from(([127, 0, 0, 1], 4000 + i)));
+    }
+    state.adjust_post_refill();
+
+    let completed = Arc::new(AtomicUsize::new(0));
+    let handle = state.runtime.handle().clone();
+
+    state.next_rehandshake_batch(5, |_addr| {
+        let completed = completed.clone();
+
+        Some(handle.spawn(async move {
+            tokio::time::sleep(Duration::from_secs(3)).await;
+            completed.fetch_add(1, Ordering::Relaxed);
+        }))
+    });
+
+    // All handshakes should be complete
+    assert_eq!(completed.load(Ordering::Relaxed), 5);
+}
+
+#[test]
+fn test_respects_60_second_deadline() {
+    // Use a short rehandshake period so we try to schedule many handshakes
+    let mut state = RehandshakeState::new_with_paused_time(Duration::from_secs(120));
+
+    // Add many peers
+    for i in 0..100 {
+        state.push(SocketAddr::from(([127, 0, 0, 1], 4000 + i)));
+    }
+    state.adjust_post_refill();
+
+    let scheduled = Arc::new(AtomicUsize::new(0));
+    let handle = state.runtime.handle().clone();
+
+    state.next_rehandshake_batch(100, |_addr| {
+        let scheduled = scheduled.clone();
+
+        scheduled.fetch_add(1, Ordering::Relaxed);
+
+        Some(handle.spawn(async move {
+            // Each handshake takes 10 seconds
+            tokio::time::sleep(Duration::from_secs(10)).await;
+        }))
+    });
+
+    // With 2 concurrent slots and 10s per handshake, we can complete at most
+    // 60s / 10s * 2 = 12 handshakes before hitting the deadline.
+    // Allow for 13 due to timing granularity.
+    let count = scheduled.load(Ordering::Relaxed);
+    assert!(count <= 13, "scheduled {count} handshakes, expected <= 13");
+
+    // Should have items left in queue
+    assert!(!state.queue.is_empty());
+}
+
+#[test]
+fn test_keeps_unscheduled_in_queue() {
+    // Use a short rehandshake period
+    let mut state = RehandshakeState::new_with_paused_time(Duration::from_secs(60));
+
+    for i in 0..20 {
+        state.push(SocketAddr::from(([127, 0, 0, 1], 4000 + i)));
+    }
+    state.adjust_post_refill();
+
+    let initial_count = state.queue.len();
+    let handle = state.runtime.handle().clone();
+
+    state.next_rehandshake_batch(20, |_addr| {
+        Some(handle.spawn(async move {
+            // Each handshake takes 30 seconds
+            tokio::time::sleep(Duration::from_secs(30)).await;
+        }))
+    });
+
+    let scheduled = initial_count - state.queue.len();
+    assert!(
+        scheduled < initial_count,
+        "should not schedule all handshakes"
+    );
+    assert!(
+        !state.queue.is_empty(),
+        "should keep unscheduled items in queue"
+    );
+}
+
+#[test]
+fn test_tail_handshake_scheduling() {
+    // Use a long rehandshake period so tail handshake logic is used
+    let mut state = RehandshakeState::new_with_paused_time(Duration::from_secs(3600));
+
+    // Single peer - should use tail handshake logic
+    state.push(SocketAddr::from(([127, 0, 0, 1], 4000)));
+
+    let scheduled = Arc::new(AtomicUsize::new(0));
+    let handle = state.runtime.handle().clone();
+
+    // Call batch enough times that we should go through the full hour. If we scheduled in the last
+    // period, we'll need to include one more period since it'll slip into the next hour.
+    for _ in 0..61 {
+        state.next_rehandshake_batch(1, |_addr| {
+            scheduled.fetch_add(1, Ordering::Relaxed);
+            Some(handle.spawn(async move {}))
+        });
+
+        // Advance time by 60 seconds (one batch period)
+        state.runtime.block_on(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+    }
+
+    // Should have scheduled at least one handshake across all calls
+    assert!(
+        scheduled.load(Ordering::Relaxed) > 0,
+        "should schedule at least one tail handshake"
+    );
+}

--- a/dc/s2n-quic-dc/src/path/secret/map/store.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/store.rs
@@ -12,6 +12,7 @@ use core::time::Duration;
 use s2n_codec::EncoderBuffer;
 use s2n_quic_core::varint::VarInt;
 use std::{net::SocketAddr, sync::Arc};
+use tokio::task::JoinHandle;
 
 pub trait Store: 'static + Send + Sync {
     fn secrets_len(&self) -> usize;
@@ -66,7 +67,7 @@ pub trait Store: 'static + Send + Sync {
 
     fn register_request_handshake(
         &self,
-        cb: Box<dyn Fn(SocketAddr, HandshakeReason) + Send + Sync>,
+        cb: Box<dyn Fn(SocketAddr, HandshakeReason) -> Option<JoinHandle<()>> + Send + Sync>,
     );
 
     fn check_dedup(

--- a/quic/s2n-quic/src/provider/dc/mtu_confirm.rs
+++ b/quic/s2n-quic/src/provider/dc/mtu_confirm.rs
@@ -11,7 +11,7 @@ use s2n_quic_core::{
     },
 };
 use std::time::Duration;
-use tokio::{runtime::Handle, sync::watch};
+use tokio::sync::watch;
 
 /// `event::Subscriber` used for ensuring an s2n-quic client or server negotiating dc
 /// waits for post-handshake MTU probing to complete
@@ -56,7 +56,7 @@ impl MtuConfirmComplete {
                         if #[cfg(any(test, feature = "unstable-provider-io-testing"))] {
                             // We might be running in cfg(test) with a real tokio runtime, not against the bach provider.
                             // Hence, we use Handle::try_current to test if a tokio runtime has been started.
-                            if Handle::try_current().is_err() {
+                            if tokio::runtime::Handle::try_current().is_err() {
                                 crate::provider::io::testing::time::delay(Duration::from_secs(1)).await;
                             } else {
                                 tokio::time::sleep(Duration::from_secs(1)).await;


### PR DESCRIPTION
### Release Summary:

* fix(s2-quic-dc): Limit background re-handshaking concurrency

### Resolved issues:

n/a

### Description of changes: 

This limits background handshake concurrency to avoid using up the concurrency limiter in the handshake client. With 500k peers (our design limit today) and 10 second timeouts for handshakes, this should translate to ~30 days to re-handshake if 100% of handshakes timeout. That's definitely much longer than our goal of 24 hours, but in practice we don't expect that rate of failures. To hit the 24 hour mark a roughly 3% failure rate is needed given the expected behavior of ~10 second failures and ~20ms successes. Realistically success should be closer to 5ms which further raises our allowed failure rate.

```
>>> 500_000*(0.03*10+0.97*0.02)/2/3600/24
0.9241898148148149 days
```

I expect that in the future we'll want to tweak our timeouts (especially for background handshakes) but this change at least limits the worst impact from background handshaking on application-initiated requests. If all handshakes are succeeding quickly (<= 100ms) this should limit to at most 1 handshake going at a time. This supports ~864k peers (`60*1000/100 = 600 handshakes/minute, 600*60*24 = 864k handshakes per day`), which is significantly more than the 500k we aim for.

### Call-outs:

n/a

### Testing:

See added tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

