### PR TITLE
ci(interop): bump network simulator image

### DIFF
--- a/.github/workflows/qns.yml
+++ b/.github/workflows/qns.yml
@@ -20,7 +20,7 @@ env:
   # up with the changes, though.
   INTEROP_RUNNER_REF: bda2d276de79cd016e4d90fd57ff2d863b05abe5
   # This should be updated when updating wesleyrosenblum/quic-network-simulator
-  NETWORK_SIMULATOR_REF: e995675580739a341b65207f685efb1c23e5ce2b
+  NETWORK_SIMULATOR_REF: sha256:8057abbab7a8b382df2504ee7d1a899637eff39148b9cff5b4682580155e6f96
   IPERF_ENDPOINT_REF: sha256:cb50cc8019d45d9cad5faecbe46a3c21dd5e871949819a5175423755a9045106
   WIRESHARK_VERSION: 4.4.2
   CDN: https://dnglbrstg7yg.cloudfront.net


### PR DESCRIPTION
### Resolved issues:
CI has been failing due to a bug in the interop network simulator during container cleanup. The simulator expected PIDs to be returned as a single line, but jobs -p can emit multi-line output, causing incorrect parsing and
leading to runs being marked unsupported.
### Description of changes: 
- Update NETWORK_SIMULATOR_REF to an image that correctly handles multi-line PID output (see https://github.com/WesleyRosenblum/quic-network-simulator/pull/3)
- Create the results/ directory before invoking the interop runner to avoid path assumptions in the workflow.

### Call-outs:
This issue has already been fixed upstream in the QUIC interop simulator ([quic-interop/quic-network-simulator#142](https://github.com/quic-interop/quic-network-simulator/pull/142)).

Longer term, we should consider moving away from our custom fork and staying closer to upstream so fixes like this come in automatically. There are some differences today, but they appear configurable in the s2n-quic build used
by CI. I will open a follow-up issue to track that alignment work.
### Testing:
- The workflow on this PR passes.
- Running the patched image locally shows success for tests that were
previously (incorrectly) reported as unsupported.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

