### PR TITLE
feat(s2n-quic-dc): expose PathSecretId from stream handles

### DIFF
--- a/dc/s2n-quic-dc/src/credentials.rs
+++ b/dc/s2n-quic-dc/src/credentials.rs
@@ -45,6 +45,12 @@ impl fmt::Debug for Id {
     }
 }
 
+impl fmt::Display for Id {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        format_args!("{:#01x}", u128::from_be_bytes(self.0)).fmt(f)
+    }
+}
+
 impl From<[u8; 16]> for Id {
     #[inline]
     fn from(v: [u8; 16]) -> Self {

--- a/dc/s2n-quic-dc/src/stream/application.rs
+++ b/dc/s2n-quic-dc/src/stream/application.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    credentials::Id,
     event::{self, EndpointPublisher as _},
     stream::{
         recv::application::{self as recv, Reader},
@@ -146,6 +147,11 @@ where
     #[inline]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.read.local_addr()
+    }
+
+    #[inline]
+    pub fn path_secret_id(&self) -> &Id {
+        self.read.path_secret_id()
     }
 
     #[inline]

--- a/dc/s2n-quic-dc/src/stream/recv/application.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/application.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     clock::Timer,
+    credentials::Id,
     event::{self, ConnectionPublisher as _},
     msg,
     stream::{
@@ -132,6 +133,11 @@ where
     #[inline]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.0.sockets.read_application().local_addr()
+    }
+
+    #[inline]
+    pub fn path_secret_id(&self) -> &Id {
+        &self.0.shared.credentials().id
     }
 
     #[inline]

--- a/dc/s2n-quic-dc/src/stream/send/application.rs
+++ b/dc/s2n-quic-dc/src/stream/send/application.rs
@@ -3,6 +3,7 @@
 
 use crate::{
     clock,
+    credentials::Id,
     event::{self, ConnectionPublisher},
     msg,
     stream::{
@@ -84,6 +85,11 @@ where
     #[inline]
     pub fn local_addr(&self) -> io::Result<SocketAddr> {
         self.0.sockets.write_application().local_addr()
+    }
+
+    #[inline]
+    pub fn path_secret_id(&self) -> &Id {
+        &self.0.shared.credentials().id
     }
 
     #[inline]


### PR DESCRIPTION
### Release Summary:

* feat(s2n-quic-dc): Expose PathSecretId from stream handles

### Resolved issues:

n/a

### Description of changes: 

This lets users correlate their stream with a handshake, including across client + server boundaries.

### Call-outs:

n/a

### Testing:

n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

