### PR TITLE
chore(s2n-quic-transport): use try_recv from futures_channel crate

### DIFF
--- a/quic/s2n-quic-transport/src/connection/connection_container.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container.rs
@@ -740,7 +740,7 @@ impl<C: connection::Trait, L: connection::Lock<C>> ConnectionContainer<C, L> {
         self.connector_receiver.close();
 
         // drain the connector_receiver queue
-        while let Ok(Some(request)) = self.connector_receiver.try_next() {
+        while let Ok(request) = self.connector_receiver.try_recv() {
             if request
                 .sender
                 .send(Err(connection::Error::endpoint_closing()))

--- a/quic/s2n-quic-transport/src/endpoint/close.rs
+++ b/quic/s2n-quic-transport/src/endpoint/close.rs
@@ -34,8 +34,8 @@ impl CloseHandle {
         if self.first_waker.is_some() {
             Poll::Ready(())
         } else {
-            match self.close_receiver.try_next() {
-                Ok(Some(waker)) => {
+            match self.close_receiver.try_recv() {
+                Ok(waker) => {
                     self.first_waker = Some(waker);
                     Poll::Ready(())
                 }
@@ -52,7 +52,7 @@ impl CloseHandle {
         if let Some(waker) = self.first_waker.take() {
             waker.wake();
         }
-        while let Ok(Some(waker)) = self.close_receiver.try_next() {
+        while let Ok(waker) = self.close_receiver.try_recv() {
             waker.wake_by_ref();
         }
     }


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

Replace deprecated method `try_next` with `try_recv` from the `futures_channel` crate to resolve clippy issue.

There is a clippy warning which blocks the s2n-quic CI, citing that we are using deprecated method from `futures_channel` crate. Such deprecation was made in https://github.com/rust-lang/futures-rs/pull/2944. We need to update that in order to unblock the CI.

### Call-outs:

Our automatic clippy bot can't fix clippy issues that is caused by warnings, so we need to manually fix this issue. This error was detected in a PR CI run: https://github.com/aws/s2n-quic/actions/runs/22065561659/job/63756383471?pr=2973:
```
error: use of deprecated method `futures_channel::mpsc::Receiver::<T>::try_next`: please use `try_recv` instead
   --> quic/s2n-quic-transport/src/connection/connection_container.rs:743:63
    |
743 |         while let Ok(Some(request)) = self.connector_receiver.try_next() {
    |                                                               ^^^^^^^^
    |
    = note: `-D deprecated` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(deprecated)]`
```

### Testing:

CI should pass. The clippy job should pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

