### PR TITLE
Add From<net::IpAddr> impl for IpAddress

### DIFF
--- a/quic/s2n-quic-core/src/inet/ip.rs
+++ b/quic/s2n-quic-core/src/inet/ip.rs
@@ -111,6 +111,15 @@ impl<'a> From<&'a IpV6Address> for IpAddressRef<'a> {
     }
 }
 
+impl From<net::IpAddr> for IpAddress {
+    fn from(addr: net::IpAddr) -> Self {
+        match addr {
+            net::IpAddr::V4(addr) => Self::Ipv4(addr.into()),
+            net::IpAddr::V6(addr) => Self::Ipv6(addr.into()),
+        }
+    }
+}
+
 /// An IP socket address, either IPv4 or IPv6, with a specific port.
 ///
 /// Instead of using `std::net::SocketAddr`, this implementation


### PR DESCRIPTION
### Release Summary:

Add From<net::IpAddr> impl for IpAddress

### Resolved issues:

### Description of changes: 

Similar impls already exist on SocketAddr, Ipv4Addr, and Ipv6Addr, but not on IpAddr.

### Call-outs:

This will likely be used by some upcoming s2n-quic-dc changes, but splitting this out since it's in s2n-quic-core (which has a slower release process).

### Testing:

No tests added.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

