### PR TITLE
fix(ci): trigger title check upon pull request and title update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -843,24 +843,6 @@ jobs:
           cat /tmp/typos.json
           ! grep -q '[^[:space:]]' /tmp/typos.json
 
-  validate-pr-title:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - name: PR Conventional Commit Validation
-        id: cc_check
-        if: github.event_name == 'pull_request_target'
-        uses: ytanikin/pr-conventional-commits@1.5.1
-        with:
-          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert","build"]'
-          add_label: 'false'
-      - name: Failure case
-        if: github.event_name == 'pull_request_target' && steps.cc_check.outcome != 'success'
-        run: |
-          echo "Make sure the PR title/commit follows https://www.conventionalcommits.org/"
-          exit 1
-
-
   kani:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci_pr_title.yml
+++ b/.github/workflows/ci_pr_title.yml
@@ -1,0 +1,23 @@
+name: PR Title Validation
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited]
+permissions:
+  contents: read
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: PR Conventional Commit Validation
+        uses: ytanikin/pr-conventional-commits@1.5.1
+        with:
+          task_types: '["feat","fix","docs","test","ci","refactor","perf","chore","revert","build"]'
+          add_label: 'false'
+      - name: Failure case
+        if: failure()
+        run: |
+          echo "Make sure the PR title/commit follows https://www.conventionalcommits.org/"
+          exit 1


### PR DESCRIPTION
### Resolved issues:
Currently, PR title check isn't running. See https://github.com/aws/s2n-quic/actions/runs/22103978012/job/63881227787 for an example.

The validate-pr-title job's if condition checks for `pull_request_target`, but the workflow is triggered by `pull_request`. Since these are different event types, the validation step is always skipped.

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary. If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff. -->

Change `github.event_name == 'pull_request_target'` to `github.event_name == 'pull_request'` in the if conditions of the validate-pr-title job to match the workflow's trigger event.

This PR also adds a new trigger to the workflow so that it is triggered upon title/description changes. New commit is required to trigger the workflow otherwise.

The `validate-pr-title` job is split into its own workflow to avoid re-triggering all the other jobs on title edits.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

This is the same changes made on s2n-tls repo:
- https://github.com/aws/s2n-tls/pull/5744
- https://github.com/aws/s2n-tls/pull/5749

### Testing:

Workflow is now running: https://github.com/aws/s2n-quic/actions/runs/22195489872/job/64194556975?pr=2984
Workflow updates and fails upon bad PR title: https://github.com/aws/s2n-quic/actions/runs/22195547275/job/64194746282?pr=2984#step:4:9

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

