### PR TITLE
feat(s2n-quic-dc): Split out unknown path secret in acceptor from Local errors

### DIFF
--- a/dc/s2n-quic-dc/events/acceptor.rs
+++ b/dc/s2n-quic-dc/events/acceptor.rs
@@ -207,8 +207,10 @@ enum AcceptorTcpIoErrorSource {
     /// Something within dcQUIC failed related to the remote state or network contents (e.g.,
     /// parsing the packet)
     Remote,
-    /// Something in the local application state was wrong (e.g., missing credentials).
+    /// Something in the local application state was wrong.
     Local,
+    /// Unknown path secret for remote stream.
+    UnknownPathSecret,
     /// Something went wrong that we didn't expect to happen.
     /// This is used for failures that aren't expected to relate to dcQUIC state at all.
     System,

--- a/dc/s2n-quic-dc/src/event/generated.rs
+++ b/dc/s2n-quic-dc/src/event/generated.rs
@@ -584,8 +584,11 @@ pub mod api {
         #[doc = " parsing the packet)"]
         Remote {},
         #[non_exhaustive]
-        #[doc = " Something in the local application state was wrong (e.g., missing credentials)."]
+        #[doc = " Something in the local application state was wrong."]
         Local {},
+        #[non_exhaustive]
+        #[doc = " Unknown path secret for remote stream."]
+        UnknownPathSecret {},
         #[non_exhaustive]
         #[doc = " Something went wrong that we didn't expect to happen."]
         #[doc = " This is used for failures that aren't expected to relate to dcQUIC state at all."]
@@ -624,8 +627,13 @@ pub mod api {
             }
             .build(),
             aggregate::info::variant::Builder {
-                name: aggregate::info::Str::new("SYSTEM\0"),
+                name: aggregate::info::Str::new("UNKNOWN_PATH_SECRET\0"),
                 id: 6usize,
+            }
+            .build(),
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("SYSTEM\0"),
+                id: 7usize,
             }
             .build(),
         ];
@@ -638,7 +646,8 @@ pub mod api {
                 Self::Recv { .. } => 3usize,
                 Self::Remote { .. } => 4usize,
                 Self::Local { .. } => 5usize,
-                Self::System { .. } => 6usize,
+                Self::UnknownPathSecret { .. } => 6usize,
+                Self::System { .. } => 7usize,
             }
         }
     }
@@ -4237,8 +4246,10 @@ pub mod builder {
         #[doc = " Something within dcQUIC failed related to the remote state or network contents (e.g.,"]
         #[doc = " parsing the packet)"]
         Remote,
-        #[doc = " Something in the local application state was wrong (e.g., missing credentials)."]
+        #[doc = " Something in the local application state was wrong."]
         Local,
+        #[doc = " Unknown path secret for remote stream."]
+        UnknownPathSecret,
         #[doc = " Something went wrong that we didn't expect to happen."]
         #[doc = " This is used for failures that aren't expected to relate to dcQUIC state at all."]
         System,
@@ -4254,6 +4265,7 @@ pub mod builder {
                 Self::Recv => Recv {},
                 Self::Remote => Remote {},
                 Self::Local => Local {},
+                Self::UnknownPathSecret => UnknownPathSecret {},
                 Self::System => System {},
             }
         }

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
@@ -426,7 +426,7 @@ where
                             // missing credentials.
                             error: WorkerError {
                                 error,
-                                source: event::builder::AcceptorTcpIoErrorSource::Local,
+                                source: event::builder::AcceptorTcpIoErrorSource::UnknownPathSecret,
                             },
                         };
                         continue;
@@ -437,7 +437,7 @@ where
                     }
                     return Err(WorkerError {
                         error,
-                        source: event::builder::AcceptorTcpIoErrorSource::Local,
+                        source: event::builder::AcceptorTcpIoErrorSource::UnknownPathSecret,
                     })
                     .into();
                 }
@@ -822,7 +822,7 @@ where
                         offset: 0,
                         buffer: secret_control,
                         error: WorkerError {
-                            source: event::builder::AcceptorTcpIoErrorSource::Local,
+                            source: event::builder::AcceptorTcpIoErrorSource::UnknownPathSecret,
                             error,
                         },
                     };
@@ -833,7 +833,7 @@ where
                     drop(socket);
                 }
                 return Err(WorkerError {
-                    source: event::builder::AcceptorTcpIoErrorSource::Local,
+                    source: event::builder::AcceptorTcpIoErrorSource::UnknownPathSecret,
                     error,
                 })
                 .into();


### PR DESCRIPTION
### Release Summary:

* feat(s2n-quic-dc): Split out missing credentials from Local errors

### Resolved issues:

n/a

### Description of changes: 

I _think_ local errors should almost always be due to local errors, but right now we mix these two events into one, which makes that hard to tell. (If I'm reading our code right, the exception is Tokio re-registration can theoretically fail, though it shouldn't happen in practice).

### Call-outs:

n/a

### Testing:

Changes shouldn't need extra testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

