### PR TITLE
feat(s2n-quic-dc-metrics): Cleanup old querylog files

### DIFF
--- a/dc/s2n-quic-dc-metrics/src/appender.rs
+++ b/dc/s2n-quic-dc-metrics/src/appender.rs
@@ -9,18 +9,119 @@ use std::{
 
 use chrono::{DateTime, Duration, Timelike, Utc};
 
+trait Filesystem: Send + Sync + 'static {
+    fn create_dir(&self, path: &Path) -> Result<()>;
+    fn open(&self, path: &Path) -> Result<Box<dyn Write + Send + Sync + 'static>>;
+    fn list_files(&self, dir: &Path) -> Vec<PathBuf>;
+    fn remove(&self, path: &Path) -> Result<()>;
+}
+
+struct OsFilesystem;
+
+impl Filesystem for OsFilesystem {
+    fn create_dir(&self, path: &Path) -> Result<()> {
+        std::fs::create_dir_all(path)
+    }
+
+    fn open(&self, path: &Path) -> Result<Box<dyn Write + Send + Sync + 'static>> {
+        let f = OpenOptions::new()
+            .read(false)
+            .create(true)
+            .append(true)
+            .open(path)?;
+        Ok(Box::new(f))
+    }
+
+    fn list_files(&self, dir: &Path) -> Vec<PathBuf> {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return Vec::new();
+        };
+        entries
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_type().map_or(false, |t| t.is_file()))
+            .map(|e| e.path())
+            .collect()
+    }
+
+    fn remove(&self, path: &Path) -> Result<()> {
+        std::fs::remove_file(path)
+    }
+}
+
+struct NoopFilesystem;
+
+impl Filesystem for NoopFilesystem {
+    fn create_dir(&self, _path: &Path) -> Result<()> {
+        Ok(())
+    }
+
+    fn open(&self, _path: &Path) -> Result<Box<dyn Write + Send + Sync + 'static>> {
+        Ok(Box::new(std::io::sink()))
+    }
+
+    fn list_files(&self, _dir: &Path) -> Vec<PathBuf> {
+        Vec::new()
+    }
+
+    fn remove(&self, _path: &Path) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub struct Builder {
+    fs: Box<dyn Filesystem>,
+    base_path: PathBuf,
+    filename_prefix: String,
+    log_rotation: std::time::Duration,
+    max_files: usize,
+}
+
+impl Builder {
+    pub fn new(
+        base_path: PathBuf,
+        filename_prefix: String,
+        log_rotation: std::time::Duration,
+    ) -> Self {
+        Self {
+            fs: Box::new(OsFilesystem),
+            base_path,
+            filename_prefix,
+            log_rotation,
+            max_files: 0,
+        }
+    }
+
+    pub fn max_files(&mut self, max_files: usize) -> &mut Self {
+        self.max_files = max_files;
+        self
+    }
+
+    pub fn build(self) -> Result<MetricsWriter> {
+        self.fs.create_dir(&self.base_path)?;
+
+        Ok(MetricsWriter {
+            fs: self.fs,
+            base_path: self.base_path,
+            filename_prefix: self.filename_prefix,
+            active: None,
+            log_rotation: Duration::from_std(self.log_rotation)
+                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?,
+            time_source: Box::new(Utc::now),
+            max_files: self.max_files,
+        })
+    }
+}
+
 /// Rolling service log writer. Automatically opens new service log files each period (supports
 /// hourly and sub-hourly rotation).
 pub struct MetricsWriter {
+    fs: Box<dyn Filesystem>,
     base_path: PathBuf,
     filename_prefix: String,
     active: Option<ActiveWriter>,
     time_source: Box<dyn Fn() -> DateTime<Utc> + Send + Sync + 'static>,
-    #[allow(clippy::type_complexity)]
-    file_factory: Box<
-        dyn Fn(&Path) -> Result<Box<dyn Write + Send + Sync + 'static>> + Send + Sync + 'static,
-    >,
     log_rotation: Duration,
+    max_files: usize,
 }
 
 impl std::fmt::Debug for MetricsWriter {
@@ -29,11 +130,20 @@ impl std::fmt::Debug for MetricsWriter {
             .field("base_path", &self.base_path)
             .field("filename_prefix", &self.filename_prefix)
             .field("active", &self.active)
+            .field("max_files", &self.max_files)
             .finish()
     }
 }
 
 impl MetricsWriter {
+    pub fn builder(
+        base_path: PathBuf,
+        filename_prefix: String,
+        log_rotation: std::time::Duration,
+    ) -> Builder {
+        Builder::new(base_path, filename_prefix, log_rotation)
+    }
+
     /// Creates a new metrics writer.
     ///
     /// Arguments:
@@ -45,35 +155,18 @@ impl MetricsWriter {
         filename_prefix: String,
         log_rotation: std::time::Duration,
     ) -> Result<Self> {
-        std::fs::create_dir_all(&base_path)?;
-
-        Ok(Self {
-            base_path,
-            filename_prefix,
-            active: None,
-            log_rotation: Duration::from_std(log_rotation)
-                .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?,
-            time_source: Box::new(Utc::now),
-            file_factory: Box::new(|path| {
-                let f = OpenOptions::new()
-                    .read(false)
-                    .create(true)
-                    .append(true)
-                    .open(path)?;
-
-                Ok(Box::new(f))
-            }),
-        })
+        Builder::new(base_path, filename_prefix, log_rotation).build()
     }
 
     pub fn noop() -> MetricsWriter {
         Self {
+            fs: Box::new(NoopFilesystem),
             base_path: PathBuf::new(),
             filename_prefix: String::new(),
             active: None,
             log_rotation: Duration::try_minutes(60).unwrap(),
             time_source: Box::new(Utc::now),
-            file_factory: Box::new(|_| Ok(Box::new(std::io::sink()))),
+            max_files: 0,
         }
     }
 }
@@ -115,7 +208,8 @@ impl<T: Write> Drop for FlushOnDrop<T> {
 
 impl MetricsWriter {
     /// Obtains an object which will write to the currently opened service log
-    /// file. May open a new service log file if necessary.
+    /// file. May open a new service log file if necessary. May delete old
+    /// service log files if the configured max file count has been exceeded.
     ///
     /// The returned object will flush any unwritten data when dropped.
     pub fn writer(&'_ mut self) -> std::io::Result<impl std::io::Write + '_> {
@@ -134,6 +228,33 @@ impl MetricsWriter {
         Ok(FlushOnDrop(&mut self.active.as_mut().unwrap().writer))
     }
 
+    fn cleanup_old_files(&self) {
+        if self.max_files == 0 {
+            return;
+        }
+
+        let prefix = self.base_path.join(format!("{}.", self.filename_prefix));
+        let prefix = prefix.as_os_str().as_encoded_bytes();
+        let mut files: Vec<_> = self
+            .fs
+            .list_files(&self.base_path)
+            .into_iter()
+            .filter(|path| path.as_os_str().as_encoded_bytes().starts_with(prefix))
+            .collect();
+
+        if files.len() <= self.max_files {
+            return;
+        }
+
+        // Each file includes a timestamp. So, when sorted ascending by path, the first files are
+        // the oldest, and should be deleted first.
+        files.sort();
+
+        for path in &files[..files.len() - self.max_files] {
+            let _ = self.fs.remove(path);
+        }
+    }
+
     fn open_writer(&self, now: DateTime<Utc>) -> std::io::Result<ActiveWriter> {
         let mut filename = format!("{}.{}", &self.filename_prefix, now.format("%Y-%m-%d-%H"));
         let mut start_time = now.date_naive().and_hms_opt(now.hour(), 0, 0).unwrap();
@@ -148,7 +269,8 @@ impl MetricsWriter {
         let mut path = self.base_path.clone();
         path.push(filename);
 
-        let file = (self.file_factory)(&path)?;
+        let file = self.fs.open(&path)?;
+        self.cleanup_old_files();
         let deadline = start_time.checked_add_signed(self.log_rotation).unwrap();
 
         Ok(ActiveWriter {
@@ -162,7 +284,7 @@ impl MetricsWriter {
 
 #[cfg(test)]
 mod test {
-    use std::{collections::VecDeque, sync::Arc};
+    use std::{collections::BTreeMap, sync::Arc};
 
     use super::*;
 
@@ -188,40 +310,89 @@ mod test {
         }
     }
 
-    #[derive(Default)]
-    struct MockFilesystem(Arc<Mutex<VecDeque<(PathBuf, MutexBuf)>>>);
+    #[derive(Clone, Default)]
+    struct MockFilesystem(Arc<Mutex<BTreeMap<PathBuf, MutexBuf>>>);
 
     impl MockFilesystem {
         fn new() -> Self {
             Self::default()
         }
 
-        #[allow(clippy::unnecessary_wraps)] // match non-test api
-        fn open(
-            &self,
-            path: impl Into<PathBuf>,
-        ) -> std::io::Result<Box<dyn Write + Send + Sync + 'static>> {
-            let mut lock = self.0.lock().unwrap();
-
-            let buf = MutexBuf::default();
-            lock.push_back((path.into(), buf.clone()));
-
-            Ok(Box::new(MutexStringWriter(buf)))
-        }
-
         #[track_caller]
         fn assert_opened(&self, path: impl AsRef<Path>) -> MutexBuf {
-            let mut lock = self.0.lock().unwrap();
-
-            let (last_path, last_buf) = lock.pop_front().expect("No files opened");
-
-            assert_eq!(&last_path, path.as_ref());
-
-            last_buf
+            let key = path.as_ref();
+            self.0
+                .lock()
+                .unwrap()
+                .remove(key)
+                .unwrap_or_else(|| panic!("File not opened: {}", key.display()))
+                .clone()
         }
 
         fn assert_not_opened(&self) {
             assert!(self.0.lock().unwrap().is_empty());
+        }
+    }
+
+    impl Filesystem for MockFilesystem {
+        fn create_dir(&self, _path: &Path) -> Result<()> {
+            Ok(())
+        }
+
+        fn open(&self, path: &Path) -> Result<Box<dyn Write + Send + Sync + 'static>> {
+            let buf = MutexBuf::default();
+            self.0
+                .lock()
+                .unwrap()
+                .insert(path.to_path_buf(), buf.clone());
+            Ok(Box::new(MutexStringWriter(buf)))
+        }
+
+        fn list_files(&self, dir: &Path) -> Vec<PathBuf> {
+            self.0
+                .lock()
+                .unwrap()
+                .keys()
+                .filter(|p| p.parent() == Some(dir))
+                .cloned()
+                .collect()
+        }
+
+        fn remove(&self, path: &Path) -> Result<()> {
+            self.0.lock().unwrap().remove(path);
+            Ok(())
+        }
+    }
+
+    fn test_writer(
+        fs: MockFilesystem,
+        now: Arc<Mutex<DateTime<Utc>>>,
+        log_rotation: Duration,
+        max_files: usize,
+    ) -> MetricsWriter {
+        MetricsWriter {
+            base_path: "/foo/bar".into(),
+            filename_prefix: "baz".into(),
+            active: None,
+            time_source: Box::new(move || *now.lock().unwrap()),
+            fs: Box::new(fs),
+            log_rotation,
+            max_files,
+        }
+    }
+
+    #[test]
+    fn test_os_list_files() {
+        let fs = OsFilesystem;
+        let dir = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let files = fs.list_files(dir);
+
+        // Cargo.toml should be listed
+        assert!(files.iter().any(|p| p.file_name().unwrap() == "Cargo.toml"));
+
+        // No directories should be listed (e.g. src/)
+        for path in &files {
+            assert!(path.is_file(), "{} is not a file", path.display());
         }
     }
 
@@ -233,21 +404,8 @@ mod test {
                 .unwrap(),
         ));
 
-        let time_source = { Box::new(move || *now.lock().unwrap()) };
-
-        let files = Arc::new(MockFilesystem::new());
-
-        let mut writer = MetricsWriter {
-            base_path: "/foo/bar".into(),
-            filename_prefix: "baz".into(),
-            active: None,
-            time_source,
-            file_factory: {
-                let files = files.clone();
-                Box::new(move |path| files.open(path))
-            },
-            log_rotation: Duration::minutes(60),
-        };
+        let files = MockFilesystem::default();
+        let mut writer = test_writer(files.clone(), now, Duration::minutes(60), 0);
 
         write!(&mut writer.writer().unwrap(), "foobar").unwrap();
 
@@ -271,24 +429,8 @@ mod test {
                 .unwrap(),
         ));
 
-        let time_source = {
-            let now = now.clone();
-            Box::new(move || *now.lock().unwrap())
-        };
-
-        let files = Arc::new(MockFilesystem::new());
-
-        let mut writer = MetricsWriter {
-            base_path: "/foo/bar".into(),
-            filename_prefix: "baz".into(),
-            active: None,
-            time_source,
-            file_factory: {
-                let files = files.clone();
-                Box::new(move |path| files.open(path))
-            },
-            log_rotation: Duration::minutes(60),
-        };
+        let files = MockFilesystem::default();
+        let mut writer = test_writer(files.clone(), now.clone(), Duration::minutes(60), 0);
 
         write!(&mut writer.writer().unwrap(), "foobar").unwrap();
 
@@ -328,24 +470,8 @@ mod test {
                 .unwrap(),
         ));
 
-        let time_source = {
-            let now = now.clone();
-            Box::new(move || *now.lock().unwrap())
-        };
-
-        let files = Arc::new(MockFilesystem::new());
-
-        let mut writer = MetricsWriter {
-            base_path: "/foo/bar".into(),
-            filename_prefix: "baz".into(),
-            active: None,
-            time_source,
-            file_factory: {
-                let files = files.clone();
-                Box::new(move |path| files.open(path))
-            },
-            log_rotation: Duration::minutes(5),
-        };
+        let files = MockFilesystem::default();
+        let mut writer = test_writer(files.clone(), now.clone(), Duration::minutes(5), 0);
 
         write!(&mut writer.writer().unwrap(), "foobar").unwrap();
 
@@ -385,24 +511,8 @@ mod test {
                 .unwrap(),
         ));
 
-        let time_source = {
-            let now = now.clone();
-            Box::new(move || *now.lock().unwrap())
-        };
-
-        let files = Arc::new(MockFilesystem::new());
-
-        let mut writer = MetricsWriter {
-            base_path: "/foo/bar".into(),
-            filename_prefix: "baz".into(),
-            active: None,
-            time_source,
-            file_factory: {
-                let files = files.clone();
-                Box::new(move |path| files.open(path))
-            },
-            log_rotation: Duration::minutes(60),
-        };
+        let files = MockFilesystem::default();
+        let mut writer = test_writer(files.clone(), now.clone(), Duration::minutes(60), 0);
 
         write!(&mut writer.writer().unwrap(), "foobar").unwrap();
 
@@ -428,21 +538,8 @@ mod test {
                 .unwrap(),
         ));
 
-        let time_source = { Box::new(move || *now.lock().unwrap()) };
-
-        let files = Arc::new(MockFilesystem::new());
-
-        let mut writer = MetricsWriter {
-            base_path: "/foo/bar".into(),
-            filename_prefix: "baz".into(),
-            active: None,
-            time_source,
-            file_factory: {
-                let files = files.clone();
-                Box::new(move |path| files.open(path))
-            },
-            log_rotation: Duration::minutes(60),
-        };
+        let files = MockFilesystem::default();
+        let mut writer = test_writer(files.clone(), now, Duration::minutes(60), 0);
 
         let mut handle = writer.writer().unwrap();
         let buf = files.assert_opened("/foo/bar/baz.2020-01-01-00");
@@ -453,5 +550,85 @@ mod test {
 
         drop(handle);
         assert_eq!((true, vec![b'x']), buf.lock().unwrap().clone());
+    }
+
+    #[test]
+    fn test_cleanup_deletes_oldest_files() {
+        let now = Arc::new(Mutex::new(
+            "2020-01-01T05:00:00+00:00"
+                .parse::<DateTime<Utc>>()
+                .unwrap(),
+        ));
+
+        let files = MockFilesystem::default();
+        for name in [
+            "baz.2020-01-01-00",
+            "baz.2020-01-01-01",
+            "baz.2020-01-01-02",
+            "baz.2020-01-01-03",
+            "baz.2020-01-01-04",
+            "other_file.txt",
+        ] {
+            let _ = files.open(Path::new("/foo/bar").join(name).as_path());
+        }
+        let mut writer = test_writer(files.clone(), now, Duration::minutes(60), 3);
+
+        write!(&mut writer.writer().unwrap(), "new data").unwrap();
+
+        assert_eq!(
+            files.list_files(Path::new("/foo/bar")),
+            vec![
+                PathBuf::from("/foo/bar/baz.2020-01-01-03"),
+                PathBuf::from("/foo/bar/baz.2020-01-01-04"),
+                PathBuf::from("/foo/bar/baz.2020-01-01-05"),
+                PathBuf::from("/foo/bar/other_file.txt"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_cleanup_disabled_when_max_files_is_zero() {
+        let now = Arc::new(Mutex::new(
+            "2020-01-01T05:00:00+00:00"
+                .parse::<DateTime<Utc>>()
+                .unwrap(),
+        ));
+
+        let files = MockFilesystem::default();
+        for hour in 0..5 {
+            let _ = files.open(&Path::new("/foo/bar").join(format!("baz.2020-01-01-{hour:02}")));
+        }
+        let mut writer = test_writer(files.clone(), now, Duration::minutes(60), 0);
+
+        write!(&mut writer.writer().unwrap(), "new data").unwrap();
+
+        assert_eq!(files.list_files(Path::new("/foo/bar")).len(), 6);
+    }
+
+    #[test]
+    fn test_cleanup_across_multiple_rotations() {
+        let now = Arc::new(Mutex::new(
+            "2020-01-01T00:00:00+00:00"
+                .parse::<DateTime<Utc>>()
+                .unwrap(),
+        ));
+
+        let files = MockFilesystem::default();
+        let mut writer = test_writer(files.clone(), now.clone(), Duration::minutes(60), 2);
+
+        for hour in 0..4u32 {
+            *now.lock().unwrap() = format!("2020-01-01T{hour:02}:00:00+00:00")
+                .parse::<DateTime<Utc>>()
+                .unwrap();
+            write!(&mut writer.writer().unwrap(), "hour {hour}").unwrap();
+        }
+
+        assert_eq!(
+            files.list_files(Path::new("/foo/bar")),
+            vec![
+                PathBuf::from("/foo/bar/baz.2020-01-01-02"),
+                PathBuf::from("/foo/bar/baz.2020-01-01-03"),
+            ]
+        );
     }
 }

--- a/dc/s2n-quic-dc-metrics/src/appender.rs
+++ b/dc/s2n-quic-dc-metrics/src/appender.rs
@@ -38,7 +38,7 @@ impl Filesystem for OsFilesystem {
         };
         entries
             .filter_map(|e| e.ok())
-            .filter(|e| e.file_type().map_or(false, |t| t.is_file()))
+            .filter(|e| e.file_type().is_ok_and(|t| t.is_file()))
             .map(|e| e.path())
             .collect()
     }
@@ -314,10 +314,6 @@ mod test {
     struct MockFilesystem(Arc<Mutex<BTreeMap<PathBuf, MutexBuf>>>);
 
     impl MockFilesystem {
-        fn new() -> Self {
-            Self::default()
-        }
-
         #[track_caller]
         fn assert_opened(&self, path: impl AsRef<Path>) -> MutexBuf {
             let key = path.as_ref();


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

Adds an option to `MetricsWriter` in s2n-quic-dc-metrics to cleanup old log files.

### Resolved issues:

None

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary. If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff. -->

[MetricsWriter](https://github.com/aws/s2n-quic/blob/19b63d8a6b6e4268a6914cd0f2f0c6599c111fc6/dc/s2n-quic-dc-metrics/src/appender.rs#L14) writes metrics to a directory by rotating log files. Currently, s2n-quic-dc-metrics provides no way to cleanup these files, so without some external mechanism, they will keep accumulating forever until the disk fills up.

This PR adds a new `max_files` option, which allows `MetricsWriter` to delete the oldest log files past the configured threshold when creating new files. This solution is modeled after the [tracing-appender RollingFileAppender](https://docs.rs/tracing-appender/latest/tracing_appender/rolling/struct.Builder.html#method.max_log_files).

### Call-outs:

None

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

New unit tests were added for the cleanup behavior. A `Filesystem` trait was created so the functionality can be swapped to an in-memory version for testing, so we don't manipulate the real filesystem in our unit tests.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

