### PR TITLE
fix(s2n-quic-dc): Avoid propagating rehandshake task cancellation as a panic

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map/rehandshake.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/rehandshake.rs
@@ -146,7 +146,11 @@ impl RehandshakeState {
 
             if let Some(handle) = request_handshake(entry.unmap().into()) {
                 let wrapped = self.runtime.spawn(async move {
-                    handle.await.expect("propagate panic");
+                    if let Err(err) = handle.await {
+                        if let Ok(panic) = err.try_into_panic() {
+                            std::panic::resume_unwind(panic);
+                        }
+                    }
                     drop(permit);
                 });
                 handles.push(wrapped);
@@ -157,7 +161,11 @@ impl RehandshakeState {
 
         // Wait for all tasks to complete
         for handle in handles {
-            self.runtime.block_on(handle).expect("propagate panic");
+            if let Err(err) = self.runtime.block_on(handle) {
+                if let Ok(panic) = err.try_into_panic() {
+                    std::panic::resume_unwind(panic);
+                }
+            }
         }
 
         to_select

--- a/dc/s2n-quic-dc/src/path/secret/map/rehandshake/test.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/rehandshake/test.rs
@@ -173,6 +173,24 @@ fn test_keeps_unscheduled_in_queue() {
 }
 
 #[test]
+fn test_cancelled_task_does_not_panic() {
+    let mut state = RehandshakeState::new_with_paused_time(Duration::from_secs(60));
+
+    state.push(SocketAddr::from(([127, 0, 0, 1], 4000)));
+    state.adjust_post_refill();
+
+    // Return a handle to a task that we immediately abort, simulating runtime shutdown
+    let handle = state.runtime.handle().clone();
+    state.next_rehandshake_batch(1, |_addr| {
+        let h = handle.spawn(async {
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        });
+        h.abort();
+        Some(h)
+    });
+}
+
+#[test]
 fn test_tail_handshake_scheduling() {
     // Use a long rehandshake period so tail handshake logic is used
     let mut state = RehandshakeState::new_with_paused_time(Duration::from_secs(3600));

--- a/dc/s2n-quic-dc/src/path/secret/map/rehandshake/test.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/rehandshake/test.rs
@@ -177,7 +177,6 @@ fn test_cancelled_task_does_not_panic() {
     let mut state = RehandshakeState::new_with_paused_time(Duration::from_secs(60));
 
     state.push(SocketAddr::from(([127, 0, 0, 1], 4000)));
-    state.adjust_post_refill();
 
     // Return a handle to a task that we immediately abort, simulating runtime shutdown
     let handle = state.runtime.handle().clone();


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

N/A

### Description of changes: 

<!-- Describe s2n-quic’s current behavior and how your code changes that behavior. If there are no issues this pr is resolving, explain why this change is necessary. If a callout is specific to a section of code, it might make more sense to leave a comment on your own PR file diff. -->

This fixes a panic when the handshake runtime is dropped. The task sees cancellation which we can ignore.

### Call-outs:

<!--Address any potentially confusing code. Is there code added that needs to be cleaned up later? Is there code that is missing because it’s still in development?-->

### Testing:

<!--How is this change tested (unit tests, fuzz tests, etc.)? Are there any testing steps to be verified by the reviewer?
How can you convince your reviewers that this PR is safe and effective?
Is this a refactor change? If so, how have you proved that the intended behavior hasn't changed? -->

Added unit test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

