### PR TITLE
chore: add scs-dev team as code owners of dc folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 * @aws/s2n-core
+/dc/ @aws/scs-dev @aws/s2n-core


### PR DESCRIPTION
### Description of changes: 

Adds `@aws/scs-dev` as a code owner for the `/dc/` directory alongside `@aws/s2n-core`. This allows members of either team to approve PRs that touch files under `dc/`, so `scs-dev` members can review and merge their own changes without requiring a separate `s2n-core` approval.

### Call-outs:

The `*` catch-all rule still assigns `@aws/s2n-core` as the owner for everything outside of `dc/`. The `/dc/` rule is more specific and takes precedence for files in that directory, with both teams listed so either can satisfy the code owner approval requirement.

### Testing:

No code changes — this only modifies the CODEOWNERS file. Verified that the rule syntax follows [GitHub's CODEOWNERS documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
