### PR TITLE
perf: Changes dc-quic packet retry rate to be 2ms

### DIFF
--- a/dc/s2n-quic-dc/src/psk/io.rs
+++ b/dc/s2n-quic-dc/src/psk/io.rs
@@ -35,7 +35,7 @@ pub const DEFAULT_MTU: u16 = 8940;
 pub const DEFAULT_MTU: u16 = DEFAULT_BASE_MTU;
 /// Jitter PTO probes by 33% to prevent synchronized timeouts across multiple connections
 pub const DEFAULT_PTO_JITTER_PERCENTAGE: u8 = 33;
-const DEFAULT_INITIAL_RTT: Duration = Duration::from_millis(1);
+const DEFAULT_INITIAL_RTT: Duration = Duration::from_millis(2);
 
 const BUFFER_SIZE: usize = 16 * 1024;
 


### PR DESCRIPTION
### Release Summary:
Changes dc-quic packet retry rate to be 2ms

### Resolved issues:
N/A

### Description of changes: 
dc-quic's initial RTT is currently set to 1ms, which means that a packet will be resent if a connection doesn't hear back from its peer within 1ms. In the scenario of a client concurrently handshaking with 5 servers, having a retry rate this low is essentially opting in to unnecessary retries. The reason for this is that the most expensive crypto in the handshake is the client processing and responding to the flight of the server hello, certificate, and certificate request message, which is ~360us. If 5 handshakes are occurring concurrently, earlier server hellos will block later server hellos from being processed, which at the worst case is 4*360us = 1.4ms. For the later handshakes this will trigger the server to retry its server hello and also cause the client to retry its client hello. Both of these retries are unnecessary, no packets have been lost or dropped.
### Call-outs:

There is a caveat here, we pad the first packet to be ~8k, which in some environments means that it will be instantly dropped. So those connections will be slower because the first packet was dropped and now the retry rate is less aggressive. I don't know if that is a problem, but if we want to be conservative I can also decrease the initial MTU size in this change.
Also another callout is it's possible this parameter will need to be changed in the future, I think that it should be minimally 2ms for now. I don't expect this to improve latency in high concurrency scenarios where the server is the bottleneck. But I think this is a healthier setting for the rtt.

### Testing:
In a single client doing 5 handshakes concurrently with a server, this gets rid of ptoprobing events and PacketSpaceDoesNotExist events, which are evidence of retries occurring. This change has no impact on higher concurrency scenarios.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

