### PR TITLE
feat(s2n-quic): Expose client_cert_chain_der from s2n-tls handshakes

### DIFF
--- a/quic/s2n-quic-core/src/crypto/tls.rs
+++ b/quic/s2n-quic-core/src/crypto/tls.rs
@@ -106,8 +106,15 @@ pub trait TlsSession: Send {
 
     fn cipher_suite(&self) -> CipherSuite;
 
+    // The peer's verified cert chain.
     #[cfg(feature = "alloc")]
     fn peer_cert_chain_der(&self) -> Result<Vec<Vec<u8>>, ChainError>;
+
+    // This is the unverified client cert chain.
+    //
+    // https://docs.rs/s2n-tls/latest/s2n_tls/connection/struct.Connection.html#method.client_cert_chain_bytes
+    #[cfg(feature = "alloc")]
+    fn client_cert_chain_der(&self) -> Result<Option<Vec<u8>>, ChainError>;
 }
 
 #[cfg(feature = "alloc")]

--- a/quic/s2n-quic-core/src/crypto/tls/testing.rs
+++ b/quic/s2n-quic-core/src/crypto/tls/testing.rs
@@ -134,6 +134,10 @@ impl TlsSession for Session {
     fn peer_cert_chain_der(&self) -> Result<Vec<Vec<u8>>, tls::ChainError> {
         Err(tls::ChainError::failure())
     }
+
+    fn client_cert_chain_der(&self) -> Result<Option<Vec<u8>>, tls::ChainError> {
+        Err(tls::ChainError::failure())
+    }
 }
 
 #[derive(Debug)]

--- a/quic/s2n-quic-core/src/event.rs
+++ b/quic/s2n-quic-core/src/event.rs
@@ -197,6 +197,13 @@ impl<'a> TlsSession<'a> {
         self.session.peer_cert_chain_der()
     }
 
+    // Currently intended only for unstable usage
+    #[doc(hidden)]
+    #[cfg(feature = "alloc")]
+    pub fn client_cert_chain_der(&self) -> Result<Option<Vec<u8>>, crate::crypto::tls::ChainError> {
+        self.session.client_cert_chain_der()
+    }
+
     pub fn cipher_suite(&self) -> crate::event::api::CipherSuite {
         self.session.cipher_suite().into_event()
     }

--- a/quic/s2n-quic-rustls/src/session.rs
+++ b/quic/s2n-quic-rustls/src/session.rs
@@ -73,6 +73,11 @@ impl tls::TlsSession for Session {
             .map(|v| v.to_vec())
             .collect())
     }
+
+    fn client_cert_chain_der(&self) -> Result<Option<Vec<u8>>, tls::ChainError> {
+        // As far as I can tell, rustls doesn't support retrieving unverified cert chains.
+        Err(tls::ChainError::failure())
+    }
 }
 
 impl fmt::Debug for Session {

--- a/quic/s2n-quic-tls/src/session.rs
+++ b/quic/s2n-quic-tls/src/session.rs
@@ -127,6 +127,14 @@ impl tls::TlsSession for Session {
             .collect::<Result<Vec<Vec<u8>>, s2n_tls::error::Error>>()
             .map_err(|_| tls::ChainError::failure())
     }
+
+    fn client_cert_chain_der(&self) -> Result<Option<Vec<u8>>, tls::ChainError> {
+        Ok(self
+            .connection
+            .client_cert_chain_bytes()
+            .map_err(|_| tls::ChainError::failure())?
+            .map(|v| v.to_owned()))
+    }
 }
 
 impl tls::Session for Session {


### PR DESCRIPTION
### Release Summary:

n/a, no new stable surface area

### Resolved issues:

n/a

### Description of changes: 

This exposes the unverified certificate chain, which is useful for logging failed handshakes with metadata about why we rejected the peer. Today it looks like s2n-tls only exposes this for servers rejecting a client (rustls doesn't, and s2n-tls doesn't expose it on the client).

### Call-outs:

Future work in s2n-tls might expose more methods here, but I don't think we need to worry too much since it's a future consideration and this isn't stable surface area.

### Testing:

Just exposes a method through the tls::Session, I don't think it needs dedicated tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

