### PR TITLE
fix(s2n-quic-transport): perform AEAD decryption before duplicate check

### DIFF
--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -398,7 +398,9 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
         if self.is_duplicate(packet_number, path_id, path, publisher) {
             return Err(ProcessingError::Other);
         }
-
+// If decryption failed but the packet was also a duplicate,
+// the duplicate check above takes precedence and the decrypt error
+// is intentionally discarded.
         let decrypted = decrypted?;
         Ok(decrypted)
     }

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -398,9 +398,10 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
         if self.is_duplicate(packet_number, path_id, path, publisher) {
             return Err(ProcessingError::Other);
         }
-// If decryption failed but the packet was also a duplicate,
-// the duplicate check above takes precedence and the decrypt error
-// is intentionally discarded.
+
+        // If decryption failed but the packet was also a duplicate,
+        // the duplicate check above takes precedence and the decrypt error
+        // is intentionally discarded.
         let decrypted = decrypted?;
         Ok(decrypted)
     }

--- a/quic/s2n-quic-transport/src/space/handshake.rs
+++ b/quic/s2n-quic-transport/src/space/handshake.rs
@@ -375,12 +375,9 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
                 });
             })?;
 
-        if self.is_duplicate(packet.packet_number, path_id, path, publisher) {
-            return Err(ProcessingError::Other);
-        }
-
+        let packet_number = packet.packet_number;
         let packet_header =
-            event::builder::PacketHeader::new(packet.packet_number, publisher.quic_version());
+            event::builder::PacketHeader::new(packet_number, publisher.quic_version());
         let decrypted = packet.decrypt(&self.key).inspect_err(|_err| {
             publisher.on_packet_dropped(event::builder::PacketDropped {
                 reason: event::builder::PacketDropReason::DecryptionFailed {
@@ -388,7 +385,21 @@ impl<Config: endpoint::Config> HandshakeSpace<Config> {
                     path: path_event!(path, path_id),
                 },
             });
-        })?;
+        });
+
+        //= https://www.rfc-editor.org/rfc/rfc9001#section-9.5
+        //# For authentication to be
+        //# free from side channels, the entire process of header protection
+        //# removal, packet number recovery, and packet protection removal MUST
+        //# be applied together without timing and other side channels.
+
+        // We perform decryption prior to checking for duplicate to avoid short-circuiting
+        // and maintain constant-time operation.
+        if self.is_duplicate(packet_number, path_id, path, publisher) {
+            return Err(ProcessingError::Other);
+        }
+
+        let decrypted = decrypted?;
         Ok(decrypted)
     }
 }

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -408,12 +408,9 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
                 });
             })?;
 
-        if self.is_duplicate(packet.packet_number, path_id, path, publisher) {
-            return Err(ProcessingError::Other);
-        }
-
+        let packet_number = packet.packet_number;
         let packet_header =
-            event::builder::PacketHeader::new(packet.packet_number, publisher.quic_version());
+            event::builder::PacketHeader::new(packet_number, publisher.quic_version());
         let decrypted = packet.decrypt(&self.key).inspect_err(|_err| {
             publisher.on_packet_dropped(event::builder::PacketDropped {
                 reason: event::builder::PacketDropReason::DecryptionFailed {
@@ -421,7 +418,21 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
                     path: path_event!(path, path_id),
                 },
             });
-        })?;
+        });
+
+        //= https://www.rfc-editor.org/rfc/rfc9001#section-9.5
+        //# For authentication to be
+        //# free from side channels, the entire process of header protection
+        //# removal, packet number recovery, and packet protection removal MUST
+        //# be applied together without timing and other side channels.
+
+        // We perform decryption prior to checking for duplicate to avoid short-circuiting
+        // and maintain constant-time operation.
+        if self.is_duplicate(packet_number, path_id, path, publisher) {
+            return Err(ProcessingError::Other);
+        }
+
+        let decrypted = decrypted?;
 
         if Config::ENDPOINT_TYPE.is_client() && !decrypted.token.is_empty() {
             //= https://www.rfc-editor.org/rfc/rfc9000#section-17.2.2

--- a/quic/s2n-quic-transport/src/space/initial.rs
+++ b/quic/s2n-quic-transport/src/space/initial.rs
@@ -432,6 +432,9 @@ impl<Config: endpoint::Config> InitialSpace<Config> {
             return Err(ProcessingError::Other);
         }
 
+        // If decryption failed but the packet was also a duplicate,
+        // the duplicate check above takes precedence and the decrypt error
+        // is intentionally discarded.
         let decrypted = decrypted?;
 
         if Config::ENDPOINT_TYPE.is_client() && !decrypted.token.is_empty() {


### PR DESCRIPTION
### Release Summary:

### Resolved issues:
N/A

### Description of changes: 
The duplicate packet check in InitialSpace and HandshakeSpace was performed before AEAD decryption. This reorders the operations to match the existing ApplicationSpace pattern, where decryption runs before the duplicate check, per [RFC 9001 §9.5](https://www.rfc-editor.org/rfc/rfc9001#section-9.5).

### Call-outs:
The decrypt result is now stored before the duplicate check and propagated via ? afterward. This means decryption errors for duplicate packets are silently discarded (the duplicate check returns ProcessingError::Other first). This matches the ApplicationSpace behavior and is intentional since we wouldn't want to surface decrypt errors for packets we're going to reject as duplicates anyway.

### Testing:
Open to suggestions here. A dedicated test seems difficult because the observable behavior (which packets are accepted/rejected) is identical before and after the reorder, not something distinguishable through events or assertions. The ApplicationSpace doesn't have a test for this ordering either. Existing tests do pass without modification.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

