### PR TITLE
docs(s2n-quic-crypto): clarify PRK zeroization

### DIFF
--- a/quic/s2n-quic-crypto/src/cipher_suite.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite.rs
@@ -107,6 +107,9 @@ macro_rules! impl_cipher_suite {
                 fn zeroize(&mut self) {
                     self.iv.zeroize();
                     self.key.zeroize();
+                    // Note: `self.secret` (hkdf::Prk) is intentionally not zeroized here.
+                    // aws-lc-rs's Prk implements Drop and zeroizes its own key material:
+                    // https://github.com/aws/aws-lc-rs/blob/main/aws-lc-rs/src/hkdf.rs
                 }
             }
 

--- a/quic/s2n-quic-crypto/src/cipher_suite.rs
+++ b/quic/s2n-quic-crypto/src/cipher_suite.rs
@@ -107,8 +107,8 @@ macro_rules! impl_cipher_suite {
                 fn zeroize(&mut self) {
                     self.iv.zeroize();
                     self.key.zeroize();
-                    // Note: `self.secret` (hkdf::Prk) is intentionally not zeroized here.
-                    // aws-lc-rs's Prk implements Drop and zeroizes its own key material:
+                    // Note: `self.secret` (hkdf::Prk) zeroizes its own key material
+                    // via the Drop impl in aws_lc_rs::hkdf::Prk:
                     // https://github.com/aws/aws-lc-rs/blob/main/aws-lc-rs/src/hkdf.rs
                 }
             }


### PR DESCRIPTION
### Release Summary:

### Resolved Issues:
N/A

### Description of changes: 
Adds a comment to the cipher suite Zeroize impl clarifying that self.secret (hkdf::Prk) is intentionally not zeroized there because aws-lc-rs's Prk type implements Drop and handles its own zeroization. This preempts false positives that flag the omission without checking the upstream type's behavior.

### Call-outs:

N/A

### Testing:

N/A, comment-only change


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


