### PR TITLE
fix(interop): temporarily disable mvfst for rebind-addr and rebind-port

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -799,8 +799,7 @@
       "client"
     ],
     "mvfst": [
-      "client",
-      "server"
+      "client"
     ],
     "neqo": [
       "client",
@@ -850,8 +849,7 @@
       "client"
     ],
     "mvfst": [
-      "client",
-      "server"
+      "client"
     ],
     "neqo": [
       "client",


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

We are seeing that `mvfst` (as a server) interop with s2n-quic for rebind-addr and rebind-port is failing on mainline interop test: https://interop.seemann.io/quic?run=2026-04-11T15%3A47. We will disable these two tests to unblock our CI for now.

Our interop failure:
https://github.com/aws/s2n-quic/actions/runs/24380320649/job/71208299323
```
mvfst (server) - rebind-addr was expected to pass but failed
mvfst (server) - rebind-port was expected to pass but failed
```

### Call-outs:

We should looks through their recent changes to find out why these two tests are failing. Or we might cut them a ticket to ask.

### Testing:

Our interop test should pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

