### PR TITLE
docs(s2n-quic): note protocol fields in tracing output

### DIFF
--- a/quic/s2n-quic/src/provider/event/tracing.rs
+++ b/quic/s2n-quic/src/provider/event/tracing.rs
@@ -1,6 +1,9 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//! Event output includes QUIC protocol fields such as stateless reset tokens.
+//! Applications should ensure appropriate access controls on log output.
+
 pub use s2n_quic_core::event::tracing::Subscriber;
 
 #[derive(Debug, Default)]

--- a/quic/s2n-quic/src/provider/event/tracing.rs
+++ b/quic/s2n-quic/src/provider/event/tracing.rs
@@ -1,8 +1,16 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Event output includes QUIC protocol fields such as stateless reset tokens.
-//! Applications should ensure appropriate access controls on log output.
+//! Event integration with [`tracing`](https://docs.rs/tracing).
+//!
+//! # Security Considerations
+//!
+//! This module's [`Subscriber`] emits all event fields at the `DEBUG` level,
+//! including security-sensitive values such as Stateless Reset Tokens and
+//! connection identifiers. Ensure that `tracing` output is not persisted or
+//! exposed in environments where this data could be accessed by unauthorized
+//! parties. Consider implementing a custom [`event::Subscriber`](super::Subscriber)
+//! if you need to redact sensitive fields.
 
 pub use s2n_quic_core::event::tracing::Subscriber;
 


### PR DESCRIPTION
### Release Summary:

### Resolved issues:
N/A

### Description of changes: 
Adds a doc comment to the tracing event provider noting that event output includes QUIC protocol fields such as stateless reset tokens, and applications should secure log output accordingly.

### Call-outs:
N/A

### Testing:
N/A, comment-only change


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

