### PR TITLE
chore(duvet): mark one of section 9 requirements as an exception

### DIFF
--- a/quic/s2n-quic-transport/src/path/manager.rs
+++ b/quic/s2n-quic-transport/src/path/manager.rs
@@ -800,13 +800,6 @@ impl<Config: endpoint::Config> Manager<Config> {
                     //# When an endpoint has no validated path on which to send packets, it
                     //# MAY discard connection state.
 
-                    //= https://www.rfc-editor.org/rfc/rfc9000#section-9
-                    //= type=TODO
-                    //= tracking-issue=713
-                    //# An endpoint capable of connection
-                    //# migration MAY wait for a new path to become available before
-                    //# discarding connection state.
-
                     //= https://www.rfc-editor.org/rfc/rfc9000#section-9.3.2
                     //# If an endpoint has no state about the last validated peer address, it
                     //# MUST close the connection silently by discarding all connection

--- a/specs/exceptions/transport/9.toml
+++ b/specs/exceptions/transport/9.toml
@@ -7,5 +7,5 @@ migration MAY wait for a new path to become available before
 discarding connection state.
 '''
 reason = '''
-We are not going to implement this unless someone request it.
+We will not implement this optional functionality until there is a demonstrated need.
 '''

--- a/specs/exceptions/transport/9.toml
+++ b/specs/exceptions/transport/9.toml
@@ -1,0 +1,11 @@
+target = "https://www.rfc-editor.org/rfc/rfc9000#section-9"
+
+[[exception]]
+quote = '''
+An endpoint capable of connection
+migration MAY wait for a new path to become available before
+discarding connection state.
+'''
+reason = '''
+We are not going to implement this unless someone request it.
+'''


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves https://github.com/aws/s2n-quic/issues/713.

### Description of changes: 

After a offline discussion, we decided that a requirement from RFC9000:
> An endpoint capable of connection
> migration MAY wait for a new path to become available before
> discarding connection state.
will not be implemented in s2n-quic unless someone request it. Hence, we move the comment down to the exceptions section.

### Call-outs:

N/A

### Testing:

Duvet should now mark it as exception.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

