### PR TITLE
fix(s2n-quic-dc): Wire event_subscriber into s2n-quic endpoints

### DIFF
--- a/dc/s2n-quic-dc/src/psk/client/builder.rs
+++ b/dc/s2n-quic-dc/src/psk/client/builder.rs
@@ -19,7 +19,6 @@ use super::Provider;
 pub struct Builder<
     Event: s2n_quic::provider::event::Subscriber = s2n_quic::provider::event::default::Subscriber,
 > {
-    #[allow(dead_code)]
     pub(crate) event_subscriber: Event,
     pub(crate) data_window: u64,
     pub(crate) mtu: u16,

--- a/dc/s2n-quic-dc/src/psk/io.rs
+++ b/dc/s2n-quic-dc/src/psk/io.rs
@@ -91,7 +91,7 @@ impl Server {
                     let server = server
                         .with_limits(connection_limits)?
                         .with_dc(map.clone())?
-                        .with_event(event)?
+                        .with_event((event, builder.event_subscriber))?
                         .with_tls(tls_materials_provider)?;
                     if let Some(limiter) = builder.endpoint_limits {
                         server.with_endpoint_limits(limiter)?.start()?
@@ -103,7 +103,7 @@ impl Server {
                 let server = server
                     .with_limits(connection_limits)?
                     .with_dc(map.clone())?
-                    .with_event(event)?
+                    .with_event((event, builder.event_subscriber))?
                     .with_tls(tls_materials_provider)?
                     .start()?;
             }
@@ -221,7 +221,7 @@ impl Client {
         let client = client
             .with_limits(connection_limits)?
             .with_dc(map.clone())?
-            .with_event(event)?
+            .with_event((event, builder.event_subscriber))?
             .with_tls(tls_materials_provider)?
             .start()?;
 

--- a/dc/s2n-quic-dc/src/psk/server/builder.rs
+++ b/dc/s2n-quic-dc/src/psk/server/builder.rs
@@ -15,7 +15,6 @@ use super::Provider;
 pub struct Builder<
     Event: s2n_quic::provider::event::Subscriber = s2n_quic::provider::event::default::Subscriber,
 > {
-    #[allow(dead_code)]
     pub(crate) event_subscriber: Event,
     pub(crate) data_window: u64,
     pub(crate) initial_data_window: Option<u64>,


### PR DESCRIPTION
### Release Summary:

* feat(s2n-quic-dc): Expose customizing the event subscriber registered with s2n-quic endpoints

### Resolved issues:

n/a

### Description of changes: 

Previously these methods on the public builders would store but never registered the event subscriber with the eventually built endpoints, as partially indicated by the dead_code allow statements. This fixes that by wiring in the event subscriber to be registered on the underlying endpoint as expected.

### Call-outs:

n/a

### Testing:

We'll see dead code lints if we break this obviously again. Locally I do see events from a tracing subscriber registered in this way where I didn't before.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

