### PR TITLE
fix(s2n-quic-dc): Add large payload test to behavior suite

### DIFF
--- a/dc/s2n-quic-dc/src/stream/tests/behavior/write.rs
+++ b/dc/s2n-quic-dc/src/stream/tests/behavior/write.rs
@@ -184,3 +184,22 @@ async fn half_close_read_test() {
     let len = client.read(&mut buffer).await.unwrap();
     assert_eq!(len, 0);
 }
+
+/// Q: What happens when the client writes a payload equal to the maximum datagram size (32KB)?
+///
+/// A: The server receives the full payload
+#[tokio::test]
+async fn large_write_test() {
+    let context = Context::new().await;
+    let (mut client, mut server) = context.pair().await;
+
+    let large_message = vec![42u8; crate::stream::MAX_DATAGRAM_SIZE];
+
+    client.write_all(&large_message).await.unwrap();
+    client.shutdown().await.unwrap();
+
+    let mut buffer = vec![];
+    server.read_to_end(&mut buffer).await.unwrap();
+
+    assert_eq!(buffer, large_message);
+}


### PR DESCRIPTION
### Description of changes: 

Follow up from Mark's [comment](https://github.com/aws/s2n-quic/pull/3060#discussion_r3157619180) in #3060.

This test ensures that large payloads from the client up to the `MAX_DATAGRAM_SIZE` are supported in the existing tcp, udp, dcquic-tcp, and dcquic-udp pathways.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

