### PR TITLE
feat(s2n-quic-dc): Send detailed transport error information over the wire

### DIFF
--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -45,7 +45,7 @@ once_cell = "1"
 pin-project-lite = "0.2"
 rand = "0.10"
 s2n-codec = { version = "=0.78.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic = { version = "=1.78.0", path = "../../quic/s2n-quic", features = ["unstable-provider-dc", "unstable-provider-random"] }
+s2n-quic = { version = "=1.78.0", path = "../../quic/s2n-quic", features = ["unstable-provider-connection-close-formatter", "unstable-provider-dc", "unstable-provider-random"] }
 s2n-quic-core = { version = "=0.78.0", path = "../../quic/s2n-quic-core", default-features = false }
 s2n-quic-platform = { version = "=0.78.0", path = "../../quic/s2n-quic-platform" }
 s2n-tls = "0.3"

--- a/dc/s2n-quic-dc/src/connection_close.rs
+++ b/dc/s2n-quic-dc/src/connection_close.rs
@@ -4,7 +4,15 @@
 use s2n_quic::provider::connection_close_formatter::{ConnectionClose, Context, Formatter};
 use s2n_quic_core::{application, transport};
 
-/// A formatter that passes transport errors through for debuggability.
+/// A formatter that passes transport errors through transparently.
+///
+/// This differs from the default [`Production`](s2n_quic_core::connection::close::Production) formatter
+/// by preserving specific TLS alert codes (e.g., `CERTIFICATE_UNKNOWN`) over the wire.
+/// Unlike the [`Development`](s2n_quic_core::connection::close::Development) formatter
+/// this does clear the Reason Phrase field for early closure to remain compliant with RFC 9000.
+///
+/// This formatter is safe to use in controlled environments where both peers are
+/// generally expected to be trusted infrastructure.
 #[derive(Clone, Copy, Debug, Default)]
 pub struct TransparentTransport;
 

--- a/dc/s2n-quic-dc/src/connection_close.rs
+++ b/dc/s2n-quic-dc/src/connection_close.rs
@@ -1,0 +1,53 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use s2n_quic::provider::connection_close_formatter::{ConnectionClose, Context, Formatter};
+use s2n_quic_core::{application, transport};
+
+/// A formatter that passes transport errors through for debuggability.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TransparentTransport;
+
+impl Formatter for TransparentTransport {
+    fn format_transport_error(
+        &self,
+        _context: &Context,
+        error: transport::Error,
+    ) -> ConnectionClose<'_> {
+        error.into()
+    }
+
+    fn format_application_error(
+        &self,
+        _context: &Context,
+        error: application::Error,
+    ) -> ConnectionClose<'_> {
+        error.into()
+    }
+
+    fn format_early_transport_error(
+        &self,
+        context: &Context,
+        error: transport::Error,
+    ) -> ConnectionClose<'_> {
+        Self.format_transport_error(context, error)
+    }
+
+    fn format_early_application_error(
+        &self,
+        _context: &Context,
+        _error: application::Error,
+    ) -> ConnectionClose<'_> {
+        //= https://www.rfc-editor.org/rfc/rfc9000#section-10.2.3
+        //# Sending a CONNECTION_CLOSE of type 0x1d in an Initial or Handshake
+        //# packet could expose application state or be used to alter application
+        //# state.  A CONNECTION_CLOSE of type 0x1d MUST be replaced by a
+        //# CONNECTION_CLOSE of type 0x1c when sending the frame in Initial or
+        //# Handshake packets.  Otherwise, information about the application
+        //# state might be revealed.  Endpoints MUST clear the value of the
+        //# Reason Phrase field and SHOULD use the APPLICATION_ERROR code when
+        //# converting to a CONNECTION_CLOSE of type 0x1c.
+
+        transport::Error::APPLICATION_ERROR.into()
+    }
+}

--- a/dc/s2n-quic-dc/src/lib.rs
+++ b/dc/s2n-quic-dc/src/lib.rs
@@ -4,6 +4,7 @@
 pub mod allocator;
 pub mod clock;
 pub mod congestion;
+pub mod connection_close;
 pub mod control;
 pub mod credentials;
 pub mod crypto;

--- a/dc/s2n-quic-dc/src/psk/io.rs
+++ b/dc/s2n-quic-dc/src/psk/io.rs
@@ -89,6 +89,7 @@ impl Server {
             if #[cfg(any(test, feature = "testing"))] {
                 let server = {
                     let server = server
+                        .with_connection_close_formatter(crate::connection_close::TransparentTransport)?
                         .with_limits(connection_limits)?
                         .with_dc(map.clone())?
                         .with_event((event, builder.event_subscriber))?
@@ -101,6 +102,7 @@ impl Server {
                 };
             } else {
                 let server = server
+                    .with_connection_close_formatter(crate::connection_close::TransparentTransport)?
                     .with_limits(connection_limits)?
                     .with_dc(map.clone())?
                     .with_event((event, builder.event_subscriber))?
@@ -219,6 +221,7 @@ impl Client {
         let event = ((ConfirmComplete, MtuConfirmComplete), subscriber);
 
         let client = client
+            .with_connection_close_formatter(crate::connection_close::TransparentTransport)?
             .with_limits(connection_limits)?
             .with_dc(map.clone())?
             .with_event((event, builder.event_subscriber))?

--- a/dc/s2n-quic-dc/src/psk/io.rs
+++ b/dc/s2n-quic-dc/src/psk/io.rs
@@ -786,4 +786,67 @@ mod tests {
             1
         );
     }
+
+    #[tokio::test]
+    async fn transparent_transport_preserves_tls_error_code() {
+        use crate::testing::UntrustedClientProvider;
+
+        init_tracing();
+
+        let subscriber = NoopSubscriber {};
+        let tls = UntrustedClientProvider;
+
+        let server_map = Map::new(
+            Signer::new(b"default"),
+            50_000,
+            false,
+            StdClock::default(),
+            subscriber.clone(),
+        );
+
+        let server_builder = crate::psk::server::Builder::default();
+        let (server_addr_rx, _server_guard) = crate::psk::server::Provider::setup(
+            "127.0.0.1:0".parse().unwrap(),
+            server_map,
+            tls.clone(),
+            subscriber.clone(),
+            server_builder,
+        );
+
+        let client_map = Map::new(
+            Signer::new(b"default"),
+            50_000,
+            false,
+            StdClock::default(),
+            subscriber.clone(),
+        );
+
+        let client = Client::bind::<
+            <UntrustedClientProvider as Provider>::Client,
+            NoopSubscriber,
+            s2n_quic::provider::event::default::Subscriber,
+        >(
+            "0.0.0.0:0".parse().unwrap(),
+            client_map,
+            tls.start_client().unwrap(),
+            subscriber,
+            crate::psk::client::Builder::default().with_success_jitter(Duration::ZERO),
+        )
+        .unwrap();
+
+        let server_addr = server_addr_rx.await.unwrap().unwrap();
+        let server_name: s2n_quic::server::Name = "localhost".into();
+
+        let result = client
+            .connect(server_addr, HandshakeReason::User, server_name)
+            .await;
+
+        let err: io::Error = result.unwrap_err().into();
+        let err_msg = err.to_string();
+
+        assert!(
+            err_msg.contains("CERTIFICATE_UNKNOWN"),
+            "Expected CERTIFICATE_UNKNOWN, got: {err_msg}"
+        );
+    }
 }

--- a/dc/s2n-quic-dc/src/testing.rs
+++ b/dc/s2n-quic-dc/src/testing.rs
@@ -236,7 +236,10 @@ impl Provider for UntrustedClientProvider {
         let client = s2n_quic_tls_prov::Client::builder()
             .with_application_protocols(["h3"].iter())?
             .with_certificate(certificates::CERT_PEM)?
-            .with_client_identity(certificates::UNTRUSTED_CERT_PEM, certificates::UNTRUSTED_KEY_PEM)?
+            .with_client_identity(
+                certificates::UNTRUSTED_CERT_PEM,
+                certificates::UNTRUSTED_KEY_PEM,
+            )?
             .build()?;
         Ok(client)
     }

--- a/dc/s2n-quic-dc/src/testing.rs
+++ b/dc/s2n-quic-dc/src/testing.rs
@@ -215,6 +215,33 @@ impl Provider for TestTlsProvider {
     }
 }
 
+#[derive(Default, Clone)]
+pub struct UntrustedClientProvider;
+
+impl Provider for UntrustedClientProvider {
+    type Server = s2n_quic_tls_prov::Server;
+    type Client = s2n_quic_tls_prov::Client;
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    fn start_server(self) -> Result<Self::Server, Self::Error> {
+        let server = s2n_quic_tls_prov::Server::builder()
+            .with_application_protocols(["h3"].iter())?
+            .with_certificate(certificates::CERT_PEM, certificates::KEY_PEM)?
+            .with_client_authentication()?
+            .build()?;
+        Ok(server)
+    }
+
+    fn start_client(self) -> Result<Self::Client, Self::Error> {
+        let client = s2n_quic_tls_prov::Client::builder()
+            .with_application_protocols(["h3"].iter())?
+            .with_certificate(certificates::CERT_PEM)?
+            .with_client_identity(certificates::UNTRUSTED_CERT_PEM, certificates::UNTRUSTED_KEY_PEM)?
+            .build()?;
+        Ok(client)
+    }
+}
+
 #[derive(Clone, Debug, Default)]
 pub struct Pair {
     pub client_mtu: Option<u16>,

--- a/quic/s2n-quic/src/client/builder.rs
+++ b/quic/s2n-quic/src/client/builder.rs
@@ -285,6 +285,14 @@ impl<Providers: ClientProviders> Builder<Providers> {
         ClientProviders
     );
 
+    #[cfg(any(test, feature = "unstable-provider-connection-close-formatter"))]
+    impl_provider_method!(
+        /// Sets the connection close formatter provider for the [`Client`]
+        with_connection_close_formatter,
+        connection_close_formatter,
+        ClientProviders
+    );
+
     #[cfg(any(test, feature = "unstable-provider-packet-interceptor"))]
     impl_provider_method!(
         /// Sets the packet interceptor provider for the [`Client`]

--- a/quic/s2n-quic/src/client/builder.rs
+++ b/quic/s2n-quic/src/client/builder.rs
@@ -287,7 +287,34 @@ impl<Providers: ClientProviders> Builder<Providers> {
 
     #[cfg(any(test, feature = "unstable-provider-connection-close-formatter"))]
     impl_provider_method!(
-        /// Sets the connection close formatter provider for the [`Client`]
+        /// Sets the connection close formatter for the [`Client`]
+        ///
+        /// The connection close formatter controls how errors are encoded in
+        /// CONNECTION_CLOSE frames sent to the peer. The default (`Production`)
+        /// formatter removes potentially sensitive information such as specific TLS alert
+        /// codes and reason phrases.
+        ///
+        /// # Examples
+        ///
+        /// Uses the `Development` formatter which passes all errors through
+        /// unmodified. This should only be used during development.
+        ///
+        /// Alternatively, implement [`connection_close_formatter::Formatter`]
+        /// for custom behavior.
+        ///
+        /// ```rust,no_run
+        /// # use std::error::Error;
+        /// use s2n_quic::{Client, provider::connection_close_formatter};
+        /// #
+        /// # #[tokio::main]
+        /// # async fn main() -> Result<(), Box<dyn Error>> {
+        /// let client = Client::builder()
+        ///     .with_connection_close_formatter(connection_close_formatter::Development)?
+        ///     .start()?;
+        /// #
+        /// #    Ok(())
+        /// # }
+        /// ```
         with_connection_close_formatter,
         connection_close_formatter,
         ClientProviders

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -339,6 +339,14 @@ impl<Providers: ServerProviders> Builder<Providers> {
         ServerProviders
     );
 
+    #[cfg(any(test, feature = "unstable-provider-connection-close-formatter"))]
+    impl_provider_method!(
+        /// Sets the connection close formatter provider for the [`Server`]
+        with_connection_close_formatter,
+        connection_close_formatter,
+        ServerProviders
+    );
+
     #[cfg(any(test, feature = "unstable-provider-packet-interceptor"))]
     impl_provider_method!(
         /// Sets the packet interceptor provider for the [`Server`]

--- a/quic/s2n-quic/src/server/builder.rs
+++ b/quic/s2n-quic/src/server/builder.rs
@@ -341,7 +341,34 @@ impl<Providers: ServerProviders> Builder<Providers> {
 
     #[cfg(any(test, feature = "unstable-provider-connection-close-formatter"))]
     impl_provider_method!(
-        /// Sets the connection close formatter provider for the [`Server`]
+        /// Sets the connection close formatter for the [`Server`]
+        ///
+        /// The connection close formatter controls how errors are encoded in
+        /// CONNECTION_CLOSE frames sent to the peer. The default (`Production`)
+        /// formatter removes potentially sensitive information such as specific TLS alert
+        /// codes and reason phrases.
+        ///
+        /// # Examples
+        ///
+        /// Uses the `Development` formatter which passes all errors through
+        /// unmodified. This should only be used during development.
+        ///
+        /// Alternatively, implement [`connection_close_formatter::Formatter`]
+        /// for custom behavior.
+        ///
+        /// ```rust,no_run
+        /// # use std::error::Error;
+        /// use s2n_quic::{Server, provider::connection_close_formatter};
+        /// #
+        /// # #[tokio::main]
+        /// # async fn main() -> Result<(), Box<dyn Error>> {
+        /// let server = Server::builder()
+        ///     .with_connection_close_formatter(connection_close_formatter::Development)?
+        ///     .start()?;
+        /// #
+        /// #    Ok(())
+        /// # }
+        /// ```
         with_connection_close_formatter,
         connection_close_formatter,
         ServerProviders


### PR DESCRIPTION
### Release Summary:

* feat(s2n-quic): Support connection close formatter on quic endpoints
* feat(s2n-quic-dc): Send detailed transport error information over the wire

### Resolved issues:

N/A

### Description of changes: 

Currently, s2n-quic does not support overriding the connection close formatter on its endpoints. The default formatter for production does not share specific transport error reasons for security purposes.

This PR introduces support for the connection close formatter on QUIC server/client endpoints. It then utilizes this feature in s2n-quic-dc to send transport error messages as-is to the remote. 

### Call-outs:

N/A

### Testing:

A test was added to s2n-quic-dc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

