### PR TITLE
chore: add typos and copyright checks to local test script

### DIFF
--- a/.github/config/typos.toml
+++ b/.github/config/typos.toml
@@ -11,6 +11,8 @@ check-filename = true
 controllen = "controllen"
 # ECN Capable Transport
 ect = "ect"
+# inline assembly operand constraint
+inout = "inout"
 # num_rational uses "numer" as short for "numerator"
 numer = "numer"
 # Packet number

--- a/examples/rustls-mtls/Cargo.toml
+++ b/examples/rustls-mtls/Cargo.toml
@@ -7,7 +7,7 @@ authors = ["Rick Richardson <rick.richardson@gmail.com>", "AWS s2n"]
 [dependencies]
 # Remove the `provider-tls-default` feature and add `provider-tls-rustls` in order to use the rustls backend
 s2n-quic = { version = "1", path = "../../quic/s2n-quic", default-features = false, features = ["provider-address-token-default", "provider-tls-rustls", "provider-event-tracing"] }
-# rustls-pemfile was incorperated to rustls-pki-types in version 1.9.0
+# rustls-pemfile was incorporated to rustls-pki-types in version 1.9.0
 rustls-pki-types = ">=1.9"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -17,7 +17,7 @@ fips = ["s2n-quic-crypto/fips", "rustls/fips"]
 bytes = { version = "1", default-features = false }
 # By [default](https://docs.rs/crate/rustls/latest/features) rustls includes the `tls12` feature.
 rustls = { version = "0.23", default-features = false, features=["std", "aws-lc-rs", "logging"] }
-# rustls-pemfile was incorperated to rustls-pki-types in version 1.9.0
+# rustls-pemfile was incorporated to rustls-pki-types in version 1.9.0
 rustls-pki-types = ">=1.9"
 s2n-codec = { version = "=0.78.0", path = "../../common/s2n-codec", default-features = false, features = ["alloc"] }
 s2n-quic-core = { version = "=0.78.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }

--- a/scripts/local_test
+++ b/scripts/local_test
@@ -9,6 +9,8 @@
 
 set -e
 
+"$(dirname "$0")/typos"
+"$(dirname "$0")/copyright_check"
 cargo +nightly fmt --all -- --check
 cargo +stable clippy --all-features --all-targets -- -D warnings
 cargo test


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves #1634

### Description of changes:

Adds the typos and copyright_check scripts to `scripts/local_test` so spelling and copyright issues are caught locally before pushing to CI.

Also fixes an existing typo (`incorperated` → `incorporated`) and adds `inout` (an inline assembly operand constraint keyword) to the typos allow list.

### Call-outs:

### Testing:

Ran `scripts/local_test` locally and verified typos and copyright checks execute successfully before fmt/clippy/test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.