### PR TITLE
fix(s2n-quic-dc): log when handshake/accept paths exit silently

### DIFF
--- a/dc/s2n-quic-dc/src/psk/io.rs
+++ b/dc/s2n-quic-dc/src/psk/io.rs
@@ -173,6 +173,13 @@ pub(super) async fn server<
             }
         });
     }
+
+    // accept() returning None means the s2n-quic endpoint has shut down. New
+    // path secrets will no longer be provisioned, but other components of the
+    // process (e.g. SaltyLibMetrics, the stream acceptor) may continue to
+    // appear healthy, leaving operators with no signal that handshakes are
+    // silently failing. Log loudly so this condition is observable.
+    tracing::error!("QUIC handshake server accept loop exited unexpectedly");
 }
 
 #[derive(Clone)]

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
@@ -30,7 +30,7 @@ use s2n_quic_core::{
     time::{Clock, Timestamp},
 };
 use std::{future::Future, io, os::fd::OwnedFd, path::Path};
-use tracing::debug;
+use tracing::{debug, error};
 
 pub struct Context<Sub>
 where
@@ -506,8 +506,8 @@ where
                     }
                     WorkerOutput::RecordSojournTime
                 }
-                Err(_err) => {
-                    debug!("application accept queue dropped; shutting down");
+                Err(err) => {
+                    error!("application accept queue dropped; shutting down: {err:?}");
                     WorkerOutput::Exit
                 }
             }));

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
@@ -30,7 +30,7 @@ use s2n_quic_core::{
     time::{Clock, Timestamp},
 };
 use std::{future::Future, io, os::fd::OwnedFd, path::Path};
-use tracing::{debug, error};
+use tracing::debug;
 
 pub struct Context<Sub>
 where
@@ -506,8 +506,8 @@ where
                     }
                     WorkerOutput::RecordSojournTime
                 }
-                Err(err) => {
-                    error!("application accept queue dropped; shutting down: {err:?}");
+                Err(_undelivered_stream) => {
+                    debug!("application accept queue dropped; shutting down");
                     WorkerOutput::Exit
                 }
             }));

--- a/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
@@ -21,7 +21,7 @@ use crate::{
 use core::ops::ControlFlow;
 use s2n_quic_core::{inet::SocketAddress, time::Clock};
 use std::io;
-use tracing::error;
+use tracing::debug;
 
 pub struct Acceptor<S, Sub>
 where
@@ -196,8 +196,8 @@ where
 
                 Ok(ControlFlow::Continue(()))
             }
-            Err(err) => {
-                error!("application accept queue dropped; shutting down: {err:?}");
+            Err(_undelivered_stream) => {
+                debug!("application accept queue dropped; shutting down");
                 Ok(ControlFlow::Break(()))
             }
         }

--- a/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
@@ -21,7 +21,7 @@ use crate::{
 use core::ops::ControlFlow;
 use s2n_quic_core::{inet::SocketAddress, time::Clock};
 use std::io;
-use tracing::debug;
+use tracing::error;
 
 pub struct Acceptor<S, Sub>
 where
@@ -196,8 +196,8 @@ where
 
                 Ok(ControlFlow::Continue(()))
             }
-            Err(_) => {
-                debug!("application accept queue dropped; shutting down");
+            Err(err) => {
+                error!("application accept queue dropped; shutting down: {err:?}");
                 Ok(ControlFlow::Break(()))
             }
         }


### PR DESCRIPTION
The QUIC handshake server's accept loop in psk/io.rs falls off the end without any log when s2n-quic returns None, leaving operators with zero visibility that path-secret provisioning has stopped (the surrounding process can keep emitting metrics and appear healthy). Add an error-level log when the accept loop exits.

Likewise, the application accept queue being dropped is a fatal condition for the UDP and TCP acceptor workers — they break out of their loops and shut down — but it was logged at debug. Upgrade both sites to error so the failure is visible in production logs.


### Testing:

none, this is only small logging changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

