### PR TITLE
fix(interop): temporarily disable kwik for rebind-addr and rebind-port

### DIFF
--- a/.github/interop/required.json
+++ b/.github/interop/required.json
@@ -810,9 +810,7 @@
       "client",
       "server"
     ],
-    "kwik": [
-      "client"
-    ],
+    "kwik": [],
     "lsquic": [
       "client",
       "server"
@@ -863,9 +861,7 @@
       "client",
       "server"
     ],
-    "kwik": [
-      "client"
-    ],
+    "kwik": [],
     "lsquic": [
       "client",
       "server"


### PR DESCRIPTION
### Description

The kwik QUIC client is currently failing `rebind-port` and `rebind-addr` interop tests against the s2n-quic server. This is confirmed by the [public interop runner](https://interop.seemann.io) which shows `✕(BP,BA)` for kwik client vs s2n-quic server.

The automated required-checks updater (#3063) re-added kwik client to these tests, but kwik is now failing them. This unblocks PRs like #3067 that are blocked on the QNS check.

### Changes

Remove `kwik` client from the required `rebind-addr` and `rebind-port` interop checks until the upstream issue is resolved.

### Testing

CI should pass with kwik removed from these required checks.