### PR TITLE
fix(dc): Reject & treat MAX KeyId as maybe-seen in receiver

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/receiver.rs
+++ b/dc/s2n-quic-dc/src/path/secret/receiver.rs
@@ -69,9 +69,14 @@ impl State {
         }
     }
 
-    pub fn pre_authentication(&self, _identity: &Credentials) -> Result<(), Error> {
-        // TODO: Provide more useful pre-auth checks. For now just don't bother checking this, we
-        // can always rely on the post-auth check in practice, this is just a slight optimization.
+    pub fn pre_authentication(&self, identity: &Credentials) -> Result<(), Error> {
+        // Bail if we get the max key ID. This is not practically reachable on well-behaved senders
+        // (see sender.rs for comments), and lets us always return a valid KeyId from
+        // `minimum_unseen_key_id` even with non well-behaved peers.
+        if identity.key_id == KeyId::MAX {
+            return Err(Error::Unknown);
+        }
+
         Ok(())
     }
 
@@ -83,11 +88,19 @@ impl State {
                 // state. After that just +1 consistently.
                 .wrapping_add(1),
         )
-        .unwrap()
+        .unwrap_or(
+            // Saturate if we've exhausted the key ID space. Should be unreachable in practice due
+            // to the pre_authentication check above, but avoid a panic by handling it here too.
+            KeyId::MAX,
+        )
     }
 
     /// Called after decryption has been performed
     pub fn post_authentication(&self, identity: &Credentials) -> Result<(), Error> {
+        // Duplicate since it's cheap right now, can be refined in the future.
+        // In practice callers should have already run this early in the receiving process.
+        self.pre_authentication(identity)?;
+
         let mut seen = self.seen.lock().unwrap();
 
         let key_id = *identity.key_id;

--- a/dc/s2n-quic-dc/src/path/secret/receiver/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/receiver/tests.rs
@@ -294,6 +294,52 @@ fn unseen() {
 }
 
 #[test]
+fn pre_authentication_rejects_max_key_id() {
+    let subject = State::new();
+    let id = Id::from([0; 16]);
+    let result = subject.pre_authentication(&Credentials {
+        id,
+        key_id: KeyId::MAX,
+    });
+    assert_eq!(result, Err(Error::Unknown));
+}
+
+#[test]
+fn post_authentication_rejects_max_key_id() {
+    let subject = State::new();
+    let id = Id::from([0; 16]);
+
+    subject
+        .post_authentication(&Credentials {
+            id,
+            key_id: KeyId::new(0).unwrap(),
+        })
+        .unwrap();
+
+    let result = subject.post_authentication(&Credentials {
+        id,
+        key_id: KeyId::MAX,
+    });
+    assert_eq!(result, Err(Error::Unknown));
+}
+
+#[test]
+fn minimum_unseen_key_id_saturates_at_max() {
+    let subject = State::new();
+    let id = Id::from([0; 16]);
+
+    let near_max = *KeyId::MAX - 1;
+    subject
+        .post_authentication(&Credentials {
+            id,
+            key_id: KeyId::new(near_max).unwrap(),
+        })
+        .unwrap();
+
+    assert_eq!(subject.minimum_unseen_key_id(), KeyId::MAX);
+}
+
+#[test]
 #[cfg_attr(kani, kani::proof, kani::unwind(130), kani::solver(kissat))]
 #[cfg_attr(miri, ignore)] // this test is too expensive for miri
 fn insert_unequal() {


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

n/a

### Description of changes: 

This avoids panicking if an authenticated peer has a bug and sends a packet with large (maximal) key ID. This is protected against on the sender side, but a misbehaving peer could skip that logic, so avoid panicking on the server side.

### Call-outs:

n/a

### Testing:

See added unit tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

