### PR TITLE
feat: Adds a benchmark for a single dc-quic handshake

### DIFF
--- a/dc/s2n-quic-dc-benches/Cargo.toml
+++ b/dc/s2n-quic-dc-benches/Cargo.toml
@@ -7,9 +7,13 @@ publish = false
 [dependencies]
 aws-lc-rs = "1.12"
 criterion = { version = "0.8", features = ["html_reports", "async_tokio"] }
+futures = "0.3.32"
 s2n-codec = { path = "../../common/s2n-codec" }
+s2n-quic-core = { path = "../../quic/s2n-quic-core", features = ["testing"] }
 s2n-quic-dc = { path = "../s2n-quic-dc", features = ["testing"] }
+s2n-quic = { path = "../../quic/s2n-quic" }
 tokio = { version = "1", features = ["full"] }
+tokio-util = "0.7"
 
 [[bench]]
 name = "bench"

--- a/dc/s2n-quic-dc-benches/src/handshake.rs
+++ b/dc/s2n-quic-dc-benches/src/handshake.rs
@@ -1,0 +1,94 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Benchmark for a single dc-quic handshake. Useful for comparing different dc-quic configurations
+//! settings against each other. Note that because this benchmark uses real sockets
+//! the results are inherently variable, but should still be useful for relative comparisons.
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use s2n_quic::{provider::tls::Provider, server::Name};
+use s2n_quic_core::time::StdClock;
+use s2n_quic_dc::{
+    path::secret::{stateless_reset::Signer, Map},
+    testing::{NoopSubscriber, TestTlsProvider},
+};
+
+struct TestSetup {
+    client: s2n_quic_dc::psk::client::Provider,
+    server_addr: std::net::SocketAddr,
+    server_name: Name,
+}
+
+async fn setup() -> (TestSetup, tokio_util::sync::DropGuard) {
+    let server_builder = s2n_quic_dc::psk::server::Builder::default();
+
+    let tls = TestTlsProvider {};
+    let subscriber = NoopSubscriber {};
+
+    let server_map = Map::new(
+        Signer::new(b"default"),
+        50_000,
+        false,
+        StdClock::default(),
+        subscriber.clone(),
+    );
+
+    let (server_addr_rx, drop_guard) = s2n_quic_dc::psk::server::Provider::setup(
+        "127.0.0.1:0".parse().unwrap(),
+        server_map.clone(),
+        tls.clone(),
+        subscriber.clone(),
+        server_builder,
+    );
+
+    let client_map = Map::new(
+        Signer::new(b"default"),
+        50_000,
+        false,
+        StdClock::default(),
+        subscriber.clone(),
+    );
+
+    let client = s2n_quic_dc::psk::client::Provider::builder()
+        .start(
+            "0.0.0.0:0".parse().unwrap(),
+            client_map,
+            tls.start_client().unwrap(),
+            subscriber,
+            "localhost".into(),
+        )
+        .unwrap();
+
+    let server_addr = server_addr_rx.await.unwrap().unwrap();
+    let server_name: s2n_quic::server::Name = "localhost".into();
+
+    (
+        TestSetup {
+            client,
+            server_addr,
+            server_name,
+        },
+        drop_guard,
+    )
+}
+
+pub fn benchmarks(c: &mut Criterion) {
+    c.bench_function("dc-quic", move |b| {
+        b.to_async(tokio::runtime::Runtime::new().unwrap())
+            .iter_batched(
+                || futures::executor::block_on(setup()),
+                |(setup, drop_guard)| async move {
+                    setup
+                        .client
+                        .unconditionally_handshake_with_entry(setup.server_addr, setup.server_name)
+                        .await
+                        .unwrap();
+                    drop(drop_guard)
+                },
+                BatchSize::SmallInput,
+            )
+    });
+}
+
+criterion_group!(benches, benchmarks);
+criterion_main!(benches);

--- a/dc/s2n-quic-dc-benches/src/lib.rs
+++ b/dc/s2n-quic-dc-benches/src/lib.rs
@@ -5,10 +5,12 @@ use criterion::Criterion;
 
 pub mod crypto;
 pub mod datagram;
+pub mod handshake;
 pub mod streams;
 
 pub fn benchmarks(c: &mut Criterion) {
     crypto::benchmarks(c);
     datagram::benchmarks(c);
     streams::benchmarks(c);
+    handshake::benchmarks(c);
 }


### PR DESCRIPTION
### Release Summary:
### Resolved issues:

N/A

### Description of changes: 

Adds a single dc-quic handshake criterion benchmark. I want to codify this benchmark because I was sort of struggling to prove that my changes were or were not affecting dc-quic handshake times. This benchmark should help people in the future do this kind of testing without having to keep recreating their own statistical tests.

### Call-outs:
I'm not exactly sure how dc-quic is normally configured, so let me know if anything in the settings isn't a good default.

### Testing:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

