### PR TITLE
chore: Improve dc-quic benchmark accuracy

### DIFF
--- a/dc/s2n-quic-dc-benches/src/handshake.rs
+++ b/dc/s2n-quic-dc-benches/src/handshake.rs
@@ -5,21 +5,23 @@
 //! settings against each other. Note that because this benchmark uses real sockets
 //! the results are inherently variable, but should still be useful for relative comparisons.
 
-use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion};
 use s2n_quic::{provider::tls::Provider, server::Name};
 use s2n_quic_core::time::StdClock;
 use s2n_quic_dc::{
     path::secret::{stateless_reset::Signer, Map},
     testing::{NoopSubscriber, TestTlsProvider},
 };
+use std::time::{Duration, Instant};
 
 struct TestSetup {
-    client: s2n_quic_dc::psk::client::Provider,
     server_addr: std::net::SocketAddr,
     server_name: Name,
+    tls: TestTlsProvider,
+    subscriber: NoopSubscriber,
 }
 
-async fn setup() -> (TestSetup, tokio_util::sync::DropGuard) {
+async fn make_server() -> (TestSetup, tokio_util::sync::DropGuard) {
     let server_builder = s2n_quic_dc::psk::server::Builder::default();
 
     let tls = TestTlsProvider {};
@@ -41,53 +43,69 @@ async fn setup() -> (TestSetup, tokio_util::sync::DropGuard) {
         server_builder,
     );
 
-    let client_map = Map::new(
-        Signer::new(b"default"),
-        50_000,
-        false,
-        StdClock::default(),
-        subscriber.clone(),
-    );
-
-    let client = s2n_quic_dc::psk::client::Provider::builder()
-        .start(
-            "0.0.0.0:0".parse().unwrap(),
-            client_map,
-            tls.start_client().unwrap(),
-            subscriber,
-            "localhost".into(),
-        )
-        .unwrap();
-
     let server_addr = server_addr_rx.await.unwrap().unwrap();
     let server_name: s2n_quic::server::Name = "localhost".into();
 
     (
         TestSetup {
-            client,
             server_addr,
             server_name,
+            tls,
+            subscriber,
         },
         drop_guard,
     )
 }
 
+fn make_client(setup: &TestSetup) -> s2n_quic_dc::psk::client::Provider {
+    let client_map = Map::new(
+        Signer::new(b"default"),
+        50_000,
+        false,
+        StdClock::default(),
+        setup.subscriber.clone(),
+    );
+
+    s2n_quic_dc::psk::client::Provider::builder()
+        .start(
+            "0.0.0.0:0".parse().unwrap(),
+            client_map,
+            setup.tls.clone().start_client().unwrap(),
+            setup.subscriber.clone(),
+            "localhost".into(),
+        )
+        .unwrap()
+}
+
 pub fn benchmarks(c: &mut Criterion) {
-    c.bench_function("dc-quic", move |b| {
-        b.to_async(tokio::runtime::Runtime::new().unwrap())
-            .iter_batched(
-                || futures::executor::block_on(setup()),
-                |(setup, drop_guard)| async move {
-                    setup
-                        .client
-                        .unconditionally_handshake_with_entry(setup.server_addr, setup.server_name)
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let (setup, drop_guard) = runtime.block_on(make_server());
+
+    c.bench_function("handshake", |b| {
+        b.to_async(&runtime).iter_custom(|iters| {
+            let setup = &setup;
+            async move {
+                let mut total = Duration::ZERO;
+                for _ in 0..iters {
+                    // Fresh client per iteration, otherwise the handshake will be cached and reused
+                    let client = make_client(setup);
+
+                    let start = Instant::now();
+                    client
+                        .unconditionally_handshake_with_entry(
+                            setup.server_addr,
+                            setup.server_name.clone(),
+                        )
                         .await
                         .unwrap();
-                    drop(drop_guard)
-                },
-                BatchSize::SmallInput,
-            )
+                    total += start.elapsed();
+                }
+                total
+            }
+        })
     });
+
+    drop(drop_guard);
 }
 
 criterion_group!(benches, benchmarks);

--- a/dc/s2n-quic-dc/src/testing.rs
+++ b/dc/s2n-quic-dc/src/testing.rs
@@ -203,7 +203,7 @@ impl Provider for TestTlsProvider {
             .with_application_protocols(["h3"].iter())?
             .with_certificate(certificates::CERT_PEM, certificates::KEY_PEM)?
             .with_client_authentication()?
-            .with_trusted_certificate(certificates::MTLS_CLIENT_CERT)?
+            .with_trusted_certificate(certificates::CERT_PEM)?
             .build()?;
         Ok(server)
     }
@@ -212,10 +212,7 @@ impl Provider for TestTlsProvider {
         let client = s2n_quic_tls_prov::Client::builder()
             .with_application_protocols(["h3"].iter())?
             .with_certificate(certificates::CERT_PEM)?
-            .with_client_identity(
-                certificates::MTLS_CLIENT_CERT,
-                certificates::MTLS_CLIENT_KEY,
-            )?
+            .with_client_identity(certificates::CERT_PEM, certificates::KEY_PEM)?
             .build()?;
         Ok(client)
     }

--- a/dc/s2n-quic-dc/src/testing.rs
+++ b/dc/s2n-quic-dc/src/testing.rs
@@ -202,6 +202,8 @@ impl Provider for TestTlsProvider {
         let server = s2n_quic_tls_prov::Server::builder()
             .with_application_protocols(["h3"].iter())?
             .with_certificate(certificates::CERT_PEM, certificates::KEY_PEM)?
+            .with_client_authentication()?
+            .with_trusted_certificate(certificates::MTLS_CLIENT_CERT)?
             .build()?;
         Ok(server)
     }
@@ -210,6 +212,10 @@ impl Provider for TestTlsProvider {
         let client = s2n_quic_tls_prov::Client::builder()
             .with_application_protocols(["h3"].iter())?
             .with_certificate(certificates::CERT_PEM)?
+            .with_client_identity(
+                certificates::MTLS_CLIENT_CERT,
+                certificates::MTLS_CLIENT_KEY,
+            )?
             .build()?;
         Ok(client)
     }


### PR DESCRIPTION

### Description of changes: 

Here are two changes to improve the usefulness of the dc-quic criterion benchmark results. I stopped recreating the server on every iteration and I also changed the TestTlsProvider to perform mtls, as I believe this is more accurate to how dc-quic is used.

### Call-outs:



### Testing:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

