### PR TITLE
feat(s2n-quic): Packet storage feature

### DIFF
--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -39,7 +39,7 @@ const MAX_KEEP_ALIVE_PERIOD_DEFAULT: Duration = Duration::from_secs(30);
 pub const ANTI_AMPLIFICATION_MULTIPLIER: u8 = 3;
 
 pub const DEFAULT_STREAM_BATCH_SIZE: u8 = 1;
-pub const DEFAULT_STORED_PACKET_SIZE: usize = 0;
+pub const DEFAULT_PACKET_BUFFER_SIZE: usize = 0;
 
 // Maximum allowed PTO jitter percentage. Limited to 50% to prevent PTO timers
 // from becoming too short (which could cause premature timeouts) or too long
@@ -112,7 +112,7 @@ pub struct Limits {
     pub(crate) anti_amplification_multiplier: u8,
     pub(crate) stream_batch_size: u8,
     pub(crate) pto_jitter_percentage: u8,
-    pub(crate) stored_packet_size: usize,
+    pub(crate) packet_buffer_size: usize,
 }
 
 impl Default for Limits {
@@ -161,7 +161,7 @@ impl Limits {
             anti_amplification_multiplier: ANTI_AMPLIFICATION_MULTIPLIER,
             stream_batch_size: DEFAULT_STREAM_BATCH_SIZE,
             pto_jitter_percentage: DEFAULT_PTO_JITTER_PERCENTAGE,
-            stored_packet_size: DEFAULT_STORED_PACKET_SIZE,
+            packet_buffer_size: DEFAULT_PACKET_BUFFER_SIZE,
         }
     }
 
@@ -272,18 +272,21 @@ impl Limits {
     );
     setter!(with_stream_batch_size, stream_batch_size, u8);
     setter!(
-        /// Sets the maximum number of packet bytes that s2n-quic will store if the keys to decrypt them
-        /// haven't been created yet.
+        /// Set a limit on the amount of packet bytes that s2n-quic will buffer if the packet
+        /// decryption keys haven't been created yet.
         ///
-        /// We cap this to a reasonable size to avoid creating a per‑connection memory
-        /// amplification attack. We can raise the limit if this is too conservative.
-        with_stored_packet_size,
-        stored_packet_size,
+        /// A connection might receive packets that are encrypted with a key it has not yet computed,
+        /// due to packet reordering or loss. By default s2n-quic will drop these packets. This API
+        /// sets the amount of bytes that can be stored across packets per connection. This packet buffer
+        /// will be processed once the decryption keys are created.
+        with_packet_buffer_size,
+        packet_buffer_size,
         u32,
+        // Set this to a reasonable limit to avoid unnecessary memory consumption.
         |validate_value| {
             decoder_invariant!(
                 validate_value <= 10_000,
-                "Cannot store packets larger than 10,000 bytes"
+                "Cannot ever store more than 10,000 bytes across packets"
             );
         }
     );
@@ -493,8 +496,8 @@ impl Limits {
 
     #[doc(hidden)]
     #[inline]
-    pub fn stored_packet_size(&self) -> usize {
-        self.stored_packet_size
+    pub fn packet_buffer_size(&self) -> usize {
+        self.packet_buffer_size
     }
 }
 

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -39,6 +39,7 @@ const MAX_KEEP_ALIVE_PERIOD_DEFAULT: Duration = Duration::from_secs(30);
 pub const ANTI_AMPLIFICATION_MULTIPLIER: u8 = 3;
 
 pub const DEFAULT_STREAM_BATCH_SIZE: u8 = 1;
+pub const DEFAULT_STORED_PACKET_SIZE: usize = 0;
 
 // Maximum allowed PTO jitter percentage. Limited to 50% to prevent PTO timers
 // from becoming too short (which could cause premature timeouts) or too long
@@ -111,6 +112,7 @@ pub struct Limits {
     pub(crate) anti_amplification_multiplier: u8,
     pub(crate) stream_batch_size: u8,
     pub(crate) pto_jitter_percentage: u8,
+    pub(crate) stored_packet_size: usize,
 }
 
 impl Default for Limits {
@@ -159,6 +161,7 @@ impl Limits {
             anti_amplification_multiplier: ANTI_AMPLIFICATION_MULTIPLIER,
             stream_batch_size: DEFAULT_STREAM_BATCH_SIZE,
             pto_jitter_percentage: DEFAULT_PTO_JITTER_PERCENTAGE,
+            stored_packet_size: DEFAULT_STORED_PACKET_SIZE,
         }
     }
 
@@ -268,6 +271,7 @@ impl Limits {
         u64
     );
     setter!(with_stream_batch_size, stream_batch_size, u8);
+    setter!(with_stored_packet_size, stored_packet_size, usize);
     setter!(with_ack_elicitation_interval, ack_elicitation_interval, u8);
     setter!(with_max_ack_ranges, ack_ranges_limit, u8);
     setter!(
@@ -470,6 +474,12 @@ impl Limits {
     #[inline]
     pub fn stream_batch_size(&self) -> u8 {
         self.stream_batch_size
+    }
+
+    #[doc(hidden)]
+    #[inline]
+    pub fn stored_packet_size(&self) -> usize {
+        self.stored_packet_size
     }
 }
 

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -272,7 +272,7 @@ impl Limits {
     );
     setter!(with_stream_batch_size, stream_batch_size, u8);
     setter!(
-        /// Set a limit on the amount of packet bytes that s2n-quic will buffer if the packet
+        /// Sets the amount of packet bytes that s2n-quic will buffer if the packet
         /// decryption keys haven't been created yet.
         ///
         /// A connection might receive packets that are encrypted with a key it has not yet computed,

--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -271,7 +271,22 @@ impl Limits {
         u64
     );
     setter!(with_stream_batch_size, stream_batch_size, u8);
-    setter!(with_stored_packet_size, stored_packet_size, usize);
+    setter!(
+        /// Sets the maximum number of packet bytes that s2n-quic will store if the keys to decrypt them
+        /// haven't been created yet.
+        ///
+        /// We cap this to a reasonable size to avoid creating a per‑connection memory
+        /// amplification attack. We can raise the limit if this is too conservative.
+        with_stored_packet_size,
+        stored_packet_size,
+        u32,
+        |validate_value| {
+            decoder_invariant!(
+                validate_value <= 10_000,
+                "Cannot store packets larger than 10,000 bytes"
+            );
+        }
+    );
     setter!(with_ack_elicitation_interval, ack_elicitation_interval, u8);
     setter!(with_max_ack_ranges, ack_ranges_limit, u8);
     setter!(

--- a/quic/s2n-quic-core/src/packet/handshake.rs
+++ b/quic/s2n-quic-core/src/packet/handshake.rs
@@ -22,6 +22,8 @@ use crate::{
     transport,
     varint::VarInt,
 };
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 use s2n_codec::{CheckedRange, DecoderBufferMut, DecoderBufferMutResult, Encoder, EncoderValue};
 
 //= https://www.rfc-editor.org/rfc/rfc9000#section-17.2.4
@@ -65,6 +67,11 @@ pub type EncryptedHandshake<'a> =
 pub type CleartextHandshake<'a> = Handshake<&'a [u8], &'a [u8], PacketNumber, DecoderBufferMut<'a>>;
 
 impl<'a> ProtectedHandshake<'a> {
+    #[cfg(feature = "alloc")]
+    pub fn get_wire_bytes(&self) -> Vec<u8> {
+        self.payload.buffer.encode_to_vec()
+    }
+
     #[inline]
     pub(crate) fn decode(
         _tag: Tag,

--- a/quic/s2n-quic-core/src/packet/short.rs
+++ b/quic/s2n-quic-core/src/packet/short.rs
@@ -16,6 +16,8 @@ use crate::{
     },
     transport,
 };
+#[cfg(feature = "alloc")]
+use alloc::vec::Vec;
 use s2n_codec::{CheckedRange, DecoderBufferMut, DecoderBufferMutResult, Encoder, EncoderValue};
 
 //= https://www.rfc-editor.org/rfc/rfc9000#section-17.3.1
@@ -188,6 +190,10 @@ impl<'a> ProtectedShort<'a> {
         self.payload
             .get_checked_range(&self.destination_connection_id)
             .into_less_safe_slice()
+    }
+    #[cfg(feature = "alloc")]
+    pub fn get_wire_bytes(&self) -> Vec<u8> {
+        self.payload.buffer.encode_to_vec()
     }
 }
 

--- a/quic/s2n-quic-core/src/packet/short.rs
+++ b/quic/s2n-quic-core/src/packet/short.rs
@@ -191,6 +191,7 @@ impl<'a> ProtectedShort<'a> {
             .get_checked_range(&self.destination_connection_id)
             .into_less_safe_slice()
     }
+
     #[cfg(feature = "alloc")]
     pub fn get_wire_bytes(&self) -> Vec<u8> {
         self.payload.buffer.encode_to_vec()

--- a/quic/s2n-quic-tests/src/tests/slow_tls.rs
+++ b/quic/s2n-quic-tests/src/tests/slow_tls.rs
@@ -3,12 +3,13 @@
 
 use super::*;
 use s2n_quic::provider::tls::default;
-use s2n_quic_core::crypto::tls::testing::certificates::{CERT_PEM, KEY_PEM};
+use s2n_quic_core::{
+    connection::limits::Limits,
+    crypto::tls::testing::certificates::{CERT_PEM, KEY_PEM},
+};
 
 #[test]
 fn slow_tls() {
-    use s2n_quic_core::connection::limits::Limits;
-
     let model = Model::default();
 
     let server_endpoint = default::Server::builder()
@@ -30,7 +31,7 @@ fn slow_tls() {
     };
 
     // Connections will store up to 4000 bytes of packets that can't be processed yet
-    let limits = Limits::default().with_stored_packet_size(4000).unwrap();
+    let limits = Limits::default().with_packet_buffer_size(4000).unwrap();
 
     test(model.clone(), |handle| {
         let server = Server::builder()
@@ -43,7 +44,7 @@ fn slow_tls() {
         let client = Client::builder()
             .with_io(handle.builder().build().unwrap())?
             .with_tls(slow_client)?
-            .with_event((tracing_events(true, model.clone()), MyEvents))?
+            .with_event((tracing_events(true, model.clone()), SlowTlsTestEvents))?
             .with_limits(limits)?
             .start()?;
         let addr = start_server(server)?;
@@ -53,10 +54,10 @@ fn slow_tls() {
     })
     .unwrap();
 
-    struct MyEvents;
-    struct MyContext;
-    impl events::Subscriber for MyEvents {
-        type ConnectionContext = MyContext;
+    struct SlowTlsTestEvents;
+    struct SlowTlsTestContext;
+    impl events::Subscriber for SlowTlsTestEvents {
+        type ConnectionContext = SlowTlsTestContext;
 
         fn create_connection_context(
             &mut self,

--- a/quic/s2n-quic-tests/src/tests/slow_tls.rs
+++ b/quic/s2n-quic-tests/src/tests/slow_tls.rs
@@ -37,13 +37,13 @@ fn slow_tls() {
             .with_io(handle.builder().build()?)?
             .with_limits(limits)?
             .with_tls(slow_server)?
-            .with_event(tracing_events(false, model.clone()))?
+            .with_event(tracing_events(true, model.clone()))?
             .start()?;
 
         let client = Client::builder()
             .with_io(handle.builder().build().unwrap())?
             .with_tls(slow_client)?
-            .with_event((tracing_events(false, model.clone()), MyEvents))?
+            .with_event((tracing_events(true, model.clone()), MyEvents))?
             .with_limits(limits)?
             .start()?;
         let addr = start_server(server)?;

--- a/quic/s2n-quic-tests/src/tests/slow_tls.rs
+++ b/quic/s2n-quic-tests/src/tests/slow_tls.rs
@@ -7,6 +7,8 @@ use s2n_quic_core::crypto::tls::testing::certificates::{CERT_PEM, KEY_PEM};
 
 #[test]
 fn slow_tls() {
+    use s2n_quic_core::connection::limits::Limits;
+
     let model = Model::default();
 
     let server_endpoint = default::Server::builder()
@@ -27,9 +29,13 @@ fn slow_tls() {
         endpoint: client_endpoint,
     };
 
+    // Connections will store up to 4000 bytes of packets that can't be processed yet
+    let limits = Limits::default().with_stored_packet_size(4000).unwrap();
+
     test(model.clone(), |handle| {
         let server = Server::builder()
             .with_io(handle.builder().build()?)?
+            .with_limits(limits)?
             .with_tls(slow_server)?
             .with_event(tracing_events(false, model.clone()))?
             .start()?;
@@ -37,7 +43,8 @@ fn slow_tls() {
         let client = Client::builder()
             .with_io(handle.builder().build().unwrap())?
             .with_tls(slow_client)?
-            .with_event(tracing_events(false, model.clone()))?
+            .with_event((tracing_events(false, model.clone()), MyEvents))?
+            .with_limits(limits)?
             .start()?;
         let addr = start_server(server)?;
         start_client(client, addr, Data::new(1000))?;
@@ -45,4 +52,37 @@ fn slow_tls() {
         Ok(addr)
     })
     .unwrap();
+
+    struct MyEvents;
+    struct MyContext;
+    impl events::Subscriber for MyEvents {
+        type ConnectionContext = MyContext;
+
+        fn create_connection_context(
+            &mut self,
+            _meta: &events::ConnectionMeta,
+            _info: &events::ConnectionInfo,
+        ) -> Self::ConnectionContext {
+            Self::ConnectionContext {}
+        }
+        fn on_transport_parameters_received(
+            &mut self,
+            _context: &mut Self::ConnectionContext,
+            meta: &s2n_quic_core::event::api::ConnectionMeta,
+            _event: &s2n_quic_core::event::api::TransportParametersReceived,
+        ) {
+            // Slow TLS implementation has no affect on when transport parameters are received
+            assert_eq!(meta.timestamp.to_string(), "0:00:00.100000");
+        }
+
+        fn on_connection_closed(
+            &mut self,
+            _context: &mut Self::ConnectionContext,
+            meta: &s2n_quic_core::event::api::ConnectionMeta,
+            _event: &s2n_quic_core::event::api::ConnectionClosed,
+        ) {
+            // Slow TLS implementation has no affect on when the connection is shut down
+            assert_eq!(meta.timestamp.to_string(), "0:00:00.200000");
+        }
+    }
 }

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -141,6 +141,8 @@ impl connection::Trait for TestConnection {
         _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
         _conn_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
         _random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
+        _packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
+        _connection_id_format: &mut <Self::Config as endpoint::Config>::ConnectionIdFormat,
     ) -> Result<(), connection::Error> {
         Ok(())
     }
@@ -157,6 +159,7 @@ impl connection::Trait for TestConnection {
         _datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
         _conn_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
+        _connection_id_format: &<Self::Config as endpoint::Config>::ConnectionIdFormat,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -173,6 +176,7 @@ impl connection::Trait for TestConnection {
         _datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
         _conn_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
+        _connection_id_format: &<Self::Config as endpoint::Config>::ConnectionIdFormat,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }
@@ -190,6 +194,7 @@ impl connection::Trait for TestConnection {
         _datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         _dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
         _connection_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
+        _connection_id_format: &<Self::Config as endpoint::Config>::ConnectionIdFormat,
     ) -> Result<(), ProcessingError> {
         Ok(())
     }

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -186,7 +186,8 @@ pub struct ConnectionImpl<Config: endpoint::Config> {
     waker: Waker,
     event_context: EventContext<Config>,
     /// Stores packets that arrive before we have generated the next packet space
-    packet_storage: Vec<u8>,
+    packet_buffer: Vec<u8>,
+    /// Tracks which type of packet is currently stored in packet_buffer
     stored_packet_type: Option<PacketNumberSpace>,
 }
 
@@ -287,7 +288,7 @@ impl<Config: endpoint::Config> ConnectionImpl<Config> {
         packet_interceptor: &mut Config::PacketInterceptor,
         connection_id_validator: &Config::ConnectionIdFormat,
     ) -> Result<(), connection::Error> {
-        let mut payload: Vec<u8> = self.packet_storage.drain(..).collect();
+        let mut payload: Vec<u8> = self.packet_buffer.drain(..).collect();
         let buffer = DecoderBufferMut::new(payload.as_mut_slice());
 
         let destination_connection_id = self.path_manager.active_path().local_connection_id;
@@ -748,7 +749,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             wakeup_handle,
             waker,
             event_context,
-            packet_storage: Vec::new(),
+            packet_buffer: Vec::new(),
             stored_packet_type: None,
         };
 
@@ -1652,8 +1653,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             //# of later packets that allow it to compute the key.
 
             let packet_bytes = packet.get_wire_bytes();
-            if packet_bytes.len() + self.packet_storage.len() <= self.limits.stored_packet_size() {
-                self.packet_storage.extend(packet_bytes);
+            if packet_bytes.len() + self.packet_buffer.len() <= self.limits.packet_buffer_size() {
+                self.packet_buffer.extend(packet_bytes);
                 self.stored_packet_type = Some(PacketNumberSpace::Handshake)
             } else {
                 let path = &self.path_manager[path_id];
@@ -1726,11 +1727,11 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 //# of later packets that allow it to compute the key.
 
                 let packet_bytes = packet.get_wire_bytes();
-                if packet_bytes.len() <= self.limits.stored_packet_size() {
+                if packet_bytes.len() <= self.limits.packet_buffer_size() {
                     // We only store one packet of application data for now. This is due to the fact that
                     // short packets do not contain a length prefix, therefore, we would have to store additional
                     // length info per packet to properly parse them once the application space is created.
-                    self.packet_storage = packet_bytes;
+                    self.packet_buffer = packet_bytes;
                     self.stored_packet_type = Some(PacketNumberSpace::ApplicationData)
                 } else {
                     let path = &self.path_manager[path_id];

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1652,7 +1652,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             //# of later packets that allow it to compute the key.
 
             let packet_bytes = packet.get_wire_bytes();
-            if packet_bytes.len() + self.packet_storage.len() < self.limits.stored_packet_size() {
+            if packet_bytes.len() + self.packet_storage.len() <= self.limits.stored_packet_size() {
                 self.packet_storage.extend(packet_bytes);
                 self.stored_packet_type = Some(PacketNumberSpace::Handshake)
             } else {
@@ -1726,7 +1726,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 //# of later packets that allow it to compute the key.
 
                 let packet_bytes = packet.get_wire_bytes();
-                if packet_bytes.len() < self.limits.stored_packet_size() {
+                if packet_bytes.len() <= self.limits.stored_packet_size() {
                     // We only store one packet of application data for now. This is due to the fact that
                     // short packets do not contain a length prefix, therefore, we would have to store additional
                     // length info per packet to properly parse them once the application space is created.

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -12,7 +12,7 @@ use crate::{
         local_id_registry::LocalIdRegistrationError,
         ConnectionIdMapper, ConnectionInterests, ConnectionTimers, ConnectionTransmission,
         ConnectionTransmissionContext, InternalConnectionId, Parameters as ConnectionParameters,
-        ProcessingError,
+        ProcessingError, Trait,
     },
     contexts::{ConnectionApiCallContext, ConnectionOnTransmitError},
     endpoint,
@@ -21,8 +21,7 @@ use crate::{
     recovery::{recovery_event, RttEstimator},
     space::{PacketSpace, PacketSpaceManager},
     stream::{self, Manager as _},
-    transmission,
-    transmission::interest::Provider as _,
+    transmission::{self, interest::Provider as _},
     wakeup_queue::WakeupHandle,
 };
 use alloc::sync::Arc;
@@ -32,10 +31,14 @@ use core::{
     task::{Context, Poll, Waker},
     time::Duration,
 };
+use s2n_codec::DecoderBufferMut;
 use s2n_quic_core::{
-    application,
-    application::ServerName,
-    connection::{error::Error, id::Generator as _, InitialId, PeerId},
+    application::{self, ServerName},
+    connection::{
+        error::Error,
+        id::{Classification, Generator as _},
+        InitialId, PeerId,
+    },
     crypto::{tls, CryptoSuite},
     datagram::{Receiver, Sender},
     event::{
@@ -43,7 +46,7 @@ use s2n_quic_core::{
         builder::{DatagramDropReason, MtuUpdatedCause, RxStreamProgress, TxStreamProgress},
         supervisor, ConnectionPublisher as _, IntoEvent as _, Subscriber,
     },
-    inet::{DatagramInfo, SocketAddress},
+    inet::{DatagramInfo, ExplicitCongestionNotification, SocketAddress},
     io::tx,
     packet::{
         handshake::ProtectedHandshake,
@@ -182,6 +185,9 @@ pub struct ConnectionImpl<Config: endpoint::Config> {
     /// A Waker to the connection.
     waker: Waker,
     event_context: EventContext<Config>,
+    /// Stores packets that arrive before we have generated the next packet space
+    packet_storage: Vec<u8>,
+    stored_packet_type: Option<PacketNumberSpace>,
 }
 
 struct EventContext<Config: endpoint::Config> {
@@ -270,6 +276,52 @@ macro_rules! transmission_context {
 }
 
 impl<Config: endpoint::Config> ConnectionImpl<Config> {
+    fn process_stored_packets(
+        &mut self,
+        timestamp: Timestamp,
+        subscriber: &mut Config::EventSubscriber,
+        datagram: &mut Config::DatagramEndpoint,
+        dc: &mut Config::DcEndpoint,
+        limits: &mut Config::ConnectionLimits,
+        random_generator: &mut Config::RandomGenerator,
+        packet_interceptor: &mut Config::PacketInterceptor,
+        connection_id_validator: &Config::ConnectionIdFormat,
+    ) -> Result<(), connection::Error> {
+        let mut payload: Vec<u8> = self.packet_storage.drain(..).collect();
+        let buffer = DecoderBufferMut::new(payload.as_mut_slice());
+
+        let destination_connection_id = self.path_manager.active_path().local_connection_id;
+        let path_handle = self.path_manager.active_path().handle;
+
+        // Fill datagram as much as we can. We don't want to store all this information with the packet.
+        let datagram_info = DatagramInfo {
+            timestamp,
+            payload_len: 0,
+            ecn: ExplicitCongestionNotification::default(),
+            destination_connection_id,
+            destination_connection_id_classification: Classification::Local,
+            source_connection_id: None,
+        };
+        let path_id = self.path_manager.active_path_id();
+        let mut check_for_stateless_reset = false;
+
+        self.handle_remaining_packets(
+            &path_handle,
+            &datagram_info,
+            path_id,
+            connection_id_validator,
+            buffer,
+            random_generator,
+            subscriber,
+            packet_interceptor,
+            datagram,
+            dc,
+            limits,
+            &mut check_for_stateless_reset,
+        )?;
+        Ok(())
+    }
+
     fn update_crypto_state(
         &mut self,
         timestamp: Timestamp,
@@ -278,10 +330,11 @@ impl<Config: endpoint::Config> ConnectionImpl<Config> {
         dc: &mut Config::DcEndpoint,
         limits: &mut Config::ConnectionLimits,
         random_generator: &mut Config::RandomGenerator,
+        packet_interceptor: &mut Config::PacketInterceptor,
+        connection_id_validator: &Config::ConnectionIdFormat,
     ) -> Result<(), connection::Error> {
         let mut publisher = self.event_context.publisher(timestamp, subscriber);
         let space_manager = &mut self.space_manager;
-
         match space_manager.poll_crypto(
             &mut self.path_manager,
             &mut self.local_id_registry,
@@ -294,10 +347,42 @@ impl<Config: endpoint::Config> ConnectionImpl<Config> {
             limits,
             random_generator,
         ) {
-            Poll::Ready(Ok(())) => {}
+            Poll::Ready(Ok(())) => {
+                // Process any stored application packets since the application keys should now exist
+                if self.space_manager.application().is_some()
+                    && self.stored_packet_type == Some(PacketNumberSpace::ApplicationData)
+                {
+                    self.process_stored_packets(
+                        timestamp,
+                        subscriber,
+                        datagram,
+                        dc,
+                        limits,
+                        random_generator,
+                        packet_interceptor,
+                        connection_id_validator,
+                    )?;
+                }
+            }
             // use `from` instead of `into` so the location is correctly captured
             Poll::Ready(Err(err)) => return Err(connection::Error::from(err)),
-            Poll::Pending => return Ok(()),
+            Poll::Pending => {
+                // Process stored handshake packets if the handshake space was recently created
+                if self.space_manager.handshake().is_some()
+                    && self.stored_packet_type == Some(PacketNumberSpace::Handshake)
+                {
+                    self.process_stored_packets(
+                        timestamp,
+                        subscriber,
+                        datagram,
+                        dc,
+                        limits,
+                        random_generator,
+                        packet_interceptor,
+                        connection_id_validator,
+                    )?;
+                }
+            }
         }
 
         //= https://www.rfc-editor.org/rfc/rfc9000#section-7.1
@@ -323,7 +408,7 @@ impl<Config: endpoint::Config> ConnectionImpl<Config> {
         // handshake is complete so update the connection state and prepare
         // to hand it over to the application.
         if matches!(self.state, ConnectionState::Handshaking)
-            && space_manager.is_handshake_complete()
+            && self.space_manager.is_handshake_complete()
         {
             // Move into the HandshakeCompleted state. This will signal the
             // necessary interest to hand over the connection to the application.
@@ -663,6 +748,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             wakeup_handle,
             waker,
             event_context,
+            packet_storage: Vec::new(),
+            stored_packet_type: None,
         };
 
         if Config::ENDPOINT_TYPE.is_client() {
@@ -673,6 +760,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 parameters.dc_endpoint,
                 parameters.limits_endpoint,
                 parameters.random_generator,
+                parameters.interceptor_endpoint,
+                parameters.connection_id_validator,
             ) {
                 connection.with_event_publisher(
                     parameters.timestamp,
@@ -1162,6 +1251,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         dc: &mut Config::DcEndpoint,
         conn_limits: &mut Config::ConnectionLimits,
         random_generator: &mut Config::RandomGenerator,
+        packet_interceptor: &mut Config::PacketInterceptor,
+        connection_id_validator: &mut Config::ConnectionIdFormat,
     ) -> Result<(), connection::Error> {
         // reset the queued state first so that new wakeup request are not missed
         self.wakeup_handle.wakeup_handled();
@@ -1174,6 +1265,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             dc,
             conn_limits,
             random_generator,
+            packet_interceptor,
+            connection_id_validator,
         )?;
 
         if self.space_manager.handshake().is_some() && self.space_manager.is_handshake_confirmed() {
@@ -1277,6 +1370,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         datagram_endpoint: &mut Config::DatagramEndpoint,
         dc_endpoint: &mut Config::DcEndpoint,
         connection_limits_endpoint: &mut Config::ConnectionLimits,
+        connection_id_format: &Config::ConnectionIdFormat,
     ) -> Result<(), ProcessingError> {
         //= https://www.rfc-editor.org/rfc/rfc9000#section-7.2
         //= type=TODO
@@ -1320,6 +1414,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 datagram_endpoint,
                 dc_endpoint,
                 connection_limits_endpoint,
+                connection_id_format,
             )?;
         } else {
             let path = &self.path_manager[path_id];
@@ -1346,6 +1441,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         datagram_endpoint: &mut Config::DatagramEndpoint,
         dc_endpoint: &mut Config::DcEndpoint,
         connection_limits_endpoint: &mut Config::ConnectionLimits,
+        connection_id_format: &Config::ConnectionIdFormat,
     ) -> Result<(), ProcessingError> {
         let mut publisher = self.event_context.publisher(datagram.timestamp, subscriber);
         if let Some((space, handshake_status)) = self.space_manager.initial_mut() {
@@ -1407,6 +1503,8 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 dc_endpoint,
                 connection_limits_endpoint,
                 random_generator,
+                packet_interceptor,
+                connection_id_format,
             )?;
 
             // notify the connection a packet was processed
@@ -1437,6 +1535,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         datagram_endpoint: &mut Config::DatagramEndpoint,
         dc_endpoint: &mut Config::DcEndpoint,
         connection_limits_endpoint: &mut Config::ConnectionLimits,
+        connection_id_validator: &Config::ConnectionIdFormat,
     ) -> Result<(), ProcessingError> {
         let mut publisher = self.event_context.publisher(datagram.timestamp, subscriber);
 
@@ -1526,10 +1625,37 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                 dc_endpoint,
                 connection_limits_endpoint,
                 random_generator,
+                packet_interceptor,
+                connection_id_validator,
             )?;
 
             // notify the connection a packet was processed
             self.on_processed_packet(&processed_packet, subscriber)?;
+        } else if (self.stored_packet_type.is_none()
+            || self.stored_packet_type == Some(PacketNumberSpace::Handshake))
+            && !self.space_manager.is_handshake_confirmed()
+        {
+            //= https://www.rfc-editor.org/rfc/rfc9001#section-4.1.4
+            //# However, a TLS implementation could perform some of its processing
+            //# asynchronously.  In particular, the process of validating a
+            //# certificate can take some time.  While waiting for TLS processing to
+            //# complete, an endpoint SHOULD buffer received packets if they might be
+            //# processed using keys that are not yet available.  These packets can
+            //# be processed once keys are provided by TLS.  An endpoint SHOULD
+            //# continue to respond to packets that can be processed during this
+            //# time.
+
+            // https://www.rfc-editor.org/rfc/rfc9000#section-5.2.1
+            //# Due to packet reordering or loss, a client might receive packets
+            //# for a connection that are encrypted with a key it has not yet computed.
+            //# The client MAY drop these packets, or it MAY buffer them in anticipation
+            //# of later packets that allow it to compute the key.
+
+            let packet_bytes = packet.get_wire_bytes();
+            if packet_bytes.len() + self.packet_storage.len() < self.limits.stored_packet_size() {
+                self.packet_storage.extend(packet_bytes);
+                self.stored_packet_type = Some(PacketNumberSpace::Handshake)
+            }
         } else {
             let path = &self.path_manager[path_id];
             publisher.on_packet_dropped(event::builder::PacketDropped {
@@ -1574,12 +1700,39 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         //# complete.
 
         if !self.space_manager.is_handshake_complete() {
-            let path = &self.path_manager[path_id];
-            publisher.on_packet_dropped(event::builder::PacketDropped {
-                reason: event::builder::PacketDropReason::HandshakeNotComplete {
-                    path: path_event!(path, path_id),
-                },
-            });
+            if self.stored_packet_type.is_none() {
+                //= https://www.rfc-editor.org/rfc/rfc9001#section-4.1.4
+                //# However, a TLS implementation could perform some of its processing
+                //# asynchronously.  In particular, the process of validating a
+                //# certificate can take some time.  While waiting for TLS processing to
+                //# complete, an endpoint SHOULD buffer received packets if they might be
+                //# processed using keys that are not yet available.  These packets can
+                //# be processed once keys are provided by TLS.  An endpoint SHOULD
+                //# continue to respond to packets that can be processed during this
+                //# time.
+
+                // https://www.rfc-editor.org/rfc/rfc9000#section-5.2.1
+                //# Due to packet reordering or loss, a client might receive packets
+                //# for a connection that are encrypted with a key it has not yet computed.
+                //# The client MAY drop these packets, or it MAY buffer them in anticipation
+                //# of later packets that allow it to compute the key.
+
+                let packet_bytes = packet.get_wire_bytes();
+                if packet_bytes.len() < self.limits.stored_packet_size() {
+                    // We only store one packet of application data for now. This is due to the fact that
+                    // short packets do not contain a length prefix, therefore, we would have to store additional
+                    // length info per packet to properly parse them once the application space is created.
+                    self.packet_storage = packet_bytes;
+                    self.stored_packet_type = Some(PacketNumberSpace::ApplicationData)
+                }
+            } else {
+                let path = &self.path_manager[path_id];
+                publisher.on_packet_dropped(event::builder::PacketDropped {
+                    reason: event::builder::PacketDropReason::HandshakeNotComplete {
+                        path: path_event!(path, path_id),
+                    },
+                });
+            }
 
             return Ok(());
         }

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -1655,6 +1655,14 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
             if packet_bytes.len() + self.packet_storage.len() < self.limits.stored_packet_size() {
                 self.packet_storage.extend(packet_bytes);
                 self.stored_packet_type = Some(PacketNumberSpace::Handshake)
+            } else {
+                let path = &self.path_manager[path_id];
+                publisher.on_packet_dropped(event::builder::PacketDropped {
+                    reason: event::builder::PacketDropReason::PacketSpaceDoesNotExist {
+                        path: path_event!(path, path_id),
+                        packet_type: event::builder::PacketType::Handshake,
+                    },
+                });
             }
         } else {
             let path = &self.path_manager[path_id];
@@ -1724,6 +1732,13 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
                     // length info per packet to properly parse them once the application space is created.
                     self.packet_storage = packet_bytes;
                     self.stored_packet_type = Some(PacketNumberSpace::ApplicationData)
+                } else {
+                    let path = &self.path_manager[path_id];
+                    publisher.on_packet_dropped(event::builder::PacketDropped {
+                        reason: event::builder::PacketDropReason::HandshakeNotComplete {
+                            path: path_event!(path, path_id),
+                        },
+                    });
                 }
             } else {
                 let path = &self.path_manager[path_id];

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -118,6 +118,8 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
         conn_limits: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
         random_generator: &mut <Self::Config as endpoint::Config>::RandomGenerator,
+        packet_interceptor: &mut <Self::Config as endpoint::Config>::PacketInterceptor,
+        connection_id_validator: &mut <Self::Config as endpoint::Config>::ConnectionIdFormat,
     ) -> Result<(), connection::Error>;
 
     // Packet handling
@@ -135,6 +137,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
         connection_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
+        connection_id_format: &<Self::Config as endpoint::Config>::ConnectionIdFormat,
     ) -> Result<(), ProcessingError>;
 
     /// Is called when an unprotected initial packet had been received
@@ -149,6 +152,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
         connection_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
+        connection_id_format: &<Self::Config as endpoint::Config>::ConnectionIdFormat,
     ) -> Result<(), ProcessingError>;
 
     /// Is called when a handshake packet had been received
@@ -164,6 +168,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
         connection_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
+        connection_id_validator: &<Self::Config as endpoint::Config>::ConnectionIdFormat,
     ) -> Result<(), ProcessingError>;
 
     /// Is called when a short packet had been received
@@ -245,6 +250,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         datagram_endpoint: &mut <Self::Config as endpoint::Config>::DatagramEndpoint,
         dc_endpoint: &mut <Self::Config as endpoint::Config>::DcEndpoint,
         connection_limits_endpoint: &mut <Self::Config as endpoint::Config>::ConnectionLimits,
+        connection_id_format: &<Self::Config as endpoint::Config>::ConnectionIdFormat,
         check_for_stateless_reset: &mut bool,
     ) -> Result<(), connection::Error> {
         macro_rules! emit_drop_reason {
@@ -328,6 +334,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 datagram_endpoint,
                 dc_endpoint,
                 connection_limits_endpoint,
+                connection_id_format,
             ),
             ProtectedPacket::ZeroRtt(packet) => self.handle_zero_rtt_packet(
                 datagram,
@@ -348,6 +355,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 datagram_endpoint,
                 dc_endpoint,
                 connection_limits_endpoint,
+                connection_id_format,
             ),
             ProtectedPacket::Retry(packet) => self.handle_retry_packet(
                 datagram,
@@ -471,6 +479,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
                 datagram_endpoint,
                 dc_endpoint,
                 connection_limits_endpoint,
+                connection_id_validator,
                 check_for_stateless_reset,
             );
 

--- a/quic/s2n-quic-transport/src/connection/mod.rs
+++ b/quic/s2n-quic-transport/src/connection/mod.rs
@@ -91,4 +91,6 @@ pub struct Parameters<'a, Cfg: endpoint::Config> {
     pub limits_endpoint: &'a mut Cfg::ConnectionLimits,
     /// The random generator
     pub random_generator: &'a mut Cfg::RandomGenerator,
+    pub interceptor_endpoint: &'a mut Cfg::PacketInterceptor,
+    pub connection_id_validator: &'a Cfg::ConnectionIdFormat,
 }

--- a/quic/s2n-quic-transport/src/endpoint/initial.rs
+++ b/quic/s2n-quic-transport/src/endpoint/initial.rs
@@ -333,6 +333,8 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
             open_registry: None,
             limits_endpoint: endpoint_context.connection_limits,
             random_generator: endpoint_context.random_generator,
+            interceptor_endpoint: endpoint_context.packet_interceptor,
+            connection_id_validator: endpoint_context.connection_id_format,
         };
 
         let mut connection = <Config as endpoint::Config>::Connection::new(connection_parameters)?;
@@ -387,6 +389,7 @@ impl<Config: endpoint::Config> endpoint::Endpoint<Config> {
                         endpoint_context.datagram,
                         endpoint_context.dc,
                         endpoint_context.connection_limits,
+                        endpoint_context.connection_id_format,
                     )
                     .map_err(|err| {
                         use connection::ProcessingError;

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -27,7 +27,10 @@ use s2n_quic_core::{
         id::{ConnectionInfo, Generator},
         InitialId, LocalId, PeerId,
     },
-    crypto::{tls, tls::Endpoint as _, CryptoSuite, InitialKey},
+    crypto::{
+        tls::{self, Endpoint as _},
+        CryptoSuite, InitialKey,
+    },
     datagram::{Endpoint as DatagramEndpoint, PreConnectionInfo},
     dc,
     dc::Endpoint as DcEndpoint,
@@ -38,8 +41,7 @@ use s2n_quic_core::{
     inet::{datagram, DatagramInfo},
     io::{rx, tx},
     packet::{initial::ProtectedInitial, interceptor::Interceptor, ProtectedPacket},
-    path,
-    path::{mtu, Handle as _},
+    path::{self, mtu, Handle as _},
     random::Generator as _,
     stateless_reset::token::{Generator as _, LEN as StatelessResetTokenLen},
     time::{Clock, Timestamp},
@@ -223,6 +225,8 @@ impl<Cfg: Config> s2n_quic_core::endpoint::Endpoint for Endpoint<Cfg> {
                     endpoint_context.dc,
                     endpoint_context.connection_limits,
                     endpoint_context.random_generator,
+                    endpoint_context.packet_interceptor,
+                    endpoint_context.connection_id_format,
                 ) {
                     conn.close(
                         error,
@@ -635,6 +639,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                     endpoint_context.datagram,
                     endpoint_context.dc,
                     endpoint_context.connection_limits,
+                    endpoint_context.connection_id_format,
                     &mut check_for_stateless_reset,
                 ) {
                     //= https://www.rfc-editor.org/rfc/rfc9000#section-10.2.1
@@ -1298,6 +1303,8 @@ impl<Cfg: Config> Endpoint<Cfg> {
             open_registry,
             limits_endpoint: endpoint_context.connection_limits,
             random_generator: endpoint_context.random_generator,
+            interceptor_endpoint: endpoint_context.packet_interceptor,
+            connection_id_validator: endpoint_context.connection_id_format,
         };
         let connection = <Cfg as crate::endpoint::Config>::Connection::new(connection_parameters)?;
         self.connections


### PR DESCRIPTION
### Release Summary:
- Adds feature for storing packets during the s2n-quic handshake for later decryption
### Resolved issues:

resolves #2601, resolves #337, resolves #298
### Description of changes: 
This PR adds a feature for storing Handshake and OneRtt packets on a connection if the handshake space and application space haven't been created yet. This primarily occurs if you enable offloading, but technically could occur if packets arrive out of order or packet loss occurs. This does increase memory used per connection, but only by however many bytes you want to store, so it's off by default.
The primary motivation for this feature is that the offloading feature is slightly slower without it. In my testing I have found that the dc-quic handshake with offloading is ~200us slower than the non-offloaded handshake. Turning packet storage on gets rid of a packet drop and puts the performance closer to the non-offloaded handshake. 
Here's some criterion results for the dc-quic handshake that show this:

```
Baseline Handshake
                        time:   [1.2010 ms 1.2130 ms 1.2259 ms]
                        change: [−2.0838% −0.3344% +1.4047%] (p = 0.71 > 0.05)
                        No change in performance detected.

Offloaded Handshake
                        time:   [1.4852 ms 1.5258 ms 1.5732 ms]
                        change: [+20.213% +23.717% +27.705%] (p = 0.00 < 0.05)
                        Performance has regressed.

Offloaded Handshake with packet storage
                        time:   [1.2867 ms 1.3039 ms 1.3223 ms]
```

This doesn't help handshakes in high concurrency scenarios, but does affect the single s2n-quic handshake performance.

### Call-outs:
Note I am not actually turning packet storage on yet in dc-quic; that will be the next PR I put out.
### Testing:

Includes changes to slow_test to prove that this PR fixes the dropped packets problem and that now slow_tls test takes no extra clock time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

