### PR TITLE
fix(s2n-quic-dc): Fix Stacked Borrows violation in stream packet decryption

### DIFF
--- a/dc/s2n-quic-dc/src/crypto.rs
+++ b/dc/s2n-quic-dc/src/crypto.rs
@@ -104,13 +104,14 @@ pub mod open {
             payload_out: &mut UninitSlice,
         ) -> Result;
 
-        /// Decrypt a payload
+        /// Decrypt a payload in place with a separate tag
         fn decrypt_in_place(
             &self,
             key_phase: KeyPhase,
             packet_number: u64,
             header: &[u8],
-            payload_and_tag: &mut [u8],
+            payload: &mut [u8],
+            tag: &[u8],
         ) -> Result;
     }
 

--- a/dc/s2n-quic-dc/src/crypto/awslc.rs
+++ b/dc/s2n-quic-dc/src/crypto/awslc.rs
@@ -201,7 +201,8 @@ pub mod open {
             key_phase: KeyPhase,
             packet_number: u64,
             header: &[u8],
-            payload_and_tag: &mut [u8],
+            payload: &mut [u8],
+            tag: &[u8],
         ) -> Result {
             ensure!(
                 key_phase == KeyPhase::Zero,
@@ -211,7 +212,7 @@ pub mod open {
             let aad = Aad::from(header);
 
             self.key
-                .open_in_place(nonce, aad, payload_and_tag)
+                .open_in_place_separate_tag(nonce, aad, tag, payload)
                 .map_err(|_| Error::InvalidTag)?;
 
             Ok(())

--- a/dc/s2n-quic-dc/src/packet/stream/decoder.rs
+++ b/dc/s2n-quic-dc/src/packet/stream/decoder.rs
@@ -280,16 +280,7 @@ impl Packet<'_> {
 
         match space {
             stream::PacketSpace::Stream => {
-                let payload_len = self.payload.len();
-                let payload_ptr = self.payload.as_mut_ptr();
-                let tag_len = self.auth_tag.len();
-                let tag_ptr = self.auth_tag.as_mut_ptr();
-                let payload_and_tag = unsafe {
-                    debug_assert_eq!(payload_ptr.add(payload_len), tag_ptr);
-
-                    core::slice::from_raw_parts_mut(payload_ptr, payload_len + tag_len)
-                };
-                d.decrypt_in_place(key_phase, nonce, header, payload_and_tag)?;
+                d.decrypt_in_place(key_phase, nonce, header, self.payload, self.auth_tag)?;
             }
             stream::PacketSpace::Recovery => {
                 // recovery/probe packets cannot have payloads

--- a/dc/s2n-quic-dc/src/path/secret/key.rs
+++ b/dc/s2n-quic-dc/src/path/secret/key.rs
@@ -296,7 +296,8 @@ pub mod open {
             key_phase: KeyPhase,
             packet_number: u64,
             header: &[u8],
-            payload_and_tag: &mut [u8],
+            payload: &mut [u8],
+            tag: &[u8],
         ) -> open::Result {
             let opener = match key_phase {
                 KeyPhase::Zero => &self.openers[0],
@@ -308,10 +309,11 @@ pub mod open {
                 KeyPhase::Zero,
                 packet_number,
                 header,
-                payload_and_tag,
+                payload,
+                tag,
             )?;
 
-            self.on_decrypt_success(payload_and_tag.into())?;
+            self.on_decrypt_success(payload.into())?;
 
             if key_phase != self.key_phase {
                 self.needs_update.store(true, Ordering::Relaxed);
@@ -386,7 +388,8 @@ pub mod open {
             key_phase: KeyPhase,
             packet_number: u64,
             header: &[u8],
-            payload_and_tag: &mut [u8],
+            payload: &mut [u8],
+            tag: &[u8],
         ) -> open::Result {
             ensure!(
                 key_phase == KeyPhase::Zero,
@@ -394,9 +397,9 @@ pub mod open {
             );
 
             self.key
-                .decrypt_in_place(key_phase, packet_number, header, payload_and_tag)?;
+                .decrypt_in_place(key_phase, packet_number, header, payload, tag)?;
 
-            self.on_decrypt_success(payload_and_tag.into())?;
+            self.on_decrypt_success(payload.into())?;
 
             ensure!(
                 !self.opened.swap(true, Ordering::Relaxed),

--- a/dc/s2n-quic-dc/src/path/secret/schedule.rs
+++ b/dc/s2n-quic-dc/src/path/secret/schedule.rs
@@ -613,11 +613,12 @@ mod tests {
 
             assert_ne!(msg, &buf[..5]);
 
+            let (payload, tag) = buf.split_at_mut(5);
             other
                 .opener
-                .decrypt_in_place(key_phase, packet_number, header, &mut buf)?;
+                .decrypt_in_place(key_phase, packet_number, header, payload, tag)?;
 
-            assert_eq!(msg, &buf[..5]);
+            assert_eq!(msg, payload);
 
             Ok(())
         }


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

The decrypt_in_place path in the stream decoder constructed a combined payload+tag slice using from_raw_parts_mut with a pointer derived from self.payload, extending it into self.auth_tag's memory. This violates Stacked Borrows provenance rules since the pointer only has provenance over the payload bytes.

Fix by changing the open::Application::decrypt_in_place trait to accept separate payload and tag slices, using aws-lc-rs's open_in_place_separate_tag API underneath. This eliminates the need to recombine adjacent slices via raw pointer arithmetic.

### Call-outs:

n/a

### Testing:

Just CI -- should be a no-op change in practice.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

