### PR TITLE
fix(s2n-quic-dc): Fix use-after-drop in Pool::grow() race-loser path

### DIFF
--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/pool.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/pool.rs
@@ -144,7 +144,10 @@ where
             // update our local copy
             self.epoch = senders.epoch;
 
-            // free what we just allocated, since we raced with the other pool instance
+            // Drop senders first since their drop impl accesses the descriptor's fields
+            drop(pending_senders);
+
+            // Now it's safe to destroy the descriptors
             for desc in pending_desc {
                 unsafe {
                     desc.drop_in_place();


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

When two cloned Pool instances race to grow, the loser detects an epoch mismatch and enters a cleanup path. Previously, it called drop_in_place on each DescriptorInner before the pending_senders (which hold Sender handles pointing to those same descriptors) were dropped. This caused Sender::drop to call drop_sender() on already-destroyed Queue fields.

Fix by dropping pending_senders before the drop_in_place loop.

### Call-outs:

### Testing:

Unfortunately I'm not sure how easy it is to produce actual problems from this, as noted I'm not able to come up with a test case that fails (including in Miri). Ultimately the fix is a 1-line change so probably fine to merge and move on.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

