### PR TITLE
fix: cargotiming job installs clang

### DIFF
--- a/codebuild/spec/cargotiming.yml
+++ b/codebuild/spec/cargotiming.yml
@@ -16,7 +16,8 @@ phases:
       - . $HOME/.cargo/env
       - rustup override set stable
       # cmake is a dependency of quiche, which is one of our test dependencies
-      - yum update -y && yum install -y cmake
+      # clang provides libclang.so needed by bindgen (used by boring-sys via quiche)
+      - yum update -y && yum install -y cmake clang
   build:
     commands:
       - cargo build --workspace --timings --release


### PR DESCRIPTION
### Release Summary:

### Resolved issues:


### Description of changes: 

Our cargotiming job doesn't install clang dependency manually and clang is not installed on the CodeBuild job by default. Hence, add it will resolve the issue.

### Call-outs:

### Testing:

It passed in Codebuild. https://us-west-2.console.aws.amazon.com/codesuite/codebuild/003495580562/projects/CargoTiming/build/CargoTiming%3A5d055bd8-07a8-49e5-9335-e8979ae4423a/?region=us-west-2


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

