### PR TITLE
fix: Return early if connection errors while processing first packet in datagram

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map/handshake.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/handshake.rs
@@ -232,16 +232,12 @@ impl HandshakingPathInner {
         );
 
         let receiver = receiver::State::new();
-        let secret = match self.secret.take() {
-            Some(secret) => secret,
-            None => {
-                return;
-            }
-        };
 
         let entry = Entry::new(
             self.peer,
-            secret,
+            self.secret
+                .take()
+                .expect("peer tokens are only received after secrets are ready"),
             sender,
             receiver,
             self.parameters.clone(),

--- a/dc/s2n-quic-dc/src/path/secret/map/handshake.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/handshake.rs
@@ -232,12 +232,16 @@ impl HandshakingPathInner {
         );
 
         let receiver = receiver::State::new();
+        let secret = match self.secret.take() {
+            Some(secret) => secret,
+            None => {
+                return;
+            }
+        };
 
         let entry = Entry::new(
             self.peer,
-            self.secret
-                .take()
-                .expect("peer tokens are only received after secrets are ready"),
+            secret,
             sender,
             receiver,
             self.parameters.clone(),

--- a/quic/s2n-quic-core/src/dc/testing.rs
+++ b/quic/s2n-quic-core/src/dc/testing.rs
@@ -19,6 +19,7 @@ pub struct MockDcEndpoint {
     pub on_possible_secret_control_packet_count: Arc<AtomicU8>,
     pub on_possible_secret_control_packet: fn() -> bool,
     mtu_probing_complete_support: MtuProbingCompleteSupport,
+    fail_path_secrets: bool,
 }
 
 impl MockDcEndpoint {
@@ -28,6 +29,7 @@ impl MockDcEndpoint {
             on_possible_secret_control_packet_count: Arc::new(AtomicU8::default()),
             on_possible_secret_control_packet: || false,
             mtu_probing_complete_support: MtuProbingCompleteSupport::Enabled,
+            fail_path_secrets: false,
         }
     }
 
@@ -36,6 +38,11 @@ impl MockDcEndpoint {
             true => MtuProbingCompleteSupport::Enabled,
             false => MtuProbingCompleteSupport::Disabled,
         };
+        self
+    }
+
+    pub fn with_failing_path_secrets(mut self) -> Self {
+        self.fail_path_secrets = true;
         self
     }
 }
@@ -48,6 +55,7 @@ pub struct MockDcPath {
     pub stateless_reset_tokens: Vec<stateless_reset::Token>,
     pub peer_stateless_reset_tokens: Vec<stateless_reset::Token>,
     pub mtu: u16,
+    pub fail_path_secrets: bool,
 }
 
 impl dc::Endpoint for MockDcEndpoint {
@@ -56,6 +64,7 @@ impl dc::Endpoint for MockDcEndpoint {
     fn new_path(&mut self, connection_info: &ConnectionInfo) -> Option<Self::Path> {
         Some(MockDcPath {
             stateless_reset_tokens: self.stateless_reset_tokens.clone(),
+            fail_path_secrets: self.fail_path_secrets,
             mtu: connection_info
                 .application_params
                 .max_datagram_size
@@ -88,6 +97,9 @@ impl dc::Path for MockDcPath {
         _session: &impl TlsSession,
     ) -> Result<Vec<stateless_reset::Token>, transport::Error> {
         debug_assert_eq!(0, self.on_path_secrets_ready_count);
+        if self.fail_path_secrets {
+            return Err(transport::Error::application_error(VarInt::new(0)?));
+        }
         self.on_path_secrets_ready_count += 1;
         Ok(self.stateless_reset_tokens.clone())
     }

--- a/quic/s2n-quic-tests/src/tests.rs
+++ b/quic/s2n-quic-tests/src/tests.rs
@@ -73,5 +73,6 @@ mod fips;
 #[cfg(not(target_os = "windows"))]
 mod mtls;
 // This test uses real OS sockets, which conflicts with bach's simulated time scope on Windows.
+mod dc_connection_close;
 #[cfg(not(target_os = "windows"))]
 mod prioritized_socket;

--- a/quic/s2n-quic-tests/src/tests.rs
+++ b/quic/s2n-quic-tests/src/tests.rs
@@ -68,11 +68,11 @@ mod chain;
 mod client_handshake_confirm;
 #[cfg(not(target_os = "windows"))]
 mod dc;
+mod dc_connection_close;
 #[cfg(not(target_os = "windows"))]
 mod fips;
 #[cfg(not(target_os = "windows"))]
 mod mtls;
 // This test uses real OS sockets, which conflicts with bach's simulated time scope on Windows.
-mod dc_connection_close;
 #[cfg(not(target_os = "windows"))]
 mod prioritized_socket;

--- a/quic/s2n-quic-tests/src/tests.rs
+++ b/quic/s2n-quic-tests/src/tests.rs
@@ -68,6 +68,7 @@ mod chain;
 mod client_handshake_confirm;
 #[cfg(not(target_os = "windows"))]
 mod dc;
+#[cfg(not(target_os = "windows"))]
 mod dc_connection_close;
 #[cfg(not(target_os = "windows"))]
 mod fips;

--- a/quic/s2n-quic-tests/src/tests/dc_connection_close.rs
+++ b/quic/s2n-quic-tests/src/tests/dc_connection_close.rs
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 use s2n_quic_core::{
     dc::testing::MockDcEndpoint,
     event::Subscriber,

--- a/quic/s2n-quic-tests/src/tests/dc_connection_close.rs
+++ b/quic/s2n-quic-tests/src/tests/dc_connection_close.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use super::*;
 use s2n_quic_core::{
     dc::testing::MockDcEndpoint,
     event::Subscriber,
@@ -28,7 +29,6 @@ impl Subscriber for ConnectionClosedSubscriber {
         _meta: &s2n_quic_core::event::api::ConnectionMeta,
         _info: &s2n_quic_core::event::api::ConnectionInfo,
     ) -> Self::ConnectionContext {
-        ()
     }
 
     fn on_connection_closed(
@@ -81,9 +81,9 @@ impl Subscriber for ConnectionClosedSubscriber {
 
 /// This test recreates a niche bug seen on a dc-quic connection as follows:
 /// 1. The connection's MTU is low enough that the server's certificate is fragmented across two datagrams
-///     and can't fit into the server's first datagram.
+///    and can't fit into the server's first datagram.
 /// 2. The client responds with two datagrams; its Handshake packet and OneRtt packet get coalesced
-///     into the second datagram.
+///    into the second datagram.
 /// 3. The server closes the connection when given the client's certificate in the on_path_secrets application
 ///    data callback.
 /// 4. The server then continues to process the remaining OneRTT packet in the datagram, due to a bug in
@@ -93,7 +93,6 @@ impl Subscriber for ConnectionClosedSubscriber {
 /// The test asserts that no packets are processed after connection closure.
 #[test]
 fn handle_packet_failure() {
-    use super::*;
     let model = Model::default();
     model.set_max_udp_payload(MTU);
 
@@ -131,11 +130,8 @@ fn handle_packet_failure() {
         });
 
         spawn(async move {
-            match server.accept().await {
-                Some(_) => {
-                    panic!("connection should not be accepted on path_secrets failure");
-                }
-                None => {}
+            if let Some(_) = server.accept().await {
+                panic!("connection should not be accepted on path_secrets failure");
             }
         });
 

--- a/quic/s2n-quic-tests/src/tests/dc_connection_close.rs
+++ b/quic/s2n-quic-tests/src/tests/dc_connection_close.rs
@@ -1,0 +1,142 @@
+use s2n_quic_core::{
+    dc::testing::MockDcEndpoint,
+    event::Subscriber,
+    stateless_reset::{
+        token::testing::{TEST_TOKEN_1, TEST_TOKEN_2},
+        Token,
+    },
+};
+
+const SERVER_TOKENS: [Token; 1] = [TEST_TOKEN_1];
+const CLIENT_TOKENS: [Token; 1] = [TEST_TOKEN_2];
+const MTU: u16 = 1200;
+
+#[derive(Default)]
+struct ConnectionClosedSubscriber {
+    connection_closed: bool,
+    datagram_count: u8,
+}
+
+impl Subscriber for ConnectionClosedSubscriber {
+    type ConnectionContext = ();
+
+    fn create_connection_context(
+        &mut self,
+        _meta: &s2n_quic_core::event::api::ConnectionMeta,
+        _info: &s2n_quic_core::event::api::ConnectionInfo,
+    ) -> Self::ConnectionContext {
+        ()
+    }
+
+    fn on_connection_closed(
+        &mut self,
+        _context: &mut Self::ConnectionContext,
+        _meta: &s2n_quic_core::event::api::ConnectionMeta,
+        _event: &s2n_quic_core::event::api::ConnectionClosed,
+    ) {
+        self.connection_closed = true;
+    }
+
+    fn on_datagram_received(
+        &mut self,
+        _context: &mut Self::ConnectionContext,
+        _meta: &s2n_quic_core::event::api::ConnectionMeta,
+        _event: &s2n_quic_core::event::api::DatagramReceived,
+    ) {
+        self.datagram_count += 1;
+    }
+    fn on_frame_received(
+        &mut self,
+        _context: &mut Self::ConnectionContext,
+        _meta: &s2n_quic_core::event::api::ConnectionMeta,
+        event: &s2n_quic_core::event::api::FrameReceived,
+    ) {
+        // No frames are processed past connection closure
+        assert!(!self.connection_closed);
+
+        // These assertions exist to check that we have set up the test scenario correctly.
+        if self.datagram_count == 3 {
+            // First packet in third datagram is Handshake
+            assert!(matches!(
+                event.packet_header,
+                s2n_quic_core::event::api::PacketHeader::Handshake { .. }
+            ));
+        } else {
+            // No Handshake packets before the third datagram carry Crypto
+            if matches!(
+                event.packet_header,
+                s2n_quic_core::event::api::PacketHeader::Handshake { .. }
+            ) {
+                assert!(!matches!(
+                    event.frame,
+                    s2n_quic_core::event::api::Frame::Crypto { .. }
+                ));
+            }
+        }
+    }
+}
+
+/// This test recreates a niche bug seen on a dc-quic connection as follows:
+/// 1. The connection's MTU is low enough that the server's certificate is fragmented across two datagrams
+///     and can't fit into the server's first datagram.
+/// 2. The client responds with two datagrams; its Handshake packet and OneRtt packet get coalesced
+///     into the second datagram.
+/// 3. The server closes the connection when given the client's certificate in the on_path_secrets application
+///    data callback.
+/// 4. The server then continues to process the remaining OneRTT packet in the datagram, due to a bug in
+///    the error codepath. This causes a panic in the on_peer_stateless_reset callback as it expects
+///    the path_secret to be created already.
+///
+/// The test asserts that no packets are processed after connection closure.
+#[test]
+fn handle_packet_failure() {
+    use super::*;
+    let model = Model::default();
+    model.set_max_udp_payload(MTU);
+
+    test(model.clone(), |handle| {
+        let server_tls = build_server_mtls_provider(certificates::MTLS_CA_CERT)?;
+        let mut server = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(server_tls)?
+            .with_dc(MockDcEndpoint::new(&CLIENT_TOKENS).with_failing_path_secrets())?
+            .with_event((
+                tracing_events(true, model.clone()),
+                ConnectionClosedSubscriber::default(),
+            ))?
+            .start()?;
+
+        let client_tls = build_client_mtls_provider(certificates::MTLS_CA_CERT)?;
+        let client = Client::builder()
+            .with_io(
+                handle
+                    .builder()
+                    .with_internal_recv_buffer_size(MTU as usize)?
+                    .build()?,
+            )?
+            .with_tls(client_tls)?
+            .with_dc(MockDcEndpoint::new(&SERVER_TOKENS))?
+            .with_event(tracing_events(true, model.clone()))?
+            .start()?;
+
+        let addr = server.local_addr()?;
+
+        primary::spawn(async move {
+            let connect = Connect::new(addr).with_server_name("localhost");
+            let mut conn = client.connect(connect).await.unwrap();
+            assert!(matches!(conn.accept_bidirectional_stream().await, Ok(None)));
+        });
+
+        spawn(async move {
+            match server.accept().await {
+                Some(_) => {
+                    panic!("connection should not be accepted on path_secrets failure");
+                }
+                None => {}
+            }
+        });
+
+        Ok(addr)
+    })
+    .unwrap();
+}

--- a/quic/s2n-quic-tests/src/tests/dc_connection_close.rs
+++ b/quic/s2n-quic-tests/src/tests/dc_connection_close.rs
@@ -130,7 +130,7 @@ fn handle_packet_failure() {
         });
 
         spawn(async move {
-            if let Some(_) = server.accept().await {
+            if server.accept().await.is_some() {
                 panic!("connection should not be accepted on path_secrets failure");
             }
         });

--- a/quic/s2n-quic-tests/src/tests/snapshots/tests__dc__dc_mtls_handshake_auth_failure_self_test__events.snap
+++ b/quic/s2n-quic-tests/src/tests/snapshots/tests__dc__dc_mtls_handshake_auth_failure_self_test__events.snap
@@ -273,15 +273,6 @@ measure#recovery_metrics.pto_count=0
 measure#recovery_metrics.congestion_window=12000
 measure#recovery_metrics.bytes_in_flight=[REDACTED]
 count#recovery_metrics.congestion_limited=false
-count#packet_received=1
-count#packet_received.kind|ONE_RTT=1
-count#packet_received.bytes.total=[REDACTED]b
-measure#packet_received.bytes=[REDACTED]b
-count#frame_received=1
-count#frame_received.packet|ONE_RTT=1
-count#frame_received.frame|CONNECTION_CLOSE=1
-count#connection_close_frame_received=1
-count#connection_close_frame_received.packet|ONE_RTT=1
 count#platform_event_loop_sleep=1
 timer#platform_event_loop_sleep.processing_duration=1µs
 === server ===

--- a/quic/s2n-quic-tests/src/tests/snapshots/tests__dc__dc_mtls_handshake_auth_failure_with_server_offloading_test__events.snap
+++ b/quic/s2n-quic-tests/src/tests/snapshots/tests__dc__dc_mtls_handshake_auth_failure_with_server_offloading_test__events.snap
@@ -308,15 +308,6 @@ measure#recovery_metrics.pto_count=0
 measure#recovery_metrics.congestion_window=12000
 measure#recovery_metrics.bytes_in_flight=[REDACTED]
 count#recovery_metrics.congestion_limited=false
-count#packet_received=1
-count#packet_received.kind|ONE_RTT=1
-count#packet_received.bytes.total=[REDACTED]b
-measure#packet_received.bytes=[REDACTED]b
-count#frame_received=1
-count#frame_received.packet|ONE_RTT=1
-count#frame_received.frame|CONNECTION_CLOSE=1
-count#connection_close_frame_received=1
-count#connection_close_frame_received.packet|ONE_RTT=1
 count#platform_event_loop_sleep=1
 timer#platform_event_loop_sleep.processing_duration=1µs
 === server ===

--- a/quic/s2n-quic-transport/src/endpoint/mod.rs
+++ b/quic/s2n-quic-transport/src/endpoint/mod.rs
@@ -654,6 +654,7 @@ impl<Cfg: Config> Endpoint<Cfg> {
                         endpoint_context.event_subscriber,
                         endpoint_context.packet_interceptor,
                     );
+                    return Err(());
                 }
 
                 if let Err(err) = conn.handle_remaining_packets(


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

N/A

### Description of changes: 

[We had a regression in s2n-quic a while ago,](https://github.com/aws/s2n-quic/pull/1952) we removed a return statement when the connection is closing due to an error. This causes s2n-quic to continue reading packets in a datagram after connection closure, which can make dc-quic panic under atypical network conditions. I wrote a test to reproduce the failure scenario and added the return statement back in.

### Call-outs:


### Testing:

Includes test


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

