### PR TITLE
feat(s2n-quic-dc): expose application_data to datagram api

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map.rs
@@ -171,6 +171,20 @@ impl Map {
         Some(opener)
     }
 
+    pub fn open_once_with_application_data(
+        &self,
+        credentials: &Credentials,
+        queue_id: Option<VarInt>,
+        control_out: &mut Vec<u8>,
+    ) -> Option<(open::Once, Option<ApplicationData>)> {
+        let entry = self
+            .store
+            .pre_authentication(credentials, queue_id, control_out)?;
+        let application_data = entry.application_data().clone();
+        let opener = entry.uni_opener(self.clone(), credentials, queue_id);
+        Some((opener, application_data))
+    }
+
     pub fn pair_for_credentials(
         &self,
         credentials: &Credentials,


### PR DESCRIPTION
Expose the path secret map's application_data to the datagram apis with a new `open_once_with_application_data` method.

### Release Summary:

* feat(s2n-quic-dc): expose application_data to datagram api

### Resolved issues:

n/a

### Description of changes: 

New `open_once_with_application_data`  method returns the opener, as before, and adds the application_data to the response.

### Testing:

`cargo test -p s2n-quic-dc`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.