### PR TITLE
test: Adds a stress scenario for overloading a single dc-quic server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -279,7 +279,7 @@ jobs:
             target: native
             env: S2N_QUIC_PLATFORM_FEATURES_OVERRIDE=""
             # s2n-quic-dc requires platform features
-            exclude: --exclude s2n-quic-dc --exclude s2n-quic-dc-benches --exclude s2n-quic-dc-metrics
+            exclude: --exclude s2n-quic-dc --exclude s2n-quic-dc-benches --exclude s2n-quic-dc-metrics --exclude s2n-quic-bench
           - rust: stable
             os: ubuntu-latest
             target: native

--- a/dc/s2n-quic-dc-metrics/src/rseq.rs
+++ b/dc/s2n-quic-dc-metrics/src/rseq.rs
@@ -781,6 +781,7 @@ fn dlsym(symbol: &CStr) -> std::io::Result<*mut std::ffi::c_void> {
         Ok(address)
     }
 }
+
 #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
 fn thread_plus_offset(offset: libc::ptrdiff_t) -> *mut std::ffi::c_void {
     let output: *mut std::ffi::c_void;
@@ -814,9 +815,8 @@ fn from_libc() -> std::io::Result<*mut Rseq> {
 }
 
 #[allow(clippy::needless_return)]
-#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
 fn sys_rseq(rseq_abi: *mut Rseq, flags: i32) -> std::io::Result<()> {
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
     {
         let ret = unsafe {
             libc::syscall(

--- a/dc/s2n-quic-dc-metrics/src/rseq.rs
+++ b/dc/s2n-quic-dc-metrics/src/rseq.rs
@@ -118,11 +118,14 @@ pub(crate) trait Absorb: Sized + Default {
 static PRINTED_MEMBARRIER_WARNING: AtomicBool = AtomicBool::new(false);
 
 impl<T: Absorb> Channels<T> {
-    #[cfg_attr(not(target_os = "linux"), allow(unused_assignments))]
+    #[cfg_attr(
+        not(all(target_os = "linux", target_pointer_width = "64")),
+        allow(unused_assignments)
+    )]
     pub(crate) fn new() -> Self {
         let mut must_use_fallback = false;
 
-        #[cfg(target_os = "linux")]
+        #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
         {
             let ret = unsafe {
                 libc::syscall(
@@ -148,7 +151,7 @@ impl<T: Absorb> Channels<T> {
             }
         }
 
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(all(target_os = "linux", target_pointer_width = "64")))]
         {
             must_use_fallback = true;
         }
@@ -175,12 +178,12 @@ impl<T: Absorb> Channels<T> {
         len
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(all(target_os = "linux", target_pointer_width = "64")))]
     pub(crate) fn steal_pages(&self) {
         self.aggregate_fallback(true);
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
     pub(crate) fn steal_pages(&self) {
         if self.must_use_fallback {
             self.aggregate_fallback(true);
@@ -253,12 +256,12 @@ impl<T: Absorb> Channels<T> {
         self.aggregate.lock().expect("propagate panic")
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(all(target_os = "linux", target_pointer_width = "64")))]
     pub(crate) fn send_event(&self, event: u64) {
         self.fallback_push(event)
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
     pub(crate) fn send_event(&self, event: u64) {
         if self.must_use_fallback {
             return self.fallback_push(event);
@@ -269,7 +272,7 @@ impl<T: Absorb> Channels<T> {
     }
 
     // Separate function for unit testing.
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
     fn send_event_inner(&self, event: u64, rseq_ptr: NonNull<Rseq>) {
         unsafe {
             #[cfg(target_arch = "x86_64")]
@@ -482,7 +485,7 @@ impl<T: Absorb> Channels<T> {
     }
 
     #[cold]
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
     #[cfg_attr(target_arch = "aarch64", target_feature(enable = "lse"))]
     fn send_event_slow(&self, rseq_ptr: NonNull<Rseq>, serialized_event: u64) {
         let mut new_page = self.empty_pages.pop().unwrap_or_else(Page::new);
@@ -760,6 +763,7 @@ fn rseq_init() -> NonNull<Rseq> {
     rseq_ptr
 }
 
+#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
 fn dlsym(symbol: &CStr) -> std::io::Result<*mut std::ffi::c_void> {
     unsafe {
         // clear previous errors
@@ -777,7 +781,7 @@ fn dlsym(symbol: &CStr) -> std::io::Result<*mut std::ffi::c_void> {
         Ok(address)
     }
 }
-
+#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
 fn thread_plus_offset(offset: libc::ptrdiff_t) -> *mut std::ffi::c_void {
     let output: *mut std::ffi::c_void;
     // As far as I can tell, both of these should work in the most general case.
@@ -795,6 +799,7 @@ fn thread_plus_offset(offset: libc::ptrdiff_t) -> *mut std::ffi::c_void {
     output.wrapping_offset(offset)
 }
 
+#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
 fn from_libc() -> std::io::Result<*mut Rseq> {
     let _size = dlsym(c"__rseq_size")?.cast::<u32>();
     let offset = dlsym(c"__rseq_offset")?.cast::<libc::ptrdiff_t>(); // ptrdiff_t
@@ -803,7 +808,13 @@ fn from_libc() -> std::io::Result<*mut Rseq> {
     Ok(thread_plus_offset(unsafe { offset.read() }).cast())
 }
 
+#[cfg(not(all(target_os = "linux", target_pointer_width = "64")))]
+fn from_libc() -> std::io::Result<*mut Rseq> {
+    return Err(std::io::Error::from(std::io::ErrorKind::Unsupported));
+}
+
 #[allow(clippy::needless_return)]
+#[cfg(all(target_os = "linux", target_pointer_width = "64"))]
 fn sys_rseq(rseq_abi: *mut Rseq, flags: i32) -> std::io::Result<()> {
     #[cfg(target_os = "linux")]
     {
@@ -823,7 +834,7 @@ fn sys_rseq(rseq_abi: *mut Rseq, flags: i32) -> std::io::Result<()> {
         return Ok(());
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(all(target_os = "linux", target_pointer_width = "64")))]
     {
         Err(std::io::Error::from(std::io::ErrorKind::Unsupported))
     }
@@ -912,7 +923,7 @@ mod tests {
         .unwrap();
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
     #[test]
     fn check_send_branches() {
         let mut rseq = Rseq {
@@ -974,7 +985,7 @@ mod tests {
         drop(channels);
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(all(target_os = "linux", target_pointer_width = "64"))]
     #[test]
     // `lse` enablement on aarch64
     #[allow(unused_unsafe)]

--- a/quic/s2n-quic-bench/Cargo.toml
+++ b/quic/s2n-quic-bench/Cargo.toml
@@ -16,6 +16,18 @@ internet-checksum = "0.2"
 s2n-codec = { path = "../../common/s2n-codec", features = ["testing"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 
+# Dependencies for the overload-server binary
+[target.'cfg(unix)'.dependencies]
+clap = { version = "4", features = ["derive"] }
+mimalloc = "0.1"
+nix = { version = "0.31.1", features = ["socket"] }
+s2n-quic = { path = "../s2n-quic" }
+s2n-quic-dc = { path = "../../dc/s2n-quic-dc" }
+s2n-quic-dc-metrics = { path = "../../dc/s2n-quic-dc-metrics" }
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
 [[bench]]
 name = "bench"
 harness = false

--- a/quic/s2n-quic-bench/src/bin/overload-server/main.rs
+++ b/quic/s2n-quic-bench/src/bin/overload-server/main.rs
@@ -1,0 +1,14 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+#[cfg(unix)]
+#[path = "./mod.rs"]
+mod overload_server;
+
+fn main() {
+    #[cfg(not(unix))]
+    eprintln!("not supported yet outside cfg(unix)");
+
+    #[cfg(unix)]
+    overload_server::main().unwrap();
+}

--- a/quic/s2n-quic-bench/src/bin/overload-server/mod.rs
+++ b/quic/s2n-quic-bench/src/bin/overload-server/mod.rs
@@ -1,0 +1,251 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This benchmark runs a single dc-quic server and then attempts to overload it by running --concurrency
+//! number of handshakes.
+//!
+//! Metrics are printed to stdout every second.
+
+use clap::Parser;
+use s2n_quic_core::{crypto::tls::testing::certificates, time::StdClock};
+use s2n_quic_dc::{
+    path::secret::{self, stateless_reset},
+    psk::{client, server},
+};
+use s2n_quic_dc_metrics::{Registry, Unit};
+use std::{
+    net::Ipv4Addr,
+    sync::{Arc, Barrier},
+    time::{Duration, Instant},
+};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+#[global_allocator]
+static A: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+#[derive(Parser, Debug)]
+struct Args {
+    #[arg(long)]
+    concurrency: usize,
+}
+
+fn new_map(capacity: usize) -> secret::Map {
+    secret::Map::new(
+        stateless_reset::Signer::new(b"bench"),
+        capacity,
+        false,
+        StdClock::default(),
+        s2n_quic_dc::event::disabled::Subscriber::default(),
+    )
+}
+
+/// Metrics backed by s2n-quic-dc-metrics Registry for formatted display.
+#[derive(Clone)]
+struct Metrics {
+    success: s2n_quic_dc_metrics::BoolCounter,
+    latency: s2n_quic_dc_metrics::Summary,
+}
+
+impl Metrics {
+    fn new(registry: &Registry) -> Self {
+        Self {
+            success: registry.register_bool("success".into(), None),
+            latency: registry.register_summary("latency".into(), None, Unit::Microsecond),
+        }
+    }
+
+    fn record(&self, ok: bool, elapsed: Duration) {
+        self.success.record(ok);
+        self.latency.record_duration(elapsed);
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+mod mtls {
+    use super::*;
+    use s2n_quic::provider::tls;
+
+    type Error = Box<dyn std::error::Error + Send + Sync>;
+
+    pub fn build_client_mtls_provider(ca_cert: &str) -> Result<tls::default::Client, Error> {
+        let mut builder = tls::default::Client::builder()
+            .with_certificate(ca_cert)?
+            .with_client_identity(
+                certificates::MTLS_CLIENT_CERT,
+                certificates::MTLS_CLIENT_KEY,
+            )?;
+
+        builder.config_mut().with_system_certs(false)?;
+        Ok(builder.build()?)
+    }
+
+    pub fn build_server_mtls_provider(ca_cert: &str) -> Result<tls::default::Server, Error> {
+        let mut builder = tls::default::Server::builder()
+            .with_certificate(
+                certificates::MTLS_SERVER_CERT,
+                certificates::MTLS_SERVER_KEY,
+            )?
+            .with_client_authentication()?
+            .with_trusted_certificate(ca_cert)?;
+
+        builder.config_mut().with_system_certs(false)?;
+        Ok(builder.build()?)
+    }
+}
+
+pub fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    tracing_subscriber::registry()
+        .with(tracing_subscriber::EnvFilter::from_env("S2N_LOG"))
+        .with(tracing_subscriber::fmt::layer().with_ansi(false))
+        .init();
+    tracing::info!("Running...");
+
+    let Args { concurrency } = Args::parse();
+    println!("Starting benchmark with {concurrency} clients");
+
+    let sub = s2n_quic::provider::event::disabled::Subscriber;
+
+    let server = server::Provider::builder()
+        .start_blocking(
+            "127.0.0.1:0".parse().unwrap(),
+            mtls::build_server_mtls_provider(certificates::MTLS_CA_CERT)?,
+            sub,
+            new_map(500),
+        )
+        .unwrap();
+
+    let registry = Registry::new();
+    let metrics = Metrics::new(&registry);
+
+    let redirector = Arc::new(
+        tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .thread_name_fn(|| String::from("proxy"))
+            .worker_threads(8)
+            .build()
+            .unwrap(),
+    );
+
+    std::thread::spawn({
+        let r = redirector.clone();
+        move || {
+            r.block_on(std::future::pending::<()>());
+        }
+    });
+
+    let server_name: s2n_quic::server::Name = "localhost".into();
+
+    let num_groups = concurrency.div_ceil(5);
+    let barrier = Arc::new(Barrier::new(num_groups + 1));
+
+    // A redirect socket sits between a client <-> redirect <-> server.
+    //
+    // Clients can only handshake with up to 5 *distinct* server addresses, so having the redirect
+    // in the middle allows us to treat the single server as many different servers. Each client we
+    // spin up gets a set of 5 redirect sockets which we read/write from to get to the actual
+    // server.
+    for _ in 0..num_groups {
+        let sub = s2n_quic::provider::event::disabled::Subscriber;
+
+        let client = client::Provider::builder()
+            .with_success_jitter(Duration::ZERO)
+            //.with_error_jitter(Duration::ZERO)
+            //.with_await_dedup_removal(true)
+            .start(
+                "127.0.0.1:0".parse().unwrap(),
+                new_map(10),
+                mtls::build_client_mtls_provider(certificates::MTLS_CA_CERT).unwrap(),
+                sub,
+                server_name.clone(),
+            )?;
+
+        let client_addr = client.local_addr()?;
+        let server_addr = server.local_addr();
+
+        // These will redirect to the single shared server.
+        let addrs = (0..5)
+            .map(|_| {
+                let r = redirector.clone();
+                redirector.block_on(async move {
+                    let socket = tokio::net::UdpSocket::bind(std::net::SocketAddrV4::new(
+                        Ipv4Addr::LOCALHOST,
+                        0,
+                    ))
+                    .await
+                    .unwrap();
+
+                    let socket_addr = socket.local_addr().unwrap();
+
+                    // Increase receive buffer to avoid packet drops under load.
+                    // See nstat -a -r | grep 'UdpMemErrors'.
+                    nix::sys::socket::setsockopt(
+                        &socket,
+                        nix::sys::socket::sockopt::RcvBuf,
+                        &(512 * 1024),
+                    )
+                    .unwrap();
+
+                    r.spawn(async move {
+                        let mut packet = vec![0; 10_000];
+                        loop {
+                            let (len, src) = socket.recv_from(&mut packet[..]).await.unwrap();
+                            if src == server_addr {
+                                socket.send_to(&packet[..len], client_addr).await.unwrap();
+                            } else if src == client_addr {
+                                socket.send_to(&packet[..len], server_addr).await.unwrap();
+                            } else {
+                                unreachable!("unknown packet src: {:?}", src);
+                            }
+                        }
+                    });
+
+                    socket_addr
+                })
+            })
+            .collect::<Vec<_>>();
+
+        let metrics = metrics.clone();
+        let server_name = server_name.clone();
+        let barrier = barrier.clone();
+        std::thread::spawn(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+
+            rt.block_on(async move {
+                let mut futs = tokio::task::JoinSet::new();
+                let mut first = true;
+                loop {
+                    let start = Instant::now();
+                    for addr in addrs.iter().copied() {
+                        let client = client.clone();
+                        let sn = server_name.clone();
+                        futs.spawn(async move {
+                            client.unconditionally_handshake_with_entry(addr, sn).await
+                        });
+                    }
+                    while let Some(Ok(res)) = futs.join_next().await {
+                        metrics.record(res.is_ok(), start.elapsed());
+                    }
+                    if first {
+                        first = false;
+                        barrier.wait();
+                    }
+                }
+            });
+        });
+    }
+
+    barrier.wait();
+
+    // Skip the first metrics line (warmup)
+    std::thread::sleep(Duration::from_secs(1));
+    let _ = registry.take_current_metrics_line();
+
+    loop {
+        std::thread::sleep(Duration::from_secs(1));
+        let line = registry.take_current_metrics_line();
+        println!("{line}");
+    }
+}


### PR DESCRIPTION
### Release Summary:
### Resolved issues:
### Description of changes: 

This is a copy of https://github.com/aws/s2n-quic/pull/3010, which is a test that spawns many clients that all constantly handshake with a single dc-quic server. I want to commit this so that I don't have to keep on rebasing each time I come back to the test.

### Call-outs:
We might want to consider running this every day so that we can get consistent metrics about how the server behaves. This is a decent starter commit though.
### Testing:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

