### PR TITLE
fix(dc): Enable panic clippy lints in s2n-quic-dc

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,7 @@
 msrv = "1.88.0"
 # // https://github.com/aws/s2n-quic/pull/2251
 too-many-arguments-threshold = 100
+# Avoid linting on unwraps in consts and tests where they can't bubble into production panics.
+allow-unwrap-in-consts = true
+allow-unwrap-in-tests = true
+allow-panic-in-tests = true

--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -82,3 +82,12 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = ['cfg(future)', 'cfg(fuzzing)', 'cfg(kani)', 'cfg(todo)']
+
+[lints.clippy]
+panic = "deny"
+panicking_unwrap = "deny"
+panicking_overflow_checks = "deny"
+panic_in_result_fn = "deny"
+large_futures = "deny"
+unwrap_used = "deny"
+unwrap_in_result = "deny"

--- a/dc/s2n-quic-dc/src/control.rs
+++ b/dc/s2n-quic-dc/src/control.rs
@@ -11,6 +11,11 @@ pub struct Control {
 }
 
 impl Control {
+    #[expect(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "FIXME: local_addr is a fallible socket op and should propagate the error rather than unwrap"
+    )]
     pub fn new(address: SocketAddr, map: Map) -> std::io::Result<Self> {
         let socket = Arc::new(std::net::UdpSocket::bind(address)?);
         let port = socket.local_addr().unwrap().port();

--- a/dc/s2n-quic-dc/src/credentials.rs
+++ b/dc/s2n-quic-dc/src/credentials.rs
@@ -14,6 +14,13 @@ use s2n_codec::{
 pub use s2n_quic_core::varint::VarInt as KeyId;
 
 #[cfg(any(test, feature = "testing"))]
+#[allow(
+    clippy::unwrap_used,
+    clippy::unwrap_in_result,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    reason = "test-support helpers may panic to surface setup failures"
+)]
 pub mod testing;
 
 #[derive(Clone, Copy, Default, PartialEq, Eq, FromBytes, IntoBytes, Unaligned, PartialOrd, Ord)]
@@ -29,6 +36,10 @@ impl Id {
         // The ID has very high quality entropy already, so write just one half of it to keep hash
         // costs as low as possible. For the main use of the Hash impl in the fixed-size ID map
         // this translates to just directly using these bytes for the indexing.
+        #[expect(
+            clippy::unwrap_used,
+            reason = "slicing exactly 8 bytes always converts to [u8; 8]"
+        )]
         u64::from_ne_bytes(self.0[..8].try_into().unwrap())
     }
 }
@@ -79,6 +90,10 @@ impl s2n_quic_core::probe::Arg for Id {
     fn into_usdt(self) -> isize {
         // we have to truncate the bytes, but 64 bits should be unique enough for these purposes
         let slice = &self.0[..core::mem::size_of::<usize>()];
+        #[expect(
+            clippy::unwrap_used,
+            reason = "slice length equals size_of::<usize>() so the conversion always succeeds"
+        )]
         let bytes = slice.try_into().unwrap();
         usize::from_ne_bytes(bytes).into_usdt()
     }

--- a/dc/s2n-quic-dc/src/crypto/awslc.rs
+++ b/dc/s2n-quic-dc/src/crypto/awslc.rs
@@ -22,6 +22,10 @@ pub mod seal {
     impl Application {
         #[inline]
         pub fn new(key: &[u8], iv: [u8; NONCE_LEN], algorithm: &'static Algorithm) -> Self {
+            #[expect(
+                clippy::unwrap_used,
+                reason = "key sizes are statically known, moving the panic into callers isn't helpful"
+            )]
             let key = UnboundKey::new(algorithm, key).unwrap();
             let key = LessSafeKey::new(key);
             Self { key, iv: Iv(iv) }
@@ -151,6 +155,10 @@ pub mod open {
     impl Application {
         #[inline]
         pub fn new(key: &[u8], iv: [u8; NONCE_LEN], algorithm: &'static Algorithm) -> Self {
+            #[expect(
+                clippy::unwrap_used,
+                reason = "key sizes are statically known, moving the panic into callers isn't helpful"
+            )]
             let key = UnboundKey::new(algorithm, key).unwrap();
             let key = LessSafeKey::new(key);
             Self { key, iv: Iv(iv) }

--- a/dc/s2n-quic-dc/src/event.rs
+++ b/dc/s2n-quic-dc/src/event.rs
@@ -26,6 +26,15 @@ impl Meta for api::EndpointMeta {
     }
 }
 
+// The generated code is not currently held to the panic lints; suppress them here at the
+// module level rather than annotating each generated site (which would be lost on regeneration).
+#[allow(
+    clippy::panic,
+    clippy::unwrap_used,
+    clippy::unwrap_in_result,
+    clippy::panic_in_result_fn,
+    reason = "FIXME: generated event code is not yet audited for the panic lints"
+)]
 mod generated;
 pub use generated::*;
 

--- a/dc/s2n-quic-dc/src/lib.rs
+++ b/dc/s2n-quic-dc/src/lib.rs
@@ -25,6 +25,13 @@ pub mod task;
 pub mod uds;
 
 #[cfg(any(test, feature = "testing"))]
+#[allow(
+    clippy::unwrap_used,
+    clippy::unwrap_in_result,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    reason = "test-support helpers may panic to surface setup failures"
+)]
 pub mod testing;
 
 pub use s2n_quic_core::dc::{Version, SUPPORTED_VERSIONS};

--- a/dc/s2n-quic-dc/src/msg/send.rs
+++ b/dc/s2n-quic-dc/src/msg/send.rs
@@ -65,6 +65,10 @@ impl allocator::Segment for Segment {
 
 #[cfg(debug_assertions)]
 impl Drop for Segment {
+    #[expect(
+        clippy::panic,
+        reason = "debug-only leak detector that fires only when a segment was dropped without being freed"
+    )]
     fn drop(&mut self) {
         if self.idx != Idx::MAX && !std::thread::panicking() {
             panic!("message segment {} leaked", self.idx);
@@ -122,6 +126,10 @@ impl Retransmission {
 
 #[cfg(debug_assertions)]
 impl Drop for Retransmission {
+    #[expect(
+        clippy::panic,
+        reason = "debug-only leak detector that fires only when a segment was dropped without being freed"
+    )]
     fn drop(&mut self) {
         if self.idx.get() != Idx::MAX && !std::thread::panicking() {
             panic!("message segment {} leaked", self.idx.get());

--- a/dc/s2n-quic-dc/src/packet/control/encoder.rs
+++ b/dc/s2n-quic-dc/src/packet/control/encoder.rs
@@ -80,6 +80,10 @@ where
 
     if cfg!(debug_assertions) {
         let decoder = s2n_codec::DecoderBufferMut::new(slice);
+        #[expect(
+            clippy::unwrap_used,
+            reason = "debug-assertions-only round-trip check that the packet we just encoded decodes successfully"
+        )]
         let _ = super::decoder::Packet::decode(decoder, (), crypto.tag_len()).unwrap();
     }
 

--- a/dc/s2n-quic-dc/src/packet/datagram/encoder.rs
+++ b/dc/s2n-quic-dc/src/packet/datagram/encoder.rs
@@ -96,6 +96,10 @@ where
     if tag.is_connected() || tag.ack_eliciting() {
         unsafe {
             assume!(encoder.remaining_capacity() >= 8);
+            #[expect(
+                clippy::unwrap_used,
+                reason = "FIXME: change API to enforce both packet number and next_expected_control_packet either both passed or neither is passed"
+            )]
             encoder.encode(&packet_number.unwrap());
         }
     }

--- a/dc/s2n-quic-dc/src/packet/stream/decoder.rs
+++ b/dc/s2n-quic-dc/src/packet/stream/decoder.rs
@@ -323,6 +323,10 @@ impl Packet<'_> {
 
     #[inline]
     #[cfg(debug_assertions)]
+    #[expect(
+        clippy::panic_in_result_fn,
+        reason = "debug-assertions-only build that round-trip checks the retransmission re-encode against a snapshot; the asserts validate internal encode/decode consistency"
+    )]
     pub fn retransmit<K>(
         buffer: DecoderBufferMut,
         space: stream::PacketSpace,
@@ -376,11 +380,20 @@ impl Packet<'_> {
     #[cfg(debug_assertions)]
     fn snapshot(buffer: &mut [u8], crypto_tag_len: usize) -> Owned {
         let buffer = DecoderBufferMut::new(buffer);
+        #[expect(
+            clippy::unwrap_used,
+            reason = "debug-assertions-only snapshot helper decoding a buffer that was just produced by this crate's encoder, so it is guaranteed to be well-formed"
+        )]
         let (packet, _buffer) = Self::decode(buffer, (), crypto_tag_len).unwrap();
         packet.into()
     }
 
     #[inline(always)]
+    #[expect(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "FIXME: support decoding const-known slices directly into arrays"
+    )]
     fn retransmit_impl<K>(
         buffer: DecoderBufferMut,
         space: stream::PacketSpace,

--- a/dc/s2n-quic-dc/src/packet/stream/encoder.rs
+++ b/dc/s2n-quic-dc/src/packet/stream/encoder.rs
@@ -93,6 +93,10 @@ where
 
     if cfg!(debug_assertions) {
         let decoder = s2n_codec::DecoderBufferMut::new(slice);
+        #[expect(
+            clippy::unwrap_used,
+            reason = "debug-assertions-only round-trip check that the packet we just encoded decodes successfully"
+        )]
         let (packet, remaining) =
             super::decoder::Packet::decode(decoder, (), crypto.tag_len()).unwrap();
         assert!(remaining.is_empty());
@@ -164,6 +168,10 @@ where
 
     if cfg!(debug_assertions) {
         let decoder = s2n_codec::DecoderBufferMut::new(slice);
+        #[expect(
+            clippy::unwrap_used,
+            reason = "debug-assertions-only round-trip check that the packet we just encoded decodes successfully"
+        )]
         let (packet, remaining) =
             super::decoder::Packet::decode(decoder, (), crypto.tag_len()).unwrap();
         assert!(remaining.is_empty());
@@ -242,6 +250,10 @@ where
         }
     }
 
+    #[expect(
+        clippy::unwrap_used,
+        reason = "payload_len is bounded by the encoder's remaining capacity (must be <= isize::MAX bytes)"
+    )]
     let payload_len = {
         // TODO compute payload len for the given encoder
         let buffered_len = payload.buffered_len();

--- a/dc/s2n-quic-dc/src/packet/stream/id.rs
+++ b/dc/s2n-quic-dc/src/packet/stream/id.rs
@@ -128,7 +128,13 @@ impl Id {
             0b00
         };
         let value = (queue_id << 2) | is_reliable | is_bidirectional;
-        VarInt::new(value).unwrap()
+        #[expect(
+            clippy::unwrap_used,
+            reason = "queue_id is < MAX_QUEUE_ID (2^60) by construction, so (queue_id << 2) | flags is < 2^62 and always a valid VarInt"
+        )]
+        {
+            VarInt::new(value).unwrap()
+        }
     }
 
     #[inline]
@@ -140,6 +146,11 @@ impl Id {
         let is_reliable = *value & IS_RELIABLE_MASK == IS_RELIABLE_MASK;
         let is_bidirectional = *value & IS_BIDIRECTIONAL_MASK == IS_BIDIRECTIONAL_MASK;
         Some(Self {
+            #[allow(
+                clippy::unwrap_used,
+                clippy::unwrap_in_result,
+                reason = "queue_id is a right-shift of an existing VarInt and is bounds-checked against MAX_QUEUE_ID above, so it is always a valid VarInt"
+            )]
             queue_id: VarInt::new(queue_id).unwrap(),
             is_reliable,
             is_bidirectional,

--- a/dc/s2n-quic-dc/src/path/secret/map.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map.rs
@@ -84,6 +84,10 @@ impl Map {
         C: 'static + time::Clock + Send + Sync,
         S: event::Subscriber,
     {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "build only fails if a required field is unset, we control the required field set"
+        )]
         let store = state::State::builder()
             .with_signer(signer)
             .with_capacity(capacity)
@@ -292,6 +296,10 @@ impl Map {
 
     #[doc(hidden)]
     #[cfg(any(test, feature = "testing"))]
+    #[allow(
+        clippy::unwrap_used,
+        reason = "test-support helper may panic to surface setup failures"
+    )]
     pub fn for_test_with_peers(
         peers: Vec<(
             crate::path::secret::schedule::Ciphersuite,
@@ -362,6 +370,10 @@ impl Map {
     }
 
     #[cfg(any(test, feature = "testing"))]
+    #[allow(
+        clippy::unwrap_used,
+        reason = "test-support helper may panic to surface setup failures"
+    )]
     pub(crate) fn test_insert_pair(
         &self,
         local_addr: SocketAddr,

--- a/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
@@ -50,6 +50,10 @@ impl Cleaner {
             // then wait for the background thread to finish exiting.
             if std::thread::current().id() != thread.thread().id() {
                 // We expect this to terminate very quickly.
+                #[expect(
+                    clippy::unwrap_used,
+                    reason = "panicking if a panic already occurred is OK"
+                )]
                 thread.join().unwrap();
             }
         }
@@ -93,9 +97,16 @@ impl Cleaner {
 
                 // pause the rest of the time to run once a minute, not twice a minute
                 std::thread::park_timeout(next_start.saturating_duration_since(Instant::now()));
-            })
-            .unwrap();
-        *self.thread.lock().unwrap() = Some(handle);
+            });
+        #[expect(
+            clippy::unwrap_used,
+            reason = "FIXME: spawning the cleaner thread is fallible (resource exhaustion)"
+        )]
+        let handle = handle.unwrap();
+        #[expect(clippy::unwrap_used, reason = "panic only if already panicked")]
+        {
+            *self.thread.lock().unwrap() = Some(handle);
+        }
     }
 
     /// Periodic maintenance for various maps.
@@ -136,6 +147,10 @@ impl Cleaner {
         // single threaded. No concurrent access is permitted.
         state.cleaner_peer_seen.clear();
 
+        #[expect(
+            clippy::unwrap_used,
+            reason = "lock is only poisoned if another thread already panicked while holding it"
+        )]
         let mut rehandshake = state.rehandshake.lock().unwrap();
         let refill_rehandshakes = rehandshake.needs_refill();
 

--- a/dc/s2n-quic-dc/src/path/secret/map/entry.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/entry.rs
@@ -126,6 +126,10 @@ impl Entry {
     }
 
     #[cfg(any(test, feature = "testing"))]
+    #[allow(
+        clippy::unwrap_used,
+        reason = "test-support helper may panic to surface setup failures"
+    )]
     pub fn fake(peer: SocketAddr, receiver: Option<receiver::State>) -> Arc<Entry> {
         let receiver = receiver.unwrap_or_default();
 

--- a/dc/s2n-quic-dc/src/path/secret/map/handshake.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/handshake.rs
@@ -222,6 +222,10 @@ impl HandshakingPathInner {
         &mut self,
         stateless_reset_tokens: impl Iterator<Item = &'a s2n_quic_core::stateless_reset::Token>,
     ) {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "protocol invariant enforced in frame parsing"
+        )]
         // TODO: support multiple stateless reset tokens
         let sender = sender::State::new(
             stateless_reset_tokens

--- a/dc/s2n-quic-dc/src/path/secret/map/rehandshake.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/rehandshake.rs
@@ -38,6 +38,10 @@ impl RehandshakeState {
             #[cfg(test)]
             builder.start_paused(true);
         }
+        #[expect(
+            clippy::unwrap_used,
+            reason = "FIXME: building the tokio runtime is fallible (resource exhaustion); this should propagate the error rather than panic"
+        )]
         let runtime = builder.build().unwrap();
         let _guard = runtime.enter();
         let now = Instant::now();
@@ -139,6 +143,10 @@ impl RehandshakeState {
             last_spawn = Instant::now();
 
             // Wait for a slot if we're at capacity
+            #[expect(
+                clippy::unwrap_used,
+                reason = "acquire_owned only errors when the semaphore is closed, and this semaphore is never closed"
+            )]
             let permit = self
                 .runtime
                 .block_on(self.semaphore.clone().acquire_owned())

--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -164,6 +164,10 @@ impl<F: FnOnce()> Drop for PeerWriteGuard<'_, F> {
         unsafe {
             ManuallyDrop::drop(&mut self.guard);
         }
+        #[expect(
+            clippy::unwrap_used,
+            reason = "cb is always Some until this Drop impl takes it exactly once"
+        )]
         (self.cb.take().unwrap())();
     }
 }
@@ -456,6 +460,10 @@ fn control_socket() -> Option<Arc<std::net::UdpSocket>> {
     // per process.
     static CONTROL_SOCKET: Mutex<Weak<std::net::UdpSocket>> = Mutex::new(Weak::new());
 
+    #[expect(
+        clippy::unwrap_used,
+        reason = "lock is only poisoned if another thread already panicked while holding it"
+    )]
     let mut guard = CONTROL_SOCKET.lock().unwrap();
     if let Some(socket) = guard.upgrade() {
         return Some(socket);
@@ -465,6 +473,10 @@ fn control_socket() -> Option<Arc<std::net::UdpSocket>> {
     let addrs = ["[::]:0", "0.0.0.0:0"];
 
     for addr in addrs {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "addr comes from a fixed list of compile-time constant address literals that are known valid"
+        )]
         let mut options = crate::socket::Options::new(addr.parse().unwrap());
         options.blocking = false;
         options.only_v6 = false;
@@ -542,6 +554,10 @@ where
         state.peers.reserve(2 * state.max_capacity);
         state.ids.reserve(2 * state.max_capacity);
         state.cleaner_peer_seen.reserve(2 * state.max_capacity);
+        #[expect(
+            clippy::unwrap_used,
+            reason = "lock is only poisoned if another thread already panicked while holding it"
+        )]
         state
             .rehandshake
             .get_mut()
@@ -709,6 +725,10 @@ where
         self.peers.contains_key(peer)
     }
 
+    #[expect(
+        clippy::panic,
+        reason = "FIXME: inserting a duplicate path secret ID should fail the handshake rather than panic"
+    )]
     fn on_new_path_secrets(&self, entry: Arc<Entry>) {
         let id = *entry.id();
         let peer = entry.peer();
@@ -733,6 +753,10 @@ where
                 // FIXME: Consider a more interesting algorithm, e.g., scanning the first N entries
                 // if the popped entry is still live to see if we can avoid dropping a live entry.
                 // May not be worth it in practice.
+                #[expect(
+                    clippy::unwrap_used,
+                    reason = "queue is non-empty here because its length was just checked to exceed max_capacity"
+                )]
                 let element = queue.pop_front().unwrap();
                 // Drop the queue lock prior to dropping element in case we wind up deallocating
                 // This reduces lock contention and avoids interleaving locks (requiring careful

--- a/dc/s2n-quic-dc/src/path/secret/receiver.rs
+++ b/dc/s2n-quic-dc/src/path/secret/receiver.rs
@@ -96,6 +96,11 @@ impl State {
     }
 
     /// Called after decryption has been performed
+    #[expect(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "lock is only poisoned if another thread already panicked while holding it"
+    )]
     pub fn post_authentication(&self, identity: &Credentials) -> Result<(), Error> {
         // Duplicate since it's cheap right now, can be refined in the future.
         // In practice callers should have already run this early in the receiving process.

--- a/dc/s2n-quic-dc/src/path/secret/schedule.rs
+++ b/dc/s2n-quic-dc/src/path/secret/schedule.rs
@@ -231,7 +231,15 @@ impl Secret {
         let (client_key, out) = out.split_at(key_len);
         let (server_key, out) = out.split_at(key_len);
         let (client_iv, server_iv) = out.split_at(NONCE_LEN);
+        #[expect(
+            clippy::unwrap_used,
+            reason = "the slice was split off at NONCE_LEN, so it is provably the right length for the array conversion"
+        )]
         let client_iv = client_iv.try_into().unwrap();
+        #[expect(
+            clippy::unwrap_used,
+            reason = "the slice was split off at NONCE_LEN, so it is provably the right length for the array conversion"
+        )]
         let server_iv = server_iv.try_into().unwrap();
         let aead = ciphersuite.aead();
 
@@ -338,6 +346,10 @@ impl Secret {
         );
         // if the hash is ever broken, it's better to put the "more secret" data at the beginning
         let (key, iv) = out.split_at(key_len);
+        #[expect(
+            clippy::unwrap_used,
+            reason = "the remaining slice after splitting off key_len is NONCE_LEN long, matching the array conversion"
+        )]
         let iv = iv.try_into().unwrap();
         f(self.ciphersuite.aead(), key, iv)
     }
@@ -393,6 +405,10 @@ trait PrkExt {
 impl PrkExt for Prk {
     #[inline]
     fn expand_into(&self, label: &[&[u8]], out: &mut [u8]) {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "expand and fill only fail on invalid output lengths; OutLen is derived from the output slice so the length is always valid"
+        )]
         self.expand(label, OutLen(out.len()))
             .unwrap()
             .fill(out)
@@ -481,6 +497,10 @@ impl Updater {
         // (key_update, key, iv)
         let (ku, out) = out.split_at(key_len);
         let (key, iv) = out.split_at(key_len);
+        #[expect(
+            clippy::unwrap_used,
+            reason = "the remaining slice after splitting off key_len is NONCE_LEN long, matching the array conversion"
+        )]
         let iv = iv.try_into().unwrap();
 
         let ku = Self::new(ku, ciphersuite);
@@ -490,6 +510,10 @@ impl Updater {
 }
 
 #[cfg(test)]
+#[allow(
+    clippy::panic_in_result_fn,
+    reason = "test code may panic to surface failures"
+)]
 mod tests {
     use super::*;
     use crate::{

--- a/dc/s2n-quic-dc/src/path/secret/sender.rs
+++ b/dc/s2n-quic-dc/src/path/secret/sender.rs
@@ -52,6 +52,10 @@ impl State {
 
         // The atomic will not be incremented (i.e., would have panic'd above) if we do not fit
         // into a VarInt.
+        #[expect(
+            clippy::unwrap_used,
+            reason = "id was produced by a successful VarInt::try_from in fetch_update, so it is provably in range"
+        )]
         VarInt::try_from(id).unwrap()
     }
 

--- a/dc/s2n-quic-dc/src/path/secret/stateless_reset.rs
+++ b/dc/s2n-quic-dc/src/path/secret/stateless_reset.rs
@@ -22,6 +22,7 @@ impl Signer {
     /// producing invalid `UnknownPathSecret` packets.
     pub fn random() -> Self {
         let mut secret = [0u8; 32];
+        #[expect(clippy::unwrap_used, reason = "no recovery from broken entropy pool")]
         aws_lc_rs::rand::fill(&mut secret).unwrap();
         Self::new(&secret)
     }

--- a/dc/s2n-quic-dc/src/psk/client.rs
+++ b/dc/s2n-quic-dc/src/psk/client.rs
@@ -32,6 +32,10 @@ struct State {
 }
 
 fn make_runtime() -> (Arc<Runtime>, DropGuard) {
+    #[expect(
+        clippy::unwrap_used,
+        reason = "FIXME: building the tokio runtime is fallible (resource exhaustion); should propagate the error"
+    )]
     let runtime = Arc::new(
         tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -42,6 +46,10 @@ fn make_runtime() -> (Arc<Runtime>, DropGuard) {
     let token = tokio_util::sync::CancellationToken::new();
     let cancelled = token.clone().cancelled_owned();
     let rt = runtime.clone();
+    #[expect(
+        clippy::unwrap_used,
+        reason = "FIXME: spawning a thread is fallible (resource exhaustion); should propagate the error"
+    )]
     std::thread::Builder::new()
         .name(String::from("hs-client"))
         .spawn(move || {
@@ -193,6 +201,11 @@ impl Provider {
 
     /// Handshake with a peer in the background.
     #[inline]
+    #[expect(
+        clippy::panic,
+        clippy::panic_in_result_fn,
+        reason = "the panic is only reachable in the deterministic testing configuration where no runtime is present"
+    )]
     pub fn background_handshake_with(
         &self,
         peer: SocketAddr,
@@ -230,6 +243,11 @@ impl Provider {
     // We duplicate the implementation of this method with handshake_with so that we preserve the fast
     // path (not interacting with the runtime at all) for cached handshakes.
     #[inline]
+    #[expect(
+        clippy::panic,
+        clippy::panic_in_result_fn,
+        reason = "the panic is only reachable in the deterministic testing configuration where no runtime is present"
+    )]
     pub fn blocking_handshake_with(
         &self,
         peer: SocketAddr,

--- a/dc/s2n-quic-dc/src/psk/io.rs
+++ b/dc/s2n-quic-dc/src/psk/io.rs
@@ -218,6 +218,10 @@ pub(super) async fn server<
         }
     };
 
+    #[expect(
+        clippy::unwrap_used,
+        reason = "FIXME: local_addr is a fallible socket op; the error should be sent on the channel instead of unwrapped"
+    )]
     let _ = on_ready.send(Ok(server.local_addr().unwrap()));
 
     while let Some(mut connection) = server.server.accept().await {

--- a/dc/s2n-quic-dc/src/psk/server.rs
+++ b/dc/s2n-quic-dc/src/psk/server.rs
@@ -43,9 +43,11 @@ impl Provider {
         );
         let token = tokio_util::sync::CancellationToken::new();
         let cancelled = token.clone().cancelled_owned();
+        #[expect(clippy::unwrap_used, reason = "FIXME: spawning a thread is fallible (resource exhaustion); should propagate the error")]
         std::thread::Builder::new()
             .name(String::from("hs-server"))
             .spawn(move || {
+                #[expect(clippy::unwrap_used, reason = "FIXME: building the tokio runtime is fallible (resource exhaustion); should propagate the error")]
                 let rt = tokio::runtime::Builder::new_current_thread()
                     .enable_all()
                     .build()

--- a/dc/s2n-quic-dc/src/random.rs
+++ b/dc/s2n-quic-dc/src/random.rs
@@ -11,6 +11,11 @@ impl TryRng for AwsLc {
     type Error = core::convert::Infallible;
 
     #[inline]
+    #[expect(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "aws-lc-rs random fill only fails on internal RNG failure, which is not a recoverable condition"
+    )]
     fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
         let mut v = [0; 4];
         aws_lc_rs::rand::fill(&mut v).unwrap();
@@ -18,6 +23,11 @@ impl TryRng for AwsLc {
     }
 
     #[inline]
+    #[expect(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "aws-lc-rs random fill only fails on internal RNG failure, which is not a recoverable condition"
+    )]
     fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
         let mut v = [0; 8];
         aws_lc_rs::rand::fill(&mut v).unwrap();
@@ -25,6 +35,11 @@ impl TryRng for AwsLc {
     }
 
     #[inline]
+    #[expect(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "aws-lc-rs random fill only fails on internal RNG failure, which is not a recoverable condition"
+    )]
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
         aws_lc_rs::rand::fill(dest).unwrap();
         Ok(())

--- a/dc/s2n-quic-dc/src/socket/recv/descriptor.rs
+++ b/dc/s2n-quic-dc/src/socket/recv/descriptor.rs
@@ -229,6 +229,10 @@ pub struct Unfilled {
 }
 
 impl fmt::Debug for Unfilled {
+    #[expect(
+        clippy::expect_used,
+        reason = "desc is always Some except transiently during recv_with/drop, so it is present here"
+    )]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let desc = self.desc.as_ref().expect("invalid state");
         f.debug_struct("Unfilled").field("id", &desc.id()).finish()
@@ -244,6 +248,10 @@ impl Unfilled {
 
     /// Fills the packet with the given callback, if the callback is successful
     #[inline]
+    #[allow(
+        clippy::unwrap_in_result,
+        reason = "desc is always Some except transiently during recv_with/drop, so it is present here"
+    )]
     pub fn recv_with<F, E>(mut self, f: F) -> Result<Segments, (Self, E)>
     where
         F: FnOnce(&mut Addr, &mut cmsg::Receiver, IoSliceMut) -> Result<usize, E>,

--- a/dc/s2n-quic-dc/src/socket/recv/pool.rs
+++ b/dc/s2n-quic-dc/src/socket/recv/pool.rs
@@ -125,8 +125,16 @@ impl Region {
         // first create the descriptor layout
         let descriptor = Layout::new::<DescriptorInner>();
         // extend it with the address value
+        #[expect(
+            clippy::unwrap_used,
+            reason = "compile-time known layouts cannot fail in production"
+        )]
         let (header, addr_offset) = descriptor.extend(Layout::new::<Addr>()).unwrap();
         // finally place the packet data at the end
+        #[expect(
+            clippy::unwrap_used,
+            reason = "max_packet_size is a u16 so the array layout and extension cannot overflow isize"
+        )]
         let (packet, packet_offset) = header
             .extend(Layout::array::<u8>(max_packet_size as usize).unwrap())
             .unwrap();
@@ -139,6 +147,10 @@ impl Region {
         let padding_len = packet.size() - without_padding_len;
         max_packet_size = max_packet_size.saturating_add(padding_len as u16);
 
+        #[expect(
+            clippy::unwrap_used,
+            reason = "FIXME: checked_mul on user-supplied packet_count can overflow"
+        )]
         let packets = {
             // TODO use `packet.repeat(packet_count)` once stable
             // https://doc.rust-lang.org/stable/core/alloc/struct.Layout.html#method.repeat
@@ -206,6 +218,11 @@ impl Free {
     }
 
     #[inline]
+    #[allow(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "lock is only poisoned if another thread already panicked while holding it"
+    )]
     fn alloc(&self) -> Option<Unfilled> {
         let mut inner = self.0.lock().unwrap();
         let desc = inner.descriptors.pop()?;
@@ -217,6 +234,10 @@ impl Free {
 
     #[inline]
     fn record_region(&self, region: Region, mut descriptors: Vec<Descriptor>) {
+        #[allow(
+            clippy::unwrap_used,
+            reason = "lock is only poisoned if another thread already panicked while holding it"
+        )]
         let mut inner = self.0.lock().unwrap();
         inner.regions.push(region);
         let prev = inner.total;
@@ -232,6 +253,11 @@ impl Free {
     }
 
     #[inline]
+    #[allow(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "lock is only poisoned if another thread already panicked while holding it"
+    )]
     fn close(&self) -> Option<FreeInner> {
         let mut inner = self.0.lock().unwrap();
         inner.open = false;
@@ -241,6 +267,11 @@ impl Free {
 
 impl FreeList for Free {
     #[inline]
+    #[allow(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "lock is only poisoned if another thread already panicked while holding it"
+    )]
     fn free(&self, descriptor: Descriptor) -> Option<Box<dyn 'static + Send>> {
         let mut inner = self.0.lock().unwrap();
 

--- a/dc/s2n-quic-dc/src/stream.rs
+++ b/dc/s2n-quic-dc/src/stream.rs
@@ -30,8 +30,20 @@ pub(crate) mod tls;
 pub use tls::{CertificateChain, Conn as TlsConnection, ConnectionBuilder as TlsConnectionBuilder};
 
 #[cfg(any(test, feature = "testing"))]
+#[allow(
+    clippy::unwrap_used,
+    clippy::unwrap_in_result,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    reason = "test-support helpers may panic to surface setup failures"
+)]
 pub mod testing;
 #[cfg(test)]
+#[allow(
+    clippy::unwrap_in_result,
+    clippy::panic_in_result_fn,
+    reason = "test code may panic to surface failures"
+)]
 mod tests;
 
 bitflags::bitflags! {

--- a/dc/s2n-quic-dc/src/stream/application.rs
+++ b/dc/s2n-quic-dc/src/stream/application.rs
@@ -44,6 +44,10 @@ where
 {
     /// Builds the stream and emits an event indicating that the stream was built
     #[inline]
+    #[allow(
+        clippy::unwrap_in_result,
+        reason = "app_queue_time is always set by accept_stream before accept() is called on a server stream"
+    )]
     pub(crate) fn accept(self) -> io::Result<(Stream<Sub>, AcceptInfo)> {
         let kernel_start_time = self.kernel_start_time;
         let app_queue_time = self.app_queue_time.expect("set by accept_stream");

--- a/dc/s2n-quic-dc/src/stream/client/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/client/tokio.rs
@@ -586,7 +586,10 @@ where
         });
 
     let (Some(Ok(socket)), Some(Ok(entry))) = (socket, peer) else {
-        // unwrap is OK -- if socket or peer isn't present the error should be set.
+        #[expect(
+            clippy::unwrap_used,
+            reason = "if socket or peer isn't present the error is always set, as documented above"
+        )]
         return Err(error.unwrap());
     };
 

--- a/dc/s2n-quic-dc/src/stream/crypto.rs
+++ b/dc/s2n-quic-dc/src/stream/crypto.rs
@@ -69,6 +69,10 @@ impl Crypto {
         update: impl FnOnce(&mut Sealer),
     ) -> R {
         let lock = &self.app_sealer;
+        #[expect(
+            clippy::unwrap_used,
+            reason = "lock is only poisoned if another thread already panicked while holding it"
+        )]
         let mut guard = lock.lock().unwrap();
         let result = seal(&guard);
 
@@ -88,6 +92,10 @@ impl Crypto {
         subscriber: &shared::Subscriber<Sub>,
     ) -> R {
         let lock = &self.app_opener;
+        #[expect(
+            clippy::unwrap_used,
+            reason = "lock is only poisoned if another thread already panicked while holding it"
+        )]
         let mut guard = lock.lock().unwrap();
         let result = open(&guard);
 

--- a/dc/s2n-quic-dc/src/stream/endpoint.rs
+++ b/dc/s2n-quic-dc/src/stream/endpoint.rs
@@ -34,6 +34,10 @@ pub struct AcceptError {
 }
 
 #[inline]
+#[expect(
+    clippy::unwrap_used,
+    reason = "VarInt::ZERO is a constant that is always a valid normal stream Id"
+)]
 pub fn open_stream<Env, P>(
     env: &Env,
     entry: map::Peer,

--- a/dc/s2n-quic-dc/src/stream/environment.rs
+++ b/dc/s2n-quic-dc/src/stream/environment.rs
@@ -17,6 +17,13 @@ use super::recv::buffer::Buffer;
 type Result<T = (), E = io::Error> = core::result::Result<T, E>;
 
 #[cfg(any(feature = "testing", test))]
+#[allow(
+    clippy::unwrap_used,
+    clippy::unwrap_in_result,
+    clippy::panic,
+    clippy::panic_in_result_fn,
+    reason = "bach simulation environment is test-support code and may panic to surface setup failures"
+)]
 pub mod bach;
 #[cfg(feature = "tokio")]
 pub mod tokio;

--- a/dc/s2n-quic-dc/src/stream/environment/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/tokio.rs
@@ -164,6 +164,10 @@ where
 {
     #[inline]
     fn default() -> Self {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "FIXME: build() constructs tokio runtimes which can fail under resource exhaustion"
+        )]
         Self::builder().build().unwrap()
     }
 }

--- a/dc/s2n-quic-dc/src/stream/environment/tokio/pool.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/tokio/pool.rs
@@ -61,6 +61,7 @@ impl Socket {
 }
 
 impl Pool {
+    #[allow(clippy::unwrap_in_result, reason = "see unwrap_used lints below")]
     pub fn new<Sub>(
         env: &Environment<Sub>,
         mut workers: usize,
@@ -110,6 +111,10 @@ impl Pool {
 
         if let Some(sender) = acceptor {
             spawn!(|_packets: &Packets, socket: &Socket| {
+                #[expect(
+                    clippy::unwrap_used,
+                    reason = "lock is only poisoned if another thread already panicked while holding it"
+                )]
                 let queues = socket.queue.lock().unwrap();
                 let app_socket = socket.application_socket.clone();
                 let worker_socket = socket.worker_socket.clone();
@@ -129,6 +134,10 @@ impl Pool {
             });
         } else {
             spawn!(|_packets: &Packets, socket: &Socket| {
+                #[expect(
+                    clippy::unwrap_used,
+                    reason = "lock is only poisoned if another thread already panicked while holding it"
+                )]
                 let dispatch = socket.queue.lock().unwrap().dispatcher();
                 dispatch.with_map(config.map.clone())
             });
@@ -149,6 +158,10 @@ impl Pool {
         let idx = self.current.fetch_add(1, Ordering::Relaxed);
         let idx = idx & self.mask;
         let socket = &self.sockets[idx];
+        #[expect(
+            clippy::unwrap_used,
+            reason = "lock is only poisoned if another thread already panicked while holding it"
+        )]
         let (control, stream) = socket.queue.lock().unwrap().alloc_or_grow(credentials);
         let app_socket = socket.application_socket.clone();
         let worker_socket = socket.worker_socket.clone();

--- a/dc/s2n-quic-dc/src/stream/environment/tokio/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/tokio/udp.rs
@@ -135,6 +135,10 @@ where
     }
 
     #[inline]
+    #[allow(
+        clippy::unwrap_in_result,
+        reason = "the recv pool is always configured before setup is called for a Pooled peer"
+    )]
     fn setup(
         self,
         env: &Environment<Sub>,

--- a/dc/s2n-quic-dc/src/stream/recv/ack.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/ack.rs
@@ -74,6 +74,10 @@ impl Space {
                     ack_ranges: &self.packets,
                     ecn_counts,
                 };
+                #[expect(
+                    clippy::unwrap_used,
+                    reason = "an ACK frame's encoding size is bounded well below VarInt::MAX"
+                )]
                 let encoding_size: VarInt = frame.encoding_size().try_into().unwrap();
                 let encoding_size = max_data_encoding_size + encoding_size;
 

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/descriptor.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/descriptor.rs
@@ -107,6 +107,10 @@ impl<T: 'static, Key: 'static> Descriptor<T, Key> {
         let inner = self.inner();
 
         // open the queues back up for receiving
+        #[expect(
+            clippy::unwrap_used,
+            reason = "the queues only fail to open if the lock was poisoned by another thread panicking while holding it"
+        )]
         inner.stream.open_receivers(&inner.control).unwrap();
 
         // set the key on the descriptor

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/free_list.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/free_list.rs
@@ -54,6 +54,11 @@ impl<T: 'static, Key: 'static> FreeVec<T, Key> {
     }
 
     #[inline]
+    #[allow(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "the lock is only poisoned if another thread already panicked while holding it"
+    )]
     pub fn alloc(&self, key: Option<&Key>) -> Option<(Control<T, Key>, Stream<T, Key>)>
     where
         Key: Copy + Eq + Hash,
@@ -83,6 +88,10 @@ impl<T: 'static, Key: 'static> FreeVec<T, Key> {
 
     #[inline]
     pub fn record_region(&self, region: Region<T, Key>, mut descriptors: Vec<Descriptor<T, Key>>) {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "the lock is only poisoned if another thread already panicked while holding it"
+        )]
         let mut inner = self.inner.lock().unwrap();
         inner.regions.push(region);
         let prev = inner.total;
@@ -98,6 +107,11 @@ impl<T: 'static, Key: 'static> FreeVec<T, Key> {
     }
 
     #[inline]
+    #[allow(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "the lock is only poisoned if another thread already panicked while holding it"
+    )]
     fn try_free(&self) -> Option<FreeInner<T, Key>> {
         let mut inner = self.inner.lock().unwrap();
         inner.open = false;
@@ -124,6 +138,11 @@ where
     Key: 'static + Send + Sync + Eq + Hash,
 {
     #[inline]
+    #[allow(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "the lock is only poisoned if another thread already panicked while holding it"
+    )]
     fn free(&self, mut descriptor: Descriptor<T, Key>) -> Option<Box<dyn 'static + Send>> {
         if let Some(key) = unsafe {
             // SAFETY: the descriptor is only owned by the free list

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/pool.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/pool.rs
@@ -137,6 +137,10 @@ where
 
         let pending_senders: Arc<[_]> = pending_senders.into();
 
+        #[expect(
+            clippy::unwrap_used,
+            reason = "the lock is only poisoned if another thread already panicked while holding it"
+        )]
         let mut senders = self.senders.pages.write().unwrap();
 
         // check if another pool instance already updated the senders list
@@ -190,6 +194,10 @@ impl<T: 'static, Key: 'static> Region<T, Key> {
         // first create the descriptor layout
         let descriptor = Layout::new::<DescriptorInner<T, Key>>().pad_to_align();
 
+        #[expect(
+            clippy::unwrap_used,
+            reason = "page_size is the PAGE_SIZE const generic (256, or 8 under debug_assertions) and the descriptor size is a compile-time constant, so the multiplication and layout construction cannot overflow"
+        )]
         let descriptors = {
             // TODO use `descriptor.repeat(page_size)` once stable
             // https://doc.rust-lang.org/stable/core/alloc/struct.Layout.html#method.repeat

--- a/dc/s2n-quic-dc/src/stream/recv/dispatch/queue.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/dispatch/queue.rs
@@ -197,6 +197,10 @@ impl<T> Queue<T> {
     }
 
     #[inline]
+    #[expect(
+        clippy::panic_in_result_fn,
+        reason = "the panics are debug-only assertions guarding internal invariants (correct half ordering and that no receiver is already open)"
+    )]
     pub fn open_receivers(&self, control: &Self) -> Result<(), Closed> {
         #[cfg(debug_assertions)]
         {

--- a/dc/s2n-quic-dc/src/stream/recv/shared.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/shared.rs
@@ -209,6 +209,10 @@ impl State {
         Pub: event::ConnectionPublisher,
     {
         let waker = {
+            #[expect(
+                clippy::unwrap_used,
+                reason = "the lock is only poisoned if another thread already panicked while holding it"
+            )]
             let mut inner = self.inner.lock().unwrap();
             inner.receiver.on_error(error, source, publisher);
             inner.application_waker.take()

--- a/dc/s2n-quic-dc/src/stream/recv/state.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/state.rs
@@ -848,6 +848,10 @@ impl State {
         let max_data = frame::MaxData {
             maximum_data: self.max_data,
         };
+        #[expect(
+            clippy::unwrap_used,
+            reason = "a MaxData frame's encoding size is a small constant well below VarInt::MAX"
+        )]
         let max_data_encoding_size: VarInt = max_data.encoding_size().try_into().unwrap();
 
         // compute the recovery ACKs first so we have enough space for those - if we run out, the sender will
@@ -1000,6 +1004,10 @@ impl State {
             .connection_close()
             .unwrap_or_else(|| s2n_quic_core::transport::Error::NO_ERROR.into());
 
+        #[expect(
+            clippy::unwrap_used,
+            reason = "a ConnectionClose frame's encoding size is bounded well below VarInt::MAX"
+        )]
         let encoding_size = frame.encoding_size().try_into().unwrap();
 
         let result = control::encoder::encode(

--- a/dc/s2n-quic-dc/src/stream/recv/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/recv/worker.rs
@@ -183,6 +183,10 @@ where
                     ));
 
                     self.arm_peek_timer();
+                    #[expect(
+                        clippy::unwrap_used,
+                        reason = "we matched on the PeekPacket state above so this transition is always valid"
+                    )]
                     self.state.on_peek_packet().unwrap();
                     continue;
                 }
@@ -193,6 +197,10 @@ where
                     ready!(self.peek_timer.poll_ready(cx));
 
                     // the application isn't making progress so emit the timer expired event
+                    #[expect(
+                        clippy::unwrap_used,
+                        reason = "we matched on the EpochTimeout state above so this transition is always valid"
+                    )]
                     self.state.on_epoch_unchanged().unwrap();
 
                     // only log this message after the first observation

--- a/dc/s2n-quic-dc/src/stream/send/state.rs
+++ b/dc/s2n-quic-dc/src/stream/send/state.rs
@@ -94,6 +94,10 @@ impl ErrorState {
 
         match self.error.kind {
             Kind::ApplicationError { error } => Some(frame::ConnectionClose {
+                #[expect(
+                    clippy::unwrap_used,
+                    reason = "application::Error, which wraps a VarInt, so *error is within VarInt range"
+                )]
                 error_code: VarInt::new(*error).unwrap(),
                 frame_type: None,
                 reason: None,
@@ -159,6 +163,10 @@ impl State {
 
         // initialize the pending data left to send
         let mut unacked_ranges = IntervalSet::new();
+        #[expect(
+            clippy::unwrap_used,
+            reason = "inserting a single valid range into a freshly-created empty IntervalSet cannot fail"
+        )]
         unacked_ranges.insert(VarInt::ZERO..=VarInt::MAX).unwrap();
 
         let cca = congestion::Controller::new(max_datagram_size);
@@ -1030,6 +1038,10 @@ impl State {
     }
 
     #[inline]
+    #[expect(
+        clippy::unwrap_in_result,
+        reason = "the popped retransmission was just observed via peek() and the recovery packet number cannot reach 2^62 in practice"
+    )]
     fn try_transmit_retransmissions<C, Clk, Pub>(
         &mut self,
         control_key: &C,
@@ -1144,6 +1156,11 @@ impl State {
     }
 
     #[inline]
+    #[expect(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "the recovery packet number cannot reach 2^62 in practice and a ConnectionClose frame's encoding size is bounded well below VarInt::MAX"
+    )]
     pub fn try_transmit_probe<C, Clk>(
         &mut self,
         control_key: &C,
@@ -1345,6 +1362,10 @@ impl State {
 
     #[cfg(debug_assertions)]
     #[inline]
+    #[expect(
+        clippy::unwrap_used,
+        reason = "debug-only invariant check: the ranges being removed were just derived from the unacked set, so removal cannot fail"
+    )]
     fn invariants(&self) {
         if !self.unacked_ranges.is_empty() {
             let mut unacked_ranges = self.unacked_ranges.clone();

--- a/dc/s2n-quic-dc/src/stream/server.rs
+++ b/dc/s2n-quic-dc/src/stream/server.rs
@@ -57,6 +57,10 @@ impl InitialPacket {
     }
 
     #[inline]
+    #[expect(
+        clippy::unwrap_used,
+        reason = "VarInt::ZERO is provably in range for unreliable_unidirectional"
+    )]
     pub fn empty() -> Self {
         Self {
             credentials: Credentials {

--- a/dc/s2n-quic-dc/src/stream/server/manager.rs
+++ b/dc/s2n-quic-dc/src/stream/server/manager.rs
@@ -96,6 +96,10 @@ impl Default for Builder {
             backlog: None,
             workers: None,
             // FIXME: Don't default to a fixed port?
+            #[expect(
+                clippy::unwrap_used,
+                reason = "parsing a compile-time constant socket address that is known valid"
+            )]
             acceptor_addr: "[::]:4444".parse().unwrap(),
             span: None,
             enable_udp: true,
@@ -132,6 +136,10 @@ impl Builder {
             ))
         );
 
+        #[expect(
+            clippy::unwrap_used,
+            reason = "converting the constant 1 to NonZeroUsize is infallible since 1 is non-zero"
+        )]
         let concurrency: usize = self.workers.unwrap_or_else(|| {
             std::thread::available_parallelism()
                 .unwrap_or_else(|_| 1.try_into().unwrap())

--- a/dc/s2n-quic-dc/src/stream/server/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio.rs
@@ -158,6 +158,10 @@ impl Default for Builder {
             backlog: None,
             workers: None,
             // FIXME: Don't default to a fixed port?
+            #[expect(
+                clippy::unwrap_used,
+                reason = "parsing a compile-time constant socket address that is known valid"
+            )]
             acceptor_addr: "[::]:4444".parse().unwrap(),
             span: None,
             enable_udp: true,
@@ -278,6 +282,10 @@ impl Builder {
             ))
         );
 
+        #[expect(
+            clippy::unwrap_used,
+            reason = "converting the constant 1 to NonZeroUsize is infallible"
+        )]
         let concurrency: usize = self.workers.unwrap_or_else(|| {
             std::thread::available_parallelism()
                 .unwrap_or_else(|_| 1.try_into().unwrap())
@@ -312,6 +320,10 @@ impl Builder {
 
         let env = env.build()?;
 
+        #[expect(
+            clippy::unwrap_used,
+            reason = "FIXME: propagate local_addr failure from pool_addr"
+        )]
         if self.enable_udp && enable_udp_pool {
             // update the address with the selected port
             self.acceptor_addr = env.pool_addr().unwrap();

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp/manager.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp/manager.rs
@@ -303,6 +303,11 @@ where
     }
 
     #[inline]
+    #[expect(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "if no free worker is available then by_sojourn_time is guaranteed non-empty, so front() is always Some"
+    )]
     fn next_worker<C: Clock>(&mut self, clock: &C) -> Option<usize> {
         // if we have a free worker then use that
         if let Some(idx) = self.free.pop_front(&mut self.workers) {

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp/tls.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp/tls.rs
@@ -92,6 +92,10 @@ where
     Sub: event::Subscriber + Clone,
 {
     fn drop(&mut self) {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "rt is always Some until it is taken here during drop"
+        )]
         if let Some(rt) = Arc::into_inner(self.rt.take().unwrap()) {
             rt.shutdown_background();
         }
@@ -166,7 +170,12 @@ where
         let map = self.map.clone();
         let flavor = self.accept_flavor;
         let timeout = self.timeout;
-        self.rt.as_ref().unwrap().spawn(async move {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "rt is always Some until Self is dropped"
+        )]
+        let rt = self.rt.as_ref().unwrap();
+        rt.spawn(async move {
             let fut = accept_conn(
                 socket,
                 remote_addr,

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp/worker.rs
@@ -48,6 +48,10 @@ where
     Sub: event::Subscriber + Clone,
 {
     #[inline]
+    #[expect(
+        clippy::unwrap_used,
+        reason = "FIXME: local_addr() is a fallible syscall; this should propagate the error instead of unwrapping"
+    )]
     pub fn new<B: PollBehavior<Sub> + Clone>(acceptor: &super::Acceptor<Sub, B>) -> Self {
         Self {
             recv_buffer: msg::recv::Message::new(u16::MAX),
@@ -315,6 +319,10 @@ where
                 } => (buffer, *blocked_count),
                 // we encountered an error so try and send it back
                 WorkerState::Erroring { offset, buffer, .. } => {
+                    #[expect(
+                        clippy::unwrap_used,
+                        reason = "poll is only called with an active stream, as documented on Worker::poll"
+                    )]
                     let (stream, _remote_address) = stream.as_mut().unwrap();
                     let len = ready!(Pin::new(stream).poll_write(cx, &buffer[*offset..])).map_err(
                         |e| WorkerError {
@@ -344,6 +352,10 @@ where
 
             // try to read an initial packet from the socket
             let res = {
+                #[expect(
+                    clippy::unwrap_used,
+                    reason = "poll is only called with an active stream, as documented on Worker::poll"
+                )]
                 let (stream, remote_address) = stream.as_mut().unwrap();
                 WorkerState::poll_initial_packet(
                     cx,
@@ -375,7 +387,15 @@ where
 
             let initial_packet = res?;
 
+            #[expect(
+                clippy::unwrap_used,
+                reason = "subscriber_ctx is always set alongside an active stream"
+            )]
             let subscriber_ctx = subscriber_ctx.take().unwrap();
+            #[expect(
+                clippy::unwrap_used,
+                reason = "poll is only called with an active stream, as documented on Worker::poll"
+            )]
             let (socket, remote_address) = stream.take().unwrap();
 
             let initial_packet = match initial_packet {
@@ -754,6 +774,10 @@ where
                 } => (buffer, *blocked_count),
                 // we encountered an error so try and send it back
                 WorkerState::Erroring { offset, buffer, .. } => {
+                    #[expect(
+                        clippy::unwrap_used,
+                        reason = "poll is only called with an active stream, as documented on Worker::poll"
+                    )]
                     let (stream, _remote_address) = stream.as_mut().unwrap();
                     let len = ready!(Pin::new(stream).poll_write(cx, &buffer[*offset..])).map_err(
                         |error| WorkerError {
@@ -794,6 +818,10 @@ where
 
             // try to read an initial packet from the socket
             let res = {
+                #[expect(
+                    clippy::unwrap_used,
+                    reason = "poll is only called with an active stream, as documented on Worker::poll"
+                )]
                 let (stream, remote_address) = stream.as_mut().unwrap();
                 WorkerState::poll_initial_packet(
                     cx,
@@ -838,6 +866,10 @@ where
                 Err(e) => return Err(e).into(),
             };
 
+            #[expect(
+                clippy::unwrap_used,
+                reason = "poll is only called with an active stream, as documented on Worker::poll"
+            )]
             let (socket, remote_address) = stream.take().unwrap();
 
             let recv_buffer = recv_buffer.make_contiguous();

--- a/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/udp.rs
@@ -51,6 +51,10 @@ where
         secrets: &secret::Map,
         accept_flavor: accept::Flavor,
     ) -> Self {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "converting the compile-time constant 9000 is infallible since it is a valid non-zero value"
+        )]
         let acceptor = Self {
             sender: sender.clone(),
             socket,

--- a/dc/s2n-quic-dc/src/stream/tls.rs
+++ b/dc/s2n-quic-dc/src/stream/tls.rs
@@ -100,6 +100,10 @@ impl S2nTlsConnection {
         mut initial_read_buffer: Option<crate::msg::recv::Message>,
     ) -> io::Result<()> {
         std::future::poll_fn(|cx| -> Poll<io::Result<()>> {
+            #[expect(
+                clippy::unwrap_used,
+                reason = "lock is only poisoned if another thread already panicked while holding it"
+            )]
             let s2n_connection = &mut self.connection.get_mut().unwrap().0;
 
             let context = NegotiateContext {
@@ -154,6 +158,11 @@ impl S2nTlsConnection {
         .await
     }
 
+    #[expect(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "lock is only poisoned if another thread already panicked while holding it"
+    )]
     pub(crate) fn write<M, R>(
         &self,
         message: &mut M,
@@ -217,6 +226,11 @@ impl S2nTlsConnection {
     }
 
     /// Process TLS frames in `input` and write decrypted results into `output`.
+    #[expect(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "lock poisoning only occurs if another thread already panicked while holding it; setting a receive callback is effectively infallible in the s2n-tls Rust bindings"
+    )]
     pub(crate) fn read(
         &self,
         input: &mut super::recv::shared::RecvBuffer,
@@ -319,6 +333,10 @@ unsafe extern "C" fn recv_direct_cb<'a>(
     buf: *mut u8,
     len: u32,
 ) -> i32 {
+    #[expect(
+        clippy::unwrap_used,
+        reason = "ctx is the non-null NegotiateContext pointer we set on the connection before s2n-tls invokes this callback"
+    )]
     let ctx = ctx.cast::<NegotiateContext<'a>>().as_mut::<'a>().unwrap();
 
     let mut cx = std::task::Context::from_waker(ctx.waker);
@@ -371,6 +389,10 @@ unsafe extern "C" fn send_direct_cb<'a>(
     buf: *const u8,
     len: u32,
 ) -> i32 {
+    #[expect(
+        clippy::unwrap_used,
+        reason = "ctx is the non-null NegotiateContext pointer we set on the connection before s2n-tls invokes this callback"
+    )]
     let ctx = ctx.cast::<NegotiateContext<'a>>().as_ref::<'a>().unwrap();
 
     let mut cx = std::task::Context::from_waker(ctx.waker);
@@ -405,11 +427,19 @@ unsafe extern "C" fn send_io_cb<'a, M>(ctx: *mut core::ffi::c_void, buf: *const 
 where
     M: 'a + super::send::application::state::Message,
 {
+    #[expect(
+        clippy::unwrap_used,
+        reason = "ctx is the non-null message context pointer we set on the connection before s2n-tls invokes this callback"
+    )]
     let message = ctx.cast::<M>().as_mut::<'a>().unwrap();
 
     let mut buf = std::slice::from_raw_parts(buf, len as usize);
 
     while !buf.is_empty() {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "the split point is clamped to at most buf.len(), so split_off is always in range"
+        )]
         let part = buf
             .split_off(..buf.len().clamp(0, u16::MAX as usize))
             .unwrap();
@@ -435,6 +465,10 @@ where
         });
     }
 
+    #[expect(
+        clippy::unwrap_used,
+        reason = "FIXME: len comes from s2n-tls and a value greater than i32::MAX would panic"
+    )]
     i32::try_from(len).unwrap()
 }
 
@@ -443,6 +477,10 @@ where
 unsafe extern "C" fn recv_io_cb<'a>(ctx: *mut core::ffi::c_void, buf: *mut u8, len: u32) -> i32 {
     // Note that we intentionally aren't assuming unique access, since we intend to call from
     // multiple threads.
+    #[expect(
+        clippy::unwrap_used,
+        reason = "ctx is the non-null RecvBuffer context pointer we set on the connection before s2n-tls invokes this callback"
+    )]
     let mut ctx = ctx
         .cast::<super::recv::shared::RecvBuffer>()
         .as_mut::<'a>()
@@ -579,6 +617,7 @@ impl Drop for CallbackResetGuard<'_> {
     }
 }
 
+#[allow(clippy::unwrap_in_result, reason = "see unwraps below")]
 pub(crate) fn build_stream<Sub>(
     kernel_start_time: Timestamp,
     addr: std::net::SocketAddr,
@@ -604,6 +643,10 @@ where
         addr
     };
 
+    #[expect(
+        clippy::unwrap_used,
+        reason = "VarInt::ZERO is a constant that is always a valid normal stream Id"
+    )]
     let stream_id = crate::packet::stream::Id::normal(VarInt::ZERO).unwrap();
 
     let params = s2n_quic_core::dc::ApplicationParams::new(
@@ -624,6 +667,7 @@ where
     // Fake up a secret -- this will need some reworking to store the keys in the TLS state
     // probably?
     let mut secret = [0; 32];
+    #[expect(clippy::unwrap_used, reason = "entropy failure is unrecoverable")]
     aws_lc_rs::rand::fill(&mut secret).unwrap();
     let secret = crate::path::secret::schedule::Secret::new(
         crate::path::secret::schedule::Ciphersuite::AES_GCM_128_SHA256,

--- a/dc/s2n-quic-dc/src/sync/ring_deque.rs
+++ b/dc/s2n-quic-dc/src/sync/ring_deque.rs
@@ -9,6 +9,10 @@ use std::{
 };
 
 #[cfg(test)]
+#[allow(
+    clippy::panic_in_result_fn,
+    reason = "test code may panic to surface failures"
+)]
 mod tests;
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
@@ -225,6 +229,11 @@ impl<T, W: RecvWaker> RingDeque<T, W> {
     }
 
     #[inline]
+    #[expect(
+        clippy::unwrap_used,
+        clippy::unwrap_in_result,
+        reason = "lock is only poisoned if another thread already panicked while holding it"
+    )]
     fn lock(&self) -> Result<std::sync::MutexGuard<'_, Inner<T, W>>, Closed> {
         let inner = self.inner.lock().unwrap();
         ensure!(inner.open, Err(Closed));
@@ -271,6 +280,10 @@ impl RecvWaker for () {
     }
 
     #[inline(always)]
+    #[expect(
+        clippy::panic,
+        reason = "the () RecvWaker is used for non-polling queues; calling update is a programming error"
+    )]
     fn update(&mut self, _cx: &mut core::task::Context) {
         panic!("polling is disabled");
     }

--- a/dc/s2n-quic-dc/src/task/waker/set.rs
+++ b/dc/s2n-quic-dc/src/task/waker/set.rs
@@ -40,6 +40,10 @@ impl Set {
         // reserve space in the locally ready set
         self.ready.resize_for_id(id);
         let state = self.state.clone();
+        #[expect(
+            clippy::unwrap_used,
+            reason = "lock is only poisoned if another thread already panicked while holding it"
+        )]
         state.ready.lock().unwrap().resize_for_id(id);
         Waker::from(Arc::new(Slot { id, state }))
     }
@@ -47,6 +51,10 @@ impl Set {
     /// Returns all of the IDs that are woken
     #[inline]
     pub fn drain(&mut self) -> impl Iterator<Item = usize> + '_ {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "lock is only poisoned if another thread already panicked while holding it"
+        )]
         let mut state = self.state.ready.lock().unwrap();
         core::mem::swap(&mut self.ready, &mut state);
         self.ready.drain()
@@ -67,6 +75,10 @@ struct Slot {
 impl Wake for Slot {
     #[inline]
     fn wake(self: Arc<Self>) {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "lock is only poisoned if another thread already panicked while holding it"
+        )]
         let mut ready = self.state.ready.lock().unwrap();
         unsafe {
             // SAFETY: the bitset was grown at the time of the call to [`Set::waker`]

--- a/dc/s2n-quic-dc/src/task/waker/worker.rs
+++ b/dc/s2n-quic-dc/src/task/waker/worker.rs
@@ -31,12 +31,20 @@ impl Default for Waker {
 
 impl Waker {
     #[inline]
+    #[expect(
+        clippy::unwrap_used,
+        reason = "lock is only poisoned if another thread already panicked while holding it"
+    )]
     pub fn update(&self, waker: &task::Waker) {
         self.state.lock().unwrap().waker = waker.clone();
     }
 
     #[inline]
     pub fn wake(&self) {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "lock is only poisoned if another thread already panicked while holding it"
+        )]
         let state = self.state.lock().unwrap();
 
         // we only need to `wake_by_ref` if the worker is sleeping
@@ -51,6 +59,10 @@ impl Waker {
     #[inline]
     pub fn wake_forced(&self) {
         // wake the waker outside of the lock to avoid deadlocks
+        #[expect(
+            clippy::unwrap_used,
+            reason = "lock is only poisoned if another thread already panicked while holding it"
+        )]
         let waker = self.state.lock().unwrap().waker.clone();
         waker.wake();
     }
@@ -71,6 +83,10 @@ impl Waker {
 
     #[inline]
     fn swap_status(&self, status: Status) -> Status {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "lock is only poisoned if another thread already panicked while holding it"
+        )]
         let mut state = self.state.lock().unwrap();
         core::mem::replace(&mut state.status, status)
     }


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

n/a

### Description of changes: 

This doesn't fix anything just yet, just allowing the lints across the s2n-quic-dc crate with reasons annotated. FIXME reasons correspond to where we expect some follow up scrutiny to be required.

### Call-outs:

Once we upgrade to 1.95 Clippy, we should be able to use allow-unwrap-types (see [docs](https://rust-lang.github.io/rust-clippy/stable/index.html#unwrap_used)) to avoid the numerous sites where we're unwrapping potentially poisoned lock guards. Technically I think CI uses stable (i.e., >1.95) Clippy, but it's not the default in local `cargo clippy` runs and I think the cost of errors when you forget to pass `+stable` is higher than a scattering of extra lint allows.

Some of the lints are also allowed a bit in the wrong place (e.g., function rather than expression boundary). I think we can over time clean things up -- my hope is that we can reduce the amount of sites beyond just fixing FIXMEs -- but I'm not too worried about it for now. The likelihood of missing a new unwrap / panic in code review is fairly low and we can drive-by fix them as we go.

### Testing:

CI passes -- which runs clippy, and would notice if there's new lints from this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

