### PR TITLE
feat(s2n-events): Pre-format generated events with prettyplease

### DIFF
--- a/dc/s2n-quic-dc/src/event/generated.rs
+++ b/dc/s2n-quic-dc/src/event/generated.rs
@@ -9,7 +9,7 @@
 use super::*;
 pub(crate) mod metrics;
 pub mod api {
-    #![doc = r" This module contains events that are emitted to the [`Subscriber`](crate::event::Subscriber)"]
+    //! This module contains events that are emitted to the [`Subscriber`](crate::event::Subscriber)
     use super::*;
     #[allow(unused_imports)]
     use crate::event::metrics::aggregate;
@@ -17,13 +17,13 @@ pub mod api {
     pub use traits::Subscriber;
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a TCP acceptor is started"]
+    /// Emitted when a TCP acceptor is started
     pub struct AcceptorTcpStarted<'a> {
-        #[doc = " The id of the acceptor worker"]
+        /// The id of the acceptor worker
         pub id: usize,
-        #[doc = " The local address of the acceptor"]
+        /// The local address of the acceptor
         pub local_address: SocketAddress<'a>,
-        #[doc = " The backlog size"]
+        /// The backlog size
         pub backlog: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -41,20 +41,20 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a TCP acceptor completes a single iteration of the event loop"]
+    /// Emitted when a TCP acceptor completes a single iteration of the event loop
     pub struct AcceptorTcpLoopIterationCompleted {
-        #[doc = " The number of streams that are waiting on initial packets"]
+        /// The number of streams that are waiting on initial packets
         pub pending_streams: usize,
-        #[doc = " The number of slots that are not currently processing a stream"]
+        /// The number of slots that are not currently processing a stream
         pub slots_idle: usize,
-        #[doc = " The percentage of slots currently processing streams"]
+        /// The percentage of slots currently processing streams
         pub slot_utilization: f32,
-        #[doc = " The amount of time it took to complete the iteration"]
+        /// The amount of time it took to complete the iteration
         pub processing_duration: core::time::Duration,
-        #[doc = " The computed max sojourn time that is allowed for streams"]
-        #[doc = ""]
-        #[doc = " If streams consume more time than this value to initialize, they"]
-        #[doc = " may potentially be replaced by more recent streams."]
+        /// The computed max sojourn time that is allowed for streams
+        ///
+        /// If streams consume more time than this value to initialize, they
+        /// may potentially be replaced by more recent streams.
         pub max_sojourn_time: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -74,9 +74,9 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a fresh TCP stream is enqueued for processing"]
+    /// Emitted when a fresh TCP stream is enqueued for processing
     pub struct AcceptorTcpFreshEnqueued<'a> {
-        #[doc = " The remote address of the TCP stream"]
+        /// The remote address of the TCP stream
         pub remote_address: SocketAddress<'a>,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -92,13 +92,13 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a the TCP acceptor has completed a batch of stream enqueues"]
+    /// Emitted when a the TCP acceptor has completed a batch of stream enqueues
     pub struct AcceptorTcpFreshBatchCompleted {
-        #[doc = " The number of fresh TCP streams enqueued in this batch"]
+        /// The number of fresh TCP streams enqueued in this batch
         pub enqueued: usize,
-        #[doc = " The number of fresh TCP streams dropped in this batch due to capacity limits"]
+        /// The number of fresh TCP streams dropped in this batch due to capacity limits
         pub dropped: usize,
-        #[doc = " The number of TCP streams that errored in this batch"]
+        /// The number of TCP streams that errored in this batch
         pub errored: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -116,9 +116,9 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a TCP stream has been dropped"]
+    /// Emitted when a TCP stream has been dropped
     pub struct AcceptorTcpStreamDropped<'a> {
-        #[doc = " The remote address of the TCP stream"]
+        /// The remote address of the TCP stream
         pub remote_address: SocketAddress<'a>,
         pub reason: AcceptorTcpStreamDropReason,
     }
@@ -136,14 +136,14 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a TCP stream has been replaced by another stream"]
+    /// Emitted when a TCP stream has been replaced by another stream
     pub struct AcceptorTcpStreamReplaced<'a> {
-        #[doc = " The remote address of the stream being replaced"]
+        /// The remote address of the stream being replaced
         pub remote_address: SocketAddress<'a>,
-        #[doc = " The amount of time that the stream spent in the accept queue before"]
-        #[doc = " being replaced with another"]
+        /// The amount of time that the stream spent in the accept queue before
+        /// being replaced with another
         pub sojourn_time: core::time::Duration,
-        #[doc = " The amount of bytes buffered on the stream"]
+        /// The amount of bytes buffered on the stream
         pub buffer_len: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -161,22 +161,22 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a full packet has been received on the TCP stream"]
+    /// Emitted when a full packet has been received on the TCP stream
     pub struct AcceptorTcpPacketReceived<'a> {
-        #[doc = " The address of the packet's sender"]
+        /// The address of the packet's sender
         pub remote_address: SocketAddress<'a>,
-        #[doc = " The credential ID of the packet"]
+        /// The credential ID of the packet
         pub credential_id: &'a [u8],
-        #[doc = " The stream ID of the packet"]
+        /// The stream ID of the packet
         pub stream_id: u64,
-        #[doc = " The payload length of the packet"]
+        /// The payload length of the packet
         pub payload_len: usize,
-        #[doc = " If the packet includes the final bytes of the stream"]
+        /// If the packet includes the final bytes of the stream
         pub is_fin: bool,
-        #[doc = " If the packet includes the final offset of the stream"]
+        /// If the packet includes the final offset of the stream
         pub is_fin_known: bool,
-        #[doc = " The amount of time the TCP stream spent in the queue before receiving"]
-        #[doc = " the initial packet"]
+        /// The amount of time the TCP stream spent in the queue before receiving
+        /// the initial packet
         pub sojourn_time: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -198,11 +198,11 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a TLS ClientHello has been recognized on the TCP stream"]
+    /// Emitted when a TLS ClientHello has been recognized on the TCP stream
     pub struct AcceptorTcpTlsStarted<'a> {
-        #[doc = " The address of the packet's sender"]
+        /// The address of the packet's sender
         pub remote_address: SocketAddress<'a>,
-        #[doc = " The amount of time the TCP stream spent in the queue so far"]
+        /// The amount of time the TCP stream spent in the queue so far
         pub sojourn_time: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -219,12 +219,12 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a TLS stream is enqueued to the application accept queue"]
+    /// Emitted when a TLS stream is enqueued to the application accept queue
     pub struct AcceptorTcpTlsStreamEnqueued<'a> {
-        #[doc = " The address of the packet's sender"]
+        /// The address of the packet's sender
         pub remote_address: SocketAddress<'a>,
-        #[doc = " The amount of time the TCP stream spent on handshaking before enqueuing to the application"]
-        #[doc = " since being accepted from the kernel"]
+        /// The amount of time the TCP stream spent on handshaking before enqueuing to the application
+        /// since being accepted from the kernel
         pub sojourn_time: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -241,14 +241,14 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a TLS stream is rejected"]
+    /// Emitted when a TLS stream is rejected
     pub struct AcceptorTcpTlsStreamRejected<'a> {
-        #[doc = " The address of the packet's sender"]
+        /// The address of the packet's sender
         pub remote_address: SocketAddress<'a>,
-        #[doc = " The amount of time the TCP stream spent on handshaking before being rejected"]
-        #[doc = " since being accepted from the kernel"]
+        /// The amount of time the TCP stream spent on handshaking before being rejected
+        /// since being accepted from the kernel
         pub sojourn_time: core::time::Duration,
-        #[doc = " The error encountered"]
+        /// The error encountered
         pub error: &'a std::io::Error,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -266,14 +266,14 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the TCP acceptor received an invalid initial packet"]
+    /// Emitted when the TCP acceptor received an invalid initial packet
     pub struct AcceptorTcpPacketDropped<'a> {
-        #[doc = " The address of the packet's sender"]
+        /// The address of the packet's sender
         pub remote_address: SocketAddress<'a>,
-        #[doc = " The reason the packet was dropped"]
+        /// The reason the packet was dropped
         pub reason: AcceptorPacketDropReason,
-        #[doc = " The amount of time the TCP stream spent in the queue before receiving"]
-        #[doc = " an error"]
+        /// The amount of time the TCP stream spent in the queue before receiving
+        /// an error
         pub sojourn_time: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -291,17 +291,17 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the TCP stream has been enqueued for the application"]
+    /// Emitted when the TCP stream has been enqueued for the application
     pub struct AcceptorTcpStreamEnqueued<'a> {
-        #[doc = " The address of the stream's peer"]
+        /// The address of the stream's peer
         pub remote_address: SocketAddress<'a>,
-        #[doc = " The credential ID of the stream"]
+        /// The credential ID of the stream
         pub credential_id: &'a [u8],
-        #[doc = " The ID of the stream"]
+        /// The ID of the stream
         pub stream_id: u64,
-        #[doc = " The amount of time the TCP stream spent in the queue before being enqueued"]
+        /// The amount of time the TCP stream spent in the queue before being enqueued
         pub sojourn_time: core::time::Duration,
-        #[doc = " The number of times the stream was blocked on receiving more data"]
+        /// The number of times the stream was blocked on receiving more data
         pub blocked_count: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -321,9 +321,9 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the TCP acceptor encounters an IO error"]
+    /// Emitted when the TCP acceptor encounters an IO error
     pub struct AcceptorTcpIoError<'a> {
-        #[doc = " The error encountered"]
+        /// The error encountered
         pub error: &'a std::io::Error,
         pub source: AcceptorTcpIoErrorSource,
     }
@@ -341,17 +341,17 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the TCP stream has been sent over a Unix domain socket"]
+    /// Emitted when the TCP stream has been sent over a Unix domain socket
     pub struct AcceptorTcpSocketSent<'a> {
-        #[doc = " The credential ID of the stream"]
+        /// The credential ID of the stream
         pub credential_id: &'a [u8],
-        #[doc = " The ID of the stream"]
+        /// The ID of the stream
         pub stream_id: u64,
-        #[doc = " The amount of time the TCP stream spent in the queue before being sent over Unix domain socket"]
+        /// The amount of time the TCP stream spent in the queue before being sent over Unix domain socket
         pub sojourn_time: core::time::Duration,
-        #[doc = " The number of times the Unix domain socket was blocked on send"]
+        /// The number of times the Unix domain socket was blocked on send
         pub blocked_count: usize,
-        #[doc = " The len of the payload sent over the Unix domain socket"]
+        /// The len of the payload sent over the Unix domain socket
         pub payload_len: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -371,17 +371,17 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a TCP stream has been received from a Unix domain socket"]
+    /// Emitted when a TCP stream has been received from a Unix domain socket
     pub struct AcceptorTcpSocketReceived<'a> {
-        #[doc = " The address of the stream's peer"]
+        /// The address of the stream's peer
         pub remote_address: SocketAddress<'a>,
-        #[doc = " The credential ID of the stream"]
+        /// The credential ID of the stream
         pub credential_id: &'a [u8],
-        #[doc = " The ID of the stream"]
+        /// The ID of the stream
         pub stream_id: u64,
-        #[doc = " The amount of time taken from socket send to socket receive, including waiting if the kernel queue is full"]
+        /// The amount of time taken from socket send to socket receive, including waiting if the kernel queue is full
         pub transfer_time: core::time::Duration,
-        #[doc = " The len of the payload sent over the Unix domain socket"]
+        /// The len of the payload sent over the Unix domain socket
         pub payload_len: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -401,11 +401,11 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a UDP acceptor is started"]
+    /// Emitted when a UDP acceptor is started
     pub struct AcceptorUdpStarted<'a> {
-        #[doc = " The id of the acceptor worker"]
+        /// The id of the acceptor worker
         pub id: usize,
-        #[doc = " The local address of the acceptor"]
+        /// The local address of the acceptor
         pub local_address: SocketAddress<'a>,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -422,11 +422,11 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a UDP datagram is received by the acceptor"]
+    /// Emitted when a UDP datagram is received by the acceptor
     pub struct AcceptorUdpDatagramReceived<'a> {
-        #[doc = " The address of the datagram's sender"]
+        /// The address of the datagram's sender
         pub remote_address: SocketAddress<'a>,
-        #[doc = " The len of the datagram"]
+        /// The len of the datagram
         pub len: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -443,23 +443,23 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the UDP acceptor parsed a packet contained in a datagram"]
+    /// Emitted when the UDP acceptor parsed a packet contained in a datagram
     pub struct AcceptorUdpPacketReceived<'a> {
-        #[doc = " The address of the packet's sender"]
+        /// The address of the packet's sender
         pub remote_address: SocketAddress<'a>,
-        #[doc = " The credential ID of the packet"]
+        /// The credential ID of the packet
         pub credential_id: &'a [u8],
-        #[doc = " The stream ID of the packet"]
+        /// The stream ID of the packet
         pub stream_id: u64,
-        #[doc = " The payload length of the packet"]
+        /// The payload length of the packet
         pub payload_len: usize,
-        #[doc = " If the packets is a zero offset in the stream"]
+        /// If the packets is a zero offset in the stream
         pub is_zero_offset: bool,
-        #[doc = " If the packet is a retransmission"]
+        /// If the packet is a retransmission
         pub is_retransmission: bool,
-        #[doc = " If the packet includes the final bytes of the stream"]
+        /// If the packet includes the final bytes of the stream
         pub is_fin: bool,
-        #[doc = " If the packet includes the final offset of the stream"]
+        /// If the packet includes the final offset of the stream
         pub is_fin_known: bool,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -482,11 +482,11 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the UDP acceptor received an invalid initial packet"]
+    /// Emitted when the UDP acceptor received an invalid initial packet
     pub struct AcceptorUdpPacketDropped<'a> {
-        #[doc = " The address of the packet's sender"]
+        /// The address of the packet's sender
         pub remote_address: SocketAddress<'a>,
-        #[doc = " The reason the packet was dropped"]
+        /// The reason the packet was dropped
         pub reason: AcceptorPacketDropReason,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -503,13 +503,13 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the UDP stream has been enqueued for the application"]
+    /// Emitted when the UDP stream has been enqueued for the application
     pub struct AcceptorUdpStreamEnqueued<'a> {
-        #[doc = " The address of the stream's peer"]
+        /// The address of the stream's peer
         pub remote_address: SocketAddress<'a>,
-        #[doc = " The credential ID of the stream"]
+        /// The credential ID of the stream
         pub credential_id: &'a [u8],
-        #[doc = " The ID of the stream"]
+        /// The ID of the stream
         pub stream_id: u64,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -527,9 +527,9 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the UDP acceptor encounters an IO error"]
+    /// Emitted when the UDP acceptor encounters an IO error
     pub struct AcceptorUdpIoError<'a> {
-        #[doc = " The error encountered"]
+        /// The error encountered
         pub error: &'a std::io::Error,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -545,16 +545,16 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a stream has been pruned"]
+    /// Emitted when a stream has been pruned
     pub struct AcceptorStreamPruned<'a> {
-        #[doc = " The remote address of the stream"]
+        /// The remote address of the stream
         pub remote_address: SocketAddress<'a>,
-        #[doc = " The credential ID of the stream"]
+        /// The credential ID of the stream
         pub credential_id: &'a [u8],
-        #[doc = " The ID of the stream"]
+        /// The ID of the stream
         pub stream_id: u64,
-        #[doc = " The amount of time that the stream spent in the accept queue before"]
-        #[doc = " being pruned"]
+        /// The amount of time that the stream spent in the accept queue before
+        /// being pruned
         pub sojourn_time: core::time::Duration,
         pub reason: AcceptorStreamPruneReason,
     }
@@ -575,18 +575,18 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a stream has been dequeued by the application"]
+    /// Emitted when a stream has been dequeued by the application
     pub struct AcceptorStreamDequeued<'a> {
-        #[doc = " The remote address of the stream"]
+        /// The remote address of the stream
         pub remote_address: SocketAddress<'a>,
-        #[doc = " The credential ID of the stream"]
+        /// The credential ID of the stream
         pub credential_id: &'a [u8],
-        #[doc = " The ID of the stream"]
+        /// The ID of the stream
         pub stream_id: u64,
-        #[doc = " The amount of time that the stream spent in dcQUIC before being dequeued"]
+        /// The amount of time that the stream spent in dcQUIC before being dequeued
         pub sojourn_time: core::time::Duration,
-        #[doc = " The amount of time that the stream spent in the queue to the application before being"]
-        #[doc = " dequeued"]
+        /// The amount of time that the stream spent in the queue to the application before being
+        /// dequeued
         pub queue_sojourn_time: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -608,10 +608,10 @@ pub mod api {
     #[non_exhaustive]
     pub enum AcceptorTcpStreamDropReason {
         #[non_exhaustive]
-        #[doc = " There were more streams in the TCP backlog than the userspace queue can store"]
+        /// There were more streams in the TCP backlog than the userspace queue can store
         FreshQueueAtCapacity {},
         #[non_exhaustive]
-        #[doc = " There are no available slots for processing"]
+        /// There are no available slots for processing
         SlotsAtCapacity {},
     }
     impl aggregate::AsVariant for AcceptorTcpStreamDropReason {
@@ -639,30 +639,30 @@ pub mod api {
     #[non_exhaustive]
     pub enum AcceptorTcpIoErrorSource {
         #[non_exhaustive]
-        #[doc = " Problem during accept of the TCP socket"]
+        /// Problem during accept of the TCP socket
         Accept {},
         #[non_exhaustive]
-        #[doc = " Problem writing to the TCP socket"]
+        /// Problem writing to the TCP socket
         Send {},
         #[non_exhaustive]
-        #[doc = " Kernel originating from sending the TCP socket over UDS"]
+        /// Kernel originating from sending the TCP socket over UDS
         UnixSend {},
         #[non_exhaustive]
-        #[doc = " Problem reading from the TCP socket"]
+        /// Problem reading from the TCP socket
         Recv {},
         #[non_exhaustive]
-        #[doc = " Something within dcQUIC failed related to the remote state or network contents (e.g.,"]
-        #[doc = " parsing the packet)"]
+        /// Something within dcQUIC failed related to the remote state or network contents (e.g.,
+        /// parsing the packet)
         Remote {},
         #[non_exhaustive]
-        #[doc = " Something in the local application state was wrong."]
+        /// Something in the local application state was wrong.
         Local {},
         #[non_exhaustive]
-        #[doc = " Unknown path secret for remote stream."]
+        /// Unknown path secret for remote stream.
         UnknownPathSecret {},
         #[non_exhaustive]
-        #[doc = " Something went wrong that we didn't expect to happen."]
-        #[doc = " This is used for failures that aren't expected to relate to dcQUIC state at all."]
+        /// Something went wrong that we didn't expect to happen.
+        /// This is used for failures that aren't expected to relate to dcQUIC state at all.
         System {},
     }
     impl aggregate::AsVariant for AcceptorTcpIoErrorSource {
@@ -837,13 +837,13 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamWriteFlushed {
-        #[doc = " The number of bytes that the application tried to write"]
+        /// The number of bytes that the application tried to write
         pub provided_len: usize,
-        #[doc = " The amount that was written"]
+        /// The amount that was written
         pub committed_len: usize,
-        #[doc = " The amount of time it took to process the write request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and encryption overhead"]
+        /// The amount of time it took to process the write request
+        ///
+        /// Note that this includes both any syscall and encryption overhead
         pub processing_duration: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -862,13 +862,13 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamWriteFinFlushed {
-        #[doc = " The number of bytes that the application tried to write"]
+        /// The number of bytes that the application tried to write
         pub provided_len: usize,
-        #[doc = " The amount that was written"]
+        /// The amount that was written
         pub committed_len: usize,
-        #[doc = " The amount of time it took to process the write request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and encryption overhead"]
+        /// The amount of time it took to process the write request
+        ///
+        /// Note that this includes both any syscall and encryption overhead
         pub processing_duration: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -887,13 +887,13 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamWriteBlocked {
-        #[doc = " The number of bytes that the application tried to write"]
+        /// The number of bytes that the application tried to write
         pub provided_len: usize,
-        #[doc = " Indicates that the write was the final offset of the stream"]
+        /// Indicates that the write was the final offset of the stream
         pub is_fin: bool,
-        #[doc = " The amount of time it took to process the write request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and encryption overhead"]
+        /// The amount of time it took to process the write request
+        ///
+        /// Note that this includes both any syscall and encryption overhead
         pub processing_duration: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -912,15 +912,15 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamWriteErrored {
-        #[doc = " The number of bytes that the application tried to write"]
+        /// The number of bytes that the application tried to write
         pub provided_len: usize,
-        #[doc = " Indicates that the write was the final offset of the stream"]
+        /// Indicates that the write was the final offset of the stream
         pub is_fin: bool,
-        #[doc = " The amount of time it took to process the write request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and encryption overhead"]
+        /// The amount of time it took to process the write request
+        ///
+        /// Note that this includes both any syscall and encryption overhead
         pub processing_duration: core::time::Duration,
-        #[doc = " The system `errno` from the returned error"]
+        /// The system `errno` from the returned error
         pub errno: Option<i32>,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -956,7 +956,7 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamWriteAllocated {
-        #[doc = " The number of bytes that we allocated."]
+        /// The number of bytes that we allocated.
         pub allocated_len: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -973,9 +973,9 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamWriteShutdown {
-        #[doc = " The number of bytes in the send buffer at the time of shutdown"]
+        /// The number of bytes in the send buffer at the time of shutdown
         pub buffer_len: usize,
-        #[doc = " If the stream required a background task to drive the stream shutdown"]
+        /// If the stream required a background task to drive the stream shutdown
         pub background: bool,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -993,9 +993,9 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamWriteSocketFlushed {
-        #[doc = " The number of bytes that the stream tried to write to the socket"]
+        /// The number of bytes that the stream tried to write to the socket
         pub provided_len: usize,
-        #[doc = " The amount that was written"]
+        /// The amount that was written
         pub committed_len: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1013,7 +1013,7 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamWriteSocketBlocked {
-        #[doc = " The number of bytes that the stream tried to write to the socket"]
+        /// The number of bytes that the stream tried to write to the socket
         pub provided_len: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1030,9 +1030,9 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamWriteSocketErrored {
-        #[doc = " The number of bytes that the stream tried to write to the socket"]
+        /// The number of bytes that the stream tried to write to the socket
         pub provided_len: usize,
-        #[doc = " The system `errno` from the returned error"]
+        /// The system `errno` from the returned error
         pub errno: Option<i32>,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1050,13 +1050,13 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamReadFlushed {
-        #[doc = " The number of bytes that the application tried to read"]
+        /// The number of bytes that the application tried to read
         pub capacity: usize,
-        #[doc = " The amount that was read into the provided buffer"]
+        /// The amount that was read into the provided buffer
         pub committed_len: usize,
-        #[doc = " The amount of time it took to process the read request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and decryption overhead"]
+        /// The amount of time it took to process the read request
+        ///
+        /// Note that this includes both any syscall and decryption overhead
         pub processing_duration: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1075,11 +1075,11 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamReadFinFlushed {
-        #[doc = " The number of bytes that the application tried to read"]
+        /// The number of bytes that the application tried to read
         pub capacity: usize,
-        #[doc = " The amount of time it took to process the read request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and decryption overhead"]
+        /// The amount of time it took to process the read request
+        ///
+        /// Note that this includes both any syscall and decryption overhead
         pub processing_duration: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1097,11 +1097,11 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamReadBlocked {
-        #[doc = " The number of bytes that the application tried to read"]
+        /// The number of bytes that the application tried to read
         pub capacity: usize,
-        #[doc = " The amount of time it took to process the read request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and decryption overhead"]
+        /// The amount of time it took to process the read request
+        ///
+        /// Note that this includes both any syscall and decryption overhead
         pub processing_duration: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1119,13 +1119,13 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamReadErrored {
-        #[doc = " The number of bytes that the application tried to read"]
+        /// The number of bytes that the application tried to read
         pub capacity: usize,
-        #[doc = " The amount of time it took to process the read request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and decryption overhead"]
+        /// The amount of time it took to process the read request
+        ///
+        /// Note that this includes both any syscall and decryption overhead
         pub processing_duration: core::time::Duration,
-        #[doc = " The system `errno` from the returned error"]
+        /// The system `errno` from the returned error
         pub errno: Option<i32>,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1160,7 +1160,7 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamReadShutdown {
-        #[doc = " If the stream required a background task to drive the stream shutdown"]
+        /// If the stream required a background task to drive the stream shutdown
         pub background: bool,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1177,9 +1177,9 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamReadSocketFlushed {
-        #[doc = " The number of bytes that the stream tried to read from the socket"]
+        /// The number of bytes that the stream tried to read from the socket
         pub capacity: usize,
-        #[doc = " The amount that was read into the provided buffer"]
+        /// The amount that was read into the provided buffer
         pub committed_len: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1197,7 +1197,7 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamReadSocketBlocked {
-        #[doc = " The number of bytes that the stream tried to read from the socket"]
+        /// The number of bytes that the stream tried to read from the socket
         pub capacity: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1214,9 +1214,9 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamReadSocketErrored {
-        #[doc = " The number of bytes that the stream tried to read from the socket"]
+        /// The number of bytes that the stream tried to read from the socket
         pub capacity: usize,
-        #[doc = " The system `errno` from the returned error"]
+        /// The system `errno` from the returned error
         pub errno: Option<i32>,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1234,16 +1234,16 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamDecryptPacket {
-        #[doc = " Did we decrypt the packet in place, or were we able to merge the copy and decrypt?"]
+        /// Did we decrypt the packet in place, or were we able to merge the copy and decrypt?
         pub decrypted_in_place: bool,
-        #[doc = " The number of bytes we were forced to copy after decrypting in the packet buffer."]
-        #[doc = ""]
-        #[doc = " This means that the application buffer was insufficiently large to allow us to directly"]
-        #[doc = " copy as part of the decrypt. This can be non-zero even with decrypted_in_place=false, if we"]
-        #[doc = " decrypted into the reassembly buffer. Right now it doesn't take into account zero-copy"]
-        #[doc = " reads from the reassembly buffer (e.g., with specialized Bytes)."]
+        /// The number of bytes we were forced to copy after decrypting in the packet buffer.
+        ///
+        /// This means that the application buffer was insufficiently large to allow us to directly
+        /// copy as part of the decrypt. This can be non-zero even with decrypted_in_place=false, if we
+        /// decrypted into the reassembly buffer. Right now it doesn't take into account zero-copy
+        /// reads from the reassembly buffer (e.g., with specialized Bytes).
         pub forced_copy: usize,
-        #[doc = " The application buffer size that would avoid copies."]
+        /// The application buffer size that would avoid copies.
         pub required_application_buffer: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1264,7 +1264,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Tracks stream connect where dcQUIC owns the TCP connect()."]
+    /// Tracks stream connect where dcQUIC owns the TCP connect().
     pub struct StreamTcpConnect {
         pub error: bool,
         pub latency: core::time::Duration,
@@ -1283,7 +1283,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Tracks TLS stream establishment."]
+    /// Tracks TLS stream establishment.
     pub struct StreamTlsConnect {
         pub error: bool,
         pub tcp_latency: core::time::Duration,
@@ -1304,7 +1304,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Tracks stream connect where dcQUIC owns the TCP connect()."]
+    /// Tracks stream connect where dcQUIC owns the TCP connect().
     pub struct StreamConnect {
         pub error: bool,
         pub tcp_success: MaybeBoolCounter,
@@ -1325,9 +1325,9 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Tracks stream connect errors."]
-    #[doc = ""]
-    #[doc = " Currently only emitted in cases where dcQUIC owns the TCP connect too."]
+    /// Tracks stream connect errors.
+    ///
+    /// Currently only emitted in cases where dcQUIC owns the TCP connect too.
     pub struct StreamConnectError {
         pub reason: StreamTcpConnectErrorReason,
         pub latency: core::time::Duration,
@@ -1347,15 +1347,15 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamPacketTransmitted {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The size of the application data in the packet"]
+        /// The size of the application data in the packet
         pub payload_len: usize,
-        #[doc = " The packet number of the transmitted packet"]
+        /// The packet number of the transmitted packet
         pub packet_number: u64,
-        #[doc = " The offset in the stream of the first byte in the packet"]
+        /// The offset in the stream of the first byte in the packet
         pub stream_offset: u64,
-        #[doc = " Whether the packet contained the final bytes of the stream"]
+        /// Whether the packet contained the final bytes of the stream
         pub is_fin: bool,
         pub is_retransmission: bool,
     }
@@ -1378,9 +1378,9 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamProbeTransmitted {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The packet number of the transmitted packet"]
+        /// The packet number of the transmitted packet
         pub packet_number: u64,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1398,15 +1398,15 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamPacketReceived {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The size of the application data in the packet"]
+        /// The size of the application data in the packet
         pub payload_len: usize,
-        #[doc = " The packet number of the received packet"]
+        /// The packet number of the received packet
         pub packet_number: u64,
-        #[doc = " The offset in the stream of the first byte in the packet"]
+        /// The offset in the stream of the first byte in the packet
         pub stream_offset: u64,
-        #[doc = " Whether the packet contained the final bytes of the stream"]
+        /// Whether the packet contained the final bytes of the stream
         pub is_fin: bool,
         pub is_retransmission: bool,
     }
@@ -1428,19 +1428,19 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Indicates that a packet was lost on a stream"]
+    /// Indicates that a packet was lost on a stream
     pub struct StreamPacketLost {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The size of the application data in the packet"]
+        /// The size of the application data in the packet
         pub payload_len: usize,
-        #[doc = " The packet number of the lost packet"]
+        /// The packet number of the lost packet
         pub packet_number: u64,
-        #[doc = " The offset in the stream of the first byte in the packet"]
+        /// The offset in the stream of the first byte in the packet
         pub stream_offset: u64,
-        #[doc = " The time the packet was originally sent"]
+        /// The time the packet was originally sent
         pub time_sent: Timestamp,
-        #[doc = " The amount of time between when the packet was sent and when it was detected as lost"]
+        /// The amount of time between when the packet was sent and when it was detected as lost
         pub lifetime: core::time::Duration,
         pub is_retransmission: bool,
     }
@@ -1463,19 +1463,19 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Indicates that a packet was acknowledged on a stream"]
+    /// Indicates that a packet was acknowledged on a stream
     pub struct StreamPacketAcked {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The size of the application data in the packet"]
+        /// The size of the application data in the packet
         pub payload_len: usize,
-        #[doc = " The packet number of the acknowledged packet"]
+        /// The packet number of the acknowledged packet
         pub packet_number: u64,
-        #[doc = " The offset in the stream of the first byte in the packet"]
+        /// The offset in the stream of the first byte in the packet
         pub stream_offset: u64,
-        #[doc = " The time the packet was originally sent"]
+        /// The time the packet was originally sent
         pub time_sent: Timestamp,
-        #[doc = " The amount of time between when the packet was sent and when it was detected as lost"]
+        /// The amount of time between when the packet was sent and when it was detected as lost
         pub lifetime: core::time::Duration,
         pub is_retransmission: bool,
     }
@@ -1498,17 +1498,17 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Indicates that a packet was retransmitted on a stream but was not actually lost"]
+    /// Indicates that a packet was retransmitted on a stream but was not actually lost
     pub struct StreamPacketSpuriouslyRetransmitted {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The size of the application data in the packet"]
+        /// The size of the application data in the packet
         pub payload_len: usize,
-        #[doc = " The packet number of the packet"]
+        /// The packet number of the packet
         pub packet_number: u64,
-        #[doc = " The offset in the stream of the first byte in the packet"]
+        /// The offset in the stream of the first byte in the packet
         pub stream_offset: u64,
-        #[doc = " Whether the packet contained the final bytes of the stream"]
+        /// Whether the packet contained the final bytes of the stream
         pub is_fin: bool,
         pub is_retransmission: bool,
     }
@@ -1530,11 +1530,11 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Indicates that the stream received additional flow control credits"]
+    /// Indicates that the stream received additional flow control credits
     pub struct StreamMaxDataReceived {
-        #[doc = " The number of bytes of flow control credits received"]
+        /// The number of bytes of flow control credits received
         pub increase: u64,
-        #[doc = " The new offset of the stream"]
+        /// The new offset of the stream
         pub new_max_data: u64,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1552,11 +1552,11 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamControlPacketTransmitted {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The size of the control data in the packet"]
+        /// The size of the control data in the packet
         pub control_data_len: usize,
-        #[doc = " The packet number of the received control packet"]
+        /// The packet number of the received control packet
         pub packet_number: u64,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1575,13 +1575,13 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct StreamControlPacketReceived {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The size of the control data in the packet"]
+        /// The size of the control data in the packet
         pub control_data_len: usize,
-        #[doc = " The packet number of the received control packet"]
+        /// The packet number of the received control packet
         pub packet_number: u64,
-        #[doc = " Whether the packet was successfully authenticated"]
+        /// Whether the packet was successfully authenticated
         pub is_authenticated: bool,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1602,7 +1602,7 @@ pub mod api {
     #[non_exhaustive]
     pub struct StreamReceiverErrored {
         pub error: crate::stream::recv::Error,
-        #[doc = " The location where the error originated"]
+        /// The location where the error originated
         pub source: s2n_quic_core::endpoint::Location,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1621,7 +1621,7 @@ pub mod api {
     #[non_exhaustive]
     pub struct StreamSenderErrored {
         pub error: crate::stream::send::Error,
-        #[doc = " The location where the error originated"]
+        /// The location where the error originated
         pub source: s2n_quic_core::endpoint::Location,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1638,7 +1638,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a handshake packet is rejected due to an invalid field value"]
+    /// Emitted when a handshake packet is rejected due to an invalid field value
     pub struct StreamHandshakePacketRejected {
         pub reason: StreamHandshakePacketRejectedReason,
     }
@@ -1668,8 +1668,8 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Used for cases where we are racing multiple futures and exit if any of them fail, and so"]
-    #[doc = " recording success is not just a boolean value."]
+    /// Used for cases where we are racing multiple futures and exit if any of them fail, and so
+    /// recording success is not just a boolean value.
     pub enum MaybeBoolCounter {
         #[non_exhaustive]
         Success {},
@@ -1707,30 +1707,30 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Note that there's no guarantee of a particular reason if multiple reasons ~simultaneously"]
-    #[doc = " terminate the connection."]
+    /// Note that there's no guarantee of a particular reason if multiple reasons ~simultaneously
+    /// terminate the connection.
     pub enum StreamTcpConnectErrorReason {
         #[non_exhaustive]
-        #[doc = " TCP connect failed."]
+        /// TCP connect failed.
         TcpConnect {},
         #[non_exhaustive]
-        #[doc = " Handshake failed to produce credentials."]
+        /// Handshake failed to produce credentials.
         Handshake {},
         #[non_exhaustive]
-        #[doc = " When the connect future is dropped prior to returning any result."]
-        #[doc = ""]
-        #[doc = " This means the TCP connect succeeded, but the handshake hasn't yet by the time the connect"]
-        #[doc = " future was dropped."]
+        /// When the connect future is dropped prior to returning any result.
+        ///
+        /// This means the TCP connect succeeded, but the handshake hasn't yet by the time the connect
+        /// future was dropped.
         AbortedPendingHandshake {},
         #[non_exhaustive]
-        #[doc = " When the connect future is dropped prior to returning any result."]
-        #[doc = ""]
-        #[doc = " The handshake succeeded (or wasn't needed), but the TCP connect hasn't yet finished."]
+        /// When the connect future is dropped prior to returning any result.
+        ///
+        /// The handshake succeeded (or wasn't needed), but the TCP connect hasn't yet finished.
         AbortedPendingConnect {},
         #[non_exhaustive]
-        #[doc = " When the connect future is dropped prior to returning any result."]
-        #[doc = ""]
-        #[doc = " Neither the TCP connect or handshake have finished yet."]
+        /// When the connect future is dropped prior to returning any result.
+        ///
+        /// Neither the TCP connect or handshake have finished yet.
         AbortedPendingBoth {},
     }
     impl aggregate::AsVariant for StreamTcpConnectErrorReason {
@@ -1776,7 +1776,7 @@ pub mod api {
     #[non_exhaustive]
     pub enum StreamHandshakePacketRejectedReason {
         #[non_exhaustive]
-        #[doc = " The queue_id exceeds the maximum encodable value"]
+        /// The queue_id exceeds the maximum encodable value
         InvalidQueueId {},
     }
     impl aggregate::AsVariant for StreamHandshakePacketRejectedReason {
@@ -1817,7 +1817,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the DC handshake confirmation or MTU probing times out"]
+    /// Emitted when the DC handshake confirmation or MTU probing times out
     pub struct DcConnectionTimeout<'a> {
         pub peer_address: SocketAddress<'a>,
     }
@@ -1835,7 +1835,7 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct PathSecretMapInitialized {
-        #[doc = " The capacity of the path secret map"]
+        /// The capacity of the path secret map
         pub capacity: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1852,9 +1852,9 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct PathSecretMapUninitialized {
-        #[doc = " The capacity of the path secret map"]
+        /// The capacity of the path secret map
         pub capacity: usize,
-        #[doc = " The number of entries in the map"]
+        /// The number of entries in the map
         pub entries: usize,
         pub lifetime: core::time::Duration,
     }
@@ -1873,7 +1873,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a background handshake is requested"]
+    /// Emitted when a background handshake is requested
     pub struct PathSecretMapBackgroundHandshakeRequested<'a> {
         pub peer_address: SocketAddress<'a>,
     }
@@ -1890,7 +1890,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the entry is inserted into the path secret map"]
+    /// Emitted when the entry is inserted into the path secret map
     pub struct PathSecretMapEntryInserted<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -1909,7 +1909,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the entry is considered ready for use"]
+    /// Emitted when the entry is considered ready for use
     pub struct PathSecretMapEntryReady<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -1928,7 +1928,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an entry is replaced by a new one for the same `peer_address`"]
+    /// Emitted when an entry is replaced by a new one for the same `peer_address`
     pub struct PathSecretMapEntryReplaced<'a> {
         pub peer_address: SocketAddress<'a>,
         pub new_credential_id: &'a [u8],
@@ -1949,11 +1949,11 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an entry is evicted due to running out of space"]
+    /// Emitted when an entry is evicted due to running out of space
     pub struct PathSecretMapIdEntryEvicted<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
-        #[doc = " Time since insertion of this entry"]
+        /// Time since insertion of this entry
         pub age: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1971,11 +1971,11 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an entry is evicted due to running out of space"]
+    /// Emitted when an entry is evicted due to running out of space
     pub struct PathSecretMapAddressEntryEvicted<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
-        #[doc = " Time since insertion of this entry"]
+        /// Time since insertion of this entry
         pub age: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -1993,7 +1993,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an UnknownPathSecret packet was sent"]
+    /// Emitted when an UnknownPathSecret packet was sent
     pub struct UnknownPathSecretPacketSent<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -2012,7 +2012,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an UnknownPathSecret packet was received"]
+    /// Emitted when an UnknownPathSecret packet was received
     pub struct UnknownPathSecretPacketReceived<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -2031,7 +2031,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an UnknownPathSecret packet was authentic and processed"]
+    /// Emitted when an UnknownPathSecret packet was authentic and processed
     pub struct UnknownPathSecretPacketAccepted<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -2050,7 +2050,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an UnknownPathSecret packet was rejected as invalid"]
+    /// Emitted when an UnknownPathSecret packet was rejected as invalid
     pub struct UnknownPathSecretPacketRejected<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -2069,7 +2069,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an UnknownPathSecret packet was dropped due to a missing entry"]
+    /// Emitted when an UnknownPathSecret packet was dropped due to a missing entry
     pub struct UnknownPathSecretPacketDropped<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -2088,18 +2088,18 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a credential is accepted (i.e., post packet authentication and passes replay"]
-    #[doc = " check)."]
+    /// Emitted when a credential is accepted (i.e., post packet authentication and passes replay
+    /// check).
     pub struct KeyAccepted<'a> {
         pub credential_id: &'a [u8],
         pub key_id: u64,
-        #[doc = " How far away this credential is from the leading edge of key IDs (after updating the edge)."]
-        #[doc = ""]
-        #[doc = " Zero if this shifted us forward."]
+        /// How far away this credential is from the leading edge of key IDs (after updating the edge).
+        ///
+        /// Zero if this shifted us forward.
         pub gap: u64,
-        #[doc = " How far away this credential is from the leading edge of key IDs (before updating the edge)."]
-        #[doc = ""]
-        #[doc = " Zero if this didn't change the leading edge."]
+        /// How far away this credential is from the leading edge of key IDs (before updating the edge).
+        ///
+        /// Zero if this didn't change the leading edge.
         pub forward_shift: u64,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -2118,7 +2118,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when credential replay was definitely detected"]
+    /// Emitted when credential replay was definitely detected
     pub struct ReplayDefinitelyDetected<'a> {
         pub credential_id: &'a [u8],
         pub key_id: u64,
@@ -2137,8 +2137,8 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when credential replay was potentially detected, but could not be verified"]
-    #[doc = " due to a limiting tracking window"]
+    /// Emitted when credential replay was potentially detected, but could not be verified
+    /// due to a limiting tracking window
     pub struct ReplayPotentiallyDetected<'a> {
         pub credential_id: &'a [u8],
         pub key_id: u64,
@@ -2159,7 +2159,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an ReplayDetected packet was sent"]
+    /// Emitted when an ReplayDetected packet was sent
     pub struct ReplayDetectedPacketSent<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -2178,7 +2178,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an ReplayDetected packet was received"]
+    /// Emitted when an ReplayDetected packet was received
     pub struct ReplayDetectedPacketReceived<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -2197,7 +2197,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an StaleKey packet was authentic and processed"]
+    /// Emitted when an StaleKey packet was authentic and processed
     pub struct ReplayDetectedPacketAccepted<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -2218,7 +2218,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an ReplayDetected packet was rejected as invalid"]
+    /// Emitted when an ReplayDetected packet was rejected as invalid
     pub struct ReplayDetectedPacketRejected<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -2237,7 +2237,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an ReplayDetected packet was dropped due to a missing entry"]
+    /// Emitted when an ReplayDetected packet was dropped due to a missing entry
     pub struct ReplayDetectedPacketDropped<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -2256,7 +2256,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an StaleKey packet was sent"]
+    /// Emitted when an StaleKey packet was sent
     pub struct StaleKeyPacketSent<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -2275,7 +2275,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an StaleKey packet was received"]
+    /// Emitted when an StaleKey packet was received
     pub struct StaleKeyPacketReceived<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -2294,7 +2294,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an StaleKey packet was authentic and processed"]
+    /// Emitted when an StaleKey packet was authentic and processed
     pub struct StaleKeyPacketAccepted<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -2313,7 +2313,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an StaleKey packet was rejected as invalid"]
+    /// Emitted when an StaleKey packet was rejected as invalid
     pub struct StaleKeyPacketRejected<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -2332,7 +2332,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when an StaleKey packet was dropped due to a missing entry"]
+    /// Emitted when an StaleKey packet was dropped due to a missing entry
     pub struct StaleKeyPacketDropped<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -2351,9 +2351,9 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the cache is accessed by peer address"]
-    #[doc = ""]
-    #[doc = " This can be used to track cache hit ratios"]
+    /// Emitted when the cache is accessed by peer address
+    ///
+    /// This can be used to track cache hit ratios
     pub struct PathSecretMapAddressCacheAccessed<'a> {
         pub peer_address: SocketAddress<'a>,
         pub hit: bool,
@@ -2372,9 +2372,9 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the cache is accessed by peer address successfully"]
-    #[doc = ""]
-    #[doc = " Provides more information about the accessed entry."]
+    /// Emitted when the cache is accessed by peer address successfully
+    ///
+    /// Provides more information about the accessed entry.
     pub struct PathSecretMapAddressCacheAccessedHit<'a> {
         pub peer_address: SocketAddress<'a>,
         pub age: core::time::Duration,
@@ -2393,9 +2393,9 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the cache is accessed by path secret ID"]
-    #[doc = ""]
-    #[doc = " This can be used to track cache hit ratios"]
+    /// Emitted when the cache is accessed by path secret ID
+    ///
+    /// This can be used to track cache hit ratios
     pub struct PathSecretMapIdCacheAccessed<'a> {
         pub credential_id: &'a [u8],
         pub hit: bool,
@@ -2414,9 +2414,9 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the cache is accessed by path secret ID successfully"]
-    #[doc = ""]
-    #[doc = " Provides more information about the accessed entry."]
+    /// Emitted when the cache is accessed by path secret ID successfully
+    ///
+    /// Provides more information about the accessed entry.
     pub struct PathSecretMapIdCacheAccessedHit<'a> {
         pub credential_id: &'a [u8],
         pub age: core::time::Duration,
@@ -2435,43 +2435,43 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the cleaner task performed a single cycle"]
-    #[doc = ""]
-    #[doc = " This can be used to track cache utilization"]
+    /// Emitted when the cleaner task performed a single cycle
+    ///
+    /// This can be used to track cache utilization
     pub struct PathSecretMapCleanerCycled {
-        #[doc = " The number of Path Secret ID entries left after the cleaning cycle"]
+        /// The number of Path Secret ID entries left after the cleaning cycle
         pub id_entries: usize,
-        #[doc = " The number of Path Secret ID entries that were retired in the cycle"]
+        /// The number of Path Secret ID entries that were retired in the cycle
         pub id_entries_retired: usize,
-        #[doc = " Count of entries accessed since the last cycle"]
+        /// Count of entries accessed since the last cycle
         pub id_entries_active: usize,
-        #[doc = " The utilization percentage of the active number of entries after the cycle"]
+        /// The utilization percentage of the active number of entries after the cycle
         pub id_entries_active_utilization: f32,
-        #[doc = " The utilization percentage of the available number of entries after the cycle"]
+        /// The utilization percentage of the available number of entries after the cycle
         pub id_entries_utilization: f32,
-        #[doc = " The utilization percentage of the available number of entries before the cycle"]
+        /// The utilization percentage of the available number of entries before the cycle
         pub id_entries_initial_utilization: f32,
-        #[doc = " The number of SocketAddress entries left after the cleaning cycle"]
+        /// The number of SocketAddress entries left after the cleaning cycle
         pub address_entries: usize,
-        #[doc = " Count of entries accessed since the last cycle"]
+        /// Count of entries accessed since the last cycle
         pub address_entries_active: usize,
-        #[doc = " The utilization percentage of the active number of entries after the cycle"]
+        /// The utilization percentage of the active number of entries after the cycle
         pub address_entries_active_utilization: f32,
-        #[doc = " The number of SocketAddress entries that were retired in the cycle"]
+        /// The number of SocketAddress entries that were retired in the cycle
         pub address_entries_retired: usize,
-        #[doc = " The utilization percentage of the available number of address entries after the cycle"]
+        /// The utilization percentage of the available number of address entries after the cycle
         pub address_entries_utilization: f32,
-        #[doc = " The utilization percentage of the available number of address entries before the cycle"]
+        /// The utilization percentage of the available number of address entries before the cycle
         pub address_entries_initial_utilization: f32,
-        #[doc = " The number of handshake requests that are pending after the cleaning cycle"]
+        /// The number of handshake requests that are pending after the cleaning cycle
         pub handshake_requests: usize,
-        #[doc = " The number of handshake requests that were skipped in the cycle due to running out of time"]
-        #[doc = " (other background handshakes took too long to complete, and so were postponed to the next"]
-        #[doc = " cleaner cycle)."]
+        /// The number of handshake requests that were skipped in the cycle due to running out of time
+        /// (other background handshakes took too long to complete, and so were postponed to the next
+        /// cleaner cycle).
         pub handshake_requests_skipped: usize,
-        #[doc = " How long we kept the handshake lock held (this blocks completing handshakes)."]
+        /// How long we kept the handshake lock held (this blocks completing handshakes).
         pub handshake_lock_duration: core::time::Duration,
-        #[doc = " Total duration of a cycle."]
+        /// Total duration of a cycle.
         pub duration: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -2556,9 +2556,9 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a dcQUIC datagram is encrypted"]
+    /// Emitted when a dcQUIC datagram is encrypted
     pub struct PathSecretMapDatagramEncrypt {
-        #[doc = " The wire size of the encrypted datagram packet"]
+        /// The wire size of the encrypted datagram packet
         pub packet_len: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -2574,9 +2574,9 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a dcQUIC datagram is decrypted"]
+    /// Emitted when a dcQUIC datagram is decrypted
     pub struct PathSecretMapDatagramDecrypt {
-        #[doc = " The wire size of the encrypted datagram packet"]
+        /// The wire size of the encrypted datagram packet
         pub packet_len: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -2604,16 +2604,18 @@ pub mod api {
     }
 }
 pub mod tracing {
-    #![doc = r" This module contains event integration with [`tracing`](https://docs.rs/tracing)"]
+    //! This module contains event integration with [`tracing`](https://docs.rs/tracing)
     use super::api;
-    #[doc = r" Emits events with [`tracing`](https://docs.rs/tracing)"]
+    /// Emits events with [`tracing`](https://docs.rs/tracing)
     #[derive(Clone, Debug)]
     pub struct Subscriber {
         root: tracing::Span,
     }
     impl Default for Subscriber {
         fn default() -> Self {
-            let root = tracing :: span ! (target : "s2n_quic_dc" , tracing :: Level :: DEBUG , "s2n_quic_dc");
+            let root = tracing::span!(
+                target : "s2n_quic_dc", tracing::Level::DEBUG, "s2n_quic_dc"
+            );
             Self { root }
         }
     }
@@ -2630,7 +2632,10 @@ pub mod tracing {
             _info: &api::ConnectionInfo,
         ) -> Self::ConnectionContext {
             let parent = self.parent(meta);
-            tracing :: span ! (target : "s2n_quic_dc" , parent : parent , tracing :: Level :: DEBUG , "conn" , id = meta . id)
+            tracing::span!(
+                target : "s2n_quic_dc", parent : parent, tracing::Level::DEBUG, "conn",
+                id = meta.id
+            )
         }
         #[inline]
         fn on_acceptor_tcp_started(
@@ -2644,7 +2649,12 @@ pub mod tracing {
                 local_address,
                 backlog,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_started" , parent : parent , tracing :: Level :: DEBUG , { id = tracing :: field :: debug (id) , local_address = tracing :: field :: debug (local_address) , backlog = tracing :: field :: debug (backlog) });
+            tracing::event!(
+                target : "acceptor_tcp_started", parent : parent, tracing::Level::DEBUG,
+                { id = tracing::field::debug(id), local_address =
+                tracing::field::debug(local_address), backlog =
+                tracing::field::debug(backlog) }
+            );
         }
         #[inline]
         fn on_acceptor_tcp_loop_iteration_completed(
@@ -2660,7 +2670,15 @@ pub mod tracing {
                 processing_duration,
                 max_sojourn_time,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_loop_iteration_completed" , parent : parent , tracing :: Level :: DEBUG , { pending_streams = tracing :: field :: debug (pending_streams) , slots_idle = tracing :: field :: debug (slots_idle) , slot_utilization = tracing :: field :: debug (slot_utilization) , processing_duration = tracing :: field :: debug (processing_duration) , max_sojourn_time = tracing :: field :: debug (max_sojourn_time) });
+            tracing::event!(
+                target : "acceptor_tcp_loop_iteration_completed", parent : parent,
+                tracing::Level::DEBUG, { pending_streams =
+                tracing::field::debug(pending_streams), slots_idle =
+                tracing::field::debug(slots_idle), slot_utilization =
+                tracing::field::debug(slot_utilization), processing_duration =
+                tracing::field::debug(processing_duration), max_sojourn_time =
+                tracing::field::debug(max_sojourn_time) }
+            );
         }
         #[inline]
         fn on_acceptor_tcp_fresh_enqueued(
@@ -2670,7 +2688,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::AcceptorTcpFreshEnqueued { remote_address } = event;
-            tracing :: event ! (target : "acceptor_tcp_fresh_enqueued" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) });
+            tracing::event!(
+                target : "acceptor_tcp_fresh_enqueued", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address) }
+            );
         }
         #[inline]
         fn on_acceptor_tcp_fresh_batch_completed(
@@ -2684,7 +2706,12 @@ pub mod tracing {
                 dropped,
                 errored,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_fresh_batch_completed" , parent : parent , tracing :: Level :: DEBUG , { enqueued = tracing :: field :: debug (enqueued) , dropped = tracing :: field :: debug (dropped) , errored = tracing :: field :: debug (errored) });
+            tracing::event!(
+                target : "acceptor_tcp_fresh_batch_completed", parent : parent,
+                tracing::Level::DEBUG, { enqueued = tracing::field::debug(enqueued),
+                dropped = tracing::field::debug(dropped), errored =
+                tracing::field::debug(errored) }
+            );
         }
         #[inline]
         fn on_acceptor_tcp_stream_dropped(
@@ -2697,7 +2724,12 @@ pub mod tracing {
                 remote_address,
                 reason,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_stream_dropped" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , reason = tracing :: field :: debug (reason) });
+            tracing::event!(
+                target : "acceptor_tcp_stream_dropped", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), reason =
+                tracing::field::debug(reason) }
+            );
         }
         #[inline]
         fn on_acceptor_tcp_stream_replaced(
@@ -2711,7 +2743,13 @@ pub mod tracing {
                 sojourn_time,
                 buffer_len,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_stream_replaced" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , sojourn_time = tracing :: field :: debug (sojourn_time) , buffer_len = tracing :: field :: debug (buffer_len) });
+            tracing::event!(
+                target : "acceptor_tcp_stream_replaced", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), sojourn_time =
+                tracing::field::debug(sojourn_time), buffer_len =
+                tracing::field::debug(buffer_len) }
+            );
         }
         #[inline]
         fn on_acceptor_tcp_packet_received(
@@ -2729,7 +2767,17 @@ pub mod tracing {
                 is_fin_known,
                 sojourn_time,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_packet_received" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , payload_len = tracing :: field :: debug (payload_len) , is_fin = tracing :: field :: debug (is_fin) , is_fin_known = tracing :: field :: debug (is_fin_known) , sojourn_time = tracing :: field :: debug (sojourn_time) });
+            tracing::event!(
+                target : "acceptor_tcp_packet_received", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), credential_id =
+                tracing::field::debug(credential_id), stream_id =
+                tracing::field::debug(stream_id), payload_len =
+                tracing::field::debug(payload_len), is_fin =
+                tracing::field::debug(is_fin), is_fin_known =
+                tracing::field::debug(is_fin_known), sojourn_time =
+                tracing::field::debug(sojourn_time) }
+            );
         }
         #[inline]
         fn on_acceptor_tcp_tls_started(
@@ -2742,7 +2790,12 @@ pub mod tracing {
                 remote_address,
                 sojourn_time,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_tls_started" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , sojourn_time = tracing :: field :: debug (sojourn_time) });
+            tracing::event!(
+                target : "acceptor_tcp_tls_started", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), sojourn_time =
+                tracing::field::debug(sojourn_time) }
+            );
         }
         #[inline]
         fn on_acceptor_tcp_tls_stream_enqueued(
@@ -2755,7 +2808,12 @@ pub mod tracing {
                 remote_address,
                 sojourn_time,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_tls_stream_enqueued" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , sojourn_time = tracing :: field :: debug (sojourn_time) });
+            tracing::event!(
+                target : "acceptor_tcp_tls_stream_enqueued", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), sojourn_time =
+                tracing::field::debug(sojourn_time) }
+            );
         }
         #[inline]
         fn on_acceptor_tcp_tls_stream_rejected(
@@ -2769,7 +2827,13 @@ pub mod tracing {
                 sojourn_time,
                 error,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_tls_stream_rejected" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , sojourn_time = tracing :: field :: debug (sojourn_time) , error = tracing :: field :: debug (error) });
+            tracing::event!(
+                target : "acceptor_tcp_tls_stream_rejected", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), sojourn_time =
+                tracing::field::debug(sojourn_time), error = tracing::field::debug(error)
+                }
+            );
         }
         #[inline]
         fn on_acceptor_tcp_packet_dropped(
@@ -2783,7 +2847,13 @@ pub mod tracing {
                 reason,
                 sojourn_time,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , reason = tracing :: field :: debug (reason) , sojourn_time = tracing :: field :: debug (sojourn_time) });
+            tracing::event!(
+                target : "acceptor_tcp_packet_dropped", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), reason =
+                tracing::field::debug(reason), sojourn_time =
+                tracing::field::debug(sojourn_time) }
+            );
         }
         #[inline]
         fn on_acceptor_tcp_stream_enqueued(
@@ -2799,7 +2869,15 @@ pub mod tracing {
                 sojourn_time,
                 blocked_count,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_stream_enqueued" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , sojourn_time = tracing :: field :: debug (sojourn_time) , blocked_count = tracing :: field :: debug (blocked_count) });
+            tracing::event!(
+                target : "acceptor_tcp_stream_enqueued", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), credential_id =
+                tracing::field::debug(credential_id), stream_id =
+                tracing::field::debug(stream_id), sojourn_time =
+                tracing::field::debug(sojourn_time), blocked_count =
+                tracing::field::debug(blocked_count) }
+            );
         }
         #[inline]
         fn on_acceptor_tcp_io_error(
@@ -2809,7 +2887,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::AcceptorTcpIoError { error, source } = event;
-            tracing :: event ! (target : "acceptor_tcp_io_error" , parent : parent , tracing :: Level :: DEBUG , { error = tracing :: field :: debug (error) , source = tracing :: field :: debug (source) });
+            tracing::event!(
+                target : "acceptor_tcp_io_error", parent : parent, tracing::Level::DEBUG,
+                { error = tracing::field::debug(error), source =
+                tracing::field::debug(source) }
+            );
         }
         #[inline]
         fn on_acceptor_tcp_socket_sent(
@@ -2825,7 +2907,15 @@ pub mod tracing {
                 blocked_count,
                 payload_len,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_socket_sent" , parent : parent , tracing :: Level :: DEBUG , { credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , sojourn_time = tracing :: field :: debug (sojourn_time) , blocked_count = tracing :: field :: debug (blocked_count) , payload_len = tracing :: field :: debug (payload_len) });
+            tracing::event!(
+                target : "acceptor_tcp_socket_sent", parent : parent,
+                tracing::Level::DEBUG, { credential_id =
+                tracing::field::debug(credential_id), stream_id =
+                tracing::field::debug(stream_id), sojourn_time =
+                tracing::field::debug(sojourn_time), blocked_count =
+                tracing::field::debug(blocked_count), payload_len =
+                tracing::field::debug(payload_len) }
+            );
         }
         #[inline]
         fn on_acceptor_tcp_socket_received(
@@ -2841,7 +2931,15 @@ pub mod tracing {
                 transfer_time,
                 payload_len,
             } = event;
-            tracing :: event ! (target : "acceptor_tcp_socket_received" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , transfer_time = tracing :: field :: debug (transfer_time) , payload_len = tracing :: field :: debug (payload_len) });
+            tracing::event!(
+                target : "acceptor_tcp_socket_received", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), credential_id =
+                tracing::field::debug(credential_id), stream_id =
+                tracing::field::debug(stream_id), transfer_time =
+                tracing::field::debug(transfer_time), payload_len =
+                tracing::field::debug(payload_len) }
+            );
         }
         #[inline]
         fn on_acceptor_udp_started(
@@ -2851,7 +2949,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::AcceptorUdpStarted { id, local_address } = event;
-            tracing :: event ! (target : "acceptor_udp_started" , parent : parent , tracing :: Level :: DEBUG , { id = tracing :: field :: debug (id) , local_address = tracing :: field :: debug (local_address) });
+            tracing::event!(
+                target : "acceptor_udp_started", parent : parent, tracing::Level::DEBUG,
+                { id = tracing::field::debug(id), local_address =
+                tracing::field::debug(local_address) }
+            );
         }
         #[inline]
         fn on_acceptor_udp_datagram_received(
@@ -2864,7 +2966,11 @@ pub mod tracing {
                 remote_address,
                 len,
             } = event;
-            tracing :: event ! (target : "acceptor_udp_datagram_received" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , len = tracing :: field :: debug (len) });
+            tracing::event!(
+                target : "acceptor_udp_datagram_received", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), len = tracing::field::debug(len) }
+            );
         }
         #[inline]
         fn on_acceptor_udp_packet_received(
@@ -2883,7 +2989,18 @@ pub mod tracing {
                 is_fin,
                 is_fin_known,
             } = event;
-            tracing :: event ! (target : "acceptor_udp_packet_received" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , payload_len = tracing :: field :: debug (payload_len) , is_zero_offset = tracing :: field :: debug (is_zero_offset) , is_retransmission = tracing :: field :: debug (is_retransmission) , is_fin = tracing :: field :: debug (is_fin) , is_fin_known = tracing :: field :: debug (is_fin_known) });
+            tracing::event!(
+                target : "acceptor_udp_packet_received", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), credential_id =
+                tracing::field::debug(credential_id), stream_id =
+                tracing::field::debug(stream_id), payload_len =
+                tracing::field::debug(payload_len), is_zero_offset =
+                tracing::field::debug(is_zero_offset), is_retransmission =
+                tracing::field::debug(is_retransmission), is_fin =
+                tracing::field::debug(is_fin), is_fin_known =
+                tracing::field::debug(is_fin_known) }
+            );
         }
         #[inline]
         fn on_acceptor_udp_packet_dropped(
@@ -2896,7 +3013,12 @@ pub mod tracing {
                 remote_address,
                 reason,
             } = event;
-            tracing :: event ! (target : "acceptor_udp_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , reason = tracing :: field :: debug (reason) });
+            tracing::event!(
+                target : "acceptor_udp_packet_dropped", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), reason =
+                tracing::field::debug(reason) }
+            );
         }
         #[inline]
         fn on_acceptor_udp_stream_enqueued(
@@ -2910,7 +3032,13 @@ pub mod tracing {
                 credential_id,
                 stream_id,
             } = event;
-            tracing :: event ! (target : "acceptor_udp_stream_enqueued" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) });
+            tracing::event!(
+                target : "acceptor_udp_stream_enqueued", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), credential_id =
+                tracing::field::debug(credential_id), stream_id =
+                tracing::field::debug(stream_id) }
+            );
         }
         #[inline]
         fn on_acceptor_udp_io_error(
@@ -2920,7 +3048,10 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::AcceptorUdpIoError { error } = event;
-            tracing :: event ! (target : "acceptor_udp_io_error" , parent : parent , tracing :: Level :: DEBUG , { error = tracing :: field :: debug (error) });
+            tracing::event!(
+                target : "acceptor_udp_io_error", parent : parent, tracing::Level::DEBUG,
+                { error = tracing::field::debug(error) }
+            );
         }
         #[inline]
         fn on_acceptor_stream_pruned(
@@ -2936,7 +3067,15 @@ pub mod tracing {
                 sojourn_time,
                 reason,
             } = event;
-            tracing :: event ! (target : "acceptor_stream_pruned" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , sojourn_time = tracing :: field :: debug (sojourn_time) , reason = tracing :: field :: debug (reason) });
+            tracing::event!(
+                target : "acceptor_stream_pruned", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), credential_id =
+                tracing::field::debug(credential_id), stream_id =
+                tracing::field::debug(stream_id), sojourn_time =
+                tracing::field::debug(sojourn_time), reason =
+                tracing::field::debug(reason) }
+            );
         }
         #[inline]
         fn on_acceptor_stream_dequeued(
@@ -2952,7 +3091,15 @@ pub mod tracing {
                 sojourn_time,
                 queue_sojourn_time,
             } = event;
-            tracing :: event ! (target : "acceptor_stream_dequeued" , parent : parent , tracing :: Level :: DEBUG , { remote_address = tracing :: field :: debug (remote_address) , credential_id = tracing :: field :: debug (credential_id) , stream_id = tracing :: field :: debug (stream_id) , sojourn_time = tracing :: field :: debug (sojourn_time) , queue_sojourn_time = tracing :: field :: debug (queue_sojourn_time) });
+            tracing::event!(
+                target : "acceptor_stream_dequeued", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), credential_id =
+                tracing::field::debug(credential_id), stream_id =
+                tracing::field::debug(stream_id), sojourn_time =
+                tracing::field::debug(sojourn_time), queue_sojourn_time =
+                tracing::field::debug(queue_sojourn_time) }
+            );
         }
         #[inline]
         fn on_stream_write_flushed(
@@ -2967,7 +3114,12 @@ pub mod tracing {
                 committed_len,
                 processing_duration,
             } = event;
-            tracing :: event ! (target : "stream_write_flushed" , parent : id , tracing :: Level :: DEBUG , { provided_len = tracing :: field :: debug (provided_len) , committed_len = tracing :: field :: debug (committed_len) , processing_duration = tracing :: field :: debug (processing_duration) });
+            tracing::event!(
+                target : "stream_write_flushed", parent : id, tracing::Level::DEBUG, {
+                provided_len = tracing::field::debug(provided_len), committed_len =
+                tracing::field::debug(committed_len), processing_duration =
+                tracing::field::debug(processing_duration) }
+            );
         }
         #[inline]
         fn on_stream_write_fin_flushed(
@@ -2982,7 +3134,12 @@ pub mod tracing {
                 committed_len,
                 processing_duration,
             } = event;
-            tracing :: event ! (target : "stream_write_fin_flushed" , parent : id , tracing :: Level :: DEBUG , { provided_len = tracing :: field :: debug (provided_len) , committed_len = tracing :: field :: debug (committed_len) , processing_duration = tracing :: field :: debug (processing_duration) });
+            tracing::event!(
+                target : "stream_write_fin_flushed", parent : id, tracing::Level::DEBUG,
+                { provided_len = tracing::field::debug(provided_len), committed_len =
+                tracing::field::debug(committed_len), processing_duration =
+                tracing::field::debug(processing_duration) }
+            );
         }
         #[inline]
         fn on_stream_write_blocked(
@@ -2997,7 +3154,12 @@ pub mod tracing {
                 is_fin,
                 processing_duration,
             } = event;
-            tracing :: event ! (target : "stream_write_blocked" , parent : id , tracing :: Level :: DEBUG , { provided_len = tracing :: field :: debug (provided_len) , is_fin = tracing :: field :: debug (is_fin) , processing_duration = tracing :: field :: debug (processing_duration) });
+            tracing::event!(
+                target : "stream_write_blocked", parent : id, tracing::Level::DEBUG, {
+                provided_len = tracing::field::debug(provided_len), is_fin =
+                tracing::field::debug(is_fin), processing_duration =
+                tracing::field::debug(processing_duration) }
+            );
         }
         #[inline]
         fn on_stream_write_errored(
@@ -3013,7 +3175,13 @@ pub mod tracing {
                 processing_duration,
                 errno,
             } = event;
-            tracing :: event ! (target : "stream_write_errored" , parent : id , tracing :: Level :: DEBUG , { provided_len = tracing :: field :: debug (provided_len) , is_fin = tracing :: field :: debug (is_fin) , processing_duration = tracing :: field :: debug (processing_duration) , errno = tracing :: field :: debug (errno) });
+            tracing::event!(
+                target : "stream_write_errored", parent : id, tracing::Level::DEBUG, {
+                provided_len = tracing::field::debug(provided_len), is_fin =
+                tracing::field::debug(is_fin), processing_duration =
+                tracing::field::debug(processing_duration), errno =
+                tracing::field::debug(errno) }
+            );
         }
         #[inline]
         fn on_stream_write_key_updated(
@@ -3024,7 +3192,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::StreamWriteKeyUpdated { key_phase } = event;
-            tracing :: event ! (target : "stream_write_key_updated" , parent : id , tracing :: Level :: DEBUG , { key_phase = tracing :: field :: debug (key_phase) });
+            tracing::event!(
+                target : "stream_write_key_updated", parent : id, tracing::Level::DEBUG,
+                { key_phase = tracing::field::debug(key_phase) }
+            );
         }
         #[inline]
         fn on_stream_write_allocated(
@@ -3035,7 +3206,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::StreamWriteAllocated { allocated_len } = event;
-            tracing :: event ! (target : "stream_write_allocated" , parent : id , tracing :: Level :: DEBUG , { allocated_len = tracing :: field :: debug (allocated_len) });
+            tracing::event!(
+                target : "stream_write_allocated", parent : id, tracing::Level::DEBUG, {
+                allocated_len = tracing::field::debug(allocated_len) }
+            );
         }
         #[inline]
         fn on_stream_write_shutdown(
@@ -3049,7 +3223,11 @@ pub mod tracing {
                 buffer_len,
                 background,
             } = event;
-            tracing :: event ! (target : "stream_write_shutdown" , parent : id , tracing :: Level :: DEBUG , { buffer_len = tracing :: field :: debug (buffer_len) , background = tracing :: field :: debug (background) });
+            tracing::event!(
+                target : "stream_write_shutdown", parent : id, tracing::Level::DEBUG, {
+                buffer_len = tracing::field::debug(buffer_len), background =
+                tracing::field::debug(background) }
+            );
         }
         #[inline]
         fn on_stream_write_socket_flushed(
@@ -3063,7 +3241,12 @@ pub mod tracing {
                 provided_len,
                 committed_len,
             } = event;
-            tracing :: event ! (target : "stream_write_socket_flushed" , parent : id , tracing :: Level :: DEBUG , { provided_len = tracing :: field :: debug (provided_len) , committed_len = tracing :: field :: debug (committed_len) });
+            tracing::event!(
+                target : "stream_write_socket_flushed", parent : id,
+                tracing::Level::DEBUG, { provided_len =
+                tracing::field::debug(provided_len), committed_len =
+                tracing::field::debug(committed_len) }
+            );
         }
         #[inline]
         fn on_stream_write_socket_blocked(
@@ -3074,7 +3257,11 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::StreamWriteSocketBlocked { provided_len } = event;
-            tracing :: event ! (target : "stream_write_socket_blocked" , parent : id , tracing :: Level :: DEBUG , { provided_len = tracing :: field :: debug (provided_len) });
+            tracing::event!(
+                target : "stream_write_socket_blocked", parent : id,
+                tracing::Level::DEBUG, { provided_len =
+                tracing::field::debug(provided_len) }
+            );
         }
         #[inline]
         fn on_stream_write_socket_errored(
@@ -3088,7 +3275,12 @@ pub mod tracing {
                 provided_len,
                 errno,
             } = event;
-            tracing :: event ! (target : "stream_write_socket_errored" , parent : id , tracing :: Level :: DEBUG , { provided_len = tracing :: field :: debug (provided_len) , errno = tracing :: field :: debug (errno) });
+            tracing::event!(
+                target : "stream_write_socket_errored", parent : id,
+                tracing::Level::DEBUG, { provided_len =
+                tracing::field::debug(provided_len), errno = tracing::field::debug(errno)
+                }
+            );
         }
         #[inline]
         fn on_stream_read_flushed(
@@ -3103,7 +3295,12 @@ pub mod tracing {
                 committed_len,
                 processing_duration,
             } = event;
-            tracing :: event ! (target : "stream_read_flushed" , parent : id , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) , committed_len = tracing :: field :: debug (committed_len) , processing_duration = tracing :: field :: debug (processing_duration) });
+            tracing::event!(
+                target : "stream_read_flushed", parent : id, tracing::Level::DEBUG, {
+                capacity = tracing::field::debug(capacity), committed_len =
+                tracing::field::debug(committed_len), processing_duration =
+                tracing::field::debug(processing_duration) }
+            );
         }
         #[inline]
         fn on_stream_read_fin_flushed(
@@ -3117,7 +3314,11 @@ pub mod tracing {
                 capacity,
                 processing_duration,
             } = event;
-            tracing :: event ! (target : "stream_read_fin_flushed" , parent : id , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) , processing_duration = tracing :: field :: debug (processing_duration) });
+            tracing::event!(
+                target : "stream_read_fin_flushed", parent : id, tracing::Level::DEBUG, {
+                capacity = tracing::field::debug(capacity), processing_duration =
+                tracing::field::debug(processing_duration) }
+            );
         }
         #[inline]
         fn on_stream_read_blocked(
@@ -3131,7 +3332,11 @@ pub mod tracing {
                 capacity,
                 processing_duration,
             } = event;
-            tracing :: event ! (target : "stream_read_blocked" , parent : id , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) , processing_duration = tracing :: field :: debug (processing_duration) });
+            tracing::event!(
+                target : "stream_read_blocked", parent : id, tracing::Level::DEBUG, {
+                capacity = tracing::field::debug(capacity), processing_duration =
+                tracing::field::debug(processing_duration) }
+            );
         }
         #[inline]
         fn on_stream_read_errored(
@@ -3146,7 +3351,12 @@ pub mod tracing {
                 processing_duration,
                 errno,
             } = event;
-            tracing :: event ! (target : "stream_read_errored" , parent : id , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) , processing_duration = tracing :: field :: debug (processing_duration) , errno = tracing :: field :: debug (errno) });
+            tracing::event!(
+                target : "stream_read_errored", parent : id, tracing::Level::DEBUG, {
+                capacity = tracing::field::debug(capacity), processing_duration =
+                tracing::field::debug(processing_duration), errno =
+                tracing::field::debug(errno) }
+            );
         }
         #[inline]
         fn on_stream_read_key_updated(
@@ -3157,7 +3367,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::StreamReadKeyUpdated { key_phase } = event;
-            tracing :: event ! (target : "stream_read_key_updated" , parent : id , tracing :: Level :: DEBUG , { key_phase = tracing :: field :: debug (key_phase) });
+            tracing::event!(
+                target : "stream_read_key_updated", parent : id, tracing::Level::DEBUG, {
+                key_phase = tracing::field::debug(key_phase) }
+            );
         }
         #[inline]
         fn on_stream_read_shutdown(
@@ -3168,7 +3381,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::StreamReadShutdown { background } = event;
-            tracing :: event ! (target : "stream_read_shutdown" , parent : id , tracing :: Level :: DEBUG , { background = tracing :: field :: debug (background) });
+            tracing::event!(
+                target : "stream_read_shutdown", parent : id, tracing::Level::DEBUG, {
+                background = tracing::field::debug(background) }
+            );
         }
         #[inline]
         fn on_stream_read_socket_flushed(
@@ -3182,7 +3398,11 @@ pub mod tracing {
                 capacity,
                 committed_len,
             } = event;
-            tracing :: event ! (target : "stream_read_socket_flushed" , parent : id , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) , committed_len = tracing :: field :: debug (committed_len) });
+            tracing::event!(
+                target : "stream_read_socket_flushed", parent : id,
+                tracing::Level::DEBUG, { capacity = tracing::field::debug(capacity),
+                committed_len = tracing::field::debug(committed_len) }
+            );
         }
         #[inline]
         fn on_stream_read_socket_blocked(
@@ -3193,7 +3413,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::StreamReadSocketBlocked { capacity } = event;
-            tracing :: event ! (target : "stream_read_socket_blocked" , parent : id , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) });
+            tracing::event!(
+                target : "stream_read_socket_blocked", parent : id,
+                tracing::Level::DEBUG, { capacity = tracing::field::debug(capacity) }
+            );
         }
         #[inline]
         fn on_stream_read_socket_errored(
@@ -3204,7 +3427,11 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::StreamReadSocketErrored { capacity, errno } = event;
-            tracing :: event ! (target : "stream_read_socket_errored" , parent : id , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) , errno = tracing :: field :: debug (errno) });
+            tracing::event!(
+                target : "stream_read_socket_errored", parent : id,
+                tracing::Level::DEBUG, { capacity = tracing::field::debug(capacity),
+                errno = tracing::field::debug(errno) }
+            );
         }
         #[inline]
         fn on_stream_decrypt_packet(
@@ -3219,13 +3446,23 @@ pub mod tracing {
                 forced_copy,
                 required_application_buffer,
             } = event;
-            tracing :: event ! (target : "stream_decrypt_packet" , parent : id , tracing :: Level :: DEBUG , { decrypted_in_place = tracing :: field :: debug (decrypted_in_place) , forced_copy = tracing :: field :: debug (forced_copy) , required_application_buffer = tracing :: field :: debug (required_application_buffer) });
+            tracing::event!(
+                target : "stream_decrypt_packet", parent : id, tracing::Level::DEBUG, {
+                decrypted_in_place = tracing::field::debug(decrypted_in_place),
+                forced_copy = tracing::field::debug(forced_copy),
+                required_application_buffer =
+                tracing::field::debug(required_application_buffer) }
+            );
         }
         #[inline]
         fn on_stream_tcp_connect(&self, meta: &api::EndpointMeta, event: &api::StreamTcpConnect) {
             let parent = self.parent(meta);
             let api::StreamTcpConnect { error, latency } = event;
-            tracing :: event ! (target : "stream_tcp_connect" , parent : parent , tracing :: Level :: DEBUG , { error = tracing :: field :: debug (error) , latency = tracing :: field :: debug (latency) });
+            tracing::event!(
+                target : "stream_tcp_connect", parent : parent, tracing::Level::DEBUG, {
+                error = tracing::field::debug(error), latency =
+                tracing::field::debug(latency) }
+            );
         }
         #[inline]
         fn on_stream_tls_connect(&self, meta: &api::EndpointMeta, event: &api::StreamTlsConnect) {
@@ -3235,7 +3472,12 @@ pub mod tracing {
                 tcp_latency,
                 tls_latency,
             } = event;
-            tracing :: event ! (target : "stream_tls_connect" , parent : parent , tracing :: Level :: DEBUG , { error = tracing :: field :: debug (error) , tcp_latency = tracing :: field :: debug (tcp_latency) , tls_latency = tracing :: field :: debug (tls_latency) });
+            tracing::event!(
+                target : "stream_tls_connect", parent : parent, tracing::Level::DEBUG, {
+                error = tracing::field::debug(error), tcp_latency =
+                tracing::field::debug(tcp_latency), tls_latency =
+                tracing::field::debug(tls_latency) }
+            );
         }
         #[inline]
         fn on_stream_connect(&self, meta: &api::EndpointMeta, event: &api::StreamConnect) {
@@ -3245,7 +3487,12 @@ pub mod tracing {
                 tcp_success,
                 handshake_success,
             } = event;
-            tracing :: event ! (target : "stream_connect" , parent : parent , tracing :: Level :: DEBUG , { error = tracing :: field :: debug (error) , tcp_success = tracing :: field :: debug (tcp_success) , handshake_success = tracing :: field :: debug (handshake_success) });
+            tracing::event!(
+                target : "stream_connect", parent : parent, tracing::Level::DEBUG, {
+                error = tracing::field::debug(error), tcp_success =
+                tracing::field::debug(tcp_success), handshake_success =
+                tracing::field::debug(handshake_success) }
+            );
         }
         #[inline]
         fn on_stream_connect_error(
@@ -3255,7 +3502,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::StreamConnectError { reason, latency } = event;
-            tracing :: event ! (target : "stream_connect_error" , parent : parent , tracing :: Level :: DEBUG , { reason = tracing :: field :: debug (reason) , latency = tracing :: field :: debug (latency) });
+            tracing::event!(
+                target : "stream_connect_error", parent : parent, tracing::Level::DEBUG,
+                { reason = tracing::field::debug(reason), latency =
+                tracing::field::debug(latency) }
+            );
         }
         #[inline]
         fn on_stream_packet_transmitted(
@@ -3273,7 +3524,15 @@ pub mod tracing {
                 is_fin,
                 is_retransmission,
             } = event;
-            tracing :: event ! (target : "stream_packet_transmitted" , parent : id , tracing :: Level :: DEBUG , { packet_len = tracing :: field :: debug (packet_len) , payload_len = tracing :: field :: debug (payload_len) , packet_number = tracing :: field :: debug (packet_number) , stream_offset = tracing :: field :: debug (stream_offset) , is_fin = tracing :: field :: debug (is_fin) , is_retransmission = tracing :: field :: debug (is_retransmission) });
+            tracing::event!(
+                target : "stream_packet_transmitted", parent : id, tracing::Level::DEBUG,
+                { packet_len = tracing::field::debug(packet_len), payload_len =
+                tracing::field::debug(payload_len), packet_number =
+                tracing::field::debug(packet_number), stream_offset =
+                tracing::field::debug(stream_offset), is_fin =
+                tracing::field::debug(is_fin), is_retransmission =
+                tracing::field::debug(is_retransmission) }
+            );
         }
         #[inline]
         fn on_stream_probe_transmitted(
@@ -3287,7 +3546,11 @@ pub mod tracing {
                 packet_len,
                 packet_number,
             } = event;
-            tracing :: event ! (target : "stream_probe_transmitted" , parent : id , tracing :: Level :: DEBUG , { packet_len = tracing :: field :: debug (packet_len) , packet_number = tracing :: field :: debug (packet_number) });
+            tracing::event!(
+                target : "stream_probe_transmitted", parent : id, tracing::Level::DEBUG,
+                { packet_len = tracing::field::debug(packet_len), packet_number =
+                tracing::field::debug(packet_number) }
+            );
         }
         #[inline]
         fn on_stream_packet_received(
@@ -3305,7 +3568,15 @@ pub mod tracing {
                 is_fin,
                 is_retransmission,
             } = event;
-            tracing :: event ! (target : "stream_packet_received" , parent : id , tracing :: Level :: DEBUG , { packet_len = tracing :: field :: debug (packet_len) , payload_len = tracing :: field :: debug (payload_len) , packet_number = tracing :: field :: debug (packet_number) , stream_offset = tracing :: field :: debug (stream_offset) , is_fin = tracing :: field :: debug (is_fin) , is_retransmission = tracing :: field :: debug (is_retransmission) });
+            tracing::event!(
+                target : "stream_packet_received", parent : id, tracing::Level::DEBUG, {
+                packet_len = tracing::field::debug(packet_len), payload_len =
+                tracing::field::debug(payload_len), packet_number =
+                tracing::field::debug(packet_number), stream_offset =
+                tracing::field::debug(stream_offset), is_fin =
+                tracing::field::debug(is_fin), is_retransmission =
+                tracing::field::debug(is_retransmission) }
+            );
         }
         #[inline]
         fn on_stream_packet_lost(
@@ -3324,7 +3595,16 @@ pub mod tracing {
                 lifetime,
                 is_retransmission,
             } = event;
-            tracing :: event ! (target : "stream_packet_lost" , parent : id , tracing :: Level :: DEBUG , { packet_len = tracing :: field :: debug (packet_len) , payload_len = tracing :: field :: debug (payload_len) , packet_number = tracing :: field :: debug (packet_number) , stream_offset = tracing :: field :: debug (stream_offset) , time_sent = tracing :: field :: debug (time_sent) , lifetime = tracing :: field :: debug (lifetime) , is_retransmission = tracing :: field :: debug (is_retransmission) });
+            tracing::event!(
+                target : "stream_packet_lost", parent : id, tracing::Level::DEBUG, {
+                packet_len = tracing::field::debug(packet_len), payload_len =
+                tracing::field::debug(payload_len), packet_number =
+                tracing::field::debug(packet_number), stream_offset =
+                tracing::field::debug(stream_offset), time_sent =
+                tracing::field::debug(time_sent), lifetime =
+                tracing::field::debug(lifetime), is_retransmission =
+                tracing::field::debug(is_retransmission) }
+            );
         }
         #[inline]
         fn on_stream_packet_acked(
@@ -3343,7 +3623,16 @@ pub mod tracing {
                 lifetime,
                 is_retransmission,
             } = event;
-            tracing :: event ! (target : "stream_packet_acked" , parent : id , tracing :: Level :: DEBUG , { packet_len = tracing :: field :: debug (packet_len) , payload_len = tracing :: field :: debug (payload_len) , packet_number = tracing :: field :: debug (packet_number) , stream_offset = tracing :: field :: debug (stream_offset) , time_sent = tracing :: field :: debug (time_sent) , lifetime = tracing :: field :: debug (lifetime) , is_retransmission = tracing :: field :: debug (is_retransmission) });
+            tracing::event!(
+                target : "stream_packet_acked", parent : id, tracing::Level::DEBUG, {
+                packet_len = tracing::field::debug(packet_len), payload_len =
+                tracing::field::debug(payload_len), packet_number =
+                tracing::field::debug(packet_number), stream_offset =
+                tracing::field::debug(stream_offset), time_sent =
+                tracing::field::debug(time_sent), lifetime =
+                tracing::field::debug(lifetime), is_retransmission =
+                tracing::field::debug(is_retransmission) }
+            );
         }
         #[inline]
         fn on_stream_packet_spuriously_retransmitted(
@@ -3361,7 +3650,15 @@ pub mod tracing {
                 is_fin,
                 is_retransmission,
             } = event;
-            tracing :: event ! (target : "stream_packet_spuriously_retransmitted" , parent : id , tracing :: Level :: DEBUG , { packet_len = tracing :: field :: debug (packet_len) , payload_len = tracing :: field :: debug (payload_len) , packet_number = tracing :: field :: debug (packet_number) , stream_offset = tracing :: field :: debug (stream_offset) , is_fin = tracing :: field :: debug (is_fin) , is_retransmission = tracing :: field :: debug (is_retransmission) });
+            tracing::event!(
+                target : "stream_packet_spuriously_retransmitted", parent : id,
+                tracing::Level::DEBUG, { packet_len = tracing::field::debug(packet_len),
+                payload_len = tracing::field::debug(payload_len), packet_number =
+                tracing::field::debug(packet_number), stream_offset =
+                tracing::field::debug(stream_offset), is_fin =
+                tracing::field::debug(is_fin), is_retransmission =
+                tracing::field::debug(is_retransmission) }
+            );
         }
         #[inline]
         fn on_stream_max_data_received(
@@ -3375,7 +3672,11 @@ pub mod tracing {
                 increase,
                 new_max_data,
             } = event;
-            tracing :: event ! (target : "stream_max_data_received" , parent : id , tracing :: Level :: DEBUG , { increase = tracing :: field :: debug (increase) , new_max_data = tracing :: field :: debug (new_max_data) });
+            tracing::event!(
+                target : "stream_max_data_received", parent : id, tracing::Level::DEBUG,
+                { increase = tracing::field::debug(increase), new_max_data =
+                tracing::field::debug(new_max_data) }
+            );
         }
         #[inline]
         fn on_stream_control_packet_transmitted(
@@ -3390,7 +3691,12 @@ pub mod tracing {
                 control_data_len,
                 packet_number,
             } = event;
-            tracing :: event ! (target : "stream_control_packet_transmitted" , parent : id , tracing :: Level :: DEBUG , { packet_len = tracing :: field :: debug (packet_len) , control_data_len = tracing :: field :: debug (control_data_len) , packet_number = tracing :: field :: debug (packet_number) });
+            tracing::event!(
+                target : "stream_control_packet_transmitted", parent : id,
+                tracing::Level::DEBUG, { packet_len = tracing::field::debug(packet_len),
+                control_data_len = tracing::field::debug(control_data_len), packet_number
+                = tracing::field::debug(packet_number) }
+            );
         }
         #[inline]
         fn on_stream_control_packet_received(
@@ -3406,7 +3712,13 @@ pub mod tracing {
                 packet_number,
                 is_authenticated,
             } = event;
-            tracing :: event ! (target : "stream_control_packet_received" , parent : id , tracing :: Level :: DEBUG , { packet_len = tracing :: field :: debug (packet_len) , control_data_len = tracing :: field :: debug (control_data_len) , packet_number = tracing :: field :: debug (packet_number) , is_authenticated = tracing :: field :: debug (is_authenticated) });
+            tracing::event!(
+                target : "stream_control_packet_received", parent : id,
+                tracing::Level::DEBUG, { packet_len = tracing::field::debug(packet_len),
+                control_data_len = tracing::field::debug(control_data_len), packet_number
+                = tracing::field::debug(packet_number), is_authenticated =
+                tracing::field::debug(is_authenticated) }
+            );
         }
         #[inline]
         fn on_stream_receiver_errored(
@@ -3417,7 +3729,11 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::StreamReceiverErrored { error, source } = event;
-            tracing :: event ! (target : "stream_receiver_errored" , parent : id , tracing :: Level :: DEBUG , { error = tracing :: field :: debug (error) , source = tracing :: field :: debug (source) });
+            tracing::event!(
+                target : "stream_receiver_errored", parent : id, tracing::Level::DEBUG, {
+                error = tracing::field::debug(error), source =
+                tracing::field::debug(source) }
+            );
         }
         #[inline]
         fn on_stream_sender_errored(
@@ -3428,7 +3744,11 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::StreamSenderErrored { error, source } = event;
-            tracing :: event ! (target : "stream_sender_errored" , parent : id , tracing :: Level :: DEBUG , { error = tracing :: field :: debug (error) , source = tracing :: field :: debug (source) });
+            tracing::event!(
+                target : "stream_sender_errored", parent : id, tracing::Level::DEBUG, {
+                error = tracing::field::debug(error), source =
+                tracing::field::debug(source) }
+            );
         }
         #[inline]
         fn on_stream_handshake_packet_rejected(
@@ -3439,7 +3759,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::StreamHandshakePacketRejected { reason } = event;
-            tracing :: event ! (target : "stream_handshake_packet_rejected" , parent : id , tracing :: Level :: DEBUG , { reason = tracing :: field :: debug (reason) });
+            tracing::event!(
+                target : "stream_handshake_packet_rejected", parent : id,
+                tracing::Level::DEBUG, { reason = tracing::field::debug(reason) }
+            );
         }
         #[inline]
         fn on_connection_closed(
@@ -3450,7 +3773,9 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::ConnectionClosed {} = event;
-            tracing :: event ! (target : "connection_closed" , parent : id , tracing :: Level :: DEBUG , { });
+            tracing::event!(
+                target : "connection_closed", parent : id, tracing::Level::DEBUG, {}
+            );
         }
         #[inline]
         fn on_endpoint_initialized(
@@ -3465,7 +3790,12 @@ pub mod tracing {
                 tcp,
                 udp,
             } = event;
-            tracing :: event ! (target : "endpoint_initialized" , parent : parent , tracing :: Level :: DEBUG , { acceptor_addr = tracing :: field :: debug (acceptor_addr) , handshake_addr = tracing :: field :: debug (handshake_addr) , tcp = tracing :: field :: debug (tcp) , udp = tracing :: field :: debug (udp) });
+            tracing::event!(
+                target : "endpoint_initialized", parent : parent, tracing::Level::DEBUG,
+                { acceptor_addr = tracing::field::debug(acceptor_addr), handshake_addr =
+                tracing::field::debug(handshake_addr), tcp = tracing::field::debug(tcp),
+                udp = tracing::field::debug(udp) }
+            );
         }
         #[inline]
         fn on_dc_connection_timeout(
@@ -3475,7 +3805,10 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::DcConnectionTimeout { peer_address } = event;
-            tracing :: event ! (target : "dc_connection_timeout" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) });
+            tracing::event!(
+                target : "dc_connection_timeout", parent : parent, tracing::Level::DEBUG,
+                { peer_address = tracing::field::debug(peer_address) }
+            );
         }
         #[inline]
         fn on_path_secret_map_initialized(
@@ -3485,7 +3818,10 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PathSecretMapInitialized { capacity } = event;
-            tracing :: event ! (target : "path_secret_map_initialized" , parent : parent , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) });
+            tracing::event!(
+                target : "path_secret_map_initialized", parent : parent,
+                tracing::Level::DEBUG, { capacity = tracing::field::debug(capacity) }
+            );
         }
         #[inline]
         fn on_path_secret_map_uninitialized(
@@ -3499,7 +3835,12 @@ pub mod tracing {
                 entries,
                 lifetime,
             } = event;
-            tracing :: event ! (target : "path_secret_map_uninitialized" , parent : parent , tracing :: Level :: DEBUG , { capacity = tracing :: field :: debug (capacity) , entries = tracing :: field :: debug (entries) , lifetime = tracing :: field :: debug (lifetime) });
+            tracing::event!(
+                target : "path_secret_map_uninitialized", parent : parent,
+                tracing::Level::DEBUG, { capacity = tracing::field::debug(capacity),
+                entries = tracing::field::debug(entries), lifetime =
+                tracing::field::debug(lifetime) }
+            );
         }
         #[inline]
         fn on_path_secret_map_background_handshake_requested(
@@ -3509,7 +3850,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PathSecretMapBackgroundHandshakeRequested { peer_address } = event;
-            tracing :: event ! (target : "path_secret_map_background_handshake_requested" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) });
+            tracing::event!(
+                target : "path_secret_map_background_handshake_requested", parent :
+                parent, tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address) }
+            );
         }
         #[inline]
         fn on_path_secret_map_entry_inserted(
@@ -3522,7 +3867,12 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "path_secret_map_entry_inserted" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "path_secret_map_entry_inserted", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_path_secret_map_entry_ready(
@@ -3535,7 +3885,12 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "path_secret_map_entry_ready" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "path_secret_map_entry_ready", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_path_secret_map_entry_replaced(
@@ -3549,7 +3904,13 @@ pub mod tracing {
                 new_credential_id,
                 previous_credential_id,
             } = event;
-            tracing :: event ! (target : "path_secret_map_entry_replaced" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , new_credential_id = tracing :: field :: debug (new_credential_id) , previous_credential_id = tracing :: field :: debug (previous_credential_id) });
+            tracing::event!(
+                target : "path_secret_map_entry_replaced", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), new_credential_id =
+                tracing::field::debug(new_credential_id), previous_credential_id =
+                tracing::field::debug(previous_credential_id) }
+            );
         }
         #[inline]
         fn on_path_secret_map_id_entry_evicted(
@@ -3563,7 +3924,12 @@ pub mod tracing {
                 credential_id,
                 age,
             } = event;
-            tracing :: event ! (target : "path_secret_map_id_entry_evicted" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) , age = tracing :: field :: debug (age) });
+            tracing::event!(
+                target : "path_secret_map_id_entry_evicted", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id), age = tracing::field::debug(age) }
+            );
         }
         #[inline]
         fn on_path_secret_map_address_entry_evicted(
@@ -3577,7 +3943,12 @@ pub mod tracing {
                 credential_id,
                 age,
             } = event;
-            tracing :: event ! (target : "path_secret_map_address_entry_evicted" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) , age = tracing :: field :: debug (age) });
+            tracing::event!(
+                target : "path_secret_map_address_entry_evicted", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id), age = tracing::field::debug(age) }
+            );
         }
         #[inline]
         fn on_unknown_path_secret_packet_sent(
@@ -3590,7 +3961,12 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "unknown_path_secret_packet_sent" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "unknown_path_secret_packet_sent", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_unknown_path_secret_packet_received(
@@ -3603,7 +3979,12 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "unknown_path_secret_packet_received" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "unknown_path_secret_packet_received", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_unknown_path_secret_packet_accepted(
@@ -3616,7 +3997,12 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "unknown_path_secret_packet_accepted" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "unknown_path_secret_packet_accepted", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_unknown_path_secret_packet_rejected(
@@ -3629,7 +4015,12 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "unknown_path_secret_packet_rejected" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "unknown_path_secret_packet_rejected", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_unknown_path_secret_packet_dropped(
@@ -3642,7 +4033,12 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "unknown_path_secret_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "unknown_path_secret_packet_dropped", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_key_accepted(&self, meta: &api::EndpointMeta, event: &api::KeyAccepted) {
@@ -3653,7 +4049,12 @@ pub mod tracing {
                 gap,
                 forward_shift,
             } = event;
-            tracing :: event ! (target : "key_accepted" , parent : parent , tracing :: Level :: DEBUG , { credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id) , gap = tracing :: field :: debug (gap) , forward_shift = tracing :: field :: debug (forward_shift) });
+            tracing::event!(
+                target : "key_accepted", parent : parent, tracing::Level::DEBUG, {
+                credential_id = tracing::field::debug(credential_id), key_id =
+                tracing::field::debug(key_id), gap = tracing::field::debug(gap),
+                forward_shift = tracing::field::debug(forward_shift) }
+            );
         }
         #[inline]
         fn on_replay_definitely_detected(
@@ -3666,7 +4067,12 @@ pub mod tracing {
                 credential_id,
                 key_id,
             } = event;
-            tracing :: event ! (target : "replay_definitely_detected" , parent : parent , tracing :: Level :: DEBUG , { credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id) });
+            tracing::event!(
+                target : "replay_definitely_detected", parent : parent,
+                tracing::Level::DEBUG, { credential_id =
+                tracing::field::debug(credential_id), key_id =
+                tracing::field::debug(key_id) }
+            );
         }
         #[inline]
         fn on_replay_potentially_detected(
@@ -3680,7 +4086,12 @@ pub mod tracing {
                 key_id,
                 gap,
             } = event;
-            tracing :: event ! (target : "replay_potentially_detected" , parent : parent , tracing :: Level :: DEBUG , { credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id) , gap = tracing :: field :: debug (gap) });
+            tracing::event!(
+                target : "replay_potentially_detected", parent : parent,
+                tracing::Level::DEBUG, { credential_id =
+                tracing::field::debug(credential_id), key_id =
+                tracing::field::debug(key_id), gap = tracing::field::debug(gap) }
+            );
         }
         #[inline]
         fn on_replay_detected_packet_sent(
@@ -3693,7 +4104,12 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "replay_detected_packet_sent" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "replay_detected_packet_sent", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_replay_detected_packet_received(
@@ -3706,7 +4122,12 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "replay_detected_packet_received" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "replay_detected_packet_received", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_replay_detected_packet_accepted(
@@ -3720,7 +4141,13 @@ pub mod tracing {
                 credential_id,
                 key_id,
             } = event;
-            tracing :: event ! (target : "replay_detected_packet_accepted" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) , key_id = tracing :: field :: debug (key_id) });
+            tracing::event!(
+                target : "replay_detected_packet_accepted", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id), key_id =
+                tracing::field::debug(key_id) }
+            );
         }
         #[inline]
         fn on_replay_detected_packet_rejected(
@@ -3733,7 +4160,12 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "replay_detected_packet_rejected" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "replay_detected_packet_rejected", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_replay_detected_packet_dropped(
@@ -3746,7 +4178,12 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "replay_detected_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "replay_detected_packet_dropped", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_stale_key_packet_sent(
@@ -3759,7 +4196,11 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "stale_key_packet_sent" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "stale_key_packet_sent", parent : parent, tracing::Level::DEBUG,
+                { peer_address = tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_stale_key_packet_received(
@@ -3772,7 +4213,12 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "stale_key_packet_received" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "stale_key_packet_received", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_stale_key_packet_accepted(
@@ -3785,7 +4231,12 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "stale_key_packet_accepted" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "stale_key_packet_accepted", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_stale_key_packet_rejected(
@@ -3798,7 +4249,12 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "stale_key_packet_rejected" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "stale_key_packet_rejected", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_stale_key_packet_dropped(
@@ -3811,7 +4267,12 @@ pub mod tracing {
                 peer_address,
                 credential_id,
             } = event;
-            tracing :: event ! (target : "stale_key_packet_dropped" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , credential_id = tracing :: field :: debug (credential_id) });
+            tracing::event!(
+                target : "stale_key_packet_dropped", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), credential_id =
+                tracing::field::debug(credential_id) }
+            );
         }
         #[inline]
         fn on_path_secret_map_address_cache_accessed(
@@ -3821,7 +4282,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PathSecretMapAddressCacheAccessed { peer_address, hit } = event;
-            tracing :: event ! (target : "path_secret_map_address_cache_accessed" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , hit = tracing :: field :: debug (hit) });
+            tracing::event!(
+                target : "path_secret_map_address_cache_accessed", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), hit = tracing::field::debug(hit) }
+            );
         }
         #[inline]
         fn on_path_secret_map_address_cache_accessed_hit(
@@ -3831,7 +4296,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PathSecretMapAddressCacheAccessedHit { peer_address, age } = event;
-            tracing :: event ! (target : "path_secret_map_address_cache_accessed_hit" , parent : parent , tracing :: Level :: DEBUG , { peer_address = tracing :: field :: debug (peer_address) , age = tracing :: field :: debug (age) });
+            tracing::event!(
+                target : "path_secret_map_address_cache_accessed_hit", parent : parent,
+                tracing::Level::DEBUG, { peer_address =
+                tracing::field::debug(peer_address), age = tracing::field::debug(age) }
+            );
         }
         #[inline]
         fn on_path_secret_map_id_cache_accessed(
@@ -3841,7 +4310,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PathSecretMapIdCacheAccessed { credential_id, hit } = event;
-            tracing :: event ! (target : "path_secret_map_id_cache_accessed" , parent : parent , tracing :: Level :: DEBUG , { credential_id = tracing :: field :: debug (credential_id) , hit = tracing :: field :: debug (hit) });
+            tracing::event!(
+                target : "path_secret_map_id_cache_accessed", parent : parent,
+                tracing::Level::DEBUG, { credential_id =
+                tracing::field::debug(credential_id), hit = tracing::field::debug(hit) }
+            );
         }
         #[inline]
         fn on_path_secret_map_id_cache_accessed_hit(
@@ -3851,7 +4324,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PathSecretMapIdCacheAccessedHit { credential_id, age } = event;
-            tracing :: event ! (target : "path_secret_map_id_cache_accessed_hit" , parent : parent , tracing :: Level :: DEBUG , { credential_id = tracing :: field :: debug (credential_id) , age = tracing :: field :: debug (age) });
+            tracing::event!(
+                target : "path_secret_map_id_cache_accessed_hit", parent : parent,
+                tracing::Level::DEBUG, { credential_id =
+                tracing::field::debug(credential_id), age = tracing::field::debug(age) }
+            );
         }
         #[inline]
         fn on_path_secret_map_cleaner_cycled(
@@ -3878,7 +4355,31 @@ pub mod tracing {
                 handshake_lock_duration,
                 duration,
             } = event;
-            tracing :: event ! (target : "path_secret_map_cleaner_cycled" , parent : parent , tracing :: Level :: DEBUG , { id_entries = tracing :: field :: debug (id_entries) , id_entries_retired = tracing :: field :: debug (id_entries_retired) , id_entries_active = tracing :: field :: debug (id_entries_active) , id_entries_active_utilization = tracing :: field :: debug (id_entries_active_utilization) , id_entries_utilization = tracing :: field :: debug (id_entries_utilization) , id_entries_initial_utilization = tracing :: field :: debug (id_entries_initial_utilization) , address_entries = tracing :: field :: debug (address_entries) , address_entries_active = tracing :: field :: debug (address_entries_active) , address_entries_active_utilization = tracing :: field :: debug (address_entries_active_utilization) , address_entries_retired = tracing :: field :: debug (address_entries_retired) , address_entries_utilization = tracing :: field :: debug (address_entries_utilization) , address_entries_initial_utilization = tracing :: field :: debug (address_entries_initial_utilization) , handshake_requests = tracing :: field :: debug (handshake_requests) , handshake_requests_skipped = tracing :: field :: debug (handshake_requests_skipped) , handshake_lock_duration = tracing :: field :: debug (handshake_lock_duration) , duration = tracing :: field :: debug (duration) });
+            tracing::event!(
+                target : "path_secret_map_cleaner_cycled", parent : parent,
+                tracing::Level::DEBUG, { id_entries = tracing::field::debug(id_entries),
+                id_entries_retired = tracing::field::debug(id_entries_retired),
+                id_entries_active = tracing::field::debug(id_entries_active),
+                id_entries_active_utilization =
+                tracing::field::debug(id_entries_active_utilization),
+                id_entries_utilization = tracing::field::debug(id_entries_utilization),
+                id_entries_initial_utilization =
+                tracing::field::debug(id_entries_initial_utilization), address_entries =
+                tracing::field::debug(address_entries), address_entries_active =
+                tracing::field::debug(address_entries_active),
+                address_entries_active_utilization =
+                tracing::field::debug(address_entries_active_utilization),
+                address_entries_retired = tracing::field::debug(address_entries_retired),
+                address_entries_utilization =
+                tracing::field::debug(address_entries_utilization),
+                address_entries_initial_utilization =
+                tracing::field::debug(address_entries_initial_utilization),
+                handshake_requests = tracing::field::debug(handshake_requests),
+                handshake_requests_skipped =
+                tracing::field::debug(handshake_requests_skipped),
+                handshake_lock_duration = tracing::field::debug(handshake_lock_duration),
+                duration = tracing::field::debug(duration) }
+            );
         }
         #[inline]
         fn on_path_secret_map_id_write_lock(
@@ -3888,7 +4389,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PathSecretMapIdWriteLock { acquire, duration } = event;
-            tracing :: event ! (target : "path_secret_map_id_write_lock" , parent : parent , tracing :: Level :: DEBUG , { acquire = tracing :: field :: debug (acquire) , duration = tracing :: field :: debug (duration) });
+            tracing::event!(
+                target : "path_secret_map_id_write_lock", parent : parent,
+                tracing::Level::DEBUG, { acquire = tracing::field::debug(acquire),
+                duration = tracing::field::debug(duration) }
+            );
         }
         #[inline]
         fn on_path_secret_map_address_write_lock(
@@ -3898,7 +4403,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PathSecretMapAddressWriteLock { acquire, duration } = event;
-            tracing :: event ! (target : "path_secret_map_address_write_lock" , parent : parent , tracing :: Level :: DEBUG , { acquire = tracing :: field :: debug (acquire) , duration = tracing :: field :: debug (duration) });
+            tracing::event!(
+                target : "path_secret_map_address_write_lock", parent : parent,
+                tracing::Level::DEBUG, { acquire = tracing::field::debug(acquire),
+                duration = tracing::field::debug(duration) }
+            );
         }
         #[inline]
         fn on_path_secret_map_datagram_encrypt(
@@ -3908,7 +4417,10 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PathSecretMapDatagramEncrypt { packet_len } = event;
-            tracing :: event ! (target : "path_secret_map_datagram_encrypt" , parent : parent , tracing :: Level :: DEBUG , { packet_len = tracing :: field :: debug (packet_len) });
+            tracing::event!(
+                target : "path_secret_map_datagram_encrypt", parent : parent,
+                tracing::Level::DEBUG, { packet_len = tracing::field::debug(packet_len) }
+            );
         }
         #[inline]
         fn on_path_secret_map_datagram_decrypt(
@@ -3918,7 +4430,10 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PathSecretMapDatagramDecrypt { packet_len } = event;
-            tracing :: event ! (target : "path_secret_map_datagram_decrypt" , parent : parent , tracing :: Level :: DEBUG , { packet_len = tracing :: field :: debug (packet_len) });
+            tracing::event!(
+                target : "path_secret_map_datagram_decrypt", parent : parent,
+                tracing::Level::DEBUG, { packet_len = tracing::field::debug(packet_len) }
+            );
         }
     }
 }
@@ -3926,13 +4441,13 @@ pub mod builder {
     use super::*;
     pub use s2n_quic_core::event::builder::{EndpointType, SocketAddress, Subject};
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a TCP acceptor is started"]
+    /// Emitted when a TCP acceptor is started
     pub struct AcceptorTcpStarted<'a> {
-        #[doc = " The id of the acceptor worker"]
+        /// The id of the acceptor worker
         pub id: usize,
-        #[doc = " The local address of the acceptor"]
+        /// The local address of the acceptor
         pub local_address: &'a s2n_quic_core::inet::SocketAddress,
-        #[doc = " The backlog size"]
+        /// The backlog size
         pub backlog: usize,
     }
     impl<'a> IntoEvent<api::AcceptorTcpStarted<'a>> for AcceptorTcpStarted<'a> {
@@ -3951,20 +4466,20 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a TCP acceptor completes a single iteration of the event loop"]
+    /// Emitted when a TCP acceptor completes a single iteration of the event loop
     pub struct AcceptorTcpLoopIterationCompleted {
-        #[doc = " The number of streams that are waiting on initial packets"]
+        /// The number of streams that are waiting on initial packets
         pub pending_streams: usize,
-        #[doc = " The number of slots that are not currently processing a stream"]
+        /// The number of slots that are not currently processing a stream
         pub slots_idle: usize,
-        #[doc = " The percentage of slots currently processing streams"]
+        /// The percentage of slots currently processing streams
         pub slot_utilization: f32,
-        #[doc = " The amount of time it took to complete the iteration"]
+        /// The amount of time it took to complete the iteration
         pub processing_duration: core::time::Duration,
-        #[doc = " The computed max sojourn time that is allowed for streams"]
-        #[doc = ""]
-        #[doc = " If streams consume more time than this value to initialize, they"]
-        #[doc = " may potentially be replaced by more recent streams."]
+        /// The computed max sojourn time that is allowed for streams
+        ///
+        /// If streams consume more time than this value to initialize, they
+        /// may potentially be replaced by more recent streams.
         pub max_sojourn_time: core::time::Duration,
     }
     impl IntoEvent<api::AcceptorTcpLoopIterationCompleted> for AcceptorTcpLoopIterationCompleted {
@@ -3987,9 +4502,9 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a fresh TCP stream is enqueued for processing"]
+    /// Emitted when a fresh TCP stream is enqueued for processing
     pub struct AcceptorTcpFreshEnqueued<'a> {
-        #[doc = " The remote address of the TCP stream"]
+        /// The remote address of the TCP stream
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
     }
     impl<'a> IntoEvent<api::AcceptorTcpFreshEnqueued<'a>> for AcceptorTcpFreshEnqueued<'a> {
@@ -4002,13 +4517,13 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a the TCP acceptor has completed a batch of stream enqueues"]
+    /// Emitted when a the TCP acceptor has completed a batch of stream enqueues
     pub struct AcceptorTcpFreshBatchCompleted {
-        #[doc = " The number of fresh TCP streams enqueued in this batch"]
+        /// The number of fresh TCP streams enqueued in this batch
         pub enqueued: usize,
-        #[doc = " The number of fresh TCP streams dropped in this batch due to capacity limits"]
+        /// The number of fresh TCP streams dropped in this batch due to capacity limits
         pub dropped: usize,
-        #[doc = " The number of TCP streams that errored in this batch"]
+        /// The number of TCP streams that errored in this batch
         pub errored: usize,
     }
     impl IntoEvent<api::AcceptorTcpFreshBatchCompleted> for AcceptorTcpFreshBatchCompleted {
@@ -4027,9 +4542,9 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a TCP stream has been dropped"]
+    /// Emitted when a TCP stream has been dropped
     pub struct AcceptorTcpStreamDropped<'a> {
-        #[doc = " The remote address of the TCP stream"]
+        /// The remote address of the TCP stream
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
         pub reason: AcceptorTcpStreamDropReason,
     }
@@ -4047,14 +4562,14 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a TCP stream has been replaced by another stream"]
+    /// Emitted when a TCP stream has been replaced by another stream
     pub struct AcceptorTcpStreamReplaced<'a> {
-        #[doc = " The remote address of the stream being replaced"]
+        /// The remote address of the stream being replaced
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
-        #[doc = " The amount of time that the stream spent in the accept queue before"]
-        #[doc = " being replaced with another"]
+        /// The amount of time that the stream spent in the accept queue before
+        /// being replaced with another
         pub sojourn_time: core::time::Duration,
-        #[doc = " The amount of bytes buffered on the stream"]
+        /// The amount of bytes buffered on the stream
         pub buffer_len: usize,
     }
     impl<'a> IntoEvent<api::AcceptorTcpStreamReplaced<'a>> for AcceptorTcpStreamReplaced<'a> {
@@ -4073,22 +4588,22 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a full packet has been received on the TCP stream"]
+    /// Emitted when a full packet has been received on the TCP stream
     pub struct AcceptorTcpPacketReceived<'a> {
-        #[doc = " The address of the packet's sender"]
+        /// The address of the packet's sender
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
-        #[doc = " The credential ID of the packet"]
+        /// The credential ID of the packet
         pub credential_id: &'a [u8],
-        #[doc = " The stream ID of the packet"]
+        /// The stream ID of the packet
         pub stream_id: u64,
-        #[doc = " The payload length of the packet"]
+        /// The payload length of the packet
         pub payload_len: usize,
-        #[doc = " If the packet includes the final bytes of the stream"]
+        /// If the packet includes the final bytes of the stream
         pub is_fin: bool,
-        #[doc = " If the packet includes the final offset of the stream"]
+        /// If the packet includes the final offset of the stream
         pub is_fin_known: bool,
-        #[doc = " The amount of time the TCP stream spent in the queue before receiving"]
-        #[doc = " the initial packet"]
+        /// The amount of time the TCP stream spent in the queue before receiving
+        /// the initial packet
         pub sojourn_time: core::time::Duration,
     }
     impl<'a> IntoEvent<api::AcceptorTcpPacketReceived<'a>> for AcceptorTcpPacketReceived<'a> {
@@ -4115,11 +4630,11 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a TLS ClientHello has been recognized on the TCP stream"]
+    /// Emitted when a TLS ClientHello has been recognized on the TCP stream
     pub struct AcceptorTcpTlsStarted<'a> {
-        #[doc = " The address of the packet's sender"]
+        /// The address of the packet's sender
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
-        #[doc = " The amount of time the TCP stream spent in the queue so far"]
+        /// The amount of time the TCP stream spent in the queue so far
         pub sojourn_time: core::time::Duration,
     }
     impl<'a> IntoEvent<api::AcceptorTcpTlsStarted<'a>> for AcceptorTcpTlsStarted<'a> {
@@ -4136,12 +4651,12 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a TLS stream is enqueued to the application accept queue"]
+    /// Emitted when a TLS stream is enqueued to the application accept queue
     pub struct AcceptorTcpTlsStreamEnqueued<'a> {
-        #[doc = " The address of the packet's sender"]
+        /// The address of the packet's sender
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
-        #[doc = " The amount of time the TCP stream spent on handshaking before enqueuing to the application"]
-        #[doc = " since being accepted from the kernel"]
+        /// The amount of time the TCP stream spent on handshaking before enqueuing to the application
+        /// since being accepted from the kernel
         pub sojourn_time: core::time::Duration,
     }
     impl<'a> IntoEvent<api::AcceptorTcpTlsStreamEnqueued<'a>> for AcceptorTcpTlsStreamEnqueued<'a> {
@@ -4158,14 +4673,14 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a TLS stream is rejected"]
+    /// Emitted when a TLS stream is rejected
     pub struct AcceptorTcpTlsStreamRejected<'a> {
-        #[doc = " The address of the packet's sender"]
+        /// The address of the packet's sender
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
-        #[doc = " The amount of time the TCP stream spent on handshaking before being rejected"]
-        #[doc = " since being accepted from the kernel"]
+        /// The amount of time the TCP stream spent on handshaking before being rejected
+        /// since being accepted from the kernel
         pub sojourn_time: core::time::Duration,
-        #[doc = " The error encountered"]
+        /// The error encountered
         pub error: &'a std::io::Error,
     }
     impl<'a> IntoEvent<api::AcceptorTcpTlsStreamRejected<'a>> for AcceptorTcpTlsStreamRejected<'a> {
@@ -4184,14 +4699,14 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the TCP acceptor received an invalid initial packet"]
+    /// Emitted when the TCP acceptor received an invalid initial packet
     pub struct AcceptorTcpPacketDropped<'a> {
-        #[doc = " The address of the packet's sender"]
+        /// The address of the packet's sender
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
-        #[doc = " The reason the packet was dropped"]
+        /// The reason the packet was dropped
         pub reason: AcceptorPacketDropReason,
-        #[doc = " The amount of time the TCP stream spent in the queue before receiving"]
-        #[doc = " an error"]
+        /// The amount of time the TCP stream spent in the queue before receiving
+        /// an error
         pub sojourn_time: core::time::Duration,
     }
     impl<'a> IntoEvent<api::AcceptorTcpPacketDropped<'a>> for AcceptorTcpPacketDropped<'a> {
@@ -4210,17 +4725,17 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the TCP stream has been enqueued for the application"]
+    /// Emitted when the TCP stream has been enqueued for the application
     pub struct AcceptorTcpStreamEnqueued<'a> {
-        #[doc = " The address of the stream's peer"]
+        /// The address of the stream's peer
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
-        #[doc = " The credential ID of the stream"]
+        /// The credential ID of the stream
         pub credential_id: &'a [u8],
-        #[doc = " The ID of the stream"]
+        /// The ID of the stream
         pub stream_id: u64,
-        #[doc = " The amount of time the TCP stream spent in the queue before being enqueued"]
+        /// The amount of time the TCP stream spent in the queue before being enqueued
         pub sojourn_time: core::time::Duration,
-        #[doc = " The number of times the stream was blocked on receiving more data"]
+        /// The number of times the stream was blocked on receiving more data
         pub blocked_count: usize,
     }
     impl<'a> IntoEvent<api::AcceptorTcpStreamEnqueued<'a>> for AcceptorTcpStreamEnqueued<'a> {
@@ -4243,9 +4758,9 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the TCP acceptor encounters an IO error"]
+    /// Emitted when the TCP acceptor encounters an IO error
     pub struct AcceptorTcpIoError<'a> {
-        #[doc = " The error encountered"]
+        /// The error encountered
         pub error: &'a std::io::Error,
         pub source: AcceptorTcpIoErrorSource,
     }
@@ -4260,17 +4775,17 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the TCP stream has been sent over a Unix domain socket"]
+    /// Emitted when the TCP stream has been sent over a Unix domain socket
     pub struct AcceptorTcpSocketSent<'a> {
-        #[doc = " The credential ID of the stream"]
+        /// The credential ID of the stream
         pub credential_id: &'a [u8],
-        #[doc = " The ID of the stream"]
+        /// The ID of the stream
         pub stream_id: u64,
-        #[doc = " The amount of time the TCP stream spent in the queue before being sent over Unix domain socket"]
+        /// The amount of time the TCP stream spent in the queue before being sent over Unix domain socket
         pub sojourn_time: core::time::Duration,
-        #[doc = " The number of times the Unix domain socket was blocked on send"]
+        /// The number of times the Unix domain socket was blocked on send
         pub blocked_count: usize,
-        #[doc = " The len of the payload sent over the Unix domain socket"]
+        /// The len of the payload sent over the Unix domain socket
         pub payload_len: usize,
     }
     impl<'a> IntoEvent<api::AcceptorTcpSocketSent<'a>> for AcceptorTcpSocketSent<'a> {
@@ -4293,17 +4808,17 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a TCP stream has been received from a Unix domain socket"]
+    /// Emitted when a TCP stream has been received from a Unix domain socket
     pub struct AcceptorTcpSocketReceived<'a> {
-        #[doc = " The address of the stream's peer"]
+        /// The address of the stream's peer
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
-        #[doc = " The credential ID of the stream"]
+        /// The credential ID of the stream
         pub credential_id: &'a [u8],
-        #[doc = " The ID of the stream"]
+        /// The ID of the stream
         pub stream_id: u64,
-        #[doc = " The amount of time taken from socket send to socket receive, including waiting if the kernel queue is full"]
+        /// The amount of time taken from socket send to socket receive, including waiting if the kernel queue is full
         pub transfer_time: core::time::Duration,
-        #[doc = " The len of the payload sent over the Unix domain socket"]
+        /// The len of the payload sent over the Unix domain socket
         pub payload_len: usize,
     }
     impl<'a> IntoEvent<api::AcceptorTcpSocketReceived<'a>> for AcceptorTcpSocketReceived<'a> {
@@ -4326,11 +4841,11 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a UDP acceptor is started"]
+    /// Emitted when a UDP acceptor is started
     pub struct AcceptorUdpStarted<'a> {
-        #[doc = " The id of the acceptor worker"]
+        /// The id of the acceptor worker
         pub id: usize,
-        #[doc = " The local address of the acceptor"]
+        /// The local address of the acceptor
         pub local_address: SocketAddress<'a>,
     }
     impl<'a> IntoEvent<api::AcceptorUdpStarted<'a>> for AcceptorUdpStarted<'a> {
@@ -4344,11 +4859,11 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a UDP datagram is received by the acceptor"]
+    /// Emitted when a UDP datagram is received by the acceptor
     pub struct AcceptorUdpDatagramReceived<'a> {
-        #[doc = " The address of the datagram's sender"]
+        /// The address of the datagram's sender
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
-        #[doc = " The len of the datagram"]
+        /// The len of the datagram
         pub len: usize,
     }
     impl<'a> IntoEvent<api::AcceptorUdpDatagramReceived<'a>> for AcceptorUdpDatagramReceived<'a> {
@@ -4365,23 +4880,23 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the UDP acceptor parsed a packet contained in a datagram"]
+    /// Emitted when the UDP acceptor parsed a packet contained in a datagram
     pub struct AcceptorUdpPacketReceived<'a> {
-        #[doc = " The address of the packet's sender"]
+        /// The address of the packet's sender
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
-        #[doc = " The credential ID of the packet"]
+        /// The credential ID of the packet
         pub credential_id: &'a [u8],
-        #[doc = " The stream ID of the packet"]
+        /// The stream ID of the packet
         pub stream_id: u64,
-        #[doc = " The payload length of the packet"]
+        /// The payload length of the packet
         pub payload_len: usize,
-        #[doc = " If the packets is a zero offset in the stream"]
+        /// If the packets is a zero offset in the stream
         pub is_zero_offset: bool,
-        #[doc = " If the packet is a retransmission"]
+        /// If the packet is a retransmission
         pub is_retransmission: bool,
-        #[doc = " If the packet includes the final bytes of the stream"]
+        /// If the packet includes the final bytes of the stream
         pub is_fin: bool,
-        #[doc = " If the packet includes the final offset of the stream"]
+        /// If the packet includes the final offset of the stream
         pub is_fin_known: bool,
     }
     impl<'a> IntoEvent<api::AcceptorUdpPacketReceived<'a>> for AcceptorUdpPacketReceived<'a> {
@@ -4410,11 +4925,11 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the UDP acceptor received an invalid initial packet"]
+    /// Emitted when the UDP acceptor received an invalid initial packet
     pub struct AcceptorUdpPacketDropped<'a> {
-        #[doc = " The address of the packet's sender"]
+        /// The address of the packet's sender
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
-        #[doc = " The reason the packet was dropped"]
+        /// The reason the packet was dropped
         pub reason: AcceptorPacketDropReason,
     }
     impl<'a> IntoEvent<api::AcceptorUdpPacketDropped<'a>> for AcceptorUdpPacketDropped<'a> {
@@ -4431,13 +4946,13 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the UDP stream has been enqueued for the application"]
+    /// Emitted when the UDP stream has been enqueued for the application
     pub struct AcceptorUdpStreamEnqueued<'a> {
-        #[doc = " The address of the stream's peer"]
+        /// The address of the stream's peer
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
-        #[doc = " The credential ID of the stream"]
+        /// The credential ID of the stream
         pub credential_id: &'a [u8],
-        #[doc = " The ID of the stream"]
+        /// The ID of the stream
         pub stream_id: u64,
     }
     impl<'a> IntoEvent<api::AcceptorUdpStreamEnqueued<'a>> for AcceptorUdpStreamEnqueued<'a> {
@@ -4456,9 +4971,9 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the UDP acceptor encounters an IO error"]
+    /// Emitted when the UDP acceptor encounters an IO error
     pub struct AcceptorUdpIoError<'a> {
-        #[doc = " The error encountered"]
+        /// The error encountered
         pub error: &'a std::io::Error,
     }
     impl<'a> IntoEvent<api::AcceptorUdpIoError<'a>> for AcceptorUdpIoError<'a> {
@@ -4471,16 +4986,16 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a stream has been pruned"]
+    /// Emitted when a stream has been pruned
     pub struct AcceptorStreamPruned<'a> {
-        #[doc = " The remote address of the stream"]
+        /// The remote address of the stream
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
-        #[doc = " The credential ID of the stream"]
+        /// The credential ID of the stream
         pub credential_id: &'a [u8],
-        #[doc = " The ID of the stream"]
+        /// The ID of the stream
         pub stream_id: u64,
-        #[doc = " The amount of time that the stream spent in the accept queue before"]
-        #[doc = " being pruned"]
+        /// The amount of time that the stream spent in the accept queue before
+        /// being pruned
         pub sojourn_time: core::time::Duration,
         pub reason: AcceptorStreamPruneReason,
     }
@@ -4504,18 +5019,18 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a stream has been dequeued by the application"]
+    /// Emitted when a stream has been dequeued by the application
     pub struct AcceptorStreamDequeued<'a> {
-        #[doc = " The remote address of the stream"]
+        /// The remote address of the stream
         pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
-        #[doc = " The credential ID of the stream"]
+        /// The credential ID of the stream
         pub credential_id: &'a [u8],
-        #[doc = " The ID of the stream"]
+        /// The ID of the stream
         pub stream_id: u64,
-        #[doc = " The amount of time that the stream spent in dcQUIC before being dequeued"]
+        /// The amount of time that the stream spent in dcQUIC before being dequeued
         pub sojourn_time: core::time::Duration,
-        #[doc = " The amount of time that the stream spent in the queue to the application before being"]
-        #[doc = " dequeued"]
+        /// The amount of time that the stream spent in the queue to the application before being
+        /// dequeued
         pub queue_sojourn_time: core::time::Duration,
     }
     impl<'a> IntoEvent<api::AcceptorStreamDequeued<'a>> for AcceptorStreamDequeued<'a> {
@@ -4539,9 +5054,9 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub enum AcceptorTcpStreamDropReason {
-        #[doc = " There were more streams in the TCP backlog than the userspace queue can store"]
+        /// There were more streams in the TCP backlog than the userspace queue can store
         FreshQueueAtCapacity,
-        #[doc = " There are no available slots for processing"]
+        /// There are no available slots for processing
         SlotsAtCapacity,
     }
     impl IntoEvent<api::AcceptorTcpStreamDropReason> for AcceptorTcpStreamDropReason {
@@ -4556,23 +5071,23 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub enum AcceptorTcpIoErrorSource {
-        #[doc = " Problem during accept of the TCP socket"]
+        /// Problem during accept of the TCP socket
         Accept,
-        #[doc = " Problem writing to the TCP socket"]
+        /// Problem writing to the TCP socket
         Send,
-        #[doc = " Kernel originating from sending the TCP socket over UDS"]
+        /// Kernel originating from sending the TCP socket over UDS
         UnixSend,
-        #[doc = " Problem reading from the TCP socket"]
+        /// Problem reading from the TCP socket
         Recv,
-        #[doc = " Something within dcQUIC failed related to the remote state or network contents (e.g.,"]
-        #[doc = " parsing the packet)"]
+        /// Something within dcQUIC failed related to the remote state or network contents (e.g.,
+        /// parsing the packet)
         Remote,
-        #[doc = " Something in the local application state was wrong."]
+        /// Something in the local application state was wrong.
         Local,
-        #[doc = " Unknown path secret for remote stream."]
+        /// Unknown path secret for remote stream.
         UnknownPathSecret,
-        #[doc = " Something went wrong that we didn't expect to happen."]
-        #[doc = " This is used for failures that aren't expected to relate to dcQUIC state at all."]
+        /// Something went wrong that we didn't expect to happen.
+        /// This is used for failures that aren't expected to relate to dcQUIC state at all.
         System,
     }
     impl IntoEvent<api::AcceptorTcpIoErrorSource> for AcceptorTcpIoErrorSource {
@@ -4666,13 +5181,13 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamWriteFlushed {
-        #[doc = " The number of bytes that the application tried to write"]
+        /// The number of bytes that the application tried to write
         pub provided_len: usize,
-        #[doc = " The amount that was written"]
+        /// The amount that was written
         pub committed_len: usize,
-        #[doc = " The amount of time it took to process the write request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and encryption overhead"]
+        /// The amount of time it took to process the write request
+        ///
+        /// Note that this includes both any syscall and encryption overhead
         pub processing_duration: core::time::Duration,
     }
     impl IntoEvent<api::StreamWriteFlushed> for StreamWriteFlushed {
@@ -4692,13 +5207,13 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamWriteFinFlushed {
-        #[doc = " The number of bytes that the application tried to write"]
+        /// The number of bytes that the application tried to write
         pub provided_len: usize,
-        #[doc = " The amount that was written"]
+        /// The amount that was written
         pub committed_len: usize,
-        #[doc = " The amount of time it took to process the write request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and encryption overhead"]
+        /// The amount of time it took to process the write request
+        ///
+        /// Note that this includes both any syscall and encryption overhead
         pub processing_duration: core::time::Duration,
     }
     impl IntoEvent<api::StreamWriteFinFlushed> for StreamWriteFinFlushed {
@@ -4718,13 +5233,13 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamWriteBlocked {
-        #[doc = " The number of bytes that the application tried to write"]
+        /// The number of bytes that the application tried to write
         pub provided_len: usize,
-        #[doc = " Indicates that the write was the final offset of the stream"]
+        /// Indicates that the write was the final offset of the stream
         pub is_fin: bool,
-        #[doc = " The amount of time it took to process the write request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and encryption overhead"]
+        /// The amount of time it took to process the write request
+        ///
+        /// Note that this includes both any syscall and encryption overhead
         pub processing_duration: core::time::Duration,
     }
     impl IntoEvent<api::StreamWriteBlocked> for StreamWriteBlocked {
@@ -4744,15 +5259,15 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamWriteErrored {
-        #[doc = " The number of bytes that the application tried to write"]
+        /// The number of bytes that the application tried to write
         pub provided_len: usize,
-        #[doc = " Indicates that the write was the final offset of the stream"]
+        /// Indicates that the write was the final offset of the stream
         pub is_fin: bool,
-        #[doc = " The amount of time it took to process the write request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and encryption overhead"]
+        /// The amount of time it took to process the write request
+        ///
+        /// Note that this includes both any syscall and encryption overhead
         pub processing_duration: core::time::Duration,
-        #[doc = " The system `errno` from the returned error"]
+        /// The system `errno` from the returned error
         pub errno: Option<i32>,
     }
     impl IntoEvent<api::StreamWriteErrored> for StreamWriteErrored {
@@ -4787,7 +5302,7 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamWriteAllocated {
-        #[doc = " The number of bytes that we allocated."]
+        /// The number of bytes that we allocated.
         pub allocated_len: usize,
     }
     impl IntoEvent<api::StreamWriteAllocated> for StreamWriteAllocated {
@@ -4801,9 +5316,9 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamWriteShutdown {
-        #[doc = " The number of bytes in the send buffer at the time of shutdown"]
+        /// The number of bytes in the send buffer at the time of shutdown
         pub buffer_len: usize,
-        #[doc = " If the stream required a background task to drive the stream shutdown"]
+        /// If the stream required a background task to drive the stream shutdown
         pub background: bool,
     }
     impl IntoEvent<api::StreamWriteShutdown> for StreamWriteShutdown {
@@ -4821,9 +5336,9 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamWriteSocketFlushed {
-        #[doc = " The number of bytes that the stream tried to write to the socket"]
+        /// The number of bytes that the stream tried to write to the socket
         pub provided_len: usize,
-        #[doc = " The amount that was written"]
+        /// The amount that was written
         pub committed_len: usize,
     }
     impl IntoEvent<api::StreamWriteSocketFlushed> for StreamWriteSocketFlushed {
@@ -4841,7 +5356,7 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamWriteSocketBlocked {
-        #[doc = " The number of bytes that the stream tried to write to the socket"]
+        /// The number of bytes that the stream tried to write to the socket
         pub provided_len: usize,
     }
     impl IntoEvent<api::StreamWriteSocketBlocked> for StreamWriteSocketBlocked {
@@ -4855,9 +5370,9 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamWriteSocketErrored {
-        #[doc = " The number of bytes that the stream tried to write to the socket"]
+        /// The number of bytes that the stream tried to write to the socket
         pub provided_len: usize,
-        #[doc = " The system `errno` from the returned error"]
+        /// The system `errno` from the returned error
         pub errno: Option<i32>,
     }
     impl IntoEvent<api::StreamWriteSocketErrored> for StreamWriteSocketErrored {
@@ -4875,13 +5390,13 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamReadFlushed {
-        #[doc = " The number of bytes that the application tried to read"]
+        /// The number of bytes that the application tried to read
         pub capacity: usize,
-        #[doc = " The amount that was read into the provided buffer"]
+        /// The amount that was read into the provided buffer
         pub committed_len: usize,
-        #[doc = " The amount of time it took to process the read request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and decryption overhead"]
+        /// The amount of time it took to process the read request
+        ///
+        /// Note that this includes both any syscall and decryption overhead
         pub processing_duration: core::time::Duration,
     }
     impl IntoEvent<api::StreamReadFlushed> for StreamReadFlushed {
@@ -4901,11 +5416,11 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamReadFinFlushed {
-        #[doc = " The number of bytes that the application tried to read"]
+        /// The number of bytes that the application tried to read
         pub capacity: usize,
-        #[doc = " The amount of time it took to process the read request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and decryption overhead"]
+        /// The amount of time it took to process the read request
+        ///
+        /// Note that this includes both any syscall and decryption overhead
         pub processing_duration: core::time::Duration,
     }
     impl IntoEvent<api::StreamReadFinFlushed> for StreamReadFinFlushed {
@@ -4923,11 +5438,11 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamReadBlocked {
-        #[doc = " The number of bytes that the application tried to read"]
+        /// The number of bytes that the application tried to read
         pub capacity: usize,
-        #[doc = " The amount of time it took to process the read request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and decryption overhead"]
+        /// The amount of time it took to process the read request
+        ///
+        /// Note that this includes both any syscall and decryption overhead
         pub processing_duration: core::time::Duration,
     }
     impl IntoEvent<api::StreamReadBlocked> for StreamReadBlocked {
@@ -4945,13 +5460,13 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamReadErrored {
-        #[doc = " The number of bytes that the application tried to read"]
+        /// The number of bytes that the application tried to read
         pub capacity: usize,
-        #[doc = " The amount of time it took to process the read request"]
-        #[doc = ""]
-        #[doc = " Note that this includes both any syscall and decryption overhead"]
+        /// The amount of time it took to process the read request
+        ///
+        /// Note that this includes both any syscall and decryption overhead
         pub processing_duration: core::time::Duration,
-        #[doc = " The system `errno` from the returned error"]
+        /// The system `errno` from the returned error
         pub errno: Option<i32>,
     }
     impl IntoEvent<api::StreamReadErrored> for StreamReadErrored {
@@ -4984,7 +5499,7 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamReadShutdown {
-        #[doc = " If the stream required a background task to drive the stream shutdown"]
+        /// If the stream required a background task to drive the stream shutdown
         pub background: bool,
     }
     impl IntoEvent<api::StreamReadShutdown> for StreamReadShutdown {
@@ -4998,9 +5513,9 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamReadSocketFlushed {
-        #[doc = " The number of bytes that the stream tried to read from the socket"]
+        /// The number of bytes that the stream tried to read from the socket
         pub capacity: usize,
-        #[doc = " The amount that was read into the provided buffer"]
+        /// The amount that was read into the provided buffer
         pub committed_len: usize,
     }
     impl IntoEvent<api::StreamReadSocketFlushed> for StreamReadSocketFlushed {
@@ -5018,7 +5533,7 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamReadSocketBlocked {
-        #[doc = " The number of bytes that the stream tried to read from the socket"]
+        /// The number of bytes that the stream tried to read from the socket
         pub capacity: usize,
     }
     impl IntoEvent<api::StreamReadSocketBlocked> for StreamReadSocketBlocked {
@@ -5032,9 +5547,9 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamReadSocketErrored {
-        #[doc = " The number of bytes that the stream tried to read from the socket"]
+        /// The number of bytes that the stream tried to read from the socket
         pub capacity: usize,
-        #[doc = " The system `errno` from the returned error"]
+        /// The system `errno` from the returned error
         pub errno: Option<i32>,
     }
     impl IntoEvent<api::StreamReadSocketErrored> for StreamReadSocketErrored {
@@ -5049,16 +5564,16 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamDecryptPacket {
-        #[doc = " Did we decrypt the packet in place, or were we able to merge the copy and decrypt?"]
+        /// Did we decrypt the packet in place, or were we able to merge the copy and decrypt?
         pub decrypted_in_place: bool,
-        #[doc = " The number of bytes we were forced to copy after decrypting in the packet buffer."]
-        #[doc = ""]
-        #[doc = " This means that the application buffer was insufficiently large to allow us to directly"]
-        #[doc = " copy as part of the decrypt. This can be non-zero even with decrypted_in_place=false, if we"]
-        #[doc = " decrypted into the reassembly buffer. Right now it doesn't take into account zero-copy"]
-        #[doc = " reads from the reassembly buffer (e.g., with specialized Bytes)."]
+        /// The number of bytes we were forced to copy after decrypting in the packet buffer.
+        ///
+        /// This means that the application buffer was insufficiently large to allow us to directly
+        /// copy as part of the decrypt. This can be non-zero even with decrypted_in_place=false, if we
+        /// decrypted into the reassembly buffer. Right now it doesn't take into account zero-copy
+        /// reads from the reassembly buffer (e.g., with specialized Bytes).
         pub forced_copy: usize,
-        #[doc = " The application buffer size that would avoid copies."]
+        /// The application buffer size that would avoid copies.
         pub required_application_buffer: usize,
     }
     impl IntoEvent<api::StreamDecryptPacket> for StreamDecryptPacket {
@@ -5077,7 +5592,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Tracks stream connect where dcQUIC owns the TCP connect()."]
+    /// Tracks stream connect where dcQUIC owns the TCP connect().
     pub struct StreamTcpConnect {
         pub error: bool,
         pub latency: core::time::Duration,
@@ -5093,7 +5608,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Tracks TLS stream establishment."]
+    /// Tracks TLS stream establishment.
     pub struct StreamTlsConnect {
         pub error: bool,
         pub tcp_latency: core::time::Duration,
@@ -5115,7 +5630,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Tracks stream connect where dcQUIC owns the TCP connect()."]
+    /// Tracks stream connect where dcQUIC owns the TCP connect().
     pub struct StreamConnect {
         pub error: bool,
         pub tcp_success: MaybeBoolCounter,
@@ -5137,9 +5652,9 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Tracks stream connect errors."]
-    #[doc = ""]
-    #[doc = " Currently only emitted in cases where dcQUIC owns the TCP connect too."]
+    /// Tracks stream connect errors.
+    ///
+    /// Currently only emitted in cases where dcQUIC owns the TCP connect too.
     pub struct StreamConnectError {
         pub reason: StreamTcpConnectErrorReason,
         pub latency: core::time::Duration,
@@ -5156,15 +5671,15 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamPacketTransmitted {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The size of the application data in the packet"]
+        /// The size of the application data in the packet
         pub payload_len: usize,
-        #[doc = " The packet number of the transmitted packet"]
+        /// The packet number of the transmitted packet
         pub packet_number: u64,
-        #[doc = " The offset in the stream of the first byte in the packet"]
+        /// The offset in the stream of the first byte in the packet
         pub stream_offset: u64,
-        #[doc = " Whether the packet contained the final bytes of the stream"]
+        /// Whether the packet contained the final bytes of the stream
         pub is_fin: bool,
         pub is_retransmission: bool,
     }
@@ -5191,9 +5706,9 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamProbeTransmitted {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The packet number of the transmitted packet"]
+        /// The packet number of the transmitted packet
         pub packet_number: u64,
     }
     impl IntoEvent<api::StreamProbeTransmitted> for StreamProbeTransmitted {
@@ -5211,15 +5726,15 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamPacketReceived {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The size of the application data in the packet"]
+        /// The size of the application data in the packet
         pub payload_len: usize,
-        #[doc = " The packet number of the received packet"]
+        /// The packet number of the received packet
         pub packet_number: u64,
-        #[doc = " The offset in the stream of the first byte in the packet"]
+        /// The offset in the stream of the first byte in the packet
         pub stream_offset: u64,
-        #[doc = " Whether the packet contained the final bytes of the stream"]
+        /// Whether the packet contained the final bytes of the stream
         pub is_fin: bool,
         pub is_retransmission: bool,
     }
@@ -5245,19 +5760,19 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Indicates that a packet was lost on a stream"]
+    /// Indicates that a packet was lost on a stream
     pub struct StreamPacketLost {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The size of the application data in the packet"]
+        /// The size of the application data in the packet
         pub payload_len: usize,
-        #[doc = " The packet number of the lost packet"]
+        /// The packet number of the lost packet
         pub packet_number: u64,
-        #[doc = " The offset in the stream of the first byte in the packet"]
+        /// The offset in the stream of the first byte in the packet
         pub stream_offset: u64,
-        #[doc = " The time the packet was originally sent"]
+        /// The time the packet was originally sent
         pub time_sent: Timestamp,
-        #[doc = " The amount of time between when the packet was sent and when it was detected as lost"]
+        /// The amount of time between when the packet was sent and when it was detected as lost
         pub lifetime: core::time::Duration,
         pub is_retransmission: bool,
     }
@@ -5285,19 +5800,19 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Indicates that a packet was acknowledged on a stream"]
+    /// Indicates that a packet was acknowledged on a stream
     pub struct StreamPacketAcked {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The size of the application data in the packet"]
+        /// The size of the application data in the packet
         pub payload_len: usize,
-        #[doc = " The packet number of the acknowledged packet"]
+        /// The packet number of the acknowledged packet
         pub packet_number: u64,
-        #[doc = " The offset in the stream of the first byte in the packet"]
+        /// The offset in the stream of the first byte in the packet
         pub stream_offset: u64,
-        #[doc = " The time the packet was originally sent"]
+        /// The time the packet was originally sent
         pub time_sent: Timestamp,
-        #[doc = " The amount of time between when the packet was sent and when it was detected as lost"]
+        /// The amount of time between when the packet was sent and when it was detected as lost
         pub lifetime: core::time::Duration,
         pub is_retransmission: bool,
     }
@@ -5325,17 +5840,17 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Indicates that a packet was retransmitted on a stream but was not actually lost"]
+    /// Indicates that a packet was retransmitted on a stream but was not actually lost
     pub struct StreamPacketSpuriouslyRetransmitted {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The size of the application data in the packet"]
+        /// The size of the application data in the packet
         pub payload_len: usize,
-        #[doc = " The packet number of the packet"]
+        /// The packet number of the packet
         pub packet_number: u64,
-        #[doc = " The offset in the stream of the first byte in the packet"]
+        /// The offset in the stream of the first byte in the packet
         pub stream_offset: u64,
-        #[doc = " Whether the packet contained the final bytes of the stream"]
+        /// Whether the packet contained the final bytes of the stream
         pub is_fin: bool,
         pub is_retransmission: bool,
     }
@@ -5361,11 +5876,11 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Indicates that the stream received additional flow control credits"]
+    /// Indicates that the stream received additional flow control credits
     pub struct StreamMaxDataReceived {
-        #[doc = " The number of bytes of flow control credits received"]
+        /// The number of bytes of flow control credits received
         pub increase: u64,
-        #[doc = " The new offset of the stream"]
+        /// The new offset of the stream
         pub new_max_data: u64,
     }
     impl IntoEvent<api::StreamMaxDataReceived> for StreamMaxDataReceived {
@@ -5383,11 +5898,11 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamControlPacketTransmitted {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The size of the control data in the packet"]
+        /// The size of the control data in the packet
         pub control_data_len: usize,
-        #[doc = " The packet number of the received control packet"]
+        /// The packet number of the received control packet
         pub packet_number: u64,
     }
     impl IntoEvent<api::StreamControlPacketTransmitted> for StreamControlPacketTransmitted {
@@ -5407,13 +5922,13 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct StreamControlPacketReceived {
-        #[doc = " The total size of the packet"]
+        /// The total size of the packet
         pub packet_len: usize,
-        #[doc = " The size of the control data in the packet"]
+        /// The size of the control data in the packet
         pub control_data_len: usize,
-        #[doc = " The packet number of the received control packet"]
+        /// The packet number of the received control packet
         pub packet_number: u64,
-        #[doc = " Whether the packet was successfully authenticated"]
+        /// Whether the packet was successfully authenticated
         pub is_authenticated: bool,
     }
     impl IntoEvent<api::StreamControlPacketReceived> for StreamControlPacketReceived {
@@ -5436,7 +5951,7 @@ pub mod builder {
     #[derive(Clone, Debug)]
     pub struct StreamReceiverErrored {
         pub error: crate::stream::recv::Error,
-        #[doc = " The location where the error originated"]
+        /// The location where the error originated
         pub source: s2n_quic_core::endpoint::Location,
     }
     impl IntoEvent<api::StreamReceiverErrored> for StreamReceiverErrored {
@@ -5452,7 +5967,7 @@ pub mod builder {
     #[derive(Clone, Debug)]
     pub struct StreamSenderErrored {
         pub error: crate::stream::send::Error,
-        #[doc = " The location where the error originated"]
+        /// The location where the error originated
         pub source: s2n_quic_core::endpoint::Location,
     }
     impl IntoEvent<api::StreamSenderErrored> for StreamSenderErrored {
@@ -5466,7 +5981,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a handshake packet is rejected due to an invalid field value"]
+    /// Emitted when a handshake packet is rejected due to an invalid field value
     pub struct StreamHandshakePacketRejected {
         pub reason: StreamHandshakePacketRejectedReason,
     }
@@ -5489,8 +6004,8 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Used for cases where we are racing multiple futures and exit if any of them fail, and so"]
-    #[doc = " recording success is not just a boolean value."]
+    /// Used for cases where we are racing multiple futures and exit if any of them fail, and so
+    /// recording success is not just a boolean value.
     pub enum MaybeBoolCounter {
         Success,
         Failure,
@@ -5508,25 +6023,25 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Note that there's no guarantee of a particular reason if multiple reasons ~simultaneously"]
-    #[doc = " terminate the connection."]
+    /// Note that there's no guarantee of a particular reason if multiple reasons ~simultaneously
+    /// terminate the connection.
     pub enum StreamTcpConnectErrorReason {
-        #[doc = " TCP connect failed."]
+        /// TCP connect failed.
         TcpConnect,
-        #[doc = " Handshake failed to produce credentials."]
+        /// Handshake failed to produce credentials.
         Handshake,
-        #[doc = " When the connect future is dropped prior to returning any result."]
-        #[doc = ""]
-        #[doc = " This means the TCP connect succeeded, but the handshake hasn't yet by the time the connect"]
-        #[doc = " future was dropped."]
+        /// When the connect future is dropped prior to returning any result.
+        ///
+        /// This means the TCP connect succeeded, but the handshake hasn't yet by the time the connect
+        /// future was dropped.
         AbortedPendingHandshake,
-        #[doc = " When the connect future is dropped prior to returning any result."]
-        #[doc = ""]
-        #[doc = " The handshake succeeded (or wasn't needed), but the TCP connect hasn't yet finished."]
+        /// When the connect future is dropped prior to returning any result.
+        ///
+        /// The handshake succeeded (or wasn't needed), but the TCP connect hasn't yet finished.
         AbortedPendingConnect,
-        #[doc = " When the connect future is dropped prior to returning any result."]
-        #[doc = ""]
-        #[doc = " Neither the TCP connect or handshake have finished yet."]
+        /// When the connect future is dropped prior to returning any result.
+        ///
+        /// Neither the TCP connect or handshake have finished yet.
         AbortedPendingBoth,
     }
     impl IntoEvent<api::StreamTcpConnectErrorReason> for StreamTcpConnectErrorReason {
@@ -5544,7 +6059,7 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub enum StreamHandshakePacketRejectedReason {
-        #[doc = " The queue_id exceeds the maximum encodable value"]
+        /// The queue_id exceeds the maximum encodable value
         InvalidQueueId,
     }
     impl IntoEvent<api::StreamHandshakePacketRejectedReason> for StreamHandshakePacketRejectedReason {
@@ -5581,7 +6096,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the DC handshake confirmation or MTU probing times out"]
+    /// Emitted when the DC handshake confirmation or MTU probing times out
     pub struct DcConnectionTimeout<'a> {
         pub peer_address: SocketAddress<'a>,
     }
@@ -5596,7 +6111,7 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct PathSecretMapInitialized {
-        #[doc = " The capacity of the path secret map"]
+        /// The capacity of the path secret map
         pub capacity: usize,
     }
     impl IntoEvent<api::PathSecretMapInitialized> for PathSecretMapInitialized {
@@ -5610,9 +6125,9 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct PathSecretMapUninitialized {
-        #[doc = " The capacity of the path secret map"]
+        /// The capacity of the path secret map
         pub capacity: usize,
-        #[doc = " The number of entries in the map"]
+        /// The number of entries in the map
         pub entries: usize,
         pub lifetime: core::time::Duration,
     }
@@ -5632,7 +6147,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a background handshake is requested"]
+    /// Emitted when a background handshake is requested
     pub struct PathSecretMapBackgroundHandshakeRequested<'a> {
         pub peer_address: SocketAddress<'a>,
     }
@@ -5648,7 +6163,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the entry is inserted into the path secret map"]
+    /// Emitted when the entry is inserted into the path secret map
     pub struct PathSecretMapEntryInserted<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -5667,7 +6182,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the entry is considered ready for use"]
+    /// Emitted when the entry is considered ready for use
     pub struct PathSecretMapEntryReady<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -5686,7 +6201,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an entry is replaced by a new one for the same `peer_address`"]
+    /// Emitted when an entry is replaced by a new one for the same `peer_address`
     pub struct PathSecretMapEntryReplaced<'a> {
         pub peer_address: SocketAddress<'a>,
         pub new_credential_id: &'a [u8],
@@ -5708,11 +6223,11 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an entry is evicted due to running out of space"]
+    /// Emitted when an entry is evicted due to running out of space
     pub struct PathSecretMapIdEntryEvicted<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
-        #[doc = " Time since insertion of this entry"]
+        /// Time since insertion of this entry
         pub age: core::time::Duration,
     }
     impl<'a> IntoEvent<api::PathSecretMapIdEntryEvicted<'a>> for PathSecretMapIdEntryEvicted<'a> {
@@ -5731,11 +6246,11 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an entry is evicted due to running out of space"]
+    /// Emitted when an entry is evicted due to running out of space
     pub struct PathSecretMapAddressEntryEvicted<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
-        #[doc = " Time since insertion of this entry"]
+        /// Time since insertion of this entry
         pub age: core::time::Duration,
     }
     impl<'a> IntoEvent<api::PathSecretMapAddressEntryEvicted<'a>>
@@ -5756,7 +6271,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an UnknownPathSecret packet was sent"]
+    /// Emitted when an UnknownPathSecret packet was sent
     pub struct UnknownPathSecretPacketSent<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -5775,7 +6290,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an UnknownPathSecret packet was received"]
+    /// Emitted when an UnknownPathSecret packet was received
     pub struct UnknownPathSecretPacketReceived<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -5796,7 +6311,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an UnknownPathSecret packet was authentic and processed"]
+    /// Emitted when an UnknownPathSecret packet was authentic and processed
     pub struct UnknownPathSecretPacketAccepted<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -5817,7 +6332,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an UnknownPathSecret packet was rejected as invalid"]
+    /// Emitted when an UnknownPathSecret packet was rejected as invalid
     pub struct UnknownPathSecretPacketRejected<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -5838,7 +6353,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an UnknownPathSecret packet was dropped due to a missing entry"]
+    /// Emitted when an UnknownPathSecret packet was dropped due to a missing entry
     pub struct UnknownPathSecretPacketDropped<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -5857,18 +6372,18 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a credential is accepted (i.e., post packet authentication and passes replay"]
-    #[doc = " check)."]
+    /// Emitted when a credential is accepted (i.e., post packet authentication and passes replay
+    /// check).
     pub struct KeyAccepted<'a> {
         pub credential_id: &'a [u8],
         pub key_id: u64,
-        #[doc = " How far away this credential is from the leading edge of key IDs (after updating the edge)."]
-        #[doc = ""]
-        #[doc = " Zero if this shifted us forward."]
+        /// How far away this credential is from the leading edge of key IDs (after updating the edge).
+        ///
+        /// Zero if this shifted us forward.
         pub gap: u64,
-        #[doc = " How far away this credential is from the leading edge of key IDs (before updating the edge)."]
-        #[doc = ""]
-        #[doc = " Zero if this didn't change the leading edge."]
+        /// How far away this credential is from the leading edge of key IDs (before updating the edge).
+        ///
+        /// Zero if this didn't change the leading edge.
         pub forward_shift: u64,
     }
     impl<'a> IntoEvent<api::KeyAccepted<'a>> for KeyAccepted<'a> {
@@ -5889,7 +6404,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when credential replay was definitely detected"]
+    /// Emitted when credential replay was definitely detected
     pub struct ReplayDefinitelyDetected<'a> {
         pub credential_id: &'a [u8],
         pub key_id: u64,
@@ -5908,8 +6423,8 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when credential replay was potentially detected, but could not be verified"]
-    #[doc = " due to a limiting tracking window"]
+    /// Emitted when credential replay was potentially detected, but could not be verified
+    /// due to a limiting tracking window
     pub struct ReplayPotentiallyDetected<'a> {
         pub credential_id: &'a [u8],
         pub key_id: u64,
@@ -5931,7 +6446,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an ReplayDetected packet was sent"]
+    /// Emitted when an ReplayDetected packet was sent
     pub struct ReplayDetectedPacketSent<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -5950,7 +6465,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an ReplayDetected packet was received"]
+    /// Emitted when an ReplayDetected packet was received
     pub struct ReplayDetectedPacketReceived<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -5969,7 +6484,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an StaleKey packet was authentic and processed"]
+    /// Emitted when an StaleKey packet was authentic and processed
     pub struct ReplayDetectedPacketAccepted<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -5991,7 +6506,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an ReplayDetected packet was rejected as invalid"]
+    /// Emitted when an ReplayDetected packet was rejected as invalid
     pub struct ReplayDetectedPacketRejected<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -6010,7 +6525,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an ReplayDetected packet was dropped due to a missing entry"]
+    /// Emitted when an ReplayDetected packet was dropped due to a missing entry
     pub struct ReplayDetectedPacketDropped<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -6029,7 +6544,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an StaleKey packet was sent"]
+    /// Emitted when an StaleKey packet was sent
     pub struct StaleKeyPacketSent<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -6048,7 +6563,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an StaleKey packet was received"]
+    /// Emitted when an StaleKey packet was received
     pub struct StaleKeyPacketReceived<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -6067,7 +6582,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an StaleKey packet was authentic and processed"]
+    /// Emitted when an StaleKey packet was authentic and processed
     pub struct StaleKeyPacketAccepted<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -6086,7 +6601,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an StaleKey packet was rejected as invalid"]
+    /// Emitted when an StaleKey packet was rejected as invalid
     pub struct StaleKeyPacketRejected<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -6105,7 +6620,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when an StaleKey packet was dropped due to a missing entry"]
+    /// Emitted when an StaleKey packet was dropped due to a missing entry
     pub struct StaleKeyPacketDropped<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
@@ -6124,9 +6639,9 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the cache is accessed by peer address"]
-    #[doc = ""]
-    #[doc = " This can be used to track cache hit ratios"]
+    /// Emitted when the cache is accessed by peer address
+    ///
+    /// This can be used to track cache hit ratios
     pub struct PathSecretMapAddressCacheAccessed<'a> {
         pub peer_address: SocketAddress<'a>,
         pub hit: bool,
@@ -6144,9 +6659,9 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the cache is accessed by peer address successfully"]
-    #[doc = ""]
-    #[doc = " Provides more information about the accessed entry."]
+    /// Emitted when the cache is accessed by peer address successfully
+    ///
+    /// Provides more information about the accessed entry.
     pub struct PathSecretMapAddressCacheAccessedHit<'a> {
         pub peer_address: SocketAddress<'a>,
         pub age: core::time::Duration,
@@ -6164,9 +6679,9 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the cache is accessed by path secret ID"]
-    #[doc = ""]
-    #[doc = " This can be used to track cache hit ratios"]
+    /// Emitted when the cache is accessed by path secret ID
+    ///
+    /// This can be used to track cache hit ratios
     pub struct PathSecretMapIdCacheAccessed<'a> {
         pub credential_id: &'a [u8],
         pub hit: bool,
@@ -6182,9 +6697,9 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the cache is accessed by path secret ID successfully"]
-    #[doc = ""]
-    #[doc = " Provides more information about the accessed entry."]
+    /// Emitted when the cache is accessed by path secret ID successfully
+    ///
+    /// Provides more information about the accessed entry.
     pub struct PathSecretMapIdCacheAccessedHit<'a> {
         pub credential_id: &'a [u8],
         pub age: core::time::Duration,
@@ -6202,43 +6717,43 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the cleaner task performed a single cycle"]
-    #[doc = ""]
-    #[doc = " This can be used to track cache utilization"]
+    /// Emitted when the cleaner task performed a single cycle
+    ///
+    /// This can be used to track cache utilization
     pub struct PathSecretMapCleanerCycled {
-        #[doc = " The number of Path Secret ID entries left after the cleaning cycle"]
+        /// The number of Path Secret ID entries left after the cleaning cycle
         pub id_entries: usize,
-        #[doc = " The number of Path Secret ID entries that were retired in the cycle"]
+        /// The number of Path Secret ID entries that were retired in the cycle
         pub id_entries_retired: usize,
-        #[doc = " Count of entries accessed since the last cycle"]
+        /// Count of entries accessed since the last cycle
         pub id_entries_active: usize,
-        #[doc = " The utilization percentage of the active number of entries after the cycle"]
+        /// The utilization percentage of the active number of entries after the cycle
         pub id_entries_active_utilization: f32,
-        #[doc = " The utilization percentage of the available number of entries after the cycle"]
+        /// The utilization percentage of the available number of entries after the cycle
         pub id_entries_utilization: f32,
-        #[doc = " The utilization percentage of the available number of entries before the cycle"]
+        /// The utilization percentage of the available number of entries before the cycle
         pub id_entries_initial_utilization: f32,
-        #[doc = " The number of SocketAddress entries left after the cleaning cycle"]
+        /// The number of SocketAddress entries left after the cleaning cycle
         pub address_entries: usize,
-        #[doc = " Count of entries accessed since the last cycle"]
+        /// Count of entries accessed since the last cycle
         pub address_entries_active: usize,
-        #[doc = " The utilization percentage of the active number of entries after the cycle"]
+        /// The utilization percentage of the active number of entries after the cycle
         pub address_entries_active_utilization: f32,
-        #[doc = " The number of SocketAddress entries that were retired in the cycle"]
+        /// The number of SocketAddress entries that were retired in the cycle
         pub address_entries_retired: usize,
-        #[doc = " The utilization percentage of the available number of address entries after the cycle"]
+        /// The utilization percentage of the available number of address entries after the cycle
         pub address_entries_utilization: f32,
-        #[doc = " The utilization percentage of the available number of address entries before the cycle"]
+        /// The utilization percentage of the available number of address entries before the cycle
         pub address_entries_initial_utilization: f32,
-        #[doc = " The number of handshake requests that are pending after the cleaning cycle"]
+        /// The number of handshake requests that are pending after the cleaning cycle
         pub handshake_requests: usize,
-        #[doc = " The number of handshake requests that were skipped in the cycle due to running out of time"]
-        #[doc = " (other background handshakes took too long to complete, and so were postponed to the next"]
-        #[doc = " cleaner cycle)."]
+        /// The number of handshake requests that were skipped in the cycle due to running out of time
+        /// (other background handshakes took too long to complete, and so were postponed to the next
+        /// cleaner cycle).
         pub handshake_requests_skipped: usize,
-        #[doc = " How long we kept the handshake lock held (this blocks completing handshakes)."]
+        /// How long we kept the handshake lock held (this blocks completing handshakes).
         pub handshake_lock_duration: core::time::Duration,
-        #[doc = " Total duration of a cycle."]
+        /// Total duration of a cycle.
         pub duration: core::time::Duration,
     }
     impl IntoEvent<api::PathSecretMapCleanerCycled> for PathSecretMapCleanerCycled {
@@ -6314,9 +6829,9 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a dcQUIC datagram is encrypted"]
+    /// Emitted when a dcQUIC datagram is encrypted
     pub struct PathSecretMapDatagramEncrypt {
-        #[doc = " The wire size of the encrypted datagram packet"]
+        /// The wire size of the encrypted datagram packet
         pub packet_len: usize,
     }
     impl IntoEvent<api::PathSecretMapDatagramEncrypt> for PathSecretMapDatagramEncrypt {
@@ -6329,9 +6844,9 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a dcQUIC datagram is decrypted"]
+    /// Emitted when a dcQUIC datagram is decrypted
     pub struct PathSecretMapDatagramDecrypt {
-        #[doc = " The wire size of the encrypted datagram packet"]
+        /// The wire size of the encrypted datagram packet
         pub packet_len: usize,
     }
     impl IntoEvent<api::PathSecretMapDatagramDecrypt> for PathSecretMapDatagramDecrypt {
@@ -6350,58 +6865,58 @@ mod traits {
     use crate::event::Meta;
     use core::fmt;
     use s2n_quic_core::query;
-    #[doc = r" Allows for events to be subscribed to"]
+    /// Allows for events to be subscribed to
     pub trait Subscriber: 'static + Send + Sync {
-        #[doc = r" An application provided type associated with each connection."]
-        #[doc = r""]
-        #[doc = r" The context provides a mechanism for applications to provide a custom type"]
-        #[doc = r" and update it on each event, e.g. computing statistics. Each event"]
-        #[doc = r" invocation (e.g. [`Subscriber::on_packet_sent`]) also provides mutable"]
-        #[doc = r" access to the context `&mut ConnectionContext` and allows for updating the"]
-        #[doc = r" context."]
-        #[doc = r""]
-        #[doc = r" ```no_run"]
-        #[doc = r" # mod s2n_quic { pub mod provider { pub mod event {"]
-        #[doc = r" #     pub use s2n_quic_core::event::{api as events, api::ConnectionInfo, api::ConnectionMeta, Subscriber};"]
-        #[doc = r" # }}}"]
-        #[doc = r" use s2n_quic::provider::event::{"]
-        #[doc = r"     ConnectionInfo, ConnectionMeta, Subscriber, events::PacketSent"]
-        #[doc = r" };"]
-        #[doc = r""]
-        #[doc = r" pub struct MyEventSubscriber;"]
-        #[doc = r""]
-        #[doc = r" pub struct MyEventContext {"]
-        #[doc = r"     packet_sent: u64,"]
-        #[doc = r" }"]
-        #[doc = r""]
-        #[doc = r" impl Subscriber for MyEventSubscriber {"]
-        #[doc = r"     type ConnectionContext = MyEventContext;"]
-        #[doc = r""]
-        #[doc = r"     fn create_connection_context("]
-        #[doc = r"         &mut self, _meta: &ConnectionMeta,"]
-        #[doc = r"         _info: &ConnectionInfo,"]
-        #[doc = r"     ) -> Self::ConnectionContext {"]
-        #[doc = r"         MyEventContext { packet_sent: 0 }"]
-        #[doc = r"     }"]
-        #[doc = r""]
-        #[doc = r"     fn on_packet_sent("]
-        #[doc = r"         &mut self,"]
-        #[doc = r"         context: &mut Self::ConnectionContext,"]
-        #[doc = r"         _meta: &ConnectionMeta,"]
-        #[doc = r"         _event: &PacketSent,"]
-        #[doc = r"     ) {"]
-        #[doc = r"         context.packet_sent += 1;"]
-        #[doc = r"     }"]
-        #[doc = r" }"]
-        #[doc = r"  ```"]
+        /// An application provided type associated with each connection.
+        ///
+        /// The context provides a mechanism for applications to provide a custom type
+        /// and update it on each event, e.g. computing statistics. Each event
+        /// invocation (e.g. [`Subscriber::on_packet_sent`]) also provides mutable
+        /// access to the context `&mut ConnectionContext` and allows for updating the
+        /// context.
+        ///
+        /// ```no_run
+        /// # mod s2n_quic { pub mod provider { pub mod event {
+        /// #     pub use s2n_quic_core::event::{api as events, api::ConnectionInfo, api::ConnectionMeta, Subscriber};
+        /// # }}}
+        /// use s2n_quic::provider::event::{
+        ///     ConnectionInfo, ConnectionMeta, Subscriber, events::PacketSent
+        /// };
+        ///
+        /// pub struct MyEventSubscriber;
+        ///
+        /// pub struct MyEventContext {
+        ///     packet_sent: u64,
+        /// }
+        ///
+        /// impl Subscriber for MyEventSubscriber {
+        ///     type ConnectionContext = MyEventContext;
+        ///
+        ///     fn create_connection_context(
+        ///         &mut self, _meta: &ConnectionMeta,
+        ///         _info: &ConnectionInfo,
+        ///     ) -> Self::ConnectionContext {
+        ///         MyEventContext { packet_sent: 0 }
+        ///     }
+        ///
+        ///     fn on_packet_sent(
+        ///         &mut self,
+        ///         context: &mut Self::ConnectionContext,
+        ///         _meta: &ConnectionMeta,
+        ///         _event: &PacketSent,
+        ///     ) {
+        ///         context.packet_sent += 1;
+        ///     }
+        /// }
+        ///  ```
         type ConnectionContext: 'static + Send + Sync;
-        #[doc = r" Creates a context to be passed to each connection-related event"]
+        /// Creates a context to be passed to each connection-related event
         fn create_connection_context(
             &self,
             meta: &api::ConnectionMeta,
             info: &api::ConnectionInfo,
         ) -> Self::ConnectionContext;
-        #[doc = "Called when the `AcceptorTcpStarted` event is triggered"]
+        ///Called when the `AcceptorTcpStarted` event is triggered
         #[inline]
         fn on_acceptor_tcp_started(
             &self,
@@ -6411,7 +6926,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorTcpLoopIterationCompleted` event is triggered"]
+        ///Called when the `AcceptorTcpLoopIterationCompleted` event is triggered
         #[inline]
         fn on_acceptor_tcp_loop_iteration_completed(
             &self,
@@ -6421,7 +6936,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorTcpFreshEnqueued` event is triggered"]
+        ///Called when the `AcceptorTcpFreshEnqueued` event is triggered
         #[inline]
         fn on_acceptor_tcp_fresh_enqueued(
             &self,
@@ -6431,7 +6946,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorTcpFreshBatchCompleted` event is triggered"]
+        ///Called when the `AcceptorTcpFreshBatchCompleted` event is triggered
         #[inline]
         fn on_acceptor_tcp_fresh_batch_completed(
             &self,
@@ -6441,7 +6956,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorTcpStreamDropped` event is triggered"]
+        ///Called when the `AcceptorTcpStreamDropped` event is triggered
         #[inline]
         fn on_acceptor_tcp_stream_dropped(
             &self,
@@ -6451,7 +6966,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorTcpStreamReplaced` event is triggered"]
+        ///Called when the `AcceptorTcpStreamReplaced` event is triggered
         #[inline]
         fn on_acceptor_tcp_stream_replaced(
             &self,
@@ -6461,7 +6976,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorTcpPacketReceived` event is triggered"]
+        ///Called when the `AcceptorTcpPacketReceived` event is triggered
         #[inline]
         fn on_acceptor_tcp_packet_received(
             &self,
@@ -6471,7 +6986,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorTcpTlsStarted` event is triggered"]
+        ///Called when the `AcceptorTcpTlsStarted` event is triggered
         #[inline]
         fn on_acceptor_tcp_tls_started(
             &self,
@@ -6481,7 +6996,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorTcpTlsStreamEnqueued` event is triggered"]
+        ///Called when the `AcceptorTcpTlsStreamEnqueued` event is triggered
         #[inline]
         fn on_acceptor_tcp_tls_stream_enqueued(
             &self,
@@ -6491,7 +7006,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorTcpTlsStreamRejected` event is triggered"]
+        ///Called when the `AcceptorTcpTlsStreamRejected` event is triggered
         #[inline]
         fn on_acceptor_tcp_tls_stream_rejected(
             &self,
@@ -6501,7 +7016,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorTcpPacketDropped` event is triggered"]
+        ///Called when the `AcceptorTcpPacketDropped` event is triggered
         #[inline]
         fn on_acceptor_tcp_packet_dropped(
             &self,
@@ -6511,7 +7026,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorTcpStreamEnqueued` event is triggered"]
+        ///Called when the `AcceptorTcpStreamEnqueued` event is triggered
         #[inline]
         fn on_acceptor_tcp_stream_enqueued(
             &self,
@@ -6521,7 +7036,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorTcpIoError` event is triggered"]
+        ///Called when the `AcceptorTcpIoError` event is triggered
         #[inline]
         fn on_acceptor_tcp_io_error(
             &self,
@@ -6531,7 +7046,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorTcpSocketSent` event is triggered"]
+        ///Called when the `AcceptorTcpSocketSent` event is triggered
         #[inline]
         fn on_acceptor_tcp_socket_sent(
             &self,
@@ -6541,7 +7056,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorTcpSocketReceived` event is triggered"]
+        ///Called when the `AcceptorTcpSocketReceived` event is triggered
         #[inline]
         fn on_acceptor_tcp_socket_received(
             &self,
@@ -6551,7 +7066,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorUdpStarted` event is triggered"]
+        ///Called when the `AcceptorUdpStarted` event is triggered
         #[inline]
         fn on_acceptor_udp_started(
             &self,
@@ -6561,7 +7076,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorUdpDatagramReceived` event is triggered"]
+        ///Called when the `AcceptorUdpDatagramReceived` event is triggered
         #[inline]
         fn on_acceptor_udp_datagram_received(
             &self,
@@ -6571,7 +7086,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorUdpPacketReceived` event is triggered"]
+        ///Called when the `AcceptorUdpPacketReceived` event is triggered
         #[inline]
         fn on_acceptor_udp_packet_received(
             &self,
@@ -6581,7 +7096,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorUdpPacketDropped` event is triggered"]
+        ///Called when the `AcceptorUdpPacketDropped` event is triggered
         #[inline]
         fn on_acceptor_udp_packet_dropped(
             &self,
@@ -6591,7 +7106,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorUdpStreamEnqueued` event is triggered"]
+        ///Called when the `AcceptorUdpStreamEnqueued` event is triggered
         #[inline]
         fn on_acceptor_udp_stream_enqueued(
             &self,
@@ -6601,7 +7116,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorUdpIoError` event is triggered"]
+        ///Called when the `AcceptorUdpIoError` event is triggered
         #[inline]
         fn on_acceptor_udp_io_error(
             &self,
@@ -6611,7 +7126,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorStreamPruned` event is triggered"]
+        ///Called when the `AcceptorStreamPruned` event is triggered
         #[inline]
         fn on_acceptor_stream_pruned(
             &self,
@@ -6621,7 +7136,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AcceptorStreamDequeued` event is triggered"]
+        ///Called when the `AcceptorStreamDequeued` event is triggered
         #[inline]
         fn on_acceptor_stream_dequeued(
             &self,
@@ -6631,7 +7146,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamWriteFlushed` event is triggered"]
+        ///Called when the `StreamWriteFlushed` event is triggered
         #[inline]
         fn on_stream_write_flushed(
             &self,
@@ -6643,7 +7158,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamWriteFinFlushed` event is triggered"]
+        ///Called when the `StreamWriteFinFlushed` event is triggered
         #[inline]
         fn on_stream_write_fin_flushed(
             &self,
@@ -6655,7 +7170,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamWriteBlocked` event is triggered"]
+        ///Called when the `StreamWriteBlocked` event is triggered
         #[inline]
         fn on_stream_write_blocked(
             &self,
@@ -6667,7 +7182,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamWriteErrored` event is triggered"]
+        ///Called when the `StreamWriteErrored` event is triggered
         #[inline]
         fn on_stream_write_errored(
             &self,
@@ -6679,7 +7194,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamWriteKeyUpdated` event is triggered"]
+        ///Called when the `StreamWriteKeyUpdated` event is triggered
         #[inline]
         fn on_stream_write_key_updated(
             &self,
@@ -6691,7 +7206,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamWriteAllocated` event is triggered"]
+        ///Called when the `StreamWriteAllocated` event is triggered
         #[inline]
         fn on_stream_write_allocated(
             &self,
@@ -6703,7 +7218,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamWriteShutdown` event is triggered"]
+        ///Called when the `StreamWriteShutdown` event is triggered
         #[inline]
         fn on_stream_write_shutdown(
             &self,
@@ -6715,7 +7230,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamWriteSocketFlushed` event is triggered"]
+        ///Called when the `StreamWriteSocketFlushed` event is triggered
         #[inline]
         fn on_stream_write_socket_flushed(
             &self,
@@ -6727,7 +7242,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamWriteSocketBlocked` event is triggered"]
+        ///Called when the `StreamWriteSocketBlocked` event is triggered
         #[inline]
         fn on_stream_write_socket_blocked(
             &self,
@@ -6739,7 +7254,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamWriteSocketErrored` event is triggered"]
+        ///Called when the `StreamWriteSocketErrored` event is triggered
         #[inline]
         fn on_stream_write_socket_errored(
             &self,
@@ -6751,7 +7266,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamReadFlushed` event is triggered"]
+        ///Called when the `StreamReadFlushed` event is triggered
         #[inline]
         fn on_stream_read_flushed(
             &self,
@@ -6763,7 +7278,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamReadFinFlushed` event is triggered"]
+        ///Called when the `StreamReadFinFlushed` event is triggered
         #[inline]
         fn on_stream_read_fin_flushed(
             &self,
@@ -6775,7 +7290,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamReadBlocked` event is triggered"]
+        ///Called when the `StreamReadBlocked` event is triggered
         #[inline]
         fn on_stream_read_blocked(
             &self,
@@ -6787,7 +7302,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamReadErrored` event is triggered"]
+        ///Called when the `StreamReadErrored` event is triggered
         #[inline]
         fn on_stream_read_errored(
             &self,
@@ -6799,7 +7314,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamReadKeyUpdated` event is triggered"]
+        ///Called when the `StreamReadKeyUpdated` event is triggered
         #[inline]
         fn on_stream_read_key_updated(
             &self,
@@ -6811,7 +7326,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamReadShutdown` event is triggered"]
+        ///Called when the `StreamReadShutdown` event is triggered
         #[inline]
         fn on_stream_read_shutdown(
             &self,
@@ -6823,7 +7338,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamReadSocketFlushed` event is triggered"]
+        ///Called when the `StreamReadSocketFlushed` event is triggered
         #[inline]
         fn on_stream_read_socket_flushed(
             &self,
@@ -6835,7 +7350,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamReadSocketBlocked` event is triggered"]
+        ///Called when the `StreamReadSocketBlocked` event is triggered
         #[inline]
         fn on_stream_read_socket_blocked(
             &self,
@@ -6847,7 +7362,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamReadSocketErrored` event is triggered"]
+        ///Called when the `StreamReadSocketErrored` event is triggered
         #[inline]
         fn on_stream_read_socket_errored(
             &self,
@@ -6859,7 +7374,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamDecryptPacket` event is triggered"]
+        ///Called when the `StreamDecryptPacket` event is triggered
         #[inline]
         fn on_stream_decrypt_packet(
             &self,
@@ -6871,25 +7386,25 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamTcpConnect` event is triggered"]
+        ///Called when the `StreamTcpConnect` event is triggered
         #[inline]
         fn on_stream_tcp_connect(&self, meta: &api::EndpointMeta, event: &api::StreamTcpConnect) {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamTlsConnect` event is triggered"]
+        ///Called when the `StreamTlsConnect` event is triggered
         #[inline]
         fn on_stream_tls_connect(&self, meta: &api::EndpointMeta, event: &api::StreamTlsConnect) {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamConnect` event is triggered"]
+        ///Called when the `StreamConnect` event is triggered
         #[inline]
         fn on_stream_connect(&self, meta: &api::EndpointMeta, event: &api::StreamConnect) {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamConnectError` event is triggered"]
+        ///Called when the `StreamConnectError` event is triggered
         #[inline]
         fn on_stream_connect_error(
             &self,
@@ -6899,7 +7414,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamPacketTransmitted` event is triggered"]
+        ///Called when the `StreamPacketTransmitted` event is triggered
         #[inline]
         fn on_stream_packet_transmitted(
             &self,
@@ -6911,7 +7426,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamProbeTransmitted` event is triggered"]
+        ///Called when the `StreamProbeTransmitted` event is triggered
         #[inline]
         fn on_stream_probe_transmitted(
             &self,
@@ -6923,7 +7438,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamPacketReceived` event is triggered"]
+        ///Called when the `StreamPacketReceived` event is triggered
         #[inline]
         fn on_stream_packet_received(
             &self,
@@ -6935,7 +7450,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamPacketLost` event is triggered"]
+        ///Called when the `StreamPacketLost` event is triggered
         #[inline]
         fn on_stream_packet_lost(
             &self,
@@ -6947,7 +7462,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamPacketAcked` event is triggered"]
+        ///Called when the `StreamPacketAcked` event is triggered
         #[inline]
         fn on_stream_packet_acked(
             &self,
@@ -6959,7 +7474,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamPacketSpuriouslyRetransmitted` event is triggered"]
+        ///Called when the `StreamPacketSpuriouslyRetransmitted` event is triggered
         #[inline]
         fn on_stream_packet_spuriously_retransmitted(
             &self,
@@ -6971,7 +7486,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamMaxDataReceived` event is triggered"]
+        ///Called when the `StreamMaxDataReceived` event is triggered
         #[inline]
         fn on_stream_max_data_received(
             &self,
@@ -6983,7 +7498,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamControlPacketTransmitted` event is triggered"]
+        ///Called when the `StreamControlPacketTransmitted` event is triggered
         #[inline]
         fn on_stream_control_packet_transmitted(
             &self,
@@ -6995,7 +7510,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamControlPacketReceived` event is triggered"]
+        ///Called when the `StreamControlPacketReceived` event is triggered
         #[inline]
         fn on_stream_control_packet_received(
             &self,
@@ -7007,7 +7522,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamReceiverErrored` event is triggered"]
+        ///Called when the `StreamReceiverErrored` event is triggered
         #[inline]
         fn on_stream_receiver_errored(
             &self,
@@ -7019,7 +7534,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamSenderErrored` event is triggered"]
+        ///Called when the `StreamSenderErrored` event is triggered
         #[inline]
         fn on_stream_sender_errored(
             &self,
@@ -7031,7 +7546,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StreamHandshakePacketRejected` event is triggered"]
+        ///Called when the `StreamHandshakePacketRejected` event is triggered
         #[inline]
         fn on_stream_handshake_packet_rejected(
             &self,
@@ -7043,7 +7558,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ConnectionClosed` event is triggered"]
+        ///Called when the `ConnectionClosed` event is triggered
         #[inline]
         fn on_connection_closed(
             &self,
@@ -7055,7 +7570,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `EndpointInitialized` event is triggered"]
+        ///Called when the `EndpointInitialized` event is triggered
         #[inline]
         fn on_endpoint_initialized(
             &self,
@@ -7065,7 +7580,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `DcConnectionTimeout` event is triggered"]
+        ///Called when the `DcConnectionTimeout` event is triggered
         #[inline]
         fn on_dc_connection_timeout(
             &self,
@@ -7075,7 +7590,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapInitialized` event is triggered"]
+        ///Called when the `PathSecretMapInitialized` event is triggered
         #[inline]
         fn on_path_secret_map_initialized(
             &self,
@@ -7085,7 +7600,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapUninitialized` event is triggered"]
+        ///Called when the `PathSecretMapUninitialized` event is triggered
         #[inline]
         fn on_path_secret_map_uninitialized(
             &self,
@@ -7095,7 +7610,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapBackgroundHandshakeRequested` event is triggered"]
+        ///Called when the `PathSecretMapBackgroundHandshakeRequested` event is triggered
         #[inline]
         fn on_path_secret_map_background_handshake_requested(
             &self,
@@ -7105,7 +7620,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapEntryInserted` event is triggered"]
+        ///Called when the `PathSecretMapEntryInserted` event is triggered
         #[inline]
         fn on_path_secret_map_entry_inserted(
             &self,
@@ -7115,7 +7630,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapEntryReady` event is triggered"]
+        ///Called when the `PathSecretMapEntryReady` event is triggered
         #[inline]
         fn on_path_secret_map_entry_ready(
             &self,
@@ -7125,7 +7640,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapEntryReplaced` event is triggered"]
+        ///Called when the `PathSecretMapEntryReplaced` event is triggered
         #[inline]
         fn on_path_secret_map_entry_replaced(
             &self,
@@ -7135,7 +7650,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapIdEntryEvicted` event is triggered"]
+        ///Called when the `PathSecretMapIdEntryEvicted` event is triggered
         #[inline]
         fn on_path_secret_map_id_entry_evicted(
             &self,
@@ -7145,7 +7660,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapAddressEntryEvicted` event is triggered"]
+        ///Called when the `PathSecretMapAddressEntryEvicted` event is triggered
         #[inline]
         fn on_path_secret_map_address_entry_evicted(
             &self,
@@ -7155,7 +7670,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `UnknownPathSecretPacketSent` event is triggered"]
+        ///Called when the `UnknownPathSecretPacketSent` event is triggered
         #[inline]
         fn on_unknown_path_secret_packet_sent(
             &self,
@@ -7165,7 +7680,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `UnknownPathSecretPacketReceived` event is triggered"]
+        ///Called when the `UnknownPathSecretPacketReceived` event is triggered
         #[inline]
         fn on_unknown_path_secret_packet_received(
             &self,
@@ -7175,7 +7690,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `UnknownPathSecretPacketAccepted` event is triggered"]
+        ///Called when the `UnknownPathSecretPacketAccepted` event is triggered
         #[inline]
         fn on_unknown_path_secret_packet_accepted(
             &self,
@@ -7185,7 +7700,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `UnknownPathSecretPacketRejected` event is triggered"]
+        ///Called when the `UnknownPathSecretPacketRejected` event is triggered
         #[inline]
         fn on_unknown_path_secret_packet_rejected(
             &self,
@@ -7195,7 +7710,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `UnknownPathSecretPacketDropped` event is triggered"]
+        ///Called when the `UnknownPathSecretPacketDropped` event is triggered
         #[inline]
         fn on_unknown_path_secret_packet_dropped(
             &self,
@@ -7205,13 +7720,13 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `KeyAccepted` event is triggered"]
+        ///Called when the `KeyAccepted` event is triggered
         #[inline]
         fn on_key_accepted(&self, meta: &api::EndpointMeta, event: &api::KeyAccepted) {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ReplayDefinitelyDetected` event is triggered"]
+        ///Called when the `ReplayDefinitelyDetected` event is triggered
         #[inline]
         fn on_replay_definitely_detected(
             &self,
@@ -7221,7 +7736,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ReplayPotentiallyDetected` event is triggered"]
+        ///Called when the `ReplayPotentiallyDetected` event is triggered
         #[inline]
         fn on_replay_potentially_detected(
             &self,
@@ -7231,7 +7746,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ReplayDetectedPacketSent` event is triggered"]
+        ///Called when the `ReplayDetectedPacketSent` event is triggered
         #[inline]
         fn on_replay_detected_packet_sent(
             &self,
@@ -7241,7 +7756,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ReplayDetectedPacketReceived` event is triggered"]
+        ///Called when the `ReplayDetectedPacketReceived` event is triggered
         #[inline]
         fn on_replay_detected_packet_received(
             &self,
@@ -7251,7 +7766,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ReplayDetectedPacketAccepted` event is triggered"]
+        ///Called when the `ReplayDetectedPacketAccepted` event is triggered
         #[inline]
         fn on_replay_detected_packet_accepted(
             &self,
@@ -7261,7 +7776,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ReplayDetectedPacketRejected` event is triggered"]
+        ///Called when the `ReplayDetectedPacketRejected` event is triggered
         #[inline]
         fn on_replay_detected_packet_rejected(
             &self,
@@ -7271,7 +7786,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ReplayDetectedPacketDropped` event is triggered"]
+        ///Called when the `ReplayDetectedPacketDropped` event is triggered
         #[inline]
         fn on_replay_detected_packet_dropped(
             &self,
@@ -7281,7 +7796,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StaleKeyPacketSent` event is triggered"]
+        ///Called when the `StaleKeyPacketSent` event is triggered
         #[inline]
         fn on_stale_key_packet_sent(
             &self,
@@ -7291,7 +7806,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StaleKeyPacketReceived` event is triggered"]
+        ///Called when the `StaleKeyPacketReceived` event is triggered
         #[inline]
         fn on_stale_key_packet_received(
             &self,
@@ -7301,7 +7816,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StaleKeyPacketAccepted` event is triggered"]
+        ///Called when the `StaleKeyPacketAccepted` event is triggered
         #[inline]
         fn on_stale_key_packet_accepted(
             &self,
@@ -7311,7 +7826,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StaleKeyPacketRejected` event is triggered"]
+        ///Called when the `StaleKeyPacketRejected` event is triggered
         #[inline]
         fn on_stale_key_packet_rejected(
             &self,
@@ -7321,7 +7836,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `StaleKeyPacketDropped` event is triggered"]
+        ///Called when the `StaleKeyPacketDropped` event is triggered
         #[inline]
         fn on_stale_key_packet_dropped(
             &self,
@@ -7331,7 +7846,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapAddressCacheAccessed` event is triggered"]
+        ///Called when the `PathSecretMapAddressCacheAccessed` event is triggered
         #[inline]
         fn on_path_secret_map_address_cache_accessed(
             &self,
@@ -7341,7 +7856,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapAddressCacheAccessedHit` event is triggered"]
+        ///Called when the `PathSecretMapAddressCacheAccessedHit` event is triggered
         #[inline]
         fn on_path_secret_map_address_cache_accessed_hit(
             &self,
@@ -7351,7 +7866,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapIdCacheAccessed` event is triggered"]
+        ///Called when the `PathSecretMapIdCacheAccessed` event is triggered
         #[inline]
         fn on_path_secret_map_id_cache_accessed(
             &self,
@@ -7361,7 +7876,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapIdCacheAccessedHit` event is triggered"]
+        ///Called when the `PathSecretMapIdCacheAccessedHit` event is triggered
         #[inline]
         fn on_path_secret_map_id_cache_accessed_hit(
             &self,
@@ -7371,7 +7886,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapCleanerCycled` event is triggered"]
+        ///Called when the `PathSecretMapCleanerCycled` event is triggered
         #[inline]
         fn on_path_secret_map_cleaner_cycled(
             &self,
@@ -7381,7 +7896,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapIdWriteLock` event is triggered"]
+        ///Called when the `PathSecretMapIdWriteLock` event is triggered
         #[inline]
         fn on_path_secret_map_id_write_lock(
             &self,
@@ -7391,7 +7906,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapAddressWriteLock` event is triggered"]
+        ///Called when the `PathSecretMapAddressWriteLock` event is triggered
         #[inline]
         fn on_path_secret_map_address_write_lock(
             &self,
@@ -7401,7 +7916,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapDatagramEncrypt` event is triggered"]
+        ///Called when the `PathSecretMapDatagramEncrypt` event is triggered
         #[inline]
         fn on_path_secret_map_datagram_encrypt(
             &self,
@@ -7411,7 +7926,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathSecretMapDatagramDecrypt` event is triggered"]
+        ///Called when the `PathSecretMapDatagramDecrypt` event is triggered
         #[inline]
         fn on_path_secret_map_datagram_decrypt(
             &self,
@@ -7421,13 +7936,13 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = r" Called for each event that relates to the endpoint and all connections"]
+        /// Called for each event that relates to the endpoint and all connections
         #[inline]
         fn on_event<M: Meta, E: Event>(&self, meta: &M, event: &E) {
             let _ = meta;
             let _ = event;
         }
-        #[doc = r" Called for each event that relates to a connection"]
+        /// Called for each event that relates to a connection
         #[inline]
         fn on_connection_event<E: Event>(
             &self,
@@ -7439,7 +7954,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = r" Used for querying the `Subscriber::ConnectionContext` on a Subscriber"]
+        /// Used for querying the `Subscriber::ConnectionContext` on a Subscriber
         #[inline]
         fn query(
             context: &Self::ConnectionContext,
@@ -8307,8 +8822,8 @@ mod traits {
             self.as_ref().on_connection_event(context, meta, event);
         }
     }
-    #[doc = r" Subscriber is implemented for a 2-element tuple to make it easy to compose multiple"]
-    #[doc = r" subscribers."]
+    /// Subscriber is implemented for a 2-element tuple to make it easy to compose multiple
+    /// subscribers.
     impl<A, B> Subscriber for (A, B)
     where
         A: Subscriber,
@@ -9243,174 +9758,174 @@ mod traits {
         }
     }
     pub trait EndpointPublisher {
-        #[doc = "Publishes a `AcceptorTcpStarted` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorTcpStarted` event to the publisher's subscriber
         fn on_acceptor_tcp_started(&self, event: builder::AcceptorTcpStarted);
-        #[doc = "Publishes a `AcceptorTcpLoopIterationCompleted` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorTcpLoopIterationCompleted` event to the publisher's subscriber
         fn on_acceptor_tcp_loop_iteration_completed(
             &self,
             event: builder::AcceptorTcpLoopIterationCompleted,
         );
-        #[doc = "Publishes a `AcceptorTcpFreshEnqueued` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorTcpFreshEnqueued` event to the publisher's subscriber
         fn on_acceptor_tcp_fresh_enqueued(&self, event: builder::AcceptorTcpFreshEnqueued);
-        #[doc = "Publishes a `AcceptorTcpFreshBatchCompleted` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorTcpFreshBatchCompleted` event to the publisher's subscriber
         fn on_acceptor_tcp_fresh_batch_completed(
             &self,
             event: builder::AcceptorTcpFreshBatchCompleted,
         );
-        #[doc = "Publishes a `AcceptorTcpStreamDropped` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorTcpStreamDropped` event to the publisher's subscriber
         fn on_acceptor_tcp_stream_dropped(&self, event: builder::AcceptorTcpStreamDropped);
-        #[doc = "Publishes a `AcceptorTcpStreamReplaced` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorTcpStreamReplaced` event to the publisher's subscriber
         fn on_acceptor_tcp_stream_replaced(&self, event: builder::AcceptorTcpStreamReplaced);
-        #[doc = "Publishes a `AcceptorTcpPacketReceived` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorTcpPacketReceived` event to the publisher's subscriber
         fn on_acceptor_tcp_packet_received(&self, event: builder::AcceptorTcpPacketReceived);
-        #[doc = "Publishes a `AcceptorTcpTlsStarted` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorTcpTlsStarted` event to the publisher's subscriber
         fn on_acceptor_tcp_tls_started(&self, event: builder::AcceptorTcpTlsStarted);
-        #[doc = "Publishes a `AcceptorTcpTlsStreamEnqueued` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorTcpTlsStreamEnqueued` event to the publisher's subscriber
         fn on_acceptor_tcp_tls_stream_enqueued(&self, event: builder::AcceptorTcpTlsStreamEnqueued);
-        #[doc = "Publishes a `AcceptorTcpTlsStreamRejected` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorTcpTlsStreamRejected` event to the publisher's subscriber
         fn on_acceptor_tcp_tls_stream_rejected(&self, event: builder::AcceptorTcpTlsStreamRejected);
-        #[doc = "Publishes a `AcceptorTcpPacketDropped` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorTcpPacketDropped` event to the publisher's subscriber
         fn on_acceptor_tcp_packet_dropped(&self, event: builder::AcceptorTcpPacketDropped);
-        #[doc = "Publishes a `AcceptorTcpStreamEnqueued` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorTcpStreamEnqueued` event to the publisher's subscriber
         fn on_acceptor_tcp_stream_enqueued(&self, event: builder::AcceptorTcpStreamEnqueued);
-        #[doc = "Publishes a `AcceptorTcpIoError` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorTcpIoError` event to the publisher's subscriber
         fn on_acceptor_tcp_io_error(&self, event: builder::AcceptorTcpIoError);
-        #[doc = "Publishes a `AcceptorTcpSocketSent` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorTcpSocketSent` event to the publisher's subscriber
         fn on_acceptor_tcp_socket_sent(&self, event: builder::AcceptorTcpSocketSent);
-        #[doc = "Publishes a `AcceptorTcpSocketReceived` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorTcpSocketReceived` event to the publisher's subscriber
         fn on_acceptor_tcp_socket_received(&self, event: builder::AcceptorTcpSocketReceived);
-        #[doc = "Publishes a `AcceptorUdpStarted` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorUdpStarted` event to the publisher's subscriber
         fn on_acceptor_udp_started(&self, event: builder::AcceptorUdpStarted);
-        #[doc = "Publishes a `AcceptorUdpDatagramReceived` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorUdpDatagramReceived` event to the publisher's subscriber
         fn on_acceptor_udp_datagram_received(&self, event: builder::AcceptorUdpDatagramReceived);
-        #[doc = "Publishes a `AcceptorUdpPacketReceived` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorUdpPacketReceived` event to the publisher's subscriber
         fn on_acceptor_udp_packet_received(&self, event: builder::AcceptorUdpPacketReceived);
-        #[doc = "Publishes a `AcceptorUdpPacketDropped` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorUdpPacketDropped` event to the publisher's subscriber
         fn on_acceptor_udp_packet_dropped(&self, event: builder::AcceptorUdpPacketDropped);
-        #[doc = "Publishes a `AcceptorUdpStreamEnqueued` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorUdpStreamEnqueued` event to the publisher's subscriber
         fn on_acceptor_udp_stream_enqueued(&self, event: builder::AcceptorUdpStreamEnqueued);
-        #[doc = "Publishes a `AcceptorUdpIoError` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorUdpIoError` event to the publisher's subscriber
         fn on_acceptor_udp_io_error(&self, event: builder::AcceptorUdpIoError);
-        #[doc = "Publishes a `AcceptorStreamPruned` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorStreamPruned` event to the publisher's subscriber
         fn on_acceptor_stream_pruned(&self, event: builder::AcceptorStreamPruned);
-        #[doc = "Publishes a `AcceptorStreamDequeued` event to the publisher's subscriber"]
+        ///Publishes a `AcceptorStreamDequeued` event to the publisher's subscriber
         fn on_acceptor_stream_dequeued(&self, event: builder::AcceptorStreamDequeued);
-        #[doc = "Publishes a `StreamTcpConnect` event to the publisher's subscriber"]
+        ///Publishes a `StreamTcpConnect` event to the publisher's subscriber
         fn on_stream_tcp_connect(&self, event: builder::StreamTcpConnect);
-        #[doc = "Publishes a `StreamTlsConnect` event to the publisher's subscriber"]
+        ///Publishes a `StreamTlsConnect` event to the publisher's subscriber
         fn on_stream_tls_connect(&self, event: builder::StreamTlsConnect);
-        #[doc = "Publishes a `StreamConnect` event to the publisher's subscriber"]
+        ///Publishes a `StreamConnect` event to the publisher's subscriber
         fn on_stream_connect(&self, event: builder::StreamConnect);
-        #[doc = "Publishes a `StreamConnectError` event to the publisher's subscriber"]
+        ///Publishes a `StreamConnectError` event to the publisher's subscriber
         fn on_stream_connect_error(&self, event: builder::StreamConnectError);
-        #[doc = "Publishes a `EndpointInitialized` event to the publisher's subscriber"]
+        ///Publishes a `EndpointInitialized` event to the publisher's subscriber
         fn on_endpoint_initialized(&self, event: builder::EndpointInitialized);
-        #[doc = "Publishes a `DcConnectionTimeout` event to the publisher's subscriber"]
+        ///Publishes a `DcConnectionTimeout` event to the publisher's subscriber
         fn on_dc_connection_timeout(&self, event: builder::DcConnectionTimeout);
-        #[doc = "Publishes a `PathSecretMapInitialized` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapInitialized` event to the publisher's subscriber
         fn on_path_secret_map_initialized(&self, event: builder::PathSecretMapInitialized);
-        #[doc = "Publishes a `PathSecretMapUninitialized` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapUninitialized` event to the publisher's subscriber
         fn on_path_secret_map_uninitialized(&self, event: builder::PathSecretMapUninitialized);
-        #[doc = "Publishes a `PathSecretMapBackgroundHandshakeRequested` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapBackgroundHandshakeRequested` event to the publisher's subscriber
         fn on_path_secret_map_background_handshake_requested(
             &self,
             event: builder::PathSecretMapBackgroundHandshakeRequested,
         );
-        #[doc = "Publishes a `PathSecretMapEntryInserted` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapEntryInserted` event to the publisher's subscriber
         fn on_path_secret_map_entry_inserted(&self, event: builder::PathSecretMapEntryInserted);
-        #[doc = "Publishes a `PathSecretMapEntryReady` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapEntryReady` event to the publisher's subscriber
         fn on_path_secret_map_entry_ready(&self, event: builder::PathSecretMapEntryReady);
-        #[doc = "Publishes a `PathSecretMapEntryReplaced` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapEntryReplaced` event to the publisher's subscriber
         fn on_path_secret_map_entry_replaced(&self, event: builder::PathSecretMapEntryReplaced);
-        #[doc = "Publishes a `PathSecretMapIdEntryEvicted` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapIdEntryEvicted` event to the publisher's subscriber
         fn on_path_secret_map_id_entry_evicted(&self, event: builder::PathSecretMapIdEntryEvicted);
-        #[doc = "Publishes a `PathSecretMapAddressEntryEvicted` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapAddressEntryEvicted` event to the publisher's subscriber
         fn on_path_secret_map_address_entry_evicted(
             &self,
             event: builder::PathSecretMapAddressEntryEvicted,
         );
-        #[doc = "Publishes a `UnknownPathSecretPacketSent` event to the publisher's subscriber"]
+        ///Publishes a `UnknownPathSecretPacketSent` event to the publisher's subscriber
         fn on_unknown_path_secret_packet_sent(&self, event: builder::UnknownPathSecretPacketSent);
-        #[doc = "Publishes a `UnknownPathSecretPacketReceived` event to the publisher's subscriber"]
+        ///Publishes a `UnknownPathSecretPacketReceived` event to the publisher's subscriber
         fn on_unknown_path_secret_packet_received(
             &self,
             event: builder::UnknownPathSecretPacketReceived,
         );
-        #[doc = "Publishes a `UnknownPathSecretPacketAccepted` event to the publisher's subscriber"]
+        ///Publishes a `UnknownPathSecretPacketAccepted` event to the publisher's subscriber
         fn on_unknown_path_secret_packet_accepted(
             &self,
             event: builder::UnknownPathSecretPacketAccepted,
         );
-        #[doc = "Publishes a `UnknownPathSecretPacketRejected` event to the publisher's subscriber"]
+        ///Publishes a `UnknownPathSecretPacketRejected` event to the publisher's subscriber
         fn on_unknown_path_secret_packet_rejected(
             &self,
             event: builder::UnknownPathSecretPacketRejected,
         );
-        #[doc = "Publishes a `UnknownPathSecretPacketDropped` event to the publisher's subscriber"]
+        ///Publishes a `UnknownPathSecretPacketDropped` event to the publisher's subscriber
         fn on_unknown_path_secret_packet_dropped(
             &self,
             event: builder::UnknownPathSecretPacketDropped,
         );
-        #[doc = "Publishes a `KeyAccepted` event to the publisher's subscriber"]
+        ///Publishes a `KeyAccepted` event to the publisher's subscriber
         fn on_key_accepted(&self, event: builder::KeyAccepted);
-        #[doc = "Publishes a `ReplayDefinitelyDetected` event to the publisher's subscriber"]
+        ///Publishes a `ReplayDefinitelyDetected` event to the publisher's subscriber
         fn on_replay_definitely_detected(&self, event: builder::ReplayDefinitelyDetected);
-        #[doc = "Publishes a `ReplayPotentiallyDetected` event to the publisher's subscriber"]
+        ///Publishes a `ReplayPotentiallyDetected` event to the publisher's subscriber
         fn on_replay_potentially_detected(&self, event: builder::ReplayPotentiallyDetected);
-        #[doc = "Publishes a `ReplayDetectedPacketSent` event to the publisher's subscriber"]
+        ///Publishes a `ReplayDetectedPacketSent` event to the publisher's subscriber
         fn on_replay_detected_packet_sent(&self, event: builder::ReplayDetectedPacketSent);
-        #[doc = "Publishes a `ReplayDetectedPacketReceived` event to the publisher's subscriber"]
+        ///Publishes a `ReplayDetectedPacketReceived` event to the publisher's subscriber
         fn on_replay_detected_packet_received(&self, event: builder::ReplayDetectedPacketReceived);
-        #[doc = "Publishes a `ReplayDetectedPacketAccepted` event to the publisher's subscriber"]
+        ///Publishes a `ReplayDetectedPacketAccepted` event to the publisher's subscriber
         fn on_replay_detected_packet_accepted(&self, event: builder::ReplayDetectedPacketAccepted);
-        #[doc = "Publishes a `ReplayDetectedPacketRejected` event to the publisher's subscriber"]
+        ///Publishes a `ReplayDetectedPacketRejected` event to the publisher's subscriber
         fn on_replay_detected_packet_rejected(&self, event: builder::ReplayDetectedPacketRejected);
-        #[doc = "Publishes a `ReplayDetectedPacketDropped` event to the publisher's subscriber"]
+        ///Publishes a `ReplayDetectedPacketDropped` event to the publisher's subscriber
         fn on_replay_detected_packet_dropped(&self, event: builder::ReplayDetectedPacketDropped);
-        #[doc = "Publishes a `StaleKeyPacketSent` event to the publisher's subscriber"]
+        ///Publishes a `StaleKeyPacketSent` event to the publisher's subscriber
         fn on_stale_key_packet_sent(&self, event: builder::StaleKeyPacketSent);
-        #[doc = "Publishes a `StaleKeyPacketReceived` event to the publisher's subscriber"]
+        ///Publishes a `StaleKeyPacketReceived` event to the publisher's subscriber
         fn on_stale_key_packet_received(&self, event: builder::StaleKeyPacketReceived);
-        #[doc = "Publishes a `StaleKeyPacketAccepted` event to the publisher's subscriber"]
+        ///Publishes a `StaleKeyPacketAccepted` event to the publisher's subscriber
         fn on_stale_key_packet_accepted(&self, event: builder::StaleKeyPacketAccepted);
-        #[doc = "Publishes a `StaleKeyPacketRejected` event to the publisher's subscriber"]
+        ///Publishes a `StaleKeyPacketRejected` event to the publisher's subscriber
         fn on_stale_key_packet_rejected(&self, event: builder::StaleKeyPacketRejected);
-        #[doc = "Publishes a `StaleKeyPacketDropped` event to the publisher's subscriber"]
+        ///Publishes a `StaleKeyPacketDropped` event to the publisher's subscriber
         fn on_stale_key_packet_dropped(&self, event: builder::StaleKeyPacketDropped);
-        #[doc = "Publishes a `PathSecretMapAddressCacheAccessed` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapAddressCacheAccessed` event to the publisher's subscriber
         fn on_path_secret_map_address_cache_accessed(
             &self,
             event: builder::PathSecretMapAddressCacheAccessed,
         );
-        #[doc = "Publishes a `PathSecretMapAddressCacheAccessedHit` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapAddressCacheAccessedHit` event to the publisher's subscriber
         fn on_path_secret_map_address_cache_accessed_hit(
             &self,
             event: builder::PathSecretMapAddressCacheAccessedHit,
         );
-        #[doc = "Publishes a `PathSecretMapIdCacheAccessed` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapIdCacheAccessed` event to the publisher's subscriber
         fn on_path_secret_map_id_cache_accessed(
             &self,
             event: builder::PathSecretMapIdCacheAccessed,
         );
-        #[doc = "Publishes a `PathSecretMapIdCacheAccessedHit` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapIdCacheAccessedHit` event to the publisher's subscriber
         fn on_path_secret_map_id_cache_accessed_hit(
             &self,
             event: builder::PathSecretMapIdCacheAccessedHit,
         );
-        #[doc = "Publishes a `PathSecretMapCleanerCycled` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapCleanerCycled` event to the publisher's subscriber
         fn on_path_secret_map_cleaner_cycled(&self, event: builder::PathSecretMapCleanerCycled);
-        #[doc = "Publishes a `PathSecretMapIdWriteLock` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapIdWriteLock` event to the publisher's subscriber
         fn on_path_secret_map_id_write_lock(&self, event: builder::PathSecretMapIdWriteLock);
-        #[doc = "Publishes a `PathSecretMapAddressWriteLock` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapAddressWriteLock` event to the publisher's subscriber
         fn on_path_secret_map_address_write_lock(
             &self,
             event: builder::PathSecretMapAddressWriteLock,
         );
-        #[doc = "Publishes a `PathSecretMapDatagramEncrypt` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapDatagramEncrypt` event to the publisher's subscriber
         fn on_path_secret_map_datagram_encrypt(&self, event: builder::PathSecretMapDatagramEncrypt);
-        #[doc = "Publishes a `PathSecretMapDatagramDecrypt` event to the publisher's subscriber"]
+        ///Publishes a `PathSecretMapDatagramDecrypt` event to the publisher's subscriber
         fn on_path_secret_map_datagram_decrypt(&self, event: builder::PathSecretMapDatagramDecrypt);
-        #[doc = r" Returns the QUIC version, if any"]
+        /// Returns the QUIC version, if any
         fn quic_version(&self) -> Option<u32>;
     }
     pub struct EndpointPublisherSubscriber<'a, Sub: Subscriber> {
@@ -9934,84 +10449,84 @@ mod traits {
         }
     }
     pub trait ConnectionPublisher {
-        #[doc = "Publishes a `StreamWriteFlushed` event to the publisher's subscriber"]
+        ///Publishes a `StreamWriteFlushed` event to the publisher's subscriber
         fn on_stream_write_flushed(&self, event: builder::StreamWriteFlushed);
-        #[doc = "Publishes a `StreamWriteFinFlushed` event to the publisher's subscriber"]
+        ///Publishes a `StreamWriteFinFlushed` event to the publisher's subscriber
         fn on_stream_write_fin_flushed(&self, event: builder::StreamWriteFinFlushed);
-        #[doc = "Publishes a `StreamWriteBlocked` event to the publisher's subscriber"]
+        ///Publishes a `StreamWriteBlocked` event to the publisher's subscriber
         fn on_stream_write_blocked(&self, event: builder::StreamWriteBlocked);
-        #[doc = "Publishes a `StreamWriteErrored` event to the publisher's subscriber"]
+        ///Publishes a `StreamWriteErrored` event to the publisher's subscriber
         fn on_stream_write_errored(&self, event: builder::StreamWriteErrored);
-        #[doc = "Publishes a `StreamWriteKeyUpdated` event to the publisher's subscriber"]
+        ///Publishes a `StreamWriteKeyUpdated` event to the publisher's subscriber
         fn on_stream_write_key_updated(&self, event: builder::StreamWriteKeyUpdated);
-        #[doc = "Publishes a `StreamWriteAllocated` event to the publisher's subscriber"]
+        ///Publishes a `StreamWriteAllocated` event to the publisher's subscriber
         fn on_stream_write_allocated(&self, event: builder::StreamWriteAllocated);
-        #[doc = "Publishes a `StreamWriteShutdown` event to the publisher's subscriber"]
+        ///Publishes a `StreamWriteShutdown` event to the publisher's subscriber
         fn on_stream_write_shutdown(&self, event: builder::StreamWriteShutdown);
-        #[doc = "Publishes a `StreamWriteSocketFlushed` event to the publisher's subscriber"]
+        ///Publishes a `StreamWriteSocketFlushed` event to the publisher's subscriber
         fn on_stream_write_socket_flushed(&self, event: builder::StreamWriteSocketFlushed);
-        #[doc = "Publishes a `StreamWriteSocketBlocked` event to the publisher's subscriber"]
+        ///Publishes a `StreamWriteSocketBlocked` event to the publisher's subscriber
         fn on_stream_write_socket_blocked(&self, event: builder::StreamWriteSocketBlocked);
-        #[doc = "Publishes a `StreamWriteSocketErrored` event to the publisher's subscriber"]
+        ///Publishes a `StreamWriteSocketErrored` event to the publisher's subscriber
         fn on_stream_write_socket_errored(&self, event: builder::StreamWriteSocketErrored);
-        #[doc = "Publishes a `StreamReadFlushed` event to the publisher's subscriber"]
+        ///Publishes a `StreamReadFlushed` event to the publisher's subscriber
         fn on_stream_read_flushed(&self, event: builder::StreamReadFlushed);
-        #[doc = "Publishes a `StreamReadFinFlushed` event to the publisher's subscriber"]
+        ///Publishes a `StreamReadFinFlushed` event to the publisher's subscriber
         fn on_stream_read_fin_flushed(&self, event: builder::StreamReadFinFlushed);
-        #[doc = "Publishes a `StreamReadBlocked` event to the publisher's subscriber"]
+        ///Publishes a `StreamReadBlocked` event to the publisher's subscriber
         fn on_stream_read_blocked(&self, event: builder::StreamReadBlocked);
-        #[doc = "Publishes a `StreamReadErrored` event to the publisher's subscriber"]
+        ///Publishes a `StreamReadErrored` event to the publisher's subscriber
         fn on_stream_read_errored(&self, event: builder::StreamReadErrored);
-        #[doc = "Publishes a `StreamReadKeyUpdated` event to the publisher's subscriber"]
+        ///Publishes a `StreamReadKeyUpdated` event to the publisher's subscriber
         fn on_stream_read_key_updated(&self, event: builder::StreamReadKeyUpdated);
-        #[doc = "Publishes a `StreamReadShutdown` event to the publisher's subscriber"]
+        ///Publishes a `StreamReadShutdown` event to the publisher's subscriber
         fn on_stream_read_shutdown(&self, event: builder::StreamReadShutdown);
-        #[doc = "Publishes a `StreamReadSocketFlushed` event to the publisher's subscriber"]
+        ///Publishes a `StreamReadSocketFlushed` event to the publisher's subscriber
         fn on_stream_read_socket_flushed(&self, event: builder::StreamReadSocketFlushed);
-        #[doc = "Publishes a `StreamReadSocketBlocked` event to the publisher's subscriber"]
+        ///Publishes a `StreamReadSocketBlocked` event to the publisher's subscriber
         fn on_stream_read_socket_blocked(&self, event: builder::StreamReadSocketBlocked);
-        #[doc = "Publishes a `StreamReadSocketErrored` event to the publisher's subscriber"]
+        ///Publishes a `StreamReadSocketErrored` event to the publisher's subscriber
         fn on_stream_read_socket_errored(&self, event: builder::StreamReadSocketErrored);
-        #[doc = "Publishes a `StreamDecryptPacket` event to the publisher's subscriber"]
+        ///Publishes a `StreamDecryptPacket` event to the publisher's subscriber
         fn on_stream_decrypt_packet(&self, event: builder::StreamDecryptPacket);
-        #[doc = "Publishes a `StreamPacketTransmitted` event to the publisher's subscriber"]
+        ///Publishes a `StreamPacketTransmitted` event to the publisher's subscriber
         fn on_stream_packet_transmitted(&self, event: builder::StreamPacketTransmitted);
-        #[doc = "Publishes a `StreamProbeTransmitted` event to the publisher's subscriber"]
+        ///Publishes a `StreamProbeTransmitted` event to the publisher's subscriber
         fn on_stream_probe_transmitted(&self, event: builder::StreamProbeTransmitted);
-        #[doc = "Publishes a `StreamPacketReceived` event to the publisher's subscriber"]
+        ///Publishes a `StreamPacketReceived` event to the publisher's subscriber
         fn on_stream_packet_received(&self, event: builder::StreamPacketReceived);
-        #[doc = "Publishes a `StreamPacketLost` event to the publisher's subscriber"]
+        ///Publishes a `StreamPacketLost` event to the publisher's subscriber
         fn on_stream_packet_lost(&self, event: builder::StreamPacketLost);
-        #[doc = "Publishes a `StreamPacketAcked` event to the publisher's subscriber"]
+        ///Publishes a `StreamPacketAcked` event to the publisher's subscriber
         fn on_stream_packet_acked(&self, event: builder::StreamPacketAcked);
-        #[doc = "Publishes a `StreamPacketSpuriouslyRetransmitted` event to the publisher's subscriber"]
+        ///Publishes a `StreamPacketSpuriouslyRetransmitted` event to the publisher's subscriber
         fn on_stream_packet_spuriously_retransmitted(
             &self,
             event: builder::StreamPacketSpuriouslyRetransmitted,
         );
-        #[doc = "Publishes a `StreamMaxDataReceived` event to the publisher's subscriber"]
+        ///Publishes a `StreamMaxDataReceived` event to the publisher's subscriber
         fn on_stream_max_data_received(&self, event: builder::StreamMaxDataReceived);
-        #[doc = "Publishes a `StreamControlPacketTransmitted` event to the publisher's subscriber"]
+        ///Publishes a `StreamControlPacketTransmitted` event to the publisher's subscriber
         fn on_stream_control_packet_transmitted(
             &self,
             event: builder::StreamControlPacketTransmitted,
         );
-        #[doc = "Publishes a `StreamControlPacketReceived` event to the publisher's subscriber"]
+        ///Publishes a `StreamControlPacketReceived` event to the publisher's subscriber
         fn on_stream_control_packet_received(&self, event: builder::StreamControlPacketReceived);
-        #[doc = "Publishes a `StreamReceiverErrored` event to the publisher's subscriber"]
+        ///Publishes a `StreamReceiverErrored` event to the publisher's subscriber
         fn on_stream_receiver_errored(&self, event: builder::StreamReceiverErrored);
-        #[doc = "Publishes a `StreamSenderErrored` event to the publisher's subscriber"]
+        ///Publishes a `StreamSenderErrored` event to the publisher's subscriber
         fn on_stream_sender_errored(&self, event: builder::StreamSenderErrored);
-        #[doc = "Publishes a `StreamHandshakePacketRejected` event to the publisher's subscriber"]
+        ///Publishes a `StreamHandshakePacketRejected` event to the publisher's subscriber
         fn on_stream_handshake_packet_rejected(
             &self,
             event: builder::StreamHandshakePacketRejected,
         );
-        #[doc = "Publishes a `ConnectionClosed` event to the publisher's subscriber"]
+        ///Publishes a `ConnectionClosed` event to the publisher's subscriber
         fn on_connection_closed(&self, event: builder::ConnectionClosed);
-        #[doc = r" Returns the QUIC version negotiated for the current connection, if any"]
+        /// Returns the QUIC version negotiated for the current connection, if any
         fn quic_version(&self) -> u32;
-        #[doc = r" Returns the [`Subject`] for the current publisher"]
+        /// Returns the [`Subject`] for the current publisher
         fn subject(&self) -> api::Subject;
     }
     pub struct ConnectionPublisherSubscriber<'a, Sub: Subscriber> {
@@ -10451,21 +10966,21 @@ pub mod testing {
             }
         }
         impl Subscriber {
-            #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+            /// Creates a subscriber with snapshot assertions enabled
             #[track_caller]
             pub fn snapshot() -> Self {
                 let mut sub = Self::no_snapshot();
                 sub.location = Location::from_thread_name();
                 sub
             }
-            #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+            /// Creates a subscriber with snapshot assertions enabled
             #[track_caller]
             pub fn named_snapshot<Name: core::fmt::Display>(name: Name) -> Self {
                 let mut sub = Self::no_snapshot();
                 sub.location = Some(Location::new(name));
                 sub
             }
-            #[doc = r" Creates a subscriber with snapshot assertions disabled"]
+            /// Creates a subscriber with snapshot assertions disabled
             pub fn no_snapshot() -> Self {
                 Self {
                     location: None,
@@ -11407,21 +11922,21 @@ pub mod testing {
         }
     }
     impl Subscriber {
-        #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+        /// Creates a subscriber with snapshot assertions enabled
         #[track_caller]
         pub fn snapshot() -> Self {
             let mut sub = Self::no_snapshot();
             sub.location = Location::from_thread_name();
             sub
         }
-        #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+        /// Creates a subscriber with snapshot assertions enabled
         #[track_caller]
         pub fn named_snapshot<Name: core::fmt::Display>(name: Name) -> Self {
             let mut sub = Self::no_snapshot();
             sub.location = Some(Location::new(name));
             sub
         }
-        #[doc = r" Creates a subscriber with snapshot assertions disabled"]
+        /// Creates a subscriber with snapshot assertions disabled
         pub fn no_snapshot() -> Self {
             Self {
                 location: None,
@@ -12854,21 +13369,21 @@ pub mod testing {
         pub path_secret_map_datagram_decrypt: AtomicU64,
     }
     impl Publisher {
-        #[doc = r" Creates a publisher with snapshot assertions enabled"]
+        /// Creates a publisher with snapshot assertions enabled
         #[track_caller]
         pub fn snapshot() -> Self {
             let mut sub = Self::no_snapshot();
             sub.location = Location::from_thread_name();
             sub
         }
-        #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+        /// Creates a subscriber with snapshot assertions enabled
         #[track_caller]
         pub fn named_snapshot<Name: core::fmt::Display>(name: Name) -> Self {
             let mut sub = Self::no_snapshot();
             sub.location = Some(Location::new(name));
             sub
         }
-        #[doc = r" Creates a publisher with snapshot assertions disabled"]
+        /// Creates a publisher with snapshot assertions disabled
         pub fn no_snapshot() -> Self {
             Self {
                 location: None,

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -1350,7 +1350,8 @@ mod id {
         NominalCounters::NOMINAL_COUNTERS_ENDPOINT_INITIALIZED__HANDSHAKE__PROTOCOL as usize;
     pub const NOMINAL_COUNTERS_DC_CONNECTION_TIMEOUT__PEER_ADDRESS__PROTOCOL: usize =
         NominalCounters::NOMINAL_COUNTERS_DC_CONNECTION_TIMEOUT__PEER_ADDRESS__PROTOCOL as usize;
-    pub const NOMINAL_COUNTERS_PATH_SECRET_MAP_BACKGROUND_HANDSHAKE_REQUESTED__PEER_ADDRESS__PROTOCOL : usize = NominalCounters :: NOMINAL_COUNTERS_PATH_SECRET_MAP_BACKGROUND_HANDSHAKE_REQUESTED__PEER_ADDRESS__PROTOCOL as usize ;
+    pub const NOMINAL_COUNTERS_PATH_SECRET_MAP_BACKGROUND_HANDSHAKE_REQUESTED__PEER_ADDRESS__PROTOCOL: usize = NominalCounters::NOMINAL_COUNTERS_PATH_SECRET_MAP_BACKGROUND_HANDSHAKE_REQUESTED__PEER_ADDRESS__PROTOCOL
+        as usize;
     pub const NOMINAL_COUNTERS_PATH_SECRET_MAP_ENTRY_INSERTED__PEER_ADDRESS__PROTOCOL: usize =
         NominalCounters::NOMINAL_COUNTERS_PATH_SECRET_MAP_ENTRY_INSERTED__PEER_ADDRESS__PROTOCOL
             as usize;
@@ -1363,13 +1364,17 @@ mod id {
     pub const NOMINAL_COUNTERS_PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL: usize =
         NominalCounters::NOMINAL_COUNTERS_PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL
             as usize;
-    pub const NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL : usize = NominalCounters :: NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL as usize ;
+    pub const NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL: usize = NominalCounters::NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL
+        as usize;
     pub const NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_SENT__PEER_ADDRESS__PROTOCOL: usize =
         NominalCounters::NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_SENT__PEER_ADDRESS__PROTOCOL
             as usize;
-    pub const NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL : usize = NominalCounters :: NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL as usize ;
-    pub const NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL : usize = NominalCounters :: NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL as usize ;
-    pub const NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL : usize = NominalCounters :: NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL as usize ;
+    pub const NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL: usize = NominalCounters::NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL
+        as usize;
+    pub const NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL: usize = NominalCounters::NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL
+        as usize;
+    pub const NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL: usize = NominalCounters::NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL
+        as usize;
     pub const NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL: usize =
         NominalCounters::NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL
             as usize;
@@ -1401,8 +1406,10 @@ mod id {
             as usize;
     pub const NOMINAL_COUNTERS_STALE_KEY_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL: usize =
         NominalCounters::NOMINAL_COUNTERS_STALE_KEY_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL as usize;
-    pub const NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__PEER_ADDRESS__PROTOCOL : usize = NominalCounters :: NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__PEER_ADDRESS__PROTOCOL as usize ;
-    pub const NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED_HIT__PEER_ADDRESS__PROTOCOL : usize = NominalCounters :: NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED_HIT__PEER_ADDRESS__PROTOCOL as usize ;
+    pub const NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__PEER_ADDRESS__PROTOCOL: usize = NominalCounters::NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__PEER_ADDRESS__PROTOCOL
+        as usize;
+    pub const NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED_HIT__PEER_ADDRESS__PROTOCOL: usize = NominalCounters::NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED_HIT__PEER_ADDRESS__PROTOCOL
+        as usize;
     #[allow(non_camel_case_types)]
     #[allow(clippy::upper_case_acronyms)]
     enum Measures {
@@ -3885,12 +3892,12 @@ impl<R: Registry + Default> Default for Subscriber<R> {
     }
 }
 impl<R: Registry> Subscriber<R> {
-    #[doc = r" Creates a new subscriber with the given registry"]
-    #[doc = r""]
-    #[doc = r" # Note"]
-    #[doc = r""]
-    #[doc = r" All of the recorders are registered on initialization and cached for the lifetime"]
-    #[doc = r" of the subscriber."]
+    /// Creates a new subscriber with the given registry
+    ///
+    /// # Note
+    ///
+    /// All of the recorders are registered on initialization and cached for the lifetime
+    /// of the subscriber.
     #[allow(unused_mut)]
     #[inline]
     pub fn new(registry: R) -> Self {
@@ -4253,7 +4260,14 @@ impl<R: Registry> Subscriber<R> {
                 let offset = nominal_counters.len();
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters . push (registry . register_nominal_counter (& INFO [id :: PATH_SECRET_MAP_BACKGROUND_HANDSHAKE_REQUESTED__PEER_ADDRESS__PROTOCOL] , variant)) ;
+                    nominal_counters
+                        .push(
+                            registry
+                                .register_nominal_counter(
+                                    &INFO[id::PATH_SECRET_MAP_BACKGROUND_HANDSHAKE_REQUESTED__PEER_ADDRESS__PROTOCOL],
+                                    variant,
+                                ),
+                        );
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -4536,7 +4550,14 @@ impl<R: Registry> Subscriber<R> {
                 let offset = nominal_counters.len();
                 let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
-                    nominal_counters . push (registry . register_nominal_counter (& INFO [id :: PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED_HIT__PEER_ADDRESS__PROTOCOL] , variant)) ;
+                    nominal_counters
+                        .push(
+                            registry
+                                .register_nominal_counter(
+                                    &INFO[id::PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED_HIT__PEER_ADDRESS__PROTOCOL],
+                                    variant,
+                                ),
+                        );
                     count += 1;
                 }
                 debug_assert_ne!(count, 0, "field type needs at least one variant");
@@ -4875,7 +4896,7 @@ impl<R: Registry> Subscriber<R> {
             registry,
         }
     }
-    #[doc = r" Returns all of the registered counters"]
+    /// Returns all of the registered counters
     #[inline]
     pub fn counters(&self) -> impl Iterator<Item = (&'static Info, &R::Counter)> + '_ {
         self.counters
@@ -5171,7 +5192,7 @@ impl<R: Registry> Subscriber<R> {
         let counter = &self.counters[id];
         counter.record(info, value);
     }
-    #[doc = r" Returns all of the registered bool counters"]
+    /// Returns all of the registered bool counters
     #[inline]
     pub fn bool_counters(&self) -> impl Iterator<Item = (&'static Info, &R::BoolCounter)> + '_ {
         self.bool_counters
@@ -5259,14 +5280,386 @@ impl<R: Registry> Subscriber<R> {
         let counter = &self.bool_counters[id];
         counter.record(info, value);
     }
-    #[doc = r" Returns all of the registered nominal counters"]
+    /// Returns all of the registered nominal counters
     #[inline]
     pub fn nominal_counters(
         &self,
     ) -> impl Iterator<Item = (&'static Info, &[R::NominalCounter], &[info::Variant])> + '_ {
         #[allow(unused_imports)]
         use api::*;
-        self . nominal_counter_offsets . iter () . enumerate () . map (| (idx , entry) | { match idx { id :: NOMINAL_COUNTERS_ACCEPTOR_TCP_STREAM_DROPPED__REASON => { let offset = * entry ; let variants = < AcceptorTcpStreamDropReason as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: ACCEPTOR_TCP_STREAM_DROPPED__REASON] , entries , variants) } id :: NOMINAL_COUNTERS_ACCEPTOR_TCP_PACKET_DROPPED__REASON => { let offset = * entry ; let variants = < AcceptorPacketDropReason as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: ACCEPTOR_TCP_PACKET_DROPPED__REASON] , entries , variants) } id :: NOMINAL_COUNTERS_ACCEPTOR_TCP_IO_ERROR__SOURCE => { let offset = * entry ; let variants = < AcceptorTcpIoErrorSource as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: ACCEPTOR_TCP_IO_ERROR__SOURCE] , entries , variants) } id :: NOMINAL_COUNTERS_ACCEPTOR_UDP_PACKET_DROPPED__REASON => { let offset = * entry ; let variants = < AcceptorPacketDropReason as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: ACCEPTOR_UDP_PACKET_DROPPED__REASON] , entries , variants) } id :: NOMINAL_COUNTERS_ACCEPTOR_STREAM_PRUNED__REASON => { let offset = * entry ; let variants = < AcceptorStreamPruneReason as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: ACCEPTOR_STREAM_PRUNED__REASON] , entries , variants) } id :: NOMINAL_COUNTERS_STREAM_CONNECT__TCP => { let offset = * entry ; let variants = < MaybeBoolCounter as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: STREAM_CONNECT__TCP] , entries , variants) } id :: NOMINAL_COUNTERS_STREAM_CONNECT__HANDSHAKE => { let offset = * entry ; let variants = < MaybeBoolCounter as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: STREAM_CONNECT__HANDSHAKE] , entries , variants) } id :: NOMINAL_COUNTERS_STREAM_CONNECT_ERROR__REASON => { let offset = * entry ; let variants = < StreamTcpConnectErrorReason as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: STREAM_CONNECT_ERROR__REASON] , entries , variants) } id :: NOMINAL_COUNTERS_STREAM_HANDSHAKE_PACKET_REJECTED__REASON => { let offset = * entry ; let variants = < StreamHandshakePacketRejectedReason as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: STREAM_HANDSHAKE_PACKET_REJECTED__REASON] , entries , variants) } id :: NOMINAL_COUNTERS_ENDPOINT_INITIALIZED__ACCEPTOR__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: ENDPOINT_INITIALIZED__ACCEPTOR__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_ENDPOINT_INITIALIZED__HANDSHAKE__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: ENDPOINT_INITIALIZED__HANDSHAKE__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_DC_CONNECTION_TIMEOUT__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: DC_CONNECTION_TIMEOUT__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_PATH_SECRET_MAP_BACKGROUND_HANDSHAKE_REQUESTED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: PATH_SECRET_MAP_BACKGROUND_HANDSHAKE_REQUESTED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_PATH_SECRET_MAP_ENTRY_INSERTED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: PATH_SECRET_MAP_ENTRY_INSERTED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_PATH_SECRET_MAP_ENTRY_READY__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: PATH_SECRET_MAP_ENTRY_READY__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_PATH_SECRET_MAP_ENTRY_REPLACED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: PATH_SECRET_MAP_ENTRY_REPLACED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_SENT__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: UNKNOWN_PATH_SECRET_PACKET_SENT__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: UNKNOWN_PATH_SECRET_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: UNKNOWN_PATH_SECRET_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: UNKNOWN_PATH_SECRET_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_REPLAY_DETECTED_PACKET_SENT__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: REPLAY_DETECTED_PACKET_SENT__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_REPLAY_DETECTED_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: REPLAY_DETECTED_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_REPLAY_DETECTED_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: REPLAY_DETECTED_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_REPLAY_DETECTED_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: REPLAY_DETECTED_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_REPLAY_DETECTED_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: REPLAY_DETECTED_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_STALE_KEY_PACKET_SENT__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: STALE_KEY_PACKET_SENT__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_STALE_KEY_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: STALE_KEY_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_STALE_KEY_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: STALE_KEY_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_STALE_KEY_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: STALE_KEY_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_STALE_KEY_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: STALE_KEY_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__PEER_ADDRESS__PROTOCOL] , entries , variants) } id :: NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED_HIT__PEER_ADDRESS__PROTOCOL => { let offset = * entry ; let variants = < SocketAddress as AsVariant > :: VARIANTS ; let entries = & self . nominal_counters [offset .. offset + variants . len ()] ; (& INFO [id :: PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED_HIT__PEER_ADDRESS__PROTOCOL] , entries , variants) } _ => unsafe { core :: hint :: unreachable_unchecked () } , } })
+        self.nominal_counter_offsets
+            .iter()
+            .enumerate()
+            .map(|(idx, entry)| {
+                match idx {
+                    id::NOMINAL_COUNTERS_ACCEPTOR_TCP_STREAM_DROPPED__REASON => {
+                        let offset = *entry;
+                        let variants = <AcceptorTcpStreamDropReason as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::ACCEPTOR_TCP_STREAM_DROPPED__REASON],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_ACCEPTOR_TCP_PACKET_DROPPED__REASON => {
+                        let offset = *entry;
+                        let variants = <AcceptorPacketDropReason as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::ACCEPTOR_TCP_PACKET_DROPPED__REASON],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_ACCEPTOR_TCP_IO_ERROR__SOURCE => {
+                        let offset = *entry;
+                        let variants = <AcceptorTcpIoErrorSource as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (&INFO[id::ACCEPTOR_TCP_IO_ERROR__SOURCE], entries, variants)
+                    }
+                    id::NOMINAL_COUNTERS_ACCEPTOR_UDP_PACKET_DROPPED__REASON => {
+                        let offset = *entry;
+                        let variants = <AcceptorPacketDropReason as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::ACCEPTOR_UDP_PACKET_DROPPED__REASON],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_ACCEPTOR_STREAM_PRUNED__REASON => {
+                        let offset = *entry;
+                        let variants = <AcceptorStreamPruneReason as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (&INFO[id::ACCEPTOR_STREAM_PRUNED__REASON], entries, variants)
+                    }
+                    id::NOMINAL_COUNTERS_STREAM_CONNECT__TCP => {
+                        let offset = *entry;
+                        let variants = <MaybeBoolCounter as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (&INFO[id::STREAM_CONNECT__TCP], entries, variants)
+                    }
+                    id::NOMINAL_COUNTERS_STREAM_CONNECT__HANDSHAKE => {
+                        let offset = *entry;
+                        let variants = <MaybeBoolCounter as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (&INFO[id::STREAM_CONNECT__HANDSHAKE], entries, variants)
+                    }
+                    id::NOMINAL_COUNTERS_STREAM_CONNECT_ERROR__REASON => {
+                        let offset = *entry;
+                        let variants = <StreamTcpConnectErrorReason as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (&INFO[id::STREAM_CONNECT_ERROR__REASON], entries, variants)
+                    }
+                    id::NOMINAL_COUNTERS_STREAM_HANDSHAKE_PACKET_REJECTED__REASON => {
+                        let offset = *entry;
+                        let variants = <StreamHandshakePacketRejectedReason as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::STREAM_HANDSHAKE_PACKET_REJECTED__REASON],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_ENDPOINT_INITIALIZED__ACCEPTOR__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::ENDPOINT_INITIALIZED__ACCEPTOR__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_ENDPOINT_INITIALIZED__HANDSHAKE__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::ENDPOINT_INITIALIZED__HANDSHAKE__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_DC_CONNECTION_TIMEOUT__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::DC_CONNECTION_TIMEOUT__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_PATH_SECRET_MAP_BACKGROUND_HANDSHAKE_REQUESTED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::PATH_SECRET_MAP_BACKGROUND_HANDSHAKE_REQUESTED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_PATH_SECRET_MAP_ENTRY_INSERTED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::PATH_SECRET_MAP_ENTRY_INSERTED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_PATH_SECRET_MAP_ENTRY_READY__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::PATH_SECRET_MAP_ENTRY_READY__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_PATH_SECRET_MAP_ENTRY_REPLACED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::PATH_SECRET_MAP_ENTRY_REPLACED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_SENT__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::UNKNOWN_PATH_SECRET_PACKET_SENT__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::UNKNOWN_PATH_SECRET_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::UNKNOWN_PATH_SECRET_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::UNKNOWN_PATH_SECRET_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_REPLAY_DETECTED_PACKET_SENT__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::REPLAY_DETECTED_PACKET_SENT__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_REPLAY_DETECTED_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::REPLAY_DETECTED_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_REPLAY_DETECTED_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::REPLAY_DETECTED_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_REPLAY_DETECTED_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::REPLAY_DETECTED_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_REPLAY_DETECTED_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::REPLAY_DETECTED_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_STALE_KEY_PACKET_SENT__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::STALE_KEY_PACKET_SENT__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_STALE_KEY_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::STALE_KEY_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_STALE_KEY_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::STALE_KEY_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_STALE_KEY_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::STALE_KEY_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_STALE_KEY_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::STALE_KEY_PACKET_DROPPED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED_HIT__PEER_ADDRESS__PROTOCOL => {
+                        let offset = *entry;
+                        let variants = <SocketAddress as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED_HIT__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    _ => unsafe { core::hint::unreachable_unchecked() }
+                }
+            })
     }
     #[allow(dead_code)]
     #[inline(always)]
@@ -5276,10 +5669,506 @@ impl<R: Registry> Subscriber<R> {
         let counter = &self.nominal_counters[idx];
         counter.record(info, value.as_variant(), 1usize);
     }
-    #[doc = r" Returns all of the registered measures"]
+    /// Returns all of the registered measures
     #[inline]
     pub fn measures(&self) -> impl Iterator<Item = (&'static Info, &R::Measure)> + '_ {
-        self . measures . iter () . enumerate () . map (| (idx , entry) | { match idx { id :: MEASURES_ACCEPTOR_TCP_STARTED__BACKLOG => (& INFO [id :: ACCEPTOR_TCP_STARTED__BACKLOG] , entry) , id :: MEASURES_ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__PENDING_STREAMS => (& INFO [id :: ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__PENDING_STREAMS] , entry) , id :: MEASURES_ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__SLOTS_IDLE => (& INFO [id :: ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__SLOTS_IDLE] , entry) , id :: MEASURES_ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__SLOT_UTILIZATION => (& INFO [id :: ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__SLOT_UTILIZATION] , entry) , id :: MEASURES_ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__MAX_SOJOURN_TIME => (& INFO [id :: ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__MAX_SOJOURN_TIME] , entry) , id :: MEASURES_ACCEPTOR_TCP_FRESH_BATCH_COMPLETED__ENQUEUED => (& INFO [id :: ACCEPTOR_TCP_FRESH_BATCH_COMPLETED__ENQUEUED] , entry) , id :: MEASURES_ACCEPTOR_TCP_FRESH_BATCH_COMPLETED__DROPPED => (& INFO [id :: ACCEPTOR_TCP_FRESH_BATCH_COMPLETED__DROPPED] , entry) , id :: MEASURES_ACCEPTOR_TCP_FRESH_BATCH_COMPLETED__ERRORED => (& INFO [id :: ACCEPTOR_TCP_FRESH_BATCH_COMPLETED__ERRORED] , entry) , id :: MEASURES_ACCEPTOR_TCP_STREAM_REPLACED__BUFFER_LEN => (& INFO [id :: ACCEPTOR_TCP_STREAM_REPLACED__BUFFER_LEN] , entry) , id :: MEASURES_ACCEPTOR_TCP_PACKET_RECEIVED__PAYLOAD_LEN => (& INFO [id :: ACCEPTOR_TCP_PACKET_RECEIVED__PAYLOAD_LEN] , entry) , id :: MEASURES_ACCEPTOR_TCP_STREAM_ENQUEUED__BLOCKED_COUNT => (& INFO [id :: ACCEPTOR_TCP_STREAM_ENQUEUED__BLOCKED_COUNT] , entry) , id :: MEASURES_ACCEPTOR_TCP_SOCKET_SENT__BLOCKED_COUNT_STREAM => (& INFO [id :: ACCEPTOR_TCP_SOCKET_SENT__BLOCKED_COUNT_STREAM] , entry) , id :: MEASURES_ACCEPTOR_TCP_SOCKET_SENT__LEN => (& INFO [id :: ACCEPTOR_TCP_SOCKET_SENT__LEN] , entry) , id :: MEASURES_ACCEPTOR_TCP_SOCKET_RECEIVED__LEN => (& INFO [id :: ACCEPTOR_TCP_SOCKET_RECEIVED__LEN] , entry) , id :: MEASURES_ACCEPTOR_UDP_DATAGRAM_RECEIVED__LEN => (& INFO [id :: ACCEPTOR_UDP_DATAGRAM_RECEIVED__LEN] , entry) , id :: MEASURES_ACCEPTOR_UDP_PACKET_RECEIVED__PAYLOAD_LEN => (& INFO [id :: ACCEPTOR_UDP_PACKET_RECEIVED__PAYLOAD_LEN] , entry) , id :: MEASURES_STREAM_WRITE_FLUSHED__CONN => (& INFO [id :: STREAM_WRITE_FLUSHED__CONN] , entry) , id :: MEASURES_STREAM_WRITE_FLUSHED__PROVIDED => (& INFO [id :: STREAM_WRITE_FLUSHED__PROVIDED] , entry) , id :: MEASURES_STREAM_WRITE_FLUSHED__COMMITTED => (& INFO [id :: STREAM_WRITE_FLUSHED__COMMITTED] , entry) , id :: MEASURES_STREAM_WRITE_FLUSHED__COMMITTED__CONN => (& INFO [id :: STREAM_WRITE_FLUSHED__COMMITTED__CONN] , entry) , id :: MEASURES_STREAM_WRITE_FLUSHED__PROCESSING_DURATION => (& INFO [id :: STREAM_WRITE_FLUSHED__PROCESSING_DURATION] , entry) , id :: MEASURES_STREAM_WRITE_FLUSHED__PROCESSING_DURATION__CONN => (& INFO [id :: STREAM_WRITE_FLUSHED__PROCESSING_DURATION__CONN] , entry) , id :: MEASURES_STREAM_WRITE_FIN_FLUSHED__CONN => (& INFO [id :: STREAM_WRITE_FIN_FLUSHED__CONN] , entry) , id :: MEASURES_STREAM_WRITE_FIN_FLUSHED__PROVIDED => (& INFO [id :: STREAM_WRITE_FIN_FLUSHED__PROVIDED] , entry) , id :: MEASURES_STREAM_WRITE_FIN_FLUSHED__COMMITTED => (& INFO [id :: STREAM_WRITE_FIN_FLUSHED__COMMITTED] , entry) , id :: MEASURES_STREAM_WRITE_FIN_FLUSHED__COMMITTED__CONN => (& INFO [id :: STREAM_WRITE_FIN_FLUSHED__COMMITTED__CONN] , entry) , id :: MEASURES_STREAM_WRITE_FIN_FLUSHED__PROCESSING_DURATION => (& INFO [id :: STREAM_WRITE_FIN_FLUSHED__PROCESSING_DURATION] , entry) , id :: MEASURES_STREAM_WRITE_FIN_FLUSHED__PROCESSING_DURATION__CONN => (& INFO [id :: STREAM_WRITE_FIN_FLUSHED__PROCESSING_DURATION__CONN] , entry) , id :: MEASURES_STREAM_WRITE_BLOCKED__CONN => (& INFO [id :: STREAM_WRITE_BLOCKED__CONN] , entry) , id :: MEASURES_STREAM_WRITE_BLOCKED__PROVIDED => (& INFO [id :: STREAM_WRITE_BLOCKED__PROVIDED] , entry) , id :: MEASURES_STREAM_WRITE_BLOCKED__PROCESSING_DURATION => (& INFO [id :: STREAM_WRITE_BLOCKED__PROCESSING_DURATION] , entry) , id :: MEASURES_STREAM_WRITE_BLOCKED__PROCESSING_DURATION__CONN => (& INFO [id :: STREAM_WRITE_BLOCKED__PROCESSING_DURATION__CONN] , entry) , id :: MEASURES_STREAM_WRITE_ERRORED__PROVIDED => (& INFO [id :: STREAM_WRITE_ERRORED__PROVIDED] , entry) , id :: MEASURES_STREAM_WRITE_ERRORED__PROCESSING_DURATION => (& INFO [id :: STREAM_WRITE_ERRORED__PROCESSING_DURATION] , entry) , id :: MEASURES_STREAM_WRITE_ERRORED__PROCESSING_DURATION__CONN => (& INFO [id :: STREAM_WRITE_ERRORED__PROCESSING_DURATION__CONN] , entry) , id :: MEASURES_STREAM_WRITE_ALLOCATED__CONN => (& INFO [id :: STREAM_WRITE_ALLOCATED__CONN] , entry) , id :: MEASURES_STREAM_WRITE_ALLOCATED__ALLOCATED_LEN => (& INFO [id :: STREAM_WRITE_ALLOCATED__ALLOCATED_LEN] , entry) , id :: MEASURES_STREAM_WRITE_ALLOCATED__ALLOCATED_LEN__CONN => (& INFO [id :: STREAM_WRITE_ALLOCATED__ALLOCATED_LEN__CONN] , entry) , id :: MEASURES_STREAM_WRITE_SHUTDOWN__BUFFER_LEN => (& INFO [id :: STREAM_WRITE_SHUTDOWN__BUFFER_LEN] , entry) , id :: MEASURES_STREAM_WRITE_SOCKET_FLUSHED__CONN => (& INFO [id :: STREAM_WRITE_SOCKET_FLUSHED__CONN] , entry) , id :: MEASURES_STREAM_WRITE_SOCKET_FLUSHED__PROVIDED => (& INFO [id :: STREAM_WRITE_SOCKET_FLUSHED__PROVIDED] , entry) , id :: MEASURES_STREAM_WRITE_SOCKET_FLUSHED__COMMITTED => (& INFO [id :: STREAM_WRITE_SOCKET_FLUSHED__COMMITTED] , entry) , id :: MEASURES_STREAM_WRITE_SOCKET_FLUSHED__COMMITTED__CONN => (& INFO [id :: STREAM_WRITE_SOCKET_FLUSHED__COMMITTED__CONN] , entry) , id :: MEASURES_STREAM_WRITE_SOCKET_BLOCKED__CONN => (& INFO [id :: STREAM_WRITE_SOCKET_BLOCKED__CONN] , entry) , id :: MEASURES_STREAM_WRITE_SOCKET_BLOCKED__PROVIDED => (& INFO [id :: STREAM_WRITE_SOCKET_BLOCKED__PROVIDED] , entry) , id :: MEASURES_STREAM_WRITE_SOCKET_ERRORED__PROVIDED => (& INFO [id :: STREAM_WRITE_SOCKET_ERRORED__PROVIDED] , entry) , id :: MEASURES_STREAM_READ_FLUSHED__CONN => (& INFO [id :: STREAM_READ_FLUSHED__CONN] , entry) , id :: MEASURES_STREAM_READ_FLUSHED__CAPACITY => (& INFO [id :: STREAM_READ_FLUSHED__CAPACITY] , entry) , id :: MEASURES_STREAM_READ_FLUSHED__COMMITTED => (& INFO [id :: STREAM_READ_FLUSHED__COMMITTED] , entry) , id :: MEASURES_STREAM_READ_FLUSHED__COMMITTED__CONN => (& INFO [id :: STREAM_READ_FLUSHED__COMMITTED__CONN] , entry) , id :: MEASURES_STREAM_READ_FLUSHED__PROCESSING_DURATION => (& INFO [id :: STREAM_READ_FLUSHED__PROCESSING_DURATION] , entry) , id :: MEASURES_STREAM_READ_FLUSHED__PROCESSING_DURATION__CONN => (& INFO [id :: STREAM_READ_FLUSHED__PROCESSING_DURATION__CONN] , entry) , id :: MEASURES_STREAM_READ_FIN_FLUSHED__CONN => (& INFO [id :: STREAM_READ_FIN_FLUSHED__CONN] , entry) , id :: MEASURES_STREAM_READ_FIN_FLUSHED__CAPACITY => (& INFO [id :: STREAM_READ_FIN_FLUSHED__CAPACITY] , entry) , id :: MEASURES_STREAM_READ_FIN_FLUSHED__PROCESSING_DURATION => (& INFO [id :: STREAM_READ_FIN_FLUSHED__PROCESSING_DURATION] , entry) , id :: MEASURES_STREAM_READ_FIN_FLUSHED__PROCESSING_DURATION__CONN => (& INFO [id :: STREAM_READ_FIN_FLUSHED__PROCESSING_DURATION__CONN] , entry) , id :: MEASURES_STREAM_READ_BLOCKED__CAPACITY => (& INFO [id :: STREAM_READ_BLOCKED__CAPACITY] , entry) , id :: MEASURES_STREAM_READ_BLOCKED__PROCESSING_DURATION => (& INFO [id :: STREAM_READ_BLOCKED__PROCESSING_DURATION] , entry) , id :: MEASURES_STREAM_READ_BLOCKED__PROCESSING_DURATION__CONN => (& INFO [id :: STREAM_READ_BLOCKED__PROCESSING_DURATION__CONN] , entry) , id :: MEASURES_STREAM_READ_ERRORED__CAPACITY => (& INFO [id :: STREAM_READ_ERRORED__CAPACITY] , entry) , id :: MEASURES_STREAM_READ_ERRORED__PROCESSING_DURATION => (& INFO [id :: STREAM_READ_ERRORED__PROCESSING_DURATION] , entry) , id :: MEASURES_STREAM_READ_ERRORED__PROCESSING_DURATION__CONN => (& INFO [id :: STREAM_READ_ERRORED__PROCESSING_DURATION__CONN] , entry) , id :: MEASURES_STREAM_READ_SOCKET_FLUSHED__CONN => (& INFO [id :: STREAM_READ_SOCKET_FLUSHED__CONN] , entry) , id :: MEASURES_STREAM_READ_SOCKET_FLUSHED__CAPACITY => (& INFO [id :: STREAM_READ_SOCKET_FLUSHED__CAPACITY] , entry) , id :: MEASURES_STREAM_READ_SOCKET_FLUSHED__COMMITTED => (& INFO [id :: STREAM_READ_SOCKET_FLUSHED__COMMITTED] , entry) , id :: MEASURES_STREAM_READ_SOCKET_FLUSHED__COMMITTED__CONN => (& INFO [id :: STREAM_READ_SOCKET_FLUSHED__COMMITTED__CONN] , entry) , id :: MEASURES_STREAM_READ_SOCKET_BLOCKED__CONN => (& INFO [id :: STREAM_READ_SOCKET_BLOCKED__CONN] , entry) , id :: MEASURES_STREAM_READ_SOCKET_BLOCKED__CAPACITY => (& INFO [id :: STREAM_READ_SOCKET_BLOCKED__CAPACITY] , entry) , id :: MEASURES_STREAM_READ_SOCKET_ERRORED__CAPACITY => (& INFO [id :: STREAM_READ_SOCKET_ERRORED__CAPACITY] , entry) , id :: MEASURES_STREAM_DECRYPT_PACKET__FORCED_COPY => (& INFO [id :: STREAM_DECRYPT_PACKET__FORCED_COPY] , entry) , id :: MEASURES_STREAM_DECRYPT_PACKET__REQUIRED_APPLICATION_BUFFER => (& INFO [id :: STREAM_DECRYPT_PACKET__REQUIRED_APPLICATION_BUFFER] , entry) , id :: MEASURES_STREAM_PACKET_TRANSMITTED__PACKET_LEN => (& INFO [id :: STREAM_PACKET_TRANSMITTED__PACKET_LEN] , entry) , id :: MEASURES_STREAM_PACKET_TRANSMITTED__PAYLOAD_LEN => (& INFO [id :: STREAM_PACKET_TRANSMITTED__PAYLOAD_LEN] , entry) , id :: MEASURES_STREAM_PACKET_TRANSMITTED__PAYLOAD_LEN__CONN => (& INFO [id :: STREAM_PACKET_TRANSMITTED__PAYLOAD_LEN__CONN] , entry) , id :: MEASURES_STREAM_PROBE_TRANSMITTED__PACKET_LEN => (& INFO [id :: STREAM_PROBE_TRANSMITTED__PACKET_LEN] , entry) , id :: MEASURES_STREAM_PACKET_RECEIVED__PACKET_LEN => (& INFO [id :: STREAM_PACKET_RECEIVED__PACKET_LEN] , entry) , id :: MEASURES_STREAM_PACKET_RECEIVED__PAYLOAD_LEN => (& INFO [id :: STREAM_PACKET_RECEIVED__PAYLOAD_LEN] , entry) , id :: MEASURES_STREAM_PACKET_RECEIVED__PAYLOAD_LEN__CONN => (& INFO [id :: STREAM_PACKET_RECEIVED__PAYLOAD_LEN__CONN] , entry) , id :: MEASURES_STREAM_PACKET_LOST__PACKET_LEN => (& INFO [id :: STREAM_PACKET_LOST__PACKET_LEN] , entry) , id :: MEASURES_STREAM_PACKET_LOST__PAYLOAD_LEN => (& INFO [id :: STREAM_PACKET_LOST__PAYLOAD_LEN] , entry) , id :: MEASURES_STREAM_PACKET_LOST__PAYLOAD_LEN__CONN => (& INFO [id :: STREAM_PACKET_LOST__PAYLOAD_LEN__CONN] , entry) , id :: MEASURES_STREAM_PACKET_LOST__LIFETIME => (& INFO [id :: STREAM_PACKET_LOST__LIFETIME] , entry) , id :: MEASURES_STREAM_PACKET_ACKED__PACKET_LEN => (& INFO [id :: STREAM_PACKET_ACKED__PACKET_LEN] , entry) , id :: MEASURES_STREAM_PACKET_ACKED__PAYLOAD_LEN => (& INFO [id :: STREAM_PACKET_ACKED__PAYLOAD_LEN] , entry) , id :: MEASURES_STREAM_PACKET_ACKED__PAYLOAD_LEN__CONN => (& INFO [id :: STREAM_PACKET_ACKED__PAYLOAD_LEN__CONN] , entry) , id :: MEASURES_STREAM_PACKET_ACKED__LIFETIME => (& INFO [id :: STREAM_PACKET_ACKED__LIFETIME] , entry) , id :: MEASURES_STREAM_PACKET_SPURIOUSLY_RETRANSMITTED__PACKET_LEN => (& INFO [id :: STREAM_PACKET_SPURIOUSLY_RETRANSMITTED__PACKET_LEN] , entry) , id :: MEASURES_STREAM_PACKET_SPURIOUSLY_RETRANSMITTED__PAYLOAD_LEN => (& INFO [id :: STREAM_PACKET_SPURIOUSLY_RETRANSMITTED__PAYLOAD_LEN] , entry) , id :: MEASURES_STREAM_PACKET_SPURIOUSLY_RETRANSMITTED__PAYLOAD_LEN__CONN => (& INFO [id :: STREAM_PACKET_SPURIOUSLY_RETRANSMITTED__PAYLOAD_LEN__CONN] , entry) , id :: MEASURES_STREAM_MAX_DATA_RECEIVED__INCREASE => (& INFO [id :: STREAM_MAX_DATA_RECEIVED__INCREASE] , entry) , id :: MEASURES_STREAM_CONTROL_PACKET_TRANSMITTED__PACKET_LEN => (& INFO [id :: STREAM_CONTROL_PACKET_TRANSMITTED__PACKET_LEN] , entry) , id :: MEASURES_STREAM_CONTROL_PACKET_TRANSMITTED__CONTROL_DATA_LEN => (& INFO [id :: STREAM_CONTROL_PACKET_TRANSMITTED__CONTROL_DATA_LEN] , entry) , id :: MEASURES_STREAM_CONTROL_PACKET_RECEIVED__PACKET_LEN => (& INFO [id :: STREAM_CONTROL_PACKET_RECEIVED__PACKET_LEN] , entry) , id :: MEASURES_STREAM_CONTROL_PACKET_RECEIVED__CONTROL_DATA_LEN => (& INFO [id :: STREAM_CONTROL_PACKET_RECEIVED__CONTROL_DATA_LEN] , entry) , id :: MEASURES_STREAM_HANDSHAKE_PACKET_REJECTED__CONN => (& INFO [id :: STREAM_HANDSHAKE_PACKET_REJECTED__CONN] , entry) , id :: MEASURES_PATH_SECRET_MAP_INITIALIZED__CAPACITY => (& INFO [id :: PATH_SECRET_MAP_INITIALIZED__CAPACITY] , entry) , id :: MEASURES_PATH_SECRET_MAP_UNINITIALIZED__CAPACITY => (& INFO [id :: PATH_SECRET_MAP_UNINITIALIZED__CAPACITY] , entry) , id :: MEASURES_PATH_SECRET_MAP_UNINITIALIZED__ENTRIES => (& INFO [id :: PATH_SECRET_MAP_UNINITIALIZED__ENTRIES] , entry) , id :: MEASURES_PATH_SECRET_MAP_UNINITIALIZED__LIFETIME => (& INFO [id :: PATH_SECRET_MAP_UNINITIALIZED__LIFETIME] , entry) , id :: MEASURES_PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE => (& INFO [id :: PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE] , entry) , id :: MEASURES_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE => (& INFO [id :: PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE] , entry) , id :: MEASURES_KEY_ACCEPTED__GAP => (& INFO [id :: KEY_ACCEPTED__GAP] , entry) , id :: MEASURES_KEY_ACCEPTED__FORWARD_SHIFT => (& INFO [id :: KEY_ACCEPTED__FORWARD_SHIFT] , entry) , id :: MEASURES_REPLAY_POTENTIALLY_DETECTED__GAP => (& INFO [id :: REPLAY_POTENTIALLY_DETECTED__GAP] , entry) , id :: MEASURES_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED_HIT__AGE => (& INFO [id :: PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED_HIT__AGE] , entry) , id :: MEASURES_PATH_SECRET_MAP_ID_CACHE_ACCESSED_HIT__AGE => (& INFO [id :: PATH_SECRET_MAP_ID_CACHE_ACCESSED_HIT__AGE] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__RETIRED => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__RETIRED] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__ACTIVE => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__ACTIVE] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__ACTIVE__UTILIZATION => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__ACTIVE__UTILIZATION] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__UTILIZATION => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__UTILIZATION] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__UTILIZATION__INITIAL => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__UTILIZATION__INITIAL] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__ACTIVE => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__ACTIVE] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__ACTIVE__UTILIZATION => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__ACTIVE__UTILIZATION] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__RETIRED => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__RETIRED] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS__SKIPPED => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS__SKIPPED] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_LOCK_DURATION => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_LOCK_DURATION] , entry) , id :: MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION => (& INFO [id :: PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION] , entry) , id :: MEASURES_PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE => (& INFO [id :: PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE] , entry) , id :: MEASURES_PATH_SECRET_MAP_ID_WRITE_LOCK__DURATION => (& INFO [id :: PATH_SECRET_MAP_ID_WRITE_LOCK__DURATION] , entry) , id :: MEASURES_PATH_SECRET_MAP_ADDRESS_WRITE_LOCK__ACQUIRE => (& INFO [id :: PATH_SECRET_MAP_ADDRESS_WRITE_LOCK__ACQUIRE] , entry) , id :: MEASURES_PATH_SECRET_MAP_ADDRESS_WRITE_LOCK__DURATION => (& INFO [id :: PATH_SECRET_MAP_ADDRESS_WRITE_LOCK__DURATION] , entry) , id :: MEASURES_PATH_SECRET_MAP_DATAGRAM_ENCRYPT__PACKET_LEN => (& INFO [id :: PATH_SECRET_MAP_DATAGRAM_ENCRYPT__PACKET_LEN] , entry) , id :: MEASURES_PATH_SECRET_MAP_DATAGRAM_DECRYPT__PACKET_LEN => (& INFO [id :: PATH_SECRET_MAP_DATAGRAM_DECRYPT__PACKET_LEN] , entry) , _ => unsafe { core :: hint :: unreachable_unchecked () } , } })
+        self.measures
+            .iter()
+            .enumerate()
+            .map(|(idx, entry)| {
+                match idx {
+                    id::MEASURES_ACCEPTOR_TCP_STARTED__BACKLOG => {
+                        (&INFO[id::ACCEPTOR_TCP_STARTED__BACKLOG], entry)
+                    }
+                    id::MEASURES_ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__PENDING_STREAMS => {
+                        (
+                            &INFO[id::ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__PENDING_STREAMS],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__SLOTS_IDLE => {
+                        (
+                            &INFO[id::ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__SLOTS_IDLE],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__SLOT_UTILIZATION => {
+                        (
+                            &INFO[id::ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__SLOT_UTILIZATION],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__MAX_SOJOURN_TIME => {
+                        (
+                            &INFO[id::ACCEPTOR_TCP_LOOP_ITERATION_COMPLETED__MAX_SOJOURN_TIME],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_ACCEPTOR_TCP_FRESH_BATCH_COMPLETED__ENQUEUED => {
+                        (&INFO[id::ACCEPTOR_TCP_FRESH_BATCH_COMPLETED__ENQUEUED], entry)
+                    }
+                    id::MEASURES_ACCEPTOR_TCP_FRESH_BATCH_COMPLETED__DROPPED => {
+                        (&INFO[id::ACCEPTOR_TCP_FRESH_BATCH_COMPLETED__DROPPED], entry)
+                    }
+                    id::MEASURES_ACCEPTOR_TCP_FRESH_BATCH_COMPLETED__ERRORED => {
+                        (&INFO[id::ACCEPTOR_TCP_FRESH_BATCH_COMPLETED__ERRORED], entry)
+                    }
+                    id::MEASURES_ACCEPTOR_TCP_STREAM_REPLACED__BUFFER_LEN => {
+                        (&INFO[id::ACCEPTOR_TCP_STREAM_REPLACED__BUFFER_LEN], entry)
+                    }
+                    id::MEASURES_ACCEPTOR_TCP_PACKET_RECEIVED__PAYLOAD_LEN => {
+                        (&INFO[id::ACCEPTOR_TCP_PACKET_RECEIVED__PAYLOAD_LEN], entry)
+                    }
+                    id::MEASURES_ACCEPTOR_TCP_STREAM_ENQUEUED__BLOCKED_COUNT => {
+                        (&INFO[id::ACCEPTOR_TCP_STREAM_ENQUEUED__BLOCKED_COUNT], entry)
+                    }
+                    id::MEASURES_ACCEPTOR_TCP_SOCKET_SENT__BLOCKED_COUNT_STREAM => {
+                        (
+                            &INFO[id::ACCEPTOR_TCP_SOCKET_SENT__BLOCKED_COUNT_STREAM],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_ACCEPTOR_TCP_SOCKET_SENT__LEN => {
+                        (&INFO[id::ACCEPTOR_TCP_SOCKET_SENT__LEN], entry)
+                    }
+                    id::MEASURES_ACCEPTOR_TCP_SOCKET_RECEIVED__LEN => {
+                        (&INFO[id::ACCEPTOR_TCP_SOCKET_RECEIVED__LEN], entry)
+                    }
+                    id::MEASURES_ACCEPTOR_UDP_DATAGRAM_RECEIVED__LEN => {
+                        (&INFO[id::ACCEPTOR_UDP_DATAGRAM_RECEIVED__LEN], entry)
+                    }
+                    id::MEASURES_ACCEPTOR_UDP_PACKET_RECEIVED__PAYLOAD_LEN => {
+                        (&INFO[id::ACCEPTOR_UDP_PACKET_RECEIVED__PAYLOAD_LEN], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_FLUSHED__CONN => {
+                        (&INFO[id::STREAM_WRITE_FLUSHED__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_FLUSHED__PROVIDED => {
+                        (&INFO[id::STREAM_WRITE_FLUSHED__PROVIDED], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_FLUSHED__COMMITTED => {
+                        (&INFO[id::STREAM_WRITE_FLUSHED__COMMITTED], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_FLUSHED__COMMITTED__CONN => {
+                        (&INFO[id::STREAM_WRITE_FLUSHED__COMMITTED__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_FLUSHED__PROCESSING_DURATION => {
+                        (&INFO[id::STREAM_WRITE_FLUSHED__PROCESSING_DURATION], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_FLUSHED__PROCESSING_DURATION__CONN => {
+                        (
+                            &INFO[id::STREAM_WRITE_FLUSHED__PROCESSING_DURATION__CONN],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_STREAM_WRITE_FIN_FLUSHED__CONN => {
+                        (&INFO[id::STREAM_WRITE_FIN_FLUSHED__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_FIN_FLUSHED__PROVIDED => {
+                        (&INFO[id::STREAM_WRITE_FIN_FLUSHED__PROVIDED], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_FIN_FLUSHED__COMMITTED => {
+                        (&INFO[id::STREAM_WRITE_FIN_FLUSHED__COMMITTED], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_FIN_FLUSHED__COMMITTED__CONN => {
+                        (&INFO[id::STREAM_WRITE_FIN_FLUSHED__COMMITTED__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_FIN_FLUSHED__PROCESSING_DURATION => {
+                        (&INFO[id::STREAM_WRITE_FIN_FLUSHED__PROCESSING_DURATION], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_FIN_FLUSHED__PROCESSING_DURATION__CONN => {
+                        (
+                            &INFO[id::STREAM_WRITE_FIN_FLUSHED__PROCESSING_DURATION__CONN],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_STREAM_WRITE_BLOCKED__CONN => {
+                        (&INFO[id::STREAM_WRITE_BLOCKED__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_BLOCKED__PROVIDED => {
+                        (&INFO[id::STREAM_WRITE_BLOCKED__PROVIDED], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_BLOCKED__PROCESSING_DURATION => {
+                        (&INFO[id::STREAM_WRITE_BLOCKED__PROCESSING_DURATION], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_BLOCKED__PROCESSING_DURATION__CONN => {
+                        (
+                            &INFO[id::STREAM_WRITE_BLOCKED__PROCESSING_DURATION__CONN],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_STREAM_WRITE_ERRORED__PROVIDED => {
+                        (&INFO[id::STREAM_WRITE_ERRORED__PROVIDED], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_ERRORED__PROCESSING_DURATION => {
+                        (&INFO[id::STREAM_WRITE_ERRORED__PROCESSING_DURATION], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_ERRORED__PROCESSING_DURATION__CONN => {
+                        (
+                            &INFO[id::STREAM_WRITE_ERRORED__PROCESSING_DURATION__CONN],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_STREAM_WRITE_ALLOCATED__CONN => {
+                        (&INFO[id::STREAM_WRITE_ALLOCATED__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_ALLOCATED__ALLOCATED_LEN => {
+                        (&INFO[id::STREAM_WRITE_ALLOCATED__ALLOCATED_LEN], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_ALLOCATED__ALLOCATED_LEN__CONN => {
+                        (&INFO[id::STREAM_WRITE_ALLOCATED__ALLOCATED_LEN__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_SHUTDOWN__BUFFER_LEN => {
+                        (&INFO[id::STREAM_WRITE_SHUTDOWN__BUFFER_LEN], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_SOCKET_FLUSHED__CONN => {
+                        (&INFO[id::STREAM_WRITE_SOCKET_FLUSHED__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_SOCKET_FLUSHED__PROVIDED => {
+                        (&INFO[id::STREAM_WRITE_SOCKET_FLUSHED__PROVIDED], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_SOCKET_FLUSHED__COMMITTED => {
+                        (&INFO[id::STREAM_WRITE_SOCKET_FLUSHED__COMMITTED], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_SOCKET_FLUSHED__COMMITTED__CONN => {
+                        (&INFO[id::STREAM_WRITE_SOCKET_FLUSHED__COMMITTED__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_SOCKET_BLOCKED__CONN => {
+                        (&INFO[id::STREAM_WRITE_SOCKET_BLOCKED__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_SOCKET_BLOCKED__PROVIDED => {
+                        (&INFO[id::STREAM_WRITE_SOCKET_BLOCKED__PROVIDED], entry)
+                    }
+                    id::MEASURES_STREAM_WRITE_SOCKET_ERRORED__PROVIDED => {
+                        (&INFO[id::STREAM_WRITE_SOCKET_ERRORED__PROVIDED], entry)
+                    }
+                    id::MEASURES_STREAM_READ_FLUSHED__CONN => {
+                        (&INFO[id::STREAM_READ_FLUSHED__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_READ_FLUSHED__CAPACITY => {
+                        (&INFO[id::STREAM_READ_FLUSHED__CAPACITY], entry)
+                    }
+                    id::MEASURES_STREAM_READ_FLUSHED__COMMITTED => {
+                        (&INFO[id::STREAM_READ_FLUSHED__COMMITTED], entry)
+                    }
+                    id::MEASURES_STREAM_READ_FLUSHED__COMMITTED__CONN => {
+                        (&INFO[id::STREAM_READ_FLUSHED__COMMITTED__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_READ_FLUSHED__PROCESSING_DURATION => {
+                        (&INFO[id::STREAM_READ_FLUSHED__PROCESSING_DURATION], entry)
+                    }
+                    id::MEASURES_STREAM_READ_FLUSHED__PROCESSING_DURATION__CONN => {
+                        (
+                            &INFO[id::STREAM_READ_FLUSHED__PROCESSING_DURATION__CONN],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_STREAM_READ_FIN_FLUSHED__CONN => {
+                        (&INFO[id::STREAM_READ_FIN_FLUSHED__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_READ_FIN_FLUSHED__CAPACITY => {
+                        (&INFO[id::STREAM_READ_FIN_FLUSHED__CAPACITY], entry)
+                    }
+                    id::MEASURES_STREAM_READ_FIN_FLUSHED__PROCESSING_DURATION => {
+                        (&INFO[id::STREAM_READ_FIN_FLUSHED__PROCESSING_DURATION], entry)
+                    }
+                    id::MEASURES_STREAM_READ_FIN_FLUSHED__PROCESSING_DURATION__CONN => {
+                        (
+                            &INFO[id::STREAM_READ_FIN_FLUSHED__PROCESSING_DURATION__CONN],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_STREAM_READ_BLOCKED__CAPACITY => {
+                        (&INFO[id::STREAM_READ_BLOCKED__CAPACITY], entry)
+                    }
+                    id::MEASURES_STREAM_READ_BLOCKED__PROCESSING_DURATION => {
+                        (&INFO[id::STREAM_READ_BLOCKED__PROCESSING_DURATION], entry)
+                    }
+                    id::MEASURES_STREAM_READ_BLOCKED__PROCESSING_DURATION__CONN => {
+                        (
+                            &INFO[id::STREAM_READ_BLOCKED__PROCESSING_DURATION__CONN],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_STREAM_READ_ERRORED__CAPACITY => {
+                        (&INFO[id::STREAM_READ_ERRORED__CAPACITY], entry)
+                    }
+                    id::MEASURES_STREAM_READ_ERRORED__PROCESSING_DURATION => {
+                        (&INFO[id::STREAM_READ_ERRORED__PROCESSING_DURATION], entry)
+                    }
+                    id::MEASURES_STREAM_READ_ERRORED__PROCESSING_DURATION__CONN => {
+                        (
+                            &INFO[id::STREAM_READ_ERRORED__PROCESSING_DURATION__CONN],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_STREAM_READ_SOCKET_FLUSHED__CONN => {
+                        (&INFO[id::STREAM_READ_SOCKET_FLUSHED__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_READ_SOCKET_FLUSHED__CAPACITY => {
+                        (&INFO[id::STREAM_READ_SOCKET_FLUSHED__CAPACITY], entry)
+                    }
+                    id::MEASURES_STREAM_READ_SOCKET_FLUSHED__COMMITTED => {
+                        (&INFO[id::STREAM_READ_SOCKET_FLUSHED__COMMITTED], entry)
+                    }
+                    id::MEASURES_STREAM_READ_SOCKET_FLUSHED__COMMITTED__CONN => {
+                        (&INFO[id::STREAM_READ_SOCKET_FLUSHED__COMMITTED__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_READ_SOCKET_BLOCKED__CONN => {
+                        (&INFO[id::STREAM_READ_SOCKET_BLOCKED__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_READ_SOCKET_BLOCKED__CAPACITY => {
+                        (&INFO[id::STREAM_READ_SOCKET_BLOCKED__CAPACITY], entry)
+                    }
+                    id::MEASURES_STREAM_READ_SOCKET_ERRORED__CAPACITY => {
+                        (&INFO[id::STREAM_READ_SOCKET_ERRORED__CAPACITY], entry)
+                    }
+                    id::MEASURES_STREAM_DECRYPT_PACKET__FORCED_COPY => {
+                        (&INFO[id::STREAM_DECRYPT_PACKET__FORCED_COPY], entry)
+                    }
+                    id::MEASURES_STREAM_DECRYPT_PACKET__REQUIRED_APPLICATION_BUFFER => {
+                        (
+                            &INFO[id::STREAM_DECRYPT_PACKET__REQUIRED_APPLICATION_BUFFER],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_STREAM_PACKET_TRANSMITTED__PACKET_LEN => {
+                        (&INFO[id::STREAM_PACKET_TRANSMITTED__PACKET_LEN], entry)
+                    }
+                    id::MEASURES_STREAM_PACKET_TRANSMITTED__PAYLOAD_LEN => {
+                        (&INFO[id::STREAM_PACKET_TRANSMITTED__PAYLOAD_LEN], entry)
+                    }
+                    id::MEASURES_STREAM_PACKET_TRANSMITTED__PAYLOAD_LEN__CONN => {
+                        (&INFO[id::STREAM_PACKET_TRANSMITTED__PAYLOAD_LEN__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_PROBE_TRANSMITTED__PACKET_LEN => {
+                        (&INFO[id::STREAM_PROBE_TRANSMITTED__PACKET_LEN], entry)
+                    }
+                    id::MEASURES_STREAM_PACKET_RECEIVED__PACKET_LEN => {
+                        (&INFO[id::STREAM_PACKET_RECEIVED__PACKET_LEN], entry)
+                    }
+                    id::MEASURES_STREAM_PACKET_RECEIVED__PAYLOAD_LEN => {
+                        (&INFO[id::STREAM_PACKET_RECEIVED__PAYLOAD_LEN], entry)
+                    }
+                    id::MEASURES_STREAM_PACKET_RECEIVED__PAYLOAD_LEN__CONN => {
+                        (&INFO[id::STREAM_PACKET_RECEIVED__PAYLOAD_LEN__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_PACKET_LOST__PACKET_LEN => {
+                        (&INFO[id::STREAM_PACKET_LOST__PACKET_LEN], entry)
+                    }
+                    id::MEASURES_STREAM_PACKET_LOST__PAYLOAD_LEN => {
+                        (&INFO[id::STREAM_PACKET_LOST__PAYLOAD_LEN], entry)
+                    }
+                    id::MEASURES_STREAM_PACKET_LOST__PAYLOAD_LEN__CONN => {
+                        (&INFO[id::STREAM_PACKET_LOST__PAYLOAD_LEN__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_PACKET_LOST__LIFETIME => {
+                        (&INFO[id::STREAM_PACKET_LOST__LIFETIME], entry)
+                    }
+                    id::MEASURES_STREAM_PACKET_ACKED__PACKET_LEN => {
+                        (&INFO[id::STREAM_PACKET_ACKED__PACKET_LEN], entry)
+                    }
+                    id::MEASURES_STREAM_PACKET_ACKED__PAYLOAD_LEN => {
+                        (&INFO[id::STREAM_PACKET_ACKED__PAYLOAD_LEN], entry)
+                    }
+                    id::MEASURES_STREAM_PACKET_ACKED__PAYLOAD_LEN__CONN => {
+                        (&INFO[id::STREAM_PACKET_ACKED__PAYLOAD_LEN__CONN], entry)
+                    }
+                    id::MEASURES_STREAM_PACKET_ACKED__LIFETIME => {
+                        (&INFO[id::STREAM_PACKET_ACKED__LIFETIME], entry)
+                    }
+                    id::MEASURES_STREAM_PACKET_SPURIOUSLY_RETRANSMITTED__PACKET_LEN => {
+                        (
+                            &INFO[id::STREAM_PACKET_SPURIOUSLY_RETRANSMITTED__PACKET_LEN],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_STREAM_PACKET_SPURIOUSLY_RETRANSMITTED__PAYLOAD_LEN => {
+                        (
+                            &INFO[id::STREAM_PACKET_SPURIOUSLY_RETRANSMITTED__PAYLOAD_LEN],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_STREAM_PACKET_SPURIOUSLY_RETRANSMITTED__PAYLOAD_LEN__CONN => {
+                        (
+                            &INFO[id::STREAM_PACKET_SPURIOUSLY_RETRANSMITTED__PAYLOAD_LEN__CONN],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_STREAM_MAX_DATA_RECEIVED__INCREASE => {
+                        (&INFO[id::STREAM_MAX_DATA_RECEIVED__INCREASE], entry)
+                    }
+                    id::MEASURES_STREAM_CONTROL_PACKET_TRANSMITTED__PACKET_LEN => {
+                        (&INFO[id::STREAM_CONTROL_PACKET_TRANSMITTED__PACKET_LEN], entry)
+                    }
+                    id::MEASURES_STREAM_CONTROL_PACKET_TRANSMITTED__CONTROL_DATA_LEN => {
+                        (
+                            &INFO[id::STREAM_CONTROL_PACKET_TRANSMITTED__CONTROL_DATA_LEN],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_STREAM_CONTROL_PACKET_RECEIVED__PACKET_LEN => {
+                        (&INFO[id::STREAM_CONTROL_PACKET_RECEIVED__PACKET_LEN], entry)
+                    }
+                    id::MEASURES_STREAM_CONTROL_PACKET_RECEIVED__CONTROL_DATA_LEN => {
+                        (
+                            &INFO[id::STREAM_CONTROL_PACKET_RECEIVED__CONTROL_DATA_LEN],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_STREAM_HANDSHAKE_PACKET_REJECTED__CONN => {
+                        (&INFO[id::STREAM_HANDSHAKE_PACKET_REJECTED__CONN], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_INITIALIZED__CAPACITY => {
+                        (&INFO[id::PATH_SECRET_MAP_INITIALIZED__CAPACITY], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_UNINITIALIZED__CAPACITY => {
+                        (&INFO[id::PATH_SECRET_MAP_UNINITIALIZED__CAPACITY], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_UNINITIALIZED__ENTRIES => {
+                        (&INFO[id::PATH_SECRET_MAP_UNINITIALIZED__ENTRIES], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_UNINITIALIZED__LIFETIME => {
+                        (&INFO[id::PATH_SECRET_MAP_UNINITIALIZED__LIFETIME], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE => {
+                        (&INFO[id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE => {
+                        (&INFO[id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE], entry)
+                    }
+                    id::MEASURES_KEY_ACCEPTED__GAP => {
+                        (&INFO[id::KEY_ACCEPTED__GAP], entry)
+                    }
+                    id::MEASURES_KEY_ACCEPTED__FORWARD_SHIFT => {
+                        (&INFO[id::KEY_ACCEPTED__FORWARD_SHIFT], entry)
+                    }
+                    id::MEASURES_REPLAY_POTENTIALLY_DETECTED__GAP => {
+                        (&INFO[id::REPLAY_POTENTIALLY_DETECTED__GAP], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED_HIT__AGE => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED_HIT__AGE],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_ID_CACHE_ACCESSED_HIT__AGE => {
+                        (&INFO[id::PATH_SECRET_MAP_ID_CACHE_ACCESSED_HIT__AGE], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID => {
+                        (&INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__RETIRED => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__RETIRED],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__ACTIVE => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__ACTIVE],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__ACTIVE__UTILIZATION => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__ACTIVE__UTILIZATION],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__UTILIZATION => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__UTILIZATION],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__UTILIZATION__INITIAL => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__UTILIZATION__INITIAL],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__ACTIVE => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__ACTIVE],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__ACTIVE__UTILIZATION => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__ACTIVE__UTILIZATION],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__RETIRED => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__RETIRED],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS__SKIPPED => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS__SKIPPED],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_LOCK_DURATION => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_LOCK_DURATION],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE => {
+                        (&INFO[id::PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_ID_WRITE_LOCK__DURATION => {
+                        (&INFO[id::PATH_SECRET_MAP_ID_WRITE_LOCK__DURATION], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_ADDRESS_WRITE_LOCK__ACQUIRE => {
+                        (&INFO[id::PATH_SECRET_MAP_ADDRESS_WRITE_LOCK__ACQUIRE], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_ADDRESS_WRITE_LOCK__DURATION => {
+                        (&INFO[id::PATH_SECRET_MAP_ADDRESS_WRITE_LOCK__DURATION], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_DATAGRAM_ENCRYPT__PACKET_LEN => {
+                        (&INFO[id::PATH_SECRET_MAP_DATAGRAM_ENCRYPT__PACKET_LEN], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_DATAGRAM_DECRYPT__PACKET_LEN => {
+                        (&INFO[id::PATH_SECRET_MAP_DATAGRAM_DECRYPT__PACKET_LEN], entry)
+                    }
+                    _ => unsafe { core::hint::unreachable_unchecked() }
+                }
+            })
     }
     #[allow(dead_code)]
     #[inline(always)]
@@ -5288,7 +6177,7 @@ impl<R: Registry> Subscriber<R> {
         let measure = &self.measures[id];
         measure.record(info, value);
     }
-    #[doc = r" Returns all of the registered gauges"]
+    /// Returns all of the registered gauges
     #[inline]
     pub fn gauges(&self) -> impl Iterator<Item = (&'static Info, &R::Gauge)> + '_ {
         core::iter::empty()
@@ -5300,7 +6189,7 @@ impl<R: Registry> Subscriber<R> {
         let gauge = &self.gauges[id];
         gauge.record(info, value);
     }
-    #[doc = r" Returns all of the registered timers"]
+    /// Returns all of the registered timers
     #[inline]
     pub fn timers(&self) -> impl Iterator<Item = (&'static Info, &R::Timer)> + '_ {
         self.timers
@@ -7532,7 +8421,11 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
             id::COUNTERS_PATH_SECRET_MAP_BACKGROUND_HANDSHAKE_REQUESTED,
             1usize,
         );
-        self . count_nominal (id :: PATH_SECRET_MAP_BACKGROUND_HANDSHAKE_REQUESTED__PEER_ADDRESS__PROTOCOL , id :: NOMINAL_COUNTERS_PATH_SECRET_MAP_BACKGROUND_HANDSHAKE_REQUESTED__PEER_ADDRESS__PROTOCOL , & event . peer_address) ;
+        self.count_nominal(
+            id::PATH_SECRET_MAP_BACKGROUND_HANDSHAKE_REQUESTED__PEER_ADDRESS__PROTOCOL,
+            id::NOMINAL_COUNTERS_PATH_SECRET_MAP_BACKGROUND_HANDSHAKE_REQUESTED__PEER_ADDRESS__PROTOCOL,
+            &event.peer_address,
+        );
         let _ = event;
         let _ = meta;
     }

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -1065,227 +1065,329 @@ mod counter {
     }
     define!(
         extern "probe" {
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_started]
+            #[link_name = s2n_quic_dc__event__counter__acceptor_tcp_started]
             fn acceptor_tcp_started(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_loop_iteration_completed]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_loop_iteration_completed]
             fn acceptor_tcp_loop_iteration_completed(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_fresh_enqueued]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_fresh_enqueued]
             fn acceptor_tcp_fresh_enqueued(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_fresh_batch_completed]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_fresh_batch_completed]
             fn acceptor_tcp_fresh_batch_completed(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_stream_dropped]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_stream_dropped]
             fn acceptor_tcp_stream_dropped(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_stream_replaced]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_stream_replaced]
             fn acceptor_tcp_stream_replaced(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_packet_received]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_packet_received]
             fn acceptor_tcp_packet_received(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_tls_started]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_tls_started]
             fn acceptor_tcp_tls_started(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_tls_stream_enqueued]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_tls_stream_enqueued]
             fn acceptor_tcp_tls_stream_enqueued(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_tls_stream_rejected]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_tls_stream_rejected]
             fn acceptor_tcp_tls_stream_rejected(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_packet_dropped]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_packet_dropped]
             fn acceptor_tcp_packet_dropped(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_stream_enqueued]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_stream_enqueued]
             fn acceptor_tcp_stream_enqueued(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_io_error]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_io_error]
             fn acceptor_tcp_io_error(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_socket_sent]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_socket_sent]
             fn acceptor_tcp_socket_sent(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_socket_sent__blocked_count_host]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_socket_sent__blocked_count_host]
             fn acceptor_tcp_socket_sent__blocked_count_host(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_tcp_socket_received]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_socket_received]
             fn acceptor_tcp_socket_received(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_udp_started]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_udp_started]
             fn acceptor_udp_started(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_udp_datagram_received]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_udp_datagram_received]
             fn acceptor_udp_datagram_received(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_udp_packet_received]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_udp_packet_received]
             fn acceptor_udp_packet_received(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_udp_packet_dropped]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_udp_packet_dropped]
             fn acceptor_udp_packet_dropped(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_udp_stream_enqueued]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_udp_stream_enqueued]
             fn acceptor_udp_stream_enqueued(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_udp_io_error]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_udp_io_error]
             fn acceptor_udp_io_error(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_stream_pruned]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_stream_pruned]
             fn acceptor_stream_pruned(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__acceptor_stream_dequeued]
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_stream_dequeued]
             fn acceptor_stream_dequeued(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_write_flushed]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_write_flushed]
             fn stream_write_flushed(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_write_flushed__committed__total]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_write_flushed__committed__total]
             fn stream_write_flushed__committed__total(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_write_fin_flushed]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_write_fin_flushed]
             fn stream_write_fin_flushed(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_write_fin_flushed__committed__total]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_write_fin_flushed__committed__total]
             fn stream_write_fin_flushed__committed__total(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_write_blocked]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_write_blocked]
             fn stream_write_blocked(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_write_errored]
+            #[link_name = s2n_quic_dc__event__counter__stream_write_errored]
             fn stream_write_errored(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_write_key_updated]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_write_key_updated]
             fn stream_write_key_updated(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_write_allocated]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_write_allocated]
             fn stream_write_allocated(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_write_shutdown]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_write_shutdown]
             fn stream_write_shutdown(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_write_socket_flushed]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_write_socket_flushed]
             fn stream_write_socket_flushed(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_write_socket_flushed__committed__total]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_write_socket_flushed__committed__total]
             fn stream_write_socket_flushed__committed__total(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_write_socket_blocked]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_write_socket_blocked]
             fn stream_write_socket_blocked(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_write_socket_errored]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_write_socket_errored]
             fn stream_write_socket_errored(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_read_flushed]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_read_flushed]
             fn stream_read_flushed(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_read_flushed__committed__total]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_read_flushed__committed__total]
             fn stream_read_flushed__committed__total(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_read_fin_flushed]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_read_fin_flushed]
             fn stream_read_fin_flushed(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_read_blocked]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_read_blocked]
             fn stream_read_blocked(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_read_errored]
+            #[link_name = s2n_quic_dc__event__counter__stream_read_errored]
             fn stream_read_errored(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_read_key_updated]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_read_key_updated]
             fn stream_read_key_updated(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_read_shutdown]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_read_shutdown]
             fn stream_read_shutdown(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_read_socket_flushed]
+            #[link_name = s2n_quic_dc__event__counter__stream_read_socket_flushed]
             fn stream_read_socket_flushed(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_read_socket_flushed__committed__total]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_read_socket_flushed__committed__total]
             fn stream_read_socket_flushed__committed__total(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_read_socket_blocked]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_read_socket_blocked]
             fn stream_read_socket_blocked(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_read_socket_errored]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_read_socket_errored]
             fn stream_read_socket_errored(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_decrypt_packet]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_decrypt_packet]
             fn stream_decrypt_packet(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_tcp_connect]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_tcp_connect]
             fn stream_tcp_connect(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_tls_connect]
+            #[link_name = s2n_quic_dc__event__counter__stream_tls_connect]
             fn stream_tls_connect(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_connect]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_connect]
             fn stream_connect(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_connect_error]
+            #[link_name = s2n_quic_dc__event__counter__stream_connect_error]
             fn stream_connect_error(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_packet_transmitted]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_packet_transmitted]
             fn stream_packet_transmitted(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_packet_transmitted__payload_len__total]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_packet_transmitted__payload_len__total]
             fn stream_packet_transmitted__payload_len__total(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_probe_transmitted]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_probe_transmitted]
             fn stream_probe_transmitted(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_packet_received]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_packet_received]
             fn stream_packet_received(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_packet_received__payload_len__total]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_packet_received__payload_len__total]
             fn stream_packet_received__payload_len__total(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_packet_lost]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_packet_lost]
             fn stream_packet_lost(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_packet_lost__payload_len__total]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_packet_lost__payload_len__total]
             fn stream_packet_lost__payload_len__total(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_packet_acked]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_packet_acked]
             fn stream_packet_acked(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_packet_acked__payload_len__total]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_packet_acked__payload_len__total]
             fn stream_packet_acked__payload_len__total(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_packet_spuriously_retransmitted]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_packet_spuriously_retransmitted]
             fn stream_packet_spuriously_retransmitted(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_packet_spuriously_retransmitted__payload_len__total]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_packet_spuriously_retransmitted__payload_len__total]
             fn stream_packet_spuriously_retransmitted__payload_len__total(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_max_data_received]
+            #[link_name = s2n_quic_dc__event__counter__stream_max_data_received]
             fn stream_max_data_received(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_max_data_received__increase__total]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_max_data_received__increase__total]
             fn stream_max_data_received__increase__total(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_control_packet_transmitted]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_control_packet_transmitted]
             fn stream_control_packet_transmitted(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_control_packet_received]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_control_packet_received]
             fn stream_control_packet_received(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_receiver_errored]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_receiver_errored]
             fn stream_receiver_errored(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_sender_errored]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_sender_errored]
             fn stream_sender_errored(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stream_handshake_packet_rejected]
+            #[link_name =
+        s2n_quic_dc__event__counter__stream_handshake_packet_rejected]
             fn stream_handshake_packet_rejected(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__connection_closed]
+            #[link_name =
+        s2n_quic_dc__event__counter__connection_closed]
             fn connection_closed(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__endpoint_initialized]
+            #[link_name = s2n_quic_dc__event__counter__endpoint_initialized]
             fn endpoint_initialized(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__dc_connection_timeout]
+            #[link_name =
+        s2n_quic_dc__event__counter__dc_connection_timeout]
             fn dc_connection_timeout(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_initialized]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_initialized]
             fn path_secret_map_initialized(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_uninitialized]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_uninitialized]
             fn path_secret_map_uninitialized(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_background_handshake_requested]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_background_handshake_requested]
             fn path_secret_map_background_handshake_requested(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_entry_inserted]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_entry_inserted]
             fn path_secret_map_entry_inserted(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_entry_ready]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_entry_ready]
             fn path_secret_map_entry_ready(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_entry_replaced]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_entry_replaced]
             fn path_secret_map_entry_replaced(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_id_entry_evicted]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_id_entry_evicted]
             fn path_secret_map_id_entry_evicted(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_address_entry_evicted]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_address_entry_evicted]
             fn path_secret_map_address_entry_evicted(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__unknown_path_secret_packet_sent]
+            #[link_name =
+        s2n_quic_dc__event__counter__unknown_path_secret_packet_sent]
             fn unknown_path_secret_packet_sent(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__unknown_path_secret_packet_received]
+            #[link_name =
+        s2n_quic_dc__event__counter__unknown_path_secret_packet_received]
             fn unknown_path_secret_packet_received(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__unknown_path_secret_packet_accepted]
+            #[link_name =
+        s2n_quic_dc__event__counter__unknown_path_secret_packet_accepted]
             fn unknown_path_secret_packet_accepted(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__unknown_path_secret_packet_rejected]
+            #[link_name =
+        s2n_quic_dc__event__counter__unknown_path_secret_packet_rejected]
             fn unknown_path_secret_packet_rejected(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__unknown_path_secret_packet_dropped]
+            #[link_name =
+        s2n_quic_dc__event__counter__unknown_path_secret_packet_dropped]
             fn unknown_path_secret_packet_dropped(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__key_accepted]
+            #[link_name =
+        s2n_quic_dc__event__counter__key_accepted]
             fn key_accepted(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__replay_definitely_detected]
+            #[link_name = s2n_quic_dc__event__counter__replay_definitely_detected]
             fn replay_definitely_detected(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__replay_potentially_detected]
+            #[link_name =
+        s2n_quic_dc__event__counter__replay_potentially_detected]
             fn replay_potentially_detected(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__replay_detected_packet_sent]
+            #[link_name =
+        s2n_quic_dc__event__counter__replay_detected_packet_sent]
             fn replay_detected_packet_sent(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__replay_detected_packet_received]
+            #[link_name =
+        s2n_quic_dc__event__counter__replay_detected_packet_received]
             fn replay_detected_packet_received(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__replay_detected_packet_accepted]
+            #[link_name =
+        s2n_quic_dc__event__counter__replay_detected_packet_accepted]
             fn replay_detected_packet_accepted(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__replay_detected_packet_rejected]
+            #[link_name =
+        s2n_quic_dc__event__counter__replay_detected_packet_rejected]
             fn replay_detected_packet_rejected(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__replay_detected_packet_dropped]
+            #[link_name =
+        s2n_quic_dc__event__counter__replay_detected_packet_dropped]
             fn replay_detected_packet_dropped(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stale_key_packet_sent]
+            #[link_name =
+        s2n_quic_dc__event__counter__stale_key_packet_sent]
             fn stale_key_packet_sent(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stale_key_packet_received]
+            #[link_name =
+        s2n_quic_dc__event__counter__stale_key_packet_received]
             fn stale_key_packet_received(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stale_key_packet_accepted]
+            #[link_name =
+        s2n_quic_dc__event__counter__stale_key_packet_accepted]
             fn stale_key_packet_accepted(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stale_key_packet_rejected]
+            #[link_name =
+        s2n_quic_dc__event__counter__stale_key_packet_rejected]
             fn stale_key_packet_rejected(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__stale_key_packet_dropped]
+            #[link_name =
+        s2n_quic_dc__event__counter__stale_key_packet_dropped]
             fn stale_key_packet_dropped(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_address_cache_accessed]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_address_cache_accessed]
             fn path_secret_map_address_cache_accessed(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_address_cache_accessed_hit]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_address_cache_accessed_hit]
             fn path_secret_map_address_cache_accessed_hit(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_id_cache_accessed]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_id_cache_accessed]
             fn path_secret_map_id_cache_accessed(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_id_cache_accessed_hit]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_id_cache_accessed_hit]
             fn path_secret_map_id_cache_accessed_hit(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_cleaner_cycled]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_cleaner_cycled]
             fn path_secret_map_cleaner_cycled(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_id_write_lock]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_id_write_lock]
             fn path_secret_map_id_write_lock(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_address_write_lock]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_address_write_lock]
             fn path_secret_map_address_write_lock(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_datagram_encrypt]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_datagram_encrypt]
             fn path_secret_map_datagram_encrypt(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_datagram_encrypt__packet_len__total]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_datagram_encrypt__packet_len__total]
             fn path_secret_map_datagram_encrypt__packet_len__total(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_datagram_decrypt]
+            #[link_name
+        = s2n_quic_dc__event__counter__path_secret_map_datagram_decrypt]
             fn path_secret_map_datagram_decrypt(value: u64);
-            # [link_name = s2n_quic_dc__event__counter__path_secret_map_datagram_decrypt__packet_len__total]
+            #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_datagram_decrypt__packet_len__total]
             fn path_secret_map_datagram_decrypt__packet_len__total(value: u64);
         }
     );
@@ -1361,49 +1463,71 @@ mod counter {
         }
         define!(
             extern "probe" {
-                # [link_name = s2n_quic_dc__event__counter__bool__acceptor_tcp_packet_received__is_fin]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__acceptor_tcp_packet_received__is_fin]
                 fn acceptor_tcp_packet_received__is_fin(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__acceptor_tcp_packet_received__is_fin_known]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__acceptor_tcp_packet_received__is_fin_known]
                 fn acceptor_tcp_packet_received__is_fin_known(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_zero_offset]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_zero_offset]
                 fn acceptor_udp_packet_received__is_zero_offset(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_retransmission]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_retransmission]
                 fn acceptor_udp_packet_received__is_retransmission(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_fin]
+                #[link_name
+            = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_fin]
                 fn acceptor_udp_packet_received__is_fin(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_fin_known]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__acceptor_udp_packet_received__is_fin_known]
                 fn acceptor_udp_packet_received__is_fin_known(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__stream_write_shutdown__background]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__stream_write_shutdown__background]
                 fn stream_write_shutdown__background(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__stream_read_shutdown__background]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__stream_read_shutdown__background]
                 fn stream_read_shutdown__background(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__stream_decrypt_packet__decrypted_in_place]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__stream_decrypt_packet__decrypted_in_place]
                 fn stream_decrypt_packet__decrypted_in_place(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__stream_tcp_connect__error]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__stream_tcp_connect__error]
                 fn stream_tcp_connect__error(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__stream_tls_connect__error]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__stream_tls_connect__error]
                 fn stream_tls_connect__error(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__stream_connect__error]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__stream_connect__error]
                 fn stream_connect__error(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__stream_packet_transmitted__retransmission]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__stream_packet_transmitted__retransmission]
                 fn stream_packet_transmitted__retransmission(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__stream_packet_received__retransmission]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__stream_packet_received__retransmission]
                 fn stream_packet_received__retransmission(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__stream_packet_lost__retransmission]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__stream_packet_lost__retransmission]
                 fn stream_packet_lost__retransmission(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__stream_packet_acked__retransmission]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__stream_packet_acked__retransmission]
                 fn stream_packet_acked__retransmission(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__stream_packet_spuriously_retransmitted__retransmission]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__stream_packet_spuriously_retransmitted__retransmission]
                 fn stream_packet_spuriously_retransmitted__retransmission(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__stream_control_packet_received__authenticated]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__stream_control_packet_received__authenticated]
                 fn stream_control_packet_received__authenticated(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__endpoint_initialized__tcp]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__endpoint_initialized__tcp]
                 fn endpoint_initialized__tcp(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__endpoint_initialized__udp]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__endpoint_initialized__udp]
                 fn endpoint_initialized__udp(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__path_secret_map_address_cache_accessed__hit]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__path_secret_map_address_cache_accessed__hit]
                 fn path_secret_map_address_cache_accessed__hit(value: bool);
-                # [link_name = s2n_quic_dc__event__counter__bool__path_secret_map_id_cache_accessed__hit]
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__path_secret_map_id_cache_accessed__hit]
                 fn path_secret_map_id_cache_accessed__hit(value: bool);
             }
         );
@@ -1527,199 +1651,234 @@ mod counter {
         }
         define!(
             extern "probe" {
-                # [link_name = s2n_quic_dc__event__counter__nominal__acceptor_tcp_stream_dropped__reason]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__acceptor_tcp_stream_dropped__reason]
                 fn acceptor_tcp_stream_dropped__reason(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__acceptor_tcp_packet_dropped__reason]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__acceptor_tcp_packet_dropped__reason]
                 fn acceptor_tcp_packet_dropped__reason(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__acceptor_tcp_io_error__source]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__acceptor_tcp_io_error__source]
                 fn acceptor_tcp_io_error__source(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__acceptor_udp_packet_dropped__reason]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__acceptor_udp_packet_dropped__reason]
                 fn acceptor_udp_packet_dropped__reason(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__acceptor_stream_pruned__reason]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__acceptor_stream_pruned__reason]
                 fn acceptor_stream_pruned__reason(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__stream_connect__tcp]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__stream_connect__tcp]
                 fn stream_connect__tcp(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic_dc__event__counter__nominal__stream_connect__handshake]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__stream_connect__handshake]
                 fn stream_connect__handshake(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic_dc__event__counter__nominal__stream_connect_error__reason]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__stream_connect_error__reason]
                 fn stream_connect_error__reason(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic_dc__event__counter__nominal__stream_handshake_packet_rejected__reason]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__stream_handshake_packet_rejected__reason]
                 fn stream_handshake_packet_rejected__reason(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__endpoint_initialized__acceptor__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__endpoint_initialized__acceptor__protocol]
                 fn endpoint_initialized__acceptor__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__endpoint_initialized__handshake__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__endpoint_initialized__handshake__protocol]
                 fn endpoint_initialized__handshake__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__dc_connection_timeout__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__dc_connection_timeout__peer_address__protocol]
                 fn dc_connection_timeout__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__path_secret_map_background_handshake_requested__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__path_secret_map_background_handshake_requested__peer_address__protocol]
                 fn path_secret_map_background_handshake_requested__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__path_secret_map_entry_inserted__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__path_secret_map_entry_inserted__peer_address__protocol]
                 fn path_secret_map_entry_inserted__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__path_secret_map_entry_ready__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__path_secret_map_entry_ready__peer_address__protocol]
                 fn path_secret_map_entry_ready__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__path_secret_map_entry_replaced__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__path_secret_map_entry_replaced__peer_address__protocol]
                 fn path_secret_map_entry_replaced__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__path_secret_map_id_entry_evicted__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__path_secret_map_id_entry_evicted__peer_address__protocol]
                 fn path_secret_map_id_entry_evicted__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__path_secret_map_address_entry_evicted__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__path_secret_map_address_entry_evicted__peer_address__protocol]
                 fn path_secret_map_address_entry_evicted__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__unknown_path_secret_packet_sent__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__unknown_path_secret_packet_sent__peer_address__protocol]
                 fn unknown_path_secret_packet_sent__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__unknown_path_secret_packet_received__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__unknown_path_secret_packet_received__peer_address__protocol]
                 fn unknown_path_secret_packet_received__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__unknown_path_secret_packet_accepted__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__unknown_path_secret_packet_accepted__peer_address__protocol]
                 fn unknown_path_secret_packet_accepted__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__unknown_path_secret_packet_rejected__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__unknown_path_secret_packet_rejected__peer_address__protocol]
                 fn unknown_path_secret_packet_rejected__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__unknown_path_secret_packet_dropped__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__unknown_path_secret_packet_dropped__peer_address__protocol]
                 fn unknown_path_secret_packet_dropped__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__replay_detected_packet_sent__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__replay_detected_packet_sent__peer_address__protocol]
                 fn replay_detected_packet_sent__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__replay_detected_packet_received__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__replay_detected_packet_received__peer_address__protocol]
                 fn replay_detected_packet_received__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__replay_detected_packet_accepted__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__replay_detected_packet_accepted__peer_address__protocol]
                 fn replay_detected_packet_accepted__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__replay_detected_packet_rejected__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__replay_detected_packet_rejected__peer_address__protocol]
                 fn replay_detected_packet_rejected__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__replay_detected_packet_dropped__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__replay_detected_packet_dropped__peer_address__protocol]
                 fn replay_detected_packet_dropped__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__stale_key_packet_sent__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__stale_key_packet_sent__peer_address__protocol]
                 fn stale_key_packet_sent__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__stale_key_packet_received__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__stale_key_packet_received__peer_address__protocol]
                 fn stale_key_packet_received__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__stale_key_packet_accepted__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__stale_key_packet_accepted__peer_address__protocol]
                 fn stale_key_packet_accepted__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__stale_key_packet_rejected__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__stale_key_packet_rejected__peer_address__protocol]
                 fn stale_key_packet_rejected__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__stale_key_packet_dropped__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__stale_key_packet_dropped__peer_address__protocol]
                 fn stale_key_packet_dropped__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__path_secret_map_address_cache_accessed__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__path_secret_map_address_cache_accessed__peer_address__protocol]
                 fn path_secret_map_address_cache_accessed__peer_address__protocol(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic_dc__event__counter__nominal__path_secret_map_address_cache_accessed_hit__peer_address__protocol]
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__path_secret_map_address_cache_accessed_hit__peer_address__protocol]
                 fn path_secret_map_address_cache_accessed_hit__peer_address__protocol(
                     value: u64,
                     variant: u64,
@@ -2060,261 +2219,390 @@ mod measure {
     }
     define!(
         extern "probe" {
-            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_started__backlog]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_tcp_started__backlog]
             fn acceptor_tcp_started__backlog(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_loop_iteration_completed__pending_streams]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_tcp_loop_iteration_completed__pending_streams]
             fn acceptor_tcp_loop_iteration_completed__pending_streams(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_loop_iteration_completed__slots_idle]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_tcp_loop_iteration_completed__slots_idle]
             fn acceptor_tcp_loop_iteration_completed__slots_idle(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_loop_iteration_completed__slot_utilization]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_tcp_loop_iteration_completed__slot_utilization]
             fn acceptor_tcp_loop_iteration_completed__slot_utilization(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_loop_iteration_completed__max_sojourn_time]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_tcp_loop_iteration_completed__max_sojourn_time]
             fn acceptor_tcp_loop_iteration_completed__max_sojourn_time(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_fresh_batch_completed__enqueued]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_tcp_fresh_batch_completed__enqueued]
             fn acceptor_tcp_fresh_batch_completed__enqueued(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_fresh_batch_completed__dropped]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_tcp_fresh_batch_completed__dropped]
             fn acceptor_tcp_fresh_batch_completed__dropped(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_fresh_batch_completed__errored]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_tcp_fresh_batch_completed__errored]
             fn acceptor_tcp_fresh_batch_completed__errored(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_stream_replaced__buffer_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_tcp_stream_replaced__buffer_len]
             fn acceptor_tcp_stream_replaced__buffer_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_packet_received__payload_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_tcp_packet_received__payload_len]
             fn acceptor_tcp_packet_received__payload_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_stream_enqueued__blocked_count]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_tcp_stream_enqueued__blocked_count]
             fn acceptor_tcp_stream_enqueued__blocked_count(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_socket_sent__blocked_count_stream]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_tcp_socket_sent__blocked_count_stream]
             fn acceptor_tcp_socket_sent__blocked_count_stream(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_socket_sent__len]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_tcp_socket_sent__len]
             fn acceptor_tcp_socket_sent__len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__acceptor_tcp_socket_received__len]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_tcp_socket_received__len]
             fn acceptor_tcp_socket_received__len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__acceptor_udp_datagram_received__len]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_udp_datagram_received__len]
             fn acceptor_udp_datagram_received__len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__acceptor_udp_packet_received__payload_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__acceptor_udp_packet_received__payload_len]
             fn acceptor_udp_packet_received__payload_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_flushed__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_flushed__conn]
             fn stream_write_flushed__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_flushed__provided]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_flushed__provided]
             fn stream_write_flushed__provided(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_flushed__committed]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_flushed__committed]
             fn stream_write_flushed__committed(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_flushed__committed__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_flushed__committed__conn]
             fn stream_write_flushed__committed__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_flushed__processing_duration]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_flushed__processing_duration]
             fn stream_write_flushed__processing_duration(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_flushed__processing_duration__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_flushed__processing_duration__conn]
             fn stream_write_flushed__processing_duration__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_fin_flushed__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_fin_flushed__conn]
             fn stream_write_fin_flushed__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_fin_flushed__provided]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_fin_flushed__provided]
             fn stream_write_fin_flushed__provided(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_fin_flushed__committed]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_fin_flushed__committed]
             fn stream_write_fin_flushed__committed(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_fin_flushed__committed__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_fin_flushed__committed__conn]
             fn stream_write_fin_flushed__committed__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_fin_flushed__processing_duration]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_fin_flushed__processing_duration]
             fn stream_write_fin_flushed__processing_duration(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_fin_flushed__processing_duration__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_fin_flushed__processing_duration__conn]
             fn stream_write_fin_flushed__processing_duration__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_blocked__conn]
+            #[link_name
+        = s2n_quic_dc__event__measure__stream_write_blocked__conn]
             fn stream_write_blocked__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_blocked__provided]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_blocked__provided]
             fn stream_write_blocked__provided(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_blocked__processing_duration]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_blocked__processing_duration]
             fn stream_write_blocked__processing_duration(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_blocked__processing_duration__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_blocked__processing_duration__conn]
             fn stream_write_blocked__processing_duration__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_errored__provided]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_errored__provided]
             fn stream_write_errored__provided(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_errored__processing_duration]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_errored__processing_duration]
             fn stream_write_errored__processing_duration(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_errored__processing_duration__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_errored__processing_duration__conn]
             fn stream_write_errored__processing_duration__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_allocated__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_allocated__conn]
             fn stream_write_allocated__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_allocated__allocated_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_allocated__allocated_len]
             fn stream_write_allocated__allocated_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_allocated__allocated_len__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_allocated__allocated_len__conn]
             fn stream_write_allocated__allocated_len__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_shutdown__buffer_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_shutdown__buffer_len]
             fn stream_write_shutdown__buffer_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_socket_flushed__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_socket_flushed__conn]
             fn stream_write_socket_flushed__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_socket_flushed__provided]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_socket_flushed__provided]
             fn stream_write_socket_flushed__provided(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_socket_flushed__committed]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_socket_flushed__committed]
             fn stream_write_socket_flushed__committed(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_socket_flushed__committed__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_socket_flushed__committed__conn]
             fn stream_write_socket_flushed__committed__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_socket_blocked__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_socket_blocked__conn]
             fn stream_write_socket_blocked__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_socket_blocked__provided]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_socket_blocked__provided]
             fn stream_write_socket_blocked__provided(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_write_socket_errored__provided]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_write_socket_errored__provided]
             fn stream_write_socket_errored__provided(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_flushed__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_flushed__conn]
             fn stream_read_flushed__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_flushed__capacity]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_flushed__capacity]
             fn stream_read_flushed__capacity(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_flushed__committed]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_flushed__committed]
             fn stream_read_flushed__committed(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_flushed__committed__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_flushed__committed__conn]
             fn stream_read_flushed__committed__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_flushed__processing_duration]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_flushed__processing_duration]
             fn stream_read_flushed__processing_duration(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_flushed__processing_duration__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_flushed__processing_duration__conn]
             fn stream_read_flushed__processing_duration__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_fin_flushed__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_fin_flushed__conn]
             fn stream_read_fin_flushed__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_fin_flushed__capacity]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_fin_flushed__capacity]
             fn stream_read_fin_flushed__capacity(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_fin_flushed__processing_duration]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_fin_flushed__processing_duration]
             fn stream_read_fin_flushed__processing_duration(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_fin_flushed__processing_duration__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_fin_flushed__processing_duration__conn]
             fn stream_read_fin_flushed__processing_duration__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_blocked__capacity]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_blocked__capacity]
             fn stream_read_blocked__capacity(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_blocked__processing_duration]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_blocked__processing_duration]
             fn stream_read_blocked__processing_duration(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_blocked__processing_duration__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_blocked__processing_duration__conn]
             fn stream_read_blocked__processing_duration__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_errored__capacity]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_errored__capacity]
             fn stream_read_errored__capacity(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_errored__processing_duration]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_errored__processing_duration]
             fn stream_read_errored__processing_duration(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_errored__processing_duration__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_errored__processing_duration__conn]
             fn stream_read_errored__processing_duration__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_socket_flushed__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_socket_flushed__conn]
             fn stream_read_socket_flushed__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_socket_flushed__capacity]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_socket_flushed__capacity]
             fn stream_read_socket_flushed__capacity(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_socket_flushed__committed]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_socket_flushed__committed]
             fn stream_read_socket_flushed__committed(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_socket_flushed__committed__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_socket_flushed__committed__conn]
             fn stream_read_socket_flushed__committed__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_socket_blocked__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_socket_blocked__conn]
             fn stream_read_socket_blocked__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_socket_blocked__capacity]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_socket_blocked__capacity]
             fn stream_read_socket_blocked__capacity(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_read_socket_errored__capacity]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_read_socket_errored__capacity]
             fn stream_read_socket_errored__capacity(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_decrypt_packet__forced_copy]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_decrypt_packet__forced_copy]
             fn stream_decrypt_packet__forced_copy(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_decrypt_packet__required_application_buffer]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_decrypt_packet__required_application_buffer]
             fn stream_decrypt_packet__required_application_buffer(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_transmitted__packet_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_transmitted__packet_len]
             fn stream_packet_transmitted__packet_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_transmitted__payload_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_transmitted__payload_len]
             fn stream_packet_transmitted__payload_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_transmitted__payload_len__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_transmitted__payload_len__conn]
             fn stream_packet_transmitted__payload_len__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_probe_transmitted__packet_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_probe_transmitted__packet_len]
             fn stream_probe_transmitted__packet_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_received__packet_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_received__packet_len]
             fn stream_packet_received__packet_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_received__payload_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_received__payload_len]
             fn stream_packet_received__payload_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_received__payload_len__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_received__payload_len__conn]
             fn stream_packet_received__payload_len__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_lost__packet_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_lost__packet_len]
             fn stream_packet_lost__packet_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_lost__payload_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_lost__payload_len]
             fn stream_packet_lost__payload_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_lost__payload_len__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_lost__payload_len__conn]
             fn stream_packet_lost__payload_len__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_lost__lifetime]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_lost__lifetime]
             fn stream_packet_lost__lifetime(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_acked__packet_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_acked__packet_len]
             fn stream_packet_acked__packet_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_acked__payload_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_acked__payload_len]
             fn stream_packet_acked__payload_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_acked__payload_len__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_acked__payload_len__conn]
             fn stream_packet_acked__payload_len__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_acked__lifetime]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_acked__lifetime]
             fn stream_packet_acked__lifetime(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_spuriously_retransmitted__packet_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_spuriously_retransmitted__packet_len]
             fn stream_packet_spuriously_retransmitted__packet_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_spuriously_retransmitted__payload_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_packet_spuriously_retransmitted__payload_len]
             fn stream_packet_spuriously_retransmitted__payload_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_packet_spuriously_retransmitted__payload_len__conn]
+            #[link_name
+        =
+        s2n_quic_dc__event__measure__stream_packet_spuriously_retransmitted__payload_len__conn]
             fn stream_packet_spuriously_retransmitted__payload_len__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_max_data_received__increase]
+            #[link_name = s2n_quic_dc__event__measure__stream_max_data_received__increase]
             fn stream_max_data_received__increase(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_control_packet_transmitted__packet_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_control_packet_transmitted__packet_len]
             fn stream_control_packet_transmitted__packet_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_control_packet_transmitted__control_data_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_control_packet_transmitted__control_data_len]
             fn stream_control_packet_transmitted__control_data_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_control_packet_received__packet_len]
+            #[link_name
+        = s2n_quic_dc__event__measure__stream_control_packet_received__packet_len]
             fn stream_control_packet_received__packet_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_control_packet_received__control_data_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_control_packet_received__control_data_len]
             fn stream_control_packet_received__control_data_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__stream_handshake_packet_rejected__conn]
+            #[link_name =
+        s2n_quic_dc__event__measure__stream_handshake_packet_rejected__conn]
             fn stream_handshake_packet_rejected__conn(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_initialized__capacity]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_initialized__capacity]
             fn path_secret_map_initialized__capacity(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_uninitialized__capacity]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_uninitialized__capacity]
             fn path_secret_map_uninitialized__capacity(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_uninitialized__entries]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_uninitialized__entries]
             fn path_secret_map_uninitialized__entries(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_uninitialized__lifetime]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_uninitialized__lifetime]
             fn path_secret_map_uninitialized__lifetime(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_id_entry_evicted__age]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_id_entry_evicted__age]
             fn path_secret_map_id_entry_evicted__age(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_address_entry_evicted__age]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_address_entry_evicted__age]
             fn path_secret_map_address_entry_evicted__age(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__key_accepted__gap]
+            #[link_name =
+        s2n_quic_dc__event__measure__key_accepted__gap]
             fn key_accepted__gap(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__key_accepted__forward_shift]
+            #[link_name = s2n_quic_dc__event__measure__key_accepted__forward_shift]
             fn key_accepted__forward_shift(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__replay_potentially_detected__gap]
+            #[link_name =
+        s2n_quic_dc__event__measure__replay_potentially_detected__gap]
             fn replay_potentially_detected__gap(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_address_cache_accessed_hit__age]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_address_cache_accessed_hit__age]
             fn path_secret_map_address_cache_accessed_hit__age(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_id_cache_accessed_hit__age]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_id_cache_accessed_hit__age]
             fn path_secret_map_id_cache_accessed_hit__age(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__id]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__id]
             fn path_secret_map_cleaner_cycled__entries__id(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__id__retired]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__id__retired]
             fn path_secret_map_cleaner_cycled__entries__id__retired(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__id__active]
+            #[link_name
+        =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__id__active]
             fn path_secret_map_cleaner_cycled__entries__id__active(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__id__active__utilization]
+            #[link_name
+        =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__id__active__utilization]
             fn path_secret_map_cleaner_cycled__entries__id__active__utilization(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__id__utilization]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__id__utilization]
             fn path_secret_map_cleaner_cycled__entries__id__utilization(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__id__utilization__initial]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__id__utilization__initial]
             fn path_secret_map_cleaner_cycled__entries__id__utilization__initial(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__address]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__address]
             fn path_secret_map_cleaner_cycled__entries__address(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__address__active]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__address__active]
             fn path_secret_map_cleaner_cycled__entries__address__active(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__address__active__utilization]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__address__active__utilization]
             fn path_secret_map_cleaner_cycled__entries__address__active__utilization(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__address__retired]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__address__retired]
             fn path_secret_map_cleaner_cycled__entries__address__retired(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__address__utilization]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__address__utilization]
             fn path_secret_map_cleaner_cycled__entries__address__utilization(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__address__utilization__initial]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__address__utilization__initial]
             fn path_secret_map_cleaner_cycled__entries__address__utilization__initial(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__handshake_requests]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__handshake_requests]
             fn path_secret_map_cleaner_cycled__handshake_requests(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__handshake_requests__skipped]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__handshake_requests__skipped]
             fn path_secret_map_cleaner_cycled__handshake_requests__skipped(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__handshake_lock_duration]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__handshake_lock_duration]
             fn path_secret_map_cleaner_cycled__handshake_lock_duration(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__total_duration]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__total_duration]
             fn path_secret_map_cleaner_cycled__total_duration(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_id_write_lock__acquire]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_id_write_lock__acquire]
             fn path_secret_map_id_write_lock__acquire(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_id_write_lock__duration]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_id_write_lock__duration]
             fn path_secret_map_id_write_lock__duration(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_address_write_lock__acquire]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_address_write_lock__acquire]
             fn path_secret_map_address_write_lock__acquire(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_address_write_lock__duration]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_address_write_lock__duration]
             fn path_secret_map_address_write_lock__duration(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_datagram_encrypt__packet_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_datagram_encrypt__packet_len]
             fn path_secret_map_datagram_encrypt__packet_len(value: u64);
-            # [link_name = s2n_quic_dc__event__measure__path_secret_map_datagram_decrypt__packet_len]
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_datagram_decrypt__packet_len]
             fn path_secret_map_datagram_decrypt__packet_len(value: u64);
         }
     );
@@ -2407,61 +2695,84 @@ mod timer {
     }
     define!(
         extern "probe" {
-            # [link_name = s2n_quic_dc__event__timer__acceptor_tcp_loop_iteration_completed__processing_duration]
+            #[link_name =
+        s2n_quic_dc__event__timer__acceptor_tcp_loop_iteration_completed__processing_duration]
             fn acceptor_tcp_loop_iteration_completed__processing_duration(
                 value: core::time::Duration,
             );
-            # [link_name = s2n_quic_dc__event__timer__acceptor_tcp_stream_replaced__sojourn_time]
+            #[link_name =
+        s2n_quic_dc__event__timer__acceptor_tcp_stream_replaced__sojourn_time]
             fn acceptor_tcp_stream_replaced__sojourn_time(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__acceptor_tcp_packet_received__sojourn_time]
+            #[link_name =
+        s2n_quic_dc__event__timer__acceptor_tcp_packet_received__sojourn_time]
             fn acceptor_tcp_packet_received__sojourn_time(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__acceptor_tcp_tls_started__sojourn_time]
+            #[link_name = s2n_quic_dc__event__timer__acceptor_tcp_tls_started__sojourn_time]
             fn acceptor_tcp_tls_started__sojourn_time(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__acceptor_tcp_tls_stream_enqueued__sojourn_time]
+            #[link_name =
+        s2n_quic_dc__event__timer__acceptor_tcp_tls_stream_enqueued__sojourn_time]
             fn acceptor_tcp_tls_stream_enqueued__sojourn_time(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__acceptor_tcp_tls_stream_rejected__sojourn_time]
+            #[link_name =
+        s2n_quic_dc__event__timer__acceptor_tcp_tls_stream_rejected__sojourn_time]
             fn acceptor_tcp_tls_stream_rejected__sojourn_time(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__acceptor_tcp_packet_dropped__sojourn_time]
+            #[link_name =
+        s2n_quic_dc__event__timer__acceptor_tcp_packet_dropped__sojourn_time]
             fn acceptor_tcp_packet_dropped__sojourn_time(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__acceptor_tcp_stream_enqueued__sojourn_time]
+            #[link_name =
+        s2n_quic_dc__event__timer__acceptor_tcp_stream_enqueued__sojourn_time]
             fn acceptor_tcp_stream_enqueued__sojourn_time(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__acceptor_tcp_socket_sent__sojourn_time]
+            #[link_name = s2n_quic_dc__event__timer__acceptor_tcp_socket_sent__sojourn_time]
             fn acceptor_tcp_socket_sent__sojourn_time(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__acceptor_tcp_socket_received__transfer_time]
+            #[link_name =
+        s2n_quic_dc__event__timer__acceptor_tcp_socket_received__transfer_time]
             fn acceptor_tcp_socket_received__transfer_time(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__acceptor_stream_pruned__sojourn_time]
+            #[link_name = s2n_quic_dc__event__timer__acceptor_stream_pruned__sojourn_time]
             fn acceptor_stream_pruned__sojourn_time(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__acceptor_stream_dequeued__sojourn_time]
+            #[link_name =
+        s2n_quic_dc__event__timer__acceptor_stream_dequeued__sojourn_time]
             fn acceptor_stream_dequeued__sojourn_time(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__acceptor_stream_dequeued__queue_sojourn_time]
+            #[link_name
+        = s2n_quic_dc__event__timer__acceptor_stream_dequeued__queue_sojourn_time]
             fn acceptor_stream_dequeued__queue_sojourn_time(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__stream_write_flushed__latency]
+            #[link_name = s2n_quic_dc__event__timer__stream_write_flushed__latency]
             fn stream_write_flushed__latency(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__stream_write_fin_flushed__latency]
+            #[link_name =
+        s2n_quic_dc__event__timer__stream_write_fin_flushed__latency]
             fn stream_write_fin_flushed__latency(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__stream_write_blocked__latency]
+            #[link_name =
+        s2n_quic_dc__event__timer__stream_write_blocked__latency]
             fn stream_write_blocked__latency(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__stream_write_errored__latency]
+            #[link_name =
+        s2n_quic_dc__event__timer__stream_write_errored__latency]
             fn stream_write_errored__latency(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__stream_write_shutdown__latency]
+            #[link_name =
+        s2n_quic_dc__event__timer__stream_write_shutdown__latency]
             fn stream_write_shutdown__latency(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__stream_read_flushed__latency]
+            #[link_name =
+        s2n_quic_dc__event__timer__stream_read_flushed__latency]
             fn stream_read_flushed__latency(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__stream_read_fin_flushed__latency]
+            #[link_name =
+        s2n_quic_dc__event__timer__stream_read_fin_flushed__latency]
             fn stream_read_fin_flushed__latency(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__stream_read_blocked__latency]
+            #[link_name =
+        s2n_quic_dc__event__timer__stream_read_blocked__latency]
             fn stream_read_blocked__latency(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__stream_read_errored__latency]
+            #[link_name =
+        s2n_quic_dc__event__timer__stream_read_errored__latency]
             fn stream_read_errored__latency(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__stream_read_shutdown__latency]
+            #[link_name =
+        s2n_quic_dc__event__timer__stream_read_shutdown__latency]
             fn stream_read_shutdown__latency(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__stream_tcp_connect__tcp_latency]
+            #[link_name =
+        s2n_quic_dc__event__timer__stream_tcp_connect__tcp_latency]
             fn stream_tcp_connect__tcp_latency(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__stream_tls_connect__tcp_latency]
+            #[link_name =
+        s2n_quic_dc__event__timer__stream_tls_connect__tcp_latency]
             fn stream_tls_connect__tcp_latency(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__stream_tls_connect__tls_latency]
+            #[link_name =
+        s2n_quic_dc__event__timer__stream_tls_connect__tls_latency]
             fn stream_tls_connect__tls_latency(value: core::time::Duration);
-            # [link_name = s2n_quic_dc__event__timer__stream_connect_error__latency]
+            #[link_name =
+        s2n_quic_dc__event__timer__stream_connect_error__latency]
             fn stream_connect_error__latency(value: core::time::Duration);
         }
     );

--- a/quic/s2n-quic-core/src/event/generated.rs
+++ b/quic/s2n-quic-core/src/event/generated.rs
@@ -9,7 +9,7 @@
 use super::*;
 pub(crate) mod metrics;
 pub mod api {
-    #![doc = r" This module contains events that are emitted to the [`Subscriber`](crate::event::Subscriber)"]
+    //! This module contains events that are emitted to the [`Subscriber`](crate::event::Subscriber)
     use super::*;
     #[allow(unused_imports)]
     use crate::event::metrics::aggregate;
@@ -190,14 +190,14 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct EcnCounts {
-        #[doc = " A variable-length integer representing the total number of packets"]
-        #[doc = " received with the ECT(0) codepoint."]
+        /// A variable-length integer representing the total number of packets
+        /// received with the ECT(0) codepoint.
         pub ect_0_count: u64,
-        #[doc = " A variable-length integer representing the total number of packets"]
-        #[doc = " received with the ECT(1) codepoint."]
+        /// A variable-length integer representing the total number of packets
+        /// received with the ECT(1) codepoint.
         pub ect_1_count: u64,
-        #[doc = " A variable-length integer representing the total number of packets"]
-        #[doc = " received with the CE codepoint."]
+        /// A variable-length integer representing the total number of packets
+        /// received with the CE codepoint.
         pub ce_count: u64,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -246,27 +246,27 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " A bandwidth delivery rate estimate with associated metadata"]
+    /// A bandwidth delivery rate estimate with associated metadata
     pub struct RateSample {
-        #[doc = " The length of the sampling interval"]
+        /// The length of the sampling interval
         pub interval: Duration,
-        #[doc = " The amount of data in bytes marked as delivered over the sampling interval"]
+        /// The amount of data in bytes marked as delivered over the sampling interval
         pub delivered_bytes: u64,
-        #[doc = " The amount of data in bytes marked as lost over the sampling interval"]
+        /// The amount of data in bytes marked as lost over the sampling interval
         pub lost_bytes: u64,
-        #[doc = " The number of packets marked as explicit congestion experienced over the sampling interval"]
+        /// The number of packets marked as explicit congestion experienced over the sampling interval
         pub ecn_ce_count: u64,
-        #[doc = " PacketInfo::is_app_limited from the most recent acknowledged packet"]
+        /// PacketInfo::is_app_limited from the most recent acknowledged packet
         pub is_app_limited: bool,
-        #[doc = " PacketInfo::delivered_bytes from the most recent acknowledged packet"]
+        /// PacketInfo::delivered_bytes from the most recent acknowledged packet
         pub prior_delivered_bytes: u64,
-        #[doc = " PacketInfo::bytes_in_flight from the most recent acknowledged packet"]
+        /// PacketInfo::bytes_in_flight from the most recent acknowledged packet
         pub bytes_in_flight: u32,
-        #[doc = " PacketInfo::lost_bytes from the most recent acknowledged packet"]
+        /// PacketInfo::lost_bytes from the most recent acknowledged packet
         pub prior_lost_bytes: u64,
-        #[doc = " PacketInfo::ecn_ce_count from the most recent acknowledged packet"]
+        /// PacketInfo::ecn_ce_count from the most recent acknowledged packet
         pub prior_ecn_ce_count: u64,
-        #[doc = " The delivery rate for this rate sample"]
+        /// The delivery rate for this rate sample
         pub delivery_rate_bytes_per_second: u64,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -322,15 +322,15 @@ pub mod api {
     #[non_exhaustive]
     pub enum DuplicatePacketError {
         #[non_exhaustive]
-        #[doc = " The packet number was already received and is a duplicate."]
+        /// The packet number was already received and is a duplicate.
         Duplicate {},
         #[non_exhaustive]
-        #[doc = " The received packet number was outside the range of tracked packet numbers."]
-        #[doc = ""]
-        #[doc = " This can happen when packets are heavily delayed or reordered. Currently, the maximum"]
-        #[doc = " amount of reordering is limited to 128 packets. For example, if packet number `142`"]
-        #[doc = " is received, the allowed range would be limited to `14-142`. If an endpoint received"]
-        #[doc = " packet `< 14`, it would trigger this event."]
+        /// The received packet number was outside the range of tracked packet numbers.
+        ///
+        /// This can happen when packets are heavily delayed or reordered. Currently, the maximum
+        /// amount of reordering is limited to 128 packets. For example, if packet number `142`
+        /// is received, the allowed range would be limited to `14-142`. If an endpoint received
+        /// packet `< 14`, it would trigger this event.
         TooOld {},
     }
     impl aggregate::AsVariant for DuplicatePacketError {
@@ -791,14 +791,14 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " A context from which the event is being emitted"]
-    #[doc = ""]
-    #[doc = " An event can occur in the context of an Endpoint or Connection"]
+    /// A context from which the event is being emitted
+    ///
+    /// An event can occur in the context of an Endpoint or Connection
     pub enum Subject {
         #[non_exhaustive]
         Endpoint {},
         #[non_exhaustive]
-        #[doc = " This maps to an internal connection id, which is a stable identifier across CID changes."]
+        /// This maps to an internal connection id, which is a stable identifier across CID changes.
         Connection { id: u64 },
     }
     impl aggregate::AsVariant for Subject {
@@ -823,7 +823,7 @@ pub mod api {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " An endpoint may be either a Server or a Client"]
+    /// An endpoint may be either a Server or a Client
     pub enum EndpointType {
         #[non_exhaustive]
         Server {},
@@ -855,55 +855,55 @@ pub mod api {
     #[non_exhaustive]
     pub enum DatagramDropReason {
         #[non_exhaustive]
-        #[doc = " There was an error while attempting to decode the datagram."]
+        /// There was an error while attempting to decode the datagram.
         DecodingFailed {},
         #[non_exhaustive]
-        #[doc = " There was an error while parsing the Retry token."]
+        /// There was an error while parsing the Retry token.
         InvalidRetryToken {},
         #[non_exhaustive]
-        #[doc = " The peer specified an unsupported QUIC version."]
+        /// The peer specified an unsupported QUIC version.
         UnsupportedVersion {},
         #[non_exhaustive]
-        #[doc = " The peer sent an invalid Destination Connection Id."]
+        /// The peer sent an invalid Destination Connection Id.
         InvalidDestinationConnectionId {},
         #[non_exhaustive]
-        #[doc = " The peer sent an invalid Source Connection Id."]
+        /// The peer sent an invalid Source Connection Id.
         InvalidSourceConnectionId {},
         #[non_exhaustive]
-        #[doc = " Application provided invalid MTU configuration."]
+        /// Application provided invalid MTU configuration.
         InvalidMtuConfiguration {
-            #[doc = " MTU configuration for the endpoint"]
+            /// MTU configuration for the endpoint
             endpoint_mtu_config: MtuConfig,
         },
         #[non_exhaustive]
-        #[doc = " The Destination Connection Id is unknown and does not map to a Connection."]
-        #[doc = ""]
-        #[doc = " Connections are mapped to Destination Connections Ids (DCID) and packets"]
-        #[doc = " in a Datagram are routed to a connection based on the DCID in the first"]
-        #[doc = " packet. If a Connection is not found for the specified DCID then the"]
-        #[doc = " datagram can not be processed and is dropped."]
+        /// The Destination Connection Id is unknown and does not map to a Connection.
+        ///
+        /// Connections are mapped to Destination Connections Ids (DCID) and packets
+        /// in a Datagram are routed to a connection based on the DCID in the first
+        /// packet. If a Connection is not found for the specified DCID then the
+        /// datagram can not be processed and is dropped.
         UnknownDestinationConnectionId {},
         #[non_exhaustive]
-        #[doc = " The connection attempt was rejected."]
+        /// The connection attempt was rejected.
         RejectedConnectionAttempt {},
         #[non_exhaustive]
-        #[doc = " A datagram was received from an unknown server address."]
+        /// A datagram was received from an unknown server address.
         UnknownServerAddress {},
         #[non_exhaustive]
-        #[doc = " The peer initiated a connection migration before the handshake was confirmed."]
-        #[doc = ""]
-        #[doc = " Note: This drop reason is no longer emitted"]
+        /// The peer initiated a connection migration before the handshake was confirmed.
+        ///
+        /// Note: This drop reason is no longer emitted
         ConnectionMigrationDuringHandshake {},
         #[non_exhaustive]
-        #[doc = " The attempted connection migration was rejected."]
+        /// The attempted connection migration was rejected.
         RejectedConnectionMigration { reason: MigrationDenyReason },
         #[non_exhaustive]
-        #[doc = " The maximum number of paths per connection was exceeded."]
+        /// The maximum number of paths per connection was exceeded.
         PathLimitExceeded {},
         #[non_exhaustive]
-        #[doc = " The peer initiated a connection migration without supplying enough connection IDs to use."]
-        #[doc = ""]
-        #[doc = " Note: This drop reason is no longer emitted"]
+        /// The peer initiated a connection migration without supplying enough connection IDs to use.
+        ///
+        /// Note: This drop reason is no longer emitted
         InsufficientConnectionIds {},
     }
     impl aggregate::AsVariant for DatagramDropReason {
@@ -1042,10 +1042,10 @@ pub mod api {
     #[non_exhaustive]
     pub enum PacketSkipReason {
         #[non_exhaustive]
-        #[doc = " Skipped a packet number to elicit a quicker PTO acknowledgment"]
+        /// Skipped a packet number to elicit a quicker PTO acknowledgment
         PtoProbe {},
         #[non_exhaustive]
-        #[doc = " Skipped a packet number to detect an Optimistic Ack attack"]
+        /// Skipped a packet number to detect an Optimistic Ack attack
         OptimisticAckMitigation {},
     }
     impl aggregate::AsVariant for PacketSkipReason {
@@ -1073,61 +1073,61 @@ pub mod api {
     #[non_exhaustive]
     pub enum PacketDropReason<'a> {
         #[non_exhaustive]
-        #[doc = " A connection error occurred and is no longer able to process packets."]
+        /// A connection error occurred and is no longer able to process packets.
         ConnectionError { path: Path<'a> },
         #[non_exhaustive]
-        #[doc = " The handshake needed to be complete before processing the packet."]
-        #[doc = ""]
-        #[doc = " To ensure the connection stays secure, short packets can only be processed"]
-        #[doc = " once the handshake has completed."]
+        /// The handshake needed to be complete before processing the packet.
+        ///
+        /// To ensure the connection stays secure, short packets can only be processed
+        /// once the handshake has completed.
         HandshakeNotComplete { path: Path<'a> },
         #[non_exhaustive]
-        #[doc = " The packet contained a version which did not match the version negotiated"]
-        #[doc = " during the handshake."]
+        /// The packet contained a version which did not match the version negotiated
+        /// during the handshake.
         VersionMismatch { version: u32, path: Path<'a> },
         #[non_exhaustive]
-        #[doc = " A datagram contained more than one destination connection ID, which is"]
-        #[doc = " not allowed."]
+        /// A datagram contained more than one destination connection ID, which is
+        /// not allowed.
         ConnectionIdMismatch {
             packet_cid: &'a [u8],
             path: Path<'a>,
         },
         #[non_exhaustive]
-        #[doc = " There was a failure when attempting to remove header protection."]
+        /// There was a failure when attempting to remove header protection.
         UnprotectFailed { space: KeySpace, path: Path<'a> },
         #[non_exhaustive]
-        #[doc = " There was a failure when attempting to decrypt the packet."]
+        /// There was a failure when attempting to decrypt the packet.
         DecryptionFailed {
             path: Path<'a>,
             packet_header: PacketHeader,
         },
         #[non_exhaustive]
-        #[doc = " Packet decoding failed."]
-        #[doc = ""]
-        #[doc = " The payload is decoded one packet at a time. If decoding fails"]
-        #[doc = " then the remaining packets are also discarded."]
+        /// Packet decoding failed.
+        ///
+        /// The payload is decoded one packet at a time. If decoding fails
+        /// then the remaining packets are also discarded.
         DecodingFailed { path: Path<'a> },
         #[non_exhaustive]
-        #[doc = " The client received a non-empty retry token."]
+        /// The client received a non-empty retry token.
         NonEmptyRetryToken { path: Path<'a> },
         #[non_exhaustive]
-        #[doc = " A Retry packet was discarded."]
+        /// A Retry packet was discarded.
         RetryDiscarded {
             reason: RetryDiscardReason<'a>,
             path: Path<'a>,
         },
         #[non_exhaustive]
-        #[doc = " The received Initial packet was not transported in a datagram of at least 1200 bytes"]
+        /// The received Initial packet was not transported in a datagram of at least 1200 bytes
         UndersizedInitialPacket { path: Path<'a> },
         #[non_exhaustive]
-        #[doc = " The destination connection ID in the packet was the initial connection ID but was in"]
-        #[doc = " a non-initial packet."]
+        /// The destination connection ID in the packet was the initial connection ID but was in
+        /// a non-initial packet.
         InitialConnectionIdInvalidSpace {
             path: Path<'a>,
             packet_type: PacketType,
         },
         #[non_exhaustive]
-        #[doc = " The packet space for a received packet did not exist"]
+        /// The packet space for a received packet did not exist
         PacketSpaceDoesNotExist {
             path: Path<'a>,
             packet_type: PacketType,
@@ -1219,20 +1219,20 @@ pub mod api {
     #[deprecated(note = "use on_rx_ack_range_dropped event instead")]
     pub enum AckAction {
         #[non_exhaustive]
-        #[doc = " Ack range for received packets was dropped due to space constraints"]
-        #[doc = ""]
-        #[doc = " For the purpose of processing Acks, RX packet numbers are stored as"]
-        #[doc = " packet_number ranges in an IntervalSet; only lower and upper bounds"]
-        #[doc = " are stored instead of individual packet_numbers. Ranges are merged"]
-        #[doc = " when possible so only disjointed ranges are stored."]
-        #[doc = ""]
-        #[doc = " When at `capacity`, the lowest packet_number range is dropped."]
+        /// Ack range for received packets was dropped due to space constraints
+        ///
+        /// For the purpose of processing Acks, RX packet numbers are stored as
+        /// packet_number ranges in an IntervalSet; only lower and upper bounds
+        /// are stored instead of individual packet_numbers. Ranges are merged
+        /// when possible so only disjointed ranges are stored.
+        ///
+        /// When at `capacity`, the lowest packet_number range is dropped.
         RxAckRangeDropped {
-            #[doc = " The packet number range which was dropped"]
+            /// The packet number range which was dropped
             packet_number_range: core::ops::RangeInclusive<u64>,
-            #[doc = " The number of disjoint ranges the IntervalSet can store"]
+            /// The number of disjoint ranges the IntervalSet can store
             capacity: usize,
-            #[doc = " The store packet_number range in the IntervalSet"]
+            /// The store packet_number range in the IntervalSet
             stored_range: core::ops::RangeInclusive<u64>,
         },
     }
@@ -1255,17 +1255,17 @@ pub mod api {
     #[non_exhaustive]
     pub enum RetryDiscardReason<'a> {
         #[non_exhaustive]
-        #[doc = " Received a Retry packet with SCID field equal to DCID field."]
+        /// Received a Retry packet with SCID field equal to DCID field.
         ScidEqualsDcid { cid: &'a [u8] },
         #[non_exhaustive]
-        #[doc = " A client only processes at most one Retry packet."]
+        /// A client only processes at most one Retry packet.
         RetryAlreadyProcessed {},
         #[non_exhaustive]
-        #[doc = " The client discards Retry packets if a valid Initial packet"]
-        #[doc = " has been received and processed."]
+        /// The client discards Retry packets if a valid Initial packet
+        /// has been received and processed.
         InitialAlreadyProcessed {},
         #[non_exhaustive]
-        #[doc = " The Retry packet received contained an invalid retry integrity tag"]
+        /// The Retry packet received contained an invalid retry integrity tag
         InvalidIntegrityTag {},
     }
     impl<'a> aggregate::AsVariant for RetryDiscardReason<'a> {
@@ -1348,19 +1348,19 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " The current state of the ECN controller for the path"]
+    /// The current state of the ECN controller for the path
     pub enum EcnState {
         #[non_exhaustive]
-        #[doc = " ECN capability is being actively tested"]
+        /// ECN capability is being actively tested
         Testing {},
         #[non_exhaustive]
-        #[doc = " ECN capability has been tested, but not validated yet"]
+        /// ECN capability has been tested, but not validated yet
         Unknown {},
         #[non_exhaustive]
-        #[doc = " ECN capability testing has failed validation"]
+        /// ECN capability testing has failed validation
         Failed {},
         #[non_exhaustive]
-        #[doc = " ECN capability has been confirmed"]
+        /// ECN capability has been confirmed
         Capable {},
     }
     impl aggregate::AsVariant for EcnState {
@@ -1398,26 +1398,26 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Events tracking the progress of handshake status"]
+    /// Events tracking the progress of handshake status
     pub enum HandshakeStatus {
         #[non_exhaustive]
-        #[doc = " The handshake has completed."]
+        /// The handshake has completed.
         Complete {},
         #[non_exhaustive]
-        #[doc = " The handshake has been confirmed."]
+        /// The handshake has been confirmed.
         Confirmed {},
         #[non_exhaustive]
-        #[doc = " A HANDSHAKE_DONE frame was delivered or received."]
-        #[doc = ""]
-        #[doc = " A Client endpoint receives a HANDSHAKE_DONE frame and"]
-        #[doc = " only a Server is allowed to send the HANDSHAKE_DONE"]
-        #[doc = " frame."]
+        /// A HANDSHAKE_DONE frame was delivered or received.
+        ///
+        /// A Client endpoint receives a HANDSHAKE_DONE frame and
+        /// only a Server is allowed to send the HANDSHAKE_DONE
+        /// frame.
         HandshakeDoneAcked {},
         #[non_exhaustive]
-        #[doc = " A HANDSHAKE_DONE frame was declared lost."]
-        #[doc = ""]
-        #[doc = " The Server is responsible for re-transmitting the"]
-        #[doc = " HANDSHAKE_DONE frame until it is acked by the peer."]
+        /// A HANDSHAKE_DONE frame was declared lost.
+        ///
+        /// The Server is responsible for re-transmitting the
+        /// HANDSHAKE_DONE frame until it is acked by the peer.
         HandshakeDoneLost {},
     }
     impl aggregate::AsVariant for HandshakeStatus {
@@ -1455,13 +1455,13 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " The source that caused a congestion event"]
+    /// The source that caused a congestion event
     pub enum CongestionSource {
         #[non_exhaustive]
-        #[doc = " Explicit Congestion Notification"]
+        /// Explicit Congestion Notification
         Ecn {},
         #[non_exhaustive]
-        #[doc = " One or more packets were detected lost"]
+        /// One or more packets were detected lost
         PacketLoss {},
     }
     impl aggregate::AsVariant for CongestionSource {
@@ -1562,23 +1562,23 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " The reason the slow start congestion controller state has been exited"]
+    /// The reason the slow start congestion controller state has been exited
     pub enum SlowStartExitCause {
         #[non_exhaustive]
-        #[doc = " A packet was determined lost"]
+        /// A packet was determined lost
         PacketLoss {},
         #[non_exhaustive]
-        #[doc = " An Explicit Congestion Notification: Congestion Experienced marking was received"]
+        /// An Explicit Congestion Notification: Congestion Experienced marking was received
         Ecn {},
         #[non_exhaustive]
-        #[doc = " The round trip time estimate was updated"]
+        /// The round trip time estimate was updated
         Rtt {},
         #[non_exhaustive]
-        #[doc = " Slow Start exited due to a reason other than those above"]
-        #[doc = ""]
-        #[doc = " With the Cubic congestion controller, this reason is used after the initial exiting of"]
-        #[doc = " Slow Start, when the previously determined Slow Start threshold is exceed by the"]
-        #[doc = " congestion window."]
+        /// Slow Start exited due to a reason other than those above
+        ///
+        /// With the Cubic congestion controller, this reason is used after the initial exiting of
+        /// Slow Start, when the previously determined Slow Start threshold is exceed by the
+        /// congestion window.
         Other {},
     }
     impl aggregate::AsVariant for SlowStartExitCause {
@@ -1616,25 +1616,25 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " The reason the MTU was updated"]
+    /// The reason the MTU was updated
     pub enum MtuUpdatedCause {
         #[non_exhaustive]
-        #[doc = " The MTU was initialized with the default value"]
+        /// The MTU was initialized with the default value
         NewPath {},
         #[non_exhaustive]
-        #[doc = " An MTU probe was acknowledged by the peer"]
+        /// An MTU probe was acknowledged by the peer
         ProbeAcknowledged {},
         #[non_exhaustive]
-        #[doc = " A blackhole was detected"]
+        /// A blackhole was detected
         Blackhole {},
         #[non_exhaustive]
-        #[doc = " An early packet using the configured InitialMtu was lost"]
+        /// An early packet using the configured InitialMtu was lost
         InitialMtuPacketLost {},
         #[non_exhaustive]
-        #[doc = " An early packet using the configured InitialMtu was acknowledged by the peer"]
+        /// An early packet using the configured InitialMtu was acknowledged by the peer
         InitialMtuPacketAcknowledged {},
         #[non_exhaustive]
-        #[doc = " MTU probes larger than the current MTU were not acknowledged"]
+        /// MTU probes larger than the current MTU were not acknowledged
         LargerProbesLost {},
     }
     impl aggregate::AsVariant for MtuUpdatedCause {
@@ -1798,19 +1798,19 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " The mode in which a packet is being transmitted"]
+    /// The mode in which a packet is being transmitted
     pub enum TransmissionMode {
         #[non_exhaustive]
-        #[doc = " Loss recovery probing to detect lost packets"]
+        /// Loss recovery probing to detect lost packets
         LossRecoveryProbing {},
         #[non_exhaustive]
-        #[doc = " Maximum transmission unit probing to determine the path MTU"]
+        /// Maximum transmission unit probing to determine the path MTU
         MtuProbing {},
         #[non_exhaustive]
-        #[doc = " Path validation to verify peer address reachability"]
+        /// Path validation to verify peer address reachability
         PathValidationOnly {},
         #[non_exhaustive]
-        #[doc = " Normal transmission"]
+        /// Normal transmission
         Normal {},
     }
     impl aggregate::AsVariant for TransmissionMode {
@@ -1848,7 +1848,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Application level protocol"]
+    /// Application level protocol
     pub struct ApplicationProtocolInformation<'a> {
         pub chosen_application_protocol: &'a [u8],
     }
@@ -1868,7 +1868,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Server Name was negotiated for the connection"]
+    /// Server Name was negotiated for the connection
     pub struct ServerNameInformation<'a> {
         pub chosen_server_name: &'a str,
     }
@@ -1885,10 +1885,10 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Key Exchange Group was negotiated for the connection"]
-    #[doc = ""]
-    #[doc = " `contains_kem` is `true` if the `chosen_group_name`"]
-    #[doc = " contains a key encapsulation mechanism"]
+    /// Key Exchange Group was negotiated for the connection
+    ///
+    /// `contains_kem` is `true` if the `chosen_group_name`
+    /// contains a key encapsulation mechanism
     pub struct KeyExchangeGroup<'a> {
         pub chosen_group_name: &'a str,
         pub contains_kem: bool,
@@ -1907,7 +1907,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Packet was skipped with a given reason"]
+    /// Packet was skipped with a given reason
     pub struct PacketSkipped {
         pub number: u64,
         pub space: KeySpace,
@@ -1928,7 +1928,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Packet was sent by a connection"]
+    /// Packet was sent by a connection
     pub struct PacketSent {
         pub packet_header: PacketHeader,
         pub packet_len: usize,
@@ -1949,7 +1949,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Packet was received by a connection"]
+    /// Packet was received by a connection
     pub struct PacketReceived {
         pub packet_header: PacketHeader,
         pub packet_len: usize,
@@ -1968,7 +1968,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Active path was updated"]
+    /// Active path was updated
     pub struct ActivePathUpdated<'a> {
         pub previous: Path<'a>,
         pub active: Path<'a>,
@@ -1987,7 +1987,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " A new path was created"]
+    /// A new path was created
     pub struct PathCreated<'a> {
         pub active: Path<'a>,
         pub new: Path<'a>,
@@ -2006,7 +2006,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Frame was sent"]
+    /// Frame was sent
     pub struct FrameSent {
         pub packet_header: PacketHeader,
         pub path_id: u64,
@@ -2027,7 +2027,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Frame was received"]
+    /// Frame was received
     pub struct FrameReceived<'a> {
         pub packet_header: PacketHeader,
         pub path: Path<'a>,
@@ -2048,10 +2048,10 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " A `CONNECTION_CLOSE` frame was received"]
-    #[doc = ""]
-    #[doc = " This event includes additional details from the frame, particularly the"]
-    #[doc = " reason (if provided) the peer closed the connection"]
+    /// A `CONNECTION_CLOSE` frame was received
+    ///
+    /// This event includes additional details from the frame, particularly the
+    /// reason (if provided) the peer closed the connection
     pub struct ConnectionCloseFrameReceived<'a> {
         pub packet_header: PacketHeader,
         pub path: Path<'a>,
@@ -2072,7 +2072,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Packet was lost"]
+    /// Packet was lost
     pub struct PacketLost<'a> {
         pub packet_header: PacketHeader,
         pub path: Path<'a>,
@@ -2095,7 +2095,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Recovery metrics updated"]
+    /// Recovery metrics updated
     pub struct RecoveryMetrics<'a> {
         pub path: Path<'a>,
         pub min_rtt: Duration,
@@ -2130,7 +2130,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Congestion (ECN or packet loss) has occurred"]
+    /// Congestion (ECN or packet loss) has occurred
     pub struct Congestion<'a> {
         pub path: Path<'a>,
         pub source: CongestionSource,
@@ -2149,7 +2149,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Events related to ACK processing"]
+    /// Events related to ACK processing
     #[deprecated(note = "use on_rx_ack_range_dropped event instead")]
     #[allow(deprecated)]
     pub struct AckProcessed<'a> {
@@ -2172,21 +2172,21 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Ack range for received packets was dropped due to space constraints"]
-    #[doc = ""]
-    #[doc = " For the purpose of processing Acks, RX packet numbers are stored as"]
-    #[doc = " packet_number ranges in an IntervalSet; only lower and upper bounds"]
-    #[doc = " are stored instead of individual packet_numbers. Ranges are merged"]
-    #[doc = " when possible so only disjointed ranges are stored."]
-    #[doc = ""]
-    #[doc = " When at `capacity`, the lowest packet_number range is dropped."]
+    /// Ack range for received packets was dropped due to space constraints
+    ///
+    /// For the purpose of processing Acks, RX packet numbers are stored as
+    /// packet_number ranges in an IntervalSet; only lower and upper bounds
+    /// are stored instead of individual packet_numbers. Ranges are merged
+    /// when possible so only disjointed ranges are stored.
+    ///
+    /// When at `capacity`, the lowest packet_number range is dropped.
     pub struct RxAckRangeDropped<'a> {
         pub path: Path<'a>,
-        #[doc = " The packet number range which was dropped"]
+        /// The packet number range which was dropped
         pub packet_number_range: core::ops::RangeInclusive<u64>,
-        #[doc = " The number of disjoint ranges the IntervalSet can store"]
+        /// The number of disjoint ranges the IntervalSet can store
         pub capacity: usize,
-        #[doc = " The store packet_number range in the IntervalSet"]
+        /// The store packet_number range in the IntervalSet
         pub stored_range: core::ops::RangeInclusive<u64>,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -2205,7 +2205,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " ACK range was received"]
+    /// ACK range was received
     pub struct AckRangeReceived<'a> {
         pub packet_header: PacketHeader,
         pub path: Path<'a>,
@@ -2226,7 +2226,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " ACK range was sent"]
+    /// ACK range was sent
     pub struct AckRangeSent {
         pub packet_header: PacketHeader,
         pub path_id: u64,
@@ -2247,7 +2247,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Packet was dropped with the given reason"]
+    /// Packet was dropped with the given reason
     pub struct PacketDropped<'a> {
         pub reason: PacketDropReason<'a>,
     }
@@ -2264,7 +2264,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Crypto key updated"]
+    /// Crypto key updated
     pub struct KeyUpdate {
         pub key_type: KeyType,
         pub cipher_suite: CipherSuite,
@@ -2299,7 +2299,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Connection started"]
+    /// Connection started
     pub struct ConnectionStarted<'a> {
         pub path: Path<'a>,
     }
@@ -2316,7 +2316,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Duplicate packet received"]
+    /// Duplicate packet received
     pub struct DuplicatePacket<'a> {
         pub packet_header: PacketHeader,
         pub path: Path<'a>,
@@ -2337,7 +2337,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Transport parameters received by connection"]
+    /// Transport parameters received by connection
     pub struct TransportParametersReceived<'a> {
         pub transport_parameters: TransportParameters<'a>,
     }
@@ -2354,15 +2354,15 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Datagram sent by a connection"]
+    /// Datagram sent by a connection
     pub struct DatagramSent {
         pub len: u16,
-        #[doc = " The GSO offset at which this datagram was written"]
-        #[doc = ""]
-        #[doc = " If this value is greater than 0, it indicates that this datagram has been sent with other"]
-        #[doc = " segments in a single buffer."]
-        #[doc = ""]
-        #[doc = " See the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/segmentation-offloads.html#generic-segmentation-offload) for more details."]
+        /// The GSO offset at which this datagram was written
+        ///
+        /// If this value is greater than 0, it indicates that this datagram has been sent with other
+        /// segments in a single buffer.
+        ///
+        /// See the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/segmentation-offloads.html#generic-segmentation-offload) for more details.
         pub gso_offset: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -2379,7 +2379,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Datagram received by a connection"]
+    /// Datagram received by a connection
     pub struct DatagramReceived {
         pub len: u16,
     }
@@ -2396,7 +2396,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Datagram dropped by a connection"]
+    /// Datagram dropped by a connection
     pub struct DatagramDropped<'a> {
         pub local_addr: SocketAddress<'a>,
         pub remote_addr: SocketAddress<'a>,
@@ -2423,12 +2423,12 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " The remote address was changed before the handshake was complete"]
+    /// The remote address was changed before the handshake was complete
     pub struct HandshakeRemoteAddressChangeObserved<'a> {
         pub local_addr: SocketAddress<'a>,
-        #[doc = " The newly observed remote address"]
+        /// The newly observed remote address
         pub remote_addr: SocketAddress<'a>,
-        #[doc = " The remote address established from the initial packet"]
+        /// The remote address established from the initial packet
         pub initial_remote_addr: SocketAddress<'a>,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -2446,10 +2446,10 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " ConnectionId updated"]
+    /// ConnectionId updated
     pub struct ConnectionIdUpdated<'a> {
         pub path_id: u64,
-        #[doc = " The endpoint that updated its connection id"]
+        /// The endpoint that updated its connection id
         pub cid_consumer: crate::endpoint::Location,
         pub previous: ConnectionId<'a>,
         pub current: ConnectionId<'a>,
@@ -2554,7 +2554,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Path challenge updated"]
+    /// Path challenge updated
     pub struct PathChallengeUpdated<'a> {
         pub path_challenge_status: PathChallengeStatus,
         pub path: Path<'a>,
@@ -2655,13 +2655,13 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " The maximum transmission unit (MTU) and/or MTU probing status for the path has changed"]
+    /// The maximum transmission unit (MTU) and/or MTU probing status for the path has changed
     pub struct MtuUpdated {
         pub path_id: u64,
-        #[doc = " The maximum QUIC datagram size, not including UDP and IP headers"]
+        /// The maximum QUIC datagram size, not including UDP and IP headers
         pub mtu: u16,
         pub cause: MtuUpdatedCause,
-        #[doc = " The search for the maximum MTU has completed for now"]
+        /// The search for the maximum MTU has completed for now
         pub search_complete: bool,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -2680,11 +2680,11 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " MTU_PROBING_COMPLETE frame was received"]
+    /// MTU_PROBING_COMPLETE frame was received
     pub struct MtuProbingCompleteReceived<'a> {
         pub packet_header: PacketHeader,
         pub path: Path<'a>,
-        #[doc = " The confirmed MTU value from the frame"]
+        /// The confirmed MTU value from the frame
         pub mtu: u16,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -2702,7 +2702,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " The slow start congestion controller state has been exited"]
+    /// The slow start congestion controller state has been exited
     pub struct SlowStartExited {
         pub path_id: u64,
         pub cause: SlowStartExitCause,
@@ -2723,9 +2723,9 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " A new delivery rate sample has been generated"]
-    #[doc = " Note: This event is only recorded for congestion controllers that support"]
-    #[doc = "       bandwidth estimates, such as BBR"]
+    /// A new delivery rate sample has been generated
+    /// Note: This event is only recorded for congestion controllers that support
+    ///       bandwidth estimates, such as BBR
     pub struct DeliveryRateSampled {
         pub path_id: u64,
         pub rate_sample: RateSample,
@@ -2744,7 +2744,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " The pacing rate has been updated"]
+    /// The pacing rate has been updated
     pub struct PacingRateUpdated {
         pub path_id: u64,
         pub bytes_per_second: u64,
@@ -2767,7 +2767,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " The BBR state has changed"]
+    /// The BBR state has changed
     pub struct BbrStateChanged {
         pub path_id: u64,
         pub state: BbrState,
@@ -2786,7 +2786,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " The DC state has changed"]
+    /// The DC state has changed
     pub struct DcStateChanged {
         pub state: DcState,
     }
@@ -2803,10 +2803,10 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " The DC path has been created"]
+    /// The DC path has been created
     pub struct DcPathCreated<'a> {
-        #[doc = " This is the dc::Path struct, it's just type-erased. But if an event subscriber knows the"]
-        #[doc = " type they can downcast."]
+        /// This is the dc::Path struct, it's just type-erased. But if an event subscriber knows the
+        /// type they can downcast.
         pub path: &'a (dyn core::any::Any + Send + 'static),
     }
     #[cfg(any(test, feature = "testing"))]
@@ -2822,7 +2822,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Connection closed"]
+    /// Connection closed
     pub struct ConnectionClosed {
         pub error: crate::connection::Error,
     }
@@ -2839,7 +2839,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " QUIC version"]
+    /// QUIC version
     pub struct VersionInformation<'a> {
         pub server_versions: &'a [u32],
         pub client_versions: &'a [u32],
@@ -2860,7 +2860,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Packet was sent by the endpoint"]
+    /// Packet was sent by the endpoint
     pub struct EndpointPacketSent {
         pub packet_header: PacketHeader,
     }
@@ -2877,7 +2877,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Packet was received by the endpoint"]
+    /// Packet was received by the endpoint
     pub struct EndpointPacketReceived {
         pub packet_header: PacketHeader,
     }
@@ -2894,15 +2894,15 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Datagram sent by the endpoint"]
+    /// Datagram sent by the endpoint
     pub struct EndpointDatagramSent {
         pub len: u16,
-        #[doc = " The GSO offset at which this datagram was written"]
-        #[doc = ""]
-        #[doc = " If this value is greater than 0, it indicates that this datagram has been sent with other"]
-        #[doc = " segments in a single buffer."]
-        #[doc = ""]
-        #[doc = " See the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/segmentation-offloads.html#generic-segmentation-offload) for more details."]
+        /// The GSO offset at which this datagram was written
+        ///
+        /// If this value is greater than 0, it indicates that this datagram has been sent with other
+        /// segments in a single buffer.
+        ///
+        /// See the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/segmentation-offloads.html#generic-segmentation-offload) for more details.
         pub gso_offset: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -2919,7 +2919,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Datagram received by the endpoint"]
+    /// Datagram received by the endpoint
     pub struct EndpointDatagramReceived {
         pub len: u16,
     }
@@ -2936,7 +2936,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Datagram dropped by the endpoint"]
+    /// Datagram dropped by the endpoint
     pub struct EndpointDatagramDropped {
         pub len: u16,
         pub reason: DatagramDropReason,
@@ -2972,7 +2972,7 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct EndpointConnectionAttemptDeduplicated {
-        #[doc = " The internal connection ID this deduplicated with."]
+        /// The internal connection ID this deduplicated with.
         pub connection_id: u64,
         pub already_open: bool,
     }
@@ -2990,19 +2990,19 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the platform sends at least one packet"]
+    /// Emitted when the platform sends at least one packet
     pub struct PlatformTx {
-        #[doc = " The number of packets sent"]
+        /// The number of packets sent
         pub count: usize,
-        #[doc = " The number of syscalls performed"]
+        /// The number of syscalls performed
         pub syscalls: usize,
-        #[doc = " The number of syscalls that got blocked"]
+        /// The number of syscalls that got blocked
         pub blocked_syscalls: usize,
-        #[doc = " The total number of errors encountered since the last event"]
+        /// The total number of errors encountered since the last event
         pub total_errors: usize,
-        #[doc = " The number of specific error codes dropped"]
-        #[doc = ""]
-        #[doc = " This can happen when a burst of errors exceeds the capacity of the recorder"]
+        /// The number of specific error codes dropped
+        ///
+        /// This can happen when a burst of errors exceeds the capacity of the recorder
         pub dropped_errors: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -3022,9 +3022,9 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the platform returns an error while sending datagrams"]
+    /// Emitted when the platform returns an error while sending datagrams
     pub struct PlatformTxError {
-        #[doc = " The error code returned by the platform"]
+        /// The error code returned by the platform
         pub errno: i32,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -3040,19 +3040,19 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the platform receives at least one packet"]
+    /// Emitted when the platform receives at least one packet
     pub struct PlatformRx {
-        #[doc = " The number of packets received"]
+        /// The number of packets received
         pub count: usize,
-        #[doc = " The number of syscalls performed"]
+        /// The number of syscalls performed
         pub syscalls: usize,
-        #[doc = " The number of syscalls that got blocked"]
+        /// The number of syscalls that got blocked
         pub blocked_syscalls: usize,
-        #[doc = " The total number of errors encountered since the last event"]
+        /// The total number of errors encountered since the last event
         pub total_errors: usize,
-        #[doc = " The number of specific error codes dropped"]
-        #[doc = ""]
-        #[doc = " This can happen when a burst of errors exceeds the capacity of the recorder"]
+        /// The number of specific error codes dropped
+        ///
+        /// This can happen when a burst of errors exceeds the capacity of the recorder
         pub dropped_errors: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -3072,9 +3072,9 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when the platform returns an error while receiving datagrams"]
+    /// Emitted when the platform returns an error while receiving datagrams
     pub struct PlatformRxError {
-        #[doc = " The error code returned by the platform"]
+        /// The error code returned by the platform
         pub errno: i32,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -3090,7 +3090,7 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted when a platform feature is configured"]
+    /// Emitted when a platform feature is configured
     pub struct PlatformFeatureConfigured {
         pub configuration: PlatformFeatureConfiguration,
     }
@@ -3107,11 +3107,11 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
-    #[doc = " Emitted for each receive socket with per-socket packet counts"]
+    /// Emitted for each receive socket with per-socket packet counts
     pub struct PlatformRxSocketStats {
-        #[doc = " Whether this socket is the prioritized socket"]
+        /// Whether this socket is the prioritized socket
         pub is_prioritized: bool,
-        #[doc = " The number of packets received on this socket since the last event"]
+        /// The number of packets received on this socket since the last event
         pub count: usize,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -3151,9 +3151,9 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct PlatformEventLoopSleep {
-        #[doc = " The next time at which the event loop will wake"]
+        /// The next time at which the event loop will wake
         pub timeout: Option<core::time::Duration>,
-        #[doc = " The amount of time spent processing endpoint events in a single event loop"]
+        /// The amount of time spent processing endpoint events in a single event loop
         pub processing_duration: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -3171,7 +3171,7 @@ pub mod api {
     #[derive(Clone, Debug)]
     #[non_exhaustive]
     pub struct PlatformEventLoopStarted<'a> {
-        #[doc = " The local address of the socket"]
+        /// The local address of the socket
         pub local_address: SocketAddress<'a>,
     }
     #[cfg(any(test, feature = "testing"))]
@@ -3189,27 +3189,27 @@ pub mod api {
     #[non_exhaustive]
     pub enum PlatformFeatureConfiguration {
         #[non_exhaustive]
-        #[doc = " Emitted when segment offload was configured"]
+        /// Emitted when segment offload was configured
         Gso {
-            #[doc = " The maximum number of segments that can be sent in a single GSO packet"]
-            #[doc = ""]
-            #[doc = " If this value not greater than 1, GSO is disabled."]
+            /// The maximum number of segments that can be sent in a single GSO packet
+            ///
+            /// If this value not greater than 1, GSO is disabled.
             max_segments: usize,
         },
         #[non_exhaustive]
-        #[doc = " Emitted when receive segment offload was configured"]
+        /// Emitted when receive segment offload was configured
         Gro { enabled: bool },
         #[non_exhaustive]
-        #[doc = " Emitted when ECN support is configured"]
+        /// Emitted when ECN support is configured
         Ecn { enabled: bool },
         #[non_exhaustive]
-        #[doc = " Emitted when the base maximum transmission unit is configured"]
+        /// Emitted when the base maximum transmission unit is configured
         BaseMtu { mtu: u16 },
         #[non_exhaustive]
-        #[doc = " Emitted when the initial maximum transmission unit is configured"]
+        /// Emitted when the initial maximum transmission unit is configured
         InitialMtu { mtu: u16 },
         #[non_exhaustive]
-        #[doc = " Emitted when the max maximum transmission unit is configured"]
+        /// Emitted when the max maximum transmission unit is configured
         MaxMtu { mtu: u16 },
     }
     impl aggregate::AsVariant for PlatformFeatureConfiguration {
@@ -3642,7 +3642,7 @@ pub mod api {
     }
     #[cfg(feature = "alloc")]
     impl<'a> ConnectionCloseFrame<'a> {
-        #[doc = " Converts the reason to a UTF-8 `str`, including invalid characters"]
+        /// Converts the reason to a UTF-8 `str`, including invalid characters
         pub fn reason_lossy_utf8(&self) -> Option<alloc::borrow::Cow<'a, str>> {
             self.reason
                 .map(|reason| alloc::string::String::from_utf8_lossy(reason))
@@ -3779,9 +3779,9 @@ pub mod api {
 }
 #[cfg(feature = "event-tracing")]
 pub mod tracing {
-    #![doc = r" This module contains event integration with [`tracing`](https://docs.rs/tracing)"]
+    //! This module contains event integration with [`tracing`](https://docs.rs/tracing)
     use super::api;
-    #[doc = r" Emits events with [`tracing`](https://docs.rs/tracing)"]
+    /// Emits events with [`tracing`](https://docs.rs/tracing)
     #[derive(Clone, Debug)]
     pub struct Subscriber {
         client: tracing::Span,
@@ -3789,12 +3789,15 @@ pub mod tracing {
     }
     impl Default for Subscriber {
         fn default() -> Self {
-            let root =
-                tracing :: span ! (target : "s2n_quic" , tracing :: Level :: DEBUG , "s2n_quic");
-            let client =
-                tracing :: span ! (parent : root . id () , tracing :: Level :: DEBUG , "client");
-            let server =
-                tracing :: span ! (parent : root . id () , tracing :: Level :: DEBUG , "server");
+            let root = tracing::span!(
+                target : "s2n_quic", tracing::Level::DEBUG, "s2n_quic"
+            );
+            let client = tracing::span!(
+                parent : root.id(), tracing::Level::DEBUG, "client"
+            );
+            let server = tracing::span!(
+                parent : root.id(), tracing::Level::DEBUG, "server"
+            );
             Self { client, server }
         }
     }
@@ -3814,7 +3817,10 @@ pub mod tracing {
             _info: &api::ConnectionInfo,
         ) -> Self::ConnectionContext {
             let parent = self.parent(meta);
-            tracing :: span ! (target : "s2n_quic" , parent : parent , tracing :: Level :: DEBUG , "conn" , id = meta . id)
+            tracing::span!(
+                target : "s2n_quic", parent : parent, tracing::Level::DEBUG, "conn", id =
+                meta.id
+            )
         }
         #[inline]
         fn on_application_protocol_information(
@@ -3827,7 +3833,11 @@ pub mod tracing {
             let api::ApplicationProtocolInformation {
                 chosen_application_protocol,
             } = event;
-            tracing :: event ! (target : "application_protocol_information" , parent : id , tracing :: Level :: DEBUG , { chosen_application_protocol = tracing :: field :: debug (chosen_application_protocol) });
+            tracing::event!(
+                target : "application_protocol_information", parent : id,
+                tracing::Level::DEBUG, { chosen_application_protocol =
+                tracing::field::debug(chosen_application_protocol) }
+            );
         }
         #[inline]
         fn on_server_name_information(
@@ -3838,7 +3848,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::ServerNameInformation { chosen_server_name } = event;
-            tracing :: event ! (target : "server_name_information" , parent : id , tracing :: Level :: DEBUG , { chosen_server_name = tracing :: field :: debug (chosen_server_name) });
+            tracing::event!(
+                target : "server_name_information", parent : id, tracing::Level::DEBUG, {
+                chosen_server_name = tracing::field::debug(chosen_server_name) }
+            );
         }
         #[inline]
         fn on_key_exchange_group(
@@ -3852,7 +3865,11 @@ pub mod tracing {
                 chosen_group_name,
                 contains_kem,
             } = event;
-            tracing :: event ! (target : "key_exchange_group" , parent : id , tracing :: Level :: DEBUG , { chosen_group_name = tracing :: field :: debug (chosen_group_name) , contains_kem = tracing :: field :: debug (contains_kem) });
+            tracing::event!(
+                target : "key_exchange_group", parent : id, tracing::Level::DEBUG, {
+                chosen_group_name = tracing::field::debug(chosen_group_name),
+                contains_kem = tracing::field::debug(contains_kem) }
+            );
         }
         #[inline]
         fn on_packet_skipped(
@@ -3867,7 +3884,11 @@ pub mod tracing {
                 space,
                 reason,
             } = event;
-            tracing :: event ! (target : "packet_skipped" , parent : id , tracing :: Level :: DEBUG , { number = tracing :: field :: debug (number) , space = tracing :: field :: debug (space) , reason = tracing :: field :: debug (reason) });
+            tracing::event!(
+                target : "packet_skipped", parent : id, tracing::Level::DEBUG, { number =
+                tracing::field::debug(number), space = tracing::field::debug(space),
+                reason = tracing::field::debug(reason) }
+            );
         }
         #[inline]
         fn on_packet_sent(
@@ -3882,7 +3903,12 @@ pub mod tracing {
                 packet_len,
                 transmission_mode,
             } = event;
-            tracing :: event ! (target : "packet_sent" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , packet_len = tracing :: field :: debug (packet_len) , transmission_mode = tracing :: field :: debug (transmission_mode) });
+            tracing::event!(
+                target : "packet_sent", parent : id, tracing::Level::DEBUG, {
+                packet_header = tracing::field::debug(packet_header), packet_len =
+                tracing::field::debug(packet_len), transmission_mode =
+                tracing::field::debug(transmission_mode) }
+            );
         }
         #[inline]
         fn on_packet_received(
@@ -3896,7 +3922,11 @@ pub mod tracing {
                 packet_header,
                 packet_len,
             } = event;
-            tracing :: event ! (target : "packet_received" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , packet_len = tracing :: field :: debug (packet_len) });
+            tracing::event!(
+                target : "packet_received", parent : id, tracing::Level::DEBUG, {
+                packet_header = tracing::field::debug(packet_header), packet_len =
+                tracing::field::debug(packet_len) }
+            );
         }
         #[inline]
         fn on_active_path_updated(
@@ -3907,7 +3937,11 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::ActivePathUpdated { previous, active } = event;
-            tracing :: event ! (target : "active_path_updated" , parent : id , tracing :: Level :: DEBUG , { previous = tracing :: field :: debug (previous) , active = tracing :: field :: debug (active) });
+            tracing::event!(
+                target : "active_path_updated", parent : id, tracing::Level::DEBUG, {
+                previous = tracing::field::debug(previous), active =
+                tracing::field::debug(active) }
+            );
         }
         #[inline]
         fn on_path_created(
@@ -3918,7 +3952,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::PathCreated { active, new } = event;
-            tracing :: event ! (target : "path_created" , parent : id , tracing :: Level :: DEBUG , { active = tracing :: field :: debug (active) , new = tracing :: field :: debug (new) });
+            tracing::event!(
+                target : "path_created", parent : id, tracing::Level::DEBUG, { active =
+                tracing::field::debug(active), new = tracing::field::debug(new) }
+            );
         }
         #[inline]
         fn on_frame_sent(
@@ -3933,7 +3970,11 @@ pub mod tracing {
                 path_id,
                 frame,
             } = event;
-            tracing :: event ! (target : "frame_sent" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , path_id = tracing :: field :: debug (path_id) , frame = tracing :: field :: debug (frame) });
+            tracing::event!(
+                target : "frame_sent", parent : id, tracing::Level::DEBUG, {
+                packet_header = tracing::field::debug(packet_header), path_id =
+                tracing::field::debug(path_id), frame = tracing::field::debug(frame) }
+            );
         }
         #[inline]
         fn on_frame_received(
@@ -3948,7 +3989,11 @@ pub mod tracing {
                 path,
                 frame,
             } = event;
-            tracing :: event ! (target : "frame_received" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , path = tracing :: field :: debug (path) , frame = tracing :: field :: debug (frame) });
+            tracing::event!(
+                target : "frame_received", parent : id, tracing::Level::DEBUG, {
+                packet_header = tracing::field::debug(packet_header), path =
+                tracing::field::debug(path), frame = tracing::field::debug(frame) }
+            );
         }
         #[inline]
         fn on_connection_close_frame_received(
@@ -3963,7 +4008,12 @@ pub mod tracing {
                 path,
                 frame,
             } = event;
-            tracing :: event ! (target : "connection_close_frame_received" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , path = tracing :: field :: debug (path) , frame = tracing :: field :: debug (frame) });
+            tracing::event!(
+                target : "connection_close_frame_received", parent : id,
+                tracing::Level::DEBUG, { packet_header =
+                tracing::field::debug(packet_header), path = tracing::field::debug(path),
+                frame = tracing::field::debug(frame) }
+            );
         }
         #[inline]
         fn on_packet_lost(
@@ -3979,7 +4029,13 @@ pub mod tracing {
                 bytes_lost,
                 is_mtu_probe,
             } = event;
-            tracing :: event ! (target : "packet_lost" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , path = tracing :: field :: debug (path) , bytes_lost = tracing :: field :: debug (bytes_lost) , is_mtu_probe = tracing :: field :: debug (is_mtu_probe) });
+            tracing::event!(
+                target : "packet_lost", parent : id, tracing::Level::DEBUG, {
+                packet_header = tracing::field::debug(packet_header), path =
+                tracing::field::debug(path), bytes_lost =
+                tracing::field::debug(bytes_lost), is_mtu_probe =
+                tracing::field::debug(is_mtu_probe) }
+            );
         }
         #[inline]
         fn on_recovery_metrics(
@@ -4001,7 +4057,18 @@ pub mod tracing {
                 bytes_in_flight,
                 congestion_limited,
             } = event;
-            tracing :: event ! (target : "recovery_metrics" , parent : id , tracing :: Level :: DEBUG , { path = tracing :: field :: debug (path) , min_rtt = tracing :: field :: debug (min_rtt) , smoothed_rtt = tracing :: field :: debug (smoothed_rtt) , latest_rtt = tracing :: field :: debug (latest_rtt) , rtt_variance = tracing :: field :: debug (rtt_variance) , max_ack_delay = tracing :: field :: debug (max_ack_delay) , pto_count = tracing :: field :: debug (pto_count) , congestion_window = tracing :: field :: debug (congestion_window) , bytes_in_flight = tracing :: field :: debug (bytes_in_flight) , congestion_limited = tracing :: field :: debug (congestion_limited) });
+            tracing::event!(
+                target : "recovery_metrics", parent : id, tracing::Level::DEBUG, { path =
+                tracing::field::debug(path), min_rtt = tracing::field::debug(min_rtt),
+                smoothed_rtt = tracing::field::debug(smoothed_rtt), latest_rtt =
+                tracing::field::debug(latest_rtt), rtt_variance =
+                tracing::field::debug(rtt_variance), max_ack_delay =
+                tracing::field::debug(max_ack_delay), pto_count =
+                tracing::field::debug(pto_count), congestion_window =
+                tracing::field::debug(congestion_window), bytes_in_flight =
+                tracing::field::debug(bytes_in_flight), congestion_limited =
+                tracing::field::debug(congestion_limited) }
+            );
         }
         #[inline]
         fn on_congestion(
@@ -4012,7 +4079,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::Congestion { path, source } = event;
-            tracing :: event ! (target : "congestion" , parent : id , tracing :: Level :: DEBUG , { path = tracing :: field :: debug (path) , source = tracing :: field :: debug (source) });
+            tracing::event!(
+                target : "congestion", parent : id, tracing::Level::DEBUG, { path =
+                tracing::field::debug(path), source = tracing::field::debug(source) }
+            );
         }
         #[inline]
         #[allow(deprecated)]
@@ -4024,7 +4094,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::AckProcessed { action, path } = event;
-            tracing :: event ! (target : "ack_processed" , parent : id , tracing :: Level :: DEBUG , { action = tracing :: field :: debug (action) , path = tracing :: field :: debug (path) });
+            tracing::event!(
+                target : "ack_processed", parent : id, tracing::Level::DEBUG, { action =
+                tracing::field::debug(action), path = tracing::field::debug(path) }
+            );
         }
         #[inline]
         fn on_rx_ack_range_dropped(
@@ -4040,7 +4113,13 @@ pub mod tracing {
                 capacity,
                 stored_range,
             } = event;
-            tracing :: event ! (target : "rx_ack_range_dropped" , parent : id , tracing :: Level :: DEBUG , { path = tracing :: field :: debug (path) , packet_number_range = tracing :: field :: debug (packet_number_range) , capacity = tracing :: field :: debug (capacity) , stored_range = tracing :: field :: debug (stored_range) });
+            tracing::event!(
+                target : "rx_ack_range_dropped", parent : id, tracing::Level::DEBUG, {
+                path = tracing::field::debug(path), packet_number_range =
+                tracing::field::debug(packet_number_range), capacity =
+                tracing::field::debug(capacity), stored_range =
+                tracing::field::debug(stored_range) }
+            );
         }
         #[inline]
         fn on_ack_range_received(
@@ -4055,7 +4134,12 @@ pub mod tracing {
                 path,
                 ack_range,
             } = event;
-            tracing :: event ! (target : "ack_range_received" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , path = tracing :: field :: debug (path) , ack_range = tracing :: field :: debug (ack_range) });
+            tracing::event!(
+                target : "ack_range_received", parent : id, tracing::Level::DEBUG, {
+                packet_header = tracing::field::debug(packet_header), path =
+                tracing::field::debug(path), ack_range = tracing::field::debug(ack_range)
+                }
+            );
         }
         #[inline]
         fn on_ack_range_sent(
@@ -4070,7 +4154,12 @@ pub mod tracing {
                 path_id,
                 ack_range,
             } = event;
-            tracing :: event ! (target : "ack_range_sent" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , path_id = tracing :: field :: debug (path_id) , ack_range = tracing :: field :: debug (ack_range) });
+            tracing::event!(
+                target : "ack_range_sent", parent : id, tracing::Level::DEBUG, {
+                packet_header = tracing::field::debug(packet_header), path_id =
+                tracing::field::debug(path_id), ack_range =
+                tracing::field::debug(ack_range) }
+            );
         }
         #[inline]
         fn on_packet_dropped(
@@ -4081,7 +4170,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::PacketDropped { reason } = event;
-            tracing :: event ! (target : "packet_dropped" , parent : id , tracing :: Level :: DEBUG , { reason = tracing :: field :: debug (reason) });
+            tracing::event!(
+                target : "packet_dropped", parent : id, tracing::Level::DEBUG, { reason =
+                tracing::field::debug(reason) }
+            );
         }
         #[inline]
         fn on_key_update(
@@ -4095,7 +4187,11 @@ pub mod tracing {
                 key_type,
                 cipher_suite,
             } = event;
-            tracing :: event ! (target : "key_update" , parent : id , tracing :: Level :: DEBUG , { key_type = tracing :: field :: debug (key_type) , cipher_suite = tracing :: field :: debug (cipher_suite) });
+            tracing::event!(
+                target : "key_update", parent : id, tracing::Level::DEBUG, { key_type =
+                tracing::field::debug(key_type), cipher_suite =
+                tracing::field::debug(cipher_suite) }
+            );
         }
         #[inline]
         fn on_key_space_discarded(
@@ -4106,7 +4202,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::KeySpaceDiscarded { space } = event;
-            tracing :: event ! (target : "key_space_discarded" , parent : id , tracing :: Level :: DEBUG , { space = tracing :: field :: debug (space) });
+            tracing::event!(
+                target : "key_space_discarded", parent : id, tracing::Level::DEBUG, {
+                space = tracing::field::debug(space) }
+            );
         }
         #[inline]
         fn on_connection_started(
@@ -4117,7 +4216,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::ConnectionStarted { path } = event;
-            tracing :: event ! (target : "connection_started" , parent : id , tracing :: Level :: DEBUG , { path = tracing :: field :: debug (path) });
+            tracing::event!(
+                target : "connection_started", parent : id, tracing::Level::DEBUG, { path
+                = tracing::field::debug(path) }
+            );
         }
         #[inline]
         fn on_duplicate_packet(
@@ -4132,7 +4234,11 @@ pub mod tracing {
                 path,
                 error,
             } = event;
-            tracing :: event ! (target : "duplicate_packet" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , path = tracing :: field :: debug (path) , error = tracing :: field :: debug (error) });
+            tracing::event!(
+                target : "duplicate_packet", parent : id, tracing::Level::DEBUG, {
+                packet_header = tracing::field::debug(packet_header), path =
+                tracing::field::debug(path), error = tracing::field::debug(error) }
+            );
         }
         #[inline]
         fn on_transport_parameters_received(
@@ -4145,7 +4251,11 @@ pub mod tracing {
             let api::TransportParametersReceived {
                 transport_parameters,
             } = event;
-            tracing :: event ! (target : "transport_parameters_received" , parent : id , tracing :: Level :: DEBUG , { transport_parameters = tracing :: field :: debug (transport_parameters) });
+            tracing::event!(
+                target : "transport_parameters_received", parent : id,
+                tracing::Level::DEBUG, { transport_parameters =
+                tracing::field::debug(transport_parameters) }
+            );
         }
         #[inline]
         fn on_datagram_sent(
@@ -4156,7 +4266,11 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::DatagramSent { len, gso_offset } = event;
-            tracing :: event ! (target : "datagram_sent" , parent : id , tracing :: Level :: DEBUG , { len = tracing :: field :: debug (len) , gso_offset = tracing :: field :: debug (gso_offset) });
+            tracing::event!(
+                target : "datagram_sent", parent : id, tracing::Level::DEBUG, { len =
+                tracing::field::debug(len), gso_offset =
+                tracing::field::debug(gso_offset) }
+            );
         }
         #[inline]
         fn on_datagram_received(
@@ -4167,7 +4281,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::DatagramReceived { len } = event;
-            tracing :: event ! (target : "datagram_received" , parent : id , tracing :: Level :: DEBUG , { len = tracing :: field :: debug (len) });
+            tracing::event!(
+                target : "datagram_received", parent : id, tracing::Level::DEBUG, { len =
+                tracing::field::debug(len) }
+            );
         }
         #[inline]
         fn on_datagram_dropped(
@@ -4185,7 +4302,14 @@ pub mod tracing {
                 len,
                 reason,
             } = event;
-            tracing :: event ! (target : "datagram_dropped" , parent : id , tracing :: Level :: DEBUG , { local_addr = tracing :: field :: debug (local_addr) , remote_addr = tracing :: field :: debug (remote_addr) , destination_cid = tracing :: field :: debug (destination_cid) , source_cid = tracing :: field :: debug (source_cid) , len = tracing :: field :: debug (len) , reason = tracing :: field :: debug (reason) });
+            tracing::event!(
+                target : "datagram_dropped", parent : id, tracing::Level::DEBUG, {
+                local_addr = tracing::field::debug(local_addr), remote_addr =
+                tracing::field::debug(remote_addr), destination_cid =
+                tracing::field::debug(destination_cid), source_cid =
+                tracing::field::debug(source_cid), len = tracing::field::debug(len),
+                reason = tracing::field::debug(reason) }
+            );
         }
         #[inline]
         fn on_handshake_remote_address_change_observed(
@@ -4200,7 +4324,12 @@ pub mod tracing {
                 remote_addr,
                 initial_remote_addr,
             } = event;
-            tracing :: event ! (target : "handshake_remote_address_change_observed" , parent : id , tracing :: Level :: DEBUG , { local_addr = tracing :: field :: debug (local_addr) , remote_addr = tracing :: field :: debug (remote_addr) , initial_remote_addr = tracing :: field :: debug (initial_remote_addr) });
+            tracing::event!(
+                target : "handshake_remote_address_change_observed", parent : id,
+                tracing::Level::DEBUG, { local_addr = tracing::field::debug(local_addr),
+                remote_addr = tracing::field::debug(remote_addr), initial_remote_addr =
+                tracing::field::debug(initial_remote_addr) }
+            );
         }
         #[inline]
         fn on_connection_id_updated(
@@ -4216,7 +4345,13 @@ pub mod tracing {
                 previous,
                 current,
             } = event;
-            tracing :: event ! (target : "connection_id_updated" , parent : id , tracing :: Level :: DEBUG , { path_id = tracing :: field :: debug (path_id) , cid_consumer = tracing :: field :: debug (cid_consumer) , previous = tracing :: field :: debug (previous) , current = tracing :: field :: debug (current) });
+            tracing::event!(
+                target : "connection_id_updated", parent : id, tracing::Level::DEBUG, {
+                path_id = tracing::field::debug(path_id), cid_consumer =
+                tracing::field::debug(cid_consumer), previous =
+                tracing::field::debug(previous), current = tracing::field::debug(current)
+                }
+            );
         }
         #[inline]
         fn on_ecn_state_changed(
@@ -4227,7 +4362,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::EcnStateChanged { path, state } = event;
-            tracing :: event ! (target : "ecn_state_changed" , parent : id , tracing :: Level :: DEBUG , { path = tracing :: field :: debug (path) , state = tracing :: field :: debug (state) });
+            tracing::event!(
+                target : "ecn_state_changed", parent : id, tracing::Level::DEBUG, { path
+                = tracing::field::debug(path), state = tracing::field::debug(state) }
+            );
         }
         #[inline]
         fn on_connection_migration_denied(
@@ -4238,7 +4376,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::ConnectionMigrationDenied { reason } = event;
-            tracing :: event ! (target : "connection_migration_denied" , parent : id , tracing :: Level :: DEBUG , { reason = tracing :: field :: debug (reason) });
+            tracing::event!(
+                target : "connection_migration_denied", parent : id,
+                tracing::Level::DEBUG, { reason = tracing::field::debug(reason) }
+            );
         }
         #[inline]
         fn on_handshake_status_updated(
@@ -4249,7 +4390,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::HandshakeStatusUpdated { status } = event;
-            tracing :: event ! (target : "handshake_status_updated" , parent : id , tracing :: Level :: DEBUG , { status = tracing :: field :: debug (status) });
+            tracing::event!(
+                target : "handshake_status_updated", parent : id, tracing::Level::DEBUG,
+                { status = tracing::field::debug(status) }
+            );
         }
         #[inline]
         fn on_tls_exporter_ready(
@@ -4260,7 +4404,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::TlsExporterReady { session } = event;
-            tracing :: event ! (target : "tls_exporter_ready" , parent : id , tracing :: Level :: DEBUG , { session = tracing :: field :: debug (session) });
+            tracing::event!(
+                target : "tls_exporter_ready", parent : id, tracing::Level::DEBUG, {
+                session = tracing::field::debug(session) }
+            );
         }
         #[inline]
         fn on_tls_handshake_failed(
@@ -4271,7 +4418,11 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::TlsHandshakeFailed { session, error } = event;
-            tracing :: event ! (target : "tls_handshake_failed" , parent : id , tracing :: Level :: DEBUG , { session = tracing :: field :: debug (session) , error = tracing :: field :: debug (error) });
+            tracing::event!(
+                target : "tls_handshake_failed", parent : id, tracing::Level::DEBUG, {
+                session = tracing::field::debug(session), error =
+                tracing::field::debug(error) }
+            );
         }
         #[inline]
         fn on_path_challenge_updated(
@@ -4286,7 +4437,12 @@ pub mod tracing {
                 path,
                 challenge_data,
             } = event;
-            tracing :: event ! (target : "path_challenge_updated" , parent : id , tracing :: Level :: DEBUG , { path_challenge_status = tracing :: field :: debug (path_challenge_status) , path = tracing :: field :: debug (path) , challenge_data = tracing :: field :: debug (challenge_data) });
+            tracing::event!(
+                target : "path_challenge_updated", parent : id, tracing::Level::DEBUG, {
+                path_challenge_status = tracing::field::debug(path_challenge_status),
+                path = tracing::field::debug(path), challenge_data =
+                tracing::field::debug(challenge_data) }
+            );
         }
         #[inline]
         fn on_tls_client_hello(
@@ -4297,7 +4453,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::TlsClientHello { payload } = event;
-            tracing :: event ! (target : "tls_client_hello" , parent : id , tracing :: Level :: DEBUG , { payload = tracing :: field :: debug (payload) });
+            tracing::event!(
+                target : "tls_client_hello", parent : id, tracing::Level::DEBUG, {
+                payload = tracing::field::debug(payload) }
+            );
         }
         #[inline]
         fn on_tls_server_hello(
@@ -4308,7 +4467,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::TlsServerHello { payload } = event;
-            tracing :: event ! (target : "tls_server_hello" , parent : id , tracing :: Level :: DEBUG , { payload = tracing :: field :: debug (payload) });
+            tracing::event!(
+                target : "tls_server_hello", parent : id, tracing::Level::DEBUG, {
+                payload = tracing::field::debug(payload) }
+            );
         }
         #[inline]
         fn on_rx_stream_progress(
@@ -4319,7 +4481,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::RxStreamProgress { bytes } = event;
-            tracing :: event ! (target : "rx_stream_progress" , parent : id , tracing :: Level :: DEBUG , { bytes = tracing :: field :: debug (bytes) });
+            tracing::event!(
+                target : "rx_stream_progress", parent : id, tracing::Level::DEBUG, {
+                bytes = tracing::field::debug(bytes) }
+            );
         }
         #[inline]
         fn on_tx_stream_progress(
@@ -4330,7 +4495,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::TxStreamProgress { bytes } = event;
-            tracing :: event ! (target : "tx_stream_progress" , parent : id , tracing :: Level :: DEBUG , { bytes = tracing :: field :: debug (bytes) });
+            tracing::event!(
+                target : "tx_stream_progress", parent : id, tracing::Level::DEBUG, {
+                bytes = tracing::field::debug(bytes) }
+            );
         }
         #[inline]
         fn on_keep_alive_timer_expired(
@@ -4341,7 +4509,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::KeepAliveTimerExpired { timeout } = event;
-            tracing :: event ! (target : "keep_alive_timer_expired" , parent : id , tracing :: Level :: DEBUG , { timeout = tracing :: field :: debug (timeout) });
+            tracing::event!(
+                target : "keep_alive_timer_expired", parent : id, tracing::Level::DEBUG,
+                { timeout = tracing::field::debug(timeout) }
+            );
         }
         #[inline]
         fn on_mtu_updated(
@@ -4357,7 +4528,12 @@ pub mod tracing {
                 cause,
                 search_complete,
             } = event;
-            tracing :: event ! (target : "mtu_updated" , parent : id , tracing :: Level :: DEBUG , { path_id = tracing :: field :: debug (path_id) , mtu = tracing :: field :: debug (mtu) , cause = tracing :: field :: debug (cause) , search_complete = tracing :: field :: debug (search_complete) });
+            tracing::event!(
+                target : "mtu_updated", parent : id, tracing::Level::DEBUG, { path_id =
+                tracing::field::debug(path_id), mtu = tracing::field::debug(mtu), cause =
+                tracing::field::debug(cause), search_complete =
+                tracing::field::debug(search_complete) }
+            );
         }
         #[inline]
         fn on_mtu_probing_complete_received(
@@ -4372,7 +4548,12 @@ pub mod tracing {
                 path,
                 mtu,
             } = event;
-            tracing :: event ! (target : "mtu_probing_complete_received" , parent : id , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) , path = tracing :: field :: debug (path) , mtu = tracing :: field :: debug (mtu) });
+            tracing::event!(
+                target : "mtu_probing_complete_received", parent : id,
+                tracing::Level::DEBUG, { packet_header =
+                tracing::field::debug(packet_header), path = tracing::field::debug(path),
+                mtu = tracing::field::debug(mtu) }
+            );
         }
         #[inline]
         fn on_slow_start_exited(
@@ -4387,7 +4568,12 @@ pub mod tracing {
                 cause,
                 congestion_window,
             } = event;
-            tracing :: event ! (target : "slow_start_exited" , parent : id , tracing :: Level :: DEBUG , { path_id = tracing :: field :: debug (path_id) , cause = tracing :: field :: debug (cause) , congestion_window = tracing :: field :: debug (congestion_window) });
+            tracing::event!(
+                target : "slow_start_exited", parent : id, tracing::Level::DEBUG, {
+                path_id = tracing::field::debug(path_id), cause =
+                tracing::field::debug(cause), congestion_window =
+                tracing::field::debug(congestion_window) }
+            );
         }
         #[inline]
         fn on_delivery_rate_sampled(
@@ -4401,7 +4587,11 @@ pub mod tracing {
                 path_id,
                 rate_sample,
             } = event;
-            tracing :: event ! (target : "delivery_rate_sampled" , parent : id , tracing :: Level :: DEBUG , { path_id = tracing :: field :: debug (path_id) , rate_sample = tracing :: field :: debug (rate_sample) });
+            tracing::event!(
+                target : "delivery_rate_sampled", parent : id, tracing::Level::DEBUG, {
+                path_id = tracing::field::debug(path_id), rate_sample =
+                tracing::field::debug(rate_sample) }
+            );
         }
         #[inline]
         fn on_pacing_rate_updated(
@@ -4417,7 +4607,13 @@ pub mod tracing {
                 burst_size,
                 pacing_gain,
             } = event;
-            tracing :: event ! (target : "pacing_rate_updated" , parent : id , tracing :: Level :: DEBUG , { path_id = tracing :: field :: debug (path_id) , bytes_per_second = tracing :: field :: debug (bytes_per_second) , burst_size = tracing :: field :: debug (burst_size) , pacing_gain = tracing :: field :: debug (pacing_gain) });
+            tracing::event!(
+                target : "pacing_rate_updated", parent : id, tracing::Level::DEBUG, {
+                path_id = tracing::field::debug(path_id), bytes_per_second =
+                tracing::field::debug(bytes_per_second), burst_size =
+                tracing::field::debug(burst_size), pacing_gain =
+                tracing::field::debug(pacing_gain) }
+            );
         }
         #[inline]
         fn on_bbr_state_changed(
@@ -4428,7 +4624,11 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::BbrStateChanged { path_id, state } = event;
-            tracing :: event ! (target : "bbr_state_changed" , parent : id , tracing :: Level :: DEBUG , { path_id = tracing :: field :: debug (path_id) , state = tracing :: field :: debug (state) });
+            tracing::event!(
+                target : "bbr_state_changed", parent : id, tracing::Level::DEBUG, {
+                path_id = tracing::field::debug(path_id), state =
+                tracing::field::debug(state) }
+            );
         }
         #[inline]
         fn on_dc_state_changed(
@@ -4439,7 +4639,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::DcStateChanged { state } = event;
-            tracing :: event ! (target : "dc_state_changed" , parent : id , tracing :: Level :: DEBUG , { state = tracing :: field :: debug (state) });
+            tracing::event!(
+                target : "dc_state_changed", parent : id, tracing::Level::DEBUG, { state
+                = tracing::field::debug(state) }
+            );
         }
         #[inline]
         fn on_dc_path_created(
@@ -4450,7 +4653,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::DcPathCreated { path } = event;
-            tracing :: event ! (target : "dc_path_created" , parent : id , tracing :: Level :: DEBUG , { path = tracing :: field :: debug (path) });
+            tracing::event!(
+                target : "dc_path_created", parent : id, tracing::Level::DEBUG, { path =
+                tracing::field::debug(path) }
+            );
         }
         #[inline]
         fn on_connection_closed(
@@ -4461,7 +4667,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::ConnectionClosed { error } = event;
-            tracing :: event ! (target : "connection_closed" , parent : id , tracing :: Level :: DEBUG , { error = tracing :: field :: debug (error) });
+            tracing::event!(
+                target : "connection_closed", parent : id, tracing::Level::DEBUG, { error
+                = tracing::field::debug(error) }
+            );
         }
         #[inline]
         fn on_version_information(
@@ -4475,7 +4684,12 @@ pub mod tracing {
                 client_versions,
                 chosen_version,
             } = event;
-            tracing :: event ! (target : "version_information" , parent : parent , tracing :: Level :: DEBUG , { server_versions = tracing :: field :: debug (server_versions) , client_versions = tracing :: field :: debug (client_versions) , chosen_version = tracing :: field :: debug (chosen_version) });
+            tracing::event!(
+                target : "version_information", parent : parent, tracing::Level::DEBUG, {
+                server_versions = tracing::field::debug(server_versions), client_versions
+                = tracing::field::debug(client_versions), chosen_version =
+                tracing::field::debug(chosen_version) }
+            );
         }
         #[inline]
         fn on_endpoint_packet_sent(
@@ -4485,7 +4699,10 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::EndpointPacketSent { packet_header } = event;
-            tracing :: event ! (target : "endpoint_packet_sent" , parent : parent , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) });
+            tracing::event!(
+                target : "endpoint_packet_sent", parent : parent, tracing::Level::DEBUG,
+                { packet_header = tracing::field::debug(packet_header) }
+            );
         }
         #[inline]
         fn on_endpoint_packet_received(
@@ -4495,7 +4712,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::EndpointPacketReceived { packet_header } = event;
-            tracing :: event ! (target : "endpoint_packet_received" , parent : parent , tracing :: Level :: DEBUG , { packet_header = tracing :: field :: debug (packet_header) });
+            tracing::event!(
+                target : "endpoint_packet_received", parent : parent,
+                tracing::Level::DEBUG, { packet_header =
+                tracing::field::debug(packet_header) }
+            );
         }
         #[inline]
         fn on_endpoint_datagram_sent(
@@ -4505,7 +4726,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::EndpointDatagramSent { len, gso_offset } = event;
-            tracing :: event ! (target : "endpoint_datagram_sent" , parent : parent , tracing :: Level :: DEBUG , { len = tracing :: field :: debug (len) , gso_offset = tracing :: field :: debug (gso_offset) });
+            tracing::event!(
+                target : "endpoint_datagram_sent", parent : parent,
+                tracing::Level::DEBUG, { len = tracing::field::debug(len), gso_offset =
+                tracing::field::debug(gso_offset) }
+            );
         }
         #[inline]
         fn on_endpoint_datagram_received(
@@ -4515,7 +4740,10 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::EndpointDatagramReceived { len } = event;
-            tracing :: event ! (target : "endpoint_datagram_received" , parent : parent , tracing :: Level :: DEBUG , { len = tracing :: field :: debug (len) });
+            tracing::event!(
+                target : "endpoint_datagram_received", parent : parent,
+                tracing::Level::DEBUG, { len = tracing::field::debug(len) }
+            );
         }
         #[inline]
         fn on_endpoint_datagram_dropped(
@@ -4525,7 +4753,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::EndpointDatagramDropped { len, reason } = event;
-            tracing :: event ! (target : "endpoint_datagram_dropped" , parent : parent , tracing :: Level :: DEBUG , { len = tracing :: field :: debug (len) , reason = tracing :: field :: debug (reason) });
+            tracing::event!(
+                target : "endpoint_datagram_dropped", parent : parent,
+                tracing::Level::DEBUG, { len = tracing::field::debug(len), reason =
+                tracing::field::debug(reason) }
+            );
         }
         #[inline]
         fn on_endpoint_connection_attempt_failed(
@@ -4535,7 +4767,10 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::EndpointConnectionAttemptFailed { error } = event;
-            tracing :: event ! (target : "endpoint_connection_attempt_failed" , parent : parent , tracing :: Level :: DEBUG , { error = tracing :: field :: debug (error) });
+            tracing::event!(
+                target : "endpoint_connection_attempt_failed", parent : parent,
+                tracing::Level::DEBUG, { error = tracing::field::debug(error) }
+            );
         }
         #[inline]
         fn on_endpoint_connection_attempt_deduplicated(
@@ -4548,7 +4783,12 @@ pub mod tracing {
                 connection_id,
                 already_open,
             } = event;
-            tracing :: event ! (target : "endpoint_connection_attempt_deduplicated" , parent : parent , tracing :: Level :: DEBUG , { connection_id = tracing :: field :: debug (connection_id) , already_open = tracing :: field :: debug (already_open) });
+            tracing::event!(
+                target : "endpoint_connection_attempt_deduplicated", parent : parent,
+                tracing::Level::DEBUG, { connection_id =
+                tracing::field::debug(connection_id), already_open =
+                tracing::field::debug(already_open) }
+            );
         }
         #[inline]
         fn on_platform_tx(&mut self, meta: &api::EndpointMeta, event: &api::PlatformTx) {
@@ -4560,13 +4800,22 @@ pub mod tracing {
                 total_errors,
                 dropped_errors,
             } = event;
-            tracing :: event ! (target : "platform_tx" , parent : parent , tracing :: Level :: DEBUG , { count = tracing :: field :: debug (count) , syscalls = tracing :: field :: debug (syscalls) , blocked_syscalls = tracing :: field :: debug (blocked_syscalls) , total_errors = tracing :: field :: debug (total_errors) , dropped_errors = tracing :: field :: debug (dropped_errors) });
+            tracing::event!(
+                target : "platform_tx", parent : parent, tracing::Level::DEBUG, { count =
+                tracing::field::debug(count), syscalls = tracing::field::debug(syscalls),
+                blocked_syscalls = tracing::field::debug(blocked_syscalls), total_errors
+                = tracing::field::debug(total_errors), dropped_errors =
+                tracing::field::debug(dropped_errors) }
+            );
         }
         #[inline]
         fn on_platform_tx_error(&mut self, meta: &api::EndpointMeta, event: &api::PlatformTxError) {
             let parent = self.parent(meta);
             let api::PlatformTxError { errno } = event;
-            tracing :: event ! (target : "platform_tx_error" , parent : parent , tracing :: Level :: DEBUG , { errno = tracing :: field :: debug (errno) });
+            tracing::event!(
+                target : "platform_tx_error", parent : parent, tracing::Level::DEBUG, {
+                errno = tracing::field::debug(errno) }
+            );
         }
         #[inline]
         fn on_platform_rx(&mut self, meta: &api::EndpointMeta, event: &api::PlatformRx) {
@@ -4578,13 +4827,22 @@ pub mod tracing {
                 total_errors,
                 dropped_errors,
             } = event;
-            tracing :: event ! (target : "platform_rx" , parent : parent , tracing :: Level :: DEBUG , { count = tracing :: field :: debug (count) , syscalls = tracing :: field :: debug (syscalls) , blocked_syscalls = tracing :: field :: debug (blocked_syscalls) , total_errors = tracing :: field :: debug (total_errors) , dropped_errors = tracing :: field :: debug (dropped_errors) });
+            tracing::event!(
+                target : "platform_rx", parent : parent, tracing::Level::DEBUG, { count =
+                tracing::field::debug(count), syscalls = tracing::field::debug(syscalls),
+                blocked_syscalls = tracing::field::debug(blocked_syscalls), total_errors
+                = tracing::field::debug(total_errors), dropped_errors =
+                tracing::field::debug(dropped_errors) }
+            );
         }
         #[inline]
         fn on_platform_rx_error(&mut self, meta: &api::EndpointMeta, event: &api::PlatformRxError) {
             let parent = self.parent(meta);
             let api::PlatformRxError { errno } = event;
-            tracing :: event ! (target : "platform_rx_error" , parent : parent , tracing :: Level :: DEBUG , { errno = tracing :: field :: debug (errno) });
+            tracing::event!(
+                target : "platform_rx_error", parent : parent, tracing::Level::DEBUG, {
+                errno = tracing::field::debug(errno) }
+            );
         }
         #[inline]
         fn on_platform_feature_configured(
@@ -4594,7 +4852,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PlatformFeatureConfigured { configuration } = event;
-            tracing :: event ! (target : "platform_feature_configured" , parent : parent , tracing :: Level :: DEBUG , { configuration = tracing :: field :: debug (configuration) });
+            tracing::event!(
+                target : "platform_feature_configured", parent : parent,
+                tracing::Level::DEBUG, { configuration =
+                tracing::field::debug(configuration) }
+            );
         }
         #[inline]
         fn on_platform_rx_socket_stats(
@@ -4607,7 +4869,12 @@ pub mod tracing {
                 is_prioritized,
                 count,
             } = event;
-            tracing :: event ! (target : "platform_rx_socket_stats" , parent : parent , tracing :: Level :: DEBUG , { is_prioritized = tracing :: field :: debug (is_prioritized) , count = tracing :: field :: debug (count) });
+            tracing::event!(
+                target : "platform_rx_socket_stats", parent : parent,
+                tracing::Level::DEBUG, { is_prioritized =
+                tracing::field::debug(is_prioritized), count =
+                tracing::field::debug(count) }
+            );
         }
         #[inline]
         fn on_platform_event_loop_wakeup(
@@ -4622,7 +4889,14 @@ pub mod tracing {
                 tx_ready,
                 application_wakeup,
             } = event;
-            tracing :: event ! (target : "platform_event_loop_wakeup" , parent : parent , tracing :: Level :: DEBUG , { timeout_expired = tracing :: field :: debug (timeout_expired) , rx_ready = tracing :: field :: debug (rx_ready) , tx_ready = tracing :: field :: debug (tx_ready) , application_wakeup = tracing :: field :: debug (application_wakeup) });
+            tracing::event!(
+                target : "platform_event_loop_wakeup", parent : parent,
+                tracing::Level::DEBUG, { timeout_expired =
+                tracing::field::debug(timeout_expired), rx_ready =
+                tracing::field::debug(rx_ready), tx_ready =
+                tracing::field::debug(tx_ready), application_wakeup =
+                tracing::field::debug(application_wakeup) }
+            );
         }
         #[inline]
         fn on_platform_event_loop_sleep(
@@ -4635,7 +4909,11 @@ pub mod tracing {
                 timeout,
                 processing_duration,
             } = event;
-            tracing :: event ! (target : "platform_event_loop_sleep" , parent : parent , tracing :: Level :: DEBUG , { timeout = tracing :: field :: debug (timeout) , processing_duration = tracing :: field :: debug (processing_duration) });
+            tracing::event!(
+                target : "platform_event_loop_sleep", parent : parent,
+                tracing::Level::DEBUG, { timeout = tracing::field::debug(timeout),
+                processing_duration = tracing::field::debug(processing_duration) }
+            );
         }
         #[inline]
         fn on_platform_event_loop_started(
@@ -4645,7 +4923,11 @@ pub mod tracing {
         ) {
             let parent = self.parent(meta);
             let api::PlatformEventLoopStarted { local_address } = event;
-            tracing :: event ! (target : "platform_event_loop_started" , parent : parent , tracing :: Level :: DEBUG , { local_address = tracing :: field :: debug (local_address) });
+            tracing::event!(
+                target : "platform_event_loop_started", parent : parent,
+                tracing::Level::DEBUG, { local_address =
+                tracing::field::debug(local_address) }
+            );
         }
     }
 }
@@ -4842,14 +5124,14 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct EcnCounts {
-        #[doc = " A variable-length integer representing the total number of packets"]
-        #[doc = " received with the ECT(0) codepoint."]
+        /// A variable-length integer representing the total number of packets
+        /// received with the ECT(0) codepoint.
         pub ect_0_count: u64,
-        #[doc = " A variable-length integer representing the total number of packets"]
-        #[doc = " received with the ECT(1) codepoint."]
+        /// A variable-length integer representing the total number of packets
+        /// received with the ECT(1) codepoint.
         pub ect_1_count: u64,
-        #[doc = " A variable-length integer representing the total number of packets"]
-        #[doc = " received with the CE codepoint."]
+        /// A variable-length integer representing the total number of packets
+        /// received with the CE codepoint.
         pub ce_count: u64,
     }
     impl IntoEvent<api::EcnCounts> for EcnCounts {
@@ -4910,27 +5192,27 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " A bandwidth delivery rate estimate with associated metadata"]
+    /// A bandwidth delivery rate estimate with associated metadata
     pub struct RateSample {
-        #[doc = " The length of the sampling interval"]
+        /// The length of the sampling interval
         pub interval: Duration,
-        #[doc = " The amount of data in bytes marked as delivered over the sampling interval"]
+        /// The amount of data in bytes marked as delivered over the sampling interval
         pub delivered_bytes: u64,
-        #[doc = " The amount of data in bytes marked as lost over the sampling interval"]
+        /// The amount of data in bytes marked as lost over the sampling interval
         pub lost_bytes: u64,
-        #[doc = " The number of packets marked as explicit congestion experienced over the sampling interval"]
+        /// The number of packets marked as explicit congestion experienced over the sampling interval
         pub ecn_ce_count: u64,
-        #[doc = " PacketInfo::is_app_limited from the most recent acknowledged packet"]
+        /// PacketInfo::is_app_limited from the most recent acknowledged packet
         pub is_app_limited: bool,
-        #[doc = " PacketInfo::delivered_bytes from the most recent acknowledged packet"]
+        /// PacketInfo::delivered_bytes from the most recent acknowledged packet
         pub prior_delivered_bytes: u64,
-        #[doc = " PacketInfo::bytes_in_flight from the most recent acknowledged packet"]
+        /// PacketInfo::bytes_in_flight from the most recent acknowledged packet
         pub bytes_in_flight: u32,
-        #[doc = " PacketInfo::lost_bytes from the most recent acknowledged packet"]
+        /// PacketInfo::lost_bytes from the most recent acknowledged packet
         pub prior_lost_bytes: u64,
-        #[doc = " PacketInfo::ecn_ce_count from the most recent acknowledged packet"]
+        /// PacketInfo::ecn_ce_count from the most recent acknowledged packet
         pub prior_ecn_ce_count: u64,
-        #[doc = " The delivery rate for this rate sample"]
+        /// The delivery rate for this rate sample
         pub delivery_rate_bytes_per_second: u64,
     }
     impl IntoEvent<api::RateSample> for RateSample {
@@ -4985,14 +5267,14 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub enum DuplicatePacketError {
-        #[doc = " The packet number was already received and is a duplicate."]
+        /// The packet number was already received and is a duplicate.
         Duplicate,
-        #[doc = " The received packet number was outside the range of tracked packet numbers."]
-        #[doc = ""]
-        #[doc = " This can happen when packets are heavily delayed or reordered. Currently, the maximum"]
-        #[doc = " amount of reordering is limited to 128 packets. For example, if packet number `142`"]
-        #[doc = " is received, the allowed range would be limited to `14-142`. If an endpoint received"]
-        #[doc = " packet `< 14`, it would trigger this event."]
+        /// The received packet number was outside the range of tracked packet numbers.
+        ///
+        /// This can happen when packets are heavily delayed or reordered. Currently, the maximum
+        /// amount of reordering is limited to 128 packets. For example, if packet number `142`
+        /// is received, the allowed range would be limited to `14-142`. If an endpoint received
+        /// packet `< 14`, it would trigger this event.
         TooOld,
     }
     impl IntoEvent<api::DuplicatePacketError> for DuplicatePacketError {
@@ -5278,12 +5560,12 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " A context from which the event is being emitted"]
-    #[doc = ""]
-    #[doc = " An event can occur in the context of an Endpoint or Connection"]
+    /// A context from which the event is being emitted
+    ///
+    /// An event can occur in the context of an Endpoint or Connection
     pub enum Subject {
         Endpoint,
-        #[doc = " This maps to an internal connection id, which is a stable identifier across CID changes."]
+        /// This maps to an internal connection id, which is a stable identifier across CID changes.
         Connection {
             id: u64,
         },
@@ -5301,7 +5583,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " An endpoint may be either a Server or a Client"]
+    /// An endpoint may be either a Server or a Client
     pub enum EndpointType {
         Server,
         Client,
@@ -5318,43 +5600,43 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub enum DatagramDropReason {
-        #[doc = " There was an error while attempting to decode the datagram."]
+        /// There was an error while attempting to decode the datagram.
         DecodingFailed,
-        #[doc = " There was an error while parsing the Retry token."]
+        /// There was an error while parsing the Retry token.
         InvalidRetryToken,
-        #[doc = " The peer specified an unsupported QUIC version."]
+        /// The peer specified an unsupported QUIC version.
         UnsupportedVersion,
-        #[doc = " The peer sent an invalid Destination Connection Id."]
+        /// The peer sent an invalid Destination Connection Id.
         InvalidDestinationConnectionId,
-        #[doc = " The peer sent an invalid Source Connection Id."]
+        /// The peer sent an invalid Source Connection Id.
         InvalidSourceConnectionId,
-        #[doc = " Application provided invalid MTU configuration."]
+        /// Application provided invalid MTU configuration.
         InvalidMtuConfiguration {
-            #[doc = " MTU configuration for the endpoint"]
+            /// MTU configuration for the endpoint
             endpoint_mtu_config: MtuConfig,
         },
-        #[doc = " The Destination Connection Id is unknown and does not map to a Connection."]
-        #[doc = ""]
-        #[doc = " Connections are mapped to Destination Connections Ids (DCID) and packets"]
-        #[doc = " in a Datagram are routed to a connection based on the DCID in the first"]
-        #[doc = " packet. If a Connection is not found for the specified DCID then the"]
-        #[doc = " datagram can not be processed and is dropped."]
+        /// The Destination Connection Id is unknown and does not map to a Connection.
+        ///
+        /// Connections are mapped to Destination Connections Ids (DCID) and packets
+        /// in a Datagram are routed to a connection based on the DCID in the first
+        /// packet. If a Connection is not found for the specified DCID then the
+        /// datagram can not be processed and is dropped.
         UnknownDestinationConnectionId,
-        #[doc = " The connection attempt was rejected."]
+        /// The connection attempt was rejected.
         RejectedConnectionAttempt,
-        #[doc = " A datagram was received from an unknown server address."]
+        /// A datagram was received from an unknown server address.
         UnknownServerAddress,
-        #[doc = " The peer initiated a connection migration before the handshake was confirmed."]
-        #[doc = ""]
-        #[doc = " Note: This drop reason is no longer emitted"]
+        /// The peer initiated a connection migration before the handshake was confirmed.
+        ///
+        /// Note: This drop reason is no longer emitted
         ConnectionMigrationDuringHandshake,
-        #[doc = " The attempted connection migration was rejected."]
+        /// The attempted connection migration was rejected.
         RejectedConnectionMigration { reason: MigrationDenyReason },
-        #[doc = " The maximum number of paths per connection was exceeded."]
+        /// The maximum number of paths per connection was exceeded.
         PathLimitExceeded,
-        #[doc = " The peer initiated a connection migration without supplying enough connection IDs to use."]
-        #[doc = ""]
-        #[doc = " Note: This drop reason is no longer emitted"]
+        /// The peer initiated a connection migration without supplying enough connection IDs to use.
+        ///
+        /// Note: This drop reason is no longer emitted
         InsufficientConnectionIds,
     }
     impl IntoEvent<api::DatagramDropReason> for DatagramDropReason {
@@ -5405,9 +5687,9 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub enum PacketSkipReason {
-        #[doc = " Skipped a packet number to elicit a quicker PTO acknowledgment"]
+        /// Skipped a packet number to elicit a quicker PTO acknowledgment
         PtoProbe,
-        #[doc = " Skipped a packet number to detect an Optimistic Ack attack"]
+        /// Skipped a packet number to detect an Optimistic Ack attack
         OptimisticAckMitigation,
     }
     impl IntoEvent<api::PacketSkipReason> for PacketSkipReason {
@@ -5422,50 +5704,50 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub enum PacketDropReason<'a> {
-        #[doc = " A connection error occurred and is no longer able to process packets."]
+        /// A connection error occurred and is no longer able to process packets.
         ConnectionError { path: Path<'a> },
-        #[doc = " The handshake needed to be complete before processing the packet."]
-        #[doc = ""]
-        #[doc = " To ensure the connection stays secure, short packets can only be processed"]
-        #[doc = " once the handshake has completed."]
+        /// The handshake needed to be complete before processing the packet.
+        ///
+        /// To ensure the connection stays secure, short packets can only be processed
+        /// once the handshake has completed.
         HandshakeNotComplete { path: Path<'a> },
-        #[doc = " The packet contained a version which did not match the version negotiated"]
-        #[doc = " during the handshake."]
+        /// The packet contained a version which did not match the version negotiated
+        /// during the handshake.
         VersionMismatch { version: u32, path: Path<'a> },
-        #[doc = " A datagram contained more than one destination connection ID, which is"]
-        #[doc = " not allowed."]
+        /// A datagram contained more than one destination connection ID, which is
+        /// not allowed.
         ConnectionIdMismatch {
             packet_cid: &'a [u8],
             path: Path<'a>,
         },
-        #[doc = " There was a failure when attempting to remove header protection."]
+        /// There was a failure when attempting to remove header protection.
         UnprotectFailed { space: KeySpace, path: Path<'a> },
-        #[doc = " There was a failure when attempting to decrypt the packet."]
+        /// There was a failure when attempting to decrypt the packet.
         DecryptionFailed {
             path: Path<'a>,
             packet_header: PacketHeader,
         },
-        #[doc = " Packet decoding failed."]
-        #[doc = ""]
-        #[doc = " The payload is decoded one packet at a time. If decoding fails"]
-        #[doc = " then the remaining packets are also discarded."]
+        /// Packet decoding failed.
+        ///
+        /// The payload is decoded one packet at a time. If decoding fails
+        /// then the remaining packets are also discarded.
         DecodingFailed { path: Path<'a> },
-        #[doc = " The client received a non-empty retry token."]
+        /// The client received a non-empty retry token.
         NonEmptyRetryToken { path: Path<'a> },
-        #[doc = " A Retry packet was discarded."]
+        /// A Retry packet was discarded.
         RetryDiscarded {
             reason: RetryDiscardReason<'a>,
             path: Path<'a>,
         },
-        #[doc = " The received Initial packet was not transported in a datagram of at least 1200 bytes"]
+        /// The received Initial packet was not transported in a datagram of at least 1200 bytes
         UndersizedInitialPacket { path: Path<'a> },
-        #[doc = " The destination connection ID in the packet was the initial connection ID but was in"]
-        #[doc = " a non-initial packet."]
+        /// The destination connection ID in the packet was the initial connection ID but was in
+        /// a non-initial packet.
         InitialConnectionIdInvalidSpace {
             path: Path<'a>,
             packet_type: PacketType,
         },
-        #[doc = " The packet space for a received packet did not exist"]
+        /// The packet space for a received packet did not exist
         PacketSpaceDoesNotExist {
             path: Path<'a>,
             packet_type: PacketType,
@@ -5529,20 +5811,20 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub enum AckAction {
-        #[doc = " Ack range for received packets was dropped due to space constraints"]
-        #[doc = ""]
-        #[doc = " For the purpose of processing Acks, RX packet numbers are stored as"]
-        #[doc = " packet_number ranges in an IntervalSet; only lower and upper bounds"]
-        #[doc = " are stored instead of individual packet_numbers. Ranges are merged"]
-        #[doc = " when possible so only disjointed ranges are stored."]
-        #[doc = ""]
-        #[doc = " When at `capacity`, the lowest packet_number range is dropped."]
+        /// Ack range for received packets was dropped due to space constraints
+        ///
+        /// For the purpose of processing Acks, RX packet numbers are stored as
+        /// packet_number ranges in an IntervalSet; only lower and upper bounds
+        /// are stored instead of individual packet_numbers. Ranges are merged
+        /// when possible so only disjointed ranges are stored.
+        ///
+        /// When at `capacity`, the lowest packet_number range is dropped.
         RxAckRangeDropped {
-            #[doc = " The packet number range which was dropped"]
+            /// The packet number range which was dropped
             packet_number_range: core::ops::RangeInclusive<u64>,
-            #[doc = " The number of disjoint ranges the IntervalSet can store"]
+            /// The number of disjoint ranges the IntervalSet can store
             capacity: usize,
-            #[doc = " The store packet_number range in the IntervalSet"]
+            /// The store packet_number range in the IntervalSet
             stored_range: core::ops::RangeInclusive<u64>,
         },
     }
@@ -5566,14 +5848,14 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub enum RetryDiscardReason<'a> {
-        #[doc = " Received a Retry packet with SCID field equal to DCID field."]
+        /// Received a Retry packet with SCID field equal to DCID field.
         ScidEqualsDcid { cid: &'a [u8] },
-        #[doc = " A client only processes at most one Retry packet."]
+        /// A client only processes at most one Retry packet.
         RetryAlreadyProcessed,
-        #[doc = " The client discards Retry packets if a valid Initial packet"]
-        #[doc = " has been received and processed."]
+        /// The client discards Retry packets if a valid Initial packet
+        /// has been received and processed.
         InitialAlreadyProcessed,
-        #[doc = " The Retry packet received contained an invalid retry integrity tag"]
+        /// The Retry packet received contained an invalid retry integrity tag
         InvalidIntegrityTag,
     }
     impl<'a> IntoEvent<api::RetryDiscardReason<'a>> for RetryDiscardReason<'a> {
@@ -5610,15 +5892,15 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " The current state of the ECN controller for the path"]
+    /// The current state of the ECN controller for the path
     pub enum EcnState {
-        #[doc = " ECN capability is being actively tested"]
+        /// ECN capability is being actively tested
         Testing,
-        #[doc = " ECN capability has been tested, but not validated yet"]
+        /// ECN capability has been tested, but not validated yet
         Unknown,
-        #[doc = " ECN capability testing has failed validation"]
+        /// ECN capability testing has failed validation
         Failed,
-        #[doc = " ECN capability has been confirmed"]
+        /// ECN capability has been confirmed
         Capable,
     }
     impl IntoEvent<api::EcnState> for EcnState {
@@ -5634,22 +5916,22 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Events tracking the progress of handshake status"]
+    /// Events tracking the progress of handshake status
     pub enum HandshakeStatus {
-        #[doc = " The handshake has completed."]
+        /// The handshake has completed.
         Complete,
-        #[doc = " The handshake has been confirmed."]
+        /// The handshake has been confirmed.
         Confirmed,
-        #[doc = " A HANDSHAKE_DONE frame was delivered or received."]
-        #[doc = ""]
-        #[doc = " A Client endpoint receives a HANDSHAKE_DONE frame and"]
-        #[doc = " only a Server is allowed to send the HANDSHAKE_DONE"]
-        #[doc = " frame."]
+        /// A HANDSHAKE_DONE frame was delivered or received.
+        ///
+        /// A Client endpoint receives a HANDSHAKE_DONE frame and
+        /// only a Server is allowed to send the HANDSHAKE_DONE
+        /// frame.
         HandshakeDoneAcked,
-        #[doc = " A HANDSHAKE_DONE frame was declared lost."]
-        #[doc = ""]
-        #[doc = " The Server is responsible for re-transmitting the"]
-        #[doc = " HANDSHAKE_DONE frame until it is acked by the peer."]
+        /// A HANDSHAKE_DONE frame was declared lost.
+        ///
+        /// The Server is responsible for re-transmitting the
+        /// HANDSHAKE_DONE frame until it is acked by the peer.
         HandshakeDoneLost,
     }
     impl IntoEvent<api::HandshakeStatus> for HandshakeStatus {
@@ -5665,11 +5947,11 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " The source that caused a congestion event"]
+    /// The source that caused a congestion event
     pub enum CongestionSource {
-        #[doc = " Explicit Congestion Notification"]
+        /// Explicit Congestion Notification
         Ecn,
-        #[doc = " One or more packets were detected lost"]
+        /// One or more packets were detected lost
         PacketLoss,
     }
     impl IntoEvent<api::CongestionSource> for CongestionSource {
@@ -5718,19 +6000,19 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " The reason the slow start congestion controller state has been exited"]
+    /// The reason the slow start congestion controller state has been exited
     pub enum SlowStartExitCause {
-        #[doc = " A packet was determined lost"]
+        /// A packet was determined lost
         PacketLoss,
-        #[doc = " An Explicit Congestion Notification: Congestion Experienced marking was received"]
+        /// An Explicit Congestion Notification: Congestion Experienced marking was received
         Ecn,
-        #[doc = " The round trip time estimate was updated"]
+        /// The round trip time estimate was updated
         Rtt,
-        #[doc = " Slow Start exited due to a reason other than those above"]
-        #[doc = ""]
-        #[doc = " With the Cubic congestion controller, this reason is used after the initial exiting of"]
-        #[doc = " Slow Start, when the previously determined Slow Start threshold is exceed by the"]
-        #[doc = " congestion window."]
+        /// Slow Start exited due to a reason other than those above
+        ///
+        /// With the Cubic congestion controller, this reason is used after the initial exiting of
+        /// Slow Start, when the previously determined Slow Start threshold is exceed by the
+        /// congestion window.
         Other,
     }
     impl IntoEvent<api::SlowStartExitCause> for SlowStartExitCause {
@@ -5746,19 +6028,19 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " The reason the MTU was updated"]
+    /// The reason the MTU was updated
     pub enum MtuUpdatedCause {
-        #[doc = " The MTU was initialized with the default value"]
+        /// The MTU was initialized with the default value
         NewPath,
-        #[doc = " An MTU probe was acknowledged by the peer"]
+        /// An MTU probe was acknowledged by the peer
         ProbeAcknowledged,
-        #[doc = " A blackhole was detected"]
+        /// A blackhole was detected
         Blackhole,
-        #[doc = " An early packet using the configured InitialMtu was lost"]
+        /// An early packet using the configured InitialMtu was lost
         InitialMtuPacketLost,
-        #[doc = " An early packet using the configured InitialMtu was acknowledged by the peer"]
+        /// An early packet using the configured InitialMtu was acknowledged by the peer
         InitialMtuPacketAcknowledged,
-        #[doc = " MTU probes larger than the current MTU were not acknowledged"]
+        /// MTU probes larger than the current MTU were not acknowledged
         LargerProbesLost,
     }
     impl IntoEvent<api::MtuUpdatedCause> for MtuUpdatedCause {
@@ -5822,15 +6104,15 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " The mode in which a packet is being transmitted"]
+    /// The mode in which a packet is being transmitted
     pub enum TransmissionMode {
-        #[doc = " Loss recovery probing to detect lost packets"]
+        /// Loss recovery probing to detect lost packets
         LossRecoveryProbing,
-        #[doc = " Maximum transmission unit probing to determine the path MTU"]
+        /// Maximum transmission unit probing to determine the path MTU
         MtuProbing,
-        #[doc = " Path validation to verify peer address reachability"]
+        /// Path validation to verify peer address reachability
         PathValidationOnly,
-        #[doc = " Normal transmission"]
+        /// Normal transmission
         Normal,
     }
     impl IntoEvent<api::TransmissionMode> for TransmissionMode {
@@ -5846,7 +6128,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Application level protocol"]
+    /// Application level protocol
     pub struct ApplicationProtocolInformation<'a> {
         pub chosen_application_protocol: &'a [u8],
     }
@@ -5862,7 +6144,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Server Name was negotiated for the connection"]
+    /// Server Name was negotiated for the connection
     pub struct ServerNameInformation<'a> {
         pub chosen_server_name: &'a str,
     }
@@ -5876,10 +6158,10 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Key Exchange Group was negotiated for the connection"]
-    #[doc = ""]
-    #[doc = " `contains_kem` is `true` if the `chosen_group_name`"]
-    #[doc = " contains a key encapsulation mechanism"]
+    /// Key Exchange Group was negotiated for the connection
+    ///
+    /// `contains_kem` is `true` if the `chosen_group_name`
+    /// contains a key encapsulation mechanism
     pub struct KeyExchangeGroup<'a> {
         pub chosen_group_name: &'a str,
         pub contains_kem: bool,
@@ -5898,7 +6180,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Packet was skipped with a given reason"]
+    /// Packet was skipped with a given reason
     pub struct PacketSkipped {
         pub number: u64,
         pub space: KeySpace,
@@ -5920,7 +6202,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Packet was sent by a connection"]
+    /// Packet was sent by a connection
     pub struct PacketSent {
         pub packet_header: PacketHeader,
         pub packet_len: usize,
@@ -5942,7 +6224,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Packet was received by a connection"]
+    /// Packet was received by a connection
     pub struct PacketReceived {
         pub packet_header: PacketHeader,
         pub packet_len: usize,
@@ -5961,7 +6243,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Active path was updated"]
+    /// Active path was updated
     pub struct ActivePathUpdated<'a> {
         pub previous: Path<'a>,
         pub active: Path<'a>,
@@ -5977,7 +6259,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " A new path was created"]
+    /// A new path was created
     pub struct PathCreated<'a> {
         pub active: Path<'a>,
         pub new: Path<'a>,
@@ -5993,7 +6275,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Frame was sent"]
+    /// Frame was sent
     pub struct FrameSent {
         pub packet_header: PacketHeader,
         pub path_id: u64,
@@ -6015,7 +6297,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Frame was received"]
+    /// Frame was received
     pub struct FrameReceived<'a> {
         pub packet_header: PacketHeader,
         pub path: Path<'a>,
@@ -6037,10 +6319,10 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " A `CONNECTION_CLOSE` frame was received"]
-    #[doc = ""]
-    #[doc = " This event includes additional details from the frame, particularly the"]
-    #[doc = " reason (if provided) the peer closed the connection"]
+    /// A `CONNECTION_CLOSE` frame was received
+    ///
+    /// This event includes additional details from the frame, particularly the
+    /// reason (if provided) the peer closed the connection
     pub struct ConnectionCloseFrameReceived<'a> {
         pub packet_header: PacketHeader,
         pub path: Path<'a>,
@@ -6062,7 +6344,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Packet was lost"]
+    /// Packet was lost
     pub struct PacketLost<'a> {
         pub packet_header: PacketHeader,
         pub path: Path<'a>,
@@ -6087,7 +6369,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Recovery metrics updated"]
+    /// Recovery metrics updated
     pub struct RecoveryMetrics<'a> {
         pub path: Path<'a>,
         pub min_rtt: Duration,
@@ -6130,7 +6412,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Congestion (ECN or packet loss) has occurred"]
+    /// Congestion (ECN or packet loss) has occurred
     pub struct Congestion<'a> {
         pub path: Path<'a>,
         pub source: CongestionSource,
@@ -6146,7 +6428,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Events related to ACK processing"]
+    /// Events related to ACK processing
     pub struct AckProcessed<'a> {
         pub action: AckAction,
         pub path: Path<'a>,
@@ -6163,21 +6445,21 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Ack range for received packets was dropped due to space constraints"]
-    #[doc = ""]
-    #[doc = " For the purpose of processing Acks, RX packet numbers are stored as"]
-    #[doc = " packet_number ranges in an IntervalSet; only lower and upper bounds"]
-    #[doc = " are stored instead of individual packet_numbers. Ranges are merged"]
-    #[doc = " when possible so only disjointed ranges are stored."]
-    #[doc = ""]
-    #[doc = " When at `capacity`, the lowest packet_number range is dropped."]
+    /// Ack range for received packets was dropped due to space constraints
+    ///
+    /// For the purpose of processing Acks, RX packet numbers are stored as
+    /// packet_number ranges in an IntervalSet; only lower and upper bounds
+    /// are stored instead of individual packet_numbers. Ranges are merged
+    /// when possible so only disjointed ranges are stored.
+    ///
+    /// When at `capacity`, the lowest packet_number range is dropped.
     pub struct RxAckRangeDropped<'a> {
         pub path: Path<'a>,
-        #[doc = " The packet number range which was dropped"]
+        /// The packet number range which was dropped
         pub packet_number_range: core::ops::RangeInclusive<u64>,
-        #[doc = " The number of disjoint ranges the IntervalSet can store"]
+        /// The number of disjoint ranges the IntervalSet can store
         pub capacity: usize,
-        #[doc = " The store packet_number range in the IntervalSet"]
+        /// The store packet_number range in the IntervalSet
         pub stored_range: core::ops::RangeInclusive<u64>,
     }
     impl<'a> IntoEvent<api::RxAckRangeDropped<'a>> for RxAckRangeDropped<'a> {
@@ -6198,7 +6480,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " ACK range was received"]
+    /// ACK range was received
     pub struct AckRangeReceived<'a> {
         pub packet_header: PacketHeader,
         pub path: Path<'a>,
@@ -6220,7 +6502,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " ACK range was sent"]
+    /// ACK range was sent
     pub struct AckRangeSent {
         pub packet_header: PacketHeader,
         pub path_id: u64,
@@ -6242,7 +6524,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Packet was dropped with the given reason"]
+    /// Packet was dropped with the given reason
     pub struct PacketDropped<'a> {
         pub reason: PacketDropReason<'a>,
     }
@@ -6256,7 +6538,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Crypto key updated"]
+    /// Crypto key updated
     pub struct KeyUpdate {
         pub key_type: KeyType,
         pub cipher_suite: CipherSuite,
@@ -6288,7 +6570,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Connection started"]
+    /// Connection started
     pub struct ConnectionStarted<'a> {
         pub path: Path<'a>,
     }
@@ -6302,7 +6584,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Duplicate packet received"]
+    /// Duplicate packet received
     pub struct DuplicatePacket<'a> {
         pub packet_header: PacketHeader,
         pub path: Path<'a>,
@@ -6324,7 +6606,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Transport parameters received by connection"]
+    /// Transport parameters received by connection
     pub struct TransportParametersReceived<'a> {
         pub transport_parameters: TransportParameters<'a>,
     }
@@ -6340,15 +6622,15 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Datagram sent by a connection"]
+    /// Datagram sent by a connection
     pub struct DatagramSent {
         pub len: u16,
-        #[doc = " The GSO offset at which this datagram was written"]
-        #[doc = ""]
-        #[doc = " If this value is greater than 0, it indicates that this datagram has been sent with other"]
-        #[doc = " segments in a single buffer."]
-        #[doc = ""]
-        #[doc = " See the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/segmentation-offloads.html#generic-segmentation-offload) for more details."]
+        /// The GSO offset at which this datagram was written
+        ///
+        /// If this value is greater than 0, it indicates that this datagram has been sent with other
+        /// segments in a single buffer.
+        ///
+        /// See the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/segmentation-offloads.html#generic-segmentation-offload) for more details.
         pub gso_offset: usize,
     }
     impl IntoEvent<api::DatagramSent> for DatagramSent {
@@ -6362,7 +6644,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Datagram received by a connection"]
+    /// Datagram received by a connection
     pub struct DatagramReceived {
         pub len: u16,
     }
@@ -6376,7 +6658,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Datagram dropped by a connection"]
+    /// Datagram dropped by a connection
     pub struct DatagramDropped<'a> {
         pub local_addr: SocketAddress<'a>,
         pub remote_addr: SocketAddress<'a>,
@@ -6407,12 +6689,12 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " The remote address was changed before the handshake was complete"]
+    /// The remote address was changed before the handshake was complete
     pub struct HandshakeRemoteAddressChangeObserved<'a> {
         pub local_addr: SocketAddress<'a>,
-        #[doc = " The newly observed remote address"]
+        /// The newly observed remote address
         pub remote_addr: SocketAddress<'a>,
-        #[doc = " The remote address established from the initial packet"]
+        /// The remote address established from the initial packet
         pub initial_remote_addr: SocketAddress<'a>,
     }
     impl<'a> IntoEvent<api::HandshakeRemoteAddressChangeObserved<'a>>
@@ -6433,10 +6715,10 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " ConnectionId updated"]
+    /// ConnectionId updated
     pub struct ConnectionIdUpdated<'a> {
         pub path_id: u64,
-        #[doc = " The endpoint that updated its connection id"]
+        /// The endpoint that updated its connection id
         pub cid_consumer: crate::endpoint::Location,
         pub previous: ConnectionId<'a>,
         pub current: ConnectionId<'a>,
@@ -6528,7 +6810,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Path challenge updated"]
+    /// Path challenge updated
     pub struct PathChallengeUpdated<'a> {
         pub path_challenge_status: PathChallengeStatus,
         pub path: Path<'a>,
@@ -6615,13 +6897,13 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " The maximum transmission unit (MTU) and/or MTU probing status for the path has changed"]
+    /// The maximum transmission unit (MTU) and/or MTU probing status for the path has changed
     pub struct MtuUpdated {
         pub path_id: u64,
-        #[doc = " The maximum QUIC datagram size, not including UDP and IP headers"]
+        /// The maximum QUIC datagram size, not including UDP and IP headers
         pub mtu: u16,
         pub cause: MtuUpdatedCause,
-        #[doc = " The search for the maximum MTU has completed for now"]
+        /// The search for the maximum MTU has completed for now
         pub search_complete: bool,
     }
     impl IntoEvent<api::MtuUpdated> for MtuUpdated {
@@ -6642,11 +6924,11 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " MTU_PROBING_COMPLETE frame was received"]
+    /// MTU_PROBING_COMPLETE frame was received
     pub struct MtuProbingCompleteReceived<'a> {
         pub packet_header: PacketHeader,
         pub path: Path<'a>,
-        #[doc = " The confirmed MTU value from the frame"]
+        /// The confirmed MTU value from the frame
         pub mtu: u16,
     }
     impl<'a> IntoEvent<api::MtuProbingCompleteReceived<'a>> for MtuProbingCompleteReceived<'a> {
@@ -6665,7 +6947,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " The slow start congestion controller state has been exited"]
+    /// The slow start congestion controller state has been exited
     pub struct SlowStartExited {
         pub path_id: u64,
         pub cause: SlowStartExitCause,
@@ -6687,9 +6969,9 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " A new delivery rate sample has been generated"]
-    #[doc = " Note: This event is only recorded for congestion controllers that support"]
-    #[doc = "       bandwidth estimates, such as BBR"]
+    /// A new delivery rate sample has been generated
+    /// Note: This event is only recorded for congestion controllers that support
+    ///       bandwidth estimates, such as BBR
     pub struct DeliveryRateSampled {
         pub path_id: u64,
         pub rate_sample: RateSample,
@@ -6708,7 +6990,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " The pacing rate has been updated"]
+    /// The pacing rate has been updated
     pub struct PacingRateUpdated {
         pub path_id: u64,
         pub bytes_per_second: u64,
@@ -6733,7 +7015,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " The BBR state has changed"]
+    /// The BBR state has changed
     pub struct BbrStateChanged {
         pub path_id: u64,
         pub state: BbrState,
@@ -6749,7 +7031,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " The DC state has changed"]
+    /// The DC state has changed
     pub struct DcStateChanged {
         pub state: DcState,
     }
@@ -6763,10 +7045,10 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " The DC path has been created"]
+    /// The DC path has been created
     pub struct DcPathCreated<'a> {
-        #[doc = " This is the dc::Path struct, it's just type-erased. But if an event subscriber knows the"]
-        #[doc = " type they can downcast."]
+        /// This is the dc::Path struct, it's just type-erased. But if an event subscriber knows the
+        /// type they can downcast.
         pub path: &'a (dyn core::any::Any + Send + 'static),
     }
     impl<'a> IntoEvent<api::DcPathCreated<'a>> for DcPathCreated<'a> {
@@ -6779,7 +7061,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Connection closed"]
+    /// Connection closed
     pub struct ConnectionClosed {
         pub error: crate::connection::Error,
     }
@@ -6793,7 +7075,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " QUIC version"]
+    /// QUIC version
     pub struct VersionInformation<'a> {
         pub server_versions: &'a [u32],
         pub client_versions: &'a [u32],
@@ -6815,7 +7097,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Packet was sent by the endpoint"]
+    /// Packet was sent by the endpoint
     pub struct EndpointPacketSent {
         pub packet_header: PacketHeader,
     }
@@ -6829,7 +7111,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Packet was received by the endpoint"]
+    /// Packet was received by the endpoint
     pub struct EndpointPacketReceived {
         pub packet_header: PacketHeader,
     }
@@ -6843,15 +7125,15 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Datagram sent by the endpoint"]
+    /// Datagram sent by the endpoint
     pub struct EndpointDatagramSent {
         pub len: u16,
-        #[doc = " The GSO offset at which this datagram was written"]
-        #[doc = ""]
-        #[doc = " If this value is greater than 0, it indicates that this datagram has been sent with other"]
-        #[doc = " segments in a single buffer."]
-        #[doc = ""]
-        #[doc = " See the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/segmentation-offloads.html#generic-segmentation-offload) for more details."]
+        /// The GSO offset at which this datagram was written
+        ///
+        /// If this value is greater than 0, it indicates that this datagram has been sent with other
+        /// segments in a single buffer.
+        ///
+        /// See the [Linux kernel documentation](https://www.kernel.org/doc/html/latest/networking/segmentation-offloads.html#generic-segmentation-offload) for more details.
         pub gso_offset: usize,
     }
     impl IntoEvent<api::EndpointDatagramSent> for EndpointDatagramSent {
@@ -6865,7 +7147,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Datagram received by the endpoint"]
+    /// Datagram received by the endpoint
     pub struct EndpointDatagramReceived {
         pub len: u16,
     }
@@ -6879,7 +7161,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Datagram dropped by the endpoint"]
+    /// Datagram dropped by the endpoint
     pub struct EndpointDatagramDropped {
         pub len: u16,
         pub reason: DatagramDropReason,
@@ -6909,7 +7191,7 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct EndpointConnectionAttemptDeduplicated {
-        #[doc = " The internal connection ID this deduplicated with."]
+        /// The internal connection ID this deduplicated with.
         pub connection_id: u64,
         pub already_open: bool,
     }
@@ -6929,19 +7211,19 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the platform sends at least one packet"]
+    /// Emitted when the platform sends at least one packet
     pub struct PlatformTx {
-        #[doc = " The number of packets sent"]
+        /// The number of packets sent
         pub count: usize,
-        #[doc = " The number of syscalls performed"]
+        /// The number of syscalls performed
         pub syscalls: usize,
-        #[doc = " The number of syscalls that got blocked"]
+        /// The number of syscalls that got blocked
         pub blocked_syscalls: usize,
-        #[doc = " The total number of errors encountered since the last event"]
+        /// The total number of errors encountered since the last event
         pub total_errors: usize,
-        #[doc = " The number of specific error codes dropped"]
-        #[doc = ""]
-        #[doc = " This can happen when a burst of errors exceeds the capacity of the recorder"]
+        /// The number of specific error codes dropped
+        ///
+        /// This can happen when a burst of errors exceeds the capacity of the recorder
         pub dropped_errors: usize,
     }
     impl IntoEvent<api::PlatformTx> for PlatformTx {
@@ -6964,9 +7246,9 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the platform returns an error while sending datagrams"]
+    /// Emitted when the platform returns an error while sending datagrams
     pub struct PlatformTxError {
-        #[doc = " The error code returned by the platform"]
+        /// The error code returned by the platform
         pub errno: i32,
     }
     impl IntoEvent<api::PlatformTxError> for PlatformTxError {
@@ -6979,19 +7261,19 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the platform receives at least one packet"]
+    /// Emitted when the platform receives at least one packet
     pub struct PlatformRx {
-        #[doc = " The number of packets received"]
+        /// The number of packets received
         pub count: usize,
-        #[doc = " The number of syscalls performed"]
+        /// The number of syscalls performed
         pub syscalls: usize,
-        #[doc = " The number of syscalls that got blocked"]
+        /// The number of syscalls that got blocked
         pub blocked_syscalls: usize,
-        #[doc = " The total number of errors encountered since the last event"]
+        /// The total number of errors encountered since the last event
         pub total_errors: usize,
-        #[doc = " The number of specific error codes dropped"]
-        #[doc = ""]
-        #[doc = " This can happen when a burst of errors exceeds the capacity of the recorder"]
+        /// The number of specific error codes dropped
+        ///
+        /// This can happen when a burst of errors exceeds the capacity of the recorder
         pub dropped_errors: usize,
     }
     impl IntoEvent<api::PlatformRx> for PlatformRx {
@@ -7014,9 +7296,9 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when the platform returns an error while receiving datagrams"]
+    /// Emitted when the platform returns an error while receiving datagrams
     pub struct PlatformRxError {
-        #[doc = " The error code returned by the platform"]
+        /// The error code returned by the platform
         pub errno: i32,
     }
     impl IntoEvent<api::PlatformRxError> for PlatformRxError {
@@ -7029,7 +7311,7 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted when a platform feature is configured"]
+    /// Emitted when a platform feature is configured
     pub struct PlatformFeatureConfigured {
         pub configuration: PlatformFeatureConfiguration,
     }
@@ -7043,11 +7325,11 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
-    #[doc = " Emitted for each receive socket with per-socket packet counts"]
+    /// Emitted for each receive socket with per-socket packet counts
     pub struct PlatformRxSocketStats {
-        #[doc = " Whether this socket is the prioritized socket"]
+        /// Whether this socket is the prioritized socket
         pub is_prioritized: bool,
-        #[doc = " The number of packets received on this socket since the last event"]
+        /// The number of packets received on this socket since the last event
         pub count: usize,
     }
     impl IntoEvent<api::PlatformRxSocketStats> for PlatformRxSocketStats {
@@ -7089,9 +7371,9 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct PlatformEventLoopSleep {
-        #[doc = " The next time at which the event loop will wake"]
+        /// The next time at which the event loop will wake
         pub timeout: Option<core::time::Duration>,
-        #[doc = " The amount of time spent processing endpoint events in a single event loop"]
+        /// The amount of time spent processing endpoint events in a single event loop
         pub processing_duration: core::time::Duration,
     }
     impl IntoEvent<api::PlatformEventLoopSleep> for PlatformEventLoopSleep {
@@ -7109,7 +7391,7 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub struct PlatformEventLoopStarted<'a> {
-        #[doc = " The local address of the socket"]
+        /// The local address of the socket
         pub local_address: SocketAddress<'a>,
     }
     impl<'a> IntoEvent<api::PlatformEventLoopStarted<'a>> for PlatformEventLoopStarted<'a> {
@@ -7123,22 +7405,22 @@ pub mod builder {
     }
     #[derive(Clone, Debug)]
     pub enum PlatformFeatureConfiguration {
-        #[doc = " Emitted when segment offload was configured"]
+        /// Emitted when segment offload was configured
         Gso {
-            #[doc = " The maximum number of segments that can be sent in a single GSO packet"]
-            #[doc = ""]
-            #[doc = " If this value not greater than 1, GSO is disabled."]
+            /// The maximum number of segments that can be sent in a single GSO packet
+            ///
+            /// If this value not greater than 1, GSO is disabled.
             max_segments: usize,
         },
-        #[doc = " Emitted when receive segment offload was configured"]
+        /// Emitted when receive segment offload was configured
         Gro { enabled: bool },
-        #[doc = " Emitted when ECN support is configured"]
+        /// Emitted when ECN support is configured
         Ecn { enabled: bool },
-        #[doc = " Emitted when the base maximum transmission unit is configured"]
+        /// Emitted when the base maximum transmission unit is configured
         BaseMtu { mtu: u16 },
-        #[doc = " Emitted when the initial maximum transmission unit is configured"]
+        /// Emitted when the initial maximum transmission unit is configured
         InitialMtu { mtu: u16 },
-        #[doc = " Emitted when the max maximum transmission unit is configured"]
+        /// Emitted when the max maximum transmission unit is configured
         MaxMtu { mtu: u16 },
     }
     impl IntoEvent<api::PlatformFeatureConfiguration> for PlatformFeatureConfiguration {
@@ -7169,10 +7451,10 @@ pub mod builder {
     }
 }
 pub mod supervisor {
-    #![doc = r" This module contains the `supervisor::Outcome` and `supervisor::Context` for use"]
-    #![doc = r" when implementing [`Subscriber::supervisor_timeout`](crate::event::Subscriber::supervisor_timeout) and"]
-    #![doc = r" [`Subscriber::on_supervisor_timeout`](crate::event::Subscriber::on_supervisor_timeout)"]
-    #![doc = r" on a Subscriber."]
+    //! This module contains the `supervisor::Outcome` and `supervisor::Context` for use
+    //! when implementing [`Subscriber::supervisor_timeout`](crate::event::Subscriber::supervisor_timeout) and
+    //! [`Subscriber::on_supervisor_timeout`](crate::event::Subscriber::on_supervisor_timeout)
+    //! on a Subscriber.
     use crate::{
         application,
         event::{builder::SocketAddress, IntoEvent},
@@ -7180,24 +7462,24 @@ pub mod supervisor {
     #[non_exhaustive]
     #[derive(Clone, Debug, Default, Eq, PartialEq)]
     pub enum Outcome {
-        #[doc = r" Allow the connection to remain open"]
+        /// Allow the connection to remain open
         #[default]
         Continue,
-        #[doc = r" Close the connection and notify the peer"]
+        /// Close the connection and notify the peer
         Close { error_code: application::Error },
-        #[doc = r" Close the connection without notifying the peer"]
+        /// Close the connection without notifying the peer
         ImmediateClose { reason: &'static str },
     }
     #[non_exhaustive]
     #[derive(Debug)]
     pub struct Context<'a> {
-        #[doc = r" Number of handshakes that have begun but not completed"]
+        /// Number of handshakes that have begun but not completed
         pub inflight_handshakes: usize,
-        #[doc = r" Number of open connections"]
+        /// Number of open connections
         pub connection_count: usize,
-        #[doc = r" The address of the peer"]
+        /// The address of the peer
         pub remote_address: SocketAddress<'a>,
-        #[doc = r" True if the connection is in the handshake state, false otherwise"]
+        /// True if the connection is in the handshake state, false otherwise
         pub is_handshaking: bool,
     }
     impl<'a> Context<'a> {
@@ -7221,68 +7503,68 @@ mod traits {
     use super::*;
     use crate::{event::Meta, query};
     use core::fmt;
-    #[doc = r" Allows for events to be subscribed to"]
+    /// Allows for events to be subscribed to
     pub trait Subscriber: 'static + Send {
-        #[doc = r" An application provided type associated with each connection."]
-        #[doc = r""]
-        #[doc = r" The context provides a mechanism for applications to provide a custom type"]
-        #[doc = r" and update it on each event, e.g. computing statistics. Each event"]
-        #[doc = r" invocation (e.g. [`Subscriber::on_packet_sent`]) also provides mutable"]
-        #[doc = r" access to the context `&mut ConnectionContext` and allows for updating the"]
-        #[doc = r" context."]
-        #[doc = r""]
-        #[doc = r" ```no_run"]
-        #[doc = r" # mod s2n_quic { pub mod provider { pub mod event {"]
-        #[doc = r" #     pub use s2n_quic_core::event::{api as events, api::ConnectionInfo, api::ConnectionMeta, Subscriber};"]
-        #[doc = r" # }}}"]
-        #[doc = r" use s2n_quic::provider::event::{"]
-        #[doc = r"     ConnectionInfo, ConnectionMeta, Subscriber, events::PacketSent"]
-        #[doc = r" };"]
-        #[doc = r""]
-        #[doc = r" pub struct MyEventSubscriber;"]
-        #[doc = r""]
-        #[doc = r" pub struct MyEventContext {"]
-        #[doc = r"     packet_sent: u64,"]
-        #[doc = r" }"]
-        #[doc = r""]
-        #[doc = r" impl Subscriber for MyEventSubscriber {"]
-        #[doc = r"     type ConnectionContext = MyEventContext;"]
-        #[doc = r""]
-        #[doc = r"     fn create_connection_context("]
-        #[doc = r"         &mut self, _meta: &ConnectionMeta,"]
-        #[doc = r"         _info: &ConnectionInfo,"]
-        #[doc = r"     ) -> Self::ConnectionContext {"]
-        #[doc = r"         MyEventContext { packet_sent: 0 }"]
-        #[doc = r"     }"]
-        #[doc = r""]
-        #[doc = r"     fn on_packet_sent("]
-        #[doc = r"         &mut self,"]
-        #[doc = r"         context: &mut Self::ConnectionContext,"]
-        #[doc = r"         _meta: &ConnectionMeta,"]
-        #[doc = r"         _event: &PacketSent,"]
-        #[doc = r"     ) {"]
-        #[doc = r"         context.packet_sent += 1;"]
-        #[doc = r"     }"]
-        #[doc = r" }"]
-        #[doc = r"  ```"]
+        /// An application provided type associated with each connection.
+        ///
+        /// The context provides a mechanism for applications to provide a custom type
+        /// and update it on each event, e.g. computing statistics. Each event
+        /// invocation (e.g. [`Subscriber::on_packet_sent`]) also provides mutable
+        /// access to the context `&mut ConnectionContext` and allows for updating the
+        /// context.
+        ///
+        /// ```no_run
+        /// # mod s2n_quic { pub mod provider { pub mod event {
+        /// #     pub use s2n_quic_core::event::{api as events, api::ConnectionInfo, api::ConnectionMeta, Subscriber};
+        /// # }}}
+        /// use s2n_quic::provider::event::{
+        ///     ConnectionInfo, ConnectionMeta, Subscriber, events::PacketSent
+        /// };
+        ///
+        /// pub struct MyEventSubscriber;
+        ///
+        /// pub struct MyEventContext {
+        ///     packet_sent: u64,
+        /// }
+        ///
+        /// impl Subscriber for MyEventSubscriber {
+        ///     type ConnectionContext = MyEventContext;
+        ///
+        ///     fn create_connection_context(
+        ///         &mut self, _meta: &ConnectionMeta,
+        ///         _info: &ConnectionInfo,
+        ///     ) -> Self::ConnectionContext {
+        ///         MyEventContext { packet_sent: 0 }
+        ///     }
+        ///
+        ///     fn on_packet_sent(
+        ///         &mut self,
+        ///         context: &mut Self::ConnectionContext,
+        ///         _meta: &ConnectionMeta,
+        ///         _event: &PacketSent,
+        ///     ) {
+        ///         context.packet_sent += 1;
+        ///     }
+        /// }
+        ///  ```
         type ConnectionContext: 'static + Send;
-        #[doc = r" Creates a context to be passed to each connection-related event"]
+        /// Creates a context to be passed to each connection-related event
         fn create_connection_context(
             &mut self,
             meta: &api::ConnectionMeta,
             info: &api::ConnectionInfo,
         ) -> Self::ConnectionContext;
-        #[doc = r" The period at which `on_supervisor_timeout` is called"]
-        #[doc = r""]
-        #[doc = r" If multiple `event::Subscriber`s are composed together, the minimum `supervisor_timeout`"]
-        #[doc = r" across all `event::Subscriber`s will be used."]
-        #[doc = r""]
-        #[doc = r" If the `supervisor_timeout()` is `None` across all `event::Subscriber`s, connection supervision"]
-        #[doc = r" will cease for the remaining lifetime of the connection and `on_supervisor_timeout` will no longer"]
-        #[doc = r" be called."]
-        #[doc = r""]
-        #[doc = r" It is recommended to avoid setting this value less than ~100ms, as short durations"]
-        #[doc = r" may lead to higher CPU utilization."]
+        /// The period at which `on_supervisor_timeout` is called
+        ///
+        /// If multiple `event::Subscriber`s are composed together, the minimum `supervisor_timeout`
+        /// across all `event::Subscriber`s will be used.
+        ///
+        /// If the `supervisor_timeout()` is `None` across all `event::Subscriber`s, connection supervision
+        /// will cease for the remaining lifetime of the connection and `on_supervisor_timeout` will no longer
+        /// be called.
+        ///
+        /// It is recommended to avoid setting this value less than ~100ms, as short durations
+        /// may lead to higher CPU utilization.
         #[allow(unused_variables)]
         fn supervisor_timeout(
             &mut self,
@@ -7292,11 +7574,11 @@ mod traits {
         ) -> Option<Duration> {
             None
         }
-        #[doc = r" Called for each `supervisor_timeout` to determine any action to take on the connection based on the `supervisor::Outcome`"]
-        #[doc = r""]
-        #[doc = r" If multiple `event::Subscriber`s are composed together, the minimum `supervisor_timeout`"]
-        #[doc = r" across all `event::Subscriber`s will be used, and thus `on_supervisor_timeout` may be called"]
-        #[doc = r" earlier than the `supervisor_timeout` for a given `event::Subscriber` implementation."]
+        /// Called for each `supervisor_timeout` to determine any action to take on the connection based on the `supervisor::Outcome`
+        ///
+        /// If multiple `event::Subscriber`s are composed together, the minimum `supervisor_timeout`
+        /// across all `event::Subscriber`s will be used, and thus `on_supervisor_timeout` may be called
+        /// earlier than the `supervisor_timeout` for a given `event::Subscriber` implementation.
         #[allow(unused_variables)]
         fn on_supervisor_timeout(
             &mut self,
@@ -7306,7 +7588,7 @@ mod traits {
         ) -> supervisor::Outcome {
             supervisor::Outcome::default()
         }
-        #[doc = "Called when the `ApplicationProtocolInformation` event is triggered"]
+        ///Called when the `ApplicationProtocolInformation` event is triggered
         #[inline]
         fn on_application_protocol_information(
             &mut self,
@@ -7318,7 +7600,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ServerNameInformation` event is triggered"]
+        ///Called when the `ServerNameInformation` event is triggered
         #[inline]
         fn on_server_name_information(
             &mut self,
@@ -7330,7 +7612,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `KeyExchangeGroup` event is triggered"]
+        ///Called when the `KeyExchangeGroup` event is triggered
         #[inline]
         fn on_key_exchange_group(
             &mut self,
@@ -7342,7 +7624,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PacketSkipped` event is triggered"]
+        ///Called when the `PacketSkipped` event is triggered
         #[inline]
         fn on_packet_skipped(
             &mut self,
@@ -7354,7 +7636,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PacketSent` event is triggered"]
+        ///Called when the `PacketSent` event is triggered
         #[inline]
         fn on_packet_sent(
             &mut self,
@@ -7366,7 +7648,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PacketReceived` event is triggered"]
+        ///Called when the `PacketReceived` event is triggered
         #[inline]
         fn on_packet_received(
             &mut self,
@@ -7378,7 +7660,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ActivePathUpdated` event is triggered"]
+        ///Called when the `ActivePathUpdated` event is triggered
         #[inline]
         fn on_active_path_updated(
             &mut self,
@@ -7390,7 +7672,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathCreated` event is triggered"]
+        ///Called when the `PathCreated` event is triggered
         #[inline]
         fn on_path_created(
             &mut self,
@@ -7402,7 +7684,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `FrameSent` event is triggered"]
+        ///Called when the `FrameSent` event is triggered
         #[inline]
         fn on_frame_sent(
             &mut self,
@@ -7414,7 +7696,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `FrameReceived` event is triggered"]
+        ///Called when the `FrameReceived` event is triggered
         #[inline]
         fn on_frame_received(
             &mut self,
@@ -7426,7 +7708,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ConnectionCloseFrameReceived` event is triggered"]
+        ///Called when the `ConnectionCloseFrameReceived` event is triggered
         #[inline]
         fn on_connection_close_frame_received(
             &mut self,
@@ -7438,7 +7720,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PacketLost` event is triggered"]
+        ///Called when the `PacketLost` event is triggered
         #[inline]
         fn on_packet_lost(
             &mut self,
@@ -7450,7 +7732,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `RecoveryMetrics` event is triggered"]
+        ///Called when the `RecoveryMetrics` event is triggered
         #[inline]
         fn on_recovery_metrics(
             &mut self,
@@ -7462,7 +7744,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `Congestion` event is triggered"]
+        ///Called when the `Congestion` event is triggered
         #[inline]
         fn on_congestion(
             &mut self,
@@ -7474,7 +7756,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AckProcessed` event is triggered"]
+        ///Called when the `AckProcessed` event is triggered
         #[inline]
         #[deprecated(note = "use on_rx_ack_range_dropped event instead")]
         #[allow(deprecated)]
@@ -7488,7 +7770,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `RxAckRangeDropped` event is triggered"]
+        ///Called when the `RxAckRangeDropped` event is triggered
         #[inline]
         fn on_rx_ack_range_dropped(
             &mut self,
@@ -7500,7 +7782,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AckRangeReceived` event is triggered"]
+        ///Called when the `AckRangeReceived` event is triggered
         #[inline]
         fn on_ack_range_received(
             &mut self,
@@ -7512,7 +7794,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `AckRangeSent` event is triggered"]
+        ///Called when the `AckRangeSent` event is triggered
         #[inline]
         fn on_ack_range_sent(
             &mut self,
@@ -7524,7 +7806,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PacketDropped` event is triggered"]
+        ///Called when the `PacketDropped` event is triggered
         #[inline]
         fn on_packet_dropped(
             &mut self,
@@ -7536,7 +7818,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `KeyUpdate` event is triggered"]
+        ///Called when the `KeyUpdate` event is triggered
         #[inline]
         fn on_key_update(
             &mut self,
@@ -7548,7 +7830,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `KeySpaceDiscarded` event is triggered"]
+        ///Called when the `KeySpaceDiscarded` event is triggered
         #[inline]
         fn on_key_space_discarded(
             &mut self,
@@ -7560,7 +7842,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ConnectionStarted` event is triggered"]
+        ///Called when the `ConnectionStarted` event is triggered
         #[inline]
         fn on_connection_started(
             &mut self,
@@ -7572,7 +7854,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `DuplicatePacket` event is triggered"]
+        ///Called when the `DuplicatePacket` event is triggered
         #[inline]
         fn on_duplicate_packet(
             &mut self,
@@ -7584,7 +7866,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `TransportParametersReceived` event is triggered"]
+        ///Called when the `TransportParametersReceived` event is triggered
         #[inline]
         fn on_transport_parameters_received(
             &mut self,
@@ -7596,7 +7878,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `DatagramSent` event is triggered"]
+        ///Called when the `DatagramSent` event is triggered
         #[inline]
         fn on_datagram_sent(
             &mut self,
@@ -7608,7 +7890,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `DatagramReceived` event is triggered"]
+        ///Called when the `DatagramReceived` event is triggered
         #[inline]
         fn on_datagram_received(
             &mut self,
@@ -7620,7 +7902,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `DatagramDropped` event is triggered"]
+        ///Called when the `DatagramDropped` event is triggered
         #[inline]
         fn on_datagram_dropped(
             &mut self,
@@ -7632,7 +7914,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `HandshakeRemoteAddressChangeObserved` event is triggered"]
+        ///Called when the `HandshakeRemoteAddressChangeObserved` event is triggered
         #[inline]
         fn on_handshake_remote_address_change_observed(
             &mut self,
@@ -7644,7 +7926,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ConnectionIdUpdated` event is triggered"]
+        ///Called when the `ConnectionIdUpdated` event is triggered
         #[inline]
         fn on_connection_id_updated(
             &mut self,
@@ -7656,7 +7938,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `EcnStateChanged` event is triggered"]
+        ///Called when the `EcnStateChanged` event is triggered
         #[inline]
         fn on_ecn_state_changed(
             &mut self,
@@ -7668,7 +7950,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ConnectionMigrationDenied` event is triggered"]
+        ///Called when the `ConnectionMigrationDenied` event is triggered
         #[inline]
         fn on_connection_migration_denied(
             &mut self,
@@ -7680,7 +7962,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `HandshakeStatusUpdated` event is triggered"]
+        ///Called when the `HandshakeStatusUpdated` event is triggered
         #[inline]
         fn on_handshake_status_updated(
             &mut self,
@@ -7692,7 +7974,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `TlsExporterReady` event is triggered"]
+        ///Called when the `TlsExporterReady` event is triggered
         #[inline]
         fn on_tls_exporter_ready(
             &mut self,
@@ -7704,7 +7986,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `TlsHandshakeFailed` event is triggered"]
+        ///Called when the `TlsHandshakeFailed` event is triggered
         #[inline]
         fn on_tls_handshake_failed(
             &mut self,
@@ -7716,7 +7998,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PathChallengeUpdated` event is triggered"]
+        ///Called when the `PathChallengeUpdated` event is triggered
         #[inline]
         fn on_path_challenge_updated(
             &mut self,
@@ -7728,7 +8010,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `TlsClientHello` event is triggered"]
+        ///Called when the `TlsClientHello` event is triggered
         #[inline]
         fn on_tls_client_hello(
             &mut self,
@@ -7740,7 +8022,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `TlsServerHello` event is triggered"]
+        ///Called when the `TlsServerHello` event is triggered
         #[inline]
         fn on_tls_server_hello(
             &mut self,
@@ -7752,7 +8034,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `RxStreamProgress` event is triggered"]
+        ///Called when the `RxStreamProgress` event is triggered
         #[inline]
         fn on_rx_stream_progress(
             &mut self,
@@ -7764,7 +8046,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `TxStreamProgress` event is triggered"]
+        ///Called when the `TxStreamProgress` event is triggered
         #[inline]
         fn on_tx_stream_progress(
             &mut self,
@@ -7776,7 +8058,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `KeepAliveTimerExpired` event is triggered"]
+        ///Called when the `KeepAliveTimerExpired` event is triggered
         #[inline]
         fn on_keep_alive_timer_expired(
             &mut self,
@@ -7788,7 +8070,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `MtuUpdated` event is triggered"]
+        ///Called when the `MtuUpdated` event is triggered
         #[inline]
         fn on_mtu_updated(
             &mut self,
@@ -7800,7 +8082,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `MtuProbingCompleteReceived` event is triggered"]
+        ///Called when the `MtuProbingCompleteReceived` event is triggered
         #[inline]
         fn on_mtu_probing_complete_received(
             &mut self,
@@ -7812,7 +8094,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `SlowStartExited` event is triggered"]
+        ///Called when the `SlowStartExited` event is triggered
         #[inline]
         fn on_slow_start_exited(
             &mut self,
@@ -7824,7 +8106,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `DeliveryRateSampled` event is triggered"]
+        ///Called when the `DeliveryRateSampled` event is triggered
         #[inline]
         fn on_delivery_rate_sampled(
             &mut self,
@@ -7836,7 +8118,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PacingRateUpdated` event is triggered"]
+        ///Called when the `PacingRateUpdated` event is triggered
         #[inline]
         fn on_pacing_rate_updated(
             &mut self,
@@ -7848,7 +8130,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `BbrStateChanged` event is triggered"]
+        ///Called when the `BbrStateChanged` event is triggered
         #[inline]
         fn on_bbr_state_changed(
             &mut self,
@@ -7860,7 +8142,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `DcStateChanged` event is triggered"]
+        ///Called when the `DcStateChanged` event is triggered
         #[inline]
         fn on_dc_state_changed(
             &mut self,
@@ -7872,7 +8154,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `DcPathCreated` event is triggered"]
+        ///Called when the `DcPathCreated` event is triggered
         #[inline]
         fn on_dc_path_created(
             &mut self,
@@ -7884,7 +8166,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `ConnectionClosed` event is triggered"]
+        ///Called when the `ConnectionClosed` event is triggered
         #[inline]
         fn on_connection_closed(
             &mut self,
@@ -7896,7 +8178,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `VersionInformation` event is triggered"]
+        ///Called when the `VersionInformation` event is triggered
         #[inline]
         fn on_version_information(
             &mut self,
@@ -7906,7 +8188,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `EndpointPacketSent` event is triggered"]
+        ///Called when the `EndpointPacketSent` event is triggered
         #[inline]
         fn on_endpoint_packet_sent(
             &mut self,
@@ -7916,7 +8198,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `EndpointPacketReceived` event is triggered"]
+        ///Called when the `EndpointPacketReceived` event is triggered
         #[inline]
         fn on_endpoint_packet_received(
             &mut self,
@@ -7926,7 +8208,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `EndpointDatagramSent` event is triggered"]
+        ///Called when the `EndpointDatagramSent` event is triggered
         #[inline]
         fn on_endpoint_datagram_sent(
             &mut self,
@@ -7936,7 +8218,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `EndpointDatagramReceived` event is triggered"]
+        ///Called when the `EndpointDatagramReceived` event is triggered
         #[inline]
         fn on_endpoint_datagram_received(
             &mut self,
@@ -7946,7 +8228,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `EndpointDatagramDropped` event is triggered"]
+        ///Called when the `EndpointDatagramDropped` event is triggered
         #[inline]
         fn on_endpoint_datagram_dropped(
             &mut self,
@@ -7956,7 +8238,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `EndpointConnectionAttemptFailed` event is triggered"]
+        ///Called when the `EndpointConnectionAttemptFailed` event is triggered
         #[inline]
         fn on_endpoint_connection_attempt_failed(
             &mut self,
@@ -7966,7 +8248,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `EndpointConnectionAttemptDeduplicated` event is triggered"]
+        ///Called when the `EndpointConnectionAttemptDeduplicated` event is triggered
         #[inline]
         fn on_endpoint_connection_attempt_deduplicated(
             &mut self,
@@ -7976,31 +8258,31 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PlatformTx` event is triggered"]
+        ///Called when the `PlatformTx` event is triggered
         #[inline]
         fn on_platform_tx(&mut self, meta: &api::EndpointMeta, event: &api::PlatformTx) {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PlatformTxError` event is triggered"]
+        ///Called when the `PlatformTxError` event is triggered
         #[inline]
         fn on_platform_tx_error(&mut self, meta: &api::EndpointMeta, event: &api::PlatformTxError) {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PlatformRx` event is triggered"]
+        ///Called when the `PlatformRx` event is triggered
         #[inline]
         fn on_platform_rx(&mut self, meta: &api::EndpointMeta, event: &api::PlatformRx) {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PlatformRxError` event is triggered"]
+        ///Called when the `PlatformRxError` event is triggered
         #[inline]
         fn on_platform_rx_error(&mut self, meta: &api::EndpointMeta, event: &api::PlatformRxError) {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PlatformFeatureConfigured` event is triggered"]
+        ///Called when the `PlatformFeatureConfigured` event is triggered
         #[inline]
         fn on_platform_feature_configured(
             &mut self,
@@ -8010,7 +8292,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PlatformRxSocketStats` event is triggered"]
+        ///Called when the `PlatformRxSocketStats` event is triggered
         #[inline]
         fn on_platform_rx_socket_stats(
             &mut self,
@@ -8020,7 +8302,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PlatformEventLoopWakeup` event is triggered"]
+        ///Called when the `PlatformEventLoopWakeup` event is triggered
         #[inline]
         fn on_platform_event_loop_wakeup(
             &mut self,
@@ -8030,7 +8312,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PlatformEventLoopSleep` event is triggered"]
+        ///Called when the `PlatformEventLoopSleep` event is triggered
         #[inline]
         fn on_platform_event_loop_sleep(
             &mut self,
@@ -8040,7 +8322,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `PlatformEventLoopStarted` event is triggered"]
+        ///Called when the `PlatformEventLoopStarted` event is triggered
         #[inline]
         fn on_platform_event_loop_started(
             &mut self,
@@ -8050,13 +8332,13 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = r" Called for each event that relates to the endpoint and all connections"]
+        /// Called for each event that relates to the endpoint and all connections
         #[inline]
         fn on_event<M: Meta, E: Event>(&mut self, meta: &M, event: &E) {
             let _ = meta;
             let _ = event;
         }
-        #[doc = r" Called for each event that relates to a connection"]
+        /// Called for each event that relates to a connection
         #[inline]
         fn on_connection_event<E: Event>(
             &mut self,
@@ -8068,7 +8350,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = r" Used for querying the `Subscriber::ConnectionContext` on a Subscriber"]
+        /// Used for querying the `Subscriber::ConnectionContext` on a Subscriber
         #[inline]
         fn query(
             context: &Self::ConnectionContext,
@@ -8076,7 +8358,7 @@ mod traits {
         ) -> query::ControlFlow {
             query.execute(context)
         }
-        #[doc = r" Used for querying and mutating the `Subscriber::ConnectionContext` on a Subscriber"]
+        /// Used for querying and mutating the `Subscriber::ConnectionContext` on a Subscriber
         #[inline]
         fn query_mut(
             context: &mut Self::ConnectionContext,
@@ -8085,8 +8367,8 @@ mod traits {
             query.execute_mut(context)
         }
     }
-    #[doc = r" Subscriber is implemented for a 2-element tuple to make it easy to compose multiple"]
-    #[doc = r" subscribers."]
+    /// Subscriber is implemented for a 2-element tuple to make it easy to compose multiple
+    /// subscribers.
     impl<A, B> Subscriber for (A, B)
     where
         A: Subscriber,
@@ -8813,47 +9095,47 @@ mod traits {
         }
     }
     pub trait EndpointPublisher {
-        #[doc = "Publishes a `VersionInformation` event to the publisher's subscriber"]
+        ///Publishes a `VersionInformation` event to the publisher's subscriber
         fn on_version_information(&mut self, event: builder::VersionInformation);
-        #[doc = "Publishes a `EndpointPacketSent` event to the publisher's subscriber"]
+        ///Publishes a `EndpointPacketSent` event to the publisher's subscriber
         fn on_endpoint_packet_sent(&mut self, event: builder::EndpointPacketSent);
-        #[doc = "Publishes a `EndpointPacketReceived` event to the publisher's subscriber"]
+        ///Publishes a `EndpointPacketReceived` event to the publisher's subscriber
         fn on_endpoint_packet_received(&mut self, event: builder::EndpointPacketReceived);
-        #[doc = "Publishes a `EndpointDatagramSent` event to the publisher's subscriber"]
+        ///Publishes a `EndpointDatagramSent` event to the publisher's subscriber
         fn on_endpoint_datagram_sent(&mut self, event: builder::EndpointDatagramSent);
-        #[doc = "Publishes a `EndpointDatagramReceived` event to the publisher's subscriber"]
+        ///Publishes a `EndpointDatagramReceived` event to the publisher's subscriber
         fn on_endpoint_datagram_received(&mut self, event: builder::EndpointDatagramReceived);
-        #[doc = "Publishes a `EndpointDatagramDropped` event to the publisher's subscriber"]
+        ///Publishes a `EndpointDatagramDropped` event to the publisher's subscriber
         fn on_endpoint_datagram_dropped(&mut self, event: builder::EndpointDatagramDropped);
-        #[doc = "Publishes a `EndpointConnectionAttemptFailed` event to the publisher's subscriber"]
+        ///Publishes a `EndpointConnectionAttemptFailed` event to the publisher's subscriber
         fn on_endpoint_connection_attempt_failed(
             &mut self,
             event: builder::EndpointConnectionAttemptFailed,
         );
-        #[doc = "Publishes a `EndpointConnectionAttemptDeduplicated` event to the publisher's subscriber"]
+        ///Publishes a `EndpointConnectionAttemptDeduplicated` event to the publisher's subscriber
         fn on_endpoint_connection_attempt_deduplicated(
             &mut self,
             event: builder::EndpointConnectionAttemptDeduplicated,
         );
-        #[doc = "Publishes a `PlatformTx` event to the publisher's subscriber"]
+        ///Publishes a `PlatformTx` event to the publisher's subscriber
         fn on_platform_tx(&mut self, event: builder::PlatformTx);
-        #[doc = "Publishes a `PlatformTxError` event to the publisher's subscriber"]
+        ///Publishes a `PlatformTxError` event to the publisher's subscriber
         fn on_platform_tx_error(&mut self, event: builder::PlatformTxError);
-        #[doc = "Publishes a `PlatformRx` event to the publisher's subscriber"]
+        ///Publishes a `PlatformRx` event to the publisher's subscriber
         fn on_platform_rx(&mut self, event: builder::PlatformRx);
-        #[doc = "Publishes a `PlatformRxError` event to the publisher's subscriber"]
+        ///Publishes a `PlatformRxError` event to the publisher's subscriber
         fn on_platform_rx_error(&mut self, event: builder::PlatformRxError);
-        #[doc = "Publishes a `PlatformFeatureConfigured` event to the publisher's subscriber"]
+        ///Publishes a `PlatformFeatureConfigured` event to the publisher's subscriber
         fn on_platform_feature_configured(&mut self, event: builder::PlatformFeatureConfigured);
-        #[doc = "Publishes a `PlatformRxSocketStats` event to the publisher's subscriber"]
+        ///Publishes a `PlatformRxSocketStats` event to the publisher's subscriber
         fn on_platform_rx_socket_stats(&mut self, event: builder::PlatformRxSocketStats);
-        #[doc = "Publishes a `PlatformEventLoopWakeup` event to the publisher's subscriber"]
+        ///Publishes a `PlatformEventLoopWakeup` event to the publisher's subscriber
         fn on_platform_event_loop_wakeup(&mut self, event: builder::PlatformEventLoopWakeup);
-        #[doc = "Publishes a `PlatformEventLoopSleep` event to the publisher's subscriber"]
+        ///Publishes a `PlatformEventLoopSleep` event to the publisher's subscriber
         fn on_platform_event_loop_sleep(&mut self, event: builder::PlatformEventLoopSleep);
-        #[doc = "Publishes a `PlatformEventLoopStarted` event to the publisher's subscriber"]
+        ///Publishes a `PlatformEventLoopStarted` event to the publisher's subscriber
         fn on_platform_event_loop_started(&mut self, event: builder::PlatformEventLoopStarted);
-        #[doc = r" Returns the QUIC version, if any"]
+        /// Returns the QUIC version, if any
         fn quic_version(&self) -> Option<u32>;
     }
     pub struct EndpointPublisherSubscriber<'a, Sub: Subscriber> {
@@ -9009,116 +9291,116 @@ mod traits {
         }
     }
     pub trait ConnectionPublisher {
-        #[doc = "Publishes a `ApplicationProtocolInformation` event to the publisher's subscriber"]
+        ///Publishes a `ApplicationProtocolInformation` event to the publisher's subscriber
         fn on_application_protocol_information(
             &mut self,
             event: builder::ApplicationProtocolInformation,
         );
-        #[doc = "Publishes a `ServerNameInformation` event to the publisher's subscriber"]
+        ///Publishes a `ServerNameInformation` event to the publisher's subscriber
         fn on_server_name_information(&mut self, event: builder::ServerNameInformation);
-        #[doc = "Publishes a `KeyExchangeGroup` event to the publisher's subscriber"]
+        ///Publishes a `KeyExchangeGroup` event to the publisher's subscriber
         fn on_key_exchange_group(&mut self, event: builder::KeyExchangeGroup);
-        #[doc = "Publishes a `PacketSkipped` event to the publisher's subscriber"]
+        ///Publishes a `PacketSkipped` event to the publisher's subscriber
         fn on_packet_skipped(&mut self, event: builder::PacketSkipped);
-        #[doc = "Publishes a `PacketSent` event to the publisher's subscriber"]
+        ///Publishes a `PacketSent` event to the publisher's subscriber
         fn on_packet_sent(&mut self, event: builder::PacketSent);
-        #[doc = "Publishes a `PacketReceived` event to the publisher's subscriber"]
+        ///Publishes a `PacketReceived` event to the publisher's subscriber
         fn on_packet_received(&mut self, event: builder::PacketReceived);
-        #[doc = "Publishes a `ActivePathUpdated` event to the publisher's subscriber"]
+        ///Publishes a `ActivePathUpdated` event to the publisher's subscriber
         fn on_active_path_updated(&mut self, event: builder::ActivePathUpdated);
-        #[doc = "Publishes a `PathCreated` event to the publisher's subscriber"]
+        ///Publishes a `PathCreated` event to the publisher's subscriber
         fn on_path_created(&mut self, event: builder::PathCreated);
-        #[doc = "Publishes a `FrameSent` event to the publisher's subscriber"]
+        ///Publishes a `FrameSent` event to the publisher's subscriber
         fn on_frame_sent(&mut self, event: builder::FrameSent);
-        #[doc = "Publishes a `FrameReceived` event to the publisher's subscriber"]
+        ///Publishes a `FrameReceived` event to the publisher's subscriber
         fn on_frame_received(&mut self, event: builder::FrameReceived);
-        #[doc = "Publishes a `ConnectionCloseFrameReceived` event to the publisher's subscriber"]
+        ///Publishes a `ConnectionCloseFrameReceived` event to the publisher's subscriber
         fn on_connection_close_frame_received(
             &mut self,
             event: builder::ConnectionCloseFrameReceived,
         );
-        #[doc = "Publishes a `PacketLost` event to the publisher's subscriber"]
+        ///Publishes a `PacketLost` event to the publisher's subscriber
         fn on_packet_lost(&mut self, event: builder::PacketLost);
-        #[doc = "Publishes a `RecoveryMetrics` event to the publisher's subscriber"]
+        ///Publishes a `RecoveryMetrics` event to the publisher's subscriber
         fn on_recovery_metrics(&mut self, event: builder::RecoveryMetrics);
-        #[doc = "Publishes a `Congestion` event to the publisher's subscriber"]
+        ///Publishes a `Congestion` event to the publisher's subscriber
         fn on_congestion(&mut self, event: builder::Congestion);
-        #[doc = "Publishes a `AckProcessed` event to the publisher's subscriber"]
+        ///Publishes a `AckProcessed` event to the publisher's subscriber
         fn on_ack_processed(&mut self, event: builder::AckProcessed);
-        #[doc = "Publishes a `RxAckRangeDropped` event to the publisher's subscriber"]
+        ///Publishes a `RxAckRangeDropped` event to the publisher's subscriber
         fn on_rx_ack_range_dropped(&mut self, event: builder::RxAckRangeDropped);
-        #[doc = "Publishes a `AckRangeReceived` event to the publisher's subscriber"]
+        ///Publishes a `AckRangeReceived` event to the publisher's subscriber
         fn on_ack_range_received(&mut self, event: builder::AckRangeReceived);
-        #[doc = "Publishes a `AckRangeSent` event to the publisher's subscriber"]
+        ///Publishes a `AckRangeSent` event to the publisher's subscriber
         fn on_ack_range_sent(&mut self, event: builder::AckRangeSent);
-        #[doc = "Publishes a `PacketDropped` event to the publisher's subscriber"]
+        ///Publishes a `PacketDropped` event to the publisher's subscriber
         fn on_packet_dropped(&mut self, event: builder::PacketDropped);
-        #[doc = "Publishes a `KeyUpdate` event to the publisher's subscriber"]
+        ///Publishes a `KeyUpdate` event to the publisher's subscriber
         fn on_key_update(&mut self, event: builder::KeyUpdate);
-        #[doc = "Publishes a `KeySpaceDiscarded` event to the publisher's subscriber"]
+        ///Publishes a `KeySpaceDiscarded` event to the publisher's subscriber
         fn on_key_space_discarded(&mut self, event: builder::KeySpaceDiscarded);
-        #[doc = "Publishes a `ConnectionStarted` event to the publisher's subscriber"]
+        ///Publishes a `ConnectionStarted` event to the publisher's subscriber
         fn on_connection_started(&mut self, event: builder::ConnectionStarted);
-        #[doc = "Publishes a `DuplicatePacket` event to the publisher's subscriber"]
+        ///Publishes a `DuplicatePacket` event to the publisher's subscriber
         fn on_duplicate_packet(&mut self, event: builder::DuplicatePacket);
-        #[doc = "Publishes a `TransportParametersReceived` event to the publisher's subscriber"]
+        ///Publishes a `TransportParametersReceived` event to the publisher's subscriber
         fn on_transport_parameters_received(&mut self, event: builder::TransportParametersReceived);
-        #[doc = "Publishes a `DatagramSent` event to the publisher's subscriber"]
+        ///Publishes a `DatagramSent` event to the publisher's subscriber
         fn on_datagram_sent(&mut self, event: builder::DatagramSent);
-        #[doc = "Publishes a `DatagramReceived` event to the publisher's subscriber"]
+        ///Publishes a `DatagramReceived` event to the publisher's subscriber
         fn on_datagram_received(&mut self, event: builder::DatagramReceived);
-        #[doc = "Publishes a `DatagramDropped` event to the publisher's subscriber"]
+        ///Publishes a `DatagramDropped` event to the publisher's subscriber
         fn on_datagram_dropped(&mut self, event: builder::DatagramDropped);
-        #[doc = "Publishes a `HandshakeRemoteAddressChangeObserved` event to the publisher's subscriber"]
+        ///Publishes a `HandshakeRemoteAddressChangeObserved` event to the publisher's subscriber
         fn on_handshake_remote_address_change_observed(
             &mut self,
             event: builder::HandshakeRemoteAddressChangeObserved,
         );
-        #[doc = "Publishes a `ConnectionIdUpdated` event to the publisher's subscriber"]
+        ///Publishes a `ConnectionIdUpdated` event to the publisher's subscriber
         fn on_connection_id_updated(&mut self, event: builder::ConnectionIdUpdated);
-        #[doc = "Publishes a `EcnStateChanged` event to the publisher's subscriber"]
+        ///Publishes a `EcnStateChanged` event to the publisher's subscriber
         fn on_ecn_state_changed(&mut self, event: builder::EcnStateChanged);
-        #[doc = "Publishes a `ConnectionMigrationDenied` event to the publisher's subscriber"]
+        ///Publishes a `ConnectionMigrationDenied` event to the publisher's subscriber
         fn on_connection_migration_denied(&mut self, event: builder::ConnectionMigrationDenied);
-        #[doc = "Publishes a `HandshakeStatusUpdated` event to the publisher's subscriber"]
+        ///Publishes a `HandshakeStatusUpdated` event to the publisher's subscriber
         fn on_handshake_status_updated(&mut self, event: builder::HandshakeStatusUpdated);
-        #[doc = "Publishes a `TlsExporterReady` event to the publisher's subscriber"]
+        ///Publishes a `TlsExporterReady` event to the publisher's subscriber
         fn on_tls_exporter_ready(&mut self, event: builder::TlsExporterReady);
-        #[doc = "Publishes a `TlsHandshakeFailed` event to the publisher's subscriber"]
+        ///Publishes a `TlsHandshakeFailed` event to the publisher's subscriber
         fn on_tls_handshake_failed(&mut self, event: builder::TlsHandshakeFailed);
-        #[doc = "Publishes a `PathChallengeUpdated` event to the publisher's subscriber"]
+        ///Publishes a `PathChallengeUpdated` event to the publisher's subscriber
         fn on_path_challenge_updated(&mut self, event: builder::PathChallengeUpdated);
-        #[doc = "Publishes a `TlsClientHello` event to the publisher's subscriber"]
+        ///Publishes a `TlsClientHello` event to the publisher's subscriber
         fn on_tls_client_hello(&mut self, event: builder::TlsClientHello);
-        #[doc = "Publishes a `TlsServerHello` event to the publisher's subscriber"]
+        ///Publishes a `TlsServerHello` event to the publisher's subscriber
         fn on_tls_server_hello(&mut self, event: builder::TlsServerHello);
-        #[doc = "Publishes a `RxStreamProgress` event to the publisher's subscriber"]
+        ///Publishes a `RxStreamProgress` event to the publisher's subscriber
         fn on_rx_stream_progress(&mut self, event: builder::RxStreamProgress);
-        #[doc = "Publishes a `TxStreamProgress` event to the publisher's subscriber"]
+        ///Publishes a `TxStreamProgress` event to the publisher's subscriber
         fn on_tx_stream_progress(&mut self, event: builder::TxStreamProgress);
-        #[doc = "Publishes a `KeepAliveTimerExpired` event to the publisher's subscriber"]
+        ///Publishes a `KeepAliveTimerExpired` event to the publisher's subscriber
         fn on_keep_alive_timer_expired(&mut self, event: builder::KeepAliveTimerExpired);
-        #[doc = "Publishes a `MtuUpdated` event to the publisher's subscriber"]
+        ///Publishes a `MtuUpdated` event to the publisher's subscriber
         fn on_mtu_updated(&mut self, event: builder::MtuUpdated);
-        #[doc = "Publishes a `MtuProbingCompleteReceived` event to the publisher's subscriber"]
+        ///Publishes a `MtuProbingCompleteReceived` event to the publisher's subscriber
         fn on_mtu_probing_complete_received(&mut self, event: builder::MtuProbingCompleteReceived);
-        #[doc = "Publishes a `SlowStartExited` event to the publisher's subscriber"]
+        ///Publishes a `SlowStartExited` event to the publisher's subscriber
         fn on_slow_start_exited(&mut self, event: builder::SlowStartExited);
-        #[doc = "Publishes a `DeliveryRateSampled` event to the publisher's subscriber"]
+        ///Publishes a `DeliveryRateSampled` event to the publisher's subscriber
         fn on_delivery_rate_sampled(&mut self, event: builder::DeliveryRateSampled);
-        #[doc = "Publishes a `PacingRateUpdated` event to the publisher's subscriber"]
+        ///Publishes a `PacingRateUpdated` event to the publisher's subscriber
         fn on_pacing_rate_updated(&mut self, event: builder::PacingRateUpdated);
-        #[doc = "Publishes a `BbrStateChanged` event to the publisher's subscriber"]
+        ///Publishes a `BbrStateChanged` event to the publisher's subscriber
         fn on_bbr_state_changed(&mut self, event: builder::BbrStateChanged);
-        #[doc = "Publishes a `DcStateChanged` event to the publisher's subscriber"]
+        ///Publishes a `DcStateChanged` event to the publisher's subscriber
         fn on_dc_state_changed(&mut self, event: builder::DcStateChanged);
-        #[doc = "Publishes a `DcPathCreated` event to the publisher's subscriber"]
+        ///Publishes a `DcPathCreated` event to the publisher's subscriber
         fn on_dc_path_created(&mut self, event: builder::DcPathCreated);
-        #[doc = "Publishes a `ConnectionClosed` event to the publisher's subscriber"]
+        ///Publishes a `ConnectionClosed` event to the publisher's subscriber
         fn on_connection_closed(&mut self, event: builder::ConnectionClosed);
-        #[doc = r" Returns the QUIC version negotiated for the current connection, if any"]
+        /// Returns the QUIC version negotiated for the current connection, if any
         fn quic_version(&self) -> u32;
-        #[doc = r" Returns the [`Subject`] for the current publisher"]
+        /// Returns the [`Subject`] for the current publisher
         fn subject(&self) -> api::Subject;
     }
     pub struct ConnectionPublisherSubscriber<'a, Sub: Subscriber> {
@@ -9657,21 +9939,21 @@ pub mod testing {
             }
         }
         impl Subscriber {
-            #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+            /// Creates a subscriber with snapshot assertions enabled
             #[track_caller]
             pub fn snapshot() -> Self {
                 let mut sub = Self::no_snapshot();
                 sub.location = Location::from_thread_name();
                 sub
             }
-            #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+            /// Creates a subscriber with snapshot assertions enabled
             #[track_caller]
             pub fn named_snapshot<Name: core::fmt::Display>(name: Name) -> Self {
                 let mut sub = Self::no_snapshot();
                 sub.location = Some(Location::new(name));
                 sub
             }
-            #[doc = r" Creates a subscriber with snapshot assertions disabled"]
+            /// Creates a subscriber with snapshot assertions disabled
             pub fn no_snapshot() -> Self {
                 Self {
                     location: None,
@@ -9967,21 +10249,21 @@ pub mod testing {
         }
     }
     impl Subscriber {
-        #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+        /// Creates a subscriber with snapshot assertions enabled
         #[track_caller]
         pub fn snapshot() -> Self {
             let mut sub = Self::no_snapshot();
             sub.location = Location::from_thread_name();
             sub
         }
-        #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+        /// Creates a subscriber with snapshot assertions enabled
         #[track_caller]
         pub fn named_snapshot<Name: core::fmt::Display>(name: Name) -> Self {
             let mut sub = Self::no_snapshot();
             sub.location = Some(Location::new(name));
             sub
         }
-        #[doc = r" Creates a subscriber with snapshot assertions disabled"]
+        /// Creates a subscriber with snapshot assertions disabled
         pub fn no_snapshot() -> Self {
             Self {
                 location: None,
@@ -10994,21 +11276,21 @@ pub mod testing {
         pub platform_event_loop_started: u64,
     }
     impl Publisher {
-        #[doc = r" Creates a publisher with snapshot assertions enabled"]
+        /// Creates a publisher with snapshot assertions enabled
         #[track_caller]
         pub fn snapshot() -> Self {
             let mut sub = Self::no_snapshot();
             sub.location = Location::from_thread_name();
             sub
         }
-        #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+        /// Creates a subscriber with snapshot assertions enabled
         #[track_caller]
         pub fn named_snapshot<Name: core::fmt::Display>(name: Name) -> Self {
             let mut sub = Self::no_snapshot();
             sub.location = Some(Location::new(name));
             sub
         }
-        #[doc = r" Creates a publisher with snapshot assertions disabled"]
+        /// Creates a publisher with snapshot assertions disabled
         pub fn no_snapshot() -> Self {
             Self {
                 location: None,

--- a/quic/s2n-quic-core/src/event/generated/metrics/aggregate.rs
+++ b/quic/s2n-quic-core/src/event/generated/metrics/aggregate.rs
@@ -2001,12 +2001,12 @@ impl<R: Registry + Default> Default for Subscriber<R> {
     }
 }
 impl<R: Registry> Subscriber<R> {
-    #[doc = r" Creates a new subscriber with the given registry"]
-    #[doc = r""]
-    #[doc = r" # Note"]
-    #[doc = r""]
-    #[doc = r" All of the recorders are registered on initialization and cached for the lifetime"]
-    #[doc = r" of the subscriber."]
+    /// Creates a new subscriber with the given registry
+    ///
+    /// # Note
+    ///
+    /// All of the recorders are registered on initialization and cached for the lifetime
+    /// of the subscriber.
     #[allow(unused_mut)]
     #[inline]
     pub fn new(registry: R) -> Self {
@@ -2622,7 +2622,7 @@ impl<R: Registry> Subscriber<R> {
             registry,
         }
     }
-    #[doc = r" Returns all of the registered counters"]
+    /// Returns all of the registered counters
     #[inline]
     pub fn counters(&self) -> impl Iterator<Item = (&'static Info, &R::Counter)> + '_ {
         self.counters
@@ -2797,7 +2797,7 @@ impl<R: Registry> Subscriber<R> {
         let counter = &self.counters[id];
         counter.record(info, value);
     }
-    #[doc = r" Returns all of the registered bool counters"]
+    /// Returns all of the registered bool counters
     #[inline]
     pub fn bool_counters(&self) -> impl Iterator<Item = (&'static Info, &R::BoolCounter)> + '_ {
         self.bool_counters
@@ -2823,7 +2823,7 @@ impl<R: Registry> Subscriber<R> {
         let counter = &self.bool_counters[id];
         counter.record(info, value);
     }
-    #[doc = r" Returns all of the registered nominal counters"]
+    /// Returns all of the registered nominal counters
     #[inline]
     pub fn nominal_counters(
         &self,
@@ -3055,7 +3055,7 @@ impl<R: Registry> Subscriber<R> {
         let counter = &self.nominal_counters[idx];
         counter.record(info, value.as_variant(), 1usize);
     }
-    #[doc = r" Returns all of the registered measures"]
+    /// Returns all of the registered measures
     #[inline]
     pub fn measures(&self) -> impl Iterator<Item = (&'static Info, &R::Measure)> + '_ {
         self.measures
@@ -3168,7 +3168,7 @@ impl<R: Registry> Subscriber<R> {
         let measure = &self.measures[id];
         measure.record(info, value);
     }
-    #[doc = r" Returns all of the registered gauges"]
+    /// Returns all of the registered gauges
     #[inline]
     pub fn gauges(&self) -> impl Iterator<Item = (&'static Info, &R::Gauge)> + '_ {
         core::iter::empty()
@@ -3180,7 +3180,7 @@ impl<R: Registry> Subscriber<R> {
         let gauge = &self.gauges[id];
         gauge.record(info, value);
     }
-    #[doc = r" Returns all of the registered timers"]
+    /// Returns all of the registered timers
     #[inline]
     pub fn timers(&self) -> impl Iterator<Item = (&'static Info, &R::Timer)> + '_ {
         self.timers

--- a/quic/s2n-quic-core/src/event/generated/metrics/probe.rs
+++ b/quic/s2n-quic-core/src/event/generated/metrics/probe.rs
@@ -535,173 +535,226 @@ mod counter {
     }
     define!(
         extern "probe" {
-            # [link_name = s2n_quic__event__counter__application_protocol_information]
+            #[link_name =
+        s2n_quic__event__counter__application_protocol_information]
             fn application_protocol_information(value: u64);
-            # [link_name = s2n_quic__event__counter__server_name_information]
+            #[link_name =
+        s2n_quic__event__counter__server_name_information]
             fn server_name_information(value: u64);
-            # [link_name = s2n_quic__event__counter__key_exchange_group]
+            #[link_name =
+        s2n_quic__event__counter__key_exchange_group]
             fn key_exchange_group(value: u64);
-            # [link_name = s2n_quic__event__counter__packet_skipped]
+            #[link_name = s2n_quic__event__counter__packet_skipped]
             fn packet_skipped(value: u64);
-            # [link_name = s2n_quic__event__counter__packet_sent]
+            #[link_name = s2n_quic__event__counter__packet_sent]
             fn packet_sent(value: u64);
-            # [link_name = s2n_quic__event__counter__packet_sent__bytes__total]
+            #[link_name = s2n_quic__event__counter__packet_sent__bytes__total]
             fn packet_sent__bytes__total(value: u64);
-            # [link_name = s2n_quic__event__counter__packet_received]
+            #[link_name =
+        s2n_quic__event__counter__packet_received]
             fn packet_received(value: u64);
-            # [link_name = s2n_quic__event__counter__packet_received__bytes__total]
+            #[link_name = s2n_quic__event__counter__packet_received__bytes__total]
             fn packet_received__bytes__total(value: u64);
-            # [link_name = s2n_quic__event__counter__active_path_updated]
+            #[link_name =
+        s2n_quic__event__counter__active_path_updated]
             fn active_path_updated(value: u64);
-            # [link_name = s2n_quic__event__counter__path_created]
+            #[link_name = s2n_quic__event__counter__path_created]
             fn path_created(value: u64);
-            # [link_name = s2n_quic__event__counter__frame_sent]
+            #[link_name = s2n_quic__event__counter__frame_sent]
             fn frame_sent(value: u64);
-            # [link_name = s2n_quic__event__counter__frame_received]
+            #[link_name = s2n_quic__event__counter__frame_received]
             fn frame_received(value: u64);
-            # [link_name = s2n_quic__event__counter__connection_close_frame_received]
+            #[link_name =
+        s2n_quic__event__counter__connection_close_frame_received]
             fn connection_close_frame_received(value: u64);
-            # [link_name = s2n_quic__event__counter__packet_lost]
+            #[link_name =
+        s2n_quic__event__counter__packet_lost]
             fn packet_lost(value: u64);
-            # [link_name = s2n_quic__event__counter__packet_lost__bytes__total]
+            #[link_name =
+        s2n_quic__event__counter__packet_lost__bytes__total]
             fn packet_lost__bytes__total(value: u64);
-            # [link_name = s2n_quic__event__counter__recovery_metrics]
+            #[link_name =
+        s2n_quic__event__counter__recovery_metrics]
             fn recovery_metrics(value: u64);
-            # [link_name = s2n_quic__event__counter__congestion]
+            #[link_name = s2n_quic__event__counter__congestion]
             fn congestion(value: u64);
-            # [link_name = s2n_quic__event__counter__rx_ack_range_dropped]
+            #[link_name = s2n_quic__event__counter__rx_ack_range_dropped]
             fn rx_ack_range_dropped(value: u64);
-            # [link_name = s2n_quic__event__counter__ack_range_received]
+            #[link_name =
+        s2n_quic__event__counter__ack_range_received]
             fn ack_range_received(value: u64);
-            # [link_name = s2n_quic__event__counter__ack_range_sent]
+            #[link_name = s2n_quic__event__counter__ack_range_sent]
             fn ack_range_sent(value: u64);
-            # [link_name = s2n_quic__event__counter__packet_dropped]
+            #[link_name = s2n_quic__event__counter__packet_dropped]
             fn packet_dropped(value: u64);
-            # [link_name = s2n_quic__event__counter__key_update]
+            #[link_name = s2n_quic__event__counter__key_update]
             fn key_update(value: u64);
-            # [link_name = s2n_quic__event__counter__key_space_discarded]
+            #[link_name =
+        s2n_quic__event__counter__key_space_discarded]
             fn key_space_discarded(value: u64);
-            # [link_name = s2n_quic__event__counter__connection_started]
+            #[link_name = s2n_quic__event__counter__connection_started]
             fn connection_started(value: u64);
-            # [link_name = s2n_quic__event__counter__duplicate_packet]
+            #[link_name =
+        s2n_quic__event__counter__duplicate_packet]
             fn duplicate_packet(value: u64);
-            # [link_name = s2n_quic__event__counter__transport_parameters_received]
+            #[link_name = s2n_quic__event__counter__transport_parameters_received]
             fn transport_parameters_received(value: u64);
-            # [link_name = s2n_quic__event__counter__datagram_sent]
+            #[link_name =
+        s2n_quic__event__counter__datagram_sent]
             fn datagram_sent(value: u64);
-            # [link_name = s2n_quic__event__counter__datagram_sent__bytes__total]
+            #[link_name = s2n_quic__event__counter__datagram_sent__bytes__total]
             fn datagram_sent__bytes__total(value: u64);
-            # [link_name = s2n_quic__event__counter__datagram_received]
+            #[link_name =
+        s2n_quic__event__counter__datagram_received]
             fn datagram_received(value: u64);
-            # [link_name = s2n_quic__event__counter__datagram_received__bytes__total]
+            #[link_name = s2n_quic__event__counter__datagram_received__bytes__total]
             fn datagram_received__bytes__total(value: u64);
-            # [link_name = s2n_quic__event__counter__datagram_dropped]
+            #[link_name =
+        s2n_quic__event__counter__datagram_dropped]
             fn datagram_dropped(value: u64);
-            # [link_name = s2n_quic__event__counter__datagram_dropped__bytes__total]
+            #[link_name = s2n_quic__event__counter__datagram_dropped__bytes__total]
             fn datagram_dropped__bytes__total(value: u64);
-            # [link_name = s2n_quic__event__counter__handshake_remote_address_change_observed]
+            #[link_name =
+        s2n_quic__event__counter__handshake_remote_address_change_observed]
             fn handshake_remote_address_change_observed(value: u64);
-            # [link_name = s2n_quic__event__counter__connection_id_updated]
+            #[link_name =
+        s2n_quic__event__counter__connection_id_updated]
             fn connection_id_updated(value: u64);
-            # [link_name = s2n_quic__event__counter__ecn_state_changed]
+            #[link_name = s2n_quic__event__counter__ecn_state_changed]
             fn ecn_state_changed(value: u64);
-            # [link_name = s2n_quic__event__counter__connection_migration_denied]
+            #[link_name =
+        s2n_quic__event__counter__connection_migration_denied]
             fn connection_migration_denied(value: u64);
-            # [link_name = s2n_quic__event__counter__handshake_status_updated]
+            #[link_name =
+        s2n_quic__event__counter__handshake_status_updated]
             fn handshake_status_updated(value: u64);
-            # [link_name = s2n_quic__event__counter__tls_exporter_ready]
+            #[link_name =
+        s2n_quic__event__counter__tls_exporter_ready]
             fn tls_exporter_ready(value: u64);
-            # [link_name = s2n_quic__event__counter__tls_handshake_failed]
+            #[link_name = s2n_quic__event__counter__tls_handshake_failed]
             fn tls_handshake_failed(value: u64);
-            # [link_name = s2n_quic__event__counter__path_challenge_updated]
+            #[link_name =
+        s2n_quic__event__counter__path_challenge_updated]
             fn path_challenge_updated(value: u64);
-            # [link_name = s2n_quic__event__counter__tls_client_hello]
+            #[link_name = s2n_quic__event__counter__tls_client_hello]
             fn tls_client_hello(value: u64);
-            # [link_name = s2n_quic__event__counter__tls_server_hello]
+            #[link_name =
+        s2n_quic__event__counter__tls_server_hello]
             fn tls_server_hello(value: u64);
-            # [link_name = s2n_quic__event__counter__rx_stream_progress]
+            #[link_name = s2n_quic__event__counter__rx_stream_progress]
             fn rx_stream_progress(value: u64);
-            # [link_name = s2n_quic__event__counter__rx_stream_progress__bytes__total]
+            #[link_name =
+        s2n_quic__event__counter__rx_stream_progress__bytes__total]
             fn rx_stream_progress__bytes__total(value: u64);
-            # [link_name = s2n_quic__event__counter__tx_stream_progress]
+            #[link_name =
+        s2n_quic__event__counter__tx_stream_progress]
             fn tx_stream_progress(value: u64);
-            # [link_name = s2n_quic__event__counter__tx_stream_progress__bytes__total]
+            #[link_name = s2n_quic__event__counter__tx_stream_progress__bytes__total]
             fn tx_stream_progress__bytes__total(value: u64);
-            # [link_name = s2n_quic__event__counter__keep_alive_timer_expired]
+            #[link_name =
+        s2n_quic__event__counter__keep_alive_timer_expired]
             fn keep_alive_timer_expired(value: u64);
-            # [link_name = s2n_quic__event__counter__mtu_updated]
+            #[link_name =
+        s2n_quic__event__counter__mtu_updated]
             fn mtu_updated(value: u64);
-            # [link_name = s2n_quic__event__counter__mtu_probing_complete_received]
+            #[link_name =
+        s2n_quic__event__counter__mtu_probing_complete_received]
             fn mtu_probing_complete_received(value: u64);
-            # [link_name = s2n_quic__event__counter__slow_start_exited]
+            #[link_name =
+        s2n_quic__event__counter__slow_start_exited]
             fn slow_start_exited(value: u64);
-            # [link_name = s2n_quic__event__counter__delivery_rate_sampled]
+            #[link_name = s2n_quic__event__counter__delivery_rate_sampled]
             fn delivery_rate_sampled(value: u64);
-            # [link_name = s2n_quic__event__counter__pacing_rate_updated]
+            #[link_name =
+        s2n_quic__event__counter__pacing_rate_updated]
             fn pacing_rate_updated(value: u64);
-            # [link_name = s2n_quic__event__counter__bbr_state_changed]
+            #[link_name = s2n_quic__event__counter__bbr_state_changed]
             fn bbr_state_changed(value: u64);
-            # [link_name = s2n_quic__event__counter__dc_state_changed]
+            #[link_name =
+        s2n_quic__event__counter__dc_state_changed]
             fn dc_state_changed(value: u64);
-            # [link_name = s2n_quic__event__counter__dc_path_created]
+            #[link_name = s2n_quic__event__counter__dc_path_created]
             fn dc_path_created(value: u64);
-            # [link_name = s2n_quic__event__counter__connection_closed]
+            #[link_name = s2n_quic__event__counter__connection_closed]
             fn connection_closed(value: u64);
-            # [link_name = s2n_quic__event__counter__version_information]
+            #[link_name =
+        s2n_quic__event__counter__version_information]
             fn version_information(value: u64);
-            # [link_name = s2n_quic__event__counter__endpoint_packet_sent]
+            #[link_name = s2n_quic__event__counter__endpoint_packet_sent]
             fn endpoint_packet_sent(value: u64);
-            # [link_name = s2n_quic__event__counter__endpoint_packet_received]
+            #[link_name =
+        s2n_quic__event__counter__endpoint_packet_received]
             fn endpoint_packet_received(value: u64);
-            # [link_name = s2n_quic__event__counter__endpoint_datagram_sent]
+            #[link_name =
+        s2n_quic__event__counter__endpoint_datagram_sent]
             fn endpoint_datagram_sent(value: u64);
-            # [link_name = s2n_quic__event__counter__endpoint_datagram_received]
+            #[link_name = s2n_quic__event__counter__endpoint_datagram_received]
             fn endpoint_datagram_received(value: u64);
-            # [link_name = s2n_quic__event__counter__endpoint_datagram_dropped]
+            #[link_name =
+        s2n_quic__event__counter__endpoint_datagram_dropped]
             fn endpoint_datagram_dropped(value: u64);
-            # [link_name = s2n_quic__event__counter__endpoint_connection_attempt_failed]
+            #[link_name =
+        s2n_quic__event__counter__endpoint_connection_attempt_failed]
             fn endpoint_connection_attempt_failed(value: u64);
-            # [link_name = s2n_quic__event__counter__endpoint_connection_attempt_deduplicated]
+            #[link_name =
+        s2n_quic__event__counter__endpoint_connection_attempt_deduplicated]
             fn endpoint_connection_attempt_deduplicated(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_tx]
+            #[link_name =
+        s2n_quic__event__counter__platform_tx]
             fn platform_tx(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_tx__packets__total]
+            #[link_name =
+        s2n_quic__event__counter__platform_tx__packets__total]
             fn platform_tx__packets__total(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_tx__syscalls__total]
+            #[link_name =
+        s2n_quic__event__counter__platform_tx__syscalls__total]
             fn platform_tx__syscalls__total(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_tx__syscalls__blocked__total]
+            #[link_name =
+        s2n_quic__event__counter__platform_tx__syscalls__blocked__total]
             fn platform_tx__syscalls__blocked__total(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_tx__errors__total]
+            #[link_name =
+        s2n_quic__event__counter__platform_tx__errors__total]
             fn platform_tx__errors__total(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_tx__errors__dropped__total]
+            #[link_name =
+        s2n_quic__event__counter__platform_tx__errors__dropped__total]
             fn platform_tx__errors__dropped__total(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_tx_error]
+            #[link_name =
+        s2n_quic__event__counter__platform_tx_error]
             fn platform_tx_error(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_rx]
+            #[link_name = s2n_quic__event__counter__platform_rx]
             fn platform_rx(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_rx__packets__total]
+            #[link_name = s2n_quic__event__counter__platform_rx__packets__total]
             fn platform_rx__packets__total(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_rx__syscalls__total]
+            #[link_name =
+        s2n_quic__event__counter__platform_rx__syscalls__total]
             fn platform_rx__syscalls__total(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_rx__syscalls__blocked__total]
+            #[link_name =
+        s2n_quic__event__counter__platform_rx__syscalls__blocked__total]
             fn platform_rx__syscalls__blocked__total(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_rx__errors__total]
+            #[link_name =
+        s2n_quic__event__counter__platform_rx__errors__total]
             fn platform_rx__errors__total(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_rx__errors__dropped__total]
+            #[link_name =
+        s2n_quic__event__counter__platform_rx__errors__dropped__total]
             fn platform_rx__errors__dropped__total(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_rx_error]
+            #[link_name =
+        s2n_quic__event__counter__platform_rx_error]
             fn platform_rx_error(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_feature_configured]
+            #[link_name = s2n_quic__event__counter__platform_feature_configured]
             fn platform_feature_configured(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_rx_socket_stats]
+            #[link_name =
+        s2n_quic__event__counter__platform_rx_socket_stats]
             fn platform_rx_socket_stats(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_rx_socket_stats__packets__total]
+            #[link_name =
+        s2n_quic__event__counter__platform_rx_socket_stats__packets__total]
             fn platform_rx_socket_stats__packets__total(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_event_loop_wakeup]
+            #[link_name =
+        s2n_quic__event__counter__platform_event_loop_wakeup]
             fn platform_event_loop_wakeup(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_event_loop_sleep]
+            #[link_name =
+        s2n_quic__event__counter__platform_event_loop_sleep]
             fn platform_event_loop_sleep(value: u64);
-            # [link_name = s2n_quic__event__counter__platform_event_loop_started]
+            #[link_name =
+        s2n_quic__event__counter__platform_event_loop_started]
             fn platform_event_loop_started(value: u64);
         }
     );
@@ -728,11 +781,14 @@ mod counter {
         }
         define!(
             extern "probe" {
-                # [link_name = s2n_quic__event__counter__bool__packet_lost__is_mtu_probe]
+                #[link_name =
+            s2n_quic__event__counter__bool__packet_lost__is_mtu_probe]
                 fn packet_lost__is_mtu_probe(value: bool);
-                # [link_name = s2n_quic__event__counter__bool__recovery_metrics__congestion_limited]
+                #[link_name =
+            s2n_quic__event__counter__bool__recovery_metrics__congestion_limited]
                 fn recovery_metrics__congestion_limited(value: bool);
-                # [link_name = s2n_quic__event__counter__bool__mtu_updated__search_complete]
+                #[link_name =
+            s2n_quic__event__counter__bool__mtu_updated__search_complete]
                 fn mtu_updated__search_complete(value: bool);
             }
         );
@@ -802,95 +858,121 @@ mod counter {
         }
         define!(
             extern "probe" {
-                # [link_name = s2n_quic__event__counter__nominal__packet_sent__kind]
+                #[link_name =
+            s2n_quic__event__counter__nominal__packet_sent__kind]
                 fn packet_sent__kind(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__packet_sent__transmission_mode]
+                #[link_name =
+            s2n_quic__event__counter__nominal__packet_sent__transmission_mode]
                 fn packet_sent__transmission_mode(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic__event__counter__nominal__packet_received__kind]
+                #[link_name =
+            s2n_quic__event__counter__nominal__packet_received__kind]
                 fn packet_received__kind(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__frame_sent__packet]
+                #[link_name =
+            s2n_quic__event__counter__nominal__frame_sent__packet]
                 fn frame_sent__packet(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__frame_sent__frame]
+                #[link_name = s2n_quic__event__counter__nominal__frame_sent__frame]
                 fn frame_sent__frame(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__frame_received__packet]
+                #[link_name = s2n_quic__event__counter__nominal__frame_received__packet]
                 fn frame_received__packet(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__frame_received__frame]
+                #[link_name =
+            s2n_quic__event__counter__nominal__frame_received__frame]
                 fn frame_received__frame(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__connection_close_frame_received__packet]
+                #[link_name =
+            s2n_quic__event__counter__nominal__connection_close_frame_received__packet]
                 fn connection_close_frame_received__packet(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic__event__counter__nominal__packet_lost__kind]
+                #[link_name =
+            s2n_quic__event__counter__nominal__packet_lost__kind]
                 fn packet_lost__kind(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__congestion__source]
+                #[link_name = s2n_quic__event__counter__nominal__congestion__source]
                 fn congestion__source(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__ack_range_received__packet]
+                #[link_name = s2n_quic__event__counter__nominal__ack_range_received__packet]
                 fn ack_range_received__packet(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__ack_range_sent__packet]
+                #[link_name =
+            s2n_quic__event__counter__nominal__ack_range_sent__packet]
                 fn ack_range_sent__packet(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__packet_dropped__reason]
+                #[link_name =
+            s2n_quic__event__counter__nominal__packet_dropped__reason]
                 fn packet_dropped__reason(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__key_update__key_type]
+                #[link_name =
+            s2n_quic__event__counter__nominal__key_update__key_type]
                 fn key_update__key_type(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__key_update__cipher_suite]
+                #[link_name = s2n_quic__event__counter__nominal__key_update__cipher_suite]
                 fn key_update__cipher_suite(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__key_space_discarded__space]
+                #[link_name =
+            s2n_quic__event__counter__nominal__key_space_discarded__space]
                 fn key_space_discarded__space(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__duplicate_packet__kind]
+                #[link_name =
+            s2n_quic__event__counter__nominal__duplicate_packet__kind]
                 fn duplicate_packet__kind(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__duplicate_packet__error]
+                #[link_name =
+            s2n_quic__event__counter__nominal__duplicate_packet__error]
                 fn duplicate_packet__error(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__datagram_dropped__reason]
+                #[link_name =
+            s2n_quic__event__counter__nominal__datagram_dropped__reason]
                 fn datagram_dropped__reason(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__ecn_state_changed__state]
+                #[link_name =
+            s2n_quic__event__counter__nominal__ecn_state_changed__state]
                 fn ecn_state_changed__state(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__connection_migration_denied__reason]
+                #[link_name =
+            s2n_quic__event__counter__nominal__connection_migration_denied__reason]
                 fn connection_migration_denied__reason(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic__event__counter__nominal__handshake_status_updated__status]
+                #[link_name =
+            s2n_quic__event__counter__nominal__handshake_status_updated__status]
                 fn handshake_status_updated__status(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic__event__counter__nominal__path_challenge_updated__status]
+                #[link_name =
+            s2n_quic__event__counter__nominal__path_challenge_updated__status]
                 fn path_challenge_updated__status(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic__event__counter__nominal__mtu_updated__cause]
+                #[link_name =
+            s2n_quic__event__counter__nominal__mtu_updated__cause]
                 fn mtu_updated__cause(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__mtu_probing_complete_received__packet]
+                #[link_name =
+            s2n_quic__event__counter__nominal__mtu_probing_complete_received__packet]
                 fn mtu_probing_complete_received__packet(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic__event__counter__nominal__slow_start_exited__cause]
+                #[link_name =
+            s2n_quic__event__counter__nominal__slow_start_exited__cause]
                 fn slow_start_exited__cause(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__bbr_state_changed__state]
+                #[link_name =
+            s2n_quic__event__counter__nominal__bbr_state_changed__state]
                 fn bbr_state_changed__state(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__dc_state_changed__state]
+                #[link_name =
+            s2n_quic__event__counter__nominal__dc_state_changed__state]
                 fn dc_state_changed__state(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__connection_closed__error]
+                #[link_name =
+            s2n_quic__event__counter__nominal__connection_closed__error]
                 fn connection_closed__error(value: u64, variant: u64, variant_name: &info::Str);
-                # [link_name = s2n_quic__event__counter__nominal__endpoint_datagram_dropped__reason]
+                #[link_name =
+            s2n_quic__event__counter__nominal__endpoint_datagram_dropped__reason]
                 fn endpoint_datagram_dropped__reason(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
                 );
-                # [link_name = s2n_quic__event__counter__nominal__endpoint_connection_attempt_failed__error]
+                #[link_name =
+            s2n_quic__event__counter__nominal__endpoint_connection_attempt_failed__error]
                 fn endpoint_connection_attempt_failed__error(
                     value: u64,
                     variant: u64,
@@ -971,85 +1053,117 @@ mod measure {
     }
     define!(
         extern "probe" {
-            # [link_name = s2n_quic__event__measure__packet_sent__bytes]
+            #[link_name = s2n_quic__event__measure__packet_sent__bytes]
             fn packet_sent__bytes(value: u64);
-            # [link_name = s2n_quic__event__measure__packet_received__bytes]
+            #[link_name =
+        s2n_quic__event__measure__packet_received__bytes]
             fn packet_received__bytes(value: u64);
-            # [link_name = s2n_quic__event__measure__packet_lost__bytes]
+            #[link_name = s2n_quic__event__measure__packet_lost__bytes]
             fn packet_lost__bytes(value: u64);
-            # [link_name = s2n_quic__event__measure__recovery_metrics__min_rtt]
+            #[link_name =
+        s2n_quic__event__measure__recovery_metrics__min_rtt]
             fn recovery_metrics__min_rtt(value: u64);
-            # [link_name = s2n_quic__event__measure__recovery_metrics__smoothed_rtt]
+            #[link_name =
+        s2n_quic__event__measure__recovery_metrics__smoothed_rtt]
             fn recovery_metrics__smoothed_rtt(value: u64);
-            # [link_name = s2n_quic__event__measure__recovery_metrics__latest_rtt]
+            #[link_name =
+        s2n_quic__event__measure__recovery_metrics__latest_rtt]
             fn recovery_metrics__latest_rtt(value: u64);
-            # [link_name = s2n_quic__event__measure__recovery_metrics__rtt_variance]
+            #[link_name =
+        s2n_quic__event__measure__recovery_metrics__rtt_variance]
             fn recovery_metrics__rtt_variance(value: u64);
-            # [link_name = s2n_quic__event__measure__recovery_metrics__max_ack_delay]
+            #[link_name =
+        s2n_quic__event__measure__recovery_metrics__max_ack_delay]
             fn recovery_metrics__max_ack_delay(value: u64);
-            # [link_name = s2n_quic__event__measure__recovery_metrics__pto_count]
+            #[link_name =
+        s2n_quic__event__measure__recovery_metrics__pto_count]
             fn recovery_metrics__pto_count(value: u64);
-            # [link_name = s2n_quic__event__measure__recovery_metrics__congestion_window]
+            #[link_name =
+        s2n_quic__event__measure__recovery_metrics__congestion_window]
             fn recovery_metrics__congestion_window(value: u64);
-            # [link_name = s2n_quic__event__measure__recovery_metrics__bytes_in_flight]
+            #[link_name =
+        s2n_quic__event__measure__recovery_metrics__bytes_in_flight]
             fn recovery_metrics__bytes_in_flight(value: u64);
-            # [link_name = s2n_quic__event__measure__datagram_sent__bytes]
+            #[link_name =
+        s2n_quic__event__measure__datagram_sent__bytes]
             fn datagram_sent__bytes(value: u64);
-            # [link_name = s2n_quic__event__measure__datagram_sent__gso_offset]
+            #[link_name = s2n_quic__event__measure__datagram_sent__gso_offset]
             fn datagram_sent__gso_offset(value: u64);
-            # [link_name = s2n_quic__event__measure__datagram_received__bytes]
+            #[link_name =
+        s2n_quic__event__measure__datagram_received__bytes]
             fn datagram_received__bytes(value: u64);
-            # [link_name = s2n_quic__event__measure__datagram_dropped__bytes]
+            #[link_name =
+        s2n_quic__event__measure__datagram_dropped__bytes]
             fn datagram_dropped__bytes(value: u64);
-            # [link_name = s2n_quic__event__measure__rx_stream_progress__bytes]
+            #[link_name =
+        s2n_quic__event__measure__rx_stream_progress__bytes]
             fn rx_stream_progress__bytes(value: u64);
-            # [link_name = s2n_quic__event__measure__tx_stream_progress__bytes]
+            #[link_name =
+        s2n_quic__event__measure__tx_stream_progress__bytes]
             fn tx_stream_progress__bytes(value: u64);
-            # [link_name = s2n_quic__event__measure__mtu_updated__mtu]
+            #[link_name =
+        s2n_quic__event__measure__mtu_updated__mtu]
             fn mtu_updated__mtu(value: u64);
-            # [link_name = s2n_quic__event__measure__mtu_probing_complete_received__mtu]
+            #[link_name = s2n_quic__event__measure__mtu_probing_complete_received__mtu]
             fn mtu_probing_complete_received__mtu(value: u64);
-            # [link_name = s2n_quic__event__measure__slow_start_exited__congestion_window]
+            #[link_name =
+        s2n_quic__event__measure__slow_start_exited__congestion_window]
             fn slow_start_exited__congestion_window(value: u64);
-            # [link_name = s2n_quic__event__measure__pacing_rate_updated__bytes_per_second]
+            #[link_name =
+        s2n_quic__event__measure__pacing_rate_updated__bytes_per_second]
             fn pacing_rate_updated__bytes_per_second(value: u64);
-            # [link_name = s2n_quic__event__measure__pacing_rate_updated__burst_size]
+            #[link_name =
+        s2n_quic__event__measure__pacing_rate_updated__burst_size]
             fn pacing_rate_updated__burst_size(value: u64);
-            # [link_name = s2n_quic__event__measure__pacing_rate_updated__pacing_gain]
+            #[link_name =
+        s2n_quic__event__measure__pacing_rate_updated__pacing_gain]
             fn pacing_rate_updated__pacing_gain(value: u64);
-            # [link_name = s2n_quic__event__measure__endpoint_datagram_sent__bytes]
+            #[link_name =
+        s2n_quic__event__measure__endpoint_datagram_sent__bytes]
             fn endpoint_datagram_sent__bytes(value: u64);
-            # [link_name = s2n_quic__event__measure__endpoint_datagram_sent__bytes__total]
+            #[link_name =
+        s2n_quic__event__measure__endpoint_datagram_sent__bytes__total]
             fn endpoint_datagram_sent__bytes__total(value: u64);
-            # [link_name = s2n_quic__event__measure__endpoint_datagram_sent__gso_offset]
+            #[link_name =
+        s2n_quic__event__measure__endpoint_datagram_sent__gso_offset]
             fn endpoint_datagram_sent__gso_offset(value: u64);
-            # [link_name = s2n_quic__event__measure__endpoint_datagram_received__bytes]
+            #[link_name =
+        s2n_quic__event__measure__endpoint_datagram_received__bytes]
             fn endpoint_datagram_received__bytes(value: u64);
-            # [link_name = s2n_quic__event__measure__endpoint_datagram_received__bytes__total]
+            #[link_name =
+        s2n_quic__event__measure__endpoint_datagram_received__bytes__total]
             fn endpoint_datagram_received__bytes__total(value: u64);
-            # [link_name = s2n_quic__event__measure__endpoint_datagram_dropped__bytes]
+            #[link_name =
+        s2n_quic__event__measure__endpoint_datagram_dropped__bytes]
             fn endpoint_datagram_dropped__bytes(value: u64);
-            # [link_name = s2n_quic__event__measure__endpoint_datagram_dropped__bytes__total]
+            #[link_name =
+        s2n_quic__event__measure__endpoint_datagram_dropped__bytes__total]
             fn endpoint_datagram_dropped__bytes__total(value: u64);
-            # [link_name = s2n_quic__event__measure__platform_tx__packets]
+            #[link_name =
+        s2n_quic__event__measure__platform_tx__packets]
             fn platform_tx__packets(value: u64);
-            # [link_name = s2n_quic__event__measure__platform_tx__syscalls]
+            #[link_name = s2n_quic__event__measure__platform_tx__syscalls]
             fn platform_tx__syscalls(value: u64);
-            # [link_name = s2n_quic__event__measure__platform_tx__syscalls__blocked]
+            #[link_name =
+        s2n_quic__event__measure__platform_tx__syscalls__blocked]
             fn platform_tx__syscalls__blocked(value: u64);
-            # [link_name = s2n_quic__event__measure__platform_tx__errors]
+            #[link_name =
+        s2n_quic__event__measure__platform_tx__errors]
             fn platform_tx__errors(value: u64);
-            # [link_name = s2n_quic__event__measure__platform_tx__errors__dropped]
+            #[link_name = s2n_quic__event__measure__platform_tx__errors__dropped]
             fn platform_tx__errors__dropped(value: u64);
-            # [link_name = s2n_quic__event__measure__platform_rx__packets]
+            #[link_name =
+        s2n_quic__event__measure__platform_rx__packets]
             fn platform_rx__packets(value: u64);
-            # [link_name = s2n_quic__event__measure__platform_rx__syscalls]
+            #[link_name = s2n_quic__event__measure__platform_rx__syscalls]
             fn platform_rx__syscalls(value: u64);
-            # [link_name = s2n_quic__event__measure__platform_rx__syscalls__blocked]
+            #[link_name =
+        s2n_quic__event__measure__platform_rx__syscalls__blocked]
             fn platform_rx__syscalls__blocked(value: u64);
-            # [link_name = s2n_quic__event__measure__platform_rx__errors]
+            #[link_name =
+        s2n_quic__event__measure__platform_rx__errors]
             fn platform_rx__errors(value: u64);
-            # [link_name = s2n_quic__event__measure__platform_rx__errors__dropped]
+            #[link_name = s2n_quic__event__measure__platform_rx__errors__dropped]
             fn platform_rx__errors__dropped(value: u64);
         }
     );
@@ -1128,35 +1242,47 @@ mod timer {
     }
     define!(
         extern "probe" {
-            # [link_name = s2n_quic__event__timer__key_space_discarded__initial__latency]
+            #[link_name =
+        s2n_quic__event__timer__key_space_discarded__initial__latency]
             fn key_space_discarded__initial__latency(value: core::time::Duration);
-            # [link_name = s2n_quic__event__timer__key_space_discarded__handshake__latency]
+            #[link_name
+        = s2n_quic__event__timer__key_space_discarded__handshake__latency]
             fn key_space_discarded__handshake__latency(value: core::time::Duration);
-            # [link_name = s2n_quic__event__timer__key_space_discarded__one_rtt__latency]
+            #[link_name = s2n_quic__event__timer__key_space_discarded__one_rtt__latency]
             fn key_space_discarded__one_rtt__latency(value: core::time::Duration);
-            # [link_name = s2n_quic__event__timer__transport_parameters_received__latency]
+            #[link_name
+        = s2n_quic__event__timer__transport_parameters_received__latency]
             fn transport_parameters_received__latency(value: core::time::Duration);
-            # [link_name = s2n_quic__event__timer__handshake_status_updated__complete__latency]
+            #[link_name
+        = s2n_quic__event__timer__handshake_status_updated__complete__latency]
             fn handshake_status_updated__complete__latency(value: core::time::Duration);
-            # [link_name = s2n_quic__event__timer__handshake_status_updated__confirmed__latency]
+            #[link_name =
+        s2n_quic__event__timer__handshake_status_updated__confirmed__latency]
             fn handshake_status_updated__confirmed__latency(value: core::time::Duration);
-            # [link_name = s2n_quic__event__timer__handshake_status_updated__handshake_done_acked__latency]
+            #[link_name =
+        s2n_quic__event__timer__handshake_status_updated__handshake_done_acked__latency]
             fn handshake_status_updated__handshake_done_acked__latency(value: core::time::Duration);
-            # [link_name = s2n_quic__event__timer__tls_client_hello__latency]
+            #[link_name =
+        s2n_quic__event__timer__tls_client_hello__latency]
             fn tls_client_hello__latency(value: core::time::Duration);
-            # [link_name = s2n_quic__event__timer__tls_server_hello__latency]
+            #[link_name =
+        s2n_quic__event__timer__tls_server_hello__latency]
             fn tls_server_hello__latency(value: core::time::Duration);
-            # [link_name = s2n_quic__event__timer__dc_state_changed__version_negotiated__latency]
+            #[link_name =
+        s2n_quic__event__timer__dc_state_changed__version_negotiated__latency]
             fn dc_state_changed__version_negotiated__latency(value: core::time::Duration);
-            # [link_name = s2n_quic__event__timer__dc_state_changed__no_version_negotiated__latency]
+            #[link_name =
+        s2n_quic__event__timer__dc_state_changed__no_version_negotiated__latency]
             fn dc_state_changed__no_version_negotiated__latency(value: core::time::Duration);
-            # [link_name = s2n_quic__event__timer__dc_state_changed__path_secrets__latency]
+            #[link_name = s2n_quic__event__timer__dc_state_changed__path_secrets__latency]
             fn dc_state_changed__path_secrets__latency(value: core::time::Duration);
-            # [link_name = s2n_quic__event__timer__dc_state_changed__complete__latency]
+            #[link_name = s2n_quic__event__timer__dc_state_changed__complete__latency]
             fn dc_state_changed__complete__latency(value: core::time::Duration);
-            # [link_name = s2n_quic__event__timer__connection_closed__latency]
+            #[link_name =
+        s2n_quic__event__timer__connection_closed__latency]
             fn connection_closed__latency(value: core::time::Duration);
-            # [link_name = s2n_quic__event__timer__platform_event_loop_sleep__processing_duration]
+            #[link_name =
+        s2n_quic__event__timer__platform_event_loop_sleep__processing_duration]
             fn platform_event_loop_sleep__processing_duration(value: core::time::Duration);
         }
     );
@@ -1185,7 +1311,8 @@ mod timer {
         }
         define!(
             extern "probe" {
-                # [link_name = s2n_quic__event__timer__nominal__slow_start_exited__latency]
+                #[link_name =
+            s2n_quic__event__timer__nominal__slow_start_exited__latency]
                 fn slow_start_exited__latency(
                     value: core::time::Duration,
                     variant: u64,

--- a/tools/s2n-events/Cargo.toml
+++ b/tools/s2n-events/Cargo.toml
@@ -15,6 +15,7 @@ testing = []
 [dependencies]
 glob = "0.3"
 heck = "0.5"
+prettyplease = "0.2"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full", "extra-traits"] }

--- a/tools/s2n-events/src/output.rs
+++ b/tools/s2n-events/src/output.rs
@@ -71,7 +71,19 @@ impl Output {
         put!("// This file was generated with the `s2n-events` crate and any required");
         put!("// changes should be made there.");
         put!();
-        put!("{}", output.to_token_stream());
+
+        // `proc_macro2`'s token printer emits everything on a single line, which `rustfmt` can
+        // choke on for very large items (e.g. the generated `INFO` arrays). Pre-format with
+        // `prettyplease` to produce well-structured multi-line source, then hand off to `rustfmt`
+        // for the final, project-consistent formatting.
+        let tokens = output.to_token_stream();
+        let parsed: syn::File = syn::parse2(tokens).unwrap_or_else(|e| {
+            panic!(
+                "failed to parse generated tokens for {}: {e}",
+                path.display()
+            )
+        });
+        put!("{}", prettyplease::unparse(&parsed));
 
         let status = std::process::Command::new("rustfmt")
             .arg(&path)

--- a/tools/s2n-events/tests/c_ffi_events/event/generated.rs
+++ b/tools/s2n-events/tests/c_ffi_events/event/generated.rs
@@ -9,7 +9,7 @@
 use super::*;
 pub(crate) mod metrics;
 pub mod api {
-    #![doc = r" This module contains events that are emitted to the [`Subscriber`](crate::event::Subscriber)"]
+    //! This module contains events that are emitted to the [`Subscriber`](crate::event::Subscriber)
     use super::*;
     #[allow(unused_imports)]
     use crate::event::metrics::aggregate;
@@ -157,16 +157,18 @@ pub mod api {
     }
 }
 pub mod tracing {
-    #![doc = r" This module contains event integration with [`tracing`](https://docs.rs/tracing)"]
+    //! This module contains event integration with [`tracing`](https://docs.rs/tracing)
     use super::api;
-    #[doc = r" Emits events with [`tracing`](https://docs.rs/tracing)"]
+    /// Emits events with [`tracing`](https://docs.rs/tracing)
     #[derive(Clone, Debug)]
     pub struct Subscriber {
         root: tracing::Span,
     }
     impl Default for Subscriber {
         fn default() -> Self {
-            let root = tracing :: span ! (target : "c_ffi_events_test" , tracing :: Level :: DEBUG , "c_ffi_events_test");
+            let root = tracing::span!(
+                target : "c_ffi_events_test", tracing::Level::DEBUG, "c_ffi_events_test"
+            );
             Self { root }
         }
     }
@@ -183,7 +185,10 @@ pub mod tracing {
             _info: &api::ConnectionInfo,
         ) -> Self::ConnectionContext {
             let parent = self.parent(meta);
-            tracing :: span ! (target : "c_ffi_events" , parent : parent , tracing :: Level :: DEBUG , "conn" , id = meta . id)
+            tracing::span!(
+                target : "c_ffi_events", parent : parent, tracing::Level::DEBUG, "conn",
+                id = meta.id
+            )
         }
         #[inline]
         fn on_byte_array_event(
@@ -194,7 +199,10 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::ByteArrayEvent { data } = event;
-            tracing :: event ! (target : "byte_array_event" , parent : id , tracing :: Level :: DEBUG , { data = tracing :: field :: debug (data) });
+            tracing::event!(
+                target : "byte_array_event", parent : id, tracing::Level::DEBUG, { data =
+                tracing::field::debug(data) }
+            );
         }
         #[inline]
         fn on_enum_event(
@@ -205,13 +213,19 @@ pub mod tracing {
         ) {
             let id = context.id();
             let api::EnumEvent { value } = event;
-            tracing :: event ! (target : "enum_event" , parent : id , tracing :: Level :: DEBUG , { value = tracing :: field :: debug (value) });
+            tracing::event!(
+                target : "enum_event", parent : id, tracing::Level::DEBUG, { value =
+                tracing::field::debug(value) }
+            );
         }
         #[inline]
         fn on_count_event(&mut self, meta: &api::EndpointMeta, event: &api::CountEvent) {
             let parent = self.parent(meta);
             let api::CountEvent { count } = event;
-            tracing :: event ! (target : "count_event" , parent : parent , tracing :: Level :: DEBUG , { count = tracing :: field :: debug (count) });
+            tracing::event!(
+                target : "count_event", parent : parent, tracing::Level::DEBUG, { count =
+                tracing::field::debug(count) }
+            );
         }
     }
 }
@@ -328,58 +342,58 @@ mod traits {
     use crate::event::Meta;
     use core::fmt;
     use s2n_quic_core::query;
-    #[doc = r" Allows for events to be subscribed to"]
+    /// Allows for events to be subscribed to
     pub trait Subscriber: 'static + Send {
-        #[doc = r" An application provided type associated with each connection."]
-        #[doc = r""]
-        #[doc = r" The context provides a mechanism for applications to provide a custom type"]
-        #[doc = r" and update it on each event, e.g. computing statistics. Each event"]
-        #[doc = r" invocation (e.g. [`Subscriber::on_packet_sent`]) also provides mutable"]
-        #[doc = r" access to the context `&mut ConnectionContext` and allows for updating the"]
-        #[doc = r" context."]
-        #[doc = r""]
-        #[doc = r" ```no_run"]
-        #[doc = r" # mod s2n_quic { pub mod provider { pub mod event {"]
-        #[doc = r" #     pub use s2n_quic_core::event::{api as events, api::ConnectionInfo, api::ConnectionMeta, Subscriber};"]
-        #[doc = r" # }}}"]
-        #[doc = r" use s2n_quic::provider::event::{"]
-        #[doc = r"     ConnectionInfo, ConnectionMeta, Subscriber, events::PacketSent"]
-        #[doc = r" };"]
-        #[doc = r""]
-        #[doc = r" pub struct MyEventSubscriber;"]
-        #[doc = r""]
-        #[doc = r" pub struct MyEventContext {"]
-        #[doc = r"     packet_sent: u64,"]
-        #[doc = r" }"]
-        #[doc = r""]
-        #[doc = r" impl Subscriber for MyEventSubscriber {"]
-        #[doc = r"     type ConnectionContext = MyEventContext;"]
-        #[doc = r""]
-        #[doc = r"     fn create_connection_context("]
-        #[doc = r"         &mut self, _meta: &ConnectionMeta,"]
-        #[doc = r"         _info: &ConnectionInfo,"]
-        #[doc = r"     ) -> Self::ConnectionContext {"]
-        #[doc = r"         MyEventContext { packet_sent: 0 }"]
-        #[doc = r"     }"]
-        #[doc = r""]
-        #[doc = r"     fn on_packet_sent("]
-        #[doc = r"         &mut self,"]
-        #[doc = r"         context: &mut Self::ConnectionContext,"]
-        #[doc = r"         _meta: &ConnectionMeta,"]
-        #[doc = r"         _event: &PacketSent,"]
-        #[doc = r"     ) {"]
-        #[doc = r"         context.packet_sent += 1;"]
-        #[doc = r"     }"]
-        #[doc = r" }"]
-        #[doc = r"  ```"]
+        /// An application provided type associated with each connection.
+        ///
+        /// The context provides a mechanism for applications to provide a custom type
+        /// and update it on each event, e.g. computing statistics. Each event
+        /// invocation (e.g. [`Subscriber::on_packet_sent`]) also provides mutable
+        /// access to the context `&mut ConnectionContext` and allows for updating the
+        /// context.
+        ///
+        /// ```no_run
+        /// # mod s2n_quic { pub mod provider { pub mod event {
+        /// #     pub use s2n_quic_core::event::{api as events, api::ConnectionInfo, api::ConnectionMeta, Subscriber};
+        /// # }}}
+        /// use s2n_quic::provider::event::{
+        ///     ConnectionInfo, ConnectionMeta, Subscriber, events::PacketSent
+        /// };
+        ///
+        /// pub struct MyEventSubscriber;
+        ///
+        /// pub struct MyEventContext {
+        ///     packet_sent: u64,
+        /// }
+        ///
+        /// impl Subscriber for MyEventSubscriber {
+        ///     type ConnectionContext = MyEventContext;
+        ///
+        ///     fn create_connection_context(
+        ///         &mut self, _meta: &ConnectionMeta,
+        ///         _info: &ConnectionInfo,
+        ///     ) -> Self::ConnectionContext {
+        ///         MyEventContext { packet_sent: 0 }
+        ///     }
+        ///
+        ///     fn on_packet_sent(
+        ///         &mut self,
+        ///         context: &mut Self::ConnectionContext,
+        ///         _meta: &ConnectionMeta,
+        ///         _event: &PacketSent,
+        ///     ) {
+        ///         context.packet_sent += 1;
+        ///     }
+        /// }
+        ///  ```
         type ConnectionContext: 'static + Send;
-        #[doc = r" Creates a context to be passed to each connection-related event"]
+        /// Creates a context to be passed to each connection-related event
         fn create_connection_context(
             &mut self,
             meta: &api::ConnectionMeta,
             info: &api::ConnectionInfo,
         ) -> Self::ConnectionContext;
-        #[doc = "Called when the `ByteArrayEvent` event is triggered"]
+        ///Called when the `ByteArrayEvent` event is triggered
         #[inline]
         fn on_byte_array_event(
             &mut self,
@@ -391,7 +405,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `EnumEvent` event is triggered"]
+        ///Called when the `EnumEvent` event is triggered
         #[inline]
         fn on_enum_event(
             &mut self,
@@ -403,19 +417,19 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = "Called when the `CountEvent` event is triggered"]
+        ///Called when the `CountEvent` event is triggered
         #[inline]
         fn on_count_event(&mut self, meta: &api::EndpointMeta, event: &api::CountEvent) {
             let _ = meta;
             let _ = event;
         }
-        #[doc = r" Called for each event that relates to the endpoint and all connections"]
+        /// Called for each event that relates to the endpoint and all connections
         #[inline]
         fn on_event<M: Meta, E: Event>(&mut self, meta: &M, event: &E) {
             let _ = meta;
             let _ = event;
         }
-        #[doc = r" Called for each event that relates to a connection"]
+        /// Called for each event that relates to a connection
         #[inline]
         fn on_connection_event<E: Event>(
             &mut self,
@@ -427,7 +441,7 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
-        #[doc = r" Used for querying the `Subscriber::ConnectionContext` on a Subscriber"]
+        /// Used for querying the `Subscriber::ConnectionContext` on a Subscriber
         #[inline]
         fn query(
             context: &Self::ConnectionContext,
@@ -435,7 +449,7 @@ mod traits {
         ) -> query::ControlFlow {
             query.execute(context)
         }
-        #[doc = r" Used for querying and mutating the `Subscriber::ConnectionContext` on a Subscriber"]
+        /// Used for querying and mutating the `Subscriber::ConnectionContext` on a Subscriber
         #[inline]
         fn query_mut(
             context: &mut Self::ConnectionContext,
@@ -444,8 +458,8 @@ mod traits {
             query.execute_mut(context)
         }
     }
-    #[doc = r" Subscriber is implemented for a 2-element tuple to make it easy to compose multiple"]
-    #[doc = r" subscribers."]
+    /// Subscriber is implemented for a 2-element tuple to make it easy to compose multiple
+    /// subscribers.
     impl<A, B> Subscriber for (A, B)
     where
         A: Subscriber,
@@ -525,9 +539,9 @@ mod traits {
         }
     }
     pub trait EndpointPublisher {
-        #[doc = "Publishes a `CountEvent` event to the publisher's subscriber"]
+        ///Publishes a `CountEvent` event to the publisher's subscriber
         fn on_count_event(&mut self, event: builder::CountEvent);
-        #[doc = r" Returns the QUIC version, if any"]
+        /// Returns the QUIC version, if any
         fn quic_version(&self) -> Option<u32>;
     }
     pub struct EndpointPublisherSubscriber<'a, Sub: Subscriber> {
@@ -570,13 +584,13 @@ mod traits {
         }
     }
     pub trait ConnectionPublisher {
-        #[doc = "Publishes a `ByteArrayEvent` event to the publisher's subscriber"]
+        ///Publishes a `ByteArrayEvent` event to the publisher's subscriber
         fn on_byte_array_event(&mut self, event: builder::ByteArrayEvent);
-        #[doc = "Publishes a `EnumEvent` event to the publisher's subscriber"]
+        ///Publishes a `EnumEvent` event to the publisher's subscriber
         fn on_enum_event(&mut self, event: builder::EnumEvent);
-        #[doc = r" Returns the QUIC version negotiated for the current connection, if any"]
+        /// Returns the QUIC version negotiated for the current connection, if any
         fn quic_version(&self) -> u32;
-        #[doc = r" Returns the [`Subject`] for the current publisher"]
+        /// Returns the [`Subject`] for the current publisher
         fn subject(&self) -> api::Subject;
     }
     pub struct ConnectionPublisherSubscriber<'a, Sub: Subscriber> {
@@ -660,21 +674,21 @@ pub mod testing {
             }
         }
         impl Subscriber {
-            #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+            /// Creates a subscriber with snapshot assertions enabled
             #[track_caller]
             pub fn snapshot() -> Self {
                 let mut sub = Self::no_snapshot();
                 sub.location = Location::from_thread_name();
                 sub
             }
-            #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+            /// Creates a subscriber with snapshot assertions enabled
             #[track_caller]
             pub fn named_snapshot<Name: core::fmt::Display>(name: Name) -> Self {
                 let mut sub = Self::no_snapshot();
                 sub.location = Some(Location::new(name));
                 sub
             }
-            #[doc = r" Creates a subscriber with snapshot assertions disabled"]
+            /// Creates a subscriber with snapshot assertions disabled
             pub fn no_snapshot() -> Self {
                 Self {
                     location: None,
@@ -719,21 +733,21 @@ pub mod testing {
         }
     }
     impl Subscriber {
-        #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+        /// Creates a subscriber with snapshot assertions enabled
         #[track_caller]
         pub fn snapshot() -> Self {
             let mut sub = Self::no_snapshot();
             sub.location = Location::from_thread_name();
             sub
         }
-        #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+        /// Creates a subscriber with snapshot assertions enabled
         #[track_caller]
         pub fn named_snapshot<Name: core::fmt::Display>(name: Name) -> Self {
             let mut sub = Self::no_snapshot();
             sub.location = Some(Location::new(name));
             sub
         }
-        #[doc = r" Creates a subscriber with snapshot assertions disabled"]
+        /// Creates a subscriber with snapshot assertions disabled
         pub fn no_snapshot() -> Self {
             Self {
                 location: None,
@@ -797,21 +811,21 @@ pub mod testing {
         pub count_event: u64,
     }
     impl Publisher {
-        #[doc = r" Creates a publisher with snapshot assertions enabled"]
+        /// Creates a publisher with snapshot assertions enabled
         #[track_caller]
         pub fn snapshot() -> Self {
             let mut sub = Self::no_snapshot();
             sub.location = Location::from_thread_name();
             sub
         }
-        #[doc = r" Creates a subscriber with snapshot assertions enabled"]
+        /// Creates a subscriber with snapshot assertions enabled
         #[track_caller]
         pub fn named_snapshot<Name: core::fmt::Display>(name: Name) -> Self {
             let mut sub = Self::no_snapshot();
             sub.location = Some(Location::new(name));
             sub
         }
-        #[doc = r" Creates a publisher with snapshot assertions disabled"]
+        /// Creates a publisher with snapshot assertions disabled
         pub fn no_snapshot() -> Self {
             Self {
                 location: None,

--- a/tools/s2n-events/tests/c_ffi_events/event/generated/metrics/aggregate.rs
+++ b/tools/s2n-events/tests/c_ffi_events/event/generated/metrics/aggregate.rs
@@ -87,12 +87,12 @@ impl<R: Registry + Default> Default for Subscriber<R> {
     }
 }
 impl<R: Registry> Subscriber<R> {
-    #[doc = r" Creates a new subscriber with the given registry"]
-    #[doc = r""]
-    #[doc = r" # Note"]
-    #[doc = r""]
-    #[doc = r" All of the recorders are registered on initialization and cached for the lifetime"]
-    #[doc = r" of the subscriber."]
+    /// Creates a new subscriber with the given registry
+    ///
+    /// # Note
+    ///
+    /// All of the recorders are registered on initialization and cached for the lifetime
+    /// of the subscriber.
     #[allow(unused_mut)]
     #[inline]
     pub fn new(registry: R) -> Self {
@@ -139,7 +139,7 @@ impl<R: Registry> Subscriber<R> {
             registry,
         }
     }
-    #[doc = r" Returns all of the registered counters"]
+    /// Returns all of the registered counters
     #[inline]
     pub fn counters(&self) -> impl Iterator<Item = (&'static Info, &R::Counter)> + '_ {
         self.counters
@@ -159,7 +159,7 @@ impl<R: Registry> Subscriber<R> {
         let counter = &self.counters[id];
         counter.record(info, value);
     }
-    #[doc = r" Returns all of the registered bool counters"]
+    /// Returns all of the registered bool counters
     #[inline]
     pub fn bool_counters(&self) -> impl Iterator<Item = (&'static Info, &R::BoolCounter)> + '_ {
         core::iter::empty()
@@ -171,7 +171,7 @@ impl<R: Registry> Subscriber<R> {
         let counter = &self.bool_counters[id];
         counter.record(info, value);
     }
-    #[doc = r" Returns all of the registered nominal counters"]
+    /// Returns all of the registered nominal counters
     #[inline]
     pub fn nominal_counters(
         &self,
@@ -188,7 +188,7 @@ impl<R: Registry> Subscriber<R> {
         let counter = &self.nominal_counters[idx];
         counter.record(info, value.as_variant(), 1usize);
     }
-    #[doc = r" Returns all of the registered measures"]
+    /// Returns all of the registered measures
     #[inline]
     pub fn measures(&self) -> impl Iterator<Item = (&'static Info, &R::Measure)> + '_ {
         core::iter::empty()
@@ -200,7 +200,7 @@ impl<R: Registry> Subscriber<R> {
         let measure = &self.measures[id];
         measure.record(info, value);
     }
-    #[doc = r" Returns all of the registered gauges"]
+    /// Returns all of the registered gauges
     #[inline]
     pub fn gauges(&self) -> impl Iterator<Item = (&'static Info, &R::Gauge)> + '_ {
         core::iter::empty()
@@ -212,7 +212,7 @@ impl<R: Registry> Subscriber<R> {
         let gauge = &self.gauges[id];
         gauge.record(info, value);
     }
-    #[doc = r" Returns all of the registered timers"]
+    /// Returns all of the registered timers
     #[inline]
     pub fn timers(&self) -> impl Iterator<Item = (&'static Info, &R::Timer)> + '_ {
         core::iter::empty()

--- a/tools/s2n-events/tests/c_ffi_events/event/generated/metrics/probe.rs
+++ b/tools/s2n-events/tests/c_ffi_events/event/generated/metrics/probe.rs
@@ -43,11 +43,13 @@ mod counter {
     }
     define!(
         extern "probe" {
-            # [link_name = c_ffi_events__event__counter__byte_array_event]
+            #[link_name = c_ffi_events__event__counter__byte_array_event]
             fn byte_array_event(value: u64);
-            # [link_name = c_ffi_events__event__counter__enum_event]
+            #[link_name =
+        c_ffi_events__event__counter__enum_event]
             fn enum_event(value: u64);
-            # [link_name = c_ffi_events__event__counter__count_event]
+            #[link_name
+        = c_ffi_events__event__counter__count_event]
             fn count_event(value: u64);
         }
     );


### PR DESCRIPTION
### Release Summary:
### Resolved issues:

n/a

### Description of changes: 

rustfmt has longstanding bugs where long lines will be left unchanged after it runs. Unfortunately, proc-macro2's output has no way to insert a newline in TokenStreams (only if we're willing to change how we output in the first place), and we'd have to manually pepper inserting them. prettyplease is aimed to guarantee that it will always break such lines up, so the subsequent rustfmt pass is more reliable.

### Call-outs:

Unexpectedly to me, prettyplease also 'prettifies' known attributes, e.g., doc comments are made into nice syntax rather than being left as attributes. Ultimately that seems maybe even an *improvement* over the status quo; it shouldn't have any meaningful effect on rustdoc output. The handling of some more nuanced formatting where there's no knowledge of the macro being invoked (e.g., tracing::event/span!) is a bit more dubious, but I think isn't horrible.

This commit re-runs ./scripts/events. Notably this already fixes at least one pre-existing huge line (nominal_counter_offsets in dc aggregate metrics). I ran into this because adding more events was creating more such cases where everything remains on one line.

This should overall have no functional change.

### Testing:

CI should confirm events are up to date.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

