### PR TITLE
fix(s2n-quic-core): undefined behavior in CStr conversion

### DIFF
--- a/quic/s2n-quic-core/src/event/metrics/aggregate/info.rs
+++ b/quic/s2n-quic-core/src/event/metrics/aggregate/info.rs
@@ -142,7 +142,11 @@ impl AsRef<str> for Str {
 impl AsRef<CStr> for Str {
     #[inline]
     fn as_ref(&self) -> &CStr {
-        unsafe { CStr::from_bytes_with_nul_unchecked(self.as_bytes()) }
+        // Use `self.0.as_bytes()` to access the inner str directly, which
+        // includes the nul terminator. Using `self.as_bytes()` would go through
+        // `Deref` which strips the nul byte, violating the safety contract of
+        // `CStr::from_bytes_with_nul_unchecked`.
+        unsafe { CStr::from_bytes_with_nul_unchecked(self.0.as_bytes()) }
     }
 }
 

--- a/quic/s2n-quic-core/src/event/metrics/aggregate/info.rs
+++ b/quic/s2n-quic-core/src/event/metrics/aggregate/info.rs
@@ -142,9 +142,9 @@ impl AsRef<str> for Str {
 impl AsRef<CStr> for Str {
     #[inline]
     fn as_ref(&self) -> &CStr {
-        // Use `self.0.as_bytes()` to access the inner str directly, which
-        // includes the nul terminator. Using `self.as_bytes()` would go through
-        // `Deref` which strips the nul byte, violating the safety contract of
+        // Access the inner str directly via `self.0.as_bytes()` so the nul
+        // terminator is included. `self.as_bytes()` would go through `Deref`,
+        // which strips the nul byte and would violate the safety contract of
         // `CStr::from_bytes_with_nul_unchecked`.
         unsafe { CStr::from_bytes_with_nul_unchecked(self.0.as_bytes()) }
     }
@@ -154,5 +154,36 @@ impl probe::Arg for &Str {
     #[inline]
     fn into_usdt(self) -> isize {
         self.0.as_ptr() as _
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::ffi::CStr;
+
+    /// Ensures `AsRef<CStr>` returns a CStr whose bytes match the source string and whose nul terminator is preserved.
+    #[test]
+    fn str_as_cstr_is_valid() {
+        let s = Str::new("hello\0");
+        let c: &CStr = s.as_ref();
+        assert_eq!(c.to_bytes(), b"hello");
+        assert_eq!(c.to_bytes_with_nul(), b"hello\0");
+    }
+
+    #[test]
+    fn str_deref_excludes_nul() {
+        let s = Str::new("hello\0");
+        let deref: &str = s;
+        assert_eq!(deref, "hello");
+        // Ensure as_bytes via Deref does not include the nul
+        assert_eq!(s.as_bytes(), b"hello");
+    }
+
+    #[test]
+    fn str_as_ref_str_excludes_nul() {
+        let s = Str::new("test\0");
+        let r: &str = s.as_ref();
+        assert_eq!(r, "test");
     }
 }


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

This PR fixes an undefined behavior in s2n-quic-core's Str to CStr conversion. The `Str` type wraps a nul-terminated string and implements `Deref<Target = str>` by stripping the trailing nul byte (line 130: `&self.0[..len]` where `len = self.0.len() - 1`). The `AsRef<CStr>` implementation at line 145 calls `CStr::from_bytes_with_nul_unchecked(self.as_bytes())`. Because `self.as_bytes()` resolves through auto-deref to `str::as_bytes()` on the deref'd value (which has the nul byte stripped), the resulting byte slice does not contain a nul terminator. Passing non-nul-terminated bytes to `CStr::from_bytes_with_nul_unchecked` violates its safety contract and is undefined behavior. The fix is to use `self.0.as_bytes()` to access the inner str directly (which includes the nul byte), bypassing the Deref implementation.

### Call-outs:

N/A

### Testing:

Existing tests should pass.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

