### PR TITLE
feat(dc): Add metrics for current-handshake-period entries

### DIFF
--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -61,7 +61,7 @@ tracing-subscriber = { version = "0.3", features = [
 zerocopy = { version = "0.8", features = ["derive"] }
 zeroize = "1"
 parking_lot = "0.12"
-bitvec = { version = "1.0.1", default-features = false }
+bitvec = { version = "1.1.1", default-features = false }
 nix = {version = "0.31.1", features = ["socket", "uio", "fs", "time"] }
 
 [dev-dependencies]

--- a/dc/s2n-quic-dc/events/map.rs
+++ b/dc/s2n-quic-dc/events/map.rs
@@ -418,6 +418,16 @@ struct PathSecretMapCleanerCycled {
     #[measure("entries.address.utilization.initial", Percent)]
     address_entries_initial_utilization: f32,
 
+    /// The number of Path Secret ID entries created within the last rehandshake period (usually 24
+    /// hours)
+    #[measure("entries.id.in_last_hs_period")]
+    id_entries_in_last_hs_period: usize,
+
+    /// The utilization percentage of Path Secret ID entries created within the last rehandshake
+    /// period (usually 24 hours)
+    #[measure("entries.id.in_last_hs_period.utilization", Percent)]
+    id_entries_in_last_hs_period_utilization: f32,
+
     /// The number of handshake requests that are pending after the cleaning cycle
     #[measure("handshake_requests")]
     handshake_requests: usize,

--- a/dc/s2n-quic-dc/src/event/generated.rs
+++ b/dc/s2n-quic-dc/src/event/generated.rs
@@ -2463,6 +2463,12 @@ pub mod api {
         pub address_entries_utilization: f32,
         /// The utilization percentage of the available number of address entries before the cycle
         pub address_entries_initial_utilization: f32,
+        /// The number of Path Secret ID entries created within the last rehandshake period (usually 24
+        /// hours)
+        pub id_entries_in_last_hs_period: usize,
+        /// The utilization percentage of Path Secret ID entries created within the last rehandshake
+        /// period (usually 24 hours)
+        pub id_entries_in_last_hs_period_utilization: f32,
         /// The number of handshake requests that are pending after the cleaning cycle
         pub handshake_requests: usize,
         /// The number of handshake requests that were skipped in the cycle due to running out of time
@@ -2504,6 +2510,14 @@ pub mod api {
             fmt.field(
                 "address_entries_initial_utilization",
                 &self.address_entries_initial_utilization,
+            );
+            fmt.field(
+                "id_entries_in_last_hs_period",
+                &self.id_entries_in_last_hs_period,
+            );
+            fmt.field(
+                "id_entries_in_last_hs_period_utilization",
+                &self.id_entries_in_last_hs_period_utilization,
             );
             fmt.field("handshake_requests", &self.handshake_requests);
             fmt.field(
@@ -4350,6 +4364,8 @@ pub mod tracing {
                 address_entries_retired,
                 address_entries_utilization,
                 address_entries_initial_utilization,
+                id_entries_in_last_hs_period,
+                id_entries_in_last_hs_period_utilization,
                 handshake_requests,
                 handshake_requests_skipped,
                 handshake_lock_duration,
@@ -4374,6 +4390,10 @@ pub mod tracing {
                 tracing::field::debug(address_entries_utilization),
                 address_entries_initial_utilization =
                 tracing::field::debug(address_entries_initial_utilization),
+                id_entries_in_last_hs_period =
+                tracing::field::debug(id_entries_in_last_hs_period),
+                id_entries_in_last_hs_period_utilization =
+                tracing::field::debug(id_entries_in_last_hs_period_utilization),
                 handshake_requests = tracing::field::debug(handshake_requests),
                 handshake_requests_skipped =
                 tracing::field::debug(handshake_requests_skipped),
@@ -6745,6 +6765,12 @@ pub mod builder {
         pub address_entries_utilization: f32,
         /// The utilization percentage of the available number of address entries before the cycle
         pub address_entries_initial_utilization: f32,
+        /// The number of Path Secret ID entries created within the last rehandshake period (usually 24
+        /// hours)
+        pub id_entries_in_last_hs_period: usize,
+        /// The utilization percentage of Path Secret ID entries created within the last rehandshake
+        /// period (usually 24 hours)
+        pub id_entries_in_last_hs_period_utilization: f32,
         /// The number of handshake requests that are pending after the cleaning cycle
         pub handshake_requests: usize,
         /// The number of handshake requests that were skipped in the cycle due to running out of time
@@ -6772,6 +6798,8 @@ pub mod builder {
                 address_entries_retired,
                 address_entries_utilization,
                 address_entries_initial_utilization,
+                id_entries_in_last_hs_period,
+                id_entries_in_last_hs_period_utilization,
                 handshake_requests,
                 handshake_requests_skipped,
                 handshake_lock_duration,
@@ -6790,6 +6818,9 @@ pub mod builder {
                 address_entries_retired: address_entries_retired.into_event(),
                 address_entries_utilization: address_entries_utilization.into_event(),
                 address_entries_initial_utilization: address_entries_initial_utilization
+                    .into_event(),
+                id_entries_in_last_hs_period: id_entries_in_last_hs_period.into_event(),
+                id_entries_in_last_hs_period_utilization: id_entries_in_last_hs_period_utilization
                     .into_event(),
                 handshake_requests: handshake_requests.into_event(),
                 handshake_requests_skipped: handshake_requests_skipped.into_event(),

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -324,6 +324,8 @@ mod id {
         PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__RETIRED,
         PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION,
         PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL,
+        PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD,
+        PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION,
         PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS,
         PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS__SKIPPED,
         PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_LOCK_DURATION,
@@ -859,6 +861,11 @@ mod id {
         InfoId::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION as usize;
     pub const PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL: usize =
         InfoId::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL as usize;
+    pub const PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD: usize =
+        InfoId::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD as usize;
+    pub const PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION: usize =
+        InfoId::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION
+            as usize;
     pub const PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS: usize =
         InfoId::PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS as usize;
     pub const PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS__SKIPPED: usize =
@@ -1531,6 +1538,8 @@ mod id {
         MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__RETIRED,
         MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION,
         MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL,
+        MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD,
+        MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION,
         MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS,
         MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS__SKIPPED,
         MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_LOCK_DURATION,
@@ -1783,6 +1792,10 @@ mod id {
         usize =
         Measures::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL
             as usize;
+    pub const MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD: usize =
+        Measures::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD as usize;
+    pub const MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION: usize = Measures::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION
+        as usize;
     pub const MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS: usize =
         Measures::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS as usize;
     pub const MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS__SKIPPED: usize =
@@ -1889,7 +1902,7 @@ mod id {
     pub const TIMERS_STREAM_CONNECT_ERROR__LATENCY: usize =
         Timers::TIMERS_STREAM_CONNECT_ERROR__LATENCY as usize;
 }
-static INFO: &[Info; 323usize] = &[
+static INFO: &[Info; 325usize] = &[
     info::Builder {
         id: id::ACCEPTOR_TCP_STARTED,
         name: Str::new("acceptor_tcp_started\0"),
@@ -3733,6 +3746,18 @@ static INFO: &[Info; 323usize] = &[
     }
     .build(),
     info::Builder {
+        id: id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD,
+        name: Str::new("path_secret_map_cleaner_cycled.entries.id.in_last_hs_period\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION,
+        name: Str::new("path_secret_map_cleaner_cycled.entries.id.in_last_hs_period.utilization\0"),
+        units: Units::Percent,
+    }
+    .build(),
+    info::Builder {
         id: id::PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS,
         name: Str::new("path_secret_map_cleaner_cycled.handshake_requests\0"),
         units: Units::None,
@@ -3874,7 +3899,7 @@ pub struct Subscriber<R: Registry> {
     #[allow(dead_code)]
     nominal_counter_offsets: Box<[usize; 35usize]>,
     #[allow(dead_code)]
-    measures: Box<[R::Measure; 128usize]>,
+    measures: Box<[R::Measure; 130usize]>,
     #[allow(dead_code)]
     gauges: Box<[R::Gauge; 0usize]>,
     #[allow(dead_code)]
@@ -3905,7 +3930,7 @@ impl<R: Registry> Subscriber<R> {
         let mut bool_counters = Vec::with_capacity(22usize);
         let mut nominal_counters = Vec::with_capacity(35usize);
         let mut nominal_counter_offsets = Vec::with_capacity(35usize);
-        let mut measures = Vec::with_capacity(128usize);
+        let mut measures = Vec::with_capacity(130usize);
         let mut gauges = Vec::with_capacity(0usize);
         let mut timers = Vec::with_capacity(27usize);
         let mut nominal_timers = Vec::with_capacity(0usize);
@@ -4801,6 +4826,12 @@ impl<R: Registry> Subscriber<R> {
         ));
         measures.push(registry.register_measure(
             &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL],
+        ));
+        measures.push(registry.register_measure(
+            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD],
+        ));
+        measures.push(registry.register_measure(
+            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION],
         ));
         measures.push(
             registry
@@ -6121,6 +6152,18 @@ impl<R: Registry> Subscriber<R> {
                     id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL => {
                         (
                             &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION],
                             entry,
                         )
                     }
@@ -9076,6 +9119,16 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
             id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL,
             id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL,
             event.address_entries_initial_utilization,
+        );
+        self.measure(
+            id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD,
+            id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD,
+            event.id_entries_in_last_hs_period,
+        );
+        self.measure(
+            id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION,
+            id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION,
+            event.id_entries_in_last_hs_period_utilization,
         );
         self.measure(
             id::PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS,

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -320,6 +320,8 @@ mod id {
         PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__RETIRED,
         PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION,
         PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL,
+        PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD,
+        PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION,
         PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS,
         PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS__SKIPPED,
         PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_LOCK_DURATION,
@@ -855,6 +857,11 @@ mod id {
         InfoId::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION as usize;
     pub const PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL: usize =
         InfoId::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL as usize;
+    pub const PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD: usize =
+        InfoId::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD as usize;
+    pub const PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION: usize =
+        InfoId::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION
+            as usize;
     pub const PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS: usize =
         InfoId::PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS as usize;
     pub const PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS__SKIPPED: usize =
@@ -2178,6 +2185,14 @@ mod measure {
                 id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ADDRESS__UTILIZATION__INITIAL => {
                     Self(path_secret_map_cleaner_cycled__entries__address__utilization__initial)
                 }
+                id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD => {
+                    Self(path_secret_map_cleaner_cycled__entries__id__in_last_hs_period)
+                }
+                id::PATH_SECRET_MAP_CLEANER_CYCLED__ENTRIES__ID__IN_LAST_HS_PERIOD__UTILIZATION => {
+                    Self(
+                        path_secret_map_cleaner_cycled__entries__id__in_last_hs_period__utilization,
+                    )
+                }
                 id::PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS => {
                     Self(path_secret_map_cleaner_cycled__handshake_requests)
                 }
@@ -2574,6 +2589,14 @@ mod measure {
             #[link_name =
         s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__address__utilization__initial]
             fn path_secret_map_cleaner_cycled__entries__address__utilization__initial(value: u64);
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__id__in_last_hs_period]
+            fn path_secret_map_cleaner_cycled__entries__id__in_last_hs_period(value: u64);
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__entries__id__in_last_hs_period__utilization]
+            fn path_secret_map_cleaner_cycled__entries__id__in_last_hs_period__utilization(
+                value: u64,
+            );
             #[link_name =
         s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__handshake_requests]
             fn path_secret_map_cleaner_cycled__handshake_requests(value: u64);

--- a/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
@@ -126,6 +126,10 @@ impl Cleaner {
         let address_entries_initial = state.peers.len();
         let mut address_entries_retired = 0usize;
         let mut address_entries_active = 0usize;
+        // Entries created within the last rehandshake period. This tracks how much of the cache
+        // churns over a single rehandshake period, which is useful for understanding capacity
+        // pressure relative to the rate at which we re-handshake peers.
+        let mut id_entries_in_last_hs_period = 0usize;
 
         // We want to avoid taking long lived locks which affect gets on the maps (where we want
         // p100 latency to be in microseconds at most).
@@ -153,6 +157,10 @@ impl Cleaner {
         )]
         let mut rehandshake = state.rehandshake.lock().unwrap();
         let refill_rehandshakes = rehandshake.needs_refill();
+        // Compute the cutoff once (rather than calling `Instant::now()` per entry via `age()`) so
+        // we can cheaply compare each entry's creation timestamp directly. Entries created at or
+        // after this cutoff are considered to have been created within the last rehandshake period.
+        let recent_cutoff = Instant::now().checked_sub(rehandshake.rehandshake_period());
 
         // FIXME: add metrics for queue depth?
         // These are sort of equivalent to the ID map -- so maybe not worth it for now unless we
@@ -162,8 +170,17 @@ impl Cleaner {
                 return false;
             };
 
+            // Entries created within the last rehandshake period. If subtraction underflowed
+            // (period exceeds process uptime), all entries are considered recent.
+            let in_rehandshake_period =
+                recent_cutoff.is_none_or(|cutoff| entry.creation_time() >= cutoff);
+
             if entry.take_accessed_id() {
                 id_entries_active += 1;
+            }
+
+            if in_rehandshake_period {
+                id_entries_in_last_hs_period += 1;
             }
 
             // Avoid double counting by making sure we have unique peer IPs.
@@ -242,6 +259,8 @@ impl Cleaner {
                 address_entries_utilization: utilization(address_entries),
                 address_entries_initial_utilization: utilization(address_entries_initial),
                 address_entries_retired,
+                id_entries_in_last_hs_period,
+                id_entries_in_last_hs_period_utilization: utilization(id_entries_in_last_hs_period),
                 handshake_requests,
                 handshake_requests_skipped,
                 handshake_lock_duration,

--- a/dc/s2n-quic-dc/src/path/secret/map/entry.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/entry.rs
@@ -285,6 +285,10 @@ impl Entry {
         self.creation_time.elapsed()
     }
 
+    pub fn creation_time(&self) -> Instant {
+        self.creation_time
+    }
+
     pub fn receiver(&self) -> &receiver::State {
         &self.receiver
     }

--- a/dc/s2n-quic-dc/src/path/secret/map/rehandshake.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/rehandshake.rs
@@ -65,6 +65,10 @@ impl RehandshakeState {
         self.queue.is_empty()
     }
 
+    pub(super) fn rehandshake_period(&self) -> Duration {
+        self.rehandshake_period
+    }
+
     pub(super) fn push(&mut self, peer: SocketAddr) {
         self.queue.push(SocketAddress::from(peer).to_ipv6_mapped());
     }


### PR DESCRIPTION
### Release Summary:

* feat(dc): Add metrics for current-handshake-period entries

### Resolved issues:

This addresses https://github.com/aws/s2n-quic/issues/3100#issuecomment-4672638308 (not the full issue). 

### Description of changes: 

This count should exclude stale peers that are likely permanently gone, where we haven't been able to handshake in >handshake period (either actively as a client or passively as a server). We expect this to be a better metric to configure alarms on, though it'll still have false positives if there's temporary high churn.

### Call-outs:

This intentionally excludes emitting per-address counts as tracking those would require another dedup-by-address table and we don't want to spend extra memory on it.

### Testing:

Not adding extra tests, the condition here is pretty straightforward and this is just a counter.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

