### PR TITLE
chore: ignore RUSTSEC-2022-0104 for structopt in cargo-deny

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -12,7 +12,10 @@ ignore = [
   "RUSTSEC-2024-0370",
   # `ansi_term` is a dependency of `structopt` and only used in s2n-quic-qns and s2n-quic-sim
   # https://github.com/aws/s2n-quic/issues/2324
-  "RUSTSEC-2021-0139"
+  "RUSTSEC-2021-0139",
+  # `structopt` is in maintenance mode and only used in s2n-quic-qns and s2n-quic-sim
+  # https://github.com/aws/s2n-quic/issues/2324
+  "RUSTSEC-2022-0104"
 ]
 
 [bans]


### PR DESCRIPTION
### Release Summary:


### Resolved issues:
Unblocks CI for https://github.com/aws/s2n-quic/pull/3124

### Description of changes: 
The cargo-deny advisories check started [failing](https://github.com/aws/s2n-quic/actions/runs/27983430122/job/82818978399?pr=3124) on RUSTSEC-2022-0104, which flags structopt as unmaintained. structopt is only used by s2n-quic-qns and s2n-quic-sim (both publish = false), so no published crate is affected. This adds the advisory to the ignore list in cargo-deny.toml.

### Call-outs:
Follows the existing pattern for the rest of the structopt chain: #2367 (atty, proc-macro-error) and #1496 (ansi_term). Migrating off structopt is tracked in #2324 and this can be reverted once that is complete but for now this unblocks the release.

### Testing:
Existing CI should pass. The previously failing advisories check passes with this entry; no code or dependency changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

