### PR TITLE
feat(dc): Split out synthetic TLS handshake failures

### DIFF
--- a/dc/s2n-quic-dc/events/acceptor.rs
+++ b/dc/s2n-quic-dc/events/acceptor.rs
@@ -187,6 +187,27 @@ struct AcceptorTcpTlsStreamRejected<'a> {
     error: &'a std::io::Error,
 }
 
+/// Emitted when a synthetic TLS stream is rejected.
+///
+/// These are TLS streams detected as coming from a synthetic source (e.g., scanner for endpoint
+/// compliance). Typically failures here are expected at a much higher rate.
+#[event("acceptor:tcp:tls_synthetic_stream_rejected")]
+#[subject(endpoint)]
+struct AcceptorTcpSyntheticTlsStreamRejected<'a> {
+    /// The address of the packet's sender
+    #[builder(&'a s2n_quic_core::inet::SocketAddress)]
+    remote_address: SocketAddress<'a>,
+
+    /// The amount of time the TCP stream spent on handshaking before being rejected
+    /// since being accepted from the kernel
+    #[timer("sojourn_time")]
+    sojourn_time: core::time::Duration,
+
+    /// The error encountered
+    #[builder(&'a std::io::Error)]
+    error: &'a std::io::Error,
+}
+
 /// Emitted when the TCP acceptor received an invalid initial packet
 #[event("acceptor:tcp:packet_dropped")]
 #[subject(endpoint)]

--- a/dc/s2n-quic-dc/src/event/generated.rs
+++ b/dc/s2n-quic-dc/src/event/generated.rs
@@ -266,6 +266,34 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
+    /// Emitted when a synthetic TLS stream is rejected.
+    ///
+    /// These are TLS streams detected as coming from a synthetic source (e.g., scanner for endpoint
+    /// compliance). Typically failures here are expected at a much higher rate.
+    pub struct AcceptorTcpSyntheticTlsStreamRejected<'a> {
+        /// The address of the packet's sender
+        pub remote_address: SocketAddress<'a>,
+        /// The amount of time the TCP stream spent on handshaking before being rejected
+        /// since being accepted from the kernel
+        pub sojourn_time: core::time::Duration,
+        /// The error encountered
+        pub error: &'a std::io::Error,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl<'a> crate::event::snapshot::Fmt for AcceptorTcpSyntheticTlsStreamRejected<'a> {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("AcceptorTcpSyntheticTlsStreamRejected");
+            fmt.field("remote_address", &self.remote_address);
+            fmt.field("sojourn_time", &self.sojourn_time);
+            fmt.field("error", &self.error);
+            fmt.finish()
+        }
+    }
+    impl<'a> Event for AcceptorTcpSyntheticTlsStreamRejected<'a> {
+        const NAME: &'static str = "acceptor:tcp:tls_synthetic_stream_rejected";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
     /// Emitted when the TCP acceptor received an invalid initial packet
     pub struct AcceptorTcpPacketDropped<'a> {
         /// The address of the packet's sender
@@ -2836,6 +2864,26 @@ pub mod tracing {
             );
         }
         #[inline]
+        fn on_acceptor_tcp_synthetic_tls_stream_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpSyntheticTlsStreamRejected,
+        ) {
+            let parent = self.parent(meta);
+            let api::AcceptorTcpSyntheticTlsStreamRejected {
+                remote_address,
+                sojourn_time,
+                error,
+            } = event;
+            tracing::event!(
+                target : "acceptor_tcp_synthetic_tls_stream_rejected", parent : parent,
+                tracing::Level::DEBUG, { remote_address =
+                tracing::field::debug(remote_address), sojourn_time =
+                tracing::field::debug(sojourn_time), error = tracing::field::debug(error)
+                }
+            );
+        }
+        #[inline]
         fn on_acceptor_tcp_packet_dropped(
             &self,
             meta: &api::EndpointMeta,
@@ -4692,6 +4740,37 @@ pub mod builder {
                 error,
             } = self;
             api::AcceptorTcpTlsStreamRejected {
+                remote_address: remote_address.into_event(),
+                sojourn_time: sojourn_time.into_event(),
+                error: error.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    /// Emitted when a synthetic TLS stream is rejected.
+    ///
+    /// These are TLS streams detected as coming from a synthetic source (e.g., scanner for endpoint
+    /// compliance). Typically failures here are expected at a much higher rate.
+    pub struct AcceptorTcpSyntheticTlsStreamRejected<'a> {
+        /// The address of the packet's sender
+        pub remote_address: &'a s2n_quic_core::inet::SocketAddress,
+        /// The amount of time the TCP stream spent on handshaking before being rejected
+        /// since being accepted from the kernel
+        pub sojourn_time: core::time::Duration,
+        /// The error encountered
+        pub error: &'a std::io::Error,
+    }
+    impl<'a> IntoEvent<api::AcceptorTcpSyntheticTlsStreamRejected<'a>>
+        for AcceptorTcpSyntheticTlsStreamRejected<'a>
+    {
+        #[inline]
+        fn into_event(self) -> api::AcceptorTcpSyntheticTlsStreamRejected<'a> {
+            let AcceptorTcpSyntheticTlsStreamRejected {
+                remote_address,
+                sojourn_time,
+                error,
+            } = self;
+            api::AcceptorTcpSyntheticTlsStreamRejected {
                 remote_address: remote_address.into_event(),
                 sojourn_time: sojourn_time.into_event(),
                 error: error.into_event(),
@@ -7016,6 +7095,16 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
+        ///Called when the `AcceptorTcpSyntheticTlsStreamRejected` event is triggered
+        #[inline]
+        fn on_acceptor_tcp_synthetic_tls_stream_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpSyntheticTlsStreamRejected,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
         ///Called when the `AcceptorTcpPacketDropped` event is triggered
         #[inline]
         fn on_acceptor_tcp_packet_dropped(
@@ -8058,6 +8147,15 @@ mod traits {
                 .on_acceptor_tcp_tls_stream_rejected(meta, event);
         }
         #[inline]
+        fn on_acceptor_tcp_synthetic_tls_stream_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpSyntheticTlsStreamRejected,
+        ) {
+            self.as_ref()
+                .on_acceptor_tcp_synthetic_tls_stream_rejected(meta, event);
+        }
+        #[inline]
         fn on_acceptor_tcp_packet_dropped(
             &self,
             meta: &api::EndpointMeta,
@@ -8932,6 +9030,15 @@ mod traits {
             (self.1).on_acceptor_tcp_tls_stream_rejected(meta, event);
         }
         #[inline]
+        fn on_acceptor_tcp_synthetic_tls_stream_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpSyntheticTlsStreamRejected,
+        ) {
+            (self.0).on_acceptor_tcp_synthetic_tls_stream_rejected(meta, event);
+            (self.1).on_acceptor_tcp_synthetic_tls_stream_rejected(meta, event);
+        }
+        #[inline]
         fn on_acceptor_tcp_packet_dropped(
             &self,
             meta: &api::EndpointMeta,
@@ -9784,6 +9891,11 @@ mod traits {
         fn on_acceptor_tcp_tls_stream_enqueued(&self, event: builder::AcceptorTcpTlsStreamEnqueued);
         ///Publishes a `AcceptorTcpTlsStreamRejected` event to the publisher's subscriber
         fn on_acceptor_tcp_tls_stream_rejected(&self, event: builder::AcceptorTcpTlsStreamRejected);
+        ///Publishes a `AcceptorTcpSyntheticTlsStreamRejected` event to the publisher's subscriber
+        fn on_acceptor_tcp_synthetic_tls_stream_rejected(
+            &self,
+            event: builder::AcceptorTcpSyntheticTlsStreamRejected,
+        );
         ///Publishes a `AcceptorTcpPacketDropped` event to the publisher's subscriber
         fn on_acceptor_tcp_packet_dropped(&self, event: builder::AcceptorTcpPacketDropped);
         ///Publishes a `AcceptorTcpStreamEnqueued` event to the publisher's subscriber
@@ -10035,6 +10147,16 @@ mod traits {
             let event = event.into_event();
             self.subscriber
                 .on_acceptor_tcp_tls_stream_rejected(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_acceptor_tcp_synthetic_tls_stream_rejected(
+            &self,
+            event: builder::AcceptorTcpSyntheticTlsStreamRejected,
+        ) {
+            let event = event.into_event();
+            self.subscriber
+                .on_acceptor_tcp_synthetic_tls_stream_rejected(&self.meta, &event);
             self.subscriber.on_event(&self.meta, &event);
         }
         #[inline]
@@ -10900,6 +11022,7 @@ pub mod testing {
             pub acceptor_tcp_tls_started: AtomicU64,
             pub acceptor_tcp_tls_stream_enqueued: AtomicU64,
             pub acceptor_tcp_tls_stream_rejected: AtomicU64,
+            pub acceptor_tcp_synthetic_tls_stream_rejected: AtomicU64,
             pub acceptor_tcp_packet_dropped: AtomicU64,
             pub acceptor_tcp_stream_enqueued: AtomicU64,
             pub acceptor_tcp_io_error: AtomicU64,
@@ -10995,6 +11118,7 @@ pub mod testing {
                     acceptor_tcp_tls_started: AtomicU64::new(0),
                     acceptor_tcp_tls_stream_enqueued: AtomicU64::new(0),
                     acceptor_tcp_tls_stream_rejected: AtomicU64::new(0),
+                    acceptor_tcp_synthetic_tls_stream_rejected: AtomicU64::new(0),
                     acceptor_tcp_packet_dropped: AtomicU64::new(0),
                     acceptor_tcp_stream_enqueued: AtomicU64::new(0),
                     acceptor_tcp_io_error: AtomicU64::new(0),
@@ -11173,6 +11297,18 @@ pub mod testing {
                 event: &api::AcceptorTcpTlsStreamRejected,
             ) {
                 self.acceptor_tcp_tls_stream_rejected
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
+            fn on_acceptor_tcp_synthetic_tls_stream_rejected(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::AcceptorTcpSyntheticTlsStreamRejected,
+            ) {
+                self.acceptor_tcp_synthetic_tls_stream_rejected
                     .fetch_add(1, Ordering::Relaxed);
                 let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
                 let event = crate::event::snapshot::Fmt::to_snapshot(event);
@@ -11823,6 +11959,7 @@ pub mod testing {
         pub acceptor_tcp_tls_started: AtomicU64,
         pub acceptor_tcp_tls_stream_enqueued: AtomicU64,
         pub acceptor_tcp_tls_stream_rejected: AtomicU64,
+        pub acceptor_tcp_synthetic_tls_stream_rejected: AtomicU64,
         pub acceptor_tcp_packet_dropped: AtomicU64,
         pub acceptor_tcp_stream_enqueued: AtomicU64,
         pub acceptor_tcp_io_error: AtomicU64,
@@ -11951,6 +12088,7 @@ pub mod testing {
                 acceptor_tcp_tls_started: AtomicU64::new(0),
                 acceptor_tcp_tls_stream_enqueued: AtomicU64::new(0),
                 acceptor_tcp_tls_stream_rejected: AtomicU64::new(0),
+                acceptor_tcp_synthetic_tls_stream_rejected: AtomicU64::new(0),
                 acceptor_tcp_packet_dropped: AtomicU64::new(0),
                 acceptor_tcp_stream_enqueued: AtomicU64::new(0),
                 acceptor_tcp_io_error: AtomicU64::new(0),
@@ -12162,6 +12300,18 @@ pub mod testing {
             event: &api::AcceptorTcpTlsStreamRejected,
         ) {
             self.acceptor_tcp_tls_stream_rejected
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_synthetic_tls_stream_rejected(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::AcceptorTcpSyntheticTlsStreamRejected,
+        ) {
+            self.acceptor_tcp_synthetic_tls_stream_rejected
                 .fetch_add(1, Ordering::Relaxed);
             let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
             let event = crate::event::snapshot::Fmt::to_snapshot(event);
@@ -13280,6 +13430,7 @@ pub mod testing {
         pub acceptor_tcp_tls_started: AtomicU64,
         pub acceptor_tcp_tls_stream_enqueued: AtomicU64,
         pub acceptor_tcp_tls_stream_rejected: AtomicU64,
+        pub acceptor_tcp_synthetic_tls_stream_rejected: AtomicU64,
         pub acceptor_tcp_packet_dropped: AtomicU64,
         pub acceptor_tcp_stream_enqueued: AtomicU64,
         pub acceptor_tcp_io_error: AtomicU64,
@@ -13398,6 +13549,7 @@ pub mod testing {
                 acceptor_tcp_tls_started: AtomicU64::new(0),
                 acceptor_tcp_tls_stream_enqueued: AtomicU64::new(0),
                 acceptor_tcp_tls_stream_rejected: AtomicU64::new(0),
+                acceptor_tcp_synthetic_tls_stream_rejected: AtomicU64::new(0),
                 acceptor_tcp_packet_dropped: AtomicU64::new(0),
                 acceptor_tcp_stream_enqueued: AtomicU64::new(0),
                 acceptor_tcp_io_error: AtomicU64::new(0),
@@ -13574,6 +13726,17 @@ pub mod testing {
             event: builder::AcceptorTcpTlsStreamRejected,
         ) {
             self.acceptor_tcp_tls_stream_rejected
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_acceptor_tcp_synthetic_tls_stream_rejected(
+            &self,
+            event: builder::AcceptorTcpSyntheticTlsStreamRejected,
+        ) {
+            self.acceptor_tcp_synthetic_tls_stream_rejected
                 .fetch_add(1, Ordering::Relaxed);
             let event = event.into_event();
             let event = crate::event::snapshot::Fmt::to_snapshot(&event);

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -46,6 +46,8 @@ mod id {
         ACCEPTOR_TCP_TLS_STREAM_ENQUEUED__SOJOURN_TIME,
         ACCEPTOR_TCP_TLS_STREAM_REJECTED,
         ACCEPTOR_TCP_TLS_STREAM_REJECTED__SOJOURN_TIME,
+        ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED,
+        ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME,
         ACCEPTOR_TCP_PACKET_DROPPED,
         ACCEPTOR_TCP_PACKET_DROPPED__REASON,
         ACCEPTOR_TCP_PACKET_DROPPED__SOJOURN_TIME,
@@ -392,6 +394,10 @@ mod id {
         InfoId::ACCEPTOR_TCP_TLS_STREAM_REJECTED as usize;
     pub const ACCEPTOR_TCP_TLS_STREAM_REJECTED__SOJOURN_TIME: usize =
         InfoId::ACCEPTOR_TCP_TLS_STREAM_REJECTED__SOJOURN_TIME as usize;
+    pub const ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED: usize =
+        InfoId::ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED as usize;
+    pub const ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME: usize =
+        InfoId::ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME as usize;
     pub const ACCEPTOR_TCP_PACKET_DROPPED: usize = InfoId::ACCEPTOR_TCP_PACKET_DROPPED as usize;
     pub const ACCEPTOR_TCP_PACKET_DROPPED__REASON: usize =
         InfoId::ACCEPTOR_TCP_PACKET_DROPPED__REASON as usize;
@@ -903,6 +909,7 @@ mod id {
         COUNTERS_ACCEPTOR_TCP_TLS_STARTED,
         COUNTERS_ACCEPTOR_TCP_TLS_STREAM_ENQUEUED,
         COUNTERS_ACCEPTOR_TCP_TLS_STREAM_REJECTED,
+        COUNTERS_ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED,
         COUNTERS_ACCEPTOR_TCP_PACKET_DROPPED,
         COUNTERS_ACCEPTOR_TCP_STREAM_ENQUEUED,
         COUNTERS_ACCEPTOR_TCP_IO_ERROR,
@@ -1025,6 +1032,8 @@ mod id {
         Counters::COUNTERS_ACCEPTOR_TCP_TLS_STREAM_ENQUEUED as usize;
     pub const COUNTERS_ACCEPTOR_TCP_TLS_STREAM_REJECTED: usize =
         Counters::COUNTERS_ACCEPTOR_TCP_TLS_STREAM_REJECTED as usize;
+    pub const COUNTERS_ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED: usize =
+        Counters::COUNTERS_ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED as usize;
     pub const COUNTERS_ACCEPTOR_TCP_PACKET_DROPPED: usize =
         Counters::COUNTERS_ACCEPTOR_TCP_PACKET_DROPPED as usize;
     pub const COUNTERS_ACCEPTOR_TCP_STREAM_ENQUEUED: usize =
@@ -1812,6 +1821,7 @@ mod id {
         TIMERS_ACCEPTOR_TCP_TLS_STARTED__SOJOURN_TIME,
         TIMERS_ACCEPTOR_TCP_TLS_STREAM_ENQUEUED__SOJOURN_TIME,
         TIMERS_ACCEPTOR_TCP_TLS_STREAM_REJECTED__SOJOURN_TIME,
+        TIMERS_ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME,
         TIMERS_ACCEPTOR_TCP_PACKET_DROPPED__SOJOURN_TIME,
         TIMERS_ACCEPTOR_TCP_STREAM_ENQUEUED__SOJOURN_TIME,
         TIMERS_ACCEPTOR_TCP_SOCKET_SENT__SOJOURN_TIME,
@@ -1846,6 +1856,8 @@ mod id {
         Timers::TIMERS_ACCEPTOR_TCP_TLS_STREAM_ENQUEUED__SOJOURN_TIME as usize;
     pub const TIMERS_ACCEPTOR_TCP_TLS_STREAM_REJECTED__SOJOURN_TIME: usize =
         Timers::TIMERS_ACCEPTOR_TCP_TLS_STREAM_REJECTED__SOJOURN_TIME as usize;
+    pub const TIMERS_ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME: usize =
+        Timers::TIMERS_ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME as usize;
     pub const TIMERS_ACCEPTOR_TCP_PACKET_DROPPED__SOJOURN_TIME: usize =
         Timers::TIMERS_ACCEPTOR_TCP_PACKET_DROPPED__SOJOURN_TIME as usize;
     pub const TIMERS_ACCEPTOR_TCP_STREAM_ENQUEUED__SOJOURN_TIME: usize =
@@ -1889,7 +1901,7 @@ mod id {
     pub const TIMERS_STREAM_CONNECT_ERROR__LATENCY: usize =
         Timers::TIMERS_STREAM_CONNECT_ERROR__LATENCY as usize;
 }
-static INFO: &[Info; 323usize] = &[
+static INFO: &[Info; 325usize] = &[
     info::Builder {
         id: id::ACCEPTOR_TCP_STARTED,
         name: Str::new("acceptor_tcp_started\0"),
@@ -2061,6 +2073,18 @@ static INFO: &[Info; 323usize] = &[
     info::Builder {
         id: id::ACCEPTOR_TCP_TLS_STREAM_REJECTED__SOJOURN_TIME,
         name: Str::new("acceptor_tcp_tls_stream_rejected.sojourn_time\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
+        id: id::ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED,
+        name: Str::new("acceptor_tcp_synthetic_tls_stream_rejected\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: id::ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME,
+        name: Str::new("acceptor_tcp_synthetic_tls_stream_rejected.sojourn_time\0"),
         units: Units::Duration,
     }
     .build(),
@@ -3866,7 +3890,7 @@ pub struct ConnectionContext {
 }
 pub struct Subscriber<R: Registry> {
     #[allow(dead_code)]
-    counters: Box<[R::Counter; 111usize]>,
+    counters: Box<[R::Counter; 112usize]>,
     #[allow(dead_code)]
     bool_counters: Box<[R::BoolCounter; 22usize]>,
     #[allow(dead_code)]
@@ -3878,7 +3902,7 @@ pub struct Subscriber<R: Registry> {
     #[allow(dead_code)]
     gauges: Box<[R::Gauge; 0usize]>,
     #[allow(dead_code)]
-    timers: Box<[R::Timer; 27usize]>,
+    timers: Box<[R::Timer; 28usize]>,
     #[allow(dead_code)]
     nominal_timers: Box<[R::NominalTimer]>,
     #[allow(dead_code)]
@@ -3901,13 +3925,13 @@ impl<R: Registry> Subscriber<R> {
     #[allow(unused_mut)]
     #[inline]
     pub fn new(registry: R) -> Self {
-        let mut counters = Vec::with_capacity(111usize);
+        let mut counters = Vec::with_capacity(112usize);
         let mut bool_counters = Vec::with_capacity(22usize);
         let mut nominal_counters = Vec::with_capacity(35usize);
         let mut nominal_counter_offsets = Vec::with_capacity(35usize);
         let mut measures = Vec::with_capacity(128usize);
         let mut gauges = Vec::with_capacity(0usize);
-        let mut timers = Vec::with_capacity(27usize);
+        let mut timers = Vec::with_capacity(28usize);
         let mut nominal_timers = Vec::with_capacity(0usize);
         let mut nominal_timer_offsets = Vec::with_capacity(0usize);
         counters.push(registry.register_counter(&INFO[id::ACCEPTOR_TCP_STARTED]));
@@ -3920,6 +3944,8 @@ impl<R: Registry> Subscriber<R> {
         counters.push(registry.register_counter(&INFO[id::ACCEPTOR_TCP_TLS_STARTED]));
         counters.push(registry.register_counter(&INFO[id::ACCEPTOR_TCP_TLS_STREAM_ENQUEUED]));
         counters.push(registry.register_counter(&INFO[id::ACCEPTOR_TCP_TLS_STREAM_REJECTED]));
+        counters
+            .push(registry.register_counter(&INFO[id::ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED]));
         counters.push(registry.register_counter(&INFO[id::ACCEPTOR_TCP_PACKET_DROPPED]));
         counters.push(registry.register_counter(&INFO[id::ACCEPTOR_TCP_STREAM_ENQUEUED]));
         counters.push(registry.register_counter(&INFO[id::ACCEPTOR_TCP_IO_ERROR]));
@@ -4846,6 +4872,11 @@ impl<R: Registry> Subscriber<R> {
         timers.push(
             registry.register_timer(&INFO[id::ACCEPTOR_TCP_TLS_STREAM_REJECTED__SOJOURN_TIME]),
         );
+        timers.push(
+            registry.register_timer(
+                &INFO[id::ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME],
+            ),
+        );
         timers.push(registry.register_timer(&INFO[id::ACCEPTOR_TCP_PACKET_DROPPED__SOJOURN_TIME]));
         timers.push(registry.register_timer(&INFO[id::ACCEPTOR_TCP_STREAM_ENQUEUED__SOJOURN_TIME]));
         timers.push(registry.register_timer(&INFO[id::ACCEPTOR_TCP_SOCKET_SENT__SOJOURN_TIME]));
@@ -4930,6 +4961,9 @@ impl<R: Registry> Subscriber<R> {
                 }
                 id::COUNTERS_ACCEPTOR_TCP_TLS_STREAM_REJECTED => {
                     (&INFO[id::ACCEPTOR_TCP_TLS_STREAM_REJECTED], entry)
+                }
+                id::COUNTERS_ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED => {
+                    (&INFO[id::ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED], entry)
                 }
                 id::COUNTERS_ACCEPTOR_TCP_PACKET_DROPPED => {
                     (&INFO[id::ACCEPTOR_TCP_PACKET_DROPPED], entry)
@@ -6217,6 +6251,10 @@ impl<R: Registry> Subscriber<R> {
                     &INFO[id::ACCEPTOR_TCP_TLS_STREAM_REJECTED__SOJOURN_TIME],
                     entry,
                 ),
+                id::TIMERS_ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME => (
+                    &INFO[id::ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME],
+                    entry,
+                ),
                 id::TIMERS_ACCEPTOR_TCP_PACKET_DROPPED__SOJOURN_TIME => {
                     (&INFO[id::ACCEPTOR_TCP_PACKET_DROPPED__SOJOURN_TIME], entry)
                 }
@@ -6594,6 +6632,27 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
         self.time(
             id::ACCEPTOR_TCP_TLS_STREAM_REJECTED__SOJOURN_TIME,
             id::TIMERS_ACCEPTOR_TCP_TLS_STREAM_REJECTED__SOJOURN_TIME,
+            event.sojourn_time,
+        );
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_acceptor_tcp_synthetic_tls_stream_rejected(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::AcceptorTcpSyntheticTlsStreamRejected,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(
+            id::ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED,
+            id::COUNTERS_ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED,
+            1usize,
+        );
+        self.time(
+            id::ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME,
+            id::TIMERS_ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME,
             event.sojourn_time,
         );
         let _ = event;

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -42,6 +42,8 @@ mod id {
         ACCEPTOR_TCP_TLS_STREAM_ENQUEUED__SOJOURN_TIME,
         ACCEPTOR_TCP_TLS_STREAM_REJECTED,
         ACCEPTOR_TCP_TLS_STREAM_REJECTED__SOJOURN_TIME,
+        ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED,
+        ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME,
         ACCEPTOR_TCP_PACKET_DROPPED,
         ACCEPTOR_TCP_PACKET_DROPPED__REASON,
         ACCEPTOR_TCP_PACKET_DROPPED__SOJOURN_TIME,
@@ -388,6 +390,10 @@ mod id {
         InfoId::ACCEPTOR_TCP_TLS_STREAM_REJECTED as usize;
     pub const ACCEPTOR_TCP_TLS_STREAM_REJECTED__SOJOURN_TIME: usize =
         InfoId::ACCEPTOR_TCP_TLS_STREAM_REJECTED__SOJOURN_TIME as usize;
+    pub const ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED: usize =
+        InfoId::ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED as usize;
+    pub const ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME: usize =
+        InfoId::ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME as usize;
     pub const ACCEPTOR_TCP_PACKET_DROPPED: usize = InfoId::ACCEPTOR_TCP_PACKET_DROPPED as usize;
     pub const ACCEPTOR_TCP_PACKET_DROPPED__REASON: usize =
         InfoId::ACCEPTOR_TCP_PACKET_DROPPED__REASON as usize;
@@ -907,6 +913,9 @@ mod counter {
                 id::ACCEPTOR_TCP_TLS_STARTED => Self(acceptor_tcp_tls_started),
                 id::ACCEPTOR_TCP_TLS_STREAM_ENQUEUED => Self(acceptor_tcp_tls_stream_enqueued),
                 id::ACCEPTOR_TCP_TLS_STREAM_REJECTED => Self(acceptor_tcp_tls_stream_rejected),
+                id::ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED => {
+                    Self(acceptor_tcp_synthetic_tls_stream_rejected)
+                }
                 id::ACCEPTOR_TCP_PACKET_DROPPED => Self(acceptor_tcp_packet_dropped),
                 id::ACCEPTOR_TCP_STREAM_ENQUEUED => Self(acceptor_tcp_stream_enqueued),
                 id::ACCEPTOR_TCP_IO_ERROR => Self(acceptor_tcp_io_error),
@@ -1094,6 +1103,9 @@ mod counter {
             #[link_name =
         s2n_quic_dc__event__counter__acceptor_tcp_tls_stream_rejected]
             fn acceptor_tcp_tls_stream_rejected(value: u64);
+            #[link_name =
+        s2n_quic_dc__event__counter__acceptor_tcp_synthetic_tls_stream_rejected]
+            fn acceptor_tcp_synthetic_tls_stream_rejected(value: u64);
             #[link_name =
         s2n_quic_dc__event__counter__acceptor_tcp_packet_dropped]
             fn acceptor_tcp_packet_dropped(value: u64);
@@ -2649,6 +2661,9 @@ mod timer {
                 id::ACCEPTOR_TCP_TLS_STREAM_REJECTED__SOJOURN_TIME => {
                     Self(acceptor_tcp_tls_stream_rejected__sojourn_time)
                 }
+                id::ACCEPTOR_TCP_SYNTHETIC_TLS_STREAM_REJECTED__SOJOURN_TIME => {
+                    Self(acceptor_tcp_synthetic_tls_stream_rejected__sojourn_time)
+                }
                 id::ACCEPTOR_TCP_PACKET_DROPPED__SOJOURN_TIME => {
                     Self(acceptor_tcp_packet_dropped__sojourn_time)
                 }
@@ -2714,6 +2729,11 @@ mod timer {
             #[link_name =
         s2n_quic_dc__event__timer__acceptor_tcp_tls_stream_rejected__sojourn_time]
             fn acceptor_tcp_tls_stream_rejected__sojourn_time(value: core::time::Duration);
+            #[link_name =
+        s2n_quic_dc__event__timer__acceptor_tcp_synthetic_tls_stream_rejected__sojourn_time]
+            fn acceptor_tcp_synthetic_tls_stream_rejected__sojourn_time(
+                value: core::time::Duration,
+            );
             #[link_name =
         s2n_quic_dc__event__timer__acceptor_tcp_packet_dropped__sojourn_time]
             fn acceptor_tcp_packet_dropped__sojourn_time(value: core::time::Duration);

--- a/dc/s2n-quic-dc/src/stream/server/tokio/tcp/tls.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio/tcp/tls.rs
@@ -193,20 +193,44 @@ where
                 .unwrap_or_else(|_| Err(std::io::Error::from(std::io::ErrorKind::TimedOut)));
 
             if let Err(error) = result {
-                env.endpoint_publisher()
-                    .on_acceptor_tcp_tls_stream_rejected(
-                        event::builder::AcceptorTcpTlsStreamRejected {
-                            remote_address: &remote_addr,
-                            sojourn_time: env
-                                .clock()
-                                .get_time()
-                                .saturating_duration_since(kernel_accept_time),
-                            error: &error,
-                        },
-                    );
+                if error.get_ref().is_some_and(|e| e.is::<Synthetic>()) {
+                    env.endpoint_publisher()
+                        .on_acceptor_tcp_synthetic_tls_stream_rejected(
+                            event::builder::AcceptorTcpSyntheticTlsStreamRejected {
+                                remote_address: &remote_addr,
+                                sojourn_time: env
+                                    .clock()
+                                    .get_time()
+                                    .saturating_duration_since(kernel_accept_time),
+                                error: &error,
+                            },
+                        );
+                } else {
+                    env.endpoint_publisher()
+                        .on_acceptor_tcp_tls_stream_rejected(
+                            event::builder::AcceptorTcpTlsStreamRejected {
+                                remote_address: &remote_addr,
+                                sojourn_time: env
+                                    .clock()
+                                    .get_time()
+                                    .saturating_duration_since(kernel_accept_time),
+                                error: &error,
+                            },
+                        );
+                }
             }
         });
         Ok(())
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+#[error("synthetic failure: {0}")]
+struct Synthetic(#[source] std::io::Error);
+
+impl From<Synthetic> for std::io::Error {
+    fn from(value: Synthetic) -> Self {
+        std::io::Error::new(value.0.kind(), value)
     }
 }
 
@@ -233,7 +257,13 @@ async fn accept_conn<Sub: event::Subscriber + Clone>(
     let mut connection =
         crate::stream::tls::S2nTlsConnection::from_connection(socket.clone(), conn)?;
 
-    connection.negotiate(Some(buffer)).await?;
+    connection.negotiate(Some(buffer)).await.map_err(|e| {
+        if connection.is_synthetic() {
+            std::io::Error::from(Synthetic(e))
+        } else {
+            e
+        }
+    })?;
 
     // The handshake is complete at this point, so the stream should be considered open. Eventually
     // at this point we'll want to export the TLS keys from the connection and add those into the

--- a/dc/s2n-quic-dc/src/stream/tls.rs
+++ b/dc/s2n-quic-dc/src/stream/tls.rs
@@ -314,6 +314,25 @@ impl S2nTlsConnection {
     pub(crate) fn peer_cert_chain(&self) -> Option<&CertificateChain> {
         self.cert_chain.as_ref()
     }
+
+    /// Returns whether this is an inbound connection likely originating from a synthetic caller.
+    ///
+    /// Returns false if we're not sure.
+    pub(crate) fn is_synthetic(&self) -> bool {
+        #[expect(
+            clippy::unwrap_used,
+            reason = "lock is only poisoned if another thread already panicked while holding it"
+        )]
+        let mut guard = self.connection.lock().unwrap();
+        let conn: &mut s2n_tls::connection::Connection = (*guard.0).as_mut();
+        let Ok(ch) = conn.client_hello() else {
+            return false;
+        };
+        let Ok(random) = ch.random() else {
+            return false;
+        };
+        random.starts_with(b"s2n-proctor")
+    }
 }
 
 /// `NegotiateContext` for poll_negotiate.

--- a/dc/s2n-quic-dc/src/stream/tls/test.rs
+++ b/dc/s2n-quic-dc/src/stream/tls/test.rs
@@ -424,6 +424,134 @@ async fn unauthenticated_closure() {
     assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof, "{:?}", err);
 }
 
+/// Appends a single `Extension { uint16 extension_type; opaque extension_data<0..2^16-1> }` to
+/// `extensions`.
+fn push_extension(extensions: &mut Vec<u8>, extension_type: u16, extension_data: &[u8]) {
+    extensions.extend_from_slice(&extension_type.to_be_bytes());
+    extensions.extend_from_slice(&(extension_data.len() as u16).to_be_bytes());
+    extensions.extend_from_slice(extension_data);
+}
+
+/// Builds a single TLS 1.3 ClientHello record carrying the provided 32-byte client random.
+///
+/// The bytes are hand-encoded per RFC 8446 4.1.2:
+///
+/// ```text
+/// struct {
+///     ProtocolVersion legacy_version = 0x0303;    /* TLS v1.2 */
+///     Random random;
+///     opaque legacy_session_id<0..32>;
+///     CipherSuite cipher_suites<2..2^16-2>;
+///     opaque legacy_compression_methods<1..2^8-1>;
+///     Extension extensions<8..2^16-1>;
+/// } ClientHello;
+/// ```
+///
+/// It is a complete enough ClientHello (advertising TLS 1.3, a mutually-supported group, and a
+/// matching key share) that the server proceeds to send a ServerHello rather than a
+/// HelloRetryRequest. That matters because a HelloRetryRequest causes s2n-tls to discard the
+/// parsed ClientHello (and thus the client random that `is_synthetic` reads). The handshake is not
+/// expected to complete -- the peer goes away -- but the client random is recorded along the way.
+fn client_hello_record(random: &[u8; 32]) -> Vec<u8> {
+    // The secp256r1 (NIST P-256) generator point in uncompressed form (0x04 || X || Y). It is a
+    // valid point on the curve, so it serves as a well-formed key_share public key.
+    const SECP256R1_GENERATOR: [u8; 65] = [
+        0x04, 0x6b, 0x17, 0xd1, 0xf2, 0xe1, 0x2c, 0x42, 0x47, 0xf8, 0xbc, 0xe6, 0xe5, 0x63, 0xa4,
+        0x40, 0xf2, 0x77, 0x03, 0x7d, 0x81, 0x2d, 0xeb, 0x33, 0xa0, 0xf4, 0xa1, 0x39, 0x45, 0xd8,
+        0x98, 0xc2, 0x96, 0x4f, 0xe3, 0x42, 0xe2, 0xfe, 0x1a, 0x7f, 0x9b, 0x8e, 0xe7, 0xeb, 0x4a,
+        0x7c, 0x0f, 0x9e, 0x16, 0x2b, 0xce, 0x33, 0x57, 0x6b, 0x31, 0x5e, 0xce, 0xcb, 0xb6, 0x40,
+        0x68, 0x37, 0xbf, 0x51, 0xf5,
+    ];
+    const SECP256R1: u16 = 0x0017;
+
+    let mut extensions = vec![];
+    // supported_versions: advertise TLS 1.3 (0x0304), which is how a TLS 1.3 ClientHello is
+    // identified (the legacy_version below stays at 0x0303).
+    push_extension(&mut extensions, 0x002b, &[0x02, 0x03, 0x04]);
+    // supported_groups: a list of one group, secp256r1.
+    push_extension(&mut extensions, 0x000a, &[0x00, 0x02, 0x00, 0x17]);
+    // signature_algorithms: a list of one scheme, rsa_pss_rsae_sha256 (0x0804). Not actually used
+    // before the ClientHello is recorded, but a well-formed ClientHello carries one.
+    push_extension(&mut extensions, 0x000d, &[0x00, 0x02, 0x08, 0x04]);
+    // key_share: a single KeyShareEntry for secp256r1 carrying the generator point.
+    let mut key_share = vec![];
+    key_share.extend_from_slice(&SECP256R1.to_be_bytes());
+    key_share.extend_from_slice(&(SECP256R1_GENERATOR.len() as u16).to_be_bytes());
+    key_share.extend_from_slice(&SECP256R1_GENERATOR);
+    let mut key_share_ext = (key_share.len() as u16).to_be_bytes().to_vec();
+    key_share_ext.extend_from_slice(&key_share);
+    push_extension(&mut extensions, 0x0033, &key_share_ext);
+
+    // ClientHello body.
+    let mut body = vec![];
+    body.extend_from_slice(&[0x03, 0x03]); // legacy_version = TLS 1.2
+    body.extend_from_slice(random); // Random[32]
+    body.push(0x00); // legacy_session_id: empty (length 0)
+    body.extend_from_slice(&[0x00, 0x02, 0x13, 0x01]); // cipher_suites: len 2, TLS_AES_128_GCM_SHA256
+    body.extend_from_slice(&[0x01, 0x00]); // legacy_compression_methods: len 1, "null"
+    body.extend_from_slice(&(extensions.len() as u16).to_be_bytes());
+    body.extend_from_slice(&extensions);
+
+    // Handshake header: msg_type = client_hello (1), then a uint24 length.
+    let mut handshake = vec![0x01];
+    let len = body.len();
+    handshake.extend_from_slice(&[(len >> 16) as u8, (len >> 8) as u8, len as u8]);
+    handshake.extend_from_slice(&body);
+
+    // Record header: content_type = handshake (22), legacy record version, then a uint16 length.
+    let mut record = vec![0x16, 0x03, 0x01];
+    record.extend_from_slice(&(handshake.len() as u16).to_be_bytes());
+    record.extend_from_slice(&handshake);
+    record
+}
+
+/// Runs the given ClientHello record through a fresh server connection at EOF and reports whether
+/// it is classified as synthetic.
+async fn detect_synthetic(random: &[u8; 32]) -> bool {
+    // A peer that immediately closes, so the handshake reads our buffered ClientHello and then
+    // hits EOF.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        if let Ok((conn, _)) = listener.accept().await {
+            drop(conn);
+        }
+    });
+    let stream = tokio::net::TcpStream::connect(addr).await.unwrap();
+
+    let socket = Arc::new(crate::stream::socket::application::Single(stream));
+    let conn: crate::stream::tls::Conn = Box::new(
+        s2n_tls::connection::Builder::build_connection(
+            &server_config(),
+            s2n_tls::enums::Mode::Server,
+        )
+        .unwrap(),
+    );
+    let mut connection =
+        crate::stream::tls::S2nTlsConnection::from_connection(socket, conn).unwrap();
+
+    let buffer = crate::msg::recv::Message::new_from_packet(client_hello_record(random), addr);
+    // The handshake is expected to fail (we never send a complete handshake / the peer is gone),
+    // but s2n-tls parses and stores the client random first, which is what `is_synthetic` reads.
+    let _ = connection.negotiate(Some(buffer)).await;
+
+    connection.is_synthetic()
+}
+
+#[tokio::test]
+async fn detects_synthetic_client_random() {
+    let mut random = [0u8; 32];
+    random[..b"s2n-proctor".len()].copy_from_slice(b"s2n-proctor");
+    assert!(detect_synthetic(&random).await);
+}
+
+#[tokio::test]
+async fn ignores_non_synthetic_client_random() {
+    // A random without the synthetic marker must not be misclassified.
+    let random = [0x42u8; 32];
+    assert!(!detect_synthetic(&random).await);
+}
+
 #[derive(Clone)]
 struct DummyHandshake {
     hs: crate::psk::server::Provider,


### PR DESCRIPTION
### Release Summary:

* feat(s2n-quic-dc): Split out synthetic TLS handshake failures

### Resolved issues:

n/a

### Description of changes: 

This splits out TLS (not QUIC) handshakes with ClientHello indicating it's synthetic into a separate event 

### Call-outs:

None.

### Testing:

Adds some unit tests which build a fake TLS 1.3 ClientHello to test the synthetic/non-synthetic logic. I also cut https://github.com/aws/s2n-tls/issues/5961 for a suggestion to improve s2n-tls' handling of exposing data from ClientHellos, if that gets implemented we should be able to simplify the test. Claude wrote the ClientHello generation (I didn't look closely at it -- seems like it's good enough to work for the synth/non-synth testing though).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

