### PR TITLE
fix(dc): metrics merge 'conflict'

### DIFF
--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -48,7 +48,7 @@ s2n-codec = { version = "=0.83.0", path = "../../common/s2n-codec", default-feat
 s2n-quic = { version = "=1.83.0", path = "../../quic/s2n-quic", features = ["unstable-provider-connection-close-formatter", "unstable-provider-dc", "unstable-provider-random", "unstable-offload-tls"] }
 s2n-quic-core = { version = "=0.83.0", path = "../../quic/s2n-quic-core", default-features = false }
 s2n-quic-platform = { version = "=0.83.0", path = "../../quic/s2n-quic-platform" }
-s2n-tls = "0.3"
+s2n-tls = "0.3.38"
 slotmap = "1"
 hashbrown = "0.17"
 thiserror = "2"

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -1914,7 +1914,7 @@ mod id {
     pub const TIMERS_STREAM_CONNECT_ERROR__LATENCY: usize =
         Timers::TIMERS_STREAM_CONNECT_ERROR__LATENCY as usize;
 }
-static INFO: &[Info; 325usize] = &[
+static INFO: &[Info; 327usize] = &[
     info::Builder {
         id: id::ACCEPTOR_TCP_STARTED,
         name: Str::new("acceptor_tcp_started\0"),


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

n/a

### Description of changes: 

I think we merged two PRs with similar delta to this constant which resulted in build failures post-merge. Probably need to explore merge queues to avoid that?

This should fix builds on main.

### Call-outs:

n/a

### Testing:

CI + local builds pass.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

