### PR TITLE
feat(dc): Support serializing path secret map socket addrs

### DIFF
--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -78,6 +78,7 @@ s2n-quic-platform = { path = "../../quic/s2n-quic-platform", features = [
 ] }
 tokio = { version = "1", features = ["full", "test-util"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tempfile = "3.27"
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/dc/s2n-quic-dc/events/map.rs
+++ b/dc/s2n-quic-dc/events/map.rs
@@ -447,6 +447,27 @@ struct PathSecretMapCleanerCycled {
     duration: core::time::Duration,
 }
 
+#[event("path_secret_map:serialized")]
+#[subject(endpoint)]
+/// Emitted when the path secret map is serialized to disk
+struct PathSecretMapSerialized {
+    /// The number of entries written to the serialized file
+    #[measure("entries")]
+    entries: usize,
+
+    /// The size of the serialized file, in bytes
+    #[measure("file_size", Bytes)]
+    file_size: usize,
+
+    /// How long serialization took
+    #[measure("duration", Duration)]
+    duration: core::time::Duration,
+
+    /// Whether serialization failed
+    #[bool_counter("error")]
+    error: bool,
+}
+
 #[event("path_secret_map:id_cache_write_lock")]
 #[subject(endpoint)]
 struct PathSecretMapIdWriteLock {

--- a/dc/s2n-quic-dc/src/event/generated.rs
+++ b/dc/s2n-quic-dc/src/event/generated.rs
@@ -2562,6 +2562,33 @@ pub mod api {
     }
     #[derive(Clone, Debug)]
     #[non_exhaustive]
+    /// Emitted when the path secret map is serialized to disk
+    pub struct PathSecretMapSerialized {
+        /// The number of entries written to the serialized file
+        pub entries: usize,
+        /// The size of the serialized file, in bytes
+        pub file_size: usize,
+        /// How long serialization took
+        pub duration: core::time::Duration,
+        /// Whether serialization failed
+        pub error: bool,
+    }
+    #[cfg(any(test, feature = "testing"))]
+    impl crate::event::snapshot::Fmt for PathSecretMapSerialized {
+        fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {
+            let mut fmt = fmt.debug_struct("PathSecretMapSerialized");
+            fmt.field("entries", &self.entries);
+            fmt.field("file_size", &self.file_size);
+            fmt.field("duration", &self.duration);
+            fmt.field("error", &self.error);
+            fmt.finish()
+        }
+    }
+    impl Event for PathSecretMapSerialized {
+        const NAME: &'static str = "path_secret_map:serialized";
+    }
+    #[derive(Clone, Debug)]
+    #[non_exhaustive]
     pub struct PathSecretMapIdWriteLock {
         pub acquire: core::time::Duration,
         pub duration: core::time::Duration,
@@ -4447,6 +4474,26 @@ pub mod tracing {
                 tracing::field::debug(handshake_requests_skipped),
                 handshake_lock_duration = tracing::field::debug(handshake_lock_duration),
                 duration = tracing::field::debug(duration) }
+            );
+        }
+        #[inline]
+        fn on_path_secret_map_serialized(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapSerialized,
+        ) {
+            let parent = self.parent(meta);
+            let api::PathSecretMapSerialized {
+                entries,
+                file_size,
+                duration,
+                error,
+            } = event;
+            tracing::event!(
+                target : "path_secret_map_serialized", parent : parent,
+                tracing::Level::DEBUG, { entries = tracing::field::debug(entries),
+                file_size = tracing::field::debug(file_size), duration =
+                tracing::field::debug(duration), error = tracing::field::debug(error) }
             );
         }
         #[inline]
@@ -6909,6 +6956,35 @@ pub mod builder {
         }
     }
     #[derive(Clone, Debug)]
+    /// Emitted when the path secret map is serialized to disk
+    pub struct PathSecretMapSerialized {
+        /// The number of entries written to the serialized file
+        pub entries: usize,
+        /// The size of the serialized file, in bytes
+        pub file_size: usize,
+        /// How long serialization took
+        pub duration: core::time::Duration,
+        /// Whether serialization failed
+        pub error: bool,
+    }
+    impl IntoEvent<api::PathSecretMapSerialized> for PathSecretMapSerialized {
+        #[inline]
+        fn into_event(self) -> api::PathSecretMapSerialized {
+            let PathSecretMapSerialized {
+                entries,
+                file_size,
+                duration,
+                error,
+            } = self;
+            api::PathSecretMapSerialized {
+                entries: entries.into_event(),
+                file_size: file_size.into_event(),
+                duration: duration.into_event(),
+                error: error.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
     pub struct PathSecretMapIdWriteLock {
         pub acquire: core::time::Duration,
         pub duration: core::time::Duration,
@@ -8016,6 +8092,16 @@ mod traits {
             let _ = meta;
             let _ = event;
         }
+        ///Called when the `PathSecretMapSerialized` event is triggered
+        #[inline]
+        fn on_path_secret_map_serialized(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapSerialized,
+        ) {
+            let _ = meta;
+            let _ = event;
+        }
         ///Called when the `PathSecretMapIdWriteLock` event is triggered
         #[inline]
         fn on_path_secret_map_id_write_lock(
@@ -8901,6 +8987,14 @@ mod traits {
             event: &api::PathSecretMapCleanerCycled,
         ) {
             self.as_ref().on_path_secret_map_cleaner_cycled(meta, event);
+        }
+        #[inline]
+        fn on_path_secret_map_serialized(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapSerialized,
+        ) {
+            self.as_ref().on_path_secret_map_serialized(meta, event);
         }
         #[inline]
         fn on_path_secret_map_id_write_lock(
@@ -9834,6 +9928,15 @@ mod traits {
             (self.1).on_path_secret_map_cleaner_cycled(meta, event);
         }
         #[inline]
+        fn on_path_secret_map_serialized(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapSerialized,
+        ) {
+            (self.0).on_path_secret_map_serialized(meta, event);
+            (self.1).on_path_secret_map_serialized(meta, event);
+        }
+        #[inline]
         fn on_path_secret_map_id_write_lock(
             &self,
             meta: &api::EndpointMeta,
@@ -10057,6 +10160,8 @@ mod traits {
         );
         ///Publishes a `PathSecretMapCleanerCycled` event to the publisher's subscriber
         fn on_path_secret_map_cleaner_cycled(&self, event: builder::PathSecretMapCleanerCycled);
+        ///Publishes a `PathSecretMapSerialized` event to the publisher's subscriber
+        fn on_path_secret_map_serialized(&self, event: builder::PathSecretMapSerialized);
         ///Publishes a `PathSecretMapIdWriteLock` event to the publisher's subscriber
         fn on_path_secret_map_id_write_lock(&self, event: builder::PathSecretMapIdWriteLock);
         ///Publishes a `PathSecretMapAddressWriteLock` event to the publisher's subscriber
@@ -10557,6 +10662,13 @@ mod traits {
             let event = event.into_event();
             self.subscriber
                 .on_path_secret_map_cleaner_cycled(&self.meta, &event);
+            self.subscriber.on_event(&self.meta, &event);
+        }
+        #[inline]
+        fn on_path_secret_map_serialized(&self, event: builder::PathSecretMapSerialized) {
+            let event = event.into_event();
+            self.subscriber
+                .on_path_secret_map_serialized(&self.meta, &event);
             self.subscriber.on_event(&self.meta, &event);
         }
         #[inline]
@@ -11104,6 +11216,7 @@ pub mod testing {
             pub path_secret_map_id_cache_accessed: AtomicU64,
             pub path_secret_map_id_cache_accessed_hit: AtomicU64,
             pub path_secret_map_cleaner_cycled: AtomicU64,
+            pub path_secret_map_serialized: AtomicU64,
             pub path_secret_map_id_write_lock: AtomicU64,
             pub path_secret_map_address_write_lock: AtomicU64,
             pub path_secret_map_datagram_encrypt: AtomicU64,
@@ -11200,6 +11313,7 @@ pub mod testing {
                     path_secret_map_id_cache_accessed: AtomicU64::new(0),
                     path_secret_map_id_cache_accessed_hit: AtomicU64::new(0),
                     path_secret_map_cleaner_cycled: AtomicU64::new(0),
+                    path_secret_map_serialized: AtomicU64::new(0),
                     path_secret_map_id_write_lock: AtomicU64::new(0),
                     path_secret_map_address_write_lock: AtomicU64::new(0),
                     path_secret_map_datagram_encrypt: AtomicU64::new(0),
@@ -11926,6 +12040,18 @@ pub mod testing {
                 let out = format!("{meta:?} {event:?}");
                 self.output.lock().unwrap().push(out);
             }
+            fn on_path_secret_map_serialized(
+                &self,
+                meta: &api::EndpointMeta,
+                event: &api::PathSecretMapSerialized,
+            ) {
+                self.path_secret_map_serialized
+                    .fetch_add(1, Ordering::Relaxed);
+                let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+                let event = crate::event::snapshot::Fmt::to_snapshot(event);
+                let out = format!("{meta:?} {event:?}");
+                self.output.lock().unwrap().push(out);
+            }
             fn on_path_secret_map_id_write_lock(
                 &self,
                 meta: &api::EndpointMeta,
@@ -12074,6 +12200,7 @@ pub mod testing {
         pub path_secret_map_id_cache_accessed: AtomicU64,
         pub path_secret_map_id_cache_accessed_hit: AtomicU64,
         pub path_secret_map_cleaner_cycled: AtomicU64,
+        pub path_secret_map_serialized: AtomicU64,
         pub path_secret_map_id_write_lock: AtomicU64,
         pub path_secret_map_address_write_lock: AtomicU64,
         pub path_secret_map_datagram_encrypt: AtomicU64,
@@ -12203,6 +12330,7 @@ pub mod testing {
                 path_secret_map_id_cache_accessed: AtomicU64::new(0),
                 path_secret_map_id_cache_accessed_hit: AtomicU64::new(0),
                 path_secret_map_cleaner_cycled: AtomicU64::new(0),
+                path_secret_map_serialized: AtomicU64::new(0),
                 path_secret_map_id_write_lock: AtomicU64::new(0),
                 path_secret_map_address_write_lock: AtomicU64::new(0),
                 path_secret_map_datagram_encrypt: AtomicU64::new(0),
@@ -13398,6 +13526,18 @@ pub mod testing {
             let out = format!("{meta:?} {event:?}");
             self.output.lock().unwrap().push(out);
         }
+        fn on_path_secret_map_serialized(
+            &self,
+            meta: &api::EndpointMeta,
+            event: &api::PathSecretMapSerialized,
+        ) {
+            self.path_secret_map_serialized
+                .fetch_add(1, Ordering::Relaxed);
+            let meta = crate::event::snapshot::Fmt::to_snapshot(meta);
+            let event = crate::event::snapshot::Fmt::to_snapshot(event);
+            let out = format!("{meta:?} {event:?}");
+            self.output.lock().unwrap().push(out);
+        }
         fn on_path_secret_map_id_write_lock(
             &self,
             meta: &api::EndpointMeta,
@@ -13545,6 +13685,7 @@ pub mod testing {
         pub path_secret_map_id_cache_accessed: AtomicU64,
         pub path_secret_map_id_cache_accessed_hit: AtomicU64,
         pub path_secret_map_cleaner_cycled: AtomicU64,
+        pub path_secret_map_serialized: AtomicU64,
         pub path_secret_map_id_write_lock: AtomicU64,
         pub path_secret_map_address_write_lock: AtomicU64,
         pub path_secret_map_datagram_encrypt: AtomicU64,
@@ -13664,6 +13805,7 @@ pub mod testing {
                 path_secret_map_id_cache_accessed: AtomicU64::new(0),
                 path_secret_map_id_cache_accessed_hit: AtomicU64::new(0),
                 path_secret_map_cleaner_cycled: AtomicU64::new(0),
+                path_secret_map_serialized: AtomicU64::new(0),
                 path_secret_map_id_write_lock: AtomicU64::new(0),
                 path_secret_map_address_write_lock: AtomicU64::new(0),
                 path_secret_map_datagram_encrypt: AtomicU64::new(0),
@@ -14186,6 +14328,14 @@ pub mod testing {
         }
         fn on_path_secret_map_cleaner_cycled(&self, event: builder::PathSecretMapCleanerCycled) {
             self.path_secret_map_cleaner_cycled
+                .fetch_add(1, Ordering::Relaxed);
+            let event = event.into_event();
+            let event = crate::event::snapshot::Fmt::to_snapshot(&event);
+            let out = format!("{event:?}");
+            self.output.lock().unwrap().push(out);
+        }
+        fn on_path_secret_map_serialized(&self, event: builder::PathSecretMapSerialized) {
+            self.path_secret_map_serialized
                 .fetch_add(1, Ordering::Relaxed);
             let event = event.into_event();
             let event = crate::event::snapshot::Fmt::to_snapshot(&event);

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -332,6 +332,11 @@ mod id {
         PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS__SKIPPED,
         PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_LOCK_DURATION,
         PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION,
+        PATH_SECRET_MAP_SERIALIZED,
+        PATH_SECRET_MAP_SERIALIZED__ENTRIES,
+        PATH_SECRET_MAP_SERIALIZED__FILE_SIZE,
+        PATH_SECRET_MAP_SERIALIZED__DURATION,
+        PATH_SECRET_MAP_SERIALIZED__ERROR,
         PATH_SECRET_MAP_ID_WRITE_LOCK,
         PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE,
         PATH_SECRET_MAP_ID_WRITE_LOCK__DURATION,
@@ -880,6 +885,15 @@ mod id {
         InfoId::PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_LOCK_DURATION as usize;
     pub const PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION: usize =
         InfoId::PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION as usize;
+    pub const PATH_SECRET_MAP_SERIALIZED: usize = InfoId::PATH_SECRET_MAP_SERIALIZED as usize;
+    pub const PATH_SECRET_MAP_SERIALIZED__ENTRIES: usize =
+        InfoId::PATH_SECRET_MAP_SERIALIZED__ENTRIES as usize;
+    pub const PATH_SECRET_MAP_SERIALIZED__FILE_SIZE: usize =
+        InfoId::PATH_SECRET_MAP_SERIALIZED__FILE_SIZE as usize;
+    pub const PATH_SECRET_MAP_SERIALIZED__DURATION: usize =
+        InfoId::PATH_SECRET_MAP_SERIALIZED__DURATION as usize;
+    pub const PATH_SECRET_MAP_SERIALIZED__ERROR: usize =
+        InfoId::PATH_SECRET_MAP_SERIALIZED__ERROR as usize;
     pub const PATH_SECRET_MAP_ID_WRITE_LOCK: usize = InfoId::PATH_SECRET_MAP_ID_WRITE_LOCK as usize;
     pub const PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE: usize =
         InfoId::PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE as usize;
@@ -1012,6 +1026,7 @@ mod id {
         COUNTERS_PATH_SECRET_MAP_ID_CACHE_ACCESSED,
         COUNTERS_PATH_SECRET_MAP_ID_CACHE_ACCESSED_HIT,
         COUNTERS_PATH_SECRET_MAP_CLEANER_CYCLED,
+        COUNTERS_PATH_SECRET_MAP_SERIALIZED,
         COUNTERS_PATH_SECRET_MAP_ID_WRITE_LOCK,
         COUNTERS_PATH_SECRET_MAP_ADDRESS_WRITE_LOCK,
         COUNTERS_PATH_SECRET_MAP_DATAGRAM_ENCRYPT,
@@ -1221,6 +1236,8 @@ mod id {
         Counters::COUNTERS_PATH_SECRET_MAP_ID_CACHE_ACCESSED_HIT as usize;
     pub const COUNTERS_PATH_SECRET_MAP_CLEANER_CYCLED: usize =
         Counters::COUNTERS_PATH_SECRET_MAP_CLEANER_CYCLED as usize;
+    pub const COUNTERS_PATH_SECRET_MAP_SERIALIZED: usize =
+        Counters::COUNTERS_PATH_SECRET_MAP_SERIALIZED as usize;
     pub const COUNTERS_PATH_SECRET_MAP_ID_WRITE_LOCK: usize =
         Counters::COUNTERS_PATH_SECRET_MAP_ID_WRITE_LOCK as usize;
     pub const COUNTERS_PATH_SECRET_MAP_ADDRESS_WRITE_LOCK: usize =
@@ -1258,6 +1275,7 @@ mod id {
         BOOL_COUNTERS_ENDPOINT_INITIALIZED__UDP,
         BOOL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__HIT,
         BOOL_COUNTERS_PATH_SECRET_MAP_ID_CACHE_ACCESSED__HIT,
+        BOOL_COUNTERS_PATH_SECRET_MAP_SERIALIZED__ERROR,
     }
     pub const BOOL_COUNTERS_ACCEPTOR_TCP_PACKET_RECEIVED__IS_FIN: usize =
         BoolCounters::BOOL_COUNTERS_ACCEPTOR_TCP_PACKET_RECEIVED__IS_FIN as usize;
@@ -1303,6 +1321,8 @@ mod id {
         BoolCounters::BOOL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__HIT as usize;
     pub const BOOL_COUNTERS_PATH_SECRET_MAP_ID_CACHE_ACCESSED__HIT: usize =
         BoolCounters::BOOL_COUNTERS_PATH_SECRET_MAP_ID_CACHE_ACCESSED__HIT as usize;
+    pub const BOOL_COUNTERS_PATH_SECRET_MAP_SERIALIZED__ERROR: usize =
+        BoolCounters::BOOL_COUNTERS_PATH_SECRET_MAP_SERIALIZED__ERROR as usize;
     #[allow(non_camel_case_types)]
     #[allow(clippy::upper_case_acronyms)]
     enum NominalCounters {
@@ -1553,6 +1573,9 @@ mod id {
         MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS__SKIPPED,
         MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_LOCK_DURATION,
         MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION,
+        MEASURES_PATH_SECRET_MAP_SERIALIZED__ENTRIES,
+        MEASURES_PATH_SECRET_MAP_SERIALIZED__FILE_SIZE,
+        MEASURES_PATH_SECRET_MAP_SERIALIZED__DURATION,
         MEASURES_PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE,
         MEASURES_PATH_SECRET_MAP_ID_WRITE_LOCK__DURATION,
         MEASURES_PATH_SECRET_MAP_ADDRESS_WRITE_LOCK__ACQUIRE,
@@ -1813,6 +1836,12 @@ mod id {
         Measures::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_LOCK_DURATION as usize;
     pub const MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION: usize =
         Measures::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION as usize;
+    pub const MEASURES_PATH_SECRET_MAP_SERIALIZED__ENTRIES: usize =
+        Measures::MEASURES_PATH_SECRET_MAP_SERIALIZED__ENTRIES as usize;
+    pub const MEASURES_PATH_SECRET_MAP_SERIALIZED__FILE_SIZE: usize =
+        Measures::MEASURES_PATH_SECRET_MAP_SERIALIZED__FILE_SIZE as usize;
+    pub const MEASURES_PATH_SECRET_MAP_SERIALIZED__DURATION: usize =
+        Measures::MEASURES_PATH_SECRET_MAP_SERIALIZED__DURATION as usize;
     pub const MEASURES_PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE: usize =
         Measures::MEASURES_PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE as usize;
     pub const MEASURES_PATH_SECRET_MAP_ID_WRITE_LOCK__DURATION: usize =
@@ -1914,7 +1943,7 @@ mod id {
     pub const TIMERS_STREAM_CONNECT_ERROR__LATENCY: usize =
         Timers::TIMERS_STREAM_CONNECT_ERROR__LATENCY as usize;
 }
-static INFO: &[Info; 327usize] = &[
+static INFO: &[Info; 332usize] = &[
     info::Builder {
         id: id::ACCEPTOR_TCP_STARTED,
         name: Str::new("acceptor_tcp_started\0"),
@@ -3806,6 +3835,36 @@ static INFO: &[Info; 327usize] = &[
     }
     .build(),
     info::Builder {
+        id: id::PATH_SECRET_MAP_SERIALIZED,
+        name: Str::new("path_secret_map_serialized\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: id::PATH_SECRET_MAP_SERIALIZED__ENTRIES,
+        name: Str::new("path_secret_map_serialized.entries\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: id::PATH_SECRET_MAP_SERIALIZED__FILE_SIZE,
+        name: Str::new("path_secret_map_serialized.file_size\0"),
+        units: Units::Bytes,
+    }
+    .build(),
+    info::Builder {
+        id: id::PATH_SECRET_MAP_SERIALIZED__DURATION,
+        name: Str::new("path_secret_map_serialized.duration\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
+        id: id::PATH_SECRET_MAP_SERIALIZED__ERROR,
+        name: Str::new("path_secret_map_serialized.error\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
         id: id::PATH_SECRET_MAP_ID_WRITE_LOCK,
         name: Str::new("path_secret_map_id_write_lock\0"),
         units: Units::None,
@@ -3915,15 +3974,15 @@ pub struct ConnectionContext {
 }
 pub struct Subscriber<R: Registry> {
     #[allow(dead_code)]
-    counters: Box<[R::Counter; 112usize]>,
+    counters: Box<[R::Counter; 113usize]>,
     #[allow(dead_code)]
-    bool_counters: Box<[R::BoolCounter; 22usize]>,
+    bool_counters: Box<[R::BoolCounter; 23usize]>,
     #[allow(dead_code)]
     nominal_counters: Box<[R::NominalCounter]>,
     #[allow(dead_code)]
     nominal_counter_offsets: Box<[usize; 35usize]>,
     #[allow(dead_code)]
-    measures: Box<[R::Measure; 130usize]>,
+    measures: Box<[R::Measure; 133usize]>,
     #[allow(dead_code)]
     gauges: Box<[R::Gauge; 0usize]>,
     #[allow(dead_code)]
@@ -3950,11 +4009,11 @@ impl<R: Registry> Subscriber<R> {
     #[allow(unused_mut)]
     #[inline]
     pub fn new(registry: R) -> Self {
-        let mut counters = Vec::with_capacity(112usize);
-        let mut bool_counters = Vec::with_capacity(22usize);
+        let mut counters = Vec::with_capacity(113usize);
+        let mut bool_counters = Vec::with_capacity(23usize);
         let mut nominal_counters = Vec::with_capacity(35usize);
         let mut nominal_counter_offsets = Vec::with_capacity(35usize);
-        let mut measures = Vec::with_capacity(130usize);
+        let mut measures = Vec::with_capacity(133usize);
         let mut gauges = Vec::with_capacity(0usize);
         let mut timers = Vec::with_capacity(28usize);
         let mut nominal_timers = Vec::with_capacity(0usize);
@@ -4083,6 +4142,7 @@ impl<R: Registry> Subscriber<R> {
         counters.push(registry.register_counter(&INFO[id::PATH_SECRET_MAP_ID_CACHE_ACCESSED]));
         counters.push(registry.register_counter(&INFO[id::PATH_SECRET_MAP_ID_CACHE_ACCESSED_HIT]));
         counters.push(registry.register_counter(&INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED]));
+        counters.push(registry.register_counter(&INFO[id::PATH_SECRET_MAP_SERIALIZED]));
         counters.push(registry.register_counter(&INFO[id::PATH_SECRET_MAP_ID_WRITE_LOCK]));
         counters.push(registry.register_counter(&INFO[id::PATH_SECRET_MAP_ADDRESS_WRITE_LOCK]));
         counters.push(registry.register_counter(&INFO[id::PATH_SECRET_MAP_DATAGRAM_ENCRYPT]));
@@ -4147,6 +4207,8 @@ impl<R: Registry> Subscriber<R> {
         bool_counters.push(
             registry.register_bool_counter(&INFO[id::PATH_SECRET_MAP_ID_CACHE_ACCESSED__HIT]),
         );
+        bool_counters
+            .push(registry.register_bool_counter(&INFO[id::PATH_SECRET_MAP_SERIALIZED__ERROR]));
         {
             #[allow(unused_imports)]
             use api::*;
@@ -4874,6 +4936,9 @@ impl<R: Registry> Subscriber<R> {
         measures.push(
             registry.register_measure(&INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION]),
         );
+        measures.push(registry.register_measure(&INFO[id::PATH_SECRET_MAP_SERIALIZED__ENTRIES]));
+        measures.push(registry.register_measure(&INFO[id::PATH_SECRET_MAP_SERIALIZED__FILE_SIZE]));
+        measures.push(registry.register_measure(&INFO[id::PATH_SECRET_MAP_SERIALIZED__DURATION]));
         measures.push(registry.register_measure(&INFO[id::PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE]));
         measures
             .push(registry.register_measure(&INFO[id::PATH_SECRET_MAP_ID_WRITE_LOCK__DURATION]));
@@ -5227,6 +5292,9 @@ impl<R: Registry> Subscriber<R> {
                 id::COUNTERS_PATH_SECRET_MAP_CLEANER_CYCLED => {
                     (&INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED], entry)
                 }
+                id::COUNTERS_PATH_SECRET_MAP_SERIALIZED => {
+                    (&INFO[id::PATH_SECRET_MAP_SERIALIZED], entry)
+                }
                 id::COUNTERS_PATH_SECRET_MAP_ID_WRITE_LOCK => {
                     (&INFO[id::PATH_SECRET_MAP_ID_WRITE_LOCK], entry)
                 }
@@ -5334,6 +5402,9 @@ impl<R: Registry> Subscriber<R> {
                 ),
                 id::BOOL_COUNTERS_PATH_SECRET_MAP_ID_CACHE_ACCESSED__HIT => {
                     (&INFO[id::PATH_SECRET_MAP_ID_CACHE_ACCESSED__HIT], entry)
+                }
+                id::BOOL_COUNTERS_PATH_SECRET_MAP_SERIALIZED__ERROR => {
+                    (&INFO[id::PATH_SECRET_MAP_SERIALIZED__ERROR], entry)
                 }
                 _ => unsafe { core::hint::unreachable_unchecked() },
             })
@@ -6224,6 +6295,15 @@ impl<R: Registry> Subscriber<R> {
                             &INFO[id::PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION],
                             entry,
                         )
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_SERIALIZED__ENTRIES => {
+                        (&INFO[id::PATH_SECRET_MAP_SERIALIZED__ENTRIES], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_SERIALIZED__FILE_SIZE => {
+                        (&INFO[id::PATH_SECRET_MAP_SERIALIZED__FILE_SIZE], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_SERIALIZED__DURATION => {
+                        (&INFO[id::PATH_SECRET_MAP_SERIALIZED__DURATION], entry)
                     }
                     id::MEASURES_PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE => {
                         (&INFO[id::PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE], entry)
@@ -9208,6 +9288,42 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
             id::PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION,
             id::MEASURES_PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION,
             event.duration,
+        );
+        let _ = event;
+        let _ = meta;
+    }
+    #[inline]
+    fn on_path_secret_map_serialized(
+        &self,
+        meta: &api::EndpointMeta,
+        event: &api::PathSecretMapSerialized,
+    ) {
+        #[allow(unused_imports)]
+        use api::*;
+        self.count(
+            id::PATH_SECRET_MAP_SERIALIZED,
+            id::COUNTERS_PATH_SECRET_MAP_SERIALIZED,
+            1usize,
+        );
+        self.measure(
+            id::PATH_SECRET_MAP_SERIALIZED__ENTRIES,
+            id::MEASURES_PATH_SECRET_MAP_SERIALIZED__ENTRIES,
+            event.entries,
+        );
+        self.measure(
+            id::PATH_SECRET_MAP_SERIALIZED__FILE_SIZE,
+            id::MEASURES_PATH_SECRET_MAP_SERIALIZED__FILE_SIZE,
+            event.file_size,
+        );
+        self.measure(
+            id::PATH_SECRET_MAP_SERIALIZED__DURATION,
+            id::MEASURES_PATH_SECRET_MAP_SERIALIZED__DURATION,
+            event.duration,
+        );
+        self.count_bool(
+            id::PATH_SECRET_MAP_SERIALIZED__ERROR,
+            id::BOOL_COUNTERS_PATH_SECRET_MAP_SERIALIZED__ERROR,
+            event.error,
         );
         let _ = event;
         let _ = meta;

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -328,6 +328,11 @@ mod id {
         PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_REQUESTS__SKIPPED,
         PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_LOCK_DURATION,
         PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION,
+        PATH_SECRET_MAP_SERIALIZED,
+        PATH_SECRET_MAP_SERIALIZED__ENTRIES,
+        PATH_SECRET_MAP_SERIALIZED__FILE_SIZE,
+        PATH_SECRET_MAP_SERIALIZED__DURATION,
+        PATH_SECRET_MAP_SERIALIZED__ERROR,
         PATH_SECRET_MAP_ID_WRITE_LOCK,
         PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE,
         PATH_SECRET_MAP_ID_WRITE_LOCK__DURATION,
@@ -876,6 +881,15 @@ mod id {
         InfoId::PATH_SECRET_MAP_CLEANER_CYCLED__HANDSHAKE_LOCK_DURATION as usize;
     pub const PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION: usize =
         InfoId::PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION as usize;
+    pub const PATH_SECRET_MAP_SERIALIZED: usize = InfoId::PATH_SECRET_MAP_SERIALIZED as usize;
+    pub const PATH_SECRET_MAP_SERIALIZED__ENTRIES: usize =
+        InfoId::PATH_SECRET_MAP_SERIALIZED__ENTRIES as usize;
+    pub const PATH_SECRET_MAP_SERIALIZED__FILE_SIZE: usize =
+        InfoId::PATH_SECRET_MAP_SERIALIZED__FILE_SIZE as usize;
+    pub const PATH_SECRET_MAP_SERIALIZED__DURATION: usize =
+        InfoId::PATH_SECRET_MAP_SERIALIZED__DURATION as usize;
+    pub const PATH_SECRET_MAP_SERIALIZED__ERROR: usize =
+        InfoId::PATH_SECRET_MAP_SERIALIZED__ERROR as usize;
     pub const PATH_SECRET_MAP_ID_WRITE_LOCK: usize = InfoId::PATH_SECRET_MAP_ID_WRITE_LOCK as usize;
     pub const PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE: usize =
         InfoId::PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE as usize;
@@ -1060,6 +1074,7 @@ mod counter {
                     Self(path_secret_map_id_cache_accessed_hit)
                 }
                 id::PATH_SECRET_MAP_CLEANER_CYCLED => Self(path_secret_map_cleaner_cycled),
+                id::PATH_SECRET_MAP_SERIALIZED => Self(path_secret_map_serialized),
                 id::PATH_SECRET_MAP_ID_WRITE_LOCK => Self(path_secret_map_id_write_lock),
                 id::PATH_SECRET_MAP_ADDRESS_WRITE_LOCK => Self(path_secret_map_address_write_lock),
                 id::PATH_SECRET_MAP_DATAGRAM_ENCRYPT => Self(path_secret_map_datagram_encrypt),
@@ -1391,6 +1406,9 @@ mod counter {
         s2n_quic_dc__event__counter__path_secret_map_cleaner_cycled]
             fn path_secret_map_cleaner_cycled(value: u64);
             #[link_name =
+        s2n_quic_dc__event__counter__path_secret_map_serialized]
+            fn path_secret_map_serialized(value: u64);
+            #[link_name =
         s2n_quic_dc__event__counter__path_secret_map_id_write_lock]
             fn path_secret_map_id_write_lock(value: u64);
             #[link_name =
@@ -1471,6 +1489,9 @@ mod counter {
                     id::PATH_SECRET_MAP_ID_CACHE_ACCESSED__HIT => {
                         Self(path_secret_map_id_cache_accessed__hit)
                     }
+                    id::PATH_SECRET_MAP_SERIALIZED__ERROR => {
+                        Self(path_secret_map_serialized__error)
+                    }
                     _ => unreachable!("invalid info: {info:?}"),
                 }
             }
@@ -1548,6 +1569,9 @@ mod counter {
                 #[link_name =
             s2n_quic_dc__event__counter__bool__path_secret_map_id_cache_accessed__hit]
                 fn path_secret_map_id_cache_accessed__hit(value: bool);
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__path_secret_map_serialized__error]
+                fn path_secret_map_serialized__error(value: bool);
             }
         );
     }
@@ -2217,6 +2241,15 @@ mod measure {
                 id::PATH_SECRET_MAP_CLEANER_CYCLED__TOTAL_DURATION => {
                     Self(path_secret_map_cleaner_cycled__total_duration)
                 }
+                id::PATH_SECRET_MAP_SERIALIZED__ENTRIES => {
+                    Self(path_secret_map_serialized__entries)
+                }
+                id::PATH_SECRET_MAP_SERIALIZED__FILE_SIZE => {
+                    Self(path_secret_map_serialized__file_size)
+                }
+                id::PATH_SECRET_MAP_SERIALIZED__DURATION => {
+                    Self(path_secret_map_serialized__duration)
+                }
                 id::PATH_SECRET_MAP_ID_WRITE_LOCK__ACQUIRE => {
                     Self(path_secret_map_id_write_lock__acquire)
                 }
@@ -2621,6 +2654,15 @@ mod measure {
             #[link_name =
         s2n_quic_dc__event__measure__path_secret_map_cleaner_cycled__total_duration]
             fn path_secret_map_cleaner_cycled__total_duration(value: u64);
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_serialized__entries]
+            fn path_secret_map_serialized__entries(value: u64);
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_serialized__file_size]
+            fn path_secret_map_serialized__file_size(value: u64);
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_serialized__duration]
+            fn path_secret_map_serialized__duration(value: u64);
             #[link_name =
         s2n_quic_dc__event__measure__path_secret_map_id_write_lock__acquire]
             fn path_secret_map_id_write_lock__acquire(value: u64);

--- a/dc/s2n-quic-dc/src/path/secret/map.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map.rs
@@ -37,6 +37,7 @@ mod event_tests;
 pub use entry::Entry;
 use store::Store;
 
+pub(crate) use cleaner::Epoch;
 pub use entry::{
     ApplicationData, ApplicationDataError, ApplicationPair, Bidirectional, ControlPair,
 };

--- a/dc/s2n-quic-dc/src/path/secret/map.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map.rs
@@ -19,6 +19,7 @@ use std::{net::SocketAddr, sync::Arc};
 use tokio::task::JoinHandle;
 
 mod cleaner;
+mod disk;
 mod entry;
 pub mod handshake;
 mod peer;
@@ -34,7 +35,9 @@ pub mod testing;
 #[cfg(test)]
 mod event_tests;
 
+pub use disk::{deserialize, DiskEntry, Entries, Serializer, SerializerBuilder};
 pub use entry::Entry;
+use state::StateBuilderError;
 use store::Store;
 
 pub(crate) use cleaner::Epoch;
@@ -73,7 +76,76 @@ impl fmt::Debug for Map {
     }
 }
 
+/// A builder for [`Map`].
+pub struct Builder<C, S>
+where
+    C: 'static + time::Clock + Sync + Send,
+    S: event::Subscriber,
+{
+    inner: state::StateBuilder<C, S>,
+}
+
+impl<C, S> Builder<C, S>
+where
+    C: 'static + time::Clock + Sync + Send,
+    S: event::Subscriber,
+{
+    pub fn with_signer(mut self, signer: stateless_reset::Signer) -> Self {
+        self.inner = self.inner.with_signer(signer);
+        self
+    }
+
+    pub fn with_capacity(mut self, capacity: usize) -> Self {
+        self.inner = self.inner.with_capacity(capacity);
+        self
+    }
+
+    pub fn with_evict_on_unknown_path_secret(mut self, should_evict: bool) -> Self {
+        self.inner = self.inner.with_evict_on_unknown_path_secret(should_evict);
+        self
+    }
+
+    pub fn with_clock<C2: 'static + time::Clock + Sync + Send>(self, clock: C2) -> Builder<C2, S> {
+        Builder {
+            inner: self.inner.with_clock(clock),
+        }
+    }
+
+    pub fn with_subscriber<S2: event::Subscriber>(self, subscriber: S2) -> Builder<C, S2> {
+        Builder {
+            inner: self.inner.with_subscriber(subscriber),
+        }
+    }
+
+    /// Configures on-disk serialization of the map.
+    pub fn with_serializer(mut self, serializer: Serializer) -> Self {
+        self.inner = self.inner.with_serializer(serializer);
+        self
+    }
+
+    /// Builds the [`Map`].
+    pub fn build(self) -> Result<Map, MapBuilderError> {
+        Ok(Map {
+            store: self.inner.build().map_err(MapBuilderError)?,
+        })
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(transparent)]
+pub struct MapBuilderError(StateBuilderError);
+
 impl Map {
+    /// Begins configuring a [`Map`].
+    ///
+    /// The signer, capacity, clock, and subscriber are all required; [`Builder::build`] fails if
+    /// any are missing.
+    pub fn builder() -> Builder<time::StdClock, crate::event::tracing::Subscriber> {
+        Builder {
+            inner: state::State::builder(),
+        }
+    }
+
     pub fn new<C, S>(
         signer: stateless_reset::Signer,
         capacity: usize,
@@ -89,16 +161,14 @@ impl Map {
             clippy::unwrap_used,
             reason = "build only fails if a required field is unset, we control the required field set"
         )]
-        let store = state::State::builder()
+        Self::builder()
+            .with_clock(clock)
+            .with_subscriber(subscriber)
             .with_signer(signer)
             .with_capacity(capacity)
             .with_evict_on_unknown_path_secret(should_evict_on_unknown_path_secret)
-            .with_clock(clock)
-            .with_subscriber(subscriber)
             .build()
-            .unwrap();
-
-        Self { store }
+            .unwrap()
     }
 
     /// The number of trusted secrets.
@@ -119,6 +189,15 @@ impl Map {
 
     pub fn drop_state(&self) {
         self.store.drop_state();
+    }
+
+    /// Serializes the current map to disk using the serializer configured at construction.
+    ///
+    /// This is a no-op (returning `Ok(())`) if no serializer was configured. It can be called
+    /// regardless of whether background serialization is enabled, letting callers drive
+    /// serialization on their own schedule.
+    pub fn serialize_to_disk(&self) -> std::io::Result<()> {
+        self.store.serialize_to_disk()
     }
 
     pub fn contains(&self, peer: &SocketAddr) -> bool {

--- a/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
@@ -24,6 +24,16 @@ pub struct Cleaner {
     epoch: AtomicU64,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Epoch(pub(crate) u64);
+
+impl Epoch {
+    #[inline]
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
 impl Drop for Cleaner {
     fn drop(&mut self) {
         self.stop();
@@ -203,7 +213,7 @@ impl Cleaner {
 
             let retained = if let Some(retired_at) = entry.retired_at() {
                 // retain if we aren't yet ready to evict.
-                current_epoch.saturating_sub(retired_at) < eviction_cycles
+                current_epoch.saturating_sub(retired_at.get()) < eviction_cycles
             } else {
                 // always retain non-retired entries.
                 true
@@ -269,7 +279,7 @@ impl Cleaner {
         );
     }
 
-    pub fn epoch(&self) -> u64 {
-        self.epoch.load(Ordering::Relaxed)
+    pub fn epoch(&self) -> Epoch {
+        Epoch(self.epoch.load(Ordering::Relaxed))
     }
 }

--- a/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
@@ -18,6 +18,19 @@ use std::{
 
 const EVICTION_CYCLES: u64 = if cfg!(test) { 0 } else { 10 };
 
+/// The cleaner loop runs roughly once per this interval. Serialization periods are expressed as a
+/// number of these cycles, and the access-time epoch advances once per cycle.
+pub(super) const CLEANER_CYCLE: Duration = Duration::from_secs(60);
+
+/// Converts a serialization `period` into a number of cleaner cycles (at least one).
+///
+/// The cleaner already runs on a jittered ~once-per-minute cadence, so rather than jittering the
+/// serialization time separately we pick a random cycle within each window of this many cycles to
+/// serialize in. This spreads writes across processes for free.
+fn period_in_cycles(period: Duration) -> u64 {
+    (period.as_secs() / CLEANER_CYCLE.as_secs()).max(1)
+}
+
 pub struct Cleaner {
     should_stop: AtomicBool,
     thread: Mutex<Option<std::thread::JoinHandle<()>>>,
@@ -80,33 +93,68 @@ impl Cleaner {
             return;
         }
 
+        // The serialization period, expressed in cleaner cycles, if configured. The cleaner drives
+        // serialization so we don't need a second background thread.
+        let serialize_cycles = state
+            .serializer
+            .as_ref()
+            .and_then(|s| s.period())
+            .map(period_in_cycles);
+
         let state = Arc::downgrade(&state);
         let handle = std::thread::Builder::new()
             .name("dc_quic::cleaner".into())
-            .spawn(move || loop {
-                // in tests, we should try and be as deterministic as possible
-                let pause = if cfg!(test) {
-                    Duration::from_secs(60).as_millis() as u64
-                } else {
-                    rand::rng().random_range(
-                        Duration::from_secs(5).as_millis() as u64
-                            ..Duration::from_secs(60).as_millis() as u64,
-                    )
-                };
+            .spawn(move || {
+                // We serialize at most once per `serialize_cycles` window. `cycle` counts cleaner
+                // runs within the current window (wrapping back to 0 at the window boundary) and
+                // `serialize_at` is the randomly-chosen cycle within the window in which we write.
+                // Re-rolled each window so the cleaner's own jitter spreads writes across
+                // processes without a separate timer.
+                let mut cycle = 0u64;
+                let mut serialize_at =
+                    serialize_cycles.map(|cycles| rand::rng().random_range(0..cycles));
 
-                let next_start = Instant::now() + Duration::from_secs(60);
-                std::thread::park_timeout(Duration::from_millis(pause));
+                loop {
+                    // in tests, we should try and be as deterministic as possible
+                    let pause = if cfg!(test) {
+                        CLEANER_CYCLE.as_millis() as u64
+                    } else {
+                        rand::rng().random_range(
+                            Duration::from_secs(5).as_millis() as u64
+                                ..CLEANER_CYCLE.as_millis() as u64,
+                        )
+                    };
 
-                let Some(state) = state.upgrade() else {
-                    break;
-                };
-                if state.cleaner().should_stop.load(Ordering::Relaxed) {
-                    break;
+                    let next_start = Instant::now() + CLEANER_CYCLE;
+                    std::thread::park_timeout(Duration::from_millis(pause));
+
+                    let Some(state) = state.upgrade() else {
+                        break;
+                    };
+                    if state.cleaner().should_stop.load(Ordering::Relaxed) {
+                        break;
+                    }
+                    state.cleaner().clean(&state, EVICTION_CYCLES);
+
+                    // Serialize the map in the chosen cycle of each window, then advance the cycle
+                    // counter and re-roll at the window boundary.
+                    if let Some(cycles) = serialize_cycles {
+                        if Some(cycle) == serialize_at {
+                            if let Err(err) = state.serialize_to_disk() {
+                                tracing::warn!(%err, "failed to serialize path secret map to disk");
+                            }
+                        }
+
+                        cycle += 1;
+                        if cycle >= cycles {
+                            cycle = 0;
+                            serialize_at = Some(rand::rng().random_range(0..cycles));
+                        }
+                    }
+
+                    // pause the rest of the time to run once a minute, not twice a minute
+                    std::thread::park_timeout(next_start.saturating_duration_since(Instant::now()));
                 }
-                state.cleaner().clean(&state, EVICTION_CYCLES);
-
-                // pause the rest of the time to run once a minute, not twice a minute
-                std::thread::park_timeout(next_start.saturating_duration_since(Instant::now()));
             });
         #[expect(
             clippy::unwrap_used,

--- a/dc/s2n-quic-dc/src/path/secret/map/disk.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/disk.rs
@@ -215,6 +215,7 @@ impl Serializer {
     /// relative to `current_epoch`.
     ///
     /// `entries` is iterated and any still-live entry passing the recency filter is written.
+    /// Returns the number of entries written and the resulting file size.
     ///
     /// This is `pub(crate)` because it references the crate-internal [`Entry`] and [`Epoch`] types;
     /// callers outside the crate drive serialization through the path secret map builder instead.
@@ -222,7 +223,7 @@ impl Serializer {
         &self,
         entries: &[Weak<Entry>],
         current_epoch: Epoch,
-    ) -> io::Result<()> {
+    ) -> io::Result<SerializeStats> {
         self.serialize_with_max_size(entries, current_epoch, MAX_SERIALIZED_SIZE)
     }
 
@@ -233,7 +234,7 @@ impl Serializer {
         entries: &[Weak<Entry>],
         current_epoch: Epoch,
         max_size: u64,
-    ) -> io::Result<()> {
+    ) -> io::Result<SerializeStats> {
         // Hold the write lock for the whole operation so a concurrent serialization (e.g. the
         // background cleaner racing an ad-hoc call) can't clobber our `.tmp` file or rename.
         let _guard = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
@@ -256,6 +257,7 @@ impl Serializer {
             .unwrap_or(0);
         output.write_all(&started_at.to_le_bytes())?;
 
+        let mut written = 0;
         for entry in entries.iter() {
             // Stop adding new entries once the file has grown past the maximum serialized size.
             // Entries are tiny (tens of bytes) relative to the margin we keep below MAX_FILE_SIZE,
@@ -273,6 +275,7 @@ impl Serializer {
                 continue;
             }
 
+            written += 1;
             let peer = entry.peer();
             match peer {
                 SocketAddr::V4(addr) => {
@@ -300,10 +303,24 @@ impl Serializer {
 
         output.flush()?;
 
+        let file_size = output.bytes_written();
+
         std::fs::rename(&tmp_path, &self.path)?;
 
-        Ok(())
+        Ok(SerializeStats {
+            entries: written,
+            file_size,
+        })
     }
+}
+
+/// Statistics about a completed serialization.
+#[derive(Copy, Clone, Debug)]
+pub(crate) struct SerializeStats {
+    /// The number of entries written to the file.
+    pub(crate) entries: usize,
+    /// The total size of the written file, in bytes.
+    pub(crate) file_size: u64,
 }
 
 /// A single entry read back from a persisted file.

--- a/dc/s2n-quic-dc/src/path/secret/map/disk.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/disk.rs
@@ -1,0 +1,459 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements on-disk persistence for the path secret map.
+//!
+//! Only part of the information is persisted (today, just entry socket addresses).
+
+use std::{
+    fmt,
+    fs::File,
+    io::{self, BufWriter, Read, Write},
+    net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
+    path::{Path, PathBuf},
+    sync::{Mutex, Weak},
+    time::{Duration, SystemTime},
+};
+
+use crate::path::secret::map::{cleaner::CLEANER_CYCLE, Entry, Epoch};
+
+const HEADER: &str = "s2n-quic-dc path secret map";
+
+/// The version identifier written immediately after the [`HEADER`].
+const VERSION: &[u8] = b"v0";
+
+/// Maximum size of a persisted file we are willing to read into memory.
+const MAX_FILE_SIZE: u64 = 50 * 1024 * 1024;
+
+/// Stop adding new entries to a serialized file once it grows past this size. Kept a margin below
+/// [`MAX_FILE_SIZE`] so a file we write is always comfortably within the size we're willing to read
+/// back, even if the last entry pushes us slightly over the threshold.
+const MAX_SERIALIZED_SIZE: u64 = MAX_FILE_SIZE - 1024 * 1024;
+
+/// A writer that tracks how many bytes have been written through it.
+///
+/// We use this during serialization to stop adding entries once the file reaches its size cap,
+/// without having to predict each entry's encoded length by hand.
+struct CountingWriter<W> {
+    inner: W,
+    bytes_written: u64,
+}
+
+impl<W: Write> CountingWriter<W> {
+    fn new(inner: W) -> Self {
+        CountingWriter {
+            inner,
+            bytes_written: 0,
+        }
+    }
+
+    /// The total number of bytes written through this writer so far.
+    fn bytes_written(&self) -> u64 {
+        self.bytes_written
+    }
+}
+
+impl<W: Write> Write for CountingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let n = self.inner.write(buf)?;
+        self.bytes_written += n as u64;
+        Ok(n)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+fn new_writer(tmp_path: &Path) -> io::Result<CountingWriter<BufWriter<File>>> {
+    // We assume that we are the unique owner of the file path, i.e., there's no attempt to
+    // synchronize with other writers attempting to write to it. We do take some effort to
+    // avoid half-writing a file though.
+    let output = std::fs::File::options()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(tmp_path)?;
+
+    let mut output = CountingWriter::new(std::io::BufWriter::new(output));
+
+    output.write_all(HEADER.as_bytes())?;
+
+    Ok(output)
+}
+
+/// Converts a wall-clock `duration` into a number of access-time epochs (which advance once per
+/// [`CLEANER_CYCLE`]), rounding to the nearest epoch with a floor of one for any non-zero duration.
+fn duration_to_epochs(duration: Duration) -> u64 {
+    if duration.is_zero() {
+        return 0;
+    }
+    let cycle = CLEANER_CYCLE.as_secs_f64();
+    ((duration.as_secs_f64() / cycle).round() as u64).max(1)
+}
+
+/// Builds a [`Serializer`].
+///
+/// Constructed via [`Serializer::builder`].
+#[derive(Clone, Debug)]
+pub struct SerializerBuilder {
+    path: PathBuf,
+    period: Option<Duration>,
+    max_idle_epochs: Option<u64>,
+}
+
+impl SerializerBuilder {
+    /// Enables periodic serialization, roughly once per `period`.
+    ///
+    /// The cleaner drives serialization on a ~once-per-minute cadence, so `period` is rounded down
+    /// to a whole number of minutes (with a floor of one minute) and jittered automatically.
+    ///
+    /// Regardless of this period, callers can use [`Map::serialize_to_disk`] to serialize now.
+    pub fn with_period(mut self, period: Duration) -> Self {
+        self.period = Some(period);
+        self
+    }
+
+    /// Restricts serialization to entries accessed within the last `duration`.
+    ///
+    /// Note that the current implementation measures access times with roughly one minute
+    /// granularity, so `duration` is rounded to the nearest whole number of epochs (at least one
+    /// for any non-zero duration).
+    pub fn with_max_idle(mut self, duration: Duration) -> Self {
+        self.max_idle_epochs = Some(duration_to_epochs(duration));
+        self
+    }
+
+    /// Finalizes the configuration into a [`Serializer`].
+    pub fn build(self) -> io::Result<Serializer> {
+        if let Some(parent) = self.path.parent().filter(|p| !p.as_os_str().is_empty()) {
+            if !parent.is_dir() {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotFound,
+                    format!(
+                        "serializer destination directory {} does not exist",
+                        parent.display()
+                    ),
+                ));
+            }
+        }
+
+        Ok(Serializer {
+            path: self.path,
+            period: self.period,
+            max_idle_epochs: self.max_idle_epochs,
+            write_lock: Mutex::new(()),
+        })
+    }
+}
+
+/// Configuration for persisting the path secret map to disk.
+pub struct Serializer {
+    /// Where the serialized map is written.
+    path: PathBuf,
+    /// If set, the cleaner serializes the map roughly once per this duration (jittered).
+    period: Option<Duration>,
+    /// If set, entries idle for more than this many epochs are excluded from serialization.
+    ///
+    /// Access time is tracked at epoch granularity (epochs advance roughly once a minute), so this
+    /// filters by recency of use. `None` writes every still-live entry regardless of access time.
+    max_idle_epochs: Option<u64>,
+    /// Serializes concurrent writes. The background cleaner and ad-hoc callers share the same
+    /// destination (and `.tmp` staging file), so we hold this for the duration of a write to
+    /// avoid two serializations clobbering each other's temporary file or racing the rename.
+    write_lock: Mutex<()>,
+}
+
+impl fmt::Debug for Serializer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Serializer")
+            .field("path", &self.path)
+            .field("period", &self.period)
+            .field("max_idle_epochs", &self.max_idle_epochs)
+            .finish()
+    }
+}
+
+impl Serializer {
+    /// Begins configuring a serializer that writes to `path`.
+    ///
+    /// `path` should take the form `some_dir/file_name`: the parent directory (`some_dir`) must
+    /// already exist and the final component (`file_name`) names the file that will be written.
+    /// Note that a temporary file will be written at `some_dir/file_name.tmp` during each
+    /// serialization and then renamed into the passed file path. Currently the periodic
+    /// serialization will not attempt to enforce disk persistence (e.g. via fsync) or perform any
+    /// error-checking (e.g. checksums) for consistency of the written data.
+    ///
+    /// A default builder will serialize all entries only on-demand (via
+    /// [`Map::serialize_to_disk`]).
+    pub fn builder(path: impl Into<PathBuf>) -> SerializerBuilder {
+        SerializerBuilder {
+            path: path.into(),
+            period: None,
+            max_idle_epochs: None,
+        }
+    }
+
+    /// The path the serialized map is written to.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// The configured periodic serialization interval, if any.
+    pub fn period(&self) -> Option<Duration> {
+        self.period
+    }
+
+    /// The lowest access epoch that will be serialized given `current_epoch`, or `None` if every
+    /// entry should be written regardless of access time.
+    fn min_epoch(&self, current_epoch: Epoch) -> Option<u64> {
+        self.max_idle_epochs
+            .map(|window| current_epoch.get().saturating_sub(window))
+    }
+
+    /// Writes the entries in `entries` to the configured path, filtering by recency of access
+    /// relative to `current_epoch`.
+    ///
+    /// `entries` is iterated and any still-live entry passing the recency filter is written.
+    ///
+    /// This is `pub(crate)` because it references the crate-internal [`Entry`] and [`Epoch`] types;
+    /// callers outside the crate drive serialization through the path secret map builder instead.
+    pub(crate) fn serialize(
+        &self,
+        entries: &[Weak<Entry>],
+        current_epoch: Epoch,
+    ) -> io::Result<()> {
+        self.serialize_with_max_size(entries, current_epoch, MAX_SERIALIZED_SIZE)
+    }
+
+    /// As [`Serializer::serialize`], but stops adding entries once the file grows past `max_size`.
+    /// Exposed separately so tests can exercise the size cap without writing tens of megabytes.
+    fn serialize_with_max_size(
+        &self,
+        entries: &[Weak<Entry>],
+        current_epoch: Epoch,
+        max_size: u64,
+    ) -> io::Result<()> {
+        // Hold the write lock for the whole operation so a concurrent serialization (e.g. the
+        // background cleaner racing an ad-hoc call) can't clobber our `.tmp` file or rename.
+        let _guard = self.write_lock.lock().unwrap_or_else(|e| e.into_inner());
+
+        let min_epoch = self.min_epoch(current_epoch);
+
+        // Write to a temporary file and rename it into place once complete, so a reader never
+        // observes a half-written file.
+        let tmp_path = self.path.with_extension("tmp");
+        let mut output = new_writer(&tmp_path)?;
+
+        // Write a version identifier
+        output.write_all(VERSION)?;
+
+        // Record when we started writing this file, as seconds since the Unix epoch. Times before
+        // the epoch (or arithmetic errors) are clamped to 0.
+        let started_at = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        output.write_all(&started_at.to_le_bytes())?;
+
+        for entry in entries.iter() {
+            // Stop adding new entries once the file has grown past the maximum serialized size.
+            // Entries are tiny (tens of bytes) relative to the margin we keep below MAX_FILE_SIZE,
+            // so checking after the fact rather than predicting each entry's size is fine.
+            if output.bytes_written() > max_size {
+                break;
+            }
+
+            let Some(entry) = entry.upgrade() else {
+                continue;
+            };
+
+            // Skip entries idle for longer than the configured window.
+            if min_epoch.is_some_and(|min| entry.accessed_at_epoch().get() < min) {
+                continue;
+            }
+
+            let peer = entry.peer();
+            match peer {
+                SocketAddr::V4(addr) => {
+                    output.write_all(&[0])?;
+                    output.write_all(&addr.ip().octets())?;
+                    output.write_all(&addr.port().to_le_bytes())?;
+                }
+                SocketAddr::V6(addr) => {
+                    let minimal = addr.flowinfo() == 0 && addr.scope_id() == 0;
+                    if minimal {
+                        output.write_all(&[1])?;
+                    } else {
+                        output.write_all(&[2])?;
+                    }
+                    output.write_all(&addr.ip().octets())?;
+                    output.write_all(&addr.port().to_le_bytes())?;
+
+                    if !minimal {
+                        output.write_all(&addr.flowinfo().to_le_bytes())?;
+                        output.write_all(&addr.scope_id().to_le_bytes())?;
+                    }
+                }
+            }
+        }
+
+        output.flush()?;
+
+        std::fs::rename(&tmp_path, &self.path)?;
+
+        Ok(())
+    }
+}
+
+/// A single entry read back from a persisted file.
+#[derive(Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq, Eq))]
+pub struct DiskEntry {
+    pub peer: SocketAddr,
+}
+
+/// Reads the file at `path` fully into memory and returns an iterator yielding the entries it
+/// contains.
+///
+/// The file is rejected (without being read) if it is larger than [`MAX_FILE_SIZE`]. The header,
+/// version, and timestamp are validated up front; per-entry decoding happens lazily as the
+/// returned iterator is advanced, so a truncated or corrupt entry surfaces as an `Err` item rather
+/// than failing the whole call.
+pub fn deserialize(path: &Path) -> io::Result<Entries> {
+    let file = File::open(path)?;
+
+    let len = file.metadata()?.len();
+    if len > MAX_FILE_SIZE {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("file is {len} bytes, larger than the maximum of {MAX_FILE_SIZE} bytes"),
+        ));
+    }
+
+    let mut bytes = Vec::with_capacity(len as usize);
+    file.take(len).read_to_end(&mut bytes)?;
+
+    let mut reader = Reader { bytes: &bytes };
+
+    // Validate the header and version before handing the rest off to the iterator.
+    if reader.take(HEADER.len())? != HEADER.as_bytes() {
+        return Err(invalid_data("missing or invalid header"));
+    }
+    if reader.take(VERSION.len())? != VERSION {
+        return Err(invalid_data("missing or unsupported version"));
+    }
+
+    let started_at = {
+        let secs = u64::from_le_bytes(reader.take_array::<8>()?);
+        // Guard against a corrupt timestamp: `SystemTime + Duration` panics on overflow, so reject
+        // an out-of-range value as invalid data rather than aborting the whole read.
+        SystemTime::UNIX_EPOCH
+            .checked_add(Duration::from_secs(secs))
+            .ok_or_else(|| invalid_data("started_at timestamp out of range"))?
+    };
+
+    // The entries begin wherever validation left the cursor.
+    let pos = bytes.len() - reader.bytes.len();
+    Ok(Entries {
+        bytes,
+        pos,
+        started_at,
+    })
+}
+
+/// Iterator over the entries in a persisted file.
+///
+/// Owns the bytes read from disk and decodes one [`DiskEntry`] per call to [`Iterator::next`].
+pub struct Entries {
+    bytes: Vec<u8>,
+    pos: usize,
+    /// The time at which the file started being written, as recorded in its header.
+    pub started_at: SystemTime,
+}
+
+impl Iterator for Entries {
+    type Item = io::Result<DiskEntry>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.pos >= self.bytes.len() {
+            return None;
+        }
+
+        let mut reader = Reader {
+            bytes: &self.bytes[self.pos..],
+        };
+        let result = read_entry(&mut reader);
+        // Advance past whatever was consumed. On error we jump to the end so iteration stops
+        // rather than spinning on the same malformed bytes.
+        self.pos = if result.is_ok() {
+            self.bytes.len() - reader.bytes.len()
+        } else {
+            self.bytes.len()
+        };
+        Some(result)
+    }
+}
+
+/// Decodes a single entry from `reader`.
+fn read_entry(reader: &mut Reader) -> io::Result<DiskEntry> {
+    let tag = reader.take(1)?[0];
+    let peer = match tag {
+        0 => {
+            let ip = Ipv4Addr::from(reader.take_array::<4>()?);
+            let port = u16::from_le_bytes(reader.take_array::<2>()?);
+            SocketAddr::V4(SocketAddrV4::new(ip, port))
+        }
+        1 | 2 => {
+            let ip = Ipv6Addr::from(reader.take_array::<16>()?);
+            let port = u16::from_le_bytes(reader.take_array::<2>()?);
+            let (flowinfo, scope_id) = if tag == 2 {
+                (
+                    u32::from_le_bytes(reader.take_array::<4>()?),
+                    u32::from_le_bytes(reader.take_array::<4>()?),
+                )
+            } else {
+                (0, 0)
+            };
+            SocketAddr::V6(SocketAddrV6::new(ip, port, flowinfo, scope_id))
+        }
+        other => return Err(invalid_data(format!("unknown peer tag {other}"))),
+    };
+
+    Ok(DiskEntry { peer })
+}
+
+/// A cursor over an in-memory byte buffer.
+///
+/// `bytes` always holds the not-yet-consumed remainder; `take` peels prefixes off the front.
+struct Reader<'a> {
+    bytes: &'a [u8],
+}
+
+impl<'a> Reader<'a> {
+    /// Returns the next `n` bytes and advances the cursor, or an error if fewer than `n` remain.
+    fn take(&mut self, n: usize) -> io::Result<&'a [u8]> {
+        self.bytes
+            .split_off(..n)
+            .ok_or_else(|| invalid_data("unexpected end of file"))
+    }
+
+    /// Reads exactly `N` bytes and advances the cursor, returning them as a fixed-size array.
+    #[expect(
+        clippy::unwrap_in_result,
+        reason = "take(N) always yields exactly N bytes"
+    )]
+    fn take_array<const N: usize>(&mut self) -> io::Result<[u8; N]> {
+        Ok(self
+            .take(N)?
+            .try_into()
+            .expect("take(N) always returns N bytes"))
+    }
+}
+
+fn invalid_data(msg: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, msg.into())
+}
+
+#[cfg(test)]
+mod test;

--- a/dc/s2n-quic-dc/src/path/secret/map/disk/test.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/disk/test.rs
@@ -1,0 +1,260 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use crate::path::secret::map::Entry;
+use std::{
+    net::{Ipv4Addr, Ipv6Addr, SocketAddrV4, SocketAddrV6},
+    sync::Arc,
+    time::SystemTime,
+};
+
+/// Serializes `peers` (writing every entry), reads them back, and returns the decoded entries
+/// alongside the recorded `started_at` timestamp.
+fn roundtrip(peers: &[SocketAddr]) -> (SystemTime, Vec<SocketAddr>) {
+    let entries: Vec<Arc<Entry>> = peers.iter().map(|peer| Entry::fake(*peer, None)).collect();
+    // Epoch is irrelevant without a recency filter configured.
+    roundtrip_with(&entries, Epoch(0), |s| s)
+}
+
+/// Serializes `entries` through a [`Serializer`] configured by `configure` (at `current_epoch`),
+/// reads them back, and returns the decoded peers alongside the recorded `started_at` timestamp.
+fn roundtrip_with(
+    entries: &[Arc<Entry>],
+    current_epoch: Epoch,
+    configure: impl FnOnce(SerializerBuilder) -> SerializerBuilder,
+) -> (SystemTime, Vec<SocketAddr>) {
+    let weak: Vec<Weak<Entry>> = entries.iter().map(Arc::downgrade).collect();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("secrets");
+
+    let serializer = configure(Serializer::builder(&path)).build().unwrap();
+    serializer.serialize(&weak, current_epoch).unwrap();
+
+    let entries = deserialize(serializer.path()).unwrap();
+    let started_at = entries.started_at;
+    let decoded = entries.map(|e| e.unwrap().peer).collect();
+
+    (started_at, decoded)
+}
+
+#[test]
+fn roundtrip_ipv4() {
+    let peer = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(192, 0, 2, 1), 4433));
+    let (_, decoded) = roundtrip(&[peer]);
+    assert_eq!(decoded, vec![peer]);
+}
+
+#[test]
+fn roundtrip_ipv6_minimal() {
+    // flowinfo and scope_id are both zero, exercising the compact (tag 1) encoding.
+    let peer = SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 4433, 0, 0));
+    let (_, decoded) = roundtrip(&[peer]);
+    assert_eq!(decoded, vec![peer]);
+}
+
+#[test]
+fn roundtrip_ipv6_full() {
+    // Non-zero flowinfo/scope_id force the full (tag 2) encoding.
+    let peer = SocketAddr::V6(SocketAddrV6::new(
+        Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1),
+        4433,
+        7,
+        42,
+    ));
+    let (_, decoded) = roundtrip(&[peer]);
+    assert_eq!(decoded, vec![peer]);
+}
+
+#[test]
+fn roundtrip_multiple() {
+    let peers = vec![
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 1)),
+        SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 2, 0, 0)),
+        SocketAddr::V6(SocketAddrV6::new(Ipv6Addr::LOCALHOST, 3, 1, 2)),
+        SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 4), 4)),
+    ];
+    let (_, decoded) = roundtrip(&peers);
+    assert_eq!(decoded, peers);
+}
+
+#[test]
+fn roundtrip_empty() {
+    let (_, decoded) = roundtrip(&[]);
+    assert!(decoded.is_empty());
+}
+
+#[test]
+fn started_at_is_recent() {
+    let before = SystemTime::now();
+    let peer = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, 4433));
+    let (started_at, _) = roundtrip(&[peer]);
+    let after = SystemTime::now();
+
+    // The timestamp is stored at one-second granularity, so allow the truncation slack.
+    let one_sec = Duration::from_secs(1);
+    assert!(started_at + one_sec >= before);
+    assert!(started_at <= after + one_sec);
+}
+
+/// One epoch's worth of wall-clock time, used to express idle windows in the tests below. Epochs
+/// advance once per cleaner cycle.
+const EPOCH: Duration = Duration::from_secs(60);
+
+#[test]
+fn max_idle_filters_stale_entries() {
+    let recent_peer = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 1));
+    let stale_peer = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 2), 2));
+
+    let recent = Entry::fake(recent_peer, None);
+    let stale = Entry::fake(stale_peer, None);
+
+    // Mark the two entries as accessed in different epochs.
+    recent.set_accessed_addr(Epoch(10));
+    stale.set_accessed_addr(Epoch(4));
+
+    // At epoch 12 with a 5-epoch idle window, the cutoff is epoch 7: only `recent` (epoch 10)
+    // survives, `stale` (epoch 4) is dropped.
+    let (_, decoded) = roundtrip_with(&[recent, stale], Epoch(12), |s| s.with_max_idle(5 * EPOCH));
+    assert_eq!(decoded, vec![recent_peer]);
+}
+
+#[test]
+fn max_idle_boundary_is_inclusive() {
+    let peer = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 1));
+    let entry = Entry::fake(peer, None);
+    entry.set_accessed_addr(Epoch(7));
+
+    // At epoch 10 with a 3-epoch idle window the cutoff is exactly epoch 7, and an entry accessed
+    // at the cutoff is kept.
+    let (_, decoded) = roundtrip_with(&[entry], Epoch(10), |s| s.with_max_idle(3 * EPOCH));
+    assert_eq!(decoded, vec![peer]);
+}
+
+#[test]
+fn max_idle_drops_never_accessed_entries() {
+    let peer = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 1));
+    // A fake entry has never been accessed, so it sits at epoch 0 and is filtered out once the
+    // cutoff climbs above 0.
+    let entry = Entry::fake(peer, None);
+
+    let (_, decoded) = roundtrip_with(&[entry], Epoch(5), |s| s.with_max_idle(EPOCH));
+    assert!(decoded.is_empty());
+}
+
+#[test]
+fn idle_window_wider_than_epoch_keeps_everything() {
+    let peer = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 1));
+    let entry = Entry::fake(peer, None);
+    entry.set_accessed_addr(Epoch(2));
+
+    // When the idle window exceeds the current epoch the cutoff saturates at 0, so even
+    // long-idle entries are retained.
+    let (_, decoded) = roundtrip_with(&[entry], Epoch(3), |s| s.with_max_idle(100 * EPOCH));
+    assert_eq!(decoded, vec![peer]);
+}
+
+#[test]
+fn with_max_idle_rounds_to_nearest_epoch() {
+    // Sub-cycle durations round to the nearest epoch, with a floor of one epoch for any non-zero
+    // duration. Here ~1.5 epochs rounds up to 2: at epoch 5 the cutoff is epoch 3.
+    let kept_peer = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 1), 1));
+    let dropped_peer = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, 2), 2));
+
+    let kept = Entry::fake(kept_peer, None);
+    let dropped = Entry::fake(dropped_peer, None);
+    kept.set_accessed_addr(Epoch(3));
+    dropped.set_accessed_addr(Epoch(2));
+
+    let (_, decoded) = roundtrip_with(&[kept, dropped], Epoch(5), |s| {
+        s.with_max_idle(EPOCH + EPOCH / 2)
+    });
+    assert_eq!(decoded, vec![kept_peer]);
+}
+
+#[test]
+fn max_size_stops_adding_entries() {
+    // Each IPv4 entry encodes to 7 bytes (1 tag + 4 IP + 2 port). With a cap just above the
+    // header/version/timestamp prefix, only a couple of entries fit before the writer trips the
+    // limit and the rest are dropped.
+    let peers: Vec<SocketAddr> = (0..100)
+        .map(|i| SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, i as u8), i)))
+        .collect();
+    let entries: Vec<Arc<Entry>> = peers.iter().map(|peer| Entry::fake(*peer, None)).collect();
+    let weak: Vec<Weak<Entry>> = entries.iter().map(Arc::downgrade).collect();
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("secrets");
+    let serializer = Serializer::builder(&path).build().unwrap();
+
+    // Prefix is HEADER + VERSION + 8-byte timestamp; allow ~3 more entries' worth of room.
+    let prefix = (HEADER.len() + VERSION.len() + 8) as u64;
+    serializer
+        .serialize_with_max_size(&weak, Epoch(0), prefix + 20)
+        .unwrap();
+
+    let decoded: Vec<SocketAddr> = deserialize(serializer.path())
+        .unwrap()
+        .map(|e| e.unwrap().peer)
+        .collect();
+
+    // We stop only after exceeding the cap, so we get a few entries but far fewer than 100, and
+    // they are a prefix of the input in iteration order.
+    assert!(!decoded.is_empty());
+    assert!(decoded.len() < peers.len());
+    assert_eq!(decoded, peers[..decoded.len()]);
+}
+
+#[test]
+fn build_rejects_missing_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    // Parent directory does not exist.
+    let path = dir.path().join("missing").join("secrets");
+
+    let err = match Serializer::builder(&path).build() {
+        Ok(_) => panic!("expected build to reject a missing destination directory"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), io::ErrorKind::NotFound);
+}
+
+#[test]
+fn build_accepts_existing_directory() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("secrets");
+    assert!(Serializer::builder(&path).build().is_ok());
+}
+
+#[test]
+fn rejects_bad_header() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("secrets");
+    std::fs::write(&path, b"not the right header at all").unwrap();
+
+    let err = match deserialize(&path) {
+        Ok(_) => panic!("expected deserialize to reject a bad header"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}
+
+#[test]
+fn rejects_out_of_range_timestamp() {
+    // A valid header and version followed by a `started_at` of u64::MAX seconds, which would
+    // overflow `SystemTime` addition. It must surface as an error rather than panicking.
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("secrets");
+
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(HEADER.as_bytes());
+    bytes.extend_from_slice(VERSION);
+    bytes.extend_from_slice(&u64::MAX.to_le_bytes());
+    std::fs::write(&path, &bytes).unwrap();
+
+    let err = match deserialize(&path) {
+        Ok(_) => panic!("expected deserialize to reject an out-of-range timestamp"),
+        Err(err) => err,
+    };
+    assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+}

--- a/dc/s2n-quic-dc/src/path/secret/map/entry.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/entry.rs
@@ -10,6 +10,7 @@ use crate::{
     credentials::{self, Credentials},
     packet::{secret_control as control, WireVersion},
     path::secret::{
+        map::Epoch,
         open, receiver,
         schedule::{self, Initiator},
         seal, sender,
@@ -20,9 +21,10 @@ use s2n_codec::EncoderBuffer;
 use s2n_quic_core::{dc, varint::VarInt};
 use std::{
     any::Any,
+    fmt,
     net::SocketAddr,
     sync::{
-        atomic::{AtomicU32, AtomicU8, Ordering},
+        atomic::{AtomicU32, AtomicU64, AtomicU8, Ordering},
         Arc,
     },
     time::{Duration, Instant},
@@ -47,6 +49,7 @@ pub struct Entry {
     peer: SocketAddr,
     secret: schedule::Secret,
     retired: IsRetired,
+    accessed_at: AccessedAt,
     sender: sender::State,
     receiver: receiver::State,
     parameters: dc::ApplicationParams,
@@ -68,6 +71,7 @@ impl SizeOf for Entry {
             parameters,
             accessed,
             application_data,
+            accessed_at,
         } = self;
         creation_time.size()
             + peer.size()
@@ -78,6 +82,7 @@ impl SizeOf for Entry {
             + parameters.size()
             + accessed.size()
             + application_data.size()
+            + accessed_at.size()
     }
 }
 
@@ -121,6 +126,7 @@ impl Entry {
             receiver,
             parameters,
             accessed: AtomicU8::new(0),
+            accessed_at: AccessedAt(AtomicU64::new(0)),
             application_data,
         }
     }
@@ -164,11 +170,13 @@ impl Entry {
         &self.secret
     }
 
-    pub fn set_accessed_id(&self) {
+    pub fn set_accessed_id(&self, epoch: Epoch) {
+        self.accessed_at.set_accessed(epoch);
         self.accessed.fetch_or(0b10, Ordering::Relaxed);
     }
 
-    pub fn set_accessed_addr(&self) {
+    pub fn set_accessed_addr(&self, epoch: Epoch) {
+        self.accessed_at.set_accessed(epoch);
         self.accessed.fetch_or(0b01, Ordering::Relaxed);
     }
 
@@ -180,11 +188,11 @@ impl Entry {
         self.accessed.fetch_and(!0b01, Ordering::Relaxed) & 0b01 != 0
     }
 
-    pub fn retire(&self, at_epoch: u64) {
+    pub fn retire(&self, at_epoch: Epoch) {
         self.retired.retire(at_epoch);
     }
 
-    pub fn retired_at(&self) -> Option<u64> {
+    pub fn retired_at(&self) -> Option<Epoch> {
         self.retired.retired_at()
     }
 
@@ -385,3 +393,37 @@ impl ControlPair {
         Self { sealer, opener }
     }
 }
+
+// Stores a epoch (similar to RetiredAt) for the last access.
+//
+// This gives a rough sense of how long ago the most recent access was. Epochs increment roughly
+// every minute (via cleaner thread).
+#[derive(Default)]
+struct AccessedAt(AtomicU64);
+
+impl fmt::Debug for AccessedAt {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("AccessedAt")
+            .field(&self.accessed_at_epoch())
+            .finish()
+    }
+}
+
+impl AccessedAt {
+    pub fn set_accessed(&self, at_epoch: Epoch) {
+        // Intentionally load before storing -- we want to avoid contention. In practice access
+        // likely involved some contention anyway (Arc ref-count, Mutex's on the maps) but good to
+        // avoid extra cost if we can.
+        if self.0.load(Ordering::Relaxed) < at_epoch.get() {
+            // It's OK if we lose a store, at worst this makes the access time about a minute
+            // wrong, and for frequently-accessed entries that'll quickly recover.
+            self.0.store(at_epoch.get(), Ordering::Relaxed);
+        }
+    }
+
+    pub fn accessed_at_epoch(&self) -> u64 {
+        self.0.load(Ordering::Relaxed)
+    }
+}
+
+impl SizeOf for AccessedAt {}

--- a/dc/s2n-quic-dc/src/path/secret/map/entry.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/entry.rs
@@ -170,6 +170,13 @@ impl Entry {
         &self.secret
     }
 
+    /// The epoch of the most recent access to this entry (via either id or address), as recorded
+    /// by [`Self::set_accessed_id`] / [`Self::set_accessed_addr`]. Returns epoch 0 if never
+    /// accessed.
+    pub fn accessed_at_epoch(&self) -> Epoch {
+        Epoch(self.accessed_at.accessed_at_epoch())
+    }
+
     pub fn set_accessed_id(&self, epoch: Epoch) {
         self.accessed_at.set_accessed(epoch);
         self.accessed.fetch_or(0b10, Ordering::Relaxed);

--- a/dc/s2n-quic-dc/src/path/secret/map/entry/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/entry/tests.rs
@@ -15,7 +15,7 @@ fn entry_size() {
     if should_check {
         assert_eq!(
             Entry::fake((std::net::Ipv4Addr::LOCALHOST, 0).into(), None).size(),
-            307
+            315
         );
     }
 }

--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    cleaner::Cleaner, stateless_reset, ApplicationData, ApplicationDataError, Entry, Store,
+    cleaner::Cleaner, disk, stateless_reset, ApplicationData, ApplicationDataError, Entry, Store,
 };
 use crate::{
     credentials::{Credentials, Id},
@@ -32,7 +32,7 @@ mod tests;
 
 #[derive(Debug)]
 #[allow(clippy::enum_variant_names)]
-pub enum StateBuilderError {
+pub(crate) enum StateBuilderError {
     MissingSigner,
     MissingCapacity,
     MissingClock,
@@ -62,6 +62,7 @@ where
     should_evict_on_unknown_path_secret: bool,
     clock: Option<C>,
     subscriber: Option<S>,
+    serializer: Option<disk::Serializer>,
 }
 
 impl<C, S> StateBuilder<C, S>
@@ -76,6 +77,7 @@ where
             should_evict_on_unknown_path_secret: false,
             clock: None,
             subscriber: None,
+            serializer: None,
         }
     }
 
@@ -104,6 +106,7 @@ where
             should_evict_on_unknown_path_secret: self.should_evict_on_unknown_path_secret,
             signer: self.signer,
             capacity: self.capacity,
+            serializer: self.serializer,
         }
     }
 
@@ -114,7 +117,18 @@ where
             should_evict_on_unknown_path_secret: self.should_evict_on_unknown_path_secret,
             signer: self.signer,
             capacity: self.capacity,
+            serializer: self.serializer,
         }
+    }
+
+    /// Configures on-disk serialization of the map.
+    ///
+    /// The [`disk::Serializer`] carries where to write, the (optional) periodic interval, and which
+    /// entries to include by recency of access. If the serializer has a period set, the background
+    /// cleaner serializes the map periodically (jittered within the period).
+    pub fn with_serializer(mut self, serializer: disk::Serializer) -> Self {
+        self.serializer = Some(serializer);
+        self
     }
 
     pub fn build(self) -> Result<Arc<State<C, S>>, StateBuilderError> {
@@ -131,6 +145,7 @@ where
             self.should_evict_on_unknown_path_secret,
             clock,
             subscriber,
+            self.serializer,
         ))
     }
 }
@@ -421,6 +436,11 @@ where
 
     cleaner: Cleaner,
 
+    // If set, configures on-disk serialization of the map. Used both for ad-hoc serialization
+    // (via `serialize_to_disk`) and, when the serializer has background serialization enabled,
+    // periodic serialization driven by the cleaner.
+    pub(super) serializer: Option<disk::Serializer>,
+
     // Avoids allocating/deallocating on each cleaner run.
     // We use a PeerMap to save memory -- an Arc is 8 bytes, SocketAddr is 32 bytes.
     pub(super) cleaner_peer_seen: PeerMap,
@@ -515,6 +535,7 @@ where
         should_evict_on_unknown_path_secret: bool,
         clock: C,
         subscriber: S,
+        serializer: Option<disk::Serializer>,
     ) -> Arc<Self> {
         let control_socket = control_socket();
 
@@ -533,6 +554,7 @@ where
             eviction_queue: Default::default(),
             cleaner_peer_seen: Default::default(),
             cleaner: Cleaner::new(),
+            serializer,
             rehandshake: Mutex::new(super::rehandshake::RehandshakeState::new(
                 rehandshake_period,
             )),
@@ -573,6 +595,27 @@ where
             .on_path_secret_map_initialized(event::builder::PathSecretMapInitialized { capacity });
 
         state
+    }
+
+    /// Serializes the current map to disk using the configured [`disk::Serializer`].
+    ///
+    /// Does nothing (returning `Ok(())`) if no serializer was configured. The set of entries is
+    /// snapshotted from the eviction queue, which holds a weak reference to every live entry.
+    pub(super) fn serialize_to_disk(&self) -> std::io::Result<()> {
+        let Some(serializer) = self.serializer.as_ref() else {
+            return Ok(());
+        };
+
+        // Clone the weak references out under the lock so we don't hold it across the write.
+        let entries: Vec<Weak<Entry>> = {
+            let queue = self
+                .eviction_queue
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            queue.iter().cloned().collect()
+        };
+
+        serializer.serialize(&entries, self.cleaner.epoch())
     }
 
     // Sometimes called with queue lock held -- must not acquire it.
@@ -714,6 +757,11 @@ where
 
     fn should_evict_on_unknown_path_secret(&self) -> bool {
         self.should_evict_on_unknown_path_secret
+    }
+
+    fn serialize_to_disk(&self) -> std::io::Result<()> {
+        // Resolves to the inherent method on `State`, which the cleaner also uses.
+        State::serialize_to_disk(self)
     }
 
     fn drop_state(&self) {

--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -601,6 +601,9 @@ where
     ///
     /// Does nothing (returning `Ok(())`) if no serializer was configured. The set of entries is
     /// snapshotted from the eviction queue, which holds a weak reference to every live entry.
+    ///
+    /// Emits a `path_secret_map:serialized` event recording how long serialization took, the
+    /// number of entries written, the resulting file size, and whether it failed.
     pub(super) fn serialize_to_disk(&self) -> std::io::Result<()> {
         let Some(serializer) = self.serializer.as_ref() else {
             return Ok(());
@@ -615,7 +618,24 @@ where
             queue.iter().cloned().collect()
         };
 
-        serializer.serialize(&entries, self.cleaner.epoch())
+        let start = self.clock.get_time();
+        let result = serializer.serialize(&entries, self.cleaner.epoch());
+        let duration = self.clock.get_time().saturating_duration_since(start);
+
+        let (entries_written, file_size) = match &result {
+            Ok(stats) => (stats.entries, stats.file_size),
+            Err(_) => (0, 0),
+        };
+
+        self.subscriber()
+            .on_path_secret_map_serialized(event::builder::PathSecretMapSerialized {
+                entries: entries_written,
+                file_size: file_size as usize,
+                duration,
+                error: result.is_err(),
+            });
+
+        result.map(|_| ())
     }
 
     // Sometimes called with queue lock held -- must not acquire it.

--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -851,7 +851,7 @@ where
         );
 
         if let Some(entry) = &result {
-            entry.set_accessed_addr();
+            entry.set_accessed_addr(self.cleaner.epoch());
             self.subscriber()
                 .on_path_secret_map_address_cache_accessed_hit(
                     event::builder::PathSecretMapAddressCacheAccessedHit {
@@ -879,7 +879,7 @@ where
         );
 
         if let Some(entry) = &result {
-            entry.set_accessed_id();
+            entry.set_accessed_id(self.cleaner.epoch());
             self.subscriber().on_path_secret_map_id_cache_accessed_hit(
                 event::builder::PathSecretMapIdCacheAccessedHit {
                     credential_id: id.into_event(),

--- a/dc/s2n-quic-dc/src/path/secret/map/state/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state/tests.rs
@@ -120,6 +120,41 @@ fn serialize_to_disk_writes_configured_entries() {
 }
 
 #[test]
+fn serialize_to_disk_emits_event() {
+    use std::sync::atomic::Ordering;
+
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("secrets");
+
+    let subscriber = Arc::new(testing::Subscriber::no_snapshot());
+
+    let signer = stateless_reset::Signer::new(b"secret");
+    let map = State::builder()
+        .with_signer(signer)
+        .with_capacity(50)
+        .with_clock(Clock)
+        .with_subscriber(subscriber.clone())
+        .with_serializer(disk::Serializer::builder(&path).build().unwrap())
+        .build()
+        .unwrap();
+
+    // Stop background processing so the cleaner thread doesn't race our manual serialization.
+    map.cleaner.stop();
+
+    map.test_insert(fake_entry(1));
+    map.test_insert(fake_entry(2));
+
+    map.serialize_to_disk().unwrap();
+
+    assert_eq!(
+        subscriber
+            .path_secret_map_serialized
+            .load(Ordering::Relaxed),
+        1
+    );
+}
+
+#[test]
 fn serialize_to_disk_without_serializer_is_noop() {
     let signer = stateless_reset::Signer::new(b"secret");
     let map = State::builder()

--- a/dc/s2n-quic-dc/src/path/secret/map/state/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state/tests.rs
@@ -10,7 +10,7 @@ use s2n_quic_core::{dc, time::NoopClock as Clock};
 use std::{
     collections::HashSet,
     fmt,
-    net::{Ipv4Addr, SocketAddrV4},
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
 };
 
 fn fake_entry(port: u16) -> Arc<Entry> {
@@ -80,6 +80,59 @@ fn thread_shutdown() {
     }
 
     panic!("thread did not shut down after {max_time:?}");
+}
+
+#[test]
+fn serialize_to_disk_writes_configured_entries() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("secrets");
+
+    let signer = stateless_reset::Signer::new(b"secret");
+    let map = State::builder()
+        .with_signer(signer)
+        .with_capacity(50)
+        .with_clock(Clock)
+        .with_subscriber(tracing::Subscriber::default())
+        .with_serializer(disk::Serializer::builder(&path).build().unwrap())
+        .build()
+        .unwrap();
+
+    // Stop background processing so the cleaner thread doesn't race our manual serialization.
+    map.cleaner.stop();
+
+    let first = fake_entry(1);
+    let second = fake_entry(2);
+    map.test_insert(first.clone());
+    map.test_insert(second.clone());
+
+    map.serialize_to_disk().unwrap();
+
+    let mut decoded: Vec<SocketAddr> = disk::deserialize(&path)
+        .unwrap()
+        .map(|e| e.unwrap().peer)
+        .collect();
+    decoded.sort();
+
+    let mut expected = vec![*first.peer(), *second.peer()];
+    expected.sort();
+
+    assert_eq!(decoded, expected);
+}
+
+#[test]
+fn serialize_to_disk_without_serializer_is_noop() {
+    let signer = stateless_reset::Signer::new(b"secret");
+    let map = State::builder()
+        .with_signer(signer)
+        .with_capacity(50)
+        .with_clock(Clock)
+        .with_subscriber(tracing::Subscriber::default())
+        .build()
+        .unwrap();
+    map.cleaner.stop();
+
+    // No serializer configured: this is a no-op and must not error.
+    map.serialize_to_disk().unwrap();
 }
 
 #[derive(Debug, Default)]

--- a/dc/s2n-quic-dc/src/path/secret/map/status.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/status.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{Entry, Map};
-use crate::crypto;
+use crate::{crypto, path::secret::map::Epoch};
 use core::{
     fmt,
     sync::atomic::{AtomicU64, Ordering},
@@ -24,12 +24,14 @@ impl fmt::Debug for IsRetired {
 }
 
 impl IsRetired {
-    pub fn retire(&self, at_epoch: u64) {
-        self.0.store(at_epoch, Ordering::Relaxed);
+    pub fn retire(&self, at_epoch: Epoch) {
+        self.0.store(at_epoch.get(), Ordering::Relaxed);
     }
 
-    pub fn retired_at(&self) -> Option<u64> {
-        Some(self.0.load(Ordering::Relaxed)).filter(|v| *v > 0)
+    pub fn retired_at(&self) -> Option<Epoch> {
+        Some(self.0.load(Ordering::Relaxed))
+            .filter(|v| *v > 0)
+            .map(Epoch)
     }
 
     pub fn is_retired(&self) -> bool {

--- a/dc/s2n-quic-dc/src/path/secret/map/store.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/store.rs
@@ -77,6 +77,11 @@ pub trait Store: 'static + Send + Sync {
         queue_id: Option<VarInt>,
     ) -> crate::crypto::open::Result;
 
+    /// Serializes the current map to disk using the configured serializer.
+    ///
+    /// Does nothing (returning `Ok(())`) if no serializer was configured.
+    fn serialize_to_disk(&self) -> std::io::Result<()>;
+
     #[cfg(any(test, feature = "testing"))]
     fn test_insert(&self, entry: Arc<Entry>) {
         self.on_new_path_secrets(entry.clone());


### PR DESCRIPTION
### Release Summary:

* feat(dc): Support serializing path secret map socket addrs

### Resolved issues:

### Description of changes: 

This implements support for serializing (and deserializing) path secret maps, scoped to just the socket addresses. https://github.com/aws/s2n-quic/pull/3089 should be able to build atop the support here with a new file format to include (if enabled by the user) enough information to produce UPS packets on startup as well.

The current use case for this is using the stored state to discover the set of peers to handshake with when starting up; this is sometimes not easily available at runtime.

### Call-outs:

We limit the map size statically to around 50MB. In practice it should be smaller (around 5MB at a conservative 10 bytes / entry for a max-size 500k entry map -- for IPv4 only maps right now we'd be at IP (4) + Port (2) + discriminant (1) = 7 bytes/entry).

This increases entry sizes by 8 bytes to store the access information. My expectation is this is a temporary increase; a future PR can refactor away the now somewhat redundant information (e.g., accessed byte and retired 8-byte tracker can likely both be removed; at the very least we can likely merge the retired 8-byte tracker with the accessed tracking). I think we can afford the extra memory as a short-term increase.

### Testing:

Added unit tests for most of the functionality.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

