### PR TITLE
refactor(dc): Drop no-op disable API

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/key.rs
+++ b/dc/s2n-quic-dc/src/path/secret/key.rs
@@ -154,19 +154,6 @@ pub mod open {
 
     macro_rules! with_dedup {
         () => {
-            /// Disables replay prevention allowing the decryption key to be reused.
-            ///
-            /// ## Safety
-            /// Disabling replay prevention is insecure because it makes it possible for
-            /// active network attackers to cause a peer to accept previously processed
-            /// data as new. For example, if a packet contains a mutating request such
-            /// as adding +1 to a value in a database, an attacker can keep replaying
-            /// packets to increment the value beyond what the original legitimate
-            /// sender of the packet intended.
-            pub unsafe fn disable_replay_prevention(&mut self) {
-                self.dedup.disable();
-            }
-
             /// Ensures the key has not been used before
             #[inline]
             pub fn on_decrypt_success(&self, payload: &mut UninitSlice) -> open::Result {

--- a/dc/s2n-quic-dc/src/path/secret/map/status.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/status.rs
@@ -82,25 +82,15 @@ impl Dedup {
     }
 
     #[inline]
-    pub(crate) fn disable(&self) {
-        // TODO
-    }
-
-    #[inline]
     pub fn check(&self) -> crypto::open::Result {
-        *self.cell.get_or_init(|| {
-            match self.init.take() {
-                Some(DedupInit {
-                    entry,
-                    key_id,
-                    queue_id,
-                    map,
-                }) => map.store.check_dedup(&entry, key_id, queue_id),
-                None => {
-                    // Dedup has been poisoned! TODO log this
-                    Err(crypto::open::Error::ReplayPotentiallyDetected { gap: None })
-                }
-            }
+        *self.cell.get_or_init(|| match self.init.take() {
+            Some(DedupInit {
+                entry,
+                key_id,
+                queue_id,
+                map,
+            }) => map.store.check_dedup(&entry, key_id, queue_id),
+            None => Err(crypto::open::Error::ReplayPotentiallyDetected { gap: None }),
         })
     }
 }


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

This already was a no-op and doesn't appear to be used; just deleting the API makes sense. We can re-add it if it becomes needed.

### Call-outs:

n/a

### Testing:

Just deleting code (no test impact).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

