### PR TITLE
docs(dc): Recommend access controls on Unix socket

### DIFF
--- a/dc/s2n-quic-dc/src/stream/server/application.rs
+++ b/dc/s2n-quic-dc/src/stream/server/application.rs
@@ -73,6 +73,10 @@ impl Default for Builder {
 impl Builder {
     common_builder_methods!();
 
+    /// The provided path will be used to unlink + bind a Unix socket. Users on the local system
+    /// that can connect to this socket can send traffic to the application with no additional
+    /// authentication being performed, so appropriate access controls should be enforced. These
+    /// are the responsibility of the application owner.
     pub fn with_socket_path(mut self, path: &Path) -> Self {
         self.socket_path = Some(path.to_path_buf());
         self


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes:

Documents recommendation for enforcing access controls if relevant for the application.

### Call-outs:

This is mostly to help security scanning hopefully not complain about this socket path causing issues if an attacker controls the directory.

### Testing:

n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

