### PR TITLE
refactor(dc): Remove background_handshake_with from blocking handshake calls

### DIFF
--- a/dc/s2n-quic-dc/src/psk/client.rs
+++ b/dc/s2n-quic-dc/src/psk/client.rs
@@ -154,9 +154,8 @@ impl Provider {
             return Ok((peer, HandshakeKind::Cached));
         }
 
-        // Unconditionally request a background handshake. This schedules any re-handshaking
-        // needed. We put this after get_tracked because that saves us a global lock to check
-        // presence in the map in the happy path.
+        // Ensure that even if the future is dropped a handshake is driven to completion in th
+        // background.
         if self.state.runtime.is_some() {
             let _ = self.background_handshake_with(peer, server_name.clone());
         }
@@ -243,12 +242,6 @@ impl Provider {
         peer: SocketAddr,
         server_name: Name,
     ) -> std::io::Result<HandshakeKind> {
-        // Unconditionally request a background handshake. This schedules any re-handshaking
-        // needed.
-        if self.state.runtime.is_some() {
-            let _ = self.background_handshake_with(peer, server_name.clone());
-        }
-
         if self.state.map.contains(&peer) {
             return Ok(HandshakeKind::Cached);
         }


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

It's not possible to cancel a blocking handshake so the call wasn't helping mitigate cancellation. And it made the return code non-deterministic (there's a (low) chance the background handshake completes before the map is checked, resulting in an incorrect "Cached" result).



### Testing:

Just compilation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

