### PR TITLE
fix(ci): pass --config as cargo-deny global option

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -63,4 +63,5 @@ jobs:
 
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
-          command: check --config .github/config/cargo-deny.toml
+          arguments: --all-features --config .github/config/cargo-deny.toml
+          command: check


### PR DESCRIPTION
### Resolved issues:

Resolves the broken cargo-deny CI job (e.g. https://github.com/aws/s2n-quic/actions/runs/29274084082/job/86898695078).

### Description of changes: 

The cargo-deny CI job fails with error: unexpected argument '--config' because the current cargo-deny CLI requires --config before the check subcommand. This moves --config out of command and into arguments (which the action places before the subcommand). --all-features is also specified in arguments to preserve the action's previous default, which is overridden once arguments is set explicitly.

### Call-outs:

N/A

### Testing:

Existing CI


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

