### PR TITLE
fix: overload server stress test

### DIFF
--- a/dc/s2n-quic-dc/src/psk/client/builder.rs
+++ b/dc/s2n-quic-dc/src/psk/client/builder.rs
@@ -136,6 +136,29 @@ impl<Event: s2n_quic::provider::event::Subscriber> Builder<Event> {
         self
     }
 
+    /// Sets the period we wait before allowing new handshakes with the same peer (by IP:port),
+    /// after a failed handshake.
+    ///
+    /// This is the upper bound, the jitter is randomized between 1 second and the upper bound.
+    /// Setting this to [`Duration::ZERO`] will immediately allow new handshakes after failure.
+    ///
+    /// This defaults to 2 minutes.
+    pub fn with_error_jitter(mut self, period: Duration) -> Self {
+        self.handshake_queue.error_jitter = period;
+        self
+    }
+
+    /// When enabled, handshake callers will wait for the deduplication entry to be removed
+    /// before returning. This is useful for benchmarking where each iteration needs a fresh
+    /// handshake without dedup interference.
+    ///
+    /// Defaults to `false`.
+    #[doc(hidden)]
+    pub fn with_await_dedup_removal(mut self, await_dedup_removal: bool) -> Self {
+        self.handshake_queue.await_dedup_removal = await_dedup_removal;
+        self
+    }
+
     /// Bind the client to the given address.
     ///
     /// Typically the address provided can use an ephemeral port.

--- a/dc/s2n-quic-dc/src/psk/io.rs
+++ b/dc/s2n-quic-dc/src/psk/io.rs
@@ -362,6 +362,9 @@ pub(crate) struct HandshakeQueueConfig {
     /// Upper bound on the jitter delay after a successful handshake before allowing
     /// another handshake with the same peer.
     pub(crate) success_jitter: Duration,
+    /// Upper bound on the jitter delay after a failed handshake before allowing
+    /// another handshake with the same peer.
+    pub(crate) error_jitter: Duration,
     /// Maximum number of TLS handshakes that can be started concurrently.
     ///
     /// TLS handshakes have high CPU cost (~1ms) which stalls out the endpoint, so we
@@ -373,14 +376,17 @@ pub(crate) struct HandshakeQueueConfig {
     /// Keeping this bounded helps avoid unbounded work ongoing in s2n-quic (which
     /// implies unbounded packet transmit/receive work).
     pub(crate) inflight_limit: usize,
+    pub(crate) await_dedup_removal: bool,
 }
 
 impl Default for HandshakeQueueConfig {
     fn default() -> Self {
         Self {
             success_jitter: Duration::from_secs(60),
+            error_jitter: Duration::from_secs(120),
             start_limit: 5,
             inflight_limit: 750,
+            await_dedup_removal: false,
         }
     }
 }
@@ -390,6 +396,8 @@ struct HandshakeQueue {
     limiter_start: Semaphore,
     limiter_inflight: Arc<Semaphore>,
     success_jitter: Duration,
+    error_jitter: Duration,
+    await_dedup_removal: bool,
     hasher: std::collections::hash_map::RandomState,
 }
 
@@ -401,6 +409,8 @@ impl HandshakeQueue {
             success_jitter: config.success_jitter,
             inner: Default::default(),
             hasher: Default::default(),
+            error_jitter: config.error_jitter,
+            await_dedup_removal: config.await_dedup_removal,
         }
     }
 
@@ -540,7 +550,7 @@ impl HandshakeQueue {
             // This task also owns pruning our de-duplication tracking.
             let this = self.clone();
             let map_clone = map.clone();
-            tokio::spawn(async move {
+            let cleanup = tokio::spawn(async move {
                 // Use the same deadline for MTU probing - any remaining time from the 10s budget
                 if tokio::time::timeout_at(
                     deadline,
@@ -576,6 +586,10 @@ impl HandshakeQueue {
                 this.remove_entry(&entry);
             });
 
+            if self.await_dedup_removal {
+                let _ = cleanup.await;
+            }
+
             Ok::<_, io::Error>(())
         };
 
@@ -589,31 +603,38 @@ impl HandshakeQueue {
                     // eventually, but keeping it for parity for now.
                     tracing::error!("handshake with {peer} failed: {e}");
 
-                    let this = self.clone();
-                    tokio::spawn(async move {
-                        // Delay deleting the entry by a random time, up to 2 minutes.
-                        //
-                        // This avoids aggressively reconnecting to a given peer if handshakes
-                        // fail (instead we keep returning the cached error). This is good both for
-                        // fast failure (e.g., certificate issues) and for slow errors (timeouts).
-                        // In the first case, it's very unlikely the issue will be fixed within
-                        // seconds, so backing off is natural to keep aggregate handshake volume
-                        // more bounded. For the latter, backing off avoids generating undue load
-                        // on the network or server. The specific duration is not chosen
-                        // with any particular rationale, mostly intended to be a relatively small
-                        // amount (to avoid significantly extending recovery times if the server
-                        // was temporarily overloaded) while still significantly reducing handshake
-                        // volume (>60x for fast-failing handshakes and >10x for timeouts).
-                        let duration = {
-                            let mut rng = rand::rng();
-                            rng.random_range(1000..120_000)
-                        };
-                        tokio::time::sleep(Duration::from_millis(duration)).await;
+                    // Delay deleting the entry by a random time, up to 2 minutes.
+                    //
+                    // This avoids aggressively reconnecting to a given peer if handshakes
+                    // fail (instead we keep returning the cached error). This is good both for
+                    // fast failure (e.g., certificate issues) and for slow errors (timeouts).
+                    // In the first case, it's very unlikely the issue will be fixed within
+                    // seconds, so backing off is natural to keep aggregate handshake volume
+                    // more bounded. For the latter, backing off avoids generating undue load
+                    // on the network or server. The specific duration is not chosen
+                    // with any particular rationale, mostly intended to be a relatively small
+                    // amount (to avoid significantly extending recovery times if the server
+                    // was temporarily overloaded) while still significantly reducing handshake
+                    // volume (>60x for fast-failing handshakes and >10x for timeouts).
+                    if self.error_jitter.is_zero() {
+                        self.remove_entry(&entry3);
+                    } else {
+                        let this = self.clone();
+                        let error_jitter = self.error_jitter;
+                        let cleanup = tokio::spawn(async move {
+                            let duration = {
+                                let mut rng = rand::rng();
+                                let min = 1000.min(error_jitter.as_millis() as u64);
+                                rng.random_range(min..=error_jitter.as_millis() as u64)
+                            };
+                            tokio::time::sleep(Duration::from_millis(duration)).await;
+                            this.remove_entry(&entry3);
+                        });
 
-                        // If the handshake fails, we also remove the entry from the map.
-                        // This permits another handshake to start for the same peer.
-                        this.remove_entry(&entry3);
-                    });
+                        if self.await_dedup_removal {
+                            let _ = cleanup.await;
+                        }
+                    }
 
                     Err(HandshakeFailed(e))
                 } else {

--- a/quic/s2n-quic-bench/src/bin/overload-server/mod.rs
+++ b/quic/s2n-quic-bench/src/bin/overload-server/mod.rs
@@ -149,8 +149,8 @@ pub fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
 
         let client = client::Provider::builder()
             .with_success_jitter(Duration::ZERO)
-            //.with_error_jitter(Duration::ZERO)
-            //.with_await_dedup_removal(true)
+            .with_error_jitter(Duration::ZERO)
+            .with_await_dedup_removal(true)
             .start(
                 "127.0.0.1:0".parse().unwrap(),
                 new_map(10),


### PR DESCRIPTION
### Release Summary:


### Resolved issues:
### Description of changes: 

The server stress test that is currently merged does not reproduce the baseline benchmarks that I've been working with. This is due to my mistake, I didn't realize that I was relying on unmerged dc-quic APIs from this PR #3010 to create these benchmarks. One API is allowing users to turn off error jitter, which inserts a random wait time before a failed connection is allowed to retry, since random sleeps are not helpful when attempting to benchmark a scenario with lots of failed connections. with_await_dedup_removal means that we wait for connections to be deduplicated before attempting a fresh handshake. 

### Call-outs:

If we don't want to merge these APIs, I could probably just replace the stress test using s2n-quic instead of dc-quic. The reason why I don't want to do that is that dc-quic has a lot of custom settings already in place and I might overlook things if I'm only looking at vanilla s2n-quic.

### Testing:
I manually tested that these settings regenerate the expected benchmark output.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

