### PR TITLE
chore(s2n-quic-tests): remove gate on 32-bit quiche build

### DIFF
--- a/quic/s2n-quic-tests/Cargo.toml
+++ b/quic/s2n-quic-tests/Cargo.toml
@@ -14,6 +14,7 @@ publish = false
 bach = "0.1.0"
 bytes = { version = "1", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std"] }
+quiche = "0.29"
 rand = { version = "0.10", features = ["chacha"] }
 s2n-codec = { path = "../../common/s2n-codec" }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["branch-tracing", "event-tracing", "probe-tracing", "testing"] }
@@ -24,11 +25,6 @@ tokio = { version = "1", features = ["full"] }
 tracing = { version = "0.1" }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 zerocopy = { version = "0.8", features = ["derive"] }
-
-# quiche does not currently build on 32-bit platforms
-# see https://github.com/cloudflare/quiche/issues/2097
-[target.'cfg(not(target_arch = "x86"))'.dependencies]
-quiche = "0.29"
 
 # s2n-tls is required by ch_callback_server_local_address_test and doesn't build on Windows
 [target.'cfg(not(target_os = "windows"))'.dependencies]

--- a/quic/s2n-quic-tests/src/tests.rs
+++ b/quic/s2n-quic-tests/src/tests.rs
@@ -49,9 +49,6 @@ mod self_test;
 mod skip_packets;
 mod slow_tls;
 mod tls_context;
-// quiche does not currently build on 32-bit platforms
-// see https://github.com/cloudflare/quiche/issues/2097
-#[cfg(not(target_arch = "x86"))]
 mod zero_length_cid_client_connection_migration;
 
 // The ClientHelloCallback trait is only available with s2n-tls


### PR DESCRIPTION
### Description of changes:

`quiche` was previously excluded from 32-bit (`x86`) targets because the published crate vendored an incomplete `boringssl` submodule, missing `deps/boringssl/src/util/32-bit-toolchain.cmake` (see cloudflare/quiche#2097). That workaround gated both the `quiche` dependency and the `zero_length_cid_client_connection_migration` test module behind `cfg(not(target_arch = "x86"))`.

Newer `quiche` (0.29.1) no longer vendors `boringssl` directly. It depends on the `boring` crate, and the resolved `boring-sys` 4.22.0 bundles the previously-missing `32-bit-toolchain.cmake`. The root cause is gone, so this removes the workaround:

- `Cargo.toml`: move `quiche` out of the `cfg(not(target_arch = "x86"))` target block into the regular `[dependencies]`.
- `tests.rs`: declare the `zero_length_cid_client_connection_migration` module unconditionally.

### Testing:

`cargo build -p s2n-quic-tests --tests` passes natively. The 32-bit path is exercised by the existing `i686-unknown-linux-gnu` CI job, which builds the full workspace (including `s2n-quic-tests`) via `cross`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
