### PR TITLE
feat(dc): Tweak eviction on unknown path secret arrival

### DIFF
--- a/dc/s2n-quic-dc/events/map.rs
+++ b/dc/s2n-quic-dc/events/map.rs
@@ -66,6 +66,20 @@ struct PathSecretMapEntryReplaced<'a> {
 
     #[snapshot("[HIDDEN]")]
     previous_credential_id: &'a [u8],
+
+    /// Time since insertion of the replaced entry
+    #[measure("replaced_age", Duration)]
+    replaced_age: core::time::Duration,
+}
+
+#[derive(Debug, Copy, Clone)]
+enum EvictionReason {
+    /// Capacity of map exceeded.
+    Capacity,
+    /// UnknownPathSecret received, removing entry.
+    UnknownPathSecret,
+    /// A newer entry is replacing this one, so we're retiring these.
+    Retiring,
 }
 
 #[event("path_secret_map:id_entry_evicted")]
@@ -80,7 +94,14 @@ struct PathSecretMapIdEntryEvicted<'a> {
 
     /// Time since insertion of this entry
     #[measure("age", Duration)]
+    #[snapshot("[HIDDEN]")]
     age: core::time::Duration,
+
+    #[measure("time_since_last_accessed", Duration)]
+    time_since_last_accessed: core::time::Duration,
+
+    #[nominal_counter("reason")]
+    reason: EvictionReason,
 }
 
 #[event("path_secret_map:addr_entry_evicted")]
@@ -96,6 +117,12 @@ struct PathSecretMapAddressEntryEvicted<'a> {
     /// Time since insertion of this entry
     #[measure("age", Duration)]
     age: core::time::Duration,
+
+    #[measure("time_since_last_accessed", Duration)]
+    time_since_last_accessed: core::time::Duration,
+
+    #[nominal_counter("reason")]
+    reason: EvictionReason,
 }
 
 #[event("path_secret_map:unknown_path_secret_packet_sent")]
@@ -129,6 +156,17 @@ struct UnknownPathSecretPacketAccepted<'a> {
 
     #[snapshot("[HIDDEN]")]
     credential_id: &'a [u8],
+
+    /// The age of the entry the peer indicated it doesn't know about.
+    #[measure("age", Duration)]
+    #[snapshot("[HIDDEN]")]
+    age: core::time::Duration,
+
+    #[bool_counter("evicted")]
+    evicted: bool,
+
+    #[bool_counter("scheduled_handshake")]
+    scheduled_handshake: bool,
 }
 
 #[event("path_secret_map:unknown_path_secret_packet_rejected")]

--- a/dc/s2n-quic-dc/src/event/generated.rs
+++ b/dc/s2n-quic-dc/src/event/generated.rs
@@ -1961,6 +1961,8 @@ pub mod api {
         pub peer_address: SocketAddress<'a>,
         pub new_credential_id: &'a [u8],
         pub previous_credential_id: &'a [u8],
+        /// Time since insertion of the replaced entry
+        pub replaced_age: core::time::Duration,
     }
     #[cfg(any(test, feature = "testing"))]
     impl<'a> crate::event::snapshot::Fmt for PathSecretMapEntryReplaced<'a> {
@@ -1969,6 +1971,7 @@ pub mod api {
             fmt.field("peer_address", &self.peer_address);
             fmt.field("new_credential_id", &"[HIDDEN]");
             fmt.field("previous_credential_id", &"[HIDDEN]");
+            fmt.field("replaced_age", &self.replaced_age);
             fmt.finish()
         }
     }
@@ -1983,6 +1986,8 @@ pub mod api {
         pub credential_id: &'a [u8],
         /// Time since insertion of this entry
         pub age: core::time::Duration,
+        pub time_since_last_accessed: core::time::Duration,
+        pub reason: EvictionReason,
     }
     #[cfg(any(test, feature = "testing"))]
     impl<'a> crate::event::snapshot::Fmt for PathSecretMapIdEntryEvicted<'a> {
@@ -1990,7 +1995,9 @@ pub mod api {
             let mut fmt = fmt.debug_struct("PathSecretMapIdEntryEvicted");
             fmt.field("peer_address", &self.peer_address);
             fmt.field("credential_id", &"[HIDDEN]");
-            fmt.field("age", &self.age);
+            fmt.field("age", &"[HIDDEN]");
+            fmt.field("time_since_last_accessed", &self.time_since_last_accessed);
+            fmt.field("reason", &self.reason);
             fmt.finish()
         }
     }
@@ -2005,6 +2012,8 @@ pub mod api {
         pub credential_id: &'a [u8],
         /// Time since insertion of this entry
         pub age: core::time::Duration,
+        pub time_since_last_accessed: core::time::Duration,
+        pub reason: EvictionReason,
     }
     #[cfg(any(test, feature = "testing"))]
     impl<'a> crate::event::snapshot::Fmt for PathSecretMapAddressEntryEvicted<'a> {
@@ -2013,6 +2022,8 @@ pub mod api {
             fmt.field("peer_address", &self.peer_address);
             fmt.field("credential_id", &"[HIDDEN]");
             fmt.field("age", &self.age);
+            fmt.field("time_since_last_accessed", &self.time_since_last_accessed);
+            fmt.field("reason", &self.reason);
             fmt.finish()
         }
     }
@@ -2063,6 +2074,10 @@ pub mod api {
     pub struct UnknownPathSecretPacketAccepted<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
+        /// The age of the entry the peer indicated it doesn't know about.
+        pub age: core::time::Duration,
+        pub evicted: bool,
+        pub scheduled_handshake: bool,
     }
     #[cfg(any(test, feature = "testing"))]
     impl<'a> crate::event::snapshot::Fmt for UnknownPathSecretPacketAccepted<'a> {
@@ -2070,6 +2085,9 @@ pub mod api {
             let mut fmt = fmt.debug_struct("UnknownPathSecretPacketAccepted");
             fmt.field("peer_address", &self.peer_address);
             fmt.field("credential_id", &"[HIDDEN]");
+            fmt.field("age", &"[HIDDEN]");
+            fmt.field("evicted", &self.evicted);
+            fmt.field("scheduled_handshake", &self.scheduled_handshake);
             fmt.finish()
         }
     }
@@ -2658,6 +2676,46 @@ pub mod api {
     }
     impl Event for PathSecretMapDatagramDecrypt {
         const NAME: &'static str = "path_secret_map:datagram_decrypt";
+    }
+    #[non_exhaustive]
+    #[derive(Debug, Copy, Clone)]
+    pub enum EvictionReason {
+        #[non_exhaustive]
+        /// Capacity of map exceeded.
+        Capacity {},
+        #[non_exhaustive]
+        /// UnknownPathSecret received, removing entry.
+        UnknownPathSecret {},
+        #[non_exhaustive]
+        /// A newer entry is replacing this one, so we're retiring these.
+        Retiring {},
+    }
+    impl aggregate::AsVariant for EvictionReason {
+        const VARIANTS: &'static [aggregate::info::Variant] = &[
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("CAPACITY\0"),
+                id: 0usize,
+            }
+            .build(),
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("UNKNOWN_PATH_SECRET\0"),
+                id: 1usize,
+            }
+            .build(),
+            aggregate::info::variant::Builder {
+                name: aggregate::info::Str::new("RETIRING\0"),
+                id: 2usize,
+            }
+            .build(),
+        ];
+        #[inline]
+        fn variant_idx(&self) -> usize {
+            match self {
+                Self::Capacity { .. } => 0usize,
+                Self::UnknownPathSecret { .. } => 1usize,
+                Self::Retiring { .. } => 2usize,
+            }
+        }
     }
     impl IntoEvent<builder::AcceptorPacketDropReason> for s2n_codec::DecoderError {
         fn into_event(self) -> builder::AcceptorPacketDropReason {
@@ -3992,13 +4050,15 @@ pub mod tracing {
                 peer_address,
                 new_credential_id,
                 previous_credential_id,
+                replaced_age,
             } = event;
             tracing::event!(
                 target : "path_secret_map_entry_replaced", parent : parent,
                 tracing::Level::DEBUG, { peer_address =
                 tracing::field::debug(peer_address), new_credential_id =
                 tracing::field::debug(new_credential_id), previous_credential_id =
-                tracing::field::debug(previous_credential_id) }
+                tracing::field::debug(previous_credential_id), replaced_age =
+                tracing::field::debug(replaced_age) }
             );
         }
         #[inline]
@@ -4012,12 +4072,17 @@ pub mod tracing {
                 peer_address,
                 credential_id,
                 age,
+                time_since_last_accessed,
+                reason,
             } = event;
             tracing::event!(
                 target : "path_secret_map_id_entry_evicted", parent : parent,
                 tracing::Level::DEBUG, { peer_address =
                 tracing::field::debug(peer_address), credential_id =
-                tracing::field::debug(credential_id), age = tracing::field::debug(age) }
+                tracing::field::debug(credential_id), age = tracing::field::debug(age),
+                time_since_last_accessed =
+                tracing::field::debug(time_since_last_accessed), reason =
+                tracing::field::debug(reason) }
             );
         }
         #[inline]
@@ -4031,12 +4096,17 @@ pub mod tracing {
                 peer_address,
                 credential_id,
                 age,
+                time_since_last_accessed,
+                reason,
             } = event;
             tracing::event!(
                 target : "path_secret_map_address_entry_evicted", parent : parent,
                 tracing::Level::DEBUG, { peer_address =
                 tracing::field::debug(peer_address), credential_id =
-                tracing::field::debug(credential_id), age = tracing::field::debug(age) }
+                tracing::field::debug(credential_id), age = tracing::field::debug(age),
+                time_since_last_accessed =
+                tracing::field::debug(time_since_last_accessed), reason =
+                tracing::field::debug(reason) }
             );
         }
         #[inline]
@@ -4085,12 +4155,17 @@ pub mod tracing {
             let api::UnknownPathSecretPacketAccepted {
                 peer_address,
                 credential_id,
+                age,
+                evicted,
+                scheduled_handshake,
             } = event;
             tracing::event!(
                 target : "unknown_path_secret_packet_accepted", parent : parent,
                 tracing::Level::DEBUG, { peer_address =
                 tracing::field::debug(peer_address), credential_id =
-                tracing::field::debug(credential_id) }
+                tracing::field::debug(credential_id), age = tracing::field::debug(age),
+                evicted = tracing::field::debug(evicted), scheduled_handshake =
+                tracing::field::debug(scheduled_handshake) }
             );
         }
         #[inline]
@@ -6352,6 +6427,8 @@ pub mod builder {
         pub peer_address: SocketAddress<'a>,
         pub new_credential_id: &'a [u8],
         pub previous_credential_id: &'a [u8],
+        /// Time since insertion of the replaced entry
+        pub replaced_age: core::time::Duration,
     }
     impl<'a> IntoEvent<api::PathSecretMapEntryReplaced<'a>> for PathSecretMapEntryReplaced<'a> {
         #[inline]
@@ -6360,11 +6437,13 @@ pub mod builder {
                 peer_address,
                 new_credential_id,
                 previous_credential_id,
+                replaced_age,
             } = self;
             api::PathSecretMapEntryReplaced {
                 peer_address: peer_address.into_event(),
                 new_credential_id: new_credential_id.into_event(),
                 previous_credential_id: previous_credential_id.into_event(),
+                replaced_age: replaced_age.into_event(),
             }
         }
     }
@@ -6375,6 +6454,8 @@ pub mod builder {
         pub credential_id: &'a [u8],
         /// Time since insertion of this entry
         pub age: core::time::Duration,
+        pub time_since_last_accessed: core::time::Duration,
+        pub reason: EvictionReason,
     }
     impl<'a> IntoEvent<api::PathSecretMapIdEntryEvicted<'a>> for PathSecretMapIdEntryEvicted<'a> {
         #[inline]
@@ -6383,11 +6464,15 @@ pub mod builder {
                 peer_address,
                 credential_id,
                 age,
+                time_since_last_accessed,
+                reason,
             } = self;
             api::PathSecretMapIdEntryEvicted {
                 peer_address: peer_address.into_event(),
                 credential_id: credential_id.into_event(),
                 age: age.into_event(),
+                time_since_last_accessed: time_since_last_accessed.into_event(),
+                reason: reason.into_event(),
             }
         }
     }
@@ -6398,6 +6483,8 @@ pub mod builder {
         pub credential_id: &'a [u8],
         /// Time since insertion of this entry
         pub age: core::time::Duration,
+        pub time_since_last_accessed: core::time::Duration,
+        pub reason: EvictionReason,
     }
     impl<'a> IntoEvent<api::PathSecretMapAddressEntryEvicted<'a>>
         for PathSecretMapAddressEntryEvicted<'a>
@@ -6408,11 +6495,15 @@ pub mod builder {
                 peer_address,
                 credential_id,
                 age,
+                time_since_last_accessed,
+                reason,
             } = self;
             api::PathSecretMapAddressEntryEvicted {
                 peer_address: peer_address.into_event(),
                 credential_id: credential_id.into_event(),
                 age: age.into_event(),
+                time_since_last_accessed: time_since_last_accessed.into_event(),
+                reason: reason.into_event(),
             }
         }
     }
@@ -6461,6 +6552,10 @@ pub mod builder {
     pub struct UnknownPathSecretPacketAccepted<'a> {
         pub peer_address: SocketAddress<'a>,
         pub credential_id: &'a [u8],
+        /// The age of the entry the peer indicated it doesn't know about.
+        pub age: core::time::Duration,
+        pub evicted: bool,
+        pub scheduled_handshake: bool,
     }
     impl<'a> IntoEvent<api::UnknownPathSecretPacketAccepted<'a>>
         for UnknownPathSecretPacketAccepted<'a>
@@ -6470,10 +6565,16 @@ pub mod builder {
             let UnknownPathSecretPacketAccepted {
                 peer_address,
                 credential_id,
+                age,
+                evicted,
+                scheduled_handshake,
             } = self;
             api::UnknownPathSecretPacketAccepted {
                 peer_address: peer_address.into_event(),
                 credential_id: credential_id.into_event(),
+                age: age.into_event(),
+                evicted: evicted.into_event(),
+                scheduled_handshake: scheduled_handshake.into_event(),
             }
         }
     }
@@ -7041,6 +7142,26 @@ pub mod builder {
             let PathSecretMapDatagramDecrypt { packet_len } = self;
             api::PathSecretMapDatagramDecrypt {
                 packet_len: packet_len.into_event(),
+            }
+        }
+    }
+    #[derive(Clone, Debug)]
+    pub enum EvictionReason {
+        /// Capacity of map exceeded.
+        Capacity,
+        /// UnknownPathSecret received, removing entry.
+        UnknownPathSecret,
+        /// A newer entry is replacing this one, so we're retiring these.
+        Retiring,
+    }
+    impl IntoEvent<api::EvictionReason> for EvictionReason {
+        #[inline]
+        fn into_event(self) -> api::EvictionReason {
+            use api::EvictionReason::*;
+            match self {
+                Self::Capacity => Capacity {},
+                Self::UnknownPathSecret => UnknownPathSecret {},
+                Self::Retiring => Retiring {},
             }
         }
     }

--- a/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/aggregate.rs
@@ -261,18 +261,26 @@ mod id {
         PATH_SECRET_MAP_ENTRY_READY__PEER_ADDRESS__PROTOCOL,
         PATH_SECRET_MAP_ENTRY_REPLACED,
         PATH_SECRET_MAP_ENTRY_REPLACED__PEER_ADDRESS__PROTOCOL,
+        PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE,
         PATH_SECRET_MAP_ID_ENTRY_EVICTED,
         PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL,
         PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE,
+        PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED,
+        PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON,
         PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED,
         PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL,
         PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE,
+        PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED,
+        PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON,
         UNKNOWN_PATH_SECRET_PACKET_SENT,
         UNKNOWN_PATH_SECRET_PACKET_SENT__PEER_ADDRESS__PROTOCOL,
         UNKNOWN_PATH_SECRET_PACKET_RECEIVED,
         UNKNOWN_PATH_SECRET_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL,
         UNKNOWN_PATH_SECRET_PACKET_ACCEPTED,
         UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL,
+        UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE,
+        UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED,
+        UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE,
         UNKNOWN_PATH_SECRET_PACKET_REJECTED,
         UNKNOWN_PATH_SECRET_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL,
         UNKNOWN_PATH_SECRET_PACKET_DROPPED,
@@ -753,18 +761,28 @@ mod id {
         InfoId::PATH_SECRET_MAP_ENTRY_REPLACED as usize;
     pub const PATH_SECRET_MAP_ENTRY_REPLACED__PEER_ADDRESS__PROTOCOL: usize =
         InfoId::PATH_SECRET_MAP_ENTRY_REPLACED__PEER_ADDRESS__PROTOCOL as usize;
+    pub const PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE: usize =
+        InfoId::PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE as usize;
     pub const PATH_SECRET_MAP_ID_ENTRY_EVICTED: usize =
         InfoId::PATH_SECRET_MAP_ID_ENTRY_EVICTED as usize;
     pub const PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL: usize =
         InfoId::PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL as usize;
     pub const PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE: usize =
         InfoId::PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE as usize;
+    pub const PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED: usize =
+        InfoId::PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED as usize;
+    pub const PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON: usize =
+        InfoId::PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON as usize;
     pub const PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED: usize =
         InfoId::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED as usize;
     pub const PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL: usize =
         InfoId::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL as usize;
     pub const PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE: usize =
         InfoId::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE as usize;
+    pub const PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED: usize =
+        InfoId::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED as usize;
+    pub const PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON: usize =
+        InfoId::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON as usize;
     pub const UNKNOWN_PATH_SECRET_PACKET_SENT: usize =
         InfoId::UNKNOWN_PATH_SECRET_PACKET_SENT as usize;
     pub const UNKNOWN_PATH_SECRET_PACKET_SENT__PEER_ADDRESS__PROTOCOL: usize =
@@ -777,6 +795,12 @@ mod id {
         InfoId::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED as usize;
     pub const UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL: usize =
         InfoId::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL as usize;
+    pub const UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE: usize =
+        InfoId::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE as usize;
+    pub const UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED: usize =
+        InfoId::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED as usize;
+    pub const UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE: usize =
+        InfoId::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE as usize;
     pub const UNKNOWN_PATH_SECRET_PACKET_REJECTED: usize =
         InfoId::UNKNOWN_PATH_SECRET_PACKET_REJECTED as usize;
     pub const UNKNOWN_PATH_SECRET_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL: usize =
@@ -1273,6 +1297,8 @@ mod id {
         BOOL_COUNTERS_STREAM_CONTROL_PACKET_RECEIVED__AUTHENTICATED,
         BOOL_COUNTERS_ENDPOINT_INITIALIZED__TCP,
         BOOL_COUNTERS_ENDPOINT_INITIALIZED__UDP,
+        BOOL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED,
+        BOOL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE,
         BOOL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__HIT,
         BOOL_COUNTERS_PATH_SECRET_MAP_ID_CACHE_ACCESSED__HIT,
         BOOL_COUNTERS_PATH_SECRET_MAP_SERIALIZED__ERROR,
@@ -1317,6 +1343,11 @@ mod id {
         BoolCounters::BOOL_COUNTERS_ENDPOINT_INITIALIZED__TCP as usize;
     pub const BOOL_COUNTERS_ENDPOINT_INITIALIZED__UDP: usize =
         BoolCounters::BOOL_COUNTERS_ENDPOINT_INITIALIZED__UDP as usize;
+    pub const BOOL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED: usize =
+        BoolCounters::BOOL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED as usize;
+    pub const BOOL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE: usize =
+        BoolCounters::BOOL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE
+            as usize;
     pub const BOOL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__HIT: usize =
         BoolCounters::BOOL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__HIT as usize;
     pub const BOOL_COUNTERS_PATH_SECRET_MAP_ID_CACHE_ACCESSED__HIT: usize =
@@ -1343,7 +1374,9 @@ mod id {
         NOMINAL_COUNTERS_PATH_SECRET_MAP_ENTRY_READY__PEER_ADDRESS__PROTOCOL,
         NOMINAL_COUNTERS_PATH_SECRET_MAP_ENTRY_REPLACED__PEER_ADDRESS__PROTOCOL,
         NOMINAL_COUNTERS_PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL,
+        NOMINAL_COUNTERS_PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON,
         NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL,
+        NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON,
         NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_SENT__PEER_ADDRESS__PROTOCOL,
         NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL,
         NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL,
@@ -1400,8 +1433,12 @@ mod id {
     pub const NOMINAL_COUNTERS_PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL: usize =
         NominalCounters::NOMINAL_COUNTERS_PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL
             as usize;
+    pub const NOMINAL_COUNTERS_PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON: usize =
+        NominalCounters::NOMINAL_COUNTERS_PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON as usize;
     pub const NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL: usize = NominalCounters::NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL
         as usize;
+    pub const NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON: usize =
+        NominalCounters::NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON as usize;
     pub const NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_SENT__PEER_ADDRESS__PROTOCOL: usize =
         NominalCounters::NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_SENT__PEER_ADDRESS__PROTOCOL
             as usize;
@@ -1548,8 +1585,12 @@ mod id {
         MEASURES_PATH_SECRET_MAP_UNINITIALIZED__CAPACITY,
         MEASURES_PATH_SECRET_MAP_UNINITIALIZED__ENTRIES,
         MEASURES_PATH_SECRET_MAP_UNINITIALIZED__LIFETIME,
+        MEASURES_PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE,
         MEASURES_PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE,
+        MEASURES_PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED,
         MEASURES_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE,
+        MEASURES_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED,
+        MEASURES_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE,
         MEASURES_KEY_ACCEPTED__GAP,
         MEASURES_KEY_ACCEPTED__FORWARD_SHIFT,
         MEASURES_REPLAY_POTENTIALLY_DETECTED__GAP,
@@ -1781,10 +1822,18 @@ mod id {
         Measures::MEASURES_PATH_SECRET_MAP_UNINITIALIZED__ENTRIES as usize;
     pub const MEASURES_PATH_SECRET_MAP_UNINITIALIZED__LIFETIME: usize =
         Measures::MEASURES_PATH_SECRET_MAP_UNINITIALIZED__LIFETIME as usize;
+    pub const MEASURES_PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE: usize =
+        Measures::MEASURES_PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE as usize;
     pub const MEASURES_PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE: usize =
         Measures::MEASURES_PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE as usize;
+    pub const MEASURES_PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED: usize =
+        Measures::MEASURES_PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED as usize;
     pub const MEASURES_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE: usize =
         Measures::MEASURES_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE as usize;
+    pub const MEASURES_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED: usize =
+        Measures::MEASURES_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED as usize;
+    pub const MEASURES_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE: usize =
+        Measures::MEASURES_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE as usize;
     pub const MEASURES_KEY_ACCEPTED__GAP: usize = Measures::MEASURES_KEY_ACCEPTED__GAP as usize;
     pub const MEASURES_KEY_ACCEPTED__FORWARD_SHIFT: usize =
         Measures::MEASURES_KEY_ACCEPTED__FORWARD_SHIFT as usize;
@@ -1943,7 +1992,7 @@ mod id {
     pub const TIMERS_STREAM_CONNECT_ERROR__LATENCY: usize =
         Timers::TIMERS_STREAM_CONNECT_ERROR__LATENCY as usize;
 }
-static INFO: &[Info; 332usize] = &[
+static INFO: &[Info; 340usize] = &[
     info::Builder {
         id: id::ACCEPTOR_TCP_STARTED,
         name: Str::new("acceptor_tcp_started\0"),
@@ -3409,6 +3458,12 @@ static INFO: &[Info; 332usize] = &[
     }
     .build(),
     info::Builder {
+        id: id::PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE,
+        name: Str::new("path_secret_map_entry_replaced.replaced_age\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
         id: id::PATH_SECRET_MAP_ID_ENTRY_EVICTED,
         name: Str::new("path_secret_map_id_entry_evicted\0"),
         units: Units::None,
@@ -3427,6 +3482,18 @@ static INFO: &[Info; 332usize] = &[
     }
     .build(),
     info::Builder {
+        id: id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED,
+        name: Str::new("path_secret_map_id_entry_evicted.time_since_last_accessed\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
+        id: id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON,
+        name: Str::new("path_secret_map_id_entry_evicted.reason\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
         id: id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED,
         name: Str::new("path_secret_map_address_entry_evicted\0"),
         units: Units::None,
@@ -3442,6 +3509,18 @@ static INFO: &[Info; 332usize] = &[
         id: id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE,
         name: Str::new("path_secret_map_address_entry_evicted.age\0"),
         units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
+        id: id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED,
+        name: Str::new("path_secret_map_address_entry_evicted.time_since_last_accessed\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
+        id: id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON,
+        name: Str::new("path_secret_map_address_entry_evicted.reason\0"),
+        units: Units::None,
     }
     .build(),
     info::Builder {
@@ -3477,6 +3556,24 @@ static INFO: &[Info; 332usize] = &[
     info::Builder {
         id: id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL,
         name: Str::new("unknown_path_secret_packet_accepted.peer_address.protocol\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE,
+        name: Str::new("unknown_path_secret_packet_accepted.age\0"),
+        units: Units::Duration,
+    }
+    .build(),
+    info::Builder {
+        id: id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED,
+        name: Str::new("unknown_path_secret_packet_accepted.evicted\0"),
+        units: Units::None,
+    }
+    .build(),
+    info::Builder {
+        id: id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE,
+        name: Str::new("unknown_path_secret_packet_accepted.scheduled_handshake\0"),
         units: Units::None,
     }
     .build(),
@@ -3976,13 +4073,13 @@ pub struct Subscriber<R: Registry> {
     #[allow(dead_code)]
     counters: Box<[R::Counter; 113usize]>,
     #[allow(dead_code)]
-    bool_counters: Box<[R::BoolCounter; 23usize]>,
+    bool_counters: Box<[R::BoolCounter; 25usize]>,
     #[allow(dead_code)]
     nominal_counters: Box<[R::NominalCounter]>,
     #[allow(dead_code)]
-    nominal_counter_offsets: Box<[usize; 35usize]>,
+    nominal_counter_offsets: Box<[usize; 37usize]>,
     #[allow(dead_code)]
-    measures: Box<[R::Measure; 133usize]>,
+    measures: Box<[R::Measure; 137usize]>,
     #[allow(dead_code)]
     gauges: Box<[R::Gauge; 0usize]>,
     #[allow(dead_code)]
@@ -4010,10 +4107,10 @@ impl<R: Registry> Subscriber<R> {
     #[inline]
     pub fn new(registry: R) -> Self {
         let mut counters = Vec::with_capacity(113usize);
-        let mut bool_counters = Vec::with_capacity(23usize);
-        let mut nominal_counters = Vec::with_capacity(35usize);
-        let mut nominal_counter_offsets = Vec::with_capacity(35usize);
-        let mut measures = Vec::with_capacity(133usize);
+        let mut bool_counters = Vec::with_capacity(25usize);
+        let mut nominal_counters = Vec::with_capacity(37usize);
+        let mut nominal_counter_offsets = Vec::with_capacity(37usize);
+        let mut measures = Vec::with_capacity(137usize);
         let mut gauges = Vec::with_capacity(0usize);
         let mut timers = Vec::with_capacity(28usize);
         let mut nominal_timers = Vec::with_capacity(0usize);
@@ -4201,6 +4298,12 @@ impl<R: Registry> Subscriber<R> {
         );
         bool_counters.push(registry.register_bool_counter(&INFO[id::ENDPOINT_INITIALIZED__TCP]));
         bool_counters.push(registry.register_bool_counter(&INFO[id::ENDPOINT_INITIALIZED__UDP]));
+        bool_counters.push(
+            registry.register_bool_counter(&INFO[id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED]),
+        );
+        bool_counters.push(registry.register_bool_counter(
+            &INFO[id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE],
+        ));
         bool_counters.push(
             registry.register_bool_counter(&INFO[id::PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__HIT]),
         );
@@ -4441,9 +4544,35 @@ impl<R: Registry> Subscriber<R> {
             {
                 let offset = nominal_counters.len();
                 let mut count = 0;
+                for variant in <EvictionReason as AsVariant>::VARIANTS.iter() {
+                    nominal_counters.push(registry.register_nominal_counter(
+                        &INFO[id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON],
+                        variant,
+                    ));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
                 for variant in <SocketAddress as AsVariant>::VARIANTS.iter() {
                     nominal_counters.push(registry.register_nominal_counter(
                         &INFO[id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL],
+                        variant,
+                    ));
+                    count += 1;
+                }
+                debug_assert_ne!(count, 0, "field type needs at least one variant");
+                nominal_counter_offsets.push(offset);
+            }
+            {
+                let offset = nominal_counters.len();
+                let mut count = 0;
+                for variant in <EvictionReason as AsVariant>::VARIANTS.iter() {
+                    nominal_counters.push(registry.register_nominal_counter(
+                        &INFO[id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON],
                         variant,
                     ));
                     count += 1;
@@ -4862,9 +4991,20 @@ impl<R: Registry> Subscriber<R> {
         measures.push(registry.register_measure(&INFO[id::PATH_SECRET_MAP_UNINITIALIZED__ENTRIES]));
         measures
             .push(registry.register_measure(&INFO[id::PATH_SECRET_MAP_UNINITIALIZED__LIFETIME]));
+        measures.push(
+            registry.register_measure(&INFO[id::PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE]),
+        );
         measures.push(registry.register_measure(&INFO[id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE]));
+        measures.push(registry.register_measure(
+            &INFO[id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED],
+        ));
         measures
             .push(registry.register_measure(&INFO[id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE]));
+        measures.push(registry.register_measure(
+            &INFO[id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED],
+        ));
+        measures
+            .push(registry.register_measure(&INFO[id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE]));
         measures.push(registry.register_measure(&INFO[id::KEY_ACCEPTED__GAP]));
         measures.push(registry.register_measure(&INFO[id::KEY_ACCEPTED__FORWARD_SHIFT]));
         measures.push(registry.register_measure(&INFO[id::REPLAY_POTENTIALLY_DETECTED__GAP]));
@@ -5396,6 +5536,14 @@ impl<R: Registry> Subscriber<R> {
                 id::BOOL_COUNTERS_ENDPOINT_INITIALIZED__UDP => {
                     (&INFO[id::ENDPOINT_INITIALIZED__UDP], entry)
                 }
+                id::BOOL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED => (
+                    &INFO[id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED],
+                    entry,
+                ),
+                id::BOOL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE => (
+                    &INFO[id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE],
+                    entry,
+                ),
                 id::BOOL_COUNTERS_PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__HIT => (
                     &INFO[id::PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__HIT],
                     entry,
@@ -5595,6 +5743,17 @@ impl<R: Registry> Subscriber<R> {
                             variants,
                         )
                     }
+                    id::NOMINAL_COUNTERS_PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON => {
+                        let offset = *entry;
+                        let variants = <EvictionReason as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON],
+                            entries,
+                            variants,
+                        )
+                    }
                     id::NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL => {
                         let offset = *entry;
                         let variants = <SocketAddress as AsVariant>::VARIANTS;
@@ -5602,6 +5761,17 @@ impl<R: Registry> Subscriber<R> {
                             .nominal_counters[offset..offset + variants.len()];
                         (
                             &INFO[id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL],
+                            entries,
+                            variants,
+                        )
+                    }
+                    id::NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON => {
+                        let offset = *entry;
+                        let variants = <EvictionReason as AsVariant>::VARIANTS;
+                        let entries = &self
+                            .nominal_counters[offset..offset + variants.len()];
+                        (
+                            &INFO[id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON],
                             entries,
                             variants,
                         )
@@ -6167,11 +6337,29 @@ impl<R: Registry> Subscriber<R> {
                     id::MEASURES_PATH_SECRET_MAP_UNINITIALIZED__LIFETIME => {
                         (&INFO[id::PATH_SECRET_MAP_UNINITIALIZED__LIFETIME], entry)
                     }
+                    id::MEASURES_PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE => {
+                        (&INFO[id::PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE], entry)
+                    }
                     id::MEASURES_PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE => {
                         (&INFO[id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE], entry)
                     }
+                    id::MEASURES_PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED],
+                            entry,
+                        )
+                    }
                     id::MEASURES_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE => {
                         (&INFO[id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE], entry)
+                    }
+                    id::MEASURES_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED => {
+                        (
+                            &INFO[id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED],
+                            entry,
+                        )
+                    }
+                    id::MEASURES_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE => {
+                        (&INFO[id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE], entry)
                     }
                     id::MEASURES_KEY_ACCEPTED__GAP => {
                         (&INFO[id::KEY_ACCEPTED__GAP], entry)
@@ -8671,6 +8859,11 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
             id::NOMINAL_COUNTERS_PATH_SECRET_MAP_ENTRY_REPLACED__PEER_ADDRESS__PROTOCOL,
             &event.peer_address,
         );
+        self.measure(
+            id::PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE,
+            id::MEASURES_PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE,
+            event.replaced_age,
+        );
         let _ = event;
         let _ = meta;
     }
@@ -8697,6 +8890,16 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
             id::MEASURES_PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE,
             event.age,
         );
+        self.measure(
+            id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED,
+            id::MEASURES_PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED,
+            event.time_since_last_accessed,
+        );
+        self.count_nominal(
+            id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON,
+            id::NOMINAL_COUNTERS_PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON,
+            &event.reason,
+        );
         let _ = event;
         let _ = meta;
     }
@@ -8722,6 +8925,16 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
             id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE,
             id::MEASURES_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE,
             event.age,
+        );
+        self.measure(
+            id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED,
+            id::MEASURES_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED,
+            event.time_since_last_accessed,
+        );
+        self.count_nominal(
+            id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON,
+            id::NOMINAL_COUNTERS_PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON,
+            &event.reason,
         );
         let _ = event;
         let _ = meta;
@@ -8785,6 +8998,21 @@ impl<R: Registry> event::Subscriber for Subscriber<R> {
             id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL,
             id::NOMINAL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL,
             &event.peer_address,
+        );
+        self.measure(
+            id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE,
+            id::MEASURES_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE,
+            event.age,
+        );
+        self.count_bool(
+            id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED,
+            id::BOOL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED,
+            event.evicted,
+        );
+        self.count_bool(
+            id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE,
+            id::BOOL_COUNTERS_UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE,
+            event.scheduled_handshake,
         );
         let _ = event;
         let _ = meta;

--- a/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
+++ b/dc/s2n-quic-dc/src/event/generated/metrics/probe.rs
@@ -257,18 +257,26 @@ mod id {
         PATH_SECRET_MAP_ENTRY_READY__PEER_ADDRESS__PROTOCOL,
         PATH_SECRET_MAP_ENTRY_REPLACED,
         PATH_SECRET_MAP_ENTRY_REPLACED__PEER_ADDRESS__PROTOCOL,
+        PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE,
         PATH_SECRET_MAP_ID_ENTRY_EVICTED,
         PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL,
         PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE,
+        PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED,
+        PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON,
         PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED,
         PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL,
         PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE,
+        PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED,
+        PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON,
         UNKNOWN_PATH_SECRET_PACKET_SENT,
         UNKNOWN_PATH_SECRET_PACKET_SENT__PEER_ADDRESS__PROTOCOL,
         UNKNOWN_PATH_SECRET_PACKET_RECEIVED,
         UNKNOWN_PATH_SECRET_PACKET_RECEIVED__PEER_ADDRESS__PROTOCOL,
         UNKNOWN_PATH_SECRET_PACKET_ACCEPTED,
         UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL,
+        UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE,
+        UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED,
+        UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE,
         UNKNOWN_PATH_SECRET_PACKET_REJECTED,
         UNKNOWN_PATH_SECRET_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL,
         UNKNOWN_PATH_SECRET_PACKET_DROPPED,
@@ -749,18 +757,28 @@ mod id {
         InfoId::PATH_SECRET_MAP_ENTRY_REPLACED as usize;
     pub const PATH_SECRET_MAP_ENTRY_REPLACED__PEER_ADDRESS__PROTOCOL: usize =
         InfoId::PATH_SECRET_MAP_ENTRY_REPLACED__PEER_ADDRESS__PROTOCOL as usize;
+    pub const PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE: usize =
+        InfoId::PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE as usize;
     pub const PATH_SECRET_MAP_ID_ENTRY_EVICTED: usize =
         InfoId::PATH_SECRET_MAP_ID_ENTRY_EVICTED as usize;
     pub const PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL: usize =
         InfoId::PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL as usize;
     pub const PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE: usize =
         InfoId::PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE as usize;
+    pub const PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED: usize =
+        InfoId::PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED as usize;
+    pub const PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON: usize =
+        InfoId::PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON as usize;
     pub const PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED: usize =
         InfoId::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED as usize;
     pub const PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL: usize =
         InfoId::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL as usize;
     pub const PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE: usize =
         InfoId::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE as usize;
+    pub const PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED: usize =
+        InfoId::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED as usize;
+    pub const PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON: usize =
+        InfoId::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON as usize;
     pub const UNKNOWN_PATH_SECRET_PACKET_SENT: usize =
         InfoId::UNKNOWN_PATH_SECRET_PACKET_SENT as usize;
     pub const UNKNOWN_PATH_SECRET_PACKET_SENT__PEER_ADDRESS__PROTOCOL: usize =
@@ -773,6 +791,12 @@ mod id {
         InfoId::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED as usize;
     pub const UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL: usize =
         InfoId::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__PEER_ADDRESS__PROTOCOL as usize;
+    pub const UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE: usize =
+        InfoId::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE as usize;
+    pub const UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED: usize =
+        InfoId::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED as usize;
+    pub const UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE: usize =
+        InfoId::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE as usize;
     pub const UNKNOWN_PATH_SECRET_PACKET_REJECTED: usize =
         InfoId::UNKNOWN_PATH_SECRET_PACKET_REJECTED as usize;
     pub const UNKNOWN_PATH_SECRET_PACKET_REJECTED__PEER_ADDRESS__PROTOCOL: usize =
@@ -1483,6 +1507,12 @@ mod counter {
                     }
                     id::ENDPOINT_INITIALIZED__TCP => Self(endpoint_initialized__tcp),
                     id::ENDPOINT_INITIALIZED__UDP => Self(endpoint_initialized__udp),
+                    id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__EVICTED => {
+                        Self(unknown_path_secret_packet_accepted__evicted)
+                    }
+                    id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__SCHEDULED_HANDSHAKE => {
+                        Self(unknown_path_secret_packet_accepted__scheduled_handshake)
+                    }
                     id::PATH_SECRET_MAP_ADDRESS_CACHE_ACCESSED__HIT => {
                         Self(path_secret_map_address_cache_accessed__hit)
                     }
@@ -1564,6 +1594,12 @@ mod counter {
             s2n_quic_dc__event__counter__bool__endpoint_initialized__udp]
                 fn endpoint_initialized__udp(value: bool);
                 #[link_name =
+            s2n_quic_dc__event__counter__bool__unknown_path_secret_packet_accepted__evicted]
+                fn unknown_path_secret_packet_accepted__evicted(value: bool);
+                #[link_name =
+            s2n_quic_dc__event__counter__bool__unknown_path_secret_packet_accepted__scheduled_handshake]
+                fn unknown_path_secret_packet_accepted__scheduled_handshake(value: bool);
+                #[link_name =
             s2n_quic_dc__event__counter__bool__path_secret_map_address_cache_accessed__hit]
                 fn path_secret_map_address_cache_accessed__hit(value: bool);
                 #[link_name =
@@ -1624,8 +1660,14 @@ mod counter {
                     id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL => {
                         Self(path_secret_map_id_entry_evicted__peer_address__protocol)
                     }
+                    id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__REASON => {
+                        Self(path_secret_map_id_entry_evicted__reason)
+                    }
                     id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__PEER_ADDRESS__PROTOCOL => {
                         Self(path_secret_map_address_entry_evicted__peer_address__protocol)
+                    }
+                    id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__REASON => {
+                        Self(path_secret_map_address_entry_evicted__reason)
                     }
                     id::UNKNOWN_PATH_SECRET_PACKET_SENT__PEER_ADDRESS__PROTOCOL => {
                         Self(unknown_path_secret_packet_sent__peer_address__protocol)
@@ -1802,8 +1844,22 @@ mod counter {
                     variant_name: &info::Str,
                 );
                 #[link_name =
+            s2n_quic_dc__event__counter__nominal__path_secret_map_id_entry_evicted__reason]
+                fn path_secret_map_id_entry_evicted__reason(
+                    value: u64,
+                    variant: u64,
+                    variant_name: &info::Str,
+                );
+                #[link_name =
             s2n_quic_dc__event__counter__nominal__path_secret_map_address_entry_evicted__peer_address__protocol]
                 fn path_secret_map_address_entry_evicted__peer_address__protocol(
+                    value: u64,
+                    variant: u64,
+                    variant_name: &info::Str,
+                );
+                #[link_name =
+            s2n_quic_dc__event__counter__nominal__path_secret_map_address_entry_evicted__reason]
+                fn path_secret_map_address_entry_evicted__reason(
                     value: u64,
                     variant: u64,
                     variant_name: &info::Str,
@@ -2170,11 +2226,23 @@ mod measure {
                 id::PATH_SECRET_MAP_UNINITIALIZED__LIFETIME => {
                     Self(path_secret_map_uninitialized__lifetime)
                 }
+                id::PATH_SECRET_MAP_ENTRY_REPLACED__REPLACED_AGE => {
+                    Self(path_secret_map_entry_replaced__replaced_age)
+                }
                 id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__AGE => {
                     Self(path_secret_map_id_entry_evicted__age)
                 }
+                id::PATH_SECRET_MAP_ID_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED => {
+                    Self(path_secret_map_id_entry_evicted__time_since_last_accessed)
+                }
                 id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__AGE => {
                     Self(path_secret_map_address_entry_evicted__age)
+                }
+                id::PATH_SECRET_MAP_ADDRESS_ENTRY_EVICTED__TIME_SINCE_LAST_ACCESSED => {
+                    Self(path_secret_map_address_entry_evicted__time_since_last_accessed)
+                }
+                id::UNKNOWN_PATH_SECRET_PACKET_ACCEPTED__AGE => {
+                    Self(unknown_path_secret_packet_accepted__age)
                 }
                 id::KEY_ACCEPTED__GAP => Self(key_accepted__gap),
                 id::KEY_ACCEPTED__FORWARD_SHIFT => Self(key_accepted__forward_shift),
@@ -2577,11 +2645,23 @@ mod measure {
         s2n_quic_dc__event__measure__path_secret_map_uninitialized__lifetime]
             fn path_secret_map_uninitialized__lifetime(value: u64);
             #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_entry_replaced__replaced_age]
+            fn path_secret_map_entry_replaced__replaced_age(value: u64);
+            #[link_name =
         s2n_quic_dc__event__measure__path_secret_map_id_entry_evicted__age]
             fn path_secret_map_id_entry_evicted__age(value: u64);
             #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_id_entry_evicted__time_since_last_accessed]
+            fn path_secret_map_id_entry_evicted__time_since_last_accessed(value: u64);
+            #[link_name =
         s2n_quic_dc__event__measure__path_secret_map_address_entry_evicted__age]
             fn path_secret_map_address_entry_evicted__age(value: u64);
+            #[link_name =
+        s2n_quic_dc__event__measure__path_secret_map_address_entry_evicted__time_since_last_accessed]
+            fn path_secret_map_address_entry_evicted__time_since_last_accessed(value: u64);
+            #[link_name =
+        s2n_quic_dc__event__measure__unknown_path_secret_packet_accepted__age]
+            fn unknown_path_secret_packet_accepted__age(value: u64);
             #[link_name =
         s2n_quic_dc__event__measure__key_accepted__gap]
             fn key_accepted__gap(value: u64);

--- a/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/cleaner.rs
@@ -45,6 +45,11 @@ impl Epoch {
     pub fn get(self) -> u64 {
         self.0
     }
+
+    pub(crate) fn duration_since(&self, base: Epoch) -> Duration {
+        let delta = self.0.saturating_sub(base.0);
+        CLEANER_CYCLE.saturating_mul(u32::try_from(delta).unwrap_or(u32::MAX))
+    }
 }
 
 impl Drop for Cleaner {
@@ -267,7 +272,8 @@ impl Cleaner {
             };
 
             if !retained {
-                let (id_removed, peer_removed) = state.evict(&entry);
+                let (id_removed, peer_removed) =
+                    state.evict(&entry, event::builder::EvictionReason::Retiring);
                 if id_removed {
                     id_entries_retired += 1;
                 }

--- a/dc/s2n-quic-dc/src/path/secret/map/snapshots/path__secret__map__event_tests__control_packets__events.snap
+++ b/dc/s2n-quic-dc/src/path/secret/map/snapshots/path__secret__map__event_tests__control_packets__events.snap
@@ -25,8 +25,8 @@ EndpointMeta { timestamp: Timestamp(0:00:00.000001) } StaleKeyPacketRejected { p
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } ReplayDetectedPacketReceived { peer_address: 127.0.0.1:5678, credential_id: "[HIDDEN]" }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } ReplayDetectedPacketRejected { peer_address: 127.0.0.1:5678, credential_id: "[HIDDEN]" }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } UnknownPathSecretPacketReceived { peer_address: 127.0.0.1:5678, credential_id: "[HIDDEN]" }
-EndpointMeta { timestamp: Timestamp(0:00:00.000001) } UnknownPathSecretPacketAccepted { peer_address: 127.0.0.1:5678, credential_id: "[HIDDEN]" }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } PathSecretMapBackgroundHandshakeRequested { peer_address: 127.0.0.1:5678 }
+EndpointMeta { timestamp: Timestamp(0:00:00.000001) } UnknownPathSecretPacketAccepted { peer_address: 127.0.0.1:5678, credential_id: "[HIDDEN]", age: "[HIDDEN]", evicted: false, scheduled_handshake: false }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } StaleKeyPacketReceived { peer_address: 127.0.0.1:5678, credential_id: "[HIDDEN]" }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } StaleKeyPacketRejected { peer_address: 127.0.0.1:5678, credential_id: "[HIDDEN]" }
 EndpointMeta { timestamp: Timestamp(0:00:00.000001) } ReplayDetectedPacketReceived { peer_address: 127.0.0.1:5678, credential_id: "[HIDDEN]" }

--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -643,9 +643,15 @@ where
     }
 
     // Sometimes called with queue lock held -- must not acquire it.
-    pub(super) fn evict(&self, evicted: &Arc<Entry>) -> (bool, bool) {
+    pub(super) fn evict(
+        &self,
+        evicted: &Arc<Entry>,
+        reason: event::builder::EvictionReason,
+    ) -> (bool, bool) {
         let mut id_removed = false;
         let mut peer_removed = false;
+
+        let current_epoch = self.cleaner.epoch();
 
         // A concurrent cleaner can drop the entry from the `ids` map so we need to
         // re-check whether we actually evicted something.
@@ -656,6 +662,9 @@ where
                     peer_address: SocketAddress::from(*evicted.peer()).into_event(),
                     credential_id: evicted.id().into_event(),
                     age: evicted.age(),
+                    reason: reason.clone(),
+                    time_since_last_accessed: current_epoch
+                        .duration_since(evicted.accessed_at_epoch()),
                 },
             );
         }
@@ -673,6 +682,9 @@ where
                     peer_address: SocketAddress::from(*evicted.peer()).into_event(),
                     credential_id: evicted.id().into_event(),
                     age: evicted.age(),
+                    reason,
+                    time_since_last_accessed: current_epoch
+                        .duration_since(evicted.accessed_at_epoch()),
                 },
             );
         }
@@ -836,7 +848,7 @@ where
                 drop(queue);
 
                 if let Some(evicted) = element.upgrade() {
-                    self.evict(&evicted);
+                    self.evict(&evicted, event::builder::EvictionReason::Capacity);
                 }
             }
         }
@@ -867,6 +879,7 @@ where
                     peer_address: SocketAddress::from(peer).into_event(),
                     new_credential_id: id.into_event(),
                     previous_credential_id: prev_id.into_event(),
+                    replaced_age: prev.age(),
                 },
             );
         }
@@ -1027,19 +1040,44 @@ where
             return None;
         };
 
+        // Only evict if it's been at least 10 seconds since this entry was created.
+        //
+        // If this is on the server (i.e. a client is telling a server that it did not have the
+        // secret cached), this is entirely harmless to skip because clients can always
+        // negotiate a new secret. It carries the benefit that if the client has learned of the
+        // unknown path secret *after* sending UnknownPathSecret (e.g., because the server started
+        // encrypting for a secret before the handshake finished inserting on the client), we will
+        // no longer drop the just-created secret for no reason.
+        //
+        // If this is a client (i.e., the server did not have the secret cached), then evicting
+        // a just-inserted secret due to a late-arriving UnknownPathSecret is actively harmful
+        // (likely to cause impact). If the entry is genuinely unknown to the server, the
+        // requested handshake above should allow us to recover soon regardless (or we will
+        // naturally do so on a subsequent request).
+        //
+        // For a repeated fast server restart, this does lengthen the time period in which we will
+        // repeatedly see exceptions thrown on connect() rather than delaying until a handshake
+        // completes. But such fast server restarts in short succession should be rare, so this
+        // seems like a reasonable tradeoff.
+        let should_evict = self.should_evict_on_unknown_path_secret()
+            // FIXME: Adjust our tests to backdate/forward date entries instead?
+            && (cfg!(test) || entry.age() > Duration::from_secs(10));
+        let scheduled_handshake = self
+            .request_handshake(*entry.peer(), HandshakeReason::Remote)
+            .is_some();
+
         self.subscriber().on_unknown_path_secret_packet_accepted(
             event::builder::UnknownPathSecretPacketAccepted {
                 credential_id: packet.credential_id.into_event(),
                 peer_address,
+                age: entry.age(),
+                evicted: should_evict,
+                scheduled_handshake,
             },
         );
 
-        // FIXME: More actively schedule a new handshake.
-        // See comment on requested_handshakes for details.
-        self.request_handshake(*entry.peer(), HandshakeReason::Remote);
-
-        if self.should_evict_on_unknown_path_secret() {
-            self.evict(&entry);
+        if should_evict {
+            self.evict(&entry, event::builder::EvictionReason::UnknownPathSecret);
         }
 
         Some(packet)


### PR DESCRIPTION
### Release Summary:

* feat(s2n-quic-dc): Stop evicting just-created path secrets on unknown path secret packet arrival
* feat(s2n-quic-dc): Add new metrics tracking map updates more closely in relation to age and access time

### Resolved issues:

n/a

### Description of changes: 

This skips evicting path secrets on receiving unknown path secret if they are recently created, and adds a bunch of metric instrumentation that should help in investigating bugs around eviction being too eager.

### Call-outs:

n/a

### Testing:

No tests added. Most of the changes are new metrics with fairly obvious values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

