### PR TITLE
chore: update aya deps versions

### DIFF
--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -14,8 +14,8 @@ trace = ["s2n-quic-core/branch-tracing", "s2n-quic-core/probe-tracing", "s2n-qui
 xdp = ["s2n-quic/unstable-provider-io-xdp", "aya", "aya-log"]
 
 [dependencies]
-aya = { version = "0.13", optional = true }
-aya-log = { version = "0.2.1", optional = true }
+aya = { version = "0.14", optional = true }
+aya-log = { version = "0.3.0", optional = true }
 bytes = { version = "1", default-features = false }
 cfg-if = "1"
 futures = "0.3"

--- a/quic/s2n-quic-qns/src/xdp.rs
+++ b/quic/s2n-quic-qns/src/xdp.rs
@@ -82,13 +82,13 @@ impl core::str::FromStr for XdpMode {
     }
 }
 
-impl From<XdpMode> for programs::xdp::XdpFlags {
+impl From<XdpMode> for programs::xdp::XdpMode {
     fn from(mode: XdpMode) -> Self {
         match mode {
-            XdpMode::Auto => Self::default(),
-            XdpMode::Skb => Self::SKB_MODE,
-            XdpMode::Drv => Self::DRV_MODE,
-            XdpMode::Hw => Self::HW_MODE,
+            XdpMode::Auto => Self::Default,
+            XdpMode::Skb => Self::Skb,
+            XdpMode::Drv => Self::Driver,
+            XdpMode::Hw => Self::Hardware,
         }
     }
 }

--- a/quic/s2n-quic-qns/src/xdp.rs
+++ b/quic/s2n-quic-qns/src/xdp.rs
@@ -202,16 +202,20 @@ impl Xdp {
 
     fn bpf_task(&self, port: u16, rx_fds: Vec<(u32, socket::Fd)>) -> Result<()> {
         // load the default BPF program from s2n-quic-xdp
-        let mut bpf = if self.bpf_trace {
+        let (mut bpf, logger) = if self.bpf_trace {
             let mut bpf = Ebpf::load(bpf::DEFAULT_PROGRAM_TRACE)?;
 
-            if let Err(err) = aya_log::EbpfLogger::init(&mut bpf) {
-                eprint!("error initializing BPF trace: {err:?}");
-            }
+            let logger = match aya_log::EbpfLogger::init(&mut bpf) {
+                Ok(logger) => Some(logger),
+                Err(err) => {
+                    eprint!("error initializing BPF trace: {err:?}");
+                    None
+                }
+            };
 
-            bpf
+            (bpf, logger)
         } else {
-            Ebpf::load(bpf::DEFAULT_PROGRAM)?
+            (Ebpf::load(bpf::DEFAULT_PROGRAM)?, None)
         };
 
         let interface = self.interface.clone();
@@ -226,6 +230,22 @@ impl Xdp {
 
         // attach the BPF program to the interface
         let link_id = program.attach(&interface, xdp_mode)?;
+
+        // Continuously drain the eBPF trace logs, if tracing is enabled.
+        if let Some(logger) = logger {
+            let mut logger =
+                tokio::io::unix::AsyncFd::with_interest(logger, tokio::io::Interest::READABLE)?;
+            tokio::spawn(async move {
+                loop {
+                    let mut guard = logger
+                        .readable_mut()
+                        .await
+                        .expect("failed to poll eBPF logger");
+                    guard.get_inner_mut().flush();
+                    guard.clear_ready();
+                }
+            });
+        }
 
         let bpf_task = async move {
             // register the port as active

--- a/quic/s2n-quic/src/provider/random.rs
+++ b/quic/s2n-quic/src/provider/random.rs
@@ -11,7 +11,7 @@ pub trait Provider: 'static {
     fn start(self) -> Result<Self::Generator, Self::Error>;
 }
 
-pub use self::rand::{Provider as Default, Random, ReseedingRng};
+pub use self::rand::{Provider as Default, Random};
 
 impl_provider_utils!();
 

--- a/tools/xdp/ebpf/Cargo.toml
+++ b/tools/xdp/ebpf/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 
 [dependencies]
 # These crates are not published so use a git dependency for now. See https://github.com/aya-rs/aya/issues/464
-aya-ebpf = { git = "https://github.com/aya-rs/aya", tag = "aya-v0.13.0" }
-aya-log-ebpf = { git = "https://github.com/aya-rs/aya", tag = "aya-v0.13.0" }
+aya-ebpf = { git = "https://github.com/aya-rs/aya", tag = "aya-v0.14.0" }
+aya-log-ebpf = { git = "https://github.com/aya-rs/aya", tag = "aya-v0.14.0" }
 s2n-quic-core = { path = "../../../quic/s2n-quic-core", default-features = false }
 
 [features]

--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["corpus.tar.gz"]
 default = ["tokio"]
 
 [dependencies]
-aya = { version = "0.13", default-features = false }
+aya = { version = "0.14", default-features = false }
 bitflags = "2"
 errno = "0.3"
 libc = "0.2"

--- a/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfeb-trace.ebpf
+++ b/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfeb-trace.ebpf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8a6ab621e876035474166c0d272262053a10b3921d38ac2f360ec945ccb4d7c6
-size 8712
+oid sha256:bfb7bc587756644f4eedecac0c1605cdb8080780a8eca7c9bc45ace338e2d1e0
+size 11792

--- a/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfel-trace.ebpf
+++ b/tools/xdp/s2n-quic-xdp/src/bpf/s2n-quic-xdp-bpfel-trace.ebpf
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:120313d1e719daa72d167ef1eb689733a62071a8ac134fc4508acf1b94c34ea5
-size 8744
+oid sha256:46ad12ba7c31dcf1c180d773bc43ed31ab4982972d299cb49cbfdf1cfde7f4d9
+size 11824

--- a/tools/xdp/tester/Cargo.toml
+++ b/tools/xdp/tester/Cargo.toml
@@ -5,8 +5,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-aya = { version = "0.13", features = ["async_tokio"] }
-aya-log = "0.2.1"
+aya = "0.14"
+aya-log = "0.3.0"
 clap = { version = "4.1", features = ["derive"] }
 anyhow = "1.0.68"
 env_logger = "0.11"

--- a/tools/xdp/tester/src/main.rs
+++ b/tools/xdp/tester/src/main.rs
@@ -3,7 +3,7 @@
 
 use anyhow::Context;
 use aya::{
-    programs::{Xdp, XdpFlags},
+    programs::{Xdp, XdpMode},
     Ebpf,
 };
 use aya_log::EbpfLogger;
@@ -58,8 +58,8 @@ async fn main() -> Result<(), anyhow::Error> {
         return Ok(());
     }
 
-    program.attach(&opt.iface, XdpFlags::default())
-        .context("failed to attach the XDP program with default flags - try changing XdpFlags::default() to XdpFlags::SKB_MODE")?;
+    program.attach(&opt.iface, XdpMode::default())
+        .context("failed to attach the XDP program with default mode - try changing XdpMode::default() to XdpMode::Skb")?;
 
     info!("Waiting for Ctrl-C...");
     signal::ctrl_c().await?;

--- a/tools/xdp/tester/src/main.rs
+++ b/tools/xdp/tester/src/main.rs
@@ -42,11 +42,17 @@ async fn main() -> Result<(), anyhow::Error> {
 
     let mut bpf = Ebpf::load(bpf)?;
 
-    if opt.trace {
-        if let Err(e) = EbpfLogger::init(&mut bpf) {
-            warn!("failed to initialize eBPF logger: {e}");
+    let logger = if opt.trace {
+        match EbpfLogger::init(&mut bpf) {
+            Ok(logger) => Some(logger),
+            Err(e) => {
+                warn!("failed to initialize eBPF logger: {e}");
+                None
+            }
         }
-    }
+    } else {
+        None
+    };
 
     let program: &mut Xdp = bpf
         .program_mut(s2n_quic_xdp::bpf::PROGRAM_NAME)
@@ -60,6 +66,22 @@ async fn main() -> Result<(), anyhow::Error> {
 
     program.attach(&opt.iface, XdpMode::default())
         .context("failed to attach the XDP program with default mode - try changing XdpMode::default() to XdpMode::Skb")?;
+
+    // Continuously drain the eBPF trace logs to the configured logger.
+    if let Some(logger) = logger {
+        let mut logger =
+            tokio::io::unix::AsyncFd::with_interest(logger, tokio::io::Interest::READABLE)?;
+        tokio::spawn(async move {
+            loop {
+                let mut guard = logger
+                    .readable_mut()
+                    .await
+                    .expect("failed to poll eBPF logger");
+                guard.get_inner_mut().flush();
+                guard.clear_ready();
+            }
+        });
+    }
 
     info!("Waiting for Ctrl-C...");
     signal::ctrl_c().await?;


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves these four separate PRs:
resolves https://github.com/aws/s2n-quic/pull/3129,
resolves https://github.com/aws/s2n-quic/pull/3130,
resolves https://github.com/aws/s2n-quic/pull/3131,
resolves https://github.com/aws/s2n-quic/pull/3132.

### Description of changes: 

This PR updates versions for all aya dependencies. The update is done with accordance to the release from https://github.com/aya-rs/aya.

Aside from version bumps, there are two updates that I did:
1. quic/s2n-quic-qns/src/xdp.rs

The previous version aya v0.13.2 is yanked. We used the `XdpFlags` from that version and it's no longer available in the new v0.14.0. Hence, we need to update `XdpFlags` to `XdpMode` from the new version. Here are the docs for both versions to show the variable change: https://docs.rs/aya/0.13.2/aya/?search=XdpFlags and https://docs.rs/aya/latest/aya/programs/xdp/enum.XdpMode.html.

2. quic/s2n-quic/src/provider/random.rs

Removing the unused variable `ReseedingRng`.

### Call-outs:

* In aya-log 0.2, EbpfLogger::init spawned its own background tasks to drain the eBPF log perf buffer, so callers could discard the return value. In 0.3, the returned logger instead owns the log map's file descriptor and does no draining on its own. This changes the contract in two ways: (1) the logger must be kept alive. Dropping it closes the map fd and causes program.load() to fail with fd <n> is not pointing to valid bpf_map; and (2) callers must now drive log consumption themselves by polling the fd (via AsyncFd) and calling flush(). Both call sites were updated to bind the logger for the program's lifetime and spawn a task that continuously drains trace logs to the configured logger.
* Seems like the `async_tokio` feature is removed from aya v0.14.0: https://github.com/aws/s2n-quic/actions/runs/29768740165/job/88441354980?pr=3160
```
package `tester` depends on `aya` with feature `async_tokio` but `aya` does not have that feature.
```
So I removed the feature from our aya dependency in Cargo.toml.

### Testing:

Existing CI tests should verify the fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

