### PR TITLE
test(s2n-quic-tls): remove openssl dev dependency

### DIFF
--- a/examples/post-quantum/Cargo.toml
+++ b/examples/post-quantum/Cargo.toml
@@ -10,14 +10,6 @@ s2n-quic = { version = "1", path = "../../quic/s2n-quic" }
 # enable the post-quantum feature in s2n-tls
 s2n-tls = { version = "*", features = ["pq"] }
 tokio = { version = "1", features = ["full"] }
-# Build the vendored version to make it easy to test.
-#
-# For a production build, it's probably better to link to the system dependency instead
-# so you automatically get security patches.
-#
-# NOTE: The version of the `openssl-sys` crate is not the same as OpenSSL itself.
-#       Versions 1.0.1 - 3.0.0 are automatically discovered.
-openssl-sys = { version = "0.9", features = ["vendored"] }
 
 [workspace]
 members = ["."]

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -29,7 +29,7 @@ s2n-tls = { version = "0.3.31", features = ["quic"] }
 [dev-dependencies]
 checkers = "0.7"
 pin-project = { version = "1" }
-p256 = { version = "0.13", features = ["ecdsa", "pem"] }
+aws-lc-rs = "1.12"
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-rustls = { path = "../s2n-quic-rustls" }
 

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -29,18 +29,9 @@ s2n-tls = { version = "0.3.31", features = ["quic"] }
 [dev-dependencies]
 checkers = "0.7"
 pin-project = { version = "1" }
-openssl = { version = "0.10" }
-# Build the vendored version to make it easy to test in dev
-#
-# NOTE: The version of the `openssl-sys` crate is not the same as OpenSSL itself.
-#       Versions 1.0.1 - 3.0.0 are automatically discovered.
-openssl-sys = { version = "0.9", features = ["vendored"] }
+p256 = { version = "0.13", features = ["ecdsa", "pem"] }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-rustls = { path = "../s2n-quic-rustls" }
-
-# we don't use openssl-sys directly; it's just here to pin and vendor in dev
-[package.metadata.cargo-udeps.ignore]
-development = [ "openssl-sys" ]
 
 [lints.rust.unexpected_cfgs]
 level = "warn"

--- a/quic/s2n-quic-tls/src/tests.rs
+++ b/quic/s2n-quic-tls/src/tests.rs
@@ -2,20 +2,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{certificate, client, server};
+use aws_lc_rs::{
+    digest::{self, Digest},
+    signature::{EcdsaKeyPair, ECDSA_P256_SHA256_ASN1_SIGNING},
+};
 use core::{
     sync::atomic::{AtomicBool, AtomicU8, Ordering},
     task::Poll,
-};
-use p256::{
-    ecdsa::{signature::hazmat::PrehashSigner, Signature, SigningKey},
-    pkcs8::DecodePrivateKey,
 };
 use pin_project::pin_project;
 use s2n_quic_core::{
     crypto::tls::{
         self,
         testing::{
-            certificates::{CERT_PEM, KEY_PEM, UNTRUSTED_CERT_PEM, UNTRUSTED_KEY_PEM},
+            certificates::{CERT_PEM, KEY_DER, KEY_PEM, UNTRUSTED_CERT_PEM, UNTRUSTED_KEY_PEM},
             server_params,
         },
         ConnectionInfo, Endpoint,
@@ -149,14 +149,15 @@ impl ConnectionFuture for MyPrivateKeyFuture {
         let mut in_buf = vec![0; in_buf_size];
         op.input(&mut in_buf)?;
 
-        let key =
-            SigningKey::from_pkcs8_pem(KEY_PEM).expect("Failed to create SigningKey from pem");
-        // s2n-tls hands us the digest to sign, so sign the prehash directly
-        // rather than re-hashing the input.
-        let sig: Signature = key.sign_prehash(&in_buf).expect("Failed to sign input");
-        let out = sig.to_der();
+        let key = EcdsaKeyPair::from_pkcs8(&ECDSA_P256_SHA256_ASN1_SIGNING, KEY_DER)
+            .expect("Failed to create EcdsaKeyPair from pkcs8");
+        // s2n-tls hands us the already-computed digest, so import it and sign it
+        // directly rather than re-hashing the input.
+        let digest =
+            Digest::import_less_safe(&in_buf, &digest::SHA256).expect("Failed to import digest");
+        let sig = key.sign_digest(&digest).expect("Failed to sign input");
 
-        op.set_output(conn, out.as_bytes())?;
+        op.set_output(conn, sig.as_ref())?;
         Poll::Ready(Ok(()))
     }
 }

--- a/quic/s2n-quic-tls/src/tests.rs
+++ b/quic/s2n-quic-tls/src/tests.rs
@@ -6,7 +6,10 @@ use core::{
     sync::atomic::{AtomicBool, AtomicU8, Ordering},
     task::Poll,
 };
-use openssl::{ec::EcKey, ecdsa::EcdsaSig};
+use p256::{
+    ecdsa::{signature::hazmat::PrehashSigner, Signature, SigningKey},
+    pkcs8::DecodePrivateKey,
+};
 use pin_project::pin_project;
 use s2n_quic_core::{
     crypto::tls::{
@@ -146,12 +149,14 @@ impl ConnectionFuture for MyPrivateKeyFuture {
         let mut in_buf = vec![0; in_buf_size];
         op.input(&mut in_buf)?;
 
-        let key = EcKey::private_key_from_pem(KEY_PEM.as_bytes())
-            .expect("Failed to create EcKey from pem");
-        let sig = EcdsaSig::sign(&in_buf, &key).expect("Failed to sign input");
-        let out = sig.to_der().expect("Failed to convert signature to der");
+        let key =
+            SigningKey::from_pkcs8_pem(KEY_PEM).expect("Failed to create SigningKey from pem");
+        // s2n-tls hands us the digest to sign, so sign the prehash directly
+        // rather than re-hashing the input.
+        let sig: Signature = key.sign_prehash(&in_buf).expect("Failed to sign input");
+        let out = sig.to_der();
 
-        op.set_output(conn, &out)?;
+        op.set_output(conn, out.as_bytes())?;
         Poll::Ready(Ok(()))
     }
 }


### PR DESCRIPTION
### Release Summary:
<!-- If this is a feature or bug that impacts customers and is significant enough to include in the "Summary" section of the next version release, please include a brief (1-2 sentences) description of the change. The audience of this summary is customers, not maintainers or reviewers. See https://github.com/aws/s2n-tls/releases/tag/v1.5.7 for an example. Otherwise, leave this section blank -->

### Resolved issues:

N/A

### Description of changes:

Removes the `openssl` and `openssl-sys` dev-dependencies from `s2n-quic-tls`, and the leftover vendored `openssl-sys` dependency from the `post-quantum` example.

These dependencies were a leftover from when this repo vendored and linked `s2n-tls` against `openssl-sys` itself. Once the repo moved to the published `s2n-tls` crate (now backed by aws-lc), the only remaining use of `openssl` was a single private key offload test helper in `s2n-quic-tls/src/tests.rs`, and `openssl-sys` only existed to pin/vendor a build of OpenSSL for that test. The `post-quantum` example carried a similar unused vendored `openssl-sys` pin.

### Testing:

- `cargo test` in `s2n-quic-tls` passes (16/16), including `s2n_client_s2n_server_pkey_callback_test`, which exercises the private key offload path across 11 handshakes and validates the RustCrypto-produced signature end-to-end through a real `s2n-tls` handshake.
- The `post-quantum` example builds successfully without `openssl-sys`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
