### PR TITLE
fix(s2n-quic-core): allow connection migration when the port scope changes

### DIFF
--- a/quic/s2n-quic-core/src/path/migration.rs
+++ b/quic/s2n-quic-core/src/path/migration.rs
@@ -138,10 +138,11 @@ pub mod default {
             //# datagrams that match these patterns prior to validating the
             //# destination address.
 
-            // NOTE: this may cause reachability issues if a peer or NAT use different
-            //       port scopes for the same connection. Additional research may
-            //       be required to determine if this countermeasure needs to be relaxed.
-            if PortScope::new(active_addr.port()) != PortScope::new(packet_addr.port()) {
+            let active_port_scope = PortScope::new(active_addr.port());
+            let packet_port_scope = PortScope::new(packet_addr.port());
+            if active_port_scope.is_system() != packet_port_scope.is_system() {
+                // Changing port scope from the system to a non-system (user or dynamic) scope
+                // and vice versa is rejected. Any other combination is allowed.
                 return Outcome::Deny(DenyReason::PortScopeChanged);
             }
 
@@ -191,6 +192,11 @@ pub mod default {
                 1024..=49151 => Self::User,
                 49152..=65535 => Self::Dynamic,
             }
+        }
+
+        #[inline]
+        pub fn is_system(&self) -> bool {
+            self == &PortScope::System
         }
     }
 

--- a/quic/s2n-quic-tests/src/tests/connection_migration.rs
+++ b/quic/s2n-quic-tests/src/tests/connection_migration.rs
@@ -209,6 +209,30 @@ fn rebind_port(mut addr: SocketAddr) -> SocketAddr {
     addr
 }
 
+/// Rebinds the port of an address to a port in a different port scope
+///
+/// The system scope (0-1023) is never used, since migrating in or out of it is denied.
+/// The simulated network only assigns ports in the user and dynamic scopes, so the port
+/// is swapped between those two.
+fn rebind_port_change_scope(mut addr: SocketAddr) -> SocketAddr {
+    //= https://www.rfc-editor.org/rfc/rfc6335#section-6
+    // the first port of the user (1024-49151) and dynamic (49152-65535) scopes
+    const USER_SCOPE: u16 = 1024;
+    const DYNAMIC_SCOPE: u16 = 49152;
+
+    let port = addr.port();
+    let (scope, other_scope) = if port >= DYNAMIC_SCOPE {
+        (DYNAMIC_SCOPE, USER_SCOPE)
+    } else {
+        (USER_SCOPE, DYNAMIC_SCOPE)
+    };
+
+    // move to the other scope, while also advancing the offset into it so each rebind
+    // uses a port that hasn't been used before
+    addr.set_port(other_scope + (port - scope) + 1);
+    addr
+}
+
 #[test]
 fn ip_rebind_test() {
     run_test(rebind_ip);
@@ -224,13 +248,22 @@ fn ip_and_port_rebind_test() {
     run_test(|addr| rebind_ip(rebind_port(addr)));
 }
 
+/// Ensures that migrating between the user and dynamic port scopes is allowed
+#[test]
+fn port_scope_rebind_test() {
+    run_test(rebind_port_change_scope);
+}
+
 // Changes the port of the second datagram received
 #[derive(Default)]
 struct RebindPortBeforeHandshakeConfirmed {
     datagram_count: usize,
 }
 
+// a port in the dynamic scope (49152-65535)
 const REBIND_PORT: u16 = 55555;
+// a port in the system scope (0-1023), which is not in the list of blocked ports
+const SYSTEM_PORT: u16 = 443;
 impl Interceptor for RebindPortBeforeHandshakeConfirmed {
     fn intercept_rx_remote_address(&mut self, _subject: &Subject, addr: &mut RemoteAddress) {
         if (1..5).contains(&self.datagram_count) {
@@ -554,6 +587,90 @@ fn rebind_blocked_port() {
             assert!(matches!(reason, MigrationDenyReason::BlockedPort { .. }));
         }
     }
+}
+
+/// Establishes a connection with the client bound to `client_port` and then makes the
+/// server observe the client migrating to `migrated_port`, asserting that every migration
+/// attempt is denied because the port scope changed
+fn port_scope_change_test(client_port: u16, migrated_port: u16) {
+    let model = Model::default();
+    let subscriber = recorder::DatagramDropped::new();
+    let datagram_dropped_events = subscriber.events();
+
+    test(model.clone(), move |handle| {
+        let server = Server::builder()
+            .with_io(handle.builder().build()?)?
+            .with_tls(SERVER_CERTS)?
+            .with_event((tracing_events(false, model.clone()), subscriber))?
+            .with_random(Random::with_seed(456))?
+            // migrate the client once the handshake has completed
+            .with_packet_interceptor(RebindToPort {
+                port: migrated_port,
+                after: 2,
+            })?
+            .start()?;
+
+        // bind the client before the handshake starts, so the connection is established
+        // on the expected port scope
+        let client_io = handle
+            .builder()
+            .on_socket(move |socket: io::Socket| {
+                let mut addr = socket.local_addr().unwrap();
+                addr.set_port(client_port);
+                socket.rebind(addr);
+            })
+            .build()?;
+
+        let client = Client::builder()
+            .with_io(client_io)?
+            .with_tls(certificates::CERT_PEM)?
+            .with_event(tracing_events(false, model.clone()))?
+            .with_random(Random::with_seed(456))?
+            .start()?;
+
+        let addr = start_server(server)?;
+
+        primary::spawn(async move {
+            let mut connection = client
+                .connect(Connect::new(addr).with_server_name("localhost"))
+                .await
+                .unwrap();
+            let mut stream = connection.open_bidirectional_stream().await.unwrap();
+            let _ = stream.send(Bytes::from_static(b"hello")).await;
+            let _ = stream.finish();
+            let _ = stream.receive().await;
+        });
+
+        Ok(addr)
+    })
+    .unwrap();
+
+    let datagram_dropped_events = datagram_dropped_events.lock().unwrap();
+    let mut denied = 0;
+
+    for event in datagram_dropped_events.iter() {
+        if let DatagramDropReason::RejectedConnectionMigration { reason, .. } = &event.reason {
+            assert!(matches!(
+                reason,
+                MigrationDenyReason::PortScopeChanged { .. }
+            ));
+            denied += 1;
+        }
+    }
+
+    assert!(denied > 0, "the migration attempt should have been denied");
+}
+
+/// Ensures that migrating from a non-system port scope to the system port scope is denied
+#[test]
+fn rebind_system_port_scope() {
+    port_scope_change_test(REBIND_PORT, SYSTEM_PORT);
+}
+
+/// Ensures that migrating from the system port scope to a non-system port scope is denied
+#[test]
+fn rebind_from_system_port_scope() {
+    port_scope_change_test(SYSTEM_PORT, REBIND_PORT);
 }
 
 // Changes the local address after N packets


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

resolves #3040 

### Description of changes: 

Currently server rejects the QUIC connection migration if the client port's scope has changed. It looks like the port scope change can normally happen during NAT rebinding, so I don't see why such migration attempt should be rejected. The QUIC RFC also has no suggestion to reject such migration.

### Testing:

I don't think there was a test checking that migration is rejected when the port scope changes. Would be nice to have.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.