### PR TITLE
feat(s2n-quic-dc): expose Map::send_control_packet

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map.rs
@@ -350,6 +350,18 @@ impl Map {
         }
     }
 
+    /// Sends an already-encoded secret control packet in `buffer` to `dst` using the map's
+    /// control socket, emitting the corresponding packet-sent metric (e.g.
+    /// `UnknownPathSecretPacketSent`).
+    ///
+    /// `buffer` should contain a fully-encoded secret control packet, such as the one written
+    /// into the `control_out` buffer by [`Map::open_once`],
+    /// [`Map::open_once_with_application_data`], and related methods when the path secret is
+    /// unknown. Sending is best-effort: if the map has no control socket the packet is dropped.
+    pub fn send_control_packet(&self, dst: &SocketAddr, buffer: &mut [u8]) {
+        self.store.send_control_packet(dst, buffer);
+    }
+
     pub fn handle_stale_key_packet<'a>(
         &self,
         packet: &'a control::stale_key::Packet,


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

Expose a public method to send an already-encoded secret control packet via the map's control socket. Unlike sending on an unrelated socket, this routes through the same code path used internally, so packet-sent metrics (e.g. UnknownPathSecretPacketSent) are emitted.

This lets callers that receive a control packet in the control_out buffer from open_once/open_once_with_application_data send it back to the peer while keeping send metrics accurate (that are currently incorrect as a result).

We don't call this from the TCP stream acceptance code (where we send back UnknownPathSecret in-band) because we already track that metric separately. I'm not sure if that's the right decision, I have reasons for both directions, but I think for now it makes sense to land this so we can fix datagram receivers (which call open_once... in library code using s2n-quic-dc).

### Call-outs:

n/a

### Testing:

Just exposing an extra API for usage outside the Map.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

