### PR TITLE
fix(s2n-quic-transport): close all streams after Endpoint drop

### DIFF
--- a/quic/s2n-quic-platform/src/io/testing.rs
+++ b/quic/s2n-quic-platform/src/io/testing.rs
@@ -222,6 +222,10 @@ impl Handle {
             queue_send_buffer_size: None,
         }
     }
+
+    pub fn close_buffers(&self) {
+        self.buffers.close();
+    }
 }
 
 pub struct Builder {

--- a/quic/s2n-quic-tests/src/tests.rs
+++ b/quic/s2n-quic-tests/src/tests.rs
@@ -26,6 +26,7 @@ use std::{
 
 mod blackhole;
 mod buffer_limit;
+mod close_all_stream_after_endpoint_drop;
 mod connection_limits;
 mod connection_migration;
 mod deduplicate;

--- a/quic/s2n-quic-tests/src/tests/close_all_stream_after_endpoint_drop.rs
+++ b/quic/s2n-quic-tests/src/tests/close_all_stream_after_endpoint_drop.rs
@@ -1,0 +1,205 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use bach::time::timeout;
+use s2n_quic::{stream::BidirectionalStream, Connection};
+
+/// How long to wait for the endpoint close to propagate to the streams before asserting
+/// on their behavior.
+const CLOSE_PROPAGATION_DELAY: Duration = Duration::from_millis(5);
+
+/// How long an rx operation is given to return before it's considered hanging.
+const RECEIVE_TIMEOUT: Duration = Duration::from_millis(5);
+
+/// Verifies client endpoint-drop tx stream behavior.
+///
+/// After endpoint drop, tx stream send should complete with an error.
+#[test]
+fn client_tx_fails_after_endpoint_drop() {
+    let model = Model::default();
+    test(model.clone(), |handle| {
+        let server = build_server(handle, model.clone())?;
+        let server_addr = start_server(server)?;
+
+        let h = handle.clone();
+
+        let client = build_client(handle, model, true).unwrap();
+
+        primary::spawn(async move {
+            let (_connection, mut stream) = connect_and_echo(client, server_addr).await;
+
+            // Drop endpoint
+            h.close_buffers();
+
+            delay(CLOSE_PROPAGATION_DELAY).await;
+
+            let send_res = stream.send(Bytes::from("world")).await;
+            assert!(send_res.is_err());
+        });
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+/// Verifies client endpoint-drop rx stream behavior.
+///
+/// After endpoint drop, rx stream accept should complete with an error instead of hanging.
+#[test]
+fn client_rx_fails_after_endpoint_drop() {
+    let model = Model::default();
+    test(model.clone(), |handle| {
+        let server = build_server(handle, model.clone())?;
+        let server_addr = start_server(server)?;
+
+        let h = handle.clone();
+
+        let client = build_client(handle, model, true).unwrap();
+
+        primary::spawn(async move {
+            let (_connection, mut stream) = connect_and_echo(client, server_addr).await;
+
+            // Drop endpoint
+            h.close_buffers();
+
+            // The async call should return an error
+            let res = timeout(RECEIVE_TIMEOUT, async move { stream.receive().await })
+                .await
+                .unwrap();
+            assert!(res.is_err());
+        });
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+/// Verifies server endpoint-drop tx stream behavior.
+///
+/// After server endpoint drop, tx stream send should complete with an error.
+#[test]
+fn server_tx_fails_after_endpoint_drop() {
+    let model = Model::default();
+    test(model.clone(), |handle| {
+        let mut server = build_server(handle, model.clone())?;
+        let server_addr = server.local_addr()?;
+
+        let h = handle.clone();
+
+        let client = build_client(handle, model, true).unwrap();
+
+        run_echo_client(client, server_addr);
+
+        primary::spawn(async move {
+            let mut connection = server.accept().await.unwrap();
+
+            let mut stream = connection
+                .accept_bidirectional_stream()
+                .await
+                .unwrap()
+                .unwrap();
+
+            let data = stream.receive().await.unwrap().unwrap();
+            stream.send(Bytes::from("hello")).await.unwrap();
+
+            // Drop endpoint
+            h.close_buffers();
+
+            delay(CLOSE_PROPAGATION_DELAY).await;
+
+            let send_res = stream.send(data).await;
+            assert!(send_res.is_err());
+        });
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+/// Verifies server endpoint-drop rx stream behavior.
+///
+/// After server endpoint drop, rx stream receive should complete with an error instead of hanging.
+#[test]
+fn server_rx_fails_after_endpoint_drop() {
+    let model = Model::default();
+    test(model.clone(), |handle| {
+        let mut server = build_server(handle, model.clone())?;
+        let server_addr = server.local_addr()?;
+
+        let h = handle.clone();
+
+        let client = build_client(handle, model, true).unwrap();
+
+        run_echo_client(client, server_addr);
+
+        primary::spawn(async move {
+            let mut connection = server.accept().await.unwrap();
+
+            let mut stream = connection
+                .accept_bidirectional_stream()
+                .await
+                .unwrap()
+                .unwrap();
+
+            let _data = stream.receive().await.unwrap().unwrap();
+            stream.send(Bytes::from("hello")).await.unwrap();
+
+            // Drop endpoint
+            h.close_buffers();
+
+            // The async call should return an error
+            let res = timeout(RECEIVE_TIMEOUT, async move { stream.receive().await })
+                .await
+                .unwrap();
+            assert!(res.is_err());
+        });
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+/// Connects to `server_addr` and performs an echo round trip on a newly opened
+/// bidirectional stream.
+///
+/// The connection is returned along with the stream, since dropping the last connection
+/// handle would close the connection and the streams that belong to it.
+async fn connect_and_echo(
+    client: Client,
+    server_addr: SocketAddr,
+) -> (Connection, BidirectionalStream) {
+    let connect = Connect::new(server_addr).with_server_name("localhost");
+    let mut connection = client.connect(connect).await.unwrap();
+
+    let mut stream = connection.open_bidirectional_stream().await.unwrap();
+
+    let sent = Bytes::from("hello");
+    stream.send(sent.clone()).await.unwrap();
+    let received = stream.receive().await.unwrap().unwrap();
+    assert_eq!(sent, received);
+
+    (connection, stream)
+}
+
+fn run_echo_client(client: Client, server_addr: SocketAddr) {
+    spawn(async move {
+        let connect = Connect::new(server_addr).with_server_name("localhost");
+        let Ok(mut client_connection) = client.connect(connect).await else {
+            return;
+        };
+
+        let Ok(mut stream) = client_connection.open_bidirectional_stream().await else {
+            return;
+        };
+
+        let sent = Bytes::from("hello");
+        let Ok(()) = stream.send(sent.clone()).await else {
+            return;
+        };
+        _ = stream.receive().await;
+
+        // Prevent dropping the connection and the stream
+        delay(Duration::from_secs(60)).await;
+    });
+}

--- a/quic/s2n-quic-tests/src/tests/deduplicate.rs
+++ b/quic/s2n-quic-tests/src/tests/deduplicate.rs
@@ -3,7 +3,9 @@
 
 use super::*;
 use s2n_quic::provider::endpoint_limits::Outcome;
-use s2n_quic_core::{dc::testing::MockDcEndpoint, stateless_reset::token::testing::TEST_TOKEN_1};
+use s2n_quic_core::{
+    dc::testing::MockDcEndpoint, stateless_reset::token::testing::TEST_TOKEN_1, stream::StreamError,
+};
 
 const LEN: usize = 1_000_000;
 
@@ -29,16 +31,30 @@ fn deduplicate_successfully() {
 
         let addr = server.local_addr()?;
         spawn(async move {
-            let mut conn = server.accept().await.unwrap();
-            for _ in 0..2 {
-                let mut stream = conn.open_bidirectional_stream().await.unwrap();
-                stream.send(vec![42; LEN].into()).await.unwrap();
-                stream.flush().await.unwrap();
+            // The client only establishes a single connection, so the second `accept`
+            // never resolves and this task is still running when the test finishes.
+            // Dropping the endpoint at that point closes the connection, so errors here
+            // are expected and shouldn't fail the test.
+            let _: Result<(), StreamError> = async move {
+                let Some(mut conn) = server.accept().await else {
+                    return Ok(());
+                };
+                for _ in 0..2 {
+                    let mut stream = conn.open_bidirectional_stream().await?;
+                    stream.send(vec![42; LEN].into()).await?;
+                    stream.flush().await?;
+                }
+
+                let Some(mut conn) = server.accept().await else {
+                    return Ok(());
+                };
+                let mut stream = conn.open_bidirectional_stream().await?;
+                stream.send(vec![42; LEN].into()).await?;
+                stream.flush().await?;
+
+                Ok(())
             }
-            let mut conn = server.accept().await.unwrap();
-            let mut stream = conn.open_bidirectional_stream().await.unwrap();
-            stream.send(vec![42; LEN].into()).await.unwrap();
-            stream.flush().await.unwrap();
+            .await;
         });
 
         let mut server2 = Server::builder()
@@ -180,16 +196,30 @@ fn deduplicate_non_terminal() {
 
         let addr = server.local_addr()?;
         spawn(async move {
-            let mut conn = server.accept().await.unwrap();
-            for _ in 0..2 {
-                let mut stream = conn.open_bidirectional_stream().await.unwrap();
-                stream.send(vec![42; LEN].into()).await.unwrap();
-                stream.flush().await.unwrap();
+            // The client only establishes a single connection, so the second `accept`
+            // never resolves and this task is still running when the test finishes.
+            // Dropping the endpoint at that point closes the connection, so errors here
+            // are expected and shouldn't fail the test.
+            let _: Result<(), StreamError> = async move {
+                let Some(mut conn) = server.accept().await else {
+                    return Ok(());
+                };
+                for _ in 0..2 {
+                    let mut stream = conn.open_bidirectional_stream().await?;
+                    stream.send(vec![42; LEN].into()).await?;
+                    stream.flush().await?;
+                }
+
+                let Some(mut conn) = server.accept().await else {
+                    return Ok(());
+                };
+                let mut stream = conn.open_bidirectional_stream().await?;
+                stream.send(vec![42; LEN].into()).await?;
+                stream.flush().await?;
+
+                Ok(())
             }
-            let mut conn = server.accept().await.unwrap();
-            let mut stream = conn.open_bidirectional_stream().await.unwrap();
-            stream.send(vec![42; LEN].into()).await.unwrap();
-            stream.flush().await.unwrap();
+            .await;
         });
 
         let tokens = [TEST_TOKEN_1];

--- a/quic/s2n-quic-tests/src/tests/issue_1361.rs
+++ b/quic/s2n-quic-tests/src/tests/issue_1361.rs
@@ -27,12 +27,13 @@ fn stream_reset_test() {
         spawn(async move {
             while let Some(mut connection) = server.accept().await {
                 spawn(async move {
-                    while let Some(mut stream) =
-                        connection.accept_bidirectional_stream().await.unwrap()
+                    // the endpoint is dropped when the test finishes, which closes the
+                    // connection, so don't treat errors here as test failures
+                    while let Ok(Some(mut stream)) = connection.accept_bidirectional_stream().await
                     {
                         spawn(async move {
                             // drain the receive stream
-                            while stream.receive().await.unwrap().is_some() {}
+                            while let Ok(Some(_)) = stream.receive().await {}
 
                             // send data until the client resets the stream
                             while stream.send(Bytes::from_static(&[42; 1024])).await.is_ok() {}

--- a/quic/s2n-quic-transport/src/connection/api.rs
+++ b/quic/s2n-quic-transport/src/connection/api.rs
@@ -163,7 +163,8 @@ impl Connection {
     /// This will immediately terminate all outstanding streams.
     #[inline]
     pub fn close(&self, error_code: application::Error) {
-        self.api.close_connection(Some(error_code));
+        self.api
+            .close_connection(Some(connection::Error::application(error_code)));
     }
 
     #[inline]

--- a/quic/s2n-quic-transport/src/connection/api_provider.rs
+++ b/quic/s2n-quic-transport/src/connection/api_provider.rs
@@ -16,7 +16,6 @@ use core::{
     task::{Context, Poll},
 };
 use s2n_quic_core::{
-    application,
     application::ServerName,
     inet::SocketAddress,
     query::{Query, QueryMut},
@@ -53,7 +52,7 @@ pub(crate) trait ConnectionApiProvider: Sync + Send {
         context: &Context,
     ) -> Poll<Result<Stream, connection::Error>>;
 
-    fn close_connection(&self, code: Option<application::Error>);
+    fn close_connection(&self, code: Option<connection::Error>);
 
     fn server_name(&self) -> Result<Option<ServerName>, connection::Error>;
 

--- a/quic/s2n-quic-transport/src/connection/connection_container.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container.rs
@@ -32,7 +32,6 @@ use intrusive_collections::{
     intrusive_adapter, KeyAdapter, LinkedList, LinkedListLink, RBTree, RBTreeLink,
 };
 use s2n_quic_core::{
-    application,
     application::ServerName,
     event::supervisor,
     inet::SocketAddress,
@@ -296,7 +295,7 @@ impl<C: connection::Trait, L: connection::Lock<C>> ConnectionApiProvider for Con
         }
     }
 
-    fn close_connection(&self, error: Option<application::Error>) {
+    fn close_connection(&self, error: Option<connection::Error>) {
         let _: Result<(), connection::Error> = self.api_write_call(|conn| {
             conn.application_close(error);
             Ok(())
@@ -1143,6 +1142,17 @@ impl<C: connection::Trait, L: connection::Lock<C>> ConnectionContainer<C, L> {
         debug_assert!(remove_result.is_some());
 
         self.interest_lists.remove_node(connection);
+    }
+}
+
+impl<C: connection::Trait, L: connection::Lock<C>> Drop for ConnectionContainer<C, L> {
+    // ConnectionContainer dropped means Endpoint is dropped. Close all connections.
+    fn drop(&mut self) {
+        let mut cursor = self.connection_map.front();
+        while let Some(node) = cursor.get() {
+            node.close_connection(Some(connection::Error::endpoint_closing()));
+            cursor.move_next();
+        }
     }
 }
 

--- a/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_container/tests.rs
@@ -14,11 +14,12 @@ use bolero::{check, generator::*};
 use bytes::Bytes;
 use core::{
     any::Any,
+    cell::Cell,
     task::{Context, Poll},
     time::Duration,
 };
 use s2n_quic_core::{
-    application, event,
+    event,
     event::builder::DatagramDropReason,
     inet::{DatagramInfo, SocketAddress},
     io::tx,
@@ -35,6 +36,12 @@ use s2n_quic_core::{
     time::{Timer, Timestamp},
 };
 use std::sync::Mutex;
+
+thread_local! {
+    static CLOSE_CALL_COUNT: Cell<usize> = const { Cell::new(0) };
+    static APPLICATION_CLOSE_CALL_COUNT: Cell<usize> = const { Cell::new(0) };
+    static APPLICATION_CLOSE_WITH_ERROR_COUNT: Cell<usize> = const { Cell::new(0) };
+}
 
 struct TestConnection {
     accept_state: AcceptState,
@@ -90,6 +97,7 @@ impl connection::Trait for TestConnection {
     ) {
         assert!(!self.is_closed);
         assert!(!self.close_timer.is_armed());
+        CLOSE_CALL_COUNT.with(|count| count.set(count.get() + 1));
         self.close_timer.set(timestamp + Duration::from_secs(1));
     }
 
@@ -293,7 +301,11 @@ impl connection::Trait for TestConnection {
         _stream_type: Option<stream::StreamType>,
         _context: &Context,
     ) -> Poll<Result<Option<stream::StreamId>, connection::Error>> {
-        todo!()
+        if self.is_closed {
+            return Poll::Ready(Err(connection::Error::unspecified()));
+        }
+
+        Poll::Pending
     }
 
     fn poll_open_stream(
@@ -302,11 +314,20 @@ impl connection::Trait for TestConnection {
         _token: &mut connection::OpenToken,
         _context: &Context,
     ) -> Poll<Result<stream::StreamId, connection::Error>> {
-        todo!()
+        if self.is_closed {
+            return Poll::Ready(Err(connection::Error::unspecified()));
+        }
+
+        Poll::Ready(Ok(stream::StreamId::from_varint(
+            s2n_quic_core::varint::VarInt::from_u8(0),
+        )))
     }
 
-    fn application_close(&mut self, _error: Option<application::Error>) {
-        // no-op
+    fn application_close(&mut self, _error: Option<connection::Error>) {
+        APPLICATION_CLOSE_CALL_COUNT.with(|count| count.set(count.get() + 1));
+        if _error.is_some() {
+            APPLICATION_CLOSE_WITH_ERROR_COUNT.with(|count| count.set(count.get() + 1));
+        }
     }
 
     fn server_name(&self) -> Option<ServerName> {
@@ -626,4 +647,26 @@ fn container_test() {
 
         assert!(connections.next().is_none());
     });
+}
+
+#[test]
+fn drop_closes_all_connections() {
+    APPLICATION_CLOSE_CALL_COUNT.with(|count| count.set(0));
+    APPLICATION_CLOSE_WITH_ERROR_COUNT.with(|count| count.set(0));
+
+    let mut id_gen = InternalConnectionIdGenerator::new();
+    let (_handle, acceptor, connector, _close_handle) = endpoint::handle::Handle::new(100);
+
+    {
+        let mut container: ConnectionContainer<TestConnection, TestLock> =
+            ConnectionContainer::new(acceptor, connector);
+
+        for _ in 0..3 {
+            let id = id_gen.generate_id();
+            container.insert_connection(TestConnection::default(), id);
+        }
+    }
+
+    APPLICATION_CLOSE_CALL_COUNT.with(|count| assert_eq!(count.get(), 3));
+    APPLICATION_CLOSE_WITH_ERROR_COUNT.with(|count| assert_eq!(count.get(), 3));
 }

--- a/quic/s2n-quic-transport/src/connection/connection_impl.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_impl.rs
@@ -33,7 +33,7 @@ use core::{
 };
 use s2n_codec::DecoderBufferMut;
 use s2n_quic_core::{
-    application::{self, ServerName},
+    application::ServerName,
     connection::{
         error::Error,
         id::{Classification, Generator as _},
@@ -2292,7 +2292,7 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         )
     }
 
-    fn application_close(&mut self, error: Option<application::Error>) {
+    fn application_close(&mut self, error: Option<connection::Error>) {
         if self.error.is_err() {
             return;
         }
@@ -2301,7 +2301,11 @@ impl<Config: endpoint::Config> connection::Trait for ConnectionImpl<Config> {
         self.open_registry = None;
 
         if let Some(error) = error {
-            self.error = Err(connection::Error::application(error));
+            self.error = Err(error);
+            // This will put all streams into Reset state and wake all tasks
+            if let Some((space, _)) = self.space_manager.application_mut() {
+                space.stream_manager.close(error);
+            }
         } else {
             // give the connection some time to flush all outstanding streams
             self.state = ConnectionState::Flushing;

--- a/quic/s2n-quic-transport/src/connection/connection_trait.rs
+++ b/quic/s2n-quic-transport/src/connection/connection_trait.rs
@@ -21,7 +21,6 @@ use core::{
 };
 use s2n_codec::DecoderBufferMut;
 use s2n_quic_core::{
-    application,
     application::ServerName,
     event::{self, builder::DatagramDropReason, supervisor, ConnectionPublisher, IntoEvent},
     inet::{DatagramInfo, SocketAddress},
@@ -518,7 +517,7 @@ pub trait ConnectionTrait: 'static + Send + Sized {
         context: &Context,
     ) -> Poll<Result<stream::StreamId, connection::Error>>;
 
-    fn application_close(&mut self, error: Option<application::Error>);
+    fn application_close(&mut self, error: Option<connection::Error>);
 
     fn server_name(&self) -> Option<ServerName>;
 


### PR DESCRIPTION
### Release Summary:

Close all streams after `Endpoint` drop

### Resolved issues:

#3170 

### Description of changes: 

Currently, after dropping the Endpoint the following is observed:
 - tx operations succeed
 - rx operations never return from an .await

 This is concerning because Endpoint drop can happen particularly
 due to IO implementation returning an error, which makes the current
 behaviour unexpected and hard to handle.

 The expected behaviour is:
  - tx operations return an error
  - rx operations return an error

To achieve this behaviour I suggest closing all streams on Endpoint drop

### Testing:

I added tests and made sure they do not pass before the change and pass after the change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.