### PR TITLE
build(deps): replace structopt with clapv4

### DIFF
--- a/.github/config/cargo-deny.toml
+++ b/.github/config/cargo-deny.toml
@@ -1,22 +1,6 @@
 [advisories]
 yanked = "deny"
-ignore = [
-  # `atty` is a dependency of `structopt` and only used in s2n-quic-qns and s2n-quic-sim
-  # https://github.com/aws/s2n-quic/issues/2324
-  "RUSTSEC-2021-0145",
-  # `atty` is a dependency of `structopt` and only used in s2n-quic-qns and s2n-quic-sim
-  # https://github.com/aws/s2n-quic/issues/2324
-  "RUSTSEC-2024-0375",
-  # ` proc-macro-error` is a dependency of `structopt` and only used in s2n-quic-qns and s2n-quic-sim
-  # https://github.com/aws/s2n-quic/issues/2324
-  "RUSTSEC-2024-0370",
-  # `ansi_term` is a dependency of `structopt` and only used in s2n-quic-qns and s2n-quic-sim
-  # https://github.com/aws/s2n-quic/issues/2324
-  "RUSTSEC-2021-0139",
-  # `structopt` is in maintenance mode and only used in s2n-quic-qns and s2n-quic-sim
-  # https://github.com/aws/s2n-quic/issues/2324
-  "RUSTSEC-2022-0104"
-]
+ignore = []
 
 [bans]
 multiple-versions = "deny"

--- a/quic/s2n-quic-qns/Cargo.toml
+++ b/quic/s2n-quic-qns/Cargo.toml
@@ -26,7 +26,7 @@ rand = "0.10"
 s2n-codec = { path = "../../common/s2n-codec" }
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-h3 = { path = "../s2n-quic-h3" }
-structopt = "0.3"
+clap = { version = "4", features = ["derive", "env"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/quic/s2n-quic-qns/src/client/interop.rs
+++ b/quic/s2n-quic-qns/src/client/interop.rs
@@ -8,6 +8,7 @@ use crate::{
     interop::Testcase,
     task, tls, Result,
 };
+use clap::{builder::TypedValueParser as _, Args};
 use core::time::Duration;
 use s2n_quic::{client::Connect, provider::event, Client};
 use std::{
@@ -15,52 +16,56 @@ use std::{
     path::PathBuf,
     sync::Arc,
 };
-use structopt::StructOpt;
 use tokio::net::lookup_host;
 use url::{Host, Url};
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Interop {
-    #[structopt(short, long)]
+    #[clap(short, long)]
     ip: Option<std::net::IpAddr>,
 
-    #[structopt(short, long, default_value = "443")]
+    #[clap(short, long, default_value = "443")]
     port: u16,
 
-    #[structopt(long, default_value = "hq-interop")]
+    #[clap(long, default_value = "hq-interop")]
     application_protocols: Vec<String>,
 
-    #[structopt(long)]
+    #[clap(long)]
     download_dir: Option<PathBuf>,
 
-    #[structopt(long, parse(try_from_str = parse_duration))]
+    #[clap(long, value_parser = parse_duration)]
     keep_alive: Option<Duration>,
 
-    #[structopt(long, env = "TESTCASE", possible_values = &Testcase::supported(is_supported_testcase))]
+    #[clap(
+        long,
+        env = "TESTCASE",
+        value_parser = clap::builder::PossibleValuesParser::new(Testcase::supported(is_supported_testcase))
+            .map(|s| s.parse::<Testcase>().unwrap()),
+    )]
     testcase: Option<Testcase>,
 
-    #[structopt(long, default_value = "20")]
+    #[clap(long, default_value = "20")]
     concurrency: u64,
 
-    #[structopt(min_values = 1, required = true)]
+    #[clap(required = true)]
     requests: Vec<Url>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     limits: crate::limits::Limits,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     io: crate::io::Client,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     tls: tls::Client,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     runtime: crate::runtime::Runtime,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     congestion_controller: crate::congestion_control::CongestionControl,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     intercept: Intercept,
 }
 

--- a/quic/s2n-quic-qns/src/client/perf.rs
+++ b/quic/s2n-quic-qns/src/client/perf.rs
@@ -2,62 +2,62 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{client, intercept::Intercept, perf, task, tls, Result};
+use clap::Args;
 use s2n_quic::{client::Connect, provider::event, Client, Connection};
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Perf {
-    #[structopt(short, long, default_value = "127.0.0.1")]
+    #[clap(short, long, default_value = "127.0.0.1")]
     ip: std::net::IpAddr,
 
-    #[structopt(short, long, default_value = "443")]
+    #[clap(short, long, default_value = "443")]
     port: u16,
 
-    #[structopt(short, long)]
+    #[clap(short, long)]
     server_name: Option<String>,
 
     //= https://tools.ietf.org/id/draft-banks-quic-performance-00#2.1
     //# The ALPN used by the QUIC performance protocol is "perf".
-    #[structopt(long, default_value = "perf")]
+    #[clap(long, default_value = "perf")]
     application_protocols: Vec<String>,
 
     /// The total number of connections to open from the client
-    #[structopt(long, default_value = "1")]
+    #[clap(long, default_value = "1")]
     connections: usize,
 
     /// Defines the number of concurrent connections to open at any given time
-    #[structopt(long, default_value = "10")]
+    #[clap(long, default_value = "10")]
     concurrency: u64,
 
-    #[structopt(long, default_value)]
+    #[clap(long, default_value_t)]
     send: u64,
 
-    #[structopt(long, default_value)]
+    #[clap(long, default_value_t)]
     receive: u64,
 
-    #[structopt(long, default_value = "1")]
+    #[clap(long, default_value = "1")]
     streams: u64,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     limits: crate::limits::Limits,
 
     /// Logs statistics for the endpoint
-    #[structopt(long)]
+    #[clap(long)]
     stats: bool,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     io: crate::io::Client,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     tls: tls::Client,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     runtime: crate::runtime::Runtime,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     congestion_controller: crate::congestion_control::CongestionControl,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     intercept: Intercept,
 }
 

--- a/quic/s2n-quic-qns/src/congestion_control.rs
+++ b/quic/s2n-quic-qns/src/congestion_control.rs
@@ -1,14 +1,19 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::{builder::TypedValueParser as _, Args};
 use core::str::FromStr;
 use std::io;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct CongestionControl {
     /// The congestion controller to use
-    #[structopt(long = "cc", default_value = "bbr", possible_values = &["cubic","bbr"])]
+    #[clap(
+        long = "cc",
+        default_value = "bbr",
+        value_parser = clap::builder::PossibleValuesParser::new(["cubic", "bbr"])
+            .map(|s| s.parse::<CongestionController>().unwrap()),
+    )]
     pub congestion_controller: CongestionController,
 }
 

--- a/quic/s2n-quic-qns/src/intercept.rs
+++ b/quic/s2n-quic-qns/src/intercept.rs
@@ -1,6 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use clap::Args;
 use lru::LruCache;
 use rand::Rng as _;
 use s2n_codec::encoder::scatter;
@@ -13,17 +14,16 @@ use s2n_quic_core::{
     },
     path::RemoteAddress,
 };
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Intercept {
-    #[structopt(long)]
+    #[clap(long)]
     havoc_rx: bool,
 
-    #[structopt(long)]
+    #[clap(long)]
     havoc_tx: bool,
 
-    #[structopt(long)]
+    #[clap(long)]
     havoc_port: bool,
 }
 

--- a/quic/s2n-quic-qns/src/io.rs
+++ b/quic/s2n-quic-qns/src/io.rs
@@ -2,34 +2,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::Result;
+use clap::Args;
 use s2n_quic::provider::io;
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
+#[group(skip)]
 pub struct Server {
-    #[structopt(short, long, default_value = "::")]
+    #[clap(short, long, default_value = "::")]
     pub ip: std::net::IpAddr,
 
-    #[structopt(short, long, default_value = "443")]
+    #[clap(short, long, default_value = "443")]
     pub port: u16,
 
-    #[structopt(long)]
+    #[clap(long)]
     pub disable_gso: bool,
 
-    #[structopt(long, default_value = "1280")]
+    #[clap(long, default_value = "1280")]
     pub initial_mtu: u16,
 
-    #[structopt(long, default_value = "9000")]
+    #[clap(long, default_value = "9000")]
     pub max_mtu: u16,
 
-    #[structopt(long)]
+    #[clap(long)]
     pub queue_recv_buffer_size: Option<usize>,
 
-    #[structopt(long)]
+    #[clap(long)]
     pub queue_send_buffer_size: Option<usize>,
 
     #[cfg(feature = "xdp")]
-    #[structopt(flatten)]
+    #[clap(flatten)]
     xdp: crate::xdp::Xdp,
 }
 
@@ -68,28 +69,29 @@ impl Server {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
+#[group(skip)]
 pub struct Client {
-    #[structopt(long)]
+    #[clap(long)]
     pub disable_gso: bool,
 
-    #[structopt(long, default_value = "1280")]
+    #[clap(long, default_value = "1280")]
     pub initial_mtu: u16,
 
-    #[structopt(long, default_value = "9000")]
+    #[clap(long, default_value = "9000")]
     pub max_mtu: u16,
 
-    #[structopt(long)]
+    #[clap(long)]
     pub queue_recv_buffer_size: Option<usize>,
 
-    #[structopt(long)]
+    #[clap(long)]
     pub queue_send_buffer_size: Option<usize>,
 
-    #[structopt(short, long, default_value = "::")]
+    #[clap(short, long, default_value = "::")]
     pub local_ip: std::net::IpAddr,
 
     #[cfg(feature = "xdp")]
-    #[structopt(flatten)]
+    #[clap(flatten)]
     xdp: crate::xdp::Xdp,
 }
 

--- a/quic/s2n-quic-qns/src/limits.rs
+++ b/quic/s2n-quic-qns/src/limits.rs
@@ -3,25 +3,25 @@
 
 use core::time::Duration;
 
-#[derive(Debug, structopt::StructOpt)]
+#[derive(Debug, clap::Args)]
 pub struct Limits {
     /// The maximum bits/sec for each connection
-    #[structopt(long, default_value = "150")]
+    #[clap(long, default_value = "150")]
     pub max_throughput: u64,
 
     /// The expected RTT in milliseconds
-    #[structopt(long, default_value = "100")]
+    #[clap(long, default_value = "100")]
     pub expected_rtt: u64,
 
-    #[structopt(long)]
+    #[clap(long)]
     pub stream_send_buffer_size: Option<u32>,
 
     /// The maximum time (in seconds) the handshake may take to complete
-    #[structopt(long, default_value = "300")]
+    #[clap(long, default_value = "300")]
     pub max_handshake_duration: u64,
 
     /// The maximum time (in seconds) a connection will remain open without contact from the peer
-    #[structopt(long, default_value = "300")]
+    #[clap(long, default_value = "300")]
     pub max_idle_timeout: u64,
 }
 

--- a/quic/s2n-quic-qns/src/main.rs
+++ b/quic/s2n-quic-qns/src/main.rs
@@ -1,7 +1,7 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use structopt::StructOpt;
+use clap::{Parser, Subcommand};
 
 pub type Error = Box<dyn 'static + std::error::Error + Send + Sync>;
 pub type Result<T, E = Error> = core::result::Result<T, E>;
@@ -42,7 +42,7 @@ fn main() {
         .event_format(format)
         .init();
 
-    match Arguments::from_args_safe() {
+    match Arguments::try_parse() {
         Ok(args) => {
             if let Err(error) = args.run() {
                 eprintln!("Error: {error:?}");
@@ -50,35 +50,49 @@ fn main() {
             }
         }
         Err(error) => {
-            if error.use_stderr() {
+            use clap::error::ErrorKind;
+
+            // Help/version output is printed to stdout with a successful exit code
+            if matches!(
+                error.kind(),
+                ErrorKind::DisplayHelp
+                    | ErrorKind::DisplayVersion
+                    | ErrorKind::DisplayHelpOnMissingArgumentOrSubcommand
+            ) {
+                println!("{error}");
+            } else {
                 eprintln!("{error}");
 
                 // https://github.com/marten-seemann/quic-interop-runner/blob/cd223804bf3f102c3567758ea100577febe486ff/interop.py#L102
                 // The interop runner wants us to exit with code 127 when an invalid argument is passed
                 std::process::exit(127);
-            } else {
-                println!("{error}");
             }
         }
     };
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 enum Arguments {
-    Interop(Interop),
-    Perf(Perf),
+    Interop {
+        #[clap(subcommand)]
+        subject: Interop,
+    },
+    Perf {
+        #[clap(subcommand)]
+        subject: Perf,
+    },
 }
 
 impl Arguments {
     pub fn run(&self) -> Result<()> {
         match self {
-            Self::Interop(subject) => subject.run(),
-            Self::Perf(subject) => subject.run(),
+            Self::Interop { subject } => subject.run(),
+            Self::Perf { subject } => subject.run(),
         }
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Subcommand)]
 enum Interop {
     Server(server::Interop),
     Client(client::Interop),
@@ -93,7 +107,7 @@ impl Interop {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Subcommand)]
 enum Perf {
     Server(server::Perf),
     Client(client::Perf),

--- a/quic/s2n-quic-qns/src/runtime.rs
+++ b/quic/s2n-quic-qns/src/runtime.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::Result;
-use structopt::StructOpt;
+use clap::Args;
 use tokio::runtime::Runtime as Rt;
 
-#[derive(Clone, Debug, StructOpt)]
+#[derive(Clone, Debug, Args)]
 pub struct Runtime {
     /// Enables the multi-threaded runtime
-    #[structopt(long)]
+    #[clap(long)]
     multithread: Option<Option<bool>>,
 }
 

--- a/quic/s2n-quic-qns/src/server/interop.rs
+++ b/quic/s2n-quic-qns/src/server/interop.rs
@@ -8,6 +8,7 @@ use crate::{
     server::{h09, h3},
     tls, Result,
 };
+use clap::{builder::TypedValueParser as _, Args};
 use s2n_quic::{
     provider::{
         endpoint_limits,
@@ -19,36 +20,40 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use structopt::StructOpt;
 use tokio::spawn;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Interop {
-    #[structopt(long, default_value = "hq-interop")]
+    #[clap(long, default_value = "hq-interop")]
     application_protocols: Vec<String>,
 
-    #[structopt(long, default_value = ".")]
+    #[clap(long, default_value = ".")]
     www_dir: PathBuf,
 
-    #[structopt(long, env = "TESTCASE", possible_values = &Testcase::supported(is_supported_testcase))]
+    #[clap(
+        long,
+        env = "TESTCASE",
+        value_parser = clap::builder::PossibleValuesParser::new(Testcase::supported(is_supported_testcase))
+            .map(|s| s.parse::<Testcase>().unwrap()),
+    )]
     testcase: Option<Testcase>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     limits: crate::limits::Limits,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     tls: tls::Server,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     io: crate::io::Server,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     runtime: crate::runtime::Runtime,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     congestion_controller: crate::congestion_control::CongestionControl,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     intercept: Intercept,
 }
 

--- a/quic/s2n-quic-qns/src/server/perf.rs
+++ b/quic/s2n-quic-qns/src/server/perf.rs
@@ -2,45 +2,45 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{intercept::Intercept, perf, server, tls, Result};
+use clap::Args;
 use futures::future::try_join_all;
 use s2n_quic::{
     provider::event,
     stream::{BidirectionalStream, ReceiveStream, SendStream},
     Connection, Server,
 };
-use structopt::StructOpt;
 use tokio::spawn;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Perf {
     //= https://tools.ietf.org/id/draft-banks-quic-performance-00#2.1
     //# The ALPN used by the QUIC performance protocol is "perf".
-    #[structopt(long, default_value = "perf")]
+    #[clap(long, default_value = "perf")]
     application_protocols: Vec<String>,
 
-    #[structopt(long)]
+    #[clap(long)]
     connections: Option<usize>,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     limits: crate::limits::Limits,
 
     /// Logs statistics for the endpoint
-    #[structopt(long)]
+    #[clap(long)]
     stats: bool,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     tls: tls::Server,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     io: crate::io::Server,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     runtime: crate::runtime::Runtime,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     congestion_controller: crate::congestion_control::CongestionControl,
 
-    #[structopt(flatten)]
+    #[clap(flatten)]
     intercept: Intercept,
 }
 

--- a/quic/s2n-quic-qns/src/tls.rs
+++ b/quic/s2n-quic-qns/src/tls.rs
@@ -2,27 +2,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::Result;
+use clap::Args;
 use s2n_quic::provider::tls as s2n_quic_tls_provider;
 #[allow(deprecated)]
 use s2n_quic::provider::tls::rustls::rustls as rustls_crate;
 use std::{path::PathBuf, str::FromStr};
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
+#[group(skip)]
 pub struct Server {
-    #[structopt(long)]
+    #[clap(long)]
     pub certificate: Option<PathBuf>,
 
-    #[structopt(long)]
+    #[clap(long)]
     pub private_key: Option<PathBuf>,
 
-    #[structopt(long, default_value)]
+    #[clap(long, default_value_t)]
     pub tls: TlsProviders,
 
     /// The key to use for session tickets/PSKs
     ///
     /// Must be at least 16 bytes
-    #[structopt(long)]
+    #[clap(long)]
     pub ticket_key: Option<String>,
 }
 
@@ -82,16 +83,17 @@ impl Server {
     }
 }
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
+#[group(skip)]
 pub struct Client {
-    #[structopt(long)]
+    #[clap(long)]
     pub ca: Option<PathBuf>,
 
-    #[structopt(long, default_value)]
+    #[clap(long, default_value_t)]
     pub tls: TlsProviders,
 
     /// disable verification of the server certificate (rustls only)
-    #[structopt(long)]
+    #[clap(long)]
     pub disable_cert_verification: bool,
 }
 

--- a/quic/s2n-quic-qns/src/xdp.rs
+++ b/quic/s2n-quic-qns/src/xdp.rs
@@ -6,6 +6,7 @@ use aya::{
     maps::{HashMap, MapData, XskMap},
     programs, Ebpf,
 };
+use clap::Args;
 use s2n_quic::provider::io::{
     self,
     xdp::{
@@ -22,37 +23,36 @@ use s2n_quic::provider::io::{
 };
 use s2n_quic_core::task::cooldown::Cooldown;
 use std::{ffi::CString, net::SocketAddr, os::unix::io::AsRawFd, sync::Arc};
-use structopt::StructOpt;
 use tokio::{io::unix::AsyncFd, net::UdpSocket};
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Xdp {
-    #[structopt(long, default_value = "lo")]
+    #[clap(long, default_value = "lo")]
     interface: String,
 
     // Default values come from https://elixir.bootlin.com/linux/v6.3.9/source/tools/testing/selftests/bpf/xsk.h#L185
-    #[structopt(long, default_value = "2048")]
+    #[clap(long, default_value = "2048")]
     tx_queue_len: u32,
 
-    #[structopt(long, default_value = "2048")]
+    #[clap(long, default_value = "2048")]
     rx_queue_len: u32,
 
-    #[structopt(long, default_value = "4096")]
+    #[clap(long, default_value = "4096")]
     frame_size: u32,
 
-    #[structopt(long)]
+    #[clap(long)]
     xdp_stats: bool,
 
-    #[structopt(long)]
+    #[clap(long)]
     bpf_trace: bool,
 
-    #[structopt(long, default_value = "auto")]
+    #[clap(long, default_value = "auto")]
     xdp_mode: XdpMode,
 
-    #[structopt(long)]
+    #[clap(long)]
     no_checksum: bool,
 
-    #[structopt(long, default_value)]
+    #[clap(long, default_value_t)]
     rx_cooldown: u16,
 }
 

--- a/quic/s2n-quic-sim/Cargo.toml
+++ b/quic/s2n-quic-sim/Cargo.toml
@@ -24,6 +24,6 @@ s2n-quic = { path = "../s2n-quic", features = ["unstable-provider-io-testing", "
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-structopt = "0.3"
+clap = { version = "4", features = ["derive"] }
 toml = "1.0"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/quic/s2n-quic-sim/src/batch.rs
+++ b/quic/s2n-quic-sim/src/batch.rs
@@ -15,18 +15,17 @@ use std::{
     process::Command,
     str::FromStr,
 };
-use structopt::StructOpt;
 
 static INDEX: &str = include_str!("./batch.html");
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, clap::Args)]
 pub struct Batch {
     plans: Vec<Plan>,
 
-    #[structopt(short, long, default_value = "target/s2n-quic-sim")]
+    #[clap(short, long, default_value = "target/s2n-quic-sim")]
     out: PathBuf,
 
-    #[structopt(long)]
+    #[clap(long)]
     skip_run: bool,
 }
 

--- a/quic/s2n-quic-sim/src/main.rs
+++ b/quic/s2n-quic-sim/src/main.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 pub use anyhow::Error;
-use structopt::StructOpt;
+use clap::Parser;
 
 pub type Result<T = (), E = Error> = core::result::Result<T, E>;
 
@@ -12,7 +12,7 @@ mod report;
 mod run;
 mod stats;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 enum Args {
     Query(query::Query),
     Run(Box<run::Run>),
@@ -32,7 +32,7 @@ fn main() -> Result {
         .event_format(format)
         .init();
 
-    match Args::from_args() {
+    match Args::parse() {
         Args::Query(args) => args.run(),
         Args::Run(args) => args.run(),
         Args::Report(args) => args.run(),

--- a/quic/s2n-quic-sim/src/query.rs
+++ b/quic/s2n-quic-sim/src/query.rs
@@ -6,27 +6,32 @@ use crate::{
     Result,
 };
 use anyhow::anyhow;
+use clap::{builder::TypedValueParser as _, Args};
 use std::{collections::HashMap, fs, io};
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Query {
-    #[structopt(long)]
+    #[clap(long)]
     header: Option<Option<bool>>,
 
-    #[structopt(long)]
+    #[clap(long)]
     clients: Option<Option<bool>>,
 
-    #[structopt(long)]
+    #[clap(long)]
     servers: Option<Option<bool>>,
 
-    #[structopt(long, short)]
+    #[clap(long, short)]
     filter: Vec<stats::Filter>,
 
-    #[structopt(long, short, possible_values = &*stats::QUERY_NAMES)]
+    #[clap(
+        long,
+        short,
+        value_parser = clap::builder::PossibleValuesParser::new(stats::QUERY_NAMES.iter().copied())
+            .map(|s| s.parse::<stats::Query>().unwrap()),
+    )]
     query: Vec<stats::Query>,
 
-    #[structopt(long)]
+    #[clap(long)]
     with_seed: bool,
 
     input: Option<String>,

--- a/quic/s2n-quic-sim/src/report.rs
+++ b/quic/s2n-quic-sim/src/report.rs
@@ -5,35 +5,45 @@ use crate::{
     stats::{self, Connection, Filter, Parameters, Query, Stats, QUERY_NAMES},
     Result,
 };
+use clap::{builder::TypedValueParser as _, Args};
 use serde_json::json;
 use std::{
     collections::{BTreeSet, HashMap},
     fs, io,
     path::PathBuf,
 };
-use structopt::StructOpt;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Report {
-    #[structopt(long, short)]
+    #[clap(long, short)]
     filter: Vec<Filter>,
 
-    #[structopt(long, short, possible_values = &*QUERY_NAMES)]
+    #[clap(
+        long,
+        short,
+        value_parser = clap::builder::PossibleValuesParser::new(QUERY_NAMES.iter().copied())
+            .map(|s| s.parse::<Query>().unwrap()),
+    )]
     x: Query,
 
-    #[structopt(long, default_value = "100")]
+    #[clap(long, default_value = "100")]
     x_width: u32,
 
-    #[structopt(long, short, possible_values = &*QUERY_NAMES)]
+    #[clap(
+        long,
+        short,
+        value_parser = clap::builder::PossibleValuesParser::new(QUERY_NAMES.iter().copied())
+            .map(|s| s.parse::<Query>().unwrap()),
+    )]
     y: Query,
 
-    #[structopt(long, default_value = "100")]
+    #[clap(long, default_value = "100")]
     y_width: u32,
 
-    #[structopt(long)]
+    #[clap(long)]
     title: Option<String>,
 
-    #[structopt(long, default_value = "blues")]
+    #[clap(long, default_value = "blues")]
     palette: String,
 
     input: PathBuf,

--- a/quic/s2n-quic-sim/src/run.rs
+++ b/quic/s2n-quic-sim/src/run.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{stats, Result};
+use clap::Args;
 use indicatif::{ParallelProgressIterator, ProgressBar};
 use rayon::prelude::*;
 use s2n_quic::provider::io::testing::{test_seed, Model};
-use structopt::StructOpt;
 
 mod config;
 pub use config::Config;
@@ -16,15 +16,15 @@ mod events;
 mod range;
 use range::CliRange;
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Args)]
 pub struct Run {
-    #[structopt(flatten)]
+    #[clap(flatten)]
     config: Config,
 
-    #[structopt(long)]
+    #[clap(long)]
     seed: Vec<u64>,
 
-    #[structopt(long)]
+    #[clap(long)]
     progress: bool,
 }
 

--- a/quic/s2n-quic-sim/src/run/config.rs
+++ b/quic/s2n-quic-sim/src/run/config.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::CliRange;
+use clap::Args;
 use jiff::SignedDuration;
 use serde::Deserialize;
-use structopt::StructOpt;
 
 macro_rules! config {
     (struct Config { $(#[name = $name:literal] #[default = $default:literal] $field:ident: $ty:ty),* $(,)? }) => {
@@ -18,11 +18,11 @@ macro_rules! config {
         }
         use defaults::*;
 
-        #[derive(Clone, Debug, StructOpt, Deserialize)]
+        #[derive(Clone, Debug, Args, Deserialize)]
         #[serde(deny_unknown_fields)]
         pub struct Config {
             $(
-                #[structopt(long, default_value = $default)]
+                #[clap(long, default_value = $default)]
                 #[serde(default = $name)]
                 pub $field: $ty,
             )*


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

Fix the dependency check of the s2n-quic's CI. The dependency check was failing during recent days: https://github.com/aws/s2n-quic/actions/runs/30955457092/job/92147302539, because the `structopt` repo is under maintanence mode and we are encourage to migrate to clap. This PR fixes this problem for s2n-quic-sims and s2n-quic-qns crates.

### Call-outs:

N/A

### Testing:

I ran the dependency tests on my fork and the check passed: https://github.com/boquan-fang/s2n-quic/actions/runs/31030902937/job/92391054431.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

