### PR TITLE
feat(dc): Reduce thread count for UDS server

### DIFF
--- a/dc/s2n-quic-dc/src/stream/environment/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/environment/tokio.rs
@@ -62,6 +62,11 @@ where
         }
     }
 
+    pub fn with_thread_name_prefix(mut self, prefix: String) -> Self {
+        self.thread_name_prefix = Some(prefix);
+        self
+    }
+
     pub fn with_threads(mut self, threads: usize) -> Self {
         self.threads = Some(threads);
         self

--- a/dc/s2n-quic-dc/src/stream/server/application.rs
+++ b/dc/s2n-quic-dc/src/stream/server/application.rs
@@ -91,7 +91,16 @@ impl Builder {
             ))
         );
 
-        let env = env::Builder::new(subscriber).build()?;
+        let mut env = env::Builder::new(subscriber);
+
+        if !self.enable_udp {
+            // If we only have TCP, there shouldn't be significant load on the background worker
+            // threads, so reduce thread count. Only the background shutdowns get sent there for
+            // TCP workloads.
+            env = env.with_threads(1);
+        }
+
+        let env = env.build()?;
 
         let mut span = self.span.unwrap_or_else(tracing::span::Span::current);
         if span.is_none() {

--- a/dc/s2n-quic-dc/src/stream/server/manager.rs
+++ b/dc/s2n-quic-dc/src/stream/server/manager.rs
@@ -148,7 +148,12 @@ impl Builder {
 
         let backlog: usize = self.backlog.map(NonZeroU16::get).unwrap_or(DEFAULT_BACKLOG) as usize;
 
-        let env = env::Builder::new(subscriber).with_threads(concurrency);
+        // FIXME: This is configuring runtimes that likely won't be used as the manager doesn't do
+        // dataplane I/O. For now, do the easy thing and configure just one thread per threadpool.
+        // In the future we'll want to get rid of them entirely.
+        let env = env::Builder::new(subscriber)
+            .with_threads(1)
+            .with_thread_name_prefix("mgr-dc".into());
 
         let enable_udp_pool = true;
 
@@ -162,11 +167,17 @@ impl Builder {
             // TODO UDP
         }
 
-        // TODO is it better to spawn one current_thread runtime per concurrency?
+        // If we've not enabled UDP support, clamp the # of threads we spawn to the TCP worker
+        // count. No reason to spawn extra threads that would largely just sit idle.
+        let acceptor_concurrency = if self.enable_udp {
+            concurrency
+        } else {
+            concurrency.clamp(1, MAX_TCP_WORKERS)
+        };
         let acceptor_rt: runtime::Shared<S> = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
-            .thread_name("acceptor")
-            .worker_threads(concurrency)
+            .thread_name("mgr-acceptor")
+            .worker_threads(acceptor_concurrency)
             .build()?
             .into();
 
@@ -186,7 +197,7 @@ impl Builder {
         // split the backlog between all of the workers
         // this is only used in TCP, so clamp division to maximum TCP worker concurrency
         let backlog = backlog
-            .div_ceil(concurrency.clamp(0, MAX_TCP_WORKERS))
+            .div_ceil(acceptor_concurrency.clamp(0, MAX_TCP_WORKERS))
             .max(1);
         let path = self.socket_path.ok_or(io::Error::new(
             io::ErrorKind::InvalidInput,
@@ -199,7 +210,7 @@ impl Builder {
             accept_flavor: self.accept_flavor,
             linger: self.linger,
             backlog,
-            concurrency,
+            concurrency: acceptor_concurrency,
             server: &mut server,
             span,
             next_id: 0,

--- a/dc/s2n-quic-dc/src/stream/server/tokio.rs
+++ b/dc/s2n-quic-dc/src/stream/server/tokio.rs
@@ -336,11 +336,20 @@ impl Builder {
             self.enable_udp = false;
         }
 
-        // TODO is it better to spawn one current_thread runtime per concurrency?
+        // If we've not enabled UDP support, clamp the # of threads we spawn to the TCP worker
+        // count + 1. No reason to spawn extra threads that would largely just sit idle.
+        //
+        // We add one to allow for additional work done in the pruner and stats worker, even though
+        // in most cases those are fairly idle.
+        let acceptor_concurrency = if self.enable_udp {
+            concurrency
+        } else {
+            concurrency.clamp(1, MAX_TCP_WORKERS + 1)
+        };
         let acceptor_rt: runtime::Shared<S> = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .thread_name("acceptor")
-            .worker_threads(concurrency)
+            .worker_threads(acceptor_concurrency)
             .build()?
             .into();
 


### PR DESCRIPTION
### Release Summary:

* feat(dc): Reduce thread count for dcQUIC servers

### Resolved issues:

n/a

### Description of changes: 

This reduces background runtime thread count for UDS servers from 1 per vCPU to 1. This should help reduce the extra memory and startup overhead experienced as a result of spawning those threads.

### Call-outs:

n/a

### Testing:

No particular testing. Checking thread counts by inspecting /proc is possible but we'd need a test running in its own binary to do it well. I don't think that's worth setting up for this given that the configuration is relatively simple.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

