### PR TITLE
feat(s2n-quic): Switch to default_pq TLS policy by default

### DIFF
--- a/examples/post-quantum/README.md
+++ b/examples/post-quantum/README.md
@@ -1,17 +1,13 @@
 # post-quantum example
 
-When using `s2n-tls` as the TLS provider, `s2n-quic` supports post-quantum key shares. However, because the key share algorithms are going through the standardization process, this functionality is disabled by default. It can be enabled by passing a compiler flag:
+When using `s2n-tls` as the TLS provider, `s2n-quic` supports post-quantum key
+shares in the default configuration loaders. Currently s2n-quic's providers
+default to the s2n-tls `default_pq` policy, although this is not stable and may
+change in the future. See the [s2n-tls documentation](https://aws.github.io/s2n-tls/usage-guide/ch16-post-quantum.html)
+for more details.
 
-```sh
-export RUSTFLAGS=`--cfg s2n_quic_enable_pq_tls`
-```
-
-You can also add a `.cargo/config.toml` to the project (as done in this example):
-
-```toml
-[build]
-rustflags=['--cfg', 's2n_quic_enable_pq_tls']
-```
+When using `rustls` or a custom TLS provider, s2n-quic will use their
+configuration for post-quantum defaults.
 
 ## Running the example
 
@@ -28,4 +24,3 @@ cargo run --bin pq_client
 ```
 
 Inspecting traffic with wireshark will show the `key_share` extension with `Group: Unknown (12089)` in both the Client Hello and Server Hello.
-

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -33,9 +33,3 @@ pin-project = { version = "1" }
 aws-lc-rs = "1.12"
 s2n-quic-core = { path = "../s2n-quic-core", features = ["testing"] }
 s2n-quic-rustls = { path = "../s2n-quic-rustls" }
-
-[lints.rust.unexpected_cfgs]
-level = "warn"
-check-cfg = [
-    'cfg(s2n_quic_enable_pq_tls)',
-]

--- a/quic/s2n-quic-tls/src/lib.rs
+++ b/quic/s2n-quic-tls/src/lib.rs
@@ -10,10 +10,7 @@ use s2n_quic_core::application::ServerName;
 #[global_allocator]
 static ALLOCATOR: checkers::Allocator = checkers::Allocator::system();
 
-#[cfg(s2n_quic_enable_pq_tls)]
 static DEFAULT_POLICY: &s2n_tls::security::Policy = &s2n_tls::security::DEFAULT_PQ;
-#[cfg(not(s2n_quic_enable_pq_tls))]
-static DEFAULT_POLICY: &s2n_tls::security::Policy = &s2n_tls::security::DEFAULT_TLS13;
 
 #[non_exhaustive]
 pub struct ConnectionContext<'a> {


### PR DESCRIPTION
### Release Summary:

* feat(s2n-quic): Default to `default_pq` s2n-tls policy if not otherwise configured

### Resolved issues:

closes https://github.com/aws/s2n-quic/issues/2961

### Description of changes: 

This changes the default policy used by the client and server builders to `default_pq`. This should be safe for most customers to deploy and the relevant algorithms have been fairly widely adopted on the public internet. Most production deployments likely configure this setting in any case.

### Call-outs:

n/a

### Testing:

Just CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

