### PR TITLE
ci: Replace deprecated GitHub action for bpf-linker in xdp job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1065,11 +1065,10 @@ jobs:
           rustup toolchain install stable --profile minimal --component rustfmt
           rustup override set stable
 
-      - uses: camshaft/install@v1
-        with:
-          crate: bpf-linker
-
       - uses: camshaft/rust-cache@v1
+
+      - name: Install bpf-linker
+        run: cargo install bpf-linker@0.10.4
 
       - name: Build ebpf
         working-directory: tools/xdp


### PR DESCRIPTION
### Resolved issues:

Failed xdp CI job: https://github.com/aws/s2n-quic/actions/runs/31730995186/job/94551217020

### Description of changes: 

The xdp CI job was failing because `camshaft/install@v1` (which uses Node 12 internally) attempted to install the latest `bpf-linker` without a version pin. `bpf-linker` 0.11.0 now defaults to the llvm-23 feature, but stable Rust ships LLVM 22, causing the build to fail with exit code 101.

This change removes `camshaft/install@v1` and replaces it with a direct `cargo install bpf-linker@0.10.4`. Version 0.10.4 is the latest release that defaults to `rust-llvm-22`, linking against the LLVM bundled with the Rust toolchain and building cleanly on stable.

The `camshaft/rust-cache` step is also moved earlier so that `sccache` can cache the `bpf-linker` compilation on subsequent runs.

### Testing:

The xdp job should now pass without Node deprecation warnings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

