### PR TITLE
chore(release): s2n-quic v1.87.0

### DIFF
--- a/common/s2n-codec/Cargo.toml
+++ b/common/s2n-codec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-codec"
-version = "0.86.0"
+version = "0.87.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]

--- a/dc/s2n-quic-dc-metrics/Cargo.toml
+++ b/dc/s2n-quic-dc-metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-dc-metrics"
-version = "0.86.0"
+version = "0.87.0"
 description = "Crate used to generate metrics for s2n-quic-dc"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]

--- a/dc/s2n-quic-dc/Cargo.toml
+++ b/dc/s2n-quic-dc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-dc"
-version = "0.86.0"
+version = "0.87.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -44,11 +44,11 @@ num-rational = { version = "0.4", default-features = false }
 once_cell = "1"
 pin-project-lite = "0.2"
 rand = "0.10"
-s2n-codec = { version = "=0.86.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic = { version = "=1.86.0", path = "../../quic/s2n-quic", features = ["unstable-provider-connection-close-formatter", "unstable-provider-dc", "unstable-provider-random", "unstable-offload-tls"] }
-s2n-quic-core = { version = "=0.86.0", path = "../../quic/s2n-quic-core", default-features = false }
-s2n-quic-platform = { version = "=0.86.0", path = "../../quic/s2n-quic-platform" }
-s2n-quic-dc-metrics = { version= "=0.86.0", path = "../s2n-quic-dc-metrics" }
+s2n-codec = { version = "=0.87.0", path = "../../common/s2n-codec", default-features = false }
+s2n-quic = { version = "=1.87.0", path = "../../quic/s2n-quic", features = ["unstable-provider-connection-close-formatter", "unstable-provider-dc", "unstable-provider-random", "unstable-offload-tls"] }
+s2n-quic-core = { version = "=0.87.0", path = "../../quic/s2n-quic-core", default-features = false }
+s2n-quic-platform = { version = "=0.87.0", path = "../../quic/s2n-quic-platform" }
+s2n-quic-dc-metrics = { version= "=0.87.0", path = "../s2n-quic-dc-metrics" }
 s2n-tls = "0.3.38"
 slotmap = "1"
 hashbrown = "0.17"

--- a/quic/s2n-quic-core/Cargo.toml
+++ b/quic/s2n-quic-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-core"
-version = "0.86.0"
+version = "0.87.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -41,7 +41,7 @@ num-rational = { version = "0.4", default-features = false }
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 pin-project-lite = { version = "0.2" }
 probe = { version = "0.5", optional = true }
-s2n-codec = { version = "=0.86.0", path = "../../common/s2n-codec", default-features = false }
+s2n-codec = { version = "=0.87.0", path = "../../common/s2n-codec", default-features = false }
 subtle = { version = "2", default-features = false }
 tracing = { version = "0.1", default-features = false, optional = true }
 zerocopy = { version = "0.8", features = ["derive"] }

--- a/quic/s2n-quic-crypto/Cargo.toml
+++ b/quic/s2n-quic-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-crypto"
-version = "0.86.0"
+version = "0.87.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -20,8 +20,8 @@ testing = []
 aws-lc-rs = { version = "1.12", features = ["prebuilt-nasm"] }
 cfg-if = "1"
 lazy_static = "1"
-s2n-codec = { version = "=0.86.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.86.0", path = "../s2n-quic-core", default-features = false }
+s2n-codec = { version = "=0.87.0", path = "../../common/s2n-codec", default-features = false }
+s2n-quic-core = { version = "=0.87.0", path = "../s2n-quic-core", default-features = false }
 zeroize = { version = "1", default-features = false, features = ["derive"] }
 
 [dev-dependencies]

--- a/quic/s2n-quic-platform/Cargo.toml
+++ b/quic/s2n-quic-platform/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-platform"
-version = "0.86.0"
+version = "0.87.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -25,8 +25,8 @@ bolero-generator = { version = "0.13", default-features = false, optional = true
 cfg-if = "1"
 futures = { version = "0.3", default-features = false, features = ["async-await"], optional = true }
 lazy_static = { version = "1", optional = true }
-s2n-quic-core = { version = "=0.86.0", path = "../s2n-quic-core", default-features = false }
-s2n-quic-xdp = { version = "=0.86.0", path = "../../tools/xdp/s2n-quic-xdp", optional = true }
+s2n-quic-core = { version = "=0.87.0", path = "../s2n-quic-core", default-features = false }
+s2n-quic-xdp = { version = "=0.87.0", path = "../../tools/xdp/s2n-quic-xdp", optional = true }
 socket2 = { version = "0.6", features = ["all"], optional = true }
 tokio = { version = "1", default-features = false, features = ["macros", "net", "rt", "time"], optional = true }
 tracing = { version = "0.1", optional = true }

--- a/quic/s2n-quic-rustls/Cargo.toml
+++ b/quic/s2n-quic-rustls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-rustls"
-version = "0.86.0"
+version = "0.87.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -19,9 +19,9 @@ bytes = { version = "1", default-features = false }
 rustls = { version = "0.23", default-features = false, features=["std", "aws-lc-rs", "logging"] }
 # rustls-pemfile was incorporated to rustls-pki-types in version 1.9.0
 rustls-pki-types = ">=1.9"
-s2n-codec = { version = "=0.86.0", path = "../../common/s2n-codec", default-features = false, features = ["alloc"] }
-s2n-quic-core = { version = "=0.86.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
-s2n-quic-crypto = { version = "=0.86.0", path = "../s2n-quic-crypto", default-features = false }
+s2n-codec = { version = "=0.87.0", path = "../../common/s2n-codec", default-features = false, features = ["alloc"] }
+s2n-quic-core = { version = "=0.87.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
+s2n-quic-crypto = { version = "=0.87.0", path = "../s2n-quic-crypto", default-features = false }
 
 [dev-dependencies]
 insta = { version = "1", features = ["json"] }

--- a/quic/s2n-quic-tls-default/Cargo.toml
+++ b/quic/s2n-quic-tls-default/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-tls-default"
-version = "0.86.0"
+version = "0.87.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -24,10 +24,10 @@ fips = ["s2n-quic-tls?/fips"]
 # order to support the `?` syntax, we declare s2n-quic-tls as an optional dependency.
 # `s2n-quic-tls` only gets enabled based on the target.
 [dependencies]
-s2n-quic-tls = { version = "=0.86.0", path = "../s2n-quic-tls", optional = true }
+s2n-quic-tls = { version = "=0.87.0", path = "../s2n-quic-tls", optional = true }
 
 [target.'cfg(any(unix, all(target_os = "windows", target_env = "gnu")))'.dependencies]
-s2n-quic-tls = { version = "=0.86.0", path = "../s2n-quic-tls" }
+s2n-quic-tls = { version = "=0.87.0", path = "../s2n-quic-tls" }
 
 [target.'cfg(not(any(unix, all(target_os = "windows", target_env = "gnu"))))'.dependencies]
-s2n-quic-rustls = { version = "=0.86.0", path = "../s2n-quic-rustls" }
+s2n-quic-rustls = { version = "=0.87.0", path = "../s2n-quic-rustls" }

--- a/quic/s2n-quic-tls/Cargo.toml
+++ b/quic/s2n-quic-tls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-tls"
-version = "0.86.0"
+version = "0.87.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -19,9 +19,9 @@ unstable_private_key = []
 bytes = { version = "1", default-features = false }
 errno = "0.3"
 libc = "0.2"
-s2n-codec = { version = "=0.86.0", path = "../../common/s2n-codec", default-features = false }
-s2n-quic-core = { version = "=0.86.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
-s2n-quic-crypto = { version = "=0.86.0", path = "../s2n-quic-crypto", default-features = false }
+s2n-codec = { version = "=0.87.0", path = "../../common/s2n-codec", default-features = false }
+s2n-quic-core = { version = "=0.87.0", path = "../s2n-quic-core", default-features = false, features = ["alloc"] }
+s2n-quic-crypto = { version = "=0.87.0", path = "../s2n-quic-crypto", default-features = false }
 # the `on_key_exchange_group` event relies on an API added in 0.3.15
 # s2n-tls v0.3.31 and beyond allows setting multiple application context to a TLS connection
 # s2n-tls v0.3.40 and beyond builds on Windows (via the GNU/MinGW toolchain)

--- a/quic/s2n-quic-transport/Cargo.toml
+++ b/quic/s2n-quic-transport/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-transport"
-version = "0.86.0"
+version = "0.87.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -23,8 +23,8 @@ futures-core = { version = "0.3", default-features = false, features = ["alloc"]
 hashbrown = "0.17"
 intrusive-collections = "0.10"
 once_cell = "1"
-s2n-codec = { version = "=0.86.0", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
-s2n-quic-core = { version = "=0.86.0", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
+s2n-codec = { version = "=0.87.0", path = "../../common/s2n-codec", features = ["bytes"], default-features = false }
+s2n-quic-core = { version = "=0.87.0", path = "../s2n-quic-core", features = ["alloc"], default-features = false }
 siphasher = "1.0"
 smallvec = { version = "1", default-features = false }
 

--- a/quic/s2n-quic/Cargo.toml
+++ b/quic/s2n-quic/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic"
-version = "1.86.0"
+version = "1.87.0"
 description = "A Rust implementation of the IETF QUIC protocol"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -68,14 +68,14 @@ cfg-if = "1"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 humansize = { version = "2", optional = true }
 rand = { version = "0.10", features = ["chacha"] }
-s2n-codec = { version = "=0.86.0", path = "../../common/s2n-codec" }
-s2n-quic-core = { version = "=0.86.0", path = "../s2n-quic-core" }
-s2n-quic-crypto = { version = "=0.86.0", path = "../s2n-quic-crypto", optional = true }
-s2n-quic-platform = { version = "=0.86.0", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
-s2n-quic-rustls = { version = "=0.86.0", path = "../s2n-quic-rustls", optional = true }
-s2n-quic-tls = { version = "=0.86.0", path = "../s2n-quic-tls", optional = true }
-s2n-quic-tls-default = { version = "=0.86.0", path = "../s2n-quic-tls-default", optional = true }
-s2n-quic-transport = { version = "=0.86.0", path = "../s2n-quic-transport" }
+s2n-codec = { version = "=0.87.0", path = "../../common/s2n-codec" }
+s2n-quic-core = { version = "=0.87.0", path = "../s2n-quic-core" }
+s2n-quic-crypto = { version = "=0.87.0", path = "../s2n-quic-crypto", optional = true }
+s2n-quic-platform = { version = "=0.87.0", path = "../s2n-quic-platform", features = ["tokio-runtime"] }
+s2n-quic-rustls = { version = "=0.87.0", path = "../s2n-quic-rustls", optional = true }
+s2n-quic-tls = { version = "=0.87.0", path = "../s2n-quic-tls", optional = true }
+s2n-quic-tls-default = { version = "=0.87.0", path = "../s2n-quic-tls-default", optional = true }
+s2n-quic-transport = { version = "=0.87.0", path = "../s2n-quic-transport" }
 tokio = { version = "1", default-features = false, features = ["sync"] }
 tracing = { version = "0.1", optional = true }
 zerocopy = { version = "0.8", optional = true, features = ["derive"] }

--- a/tools/xdp/s2n-quic-xdp/Cargo.toml
+++ b/tools/xdp/s2n-quic-xdp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s2n-quic-xdp"
-version = "0.86.0"
+version = "0.87.0"
 description = "Internal crate used by s2n-quic"
 repository = "https://github.com/aws/s2n-quic"
 authors = ["AWS s2n"]
@@ -18,8 +18,8 @@ aya = { version = "0.14", default-features = false }
 bitflags = "2"
 errno = "0.3"
 libc = "0.2"
-s2n-codec = { version = "=0.86.0", path = "../../../common/s2n-codec" }
-s2n-quic-core = { version = "=0.86.0", path = "../../../quic/s2n-quic-core" }
+s2n-codec = { version = "=0.87.0", path = "../../../common/s2n-codec" }
+s2n-quic-core = { version = "=0.87.0", path = "../../../quic/s2n-quic-core" }
 tokio = { version = "1", features = ["net"], optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

#### Release Summary

* feat(dc): Expand information available to TLS events https://github.com/aws/s2n-quic/pull/3189
* dc-quic now takes in a Registry and uses it to instrument the offloading tasks. https://github.com/aws/s2n-quic/pull/3190
* Fixes potential race condition in offloading feature. https://github.com/aws/s2n-quic/pull/3192
* Adding a new events for users to retrieve s2n-quic's H3 connection's signature scheme information. https://github.com/aws/s2n-quic/pull/3232

### Description of changes: 

s2n-quic v1.87.0 release

### Call-outs:

N/A

### Testing:

CI tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

