### PR TITLE
feat(s2n-quic-dc): order persisted peer records by access recency

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -614,13 +614,22 @@ where
         };
 
         // Clone the weak references out under the lock so we don't hold it across the write.
-        let entries: Vec<Weak<Entry>> = {
+        let mut entries: Vec<Weak<Entry>> = {
             let queue = self
                 .eviction_queue
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
             queue.iter().cloned().collect()
         };
+
+        // Order by access recency (newest first), so the most-active peers come first regardless
+        // of when they were created.
+        entries.sort_by_cached_key(|weak| {
+            core::cmp::Reverse(
+                weak.upgrade()
+                    .map_or(0, |entry| entry.accessed_at_epoch().get()),
+            )
+        });
 
         let start = self.clock.get_time();
         let result = serializer.serialize(&entries, self.cleaner.epoch());

--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -624,6 +624,12 @@ where
 
         // Order by access recency (newest first), so the most-active peers come first regardless
         // of when they were created.
+        //
+        // Caching the key is required for correctness, not just speed: entries are still live and
+        // `accessed_at_epoch` can change concurrently (and `upgrade()` can start failing) while we
+        // sort. Recomputing the key on every comparison would then violate the total order the
+        // sort requires, which is allowed to panic. Caching reads each key exactly once, sorting a
+        // consistent snapshot.
         entries.sort_by_cached_key(|weak| {
             core::cmp::Reverse(
                 weak.upgrade()

--- a/dc/s2n-quic-dc/src/path/secret/map/state/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state/tests.rs
@@ -105,18 +105,19 @@ fn serialize_to_disk_writes_configured_entries() {
     map.test_insert(first.clone());
     map.test_insert(second.clone());
 
+    // Access `second` so it is more recently used than `first`, despite being inserted later (and
+    // so sitting behind `first` in the FIFO eviction queue).
+    assert!(map.get_by_addr_tracked(second.peer()).is_some());
+
     map.serialize_to_disk().unwrap();
 
-    let mut decoded: Vec<SocketAddr> = disk::deserialize(&path)
+    // Both entries are written, ordered most-recently-accessed first: `second` ahead of the
+    // never-accessed `first` -- i.e. by access recency, not eviction (FIFO) order.
+    let decoded: Vec<SocketAddr> = disk::deserialize(&path)
         .unwrap()
         .map(|e| e.unwrap().peer)
         .collect();
-    decoded.sort();
-
-    let mut expected = vec![*first.peer(), *second.peer()];
-    expected.sort();
-
-    assert_eq!(decoded, expected);
+    assert_eq!(decoded, vec![*second.peer(), *first.peer()]);
 }
 
 #[test]


### PR DESCRIPTION

### Release Summary:

### Resolved issues:

### Description of changes: 

serialize_to_disk snapshots the eviction queue, which is ordered FIFO by creation time, so the persisted file was written oldest-peer-first (by handshake time).  Proactive unknown path secret emission (Server Hi) thus starts on the peers handshaked longest ago rather than those most likely to still be active.

Sort the snapshot by access recency (most-recently-accessed first) before writing.

### Call-outs:

### Testing:
Ran through the SaltyLib benchmarks. Significantly improved the restart recovery benchmark I'm working, no regressions in existing benchmarks.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.