### PR TITLE
feat(s2n-quic-dc): add proactive UnknownPathSecret emission

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map.rs
@@ -4,7 +4,7 @@
 use crate::{
     credentials::{Credentials, Id},
     event,
-    packet::{secret_control as control, Packet},
+    packet::{secret_control as control, Packet, WireVersion},
     path::secret::{
         open,
         schedule::{Ciphersuite, ExportSecret},
@@ -14,6 +14,7 @@ use crate::{
     stream::TransportFeatures,
 };
 use core::fmt;
+use s2n_codec::EncoderBuffer;
 use s2n_quic_core::{dc, time, varint::VarInt};
 use std::{net::SocketAddr, sync::Arc};
 use tokio::task::JoinHandle;
@@ -23,6 +24,7 @@ mod disk;
 mod entry;
 pub mod handshake;
 mod peer;
+mod proactive_unknown_path_secret;
 mod rehandshake;
 mod size_of;
 mod state;
@@ -37,6 +39,7 @@ mod event_tests;
 
 pub use disk::{deserialize, DiskEntry, Entries, Serializer, SerializerBuilder};
 pub use entry::Entry;
+pub use proactive_unknown_path_secret::SendStats;
 use state::StateBuilderError;
 use store::Store;
 
@@ -49,6 +52,28 @@ pub use peer::Peer;
 
 pub(crate) use size_of::SizeOf;
 pub(crate) use status::Dedup;
+
+/// Encodes an authenticated `UnknownPathSecret` packet for `credential_id` into `buffer`,
+/// returning the encoded length. Shared by the reactive reply, when an incoming packet's
+/// credentials are unknown (see [`Store::pre_authentication`]), and proactive emission (see the
+/// `proactive_unknown_path_secret` module). `buffer` must be at least
+/// [`control::UnknownPathSecret::MAX_PACKET_SIZE`] bytes.
+///
+/// [`Store::pre_authentication`]: store::Store::pre_authentication
+fn encode_unknown_path_secret(
+    buffer: &mut [u8],
+    signer: &stateless_reset::Signer,
+    credential_id: Id,
+    queue_id: Option<VarInt>,
+) -> usize {
+    let packet = control::UnknownPathSecret {
+        wire_version: WireVersion::ZERO,
+        credential_id,
+        queue_id,
+    };
+    let stateless_reset = signer.sign(&credential_id);
+    packet.encode(EncoderBuffer::new(buffer), &stateless_reset)
+}
 
 // FIXME: Most of this comment is not true today, we're expecting to implement the details
 // contained here. This is presented as a roadmap.
@@ -198,6 +223,41 @@ impl Map {
     /// serialization on their own schedule.
     pub fn serialize_to_disk(&self) -> std::io::Result<()> {
         self.store.serialize_to_disk()
+    }
+
+    /// Proactively sends an authenticated [`control::UnknownPathSecret`] packet to each peer in
+    /// `entries`, telling peers holding stale cached secrets to re-handshake.
+    ///
+    /// This is the proactive counterpart to the `UnknownPathSecret` the map already sends reactively
+    /// when it receives a packet with unknown credentials. It is intended to be called once, at
+    /// startup (e.g. after a restart, over the peers recovered from the persisted map), and blocks
+    /// the calling thread until every entry has been handled or `timeout` of wall-clock time (from
+    /// the call) elapses.
+    ///
+    /// Packets are emitted at approximately `rate` packets per second (see [`SendStats`] and the
+    /// pacer in `proactive_unknown_path_secret.rs`). Entries are handled as follows:
+    ///
+    /// * An entry with a credential id has an `UnknownPathSecret` packet built, signed with the
+    ///   map's signer, and sent to its peer address. Success is counted in [`SendStats::sent`];
+    ///   an individual send failure (including a `WouldBlock` on the shared, non-blocking control
+    ///   socket, which is dropped rather than retried) is counted in [`SendStats::failed`] and does
+    ///   not abort the run.
+    /// * A v0 entry (no credential id) cannot be turned into a packet and is counted in
+    ///   [`SendStats::skipped`]; those peers recover reactively.
+    /// * Entries not reached before `timeout` elapses are counted in [`SendStats::remaining`].
+    ///
+    /// Returns `Err` only if the map has no control socket to send on. Socket creation is
+    /// best-effort at construction, so a map can lack one. Per-entry send failures are reported via
+    /// [`SendStats::failed`], not as an error.
+    pub fn send_unknown_path_secrets(
+        &self,
+        entries: impl IntoIterator<Item = DiskEntry, IntoIter: ExactSizeIterator>,
+        rate: core::num::NonZeroU32,
+        timeout: core::time::Duration,
+    ) -> std::io::Result<SendStats> {
+        let mut entries = entries.into_iter();
+        self.store
+            .send_unknown_path_secrets(&mut entries, rate, timeout)
     }
 
     pub fn contains(&self, peer: &SocketAddr) -> bool {

--- a/dc/s2n-quic-dc/src/path/secret/map/proactive_unknown_path_secret.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/proactive_unknown_path_secret.rs
@@ -1,0 +1,238 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Paced, proactive emission of [`UnknownPathSecret`] control packets.
+//!
+//! After a server restart, peers may still hold cached path secrets that this endpoint no longer
+//! knows about. Rather than waiting for each peer to discover the restart reactively (by having a
+//! request dropped and, in turn, receiving an `UnknownPathSecret` reply), we can proactively tell
+//! every persisted peer to re-handshake by sending it an authenticated `UnknownPathSecret` control
+//! packet.
+//!
+//! [`pace_attempts`] contains the transport-agnostic pacing/accounting loop. The actual packet
+//! construction and socket send live on the map's `State` (see `state.rs`); this module is kept
+//! separate so the pacer can be unit tested without a socket.
+//!
+//! [`UnknownPathSecret`]: crate::packet::secret_control::UnknownPathSecret
+
+use super::DiskEntry;
+use crate::{credentials, packet::secret_control as control, path::secret::stateless_reset};
+use core::{num::NonZeroU32, time::Duration};
+use s2n_quic_core::time::{
+    timer::Provider as _, token_bucket::TokenBucket, Clock, StdClock, Timestamp,
+};
+use std::net::SocketAddr;
+
+/// Statistics describing a completed (or deadline-truncated) run of [`Map::send_unknown_path_secrets`].
+///
+/// The four counters partition the input exactly:
+///
+/// ```text
+/// sent + failed + skipped + remaining == total number of input entries
+/// ```
+///
+/// [`Map::send_unknown_path_secrets`]: crate::path::secret::Map::send_unknown_path_secrets
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct SendStats {
+    /// Entries for which an `UnknownPathSecret` packet was successfully written to the socket.
+    pub sent: usize,
+    /// Entries whose send was attempted but failed (socket error, including `WouldBlock`, which we
+    /// drop-and-count rather than retry -- see the module docs / `state.rs`).
+    pub failed: usize,
+    /// Entries skipped without a send attempt because they carried no credential id (v0 records).
+    /// These peers recover reactively; there is no packet we can build for them.
+    pub skipped: usize,
+    /// Entries never attempted because the deadline passed first.
+    ///
+    /// This includes an entry that was pulled from the iterator and was pending a send when the
+    /// deadline hit: because no send was attempted for it, it counts as `remaining`, not `failed`.
+    pub remaining: usize,
+}
+
+/// Lower bound on the token-bucket refill interval.
+///
+/// Refills release a batch of tokens each interval, so a high rate coalesces many sends into one
+/// wakeup rather than sleeping once per packet -- a sleep-per-packet loop is capped by OS sleep
+/// granularity (~1ms) to roughly 20-30K packets/sec, below the rate a large (e.g. 500K-peer) map
+/// must sustain to drain in tens of seconds. For rates too low to need batching, the interval
+/// stretches beyond this floor so the exact rate is still honored.
+const MIN_TICK: Duration = Duration::from_millis(5);
+
+/// The pacer's view of time: read the clock, and block until a later instant.
+///
+/// Injected into [`pace_attempts`] so tests can drive pacing deterministically without real sleeps;
+/// production uses [`RealTime`]. Bundling "read the clock" and "wait" into one capability keeps them
+/// consistent -- a fake that advances its own clock on `sleep` can't be paired with a real blocking
+/// sleep (which would never advance a fake clock, hanging the loop), and vice versa.
+trait PacingTime {
+    fn now(&self) -> Timestamp;
+    fn sleep(&mut self, dur: Duration);
+}
+
+/// Production [`PacingTime`]: a real monotonic clock paired with a real blocking sleep.
+struct RealTime(StdClock);
+
+impl PacingTime for RealTime {
+    fn now(&self) -> Timestamp {
+        self.0.get_time()
+    }
+
+    fn sleep(&mut self, dur: Duration) {
+        std::thread::sleep(dur);
+    }
+}
+
+/// Builds, signs, and sends one `UnknownPathSecret` packet per entry that has a credential id,
+/// paced at approximately `rate` packets per second and stopping once `timeout` of wall-clock time
+/// elapses. This is the module's entry point; it paces against a real clock ([`RealTime`]) and
+/// [`pace_attempts`] provides the pacing loop.
+///
+/// `send` performs the actual transmission and any success-only side effect (e.g. emitting the sent
+/// event, which needs the map's subscriber); v0 entries (no credential id) are skipped without a
+/// packet.
+///
+/// A `send` error -- including `WouldBlock` backpressure on the shared, non-blocking control
+/// socket -- is counted as a failure and not retried (a tight retry would burn CPU and starve the
+/// reactive control path; the peer simply recovers reactively). `WouldBlock` is expected under
+/// load and counted silently; any other error is logged as genuinely unexpected.
+pub(super) fn emit_packets<Send>(
+    entries: &mut dyn ExactSizeIterator<Item = DiskEntry>,
+    rate: NonZeroU32,
+    timeout: Duration,
+    signer: &stateless_reset::Signer,
+    mut send: Send,
+) -> SendStats
+where
+    Send: FnMut(credentials::Id, &[u8], &SocketAddr) -> std::io::Result<()>,
+{
+    let mut time = RealTime(StdClock::default());
+    let deadline = time.now() + timeout;
+    pace_attempts(entries, rate, deadline, &mut time, |id, peer| {
+        let mut buffer = [0u8; control::UnknownPathSecret::MAX_PACKET_SIZE];
+        let len = super::encode_unknown_path_secret(&mut buffer, signer, id, None);
+
+        match send(id, &buffer[..len], &peer) {
+            Ok(()) => true,
+            Err(err) => {
+                if err.kind() != std::io::ErrorKind::WouldBlock {
+                    tracing::warn!(
+                        ?err,
+                        credential_id = ?id,
+                        "failed to send proactive UnknownPathSecret packet"
+                    );
+                }
+                false
+            }
+        }
+    })
+}
+
+/// Rate-limits calls to `attempt`, one per sendable entry, until `deadline` passes.
+///
+/// `attempt` is invoked for each entry that has a credential id and returns `true` if the packet
+/// was sent, `false` if it failed; the outcome is tallied in the returned [`SendStats`]. v0
+/// (`None`) entries carry no credential id, so they are counted as `skipped` without an attempt --
+/// and without consuming pacing budget, so a file full of v0 records drains instantly rather than
+/// being throttled.
+///
+/// ## Pacing
+///
+/// A [`TokenBucket`] meters attempts at `rate`/sec, refilling a batch of tokens on an interval of
+/// at least `MIN_TICK` (stretched longer for low rates), so a high rate releases many packets per
+/// wakeup instead of sleeping once per packet, while the burst -- including the first -- stays
+/// capped at one batch, so a stalled caller can't then dump a catch-up burst onto the shared
+/// control socket. `time` is injected so the loop can be driven deterministically in tests; in
+/// production it is [`RealTime`]. Because the bucket refills from the current time (re-read after
+/// each batch of work), time spent iterating and sending is credited against the interval rather
+/// than added on top of it.
+fn pace_attempts<T, F>(
+    entries: &mut dyn ExactSizeIterator<Item = DiskEntry>,
+    rate: NonZeroU32,
+    deadline: Timestamp,
+    time: &mut T,
+    mut attempt: F,
+) -> SendStats
+where
+    T: PacingTime,
+    F: FnMut(credentials::Id, SocketAddr) -> bool,
+{
+    let mut stats = SendStats::default();
+    let total = entries.len();
+
+    let rate = u64::from(rate.get());
+    let refill_amount = (rate * MIN_TICK.as_millis() as u64).div_ceil(1000).max(1);
+    let refill_interval = Duration::from_nanos(refill_amount * 1_000_000_000 / rate);
+    let mut bucket = TokenBucket::builder()
+        .with_refill_interval(refill_interval)
+        .with_refill_amount(refill_amount)
+        .with_max(refill_amount)
+        .build();
+
+    while let Some((id, peer)) = next_sendable(entries, &*time, deadline, &mut stats.skipped) {
+        if !wait_for_token(&mut bucket, time, deadline, refill_interval) {
+            break;
+        }
+        if attempt(id, peer) {
+            stats.sent += 1;
+        } else {
+            stats.failed += 1;
+        }
+    }
+
+    stats.remaining = total - stats.sent - stats.failed - stats.skipped;
+    stats
+}
+
+/// Blocks until a pacing token is available, sleeping via `time` between the bucket's refills.
+/// Returns `true` once a token is taken, or `false` if `deadline` passes first (the caller then
+/// leaves the current entry unattempted). `fallback_interval` is used only if the bucket has no
+/// armed refill yet, which cannot happen after the first `take`.
+fn wait_for_token<T: PacingTime>(
+    bucket: &mut TokenBucket,
+    time: &mut T,
+    deadline: Timestamp,
+    fallback_interval: Duration,
+) -> bool {
+    loop {
+        let now = time.now();
+        if now >= deadline {
+            return false;
+        }
+        if bucket.take(1, now) == 1 {
+            return true;
+        }
+        let wait = bucket
+            .next_expiration()
+            .map(|next| next.saturating_duration_since(now))
+            .unwrap_or(fallback_interval)
+            .min(deadline.saturating_duration_since(now));
+        if !wait.is_zero() {
+            time.sleep(wait);
+        }
+    }
+}
+
+/// Pulls the next entry that can be sent, discarding v0 (`None`) records along the way (each
+/// tallied in `skipped`). Returns `None` once the iterator is exhausted or the deadline passes.
+fn next_sendable(
+    entries: &mut dyn ExactSizeIterator<Item = DiskEntry>,
+    time: &impl PacingTime,
+    deadline: Timestamp,
+    skipped: &mut usize,
+) -> Option<(credentials::Id, SocketAddr)> {
+    loop {
+        if time.now() >= deadline {
+            return None;
+        }
+        match entries.next()? {
+            DiskEntry { id: None, .. } => *skipped += 1,
+            DiskEntry {
+                id: Some(id), peer, ..
+            } => return Some((id, peer)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/dc/s2n-quic-dc/src/path/secret/map/proactive_unknown_path_secret.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/proactive_unknown_path_secret.rs
@@ -18,9 +18,7 @@
 use super::DiskEntry;
 use crate::{credentials, packet::secret_control as control, path::secret::stateless_reset};
 use core::{num::NonZeroU32, time::Duration};
-use s2n_quic_core::time::{
-    timer::Provider as _, token_bucket::TokenBucket, Clock, StdClock, Timestamp,
-};
+use s2n_quic_core::time::{Clock, StdClock, Timestamp};
 use std::net::SocketAddr;
 
 /// Statistics describing a completed (or deadline-truncated) run of [`Map::send_unknown_path_secrets`].
@@ -50,42 +48,34 @@ pub struct SendStats {
     pub remaining: usize,
 }
 
-/// Lower bound on the token-bucket refill interval.
+/// Minimum pacing tick.
 ///
-/// Refills release a batch of tokens each interval, so a high rate coalesces many sends into one
-/// wakeup rather than sleeping once per packet -- a sleep-per-packet loop is capped by OS sleep
-/// granularity (~1ms) to roughly 20-30K packets/sec, below the rate a large (e.g. 500K-peer) map
-/// must sustain to drain in tens of seconds. For rates too low to need batching, the interval
-/// stretches beyond this floor so the exact rate is still honored.
+/// The pacer sends a batch of packets, then sleeps the rest of the tick, so a high rate coalesces
+/// many sends into one wakeup rather than sleeping once per packet -- a sleep-per-packet loop is
+/// capped by OS sleep granularity (~1ms) to roughly 20-30K packets/sec, below the rate a large
+/// (e.g. 500K-peer) map must sustain to drain in tens of seconds. For rates too low to need
+/// batching, the tick stretches beyond this floor so the exact rate is still honored.
 const MIN_TICK: Duration = Duration::from_millis(5);
 
-/// The pacer's view of time: read the clock, and block until a later instant.
+/// A [`Clock`] that can also block the current thread until a later instant -- the blocking analog
+/// of [`ClockWithTimer`] (which adds an async timer). Injected into [`pace_attempts`] so tests can
+/// advance time without real sleeps; production is [`StdClock`]. Bundling the wait with the clock
+/// keeps them consistent: a fake that advances itself on `sleep` can't be paired with a real one.
 ///
-/// Injected into [`pace_attempts`] so tests can drive pacing deterministically without real sleeps;
-/// production uses [`RealTime`]. Bundling "read the clock" and "wait" into one capability keeps them
-/// consistent -- a fake that advances its own clock on `sleep` can't be paired with a real blocking
-/// sleep (which would never advance a fake clock, hanging the loop), and vice versa.
-trait PacingTime {
-    fn now(&self) -> Timestamp;
-    fn sleep(&mut self, dur: Duration);
+/// [`ClockWithTimer`]: s2n_quic_core::time::clock::ClockWithTimer
+trait PacingClock: Clock {
+    fn sleep(&self, dur: Duration);
 }
 
-/// Production [`PacingTime`]: a real monotonic clock paired with a real blocking sleep.
-struct RealTime(StdClock);
-
-impl PacingTime for RealTime {
-    fn now(&self) -> Timestamp {
-        self.0.get_time()
-    }
-
-    fn sleep(&mut self, dur: Duration) {
+impl PacingClock for StdClock {
+    fn sleep(&self, dur: Duration) {
         std::thread::sleep(dur);
     }
 }
 
 /// Builds, signs, and sends one `UnknownPathSecret` packet per entry that has a credential id,
 /// paced at approximately `rate` packets per second and stopping once `timeout` of wall-clock time
-/// elapses. This is the module's entry point; it paces against a real clock ([`RealTime`]) and
+/// elapses. This is the module's entry point; it paces against a real clock ([`StdClock`]) and
 /// [`pace_attempts`] provides the pacing loop.
 ///
 /// `send` performs the actual transmission and any success-only side effect (e.g. emitting the sent
@@ -96,19 +86,16 @@ impl PacingTime for RealTime {
 /// socket -- is counted as a failure and not retried (a tight retry would burn CPU and starve the
 /// reactive control path; the peer simply recovers reactively). `WouldBlock` is expected under
 /// load and counted silently; any other error is logged as genuinely unexpected.
-pub(super) fn emit_packets<Send>(
+pub(super) fn emit_packets(
     entries: &mut dyn ExactSizeIterator<Item = DiskEntry>,
     rate: NonZeroU32,
     timeout: Duration,
     signer: &stateless_reset::Signer,
-    mut send: Send,
-) -> SendStats
-where
-    Send: FnMut(credentials::Id, &[u8], &SocketAddr) -> std::io::Result<()>,
-{
-    let mut time = RealTime(StdClock::default());
-    let deadline = time.now() + timeout;
-    pace_attempts(entries, rate, deadline, &mut time, |id, peer| {
+    mut send: impl FnMut(credentials::Id, &[u8], &SocketAddr) -> std::io::Result<()>,
+) -> SendStats {
+    let clock = StdClock::default();
+    let deadline = clock.get_time() + timeout;
+    pace_attempts(entries, rate, deadline, &clock, |id, peer| {
         let mut buffer = [0u8; control::UnknownPathSecret::MAX_PACKET_SIZE];
         let len = super::encode_unknown_path_secret(&mut buffer, signer, id, None);
 
@@ -138,45 +125,66 @@ where
 ///
 /// ## Pacing
 ///
-/// A [`TokenBucket`] meters attempts at `rate`/sec, refilling a batch of tokens on an interval of
-/// at least `MIN_TICK` (stretched longer for low rates), so a high rate releases many packets per
-/// wakeup instead of sleeping once per packet, while the burst -- including the first -- stays
-/// capped at one batch, so a stalled caller can't then dump a catch-up burst onto the shared
-/// control socket. `time` is injected so the loop can be driven deterministically in tests; in
-/// production it is [`RealTime`]. Because the bucket refills from the current time (re-read after
-/// each batch of work), time spent iterating and sending is credited against the interval rather
-/// than added on top of it.
-fn pace_attempts<T, F>(
+/// Each tick sends up to `batch` packets, then sleeps the remainder of `interval` (>= `MIN_TICK`).
+/// `batch / interval` averages `rate` per second; a high rate coalesces many sends into one wakeup
+/// (clear of the OS sleep-granularity floor), and a low rate stretches `interval` past `MIN_TICK`
+/// to hold the exact rate. The sleep is `interval` minus the time already spent sending, so send
+/// time is credited against the tick rather than added on top; and because each tick sends at most
+/// `batch`, a stalled thread can't build up a catch-up burst onto the shared control socket.
+///
+/// `clock` is injected so the loop can be driven deterministically in tests; production passes
+/// [`StdClock`].
+fn pace_attempts(
     entries: &mut dyn ExactSizeIterator<Item = DiskEntry>,
     rate: NonZeroU32,
     deadline: Timestamp,
-    time: &mut T,
-    mut attempt: F,
-) -> SendStats
-where
-    T: PacingTime,
-    F: FnMut(credentials::Id, SocketAddr) -> bool,
-{
+    clock: &impl PacingClock,
+    mut attempt: impl FnMut(credentials::Id, SocketAddr) -> bool,
+) -> SendStats {
     let mut stats = SendStats::default();
     let total = entries.len();
 
     let rate = u64::from(rate.get());
-    let refill_amount = (rate * MIN_TICK.as_millis() as u64).div_ceil(1000).max(1);
-    let refill_interval = Duration::from_nanos(refill_amount * 1_000_000_000 / rate);
-    let mut bucket = TokenBucket::builder()
-        .with_refill_interval(refill_interval)
-        .with_refill_amount(refill_amount)
-        .with_max(refill_amount)
-        .build();
+    let batch = (rate * MIN_TICK.as_millis() as u64).div_ceil(1000).max(1);
+    let interval = Duration::from_nanos(batch * 1_000_000_000 / rate);
 
-    while let Some((id, peer)) = next_sendable(entries, &*time, deadline, &mut stats.skipped) {
-        if !wait_for_token(&mut bucket, time, deadline, refill_interval) {
+    'outer: loop {
+        let tick_start = clock.get_time();
+        if tick_start >= deadline {
             break;
         }
-        if attempt(id, peer) {
-            stats.sent += 1;
+
+        for _ in 0..batch {
+            let Some((id, peer)) = next_sendable(entries, clock, deadline, &mut stats.skipped)
+            else {
+                break 'outer; // iterator exhausted or deadline passed
+            };
+            // A slow `next()` above may have crossed the deadline; don't send past it. The entry is
+            // left unsent and counted as `remaining`.
+            if clock.get_time() >= deadline {
+                break 'outer;
+            }
+            if attempt(id, peer) {
+                stats.sent += 1;
+            } else {
+                stats.failed += 1;
+            }
+        }
+
+        // Sleep the remainder of the tick, crediting the time already spent sending, capped at the
+        // deadline.
+        let now = clock.get_time();
+        if now >= deadline {
+            break;
+        }
+        let elapsed = if now > tick_start {
+            now - tick_start
         } else {
-            stats.failed += 1;
+            Duration::ZERO
+        };
+        let wait = interval.saturating_sub(elapsed).min(deadline - now);
+        if !wait.is_zero() {
+            clock.sleep(wait);
         }
     }
 
@@ -184,45 +192,20 @@ where
     stats
 }
 
-/// Blocks until a pacing token is available, sleeping via `time` between the bucket's refills.
-/// Returns `true` once a token is taken, or `false` if `deadline` passes first (the caller then
-/// leaves the current entry unattempted). `fallback_interval` is used only if the bucket has no
-/// armed refill yet, which cannot happen after the first `take`.
-fn wait_for_token<T: PacingTime>(
-    bucket: &mut TokenBucket,
-    time: &mut T,
-    deadline: Timestamp,
-    fallback_interval: Duration,
-) -> bool {
-    loop {
-        let now = time.now();
-        if now >= deadline {
-            return false;
-        }
-        if bucket.take(1, now) == 1 {
-            return true;
-        }
-        let wait = bucket
-            .next_expiration()
-            .map(|next| next.saturating_duration_since(now))
-            .unwrap_or(fallback_interval)
-            .min(deadline.saturating_duration_since(now));
-        if !wait.is_zero() {
-            time.sleep(wait);
-        }
-    }
-}
-
 /// Pulls the next entry that can be sent, discarding v0 (`None`) records along the way (each
 /// tallied in `skipped`). Returns `None` once the iterator is exhausted or the deadline passes.
+///
+/// The deadline is checked *before* each `next()`, so a crossed deadline stops the run before
+/// advancing a possibly-slow iterator, and entries beyond it stay unread -- counted as `remaining`,
+/// never skipped.
 fn next_sendable(
     entries: &mut dyn ExactSizeIterator<Item = DiskEntry>,
-    time: &impl PacingTime,
+    clock: &impl Clock,
     deadline: Timestamp,
     skipped: &mut usize,
 ) -> Option<(credentials::Id, SocketAddr)> {
     loop {
-        if time.now() >= deadline {
+        if clock.get_time() >= deadline {
             return None;
         }
         match entries.next()? {

--- a/dc/s2n-quic-dc/src/path/secret/map/proactive_unknown_path_secret/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/proactive_unknown_path_secret/tests.rs
@@ -34,18 +34,18 @@ fn v0(n: u16) -> DiskEntry {
     }
 }
 
-/// A controllable [`PacingTime`] backed by a shared cell. Simulated time advances only when
+/// A controllable [`PacingClock`] backed by a shared cell. Simulated time advances only when
 /// something explicitly moves it -- the pacer's own `sleep`, or a test's iterator/attempt via
 /// [`advance`] -- so pacing is exercised with no wall-clock dependency. Clone shares the same clock.
 ///
-/// [`advance`]: FakeTime::advance
+/// [`advance`]: FakeClock::advance
 #[derive(Clone)]
-struct FakeTime {
+struct FakeClock {
     at: Rc<Cell<Timestamp>>,
     allow_sleep: bool,
 }
 
-impl FakeTime {
+impl FakeClock {
     fn new() -> Self {
         // Safety: the duration is non-zero.
         let base = unsafe { Timestamp::from_duration(Duration::from_secs(3600)) };
@@ -63,17 +63,23 @@ impl FakeTime {
         }
     }
 
+    fn now(&self) -> Timestamp {
+        self.at.get()
+    }
+
     fn advance(&self, by: Duration) {
         self.at.set(self.at.get() + by);
     }
 }
 
-impl PacingTime for FakeTime {
-    fn now(&self) -> Timestamp {
+impl Clock for FakeClock {
+    fn get_time(&self) -> Timestamp {
         self.at.get()
     }
+}
 
-    fn sleep(&mut self, dur: Duration) {
+impl PacingClock for FakeClock {
+    fn sleep(&self, dur: Duration) {
         assert!(self.allow_sleep, "the pacer must not sleep in this test");
         self.at.set(self.at.get() + dur);
     }
@@ -92,7 +98,7 @@ fn assert_partitions(stats: &SendStats, total: usize) {
 fn v0_entries_are_skipped_not_attempted() {
     // Interleave v0 (None) and v1 (Some) entries.
     let entries = vec![v0(1), v0(2), v1(3), v0(4), v1(5)];
-    let mut time = FakeTime::frozen();
+    let time = FakeClock::frozen();
     let deadline = time.now() + Duration::from_secs(30);
 
     let mut attempts = 0;
@@ -100,7 +106,7 @@ fn v0_entries_are_skipped_not_attempted() {
         &mut entries.into_iter(),
         nz(1_000_000),
         deadline,
-        &mut time,
+        &time,
         |_id, _peer| {
             attempts += 1;
             true
@@ -126,14 +132,14 @@ fn all_v0_file_drains_without_pacing() {
     // proves it; a few entries suffice (no need to allocate a whole file or measure wall time).
     let entries: Vec<_> = (0..5).map(v0).collect();
     let total = entries.len();
-    let mut time = FakeTime::frozen();
+    let time = FakeClock::frozen();
     let deadline = time.now() + Duration::from_secs(30);
 
     let stats = pace_attempts(
         &mut entries.into_iter(),
         nz(1), // 1/sec -- would pace forever if v0 entries consumed budget
         deadline,
-        &mut time,
+        &time,
         |_id, _peer| unreachable!("no sends for a v0-only file"),
     );
 
@@ -152,7 +158,7 @@ fn all_v0_file_drains_without_pacing() {
 fn per_entry_failure_is_counted_not_fatal() {
     let entries: Vec<_> = (0..20).map(v1).collect();
     let total = entries.len();
-    let mut time = FakeTime::frozen();
+    let time = FakeClock::frozen();
     let deadline = time.now() + Duration::from_secs(30);
 
     // Fail every third attempt; the run must continue past each failure.
@@ -161,7 +167,7 @@ fn per_entry_failure_is_counted_not_fatal() {
         &mut entries.into_iter(),
         nz(1_000_000),
         deadline,
-        &mut time,
+        &time,
         |_id, _peer| {
             let fail = n.is_multiple_of(3); // indices 0,3,6,9,12,15,18 -> 7 failures
             n += 1;
@@ -186,19 +192,19 @@ fn deadline_cuts_run_short() {
     // a short deadline attempts only a bounded prefix and reports the rest as `remaining`.
     let entries: Vec<_> = (0..500).map(|n| v1((n % 250) as u8)).collect();
     let total = entries.len();
-    let mut time = FakeTime::new();
+    let time = FakeClock::new();
     let deadline = time.now() + Duration::from_millis(50);
 
     let stats = pace_attempts(
         &mut entries.into_iter(),
         nz(1_000),
         deadline,
-        &mut time,
+        &time,
         |_id, _peer| true,
     );
 
-    // At 1000/sec the bucket is 5 tokens per 5ms tick; a batch is sent at t = 0, 5, .. 45ms
-    // (10 ticks) before t = 50ms crosses the deadline -- 50 sent, the rest left as remaining.
+    // At 1000/sec the batch is 5 sends per 5ms tick, at t = 0, 5, .. 45ms (10 ticks) before
+    // t = 50ms crosses the deadline -- 50 sent, the rest left as remaining.
     assert_eq!(
         stats,
         SendStats {
@@ -212,18 +218,18 @@ fn deadline_cuts_run_short() {
 
 #[test]
 fn low_rate_is_not_quantized_up() {
-    // A rate below 1 / MIN_TICK (200/sec) must be honored, not rounded up. At 100/sec over
-    // 100ms exactly 10 attempts occur (a fixed-5ms-tick pacer would instead send ~20).
+    // A rate below 1 / MIN_TICK (200/sec) must be honored, not rounded up. At 100/sec the tick is
+    // one packet per 10ms; 10 land within the 100ms window (a fixed-5ms-tick pacer would send ~20).
     let entries: Vec<_> = (0..1000).map(|n| v1((n % 250) as u8)).collect();
     let total = entries.len();
-    let mut time = FakeTime::new();
+    let time = FakeClock::new();
     let deadline = time.now() + Duration::from_millis(100);
 
     let stats = pace_attempts(
         &mut entries.into_iter(),
         nz(100),
         deadline,
-        &mut time,
+        &time,
         |_id, _peer| true,
     );
 
@@ -239,25 +245,24 @@ fn low_rate_is_not_quantized_up() {
 }
 
 #[test]
-fn token_accounting_sustains_target_rate() {
-    // Deterministic token accounting: simulated time advances only when the pacer sleeps, so a
-    // rate far above the ~20-30K/sec sleep-per-packet ceiling still yields ~rate * window
-    // attempts. A broken pacer (unpaced burst, or stuck below the ceiling) lands far outside the
-    // band.
+fn pacing_sustains_target_rate() {
+    // Deterministic pacing: simulated time advances only when the pacer sleeps, so a rate far
+    // above the ~20-30K/sec sleep-per-packet ceiling still yields ~rate * window attempts. A
+    // broken pacer (unpaced burst, or stuck below the ceiling) lands far outside the band.
     let target = 40_000u32;
     let window = Duration::from_millis(100);
     let expected = (u64::from(target) * window.as_millis() as u64 / 1000) as usize; // 4_000
 
     // More entries than the window can drain, so the deadline (not the iterator) bounds the run.
     let entries: Vec<_> = (0..(expected * 4)).map(|n| v1((n % 251) as u8)).collect();
-    let mut time = FakeTime::new();
+    let time = FakeClock::new();
     let deadline = time.now() + window;
 
     let stats = pace_attempts(
         &mut entries.into_iter(),
         nz(target),
         deadline,
-        &mut time,
+        &time,
         |_id, _peer| true,
     );
 
@@ -271,20 +276,20 @@ fn token_accounting_sustains_target_rate() {
 
 #[test]
 fn first_batch_is_immediate() {
-    // The initial token allowance must let the first batch go out before the pacer ever sleeps.
-    // With fewer entries than one tick's budget, all of them send in the first batch and the
-    // frozen clock (whose `sleep` panics) is never touched.
+    // The first batch must go out before the pacer ever sleeps. With fewer entries than one tick's
+    // budget, all of them send in that batch and the frozen clock (whose `sleep` panics) is never
+    // touched.
     let rate = nz(100_000); // per-tick budget = 100_000 * MIN_TICK(5ms) = 500
     let entries: Vec<_> = (0..100).map(v1).collect(); // 100 < 500, fits the first batch
     let total = entries.len();
-    let mut time = FakeTime::frozen();
+    let time = FakeClock::frozen();
     let deadline = time.now() + Duration::from_secs(5);
 
     let stats = pace_attempts(
         &mut entries.into_iter(),
         rate,
         deadline,
-        &mut time,
+        &time,
         |_id, _peer| true,
     );
 
@@ -301,7 +306,7 @@ fn does_not_send_after_deadline_crossed_while_queuing() {
     // iterator advances the clock past the deadline as it yields. The pre-send recheck must then
     // stop the run without attempting a send.
     struct AdvancingIter {
-        time: FakeTime,
+        time: FakeClock,
         items: std::vec::IntoIter<DiskEntry>,
         jump: Duration,
     }
@@ -321,7 +326,7 @@ fn does_not_send_after_deadline_crossed_while_queuing() {
         }
     }
 
-    let mut time = FakeTime::frozen(); // tokens are available; the deadline, not budget, stops us
+    let time = FakeClock::frozen(); // the first batch has capacity; the deadline stops us
     let mut entries = AdvancingIter {
         time: time.clone(),
         items: vec![v1(1), v1(2)].into_iter(),
@@ -331,16 +336,10 @@ fn does_not_send_after_deadline_crossed_while_queuing() {
     let deadline = time.now() + Duration::from_millis(10);
 
     let mut attempts = 0;
-    let stats = pace_attempts(
-        &mut entries,
-        nz(100_000),
-        deadline,
-        &mut time,
-        |_id, _peer| {
-            attempts += 1;
-            true
-        },
-    );
+    let stats = pace_attempts(&mut entries, nz(100_000), deadline, &time, |_id, _peer| {
+        attempts += 1;
+        true
+    });
 
     assert_eq!(
         attempts, 0,
@@ -356,7 +355,7 @@ fn v0_after_deadline_counts_remaining_not_skipped() {
     // The send crosses the deadline (the attempt advances the clock past it); the *following*
     // v0 entry must then be counted as `remaining` -- the loop must not advance the iterator to
     // fetch and skip it after the deadline.
-    let mut time = FakeTime::frozen();
+    let time = FakeClock::frozen();
     let attempt = {
         let time = time.clone();
         move |_id, _peer| {
@@ -370,7 +369,7 @@ fn v0_after_deadline_counts_remaining_not_skipped() {
         &mut vec![v1(1), v0(2)].into_iter(),
         nz(100_000),
         deadline,
-        &mut time,
+        &time,
         attempt,
     );
 

--- a/dc/s2n-quic-dc/src/path/secret/map/proactive_unknown_path_secret/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/proactive_unknown_path_secret/tests.rs
@@ -1,0 +1,468 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::*;
+use std::{
+    cell::Cell,
+    net::{Ipv4Addr, SocketAddrV4},
+    rc::Rc,
+};
+
+fn nz(v: u32) -> NonZeroU32 {
+    NonZeroU32::new(v).unwrap()
+}
+
+fn peer(n: u16) -> SocketAddr {
+    SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, n))
+}
+
+fn id(n: u8) -> credentials::Id {
+    credentials::Id::from([n; 16])
+}
+
+fn v1(n: u8) -> DiskEntry {
+    DiskEntry {
+        peer: peer(n as u16),
+        id: Some(id(n)),
+    }
+}
+
+fn v0(n: u16) -> DiskEntry {
+    DiskEntry {
+        peer: peer(n),
+        id: None,
+    }
+}
+
+/// A controllable [`PacingTime`] backed by a shared cell. Simulated time advances only when
+/// something explicitly moves it -- the pacer's own `sleep`, or a test's iterator/attempt via
+/// [`advance`] -- so pacing is exercised with no wall-clock dependency. Clone shares the same clock.
+///
+/// [`advance`]: FakeTime::advance
+#[derive(Clone)]
+struct FakeTime {
+    at: Rc<Cell<Timestamp>>,
+    allow_sleep: bool,
+}
+
+impl FakeTime {
+    fn new() -> Self {
+        // Safety: the duration is non-zero.
+        let base = unsafe { Timestamp::from_duration(Duration::from_secs(3600)) };
+        Self {
+            at: Rc::new(Cell::new(base)),
+            allow_sleep: true,
+        }
+    }
+
+    /// Like [`new`](Self::new), but any sleep fails the test -- for runs that must not pace.
+    fn frozen() -> Self {
+        Self {
+            allow_sleep: false,
+            ..Self::new()
+        }
+    }
+
+    fn advance(&self, by: Duration) {
+        self.at.set(self.at.get() + by);
+    }
+}
+
+impl PacingTime for FakeTime {
+    fn now(&self) -> Timestamp {
+        self.at.get()
+    }
+
+    fn sleep(&mut self, dur: Duration) {
+        assert!(self.allow_sleep, "the pacer must not sleep in this test");
+        self.at.set(self.at.get() + dur);
+    }
+}
+
+/// The four counters always partition the input.
+fn assert_partitions(stats: &SendStats, total: usize) {
+    assert_eq!(
+        stats.sent + stats.failed + stats.skipped + stats.remaining,
+        total,
+        "counters must partition the input: {stats:?}"
+    );
+}
+
+#[test]
+fn v0_entries_are_skipped_not_attempted() {
+    // Interleave v0 (None) and v1 (Some) entries.
+    let entries = vec![v0(1), v0(2), v1(3), v0(4), v1(5)];
+    let mut time = FakeTime::frozen();
+    let deadline = time.now() + Duration::from_secs(30);
+
+    let mut attempts = 0;
+    let stats = pace_attempts(
+        &mut entries.into_iter(),
+        nz(1_000_000),
+        deadline,
+        &mut time,
+        |_id, _peer| {
+            attempts += 1;
+            true
+        },
+    );
+
+    assert_eq!(attempts, 2, "attempt is never invoked for v0 entries");
+    assert_eq!(
+        stats,
+        SendStats {
+            sent: 2,
+            failed: 0,
+            skipped: 3,
+            remaining: 0,
+        }
+    );
+}
+
+#[test]
+fn all_v0_file_drains_without_pacing() {
+    // A v0-only file must not be throttled: v0 entries consume no pacing budget, so the run
+    // completes without ever sleeping even at a slow rate. A frozen clock (whose `sleep` panics)
+    // proves it; a few entries suffice (no need to allocate a whole file or measure wall time).
+    let entries: Vec<_> = (0..5).map(v0).collect();
+    let total = entries.len();
+    let mut time = FakeTime::frozen();
+    let deadline = time.now() + Duration::from_secs(30);
+
+    let stats = pace_attempts(
+        &mut entries.into_iter(),
+        nz(1), // 1/sec -- would pace forever if v0 entries consumed budget
+        deadline,
+        &mut time,
+        |_id, _peer| unreachable!("no sends for a v0-only file"),
+    );
+
+    assert_eq!(
+        stats,
+        SendStats {
+            sent: 0,
+            failed: 0,
+            skipped: total,
+            remaining: 0,
+        }
+    );
+}
+
+#[test]
+fn per_entry_failure_is_counted_not_fatal() {
+    let entries: Vec<_> = (0..20).map(v1).collect();
+    let total = entries.len();
+    let mut time = FakeTime::frozen();
+    let deadline = time.now() + Duration::from_secs(30);
+
+    // Fail every third attempt; the run must continue past each failure.
+    let mut n: usize = 0;
+    let stats = pace_attempts(
+        &mut entries.into_iter(),
+        nz(1_000_000),
+        deadline,
+        &mut time,
+        |_id, _peer| {
+            let fail = n.is_multiple_of(3); // indices 0,3,6,9,12,15,18 -> 7 failures
+            n += 1;
+            !fail
+        },
+    );
+
+    assert_eq!(
+        stats,
+        SendStats {
+            sent: total - 7,
+            failed: 7,
+            skipped: 0,
+            remaining: 0,
+        }
+    );
+}
+
+#[test]
+fn deadline_cuts_run_short() {
+    // Deterministic: simulated time advances only when the pacer sleeps, so a low rate against
+    // a short deadline attempts only a bounded prefix and reports the rest as `remaining`.
+    let entries: Vec<_> = (0..500).map(|n| v1((n % 250) as u8)).collect();
+    let total = entries.len();
+    let mut time = FakeTime::new();
+    let deadline = time.now() + Duration::from_millis(50);
+
+    let stats = pace_attempts(
+        &mut entries.into_iter(),
+        nz(1_000),
+        deadline,
+        &mut time,
+        |_id, _peer| true,
+    );
+
+    // At 1000/sec the bucket is 5 tokens per 5ms tick; a batch is sent at t = 0, 5, .. 45ms
+    // (10 ticks) before t = 50ms crosses the deadline -- 50 sent, the rest left as remaining.
+    assert_eq!(
+        stats,
+        SendStats {
+            sent: 50,
+            failed: 0,
+            skipped: 0,
+            remaining: total - 50,
+        }
+    );
+}
+
+#[test]
+fn low_rate_is_not_quantized_up() {
+    // A rate below 1 / MIN_TICK (200/sec) must be honored, not rounded up. At 100/sec over
+    // 100ms exactly 10 attempts occur (a fixed-5ms-tick pacer would instead send ~20).
+    let entries: Vec<_> = (0..1000).map(|n| v1((n % 250) as u8)).collect();
+    let total = entries.len();
+    let mut time = FakeTime::new();
+    let deadline = time.now() + Duration::from_millis(100);
+
+    let stats = pace_attempts(
+        &mut entries.into_iter(),
+        nz(100),
+        deadline,
+        &mut time,
+        |_id, _peer| true,
+    );
+
+    assert_eq!(
+        stats,
+        SendStats {
+            sent: 10,
+            failed: 0,
+            skipped: 0,
+            remaining: total - 10,
+        }
+    );
+}
+
+#[test]
+fn token_accounting_sustains_target_rate() {
+    // Deterministic token accounting: simulated time advances only when the pacer sleeps, so a
+    // rate far above the ~20-30K/sec sleep-per-packet ceiling still yields ~rate * window
+    // attempts. A broken pacer (unpaced burst, or stuck below the ceiling) lands far outside the
+    // band.
+    let target = 40_000u32;
+    let window = Duration::from_millis(100);
+    let expected = (u64::from(target) * window.as_millis() as u64 / 1000) as usize; // 4_000
+
+    // More entries than the window can drain, so the deadline (not the iterator) bounds the run.
+    let entries: Vec<_> = (0..(expected * 4)).map(|n| v1((n % 251) as u8)).collect();
+    let mut time = FakeTime::new();
+    let deadline = time.now() + window;
+
+    let stats = pace_attempts(
+        &mut entries.into_iter(),
+        nz(target),
+        deadline,
+        &mut time,
+        |_id, _peer| true,
+    );
+
+    let attempts = stats.sent + stats.failed;
+    let (lo, hi) = (expected * 95 / 100, expected * 105 / 100);
+    assert!(
+        (lo..=hi).contains(&attempts),
+        "attempts {attempts} outside [{lo}, {hi}] for {target}/sec over {window:?}"
+    );
+}
+
+#[test]
+fn first_batch_is_immediate() {
+    // The initial token allowance must let the first batch go out before the pacer ever sleeps.
+    // With fewer entries than one tick's budget, all of them send in the first batch and the
+    // frozen clock (whose `sleep` panics) is never touched.
+    let rate = nz(100_000); // per-tick budget = 100_000 * MIN_TICK(5ms) = 500
+    let entries: Vec<_> = (0..100).map(v1).collect(); // 100 < 500, fits the first batch
+    let total = entries.len();
+    let mut time = FakeTime::frozen();
+    let deadline = time.now() + Duration::from_secs(5);
+
+    let stats = pace_attempts(
+        &mut entries.into_iter(),
+        rate,
+        deadline,
+        &mut time,
+        |_id, _peer| true,
+    );
+
+    assert_eq!(
+        stats.sent, total,
+        "the whole first batch sends before any sleep"
+    );
+    assert_partitions(&stats, total);
+}
+
+#[test]
+fn does_not_send_after_deadline_crossed_while_queuing() {
+    // A slow `next()` crosses the deadline *between* queuing an entry and sending it: the
+    // iterator advances the clock past the deadline as it yields. The pre-send recheck must then
+    // stop the run without attempting a send.
+    struct AdvancingIter {
+        time: FakeTime,
+        items: std::vec::IntoIter<DiskEntry>,
+        jump: Duration,
+    }
+    impl Iterator for AdvancingIter {
+        type Item = DiskEntry;
+        fn next(&mut self) -> Option<DiskEntry> {
+            let next = self.items.next();
+            if next.is_some() {
+                self.time.advance(self.jump);
+            }
+            next
+        }
+    }
+    impl ExactSizeIterator for AdvancingIter {
+        fn len(&self) -> usize {
+            self.items.len()
+        }
+    }
+
+    let mut time = FakeTime::frozen(); // tokens are available; the deadline, not budget, stops us
+    let mut entries = AdvancingIter {
+        time: time.clone(),
+        items: vec![v1(1), v1(2)].into_iter(),
+        jump: Duration::from_secs(1),
+    };
+    let total = entries.len();
+    let deadline = time.now() + Duration::from_millis(10);
+
+    let mut attempts = 0;
+    let stats = pace_attempts(
+        &mut entries,
+        nz(100_000),
+        deadline,
+        &mut time,
+        |_id, _peer| {
+            attempts += 1;
+            true
+        },
+    );
+
+    assert_eq!(
+        attempts, 0,
+        "no send once the deadline is crossed before it"
+    );
+    assert_eq!(stats.sent, 0);
+    assert_eq!(stats.remaining, total);
+    assert_partitions(&stats, total);
+}
+
+#[test]
+fn v0_after_deadline_counts_remaining_not_skipped() {
+    // The send crosses the deadline (the attempt advances the clock past it); the *following*
+    // v0 entry must then be counted as `remaining` -- the loop must not advance the iterator to
+    // fetch and skip it after the deadline.
+    let mut time = FakeTime::frozen();
+    let attempt = {
+        let time = time.clone();
+        move |_id, _peer| {
+            time.advance(Duration::from_secs(1));
+            true
+        }
+    };
+    let deadline = time.now() + Duration::from_millis(10);
+
+    let stats = pace_attempts(
+        &mut vec![v1(1), v0(2)].into_iter(),
+        nz(100_000),
+        deadline,
+        &mut time,
+        attempt,
+    );
+
+    assert_eq!(
+        stats,
+        SendStats {
+            sent: 1,
+            failed: 0,
+            skipped: 0, // the v0 past the deadline is `remaining`, not fetched-and-skipped
+            remaining: 1,
+        }
+    );
+}
+
+#[test]
+fn builds_authentic_packets_and_skips_v0() {
+    use crate::packet::secret_control as control;
+    use s2n_codec::DecoderBufferMut;
+
+    let secret = b"emission-secret";
+    let signer = stateless_reset::Signer::new(secret);
+
+    // Two v1 entries plus one v0 that must be skipped without a packet being built. A generous
+    // timeout means everything fits the first batch, so this doesn't sleep despite using real time.
+    let entries = vec![v1(1), v0(2), v1(3)];
+
+    let mut captured: Vec<(credentials::Id, Vec<u8>, SocketAddr)> = Vec::new();
+    let stats = emit_packets(
+        &mut entries.into_iter(),
+        nz(1_000_000),
+        Duration::from_secs(30),
+        &signer,
+        |id, bytes, peer| {
+            captured.push((id, bytes.to_vec(), *peer));
+            Ok(())
+        },
+    );
+
+    assert_eq!(
+        stats,
+        SendStats {
+            sent: 2,
+            failed: 0,
+            skipped: 1,
+            remaining: 0,
+        }
+    );
+    // The two v1 entries are sent, in order, to their peers -- the v0 in between is skipped.
+    let peers: Vec<_> = captured.iter().map(|(_, _, peer)| *peer).collect();
+    assert_eq!(peers, vec![peer(1), peer(3)]);
+
+    let verifier = stateless_reset::Signer::new(secret);
+    let wrong = stateless_reset::Signer::new(b"a different signer's secret");
+
+    for (id, mut bytes, _peer) in captured {
+        let (packet, _) =
+            control::unknown_path_secret::Packet::decode(DecoderBufferMut::new(&mut bytes))
+                .unwrap();
+        // Authenticates against a signer sharing the secret...
+        let authentic = packet
+            .authenticate(&verifier.sign(&id))
+            .expect("packet must verify against the signer");
+        assert_eq!(authentic.credential_id, id);
+        // ...and is rejected by a signer that does not.
+        assert!(
+            packet.authenticate(&wrong.sign(&id)).is_none(),
+            "packet must not verify against a different signer"
+        );
+    }
+}
+
+#[test]
+fn counts_send_failures() {
+    let signer = stateless_reset::Signer::new(b"secret");
+
+    // The send fails, as `WouldBlock` would on a saturated non-blocking socket; the run must
+    // count the failure rather than abort.
+    let stats = emit_packets(
+        &mut vec![v1(1)].into_iter(),
+        nz(1_000_000),
+        Duration::from_secs(30),
+        &signer,
+        |_id, _bytes, _peer| Err(std::io::Error::from(std::io::ErrorKind::WouldBlock)),
+    );
+
+    assert_eq!(
+        stats,
+        SendStats {
+            sent: 0,
+            failed: 1,
+            skipped: 0,
+            remaining: 0,
+        }
+    );
+}

--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    cleaner::Cleaner, disk, stateless_reset, ApplicationData, ApplicationDataError, Entry, Store,
+    cleaner::Cleaner, disk, proactive_unknown_path_secret, stateless_reset, ApplicationData,
+    ApplicationDataError, DiskEntry, Entry, SendStats, Store,
 };
 use crate::{
     credentials::{Credentials, Id},
@@ -1240,6 +1241,38 @@ where
                 tracing::warn!("Failed to send control packet to {:?}: {:?}", dst, e);
             }
         }
+    }
+
+    fn send_unknown_path_secrets(
+        &self,
+        entries: &mut dyn ExactSizeIterator<Item = DiskEntry>,
+        rate: core::num::NonZeroU32,
+        timeout: Duration,
+    ) -> std::io::Result<SendStats> {
+        let Some(control_socket) = self.control_socket.clone() else {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotConnected,
+                "path secret map has no control socket to send on",
+            ));
+        };
+
+        Ok(proactive_unknown_path_secret::emit_packets(
+            entries,
+            rate,
+            timeout,
+            &self.signer,
+            |id, bytes, peer| {
+                control_socket.send_to(bytes, peer)?;
+                // On success only (matching the reactive path in `send_control_packet`).
+                self.subscriber().on_unknown_path_secret_packet_sent(
+                    event::builder::UnknownPathSecretPacketSent {
+                        peer_address: SocketAddress::from(*peer).into_event(),
+                        credential_id: id.into_event(),
+                    },
+                );
+                Ok(())
+            },
+        ))
     }
 
     fn rehandshake_period(&self) -> Duration {

--- a/dc/s2n-quic-dc/src/path/secret/map/state/tests.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state/tests.rs
@@ -484,3 +484,61 @@ fn unknown_path_secret_evicts() {
     assert!(!map.ids.contains_key(entry.id()), "{:?}", map.ids);
     assert!(!map.peers.contains_key(entry.peer()), "{:?}", map.peers);
 }
+
+/// Builds a `State` whose signer uses `secret`, with background processing stopped.
+fn state_with_secret(secret: &[u8]) -> Arc<State<Clock, tracing::Subscriber>> {
+    let map = State::builder()
+        .with_signer(stateless_reset::Signer::new(secret))
+        .with_capacity(64)
+        .with_clock(Clock)
+        .with_subscriber(tracing::Subscriber::default())
+        .build()
+        .unwrap();
+    map.cleaner.stop();
+    map
+}
+
+fn disk_entry(port: u16, id: Option<u8>) -> DiskEntry {
+    DiskEntry {
+        peer: SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::LOCALHOST, port)),
+        id: id.map(|b| Id::from([b; 16])),
+    }
+}
+
+#[test]
+fn send_unknown_path_secrets_over_control_socket_ok() {
+    use core::num::NonZeroU32;
+    use std::time::Duration;
+
+    // Exercises the real control-socket send path. Packets go to loopback discard ports; the call
+    // should succeed and the counters should partition the input.
+    let map = state_with_secret(b"secret");
+    let entries: Vec<DiskEntry> = (0..16)
+        .map(|n| disk_entry(5000 + n, Some(n as u8)))
+        .collect();
+    let total = entries.len();
+
+    let result = map.send_unknown_path_secrets(
+        &mut entries.into_iter(),
+        NonZeroU32::new(100_000).unwrap(),
+        Duration::from_secs(5),
+    );
+
+    match result {
+        Ok(stats) => {
+            assert_eq!(
+                stats.sent + stats.failed + stats.skipped + stats.remaining,
+                total
+            );
+            assert_eq!(stats.skipped, 0);
+            assert_eq!(stats.remaining, 0);
+        }
+        // Some environments (e.g. sandboxes) can't create the UDP control socket, in which case
+        // there is nothing to send on. That is a supported outcome, not a test failure -- the
+        // socket-independent behavior is covered by the `proactive_unknown_path_secret` unit tests.
+        Err(err) if err.kind() == std::io::ErrorKind::NotConnected => {
+            eprintln!("skipping: no control socket available in this environment ({err})");
+        }
+        Err(err) => panic!("unexpected error: {err}"),
+    }
+}

--- a/dc/s2n-quic-dc/src/path/secret/map/store.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/store.rs
@@ -1,15 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::{ApplicationData, ApplicationDataError, Entry};
+use super::{ApplicationData, ApplicationDataError, DiskEntry, Entry, SendStats};
 use crate::{
     credentials::{Credentials, Id},
-    packet::{secret_control as control, Packet, WireVersion},
+    packet::{secret_control as control, Packet},
     path::secret::{receiver, stateless_reset},
     psk::io::HandshakeReason,
 };
 use core::time::Duration;
-use s2n_codec::EncoderBuffer;
 use s2n_quic_core::varint::VarInt;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::task::JoinHandle;
@@ -62,6 +61,22 @@ pub trait Store: 'static + Send + Sync {
     fn signer(&self) -> &stateless_reset::Signer;
 
     fn send_control_packet(&self, dst: &SocketAddr, buffer: &mut [u8]);
+
+    /// Paced, proactive emission of `UnknownPathSecret` packets to the given peers.
+    ///
+    /// Takes a `&mut dyn Iterator` rather than a generic `impl IntoIterator` so the trait stays
+    /// object-safe (`Store` is used as `Arc<dyn Store>`); the public [`Map`] method exposes the
+    /// ergonomic `impl IntoIterator` signature and adapts to this. See
+    /// [`Map::send_unknown_path_secrets`] for the full contract.
+    ///
+    /// [`Map`]: crate::path::secret::Map
+    /// [`Map::send_unknown_path_secrets`]: crate::path::secret::Map::send_unknown_path_secrets
+    fn send_unknown_path_secrets(
+        &self,
+        entries: &mut dyn ExactSizeIterator<Item = DiskEntry>,
+        rate: core::num::NonZeroU32,
+        timeout: core::time::Duration,
+    ) -> std::io::Result<SendStats>;
 
     fn rehandshake_period(&self) -> Duration;
 
@@ -117,15 +132,13 @@ pub trait Store: 'static + Send + Sync {
         control_out: &mut Vec<u8>,
     ) -> Option<Arc<Entry>> {
         let Some(state) = self.get_by_id_tracked(&identity.id) else {
-            let packet = control::UnknownPathSecret {
-                wire_version: WireVersion::ZERO,
-                credential_id: identity.id,
-                queue_id,
-            };
             control_out.resize(control::UnknownPathSecret::MAX_PACKET_SIZE, 0);
-            let stateless_reset = self.signer().sign(&identity.id);
-            let encoder = EncoderBuffer::new(control_out);
-            let len = packet.encode(encoder, &stateless_reset);
+            let len = super::encode_unknown_path_secret(
+                control_out,
+                self.signer(),
+                identity.id,
+                queue_id,
+            );
             control_out.truncate(len);
             return None;
         };


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

### Description of changes: 

The path secret map currently sends UnknownPathSecret (UPS) packets only reactively in reply to a packet whose credentials it doesn't recognize. This adds a paced, proactive counterpart, Map::send_unknown_path_secrets(entries, rate, timeout), which builds, signs, and sends an authenticated UPS to a supplied set of peers. It lets an endpoint whose map is empty after a restart tell peers with stale cached secrets to re-handshake, rather than waiting for each to discover the restart via a dropped request. This is the transport-layer piece of a broader "Server Hi" restart-recovery effort.

### Call-outs:

- The emitted UPS only authenticates if the stateless-reset signer is stable across the restart, so this assumes signer continuity (true now, but needs to be revisited if the signer becomes dynamic)

### Testing:

- Unit tests for the pacer
- Benchmarks. Will share more details on the CR


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

