### PR TITLE
fix(s2n-quic-core): reformat setter! macros in limits.rs

### DIFF
--- a/quic/s2n-quic-core/src/connection/limits.rs
+++ b/quic/s2n-quic-core/src/connection/limits.rs
@@ -217,7 +217,8 @@ impl Limits {
         /// longer than the minimum of the max_idle_timeout value advertised by both endpoints.
         with_max_idle_timeout,
         max_idle_timeout,
-        Duration);
+        Duration
+    );
 
     /// Sets both the max local and remote limits for bidirectional streams.
     #[deprecated(
@@ -321,7 +322,8 @@ impl Limits {
         /// this value is used to prevent middleboxes from losing state for UDP flows.
         with_max_keep_alive_period,
         max_keep_alive_period,
-        Duration);
+        Duration
+    );
     /// Sets whether active connection migration is supported for a server endpoint (default: true)
     ///
     /// If set to false, the `disable_active_migration` transport parameter will be sent to the


### PR DESCRIPTION
### Description of changes: 

The commit https://github.com/aws/s2n-quic/actions/runs/33406722138/job/99536470110 failed because of a formatting check in an unrelated area of the code. This cr is a short fix applying the formatting changes to unblock future commits

```
Diff in /home/runner/work/s2n-quic/s2n-quic/quic/s2n-quic-core/src/connection/limits.rs:217:
         /// longer than the minimum of the max_idle_timeout value advertised by both endpoints.
         with_max_idle_timeout,
         max_idle_timeout,
-        Duration);
+        Duration
+    );
 
     /// Sets both the max local and remote limits for bidirectional streams.
     #[deprecated(
Diff in /home/runner/work/s2n-quic/s2n-quic/quic/s2n-quic-core/src/connection/limits.rs:321:
         /// this value is used to prevent middleboxes from losing state for UDP flows.
         with_max_keep_alive_period,
         max_keep_alive_period,
-        Duration);
+        Duration
+    );
```

### Call-outs:
It might be worth exploring what issue manifested this, since this section code hasn't been changed recently 

### Testing:
- Ran cargo +nightly fmt --all -- --check on my local dev-desktop

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

