### PR TITLE
feat(dc): Enable client packet buffering

### DIFF
--- a/dc/s2n-quic-dc/src/psk/io.rs
+++ b/dc/s2n-quic-dc/src/psk/io.rs
@@ -337,7 +337,12 @@ impl Client {
             .with_bidirectional_local_data_window(builder.data_window)?
             .with_bidirectional_remote_data_window(builder.data_window)?
             .with_pto_jitter_percentage(builder.pto_jitter_percentage)?
-            .with_initial_round_trip_time(DEFAULT_INITIAL_RTT)?;
+            .with_initial_round_trip_time(DEFAULT_INITIAL_RTT)?
+            // Packet buffering on the client avoids dropping LossRecoveryProbing handshake frames
+            //
+            // This is primarily needed with large ServerHellos (e.g., with PQ), but should be
+            // harmless even without it.
+            .with_packet_buffer_size(DEFAULT_MTU as u32)?;
 
         let event = ((ConfirmComplete, MtuConfirmComplete), subscriber);
 


### PR DESCRIPTION
### Release Summary:

* feat(dc): Enable client packet buffering

### Resolved issues:

### Description of changes: 

This allows much faster recovery, since we don't need to wait for server to detect its initial packet was lost and recover from both the initial packet being lost and the subsequent handshake packet also getting lost.

### Call-outs:

I think we had previously assumed this is only useful with offloading, but (in news to me), s2n-quic will sometimes attempt loss recovery of Handshake packets *before* the Initial packets are fully ack'd (or re-sent in loss recovery packets which are always at 1200 bytes), which currently leads to those getting dropped on the client.

See a trace here, where the "client-dropped" packets add ~3ms to the handshake timeline for no good reason because the client drops them rather than waiting until .

```
# network rtt = 1ms, hybrid ML-KEM cipher, path MTU = 1500 bytes, client with initial=base=1450, server with initial = 9000/base=1450
      time  who    packet      len  mode                 frames
  00.000001  client Init #0    1422  Normal               Crypto[0..1367]
  00.000001  client Init #1    1422  Normal               Crypto[1367..1503], Pad(1230)
  00.000500  server Init #0    1249  Normal               Ack(0..=1), Crypto[0..1178]
  00.000500  server Hand #0    7663  Normal               Crypto[0..804], Pad(6797)
                   = datagram  8912  <-- DROPPED by path
  00.003000  client Init #3    1200  LossRecoveryProbing  Crypto[0..1145]
  00.003000  client Init #5    1200  LossRecoveryProbing  Crypto[0..1145]
  00.003500  server Init #2    1200  LossRecoveryProbing  Ack(5, 3, 0..=1), Crypto[0..1125]
  00.003500  server Init #4    1200  LossRecoveryProbing  Ack(5, 3, 0..=1), Crypto[0..1125]
  00.003500  server Hand #2     866  LossRecoveryProbing  Crypto[0..804] // Client-dropped without this PR
  00.003500  server Hand #4     866  LossRecoveryProbing  Crypto[0..804] // Client-dropped without this PR
  00.004000  client Init #6    1422  Normal               Ack(4, 2), Pad(1353)
  00.004500  server Init #0          DECLARED-LOST
  00.004500  server Init #5    1422  Normal               Ack(6), Crypto[1125..1178], Pad(1298)
  00.005000  client Init #7    1422  Normal               Ack(4..=5, 2), Pad(1353)
  00.008000  client Hand #0      77  LossRecoveryProbing  Ping, Pad(18)
  00.008500  server Hand #6     874  LossRecoveryProbing  Ack(0), Crypto[0..804]
  00.008500  server Hand #8     874  LossRecoveryProbing  Ack(0), Crypto[0..804]
  00.009000  client HANDSHAKE COMPLETE
```

I haven't enabled it unconditionally on the server yet -- mostly because I don't have a trace that shows it being useful. It's possible that we should do it on both sides though (open to feedback there).

cc @maddeleine

### Testing:

None here -- I want to clean up some of the large ClientHello testing and cut that, but I've tested with those larger tests that this does avoid the extra loss recovery mentioned above.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.