### PR TITLE
ci: Comment on all security review findings

### DIFF
--- a/.github/scripts/security-review-comment.sh
+++ b/.github/scripts/security-review-comment.sh
@@ -14,20 +14,36 @@ repository="${2:?repository is required}"
 pr_number="${3:?pull request number is required}"
 server_url="${4:?server URL is required}"
 
-outcome="$(jq -er '.outcome | select(. == "pass" or . == "blocking")' <<< "$result_json" 2>/dev/null || true)"
-if [[ -z "$outcome" ]]; then
+review_result="$(jq -cer '
+    select(
+      (.outcome == "pass" and
+        (.findings_count | type == "number" and floor == . and . >= 0)) or
+      (.outcome == "blocking" and
+        (.findings_count | type == "number" and floor == . and . > 0))
+    )
+    | {outcome, findings_count}
+  ' <<< "$result_json" 2>/dev/null || true)"
+if [[ -z "$review_result" ]]; then
     echo "No completed security review verdict to add to the report history."
     exit 0
 fi
 
+outcome="$(jq -r '.outcome' <<< "$review_result")"
+findings_count="$(jq -r '.findings_count' <<< "$review_result")"
 resolved_sha="$(jq -er '.resolved_sha | select(test("^[0-9a-f]{40}$"))' <<< "$result_json")"
 report_url="$FINDINGS_ROOT/s2n-quic/findings.html?pr=$pr_number&commit=$resolved_sha"
 
 short_sha="${resolved_sha:0:12}"
 commit_url="$server_url/$repository/commit/$resolved_sha"
 case "$outcome" in
-    pass) result_label="✅ Passed" ;;
-    blocking) result_label="❌ Blocking" ;;
+    pass)
+        if ((findings_count > 0)); then
+            result_label="⚠️ Findings to review"
+        else
+            result_label="✅ No findings"
+        fi
+        ;;
+    blocking) result_label="❌ Blocking findings" ;;
 esac
 
 # Ignore marker text in contributor comments; only Actions owns this comment.
@@ -41,8 +57,8 @@ comment_json="$(jq -cs --arg marker "$COMMENT_MARKER" '
 
 if [[ -z "$comment_json" ]]; then
     # A clean PR stays quiet until its first finding-producing review.
-    if [[ "$outcome" != "blocking" ]]; then
-        echo "No blocking review history exists; not creating a comment for a passing review."
+    if ((findings_count == 0)); then
+        echo "No review history exists; not creating a comment for a review without findings."
         exit 0
     fi
 

--- a/.github/scripts/security-review-workflow.sh
+++ b/.github/scripts/security-review-workflow.sh
@@ -38,15 +38,19 @@ run_review() {
 
     capture_runner "$source_version" "$pr_number"
 
-    # Accept one result object whose exit code agrees with its outcome.
+    # Accept one result object whose exit code and finding count agree with its outcome.
     if result="$(jq -cse --argjson runner_exit "$RUNNER_EXIT" '
         if length == 1 then .[0] else empty end |
+        (.findings_count |
+          type == "number" and floor == . and . >= 0) as $valid_count |
         select(
           ([.outcome, .resolved_sha, .error] | all(type == "string")) and
           (
-            ($runner_exit == 0 and .outcome == "pass") or
-            ($runner_exit == 2 and .outcome == "blocking") or
-            ($runner_exit == 1 and .outcome == "error" and (.error | length > 0))
+            ($runner_exit == 0 and .outcome == "pass" and $valid_count) or
+            ($runner_exit == 2 and .outcome == "blocking" and
+              $valid_count and .findings_count > 0) or
+            ($runner_exit == 1 and .outcome == "error" and
+              (.error | length > 0))
           )
         )
       ' <<< "$RUNNER_RESULT")"; then

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -139,7 +139,8 @@ jobs:
           publish="$(./.github/scripts/security-review-workflow.sh reconcile "$PR_NUMBER" "$REPOSITORY")"
           echo "publish=$publish" >> "$GITHUB_OUTPUT"
 
-      # REVIEW_STATUS is finer-grained than CodeBuild's own success/failure status.
+      # REVIEW_STATUS and REVIEW_FINDINGS_COUNT distinguish blocking,
+      # non-blocking-only, and clean reviews from CodeBuild's success status.
       - name: Publish security review status
         if: always() && steps.security_review.outputs.result != '' && steps.reconcile.outputs.publish == 'true'
         env:

--- a/codebuild/bin/run_security_review.sh
+++ b/codebuild/bin/run_security_review.sh
@@ -11,6 +11,7 @@ readonly PROJECT="SecurityReview-s2n-quic"
 readonly MAX_POLLS=60 # 30 minutes at the production interval
 
 RESULT_RESOLVED_SHA=""
+RESULT_FINDINGS_COUNT="null"
 
 usage() {
     cat <<'EOF'
@@ -30,11 +31,13 @@ finish_result() {
         --arg outcome "$outcome" \
         --arg resolved_sha "$RESULT_RESOLVED_SHA" \
         --arg error "$error_message" \
-        '{outcome: $outcome, resolved_sha: $resolved_sha, error: $error}'
+        --argjson findings_count "$RESULT_FINDINGS_COUNT" \
+        '{outcome: $outcome, resolved_sha: $resolved_sha, error: $error, findings_count: $findings_count}'
     exit "$exit_code"
 }
 
 finish_error() {
+    RESULT_FINDINGS_COUNT="null"
     finish_result 1 error "$1"
 }
 
@@ -62,6 +65,7 @@ run_security_review() {
     local build_id=""
     local candidate_sha=""
     local build_status=""
+    local review_outputs=""
     local review_status=""
     local poll=""
     local poll_interval="${SECURITY_REVIEW_POLL_INTERVAL_SECONDS:-30}"
@@ -172,24 +176,37 @@ run_security_review() {
                     finish_tracked
                 fi
 
-                review_status="$(jq -r '
-                    if (.exportedEnvironmentVariables | type) != "array" then
-                        empty
-                    else
-                        [.exportedEnvironmentVariables[]
-                          | select(type == "object")
-                          | select(.name == "REVIEW_STATUS")]
-                        | if length == 1 and (.[0].value | type) == "string"
-                          then .[0].value
-                          else empty
-                          end
-                    end
-                ' <<< "$build_json" 2>/dev/null || true)"
+                if ! review_outputs="$(jq -ce '
+                    .exportedEnvironmentVariables
+                    | select(type == "array")
+                    | (map(select(type == "object" and .name == "REVIEW_STATUS"))) as $statuses
+                    | (map(select(type == "object" and .name == "REVIEW_FINDINGS_COUNT"))) as $counts
+                    | select(
+                        ($statuses | length) == 1 and
+                        ($statuses[0].value | type) == "string" and
+                        ($counts | length) == 1 and
+                        ($counts[0].value | type) == "string" and
+                        ($counts[0].value | test("^(0|[1-9][0-9]*)$"))
+                      )
+                    | {
+                        status: $statuses[0].value,
+                        findings_count: ($counts[0].value | tonumber)
+                      }
+                ' <<< "$build_json")"; then
+                    finish_error "missing or invalid review outputs"
+                fi
 
+                review_status="$(jq -r '.status' <<< "$review_outputs")"
+                RESULT_FINDINGS_COUNT="$(jq -r '.findings_count' <<< "$review_outputs")"
                 case "$review_status" in
                     PASS) finish_pass ;;
-                    BLOCKING) finish_blocking ;;
-                    *) finish_error "missing or unknown review verdict" ;;
+                    BLOCKING)
+                        if ((RESULT_FINDINGS_COUNT == 0)); then
+                            finish_error "blocking verdict reported without findings"
+                        fi
+                        finish_blocking
+                        ;;
+                    *) finish_error "unknown review verdict" ;;
                 esac
                 ;;
             FAILED|FAULT|STOPPED|TIMED_OUT)


### PR DESCRIPTION
### Release Summary:

### Resolved issues:

N/A

### Description of changes:

Use the exported finding count to comment when a security review has any findings. Keep initial clean reviews quiet and reject malformed reviewer output.

Example generated PR comment:

## 🔒 Security review

| Commit | Result | Report |
|---|---|---|
| [`111111111111`](https://github.com/aws/s2n-quic/commit/1111111111111111111111111111111111111111) | ❌ Blocking findings | [View report](https://d9s1wy5tjcjzb.cloudfront.net/s2n-quic/findings.html?pr=123&commit=1111111111111111111111111111111111111111) |
| [`222222222222`](https://github.com/aws/s2n-quic/commit/2222222222222222222222222222222222222222) | ⚠️ Findings to review | [View report](https://d9s1wy5tjcjzb.cloudfront.net/s2n-quic/findings.html?pr=123&commit=2222222222222222222222222222222222222222) |
| [`333333333333`](https://github.com/aws/s2n-quic/commit/3333333333333333333333333333333333333333) | ✅ No findings | [View report](https://d9s1wy5tjcjzb.cloudfront.net/s2n-quic/findings.html?pr=123&commit=3333333333333333333333333333333333333333) |

_Report access is restricted to maintainers._

### Call-outs:

Deploy the producer that exports `REVIEW_FINDINGS_COUNT` before enabling this workflow.

### Testing:

- Shell syntax, typo, YAML, and diff checks
- Fake CodeBuild result transitions
- Fake GitHub comment-history transitions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.