### PR TITLE
perf(s2n-quic-dc): snapshot Arc entries once when serializing to disk

### DIFF
--- a/dc/s2n-quic-dc/src/path/secret/map/disk.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/disk.rs
@@ -11,7 +11,7 @@ use std::{
     io::{self, BufWriter, Read, Write},
     net::{Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
     path::{Path, PathBuf},
-    sync::{Mutex, Weak},
+    sync::{Arc, Mutex},
     time::{Duration, SystemTime},
 };
 
@@ -240,14 +240,14 @@ impl Serializer {
     /// Writes the entries in `entries` to the configured path, filtering by recency of access
     /// relative to `current_epoch`.
     ///
-    /// `entries` is iterated and any still-live entry passing the recency filter is written.
+    /// `entries` is iterated in order and any entry passing the recency filter is written.
     /// Returns the number of entries written and the resulting file size.
     ///
     /// This is `pub(crate)` because it references the crate-internal [`Entry`] and [`Epoch`] types;
     /// callers outside the crate drive serialization through the path secret map builder instead.
-    pub(crate) fn serialize(
+    pub(crate) fn serialize<'a>(
         &self,
-        entries: &[Weak<Entry>],
+        entries: impl IntoIterator<Item = &'a Arc<Entry>>,
         current_epoch: Epoch,
     ) -> io::Result<SerializeStats> {
         self.serialize_with_max_size(entries, current_epoch, MAX_SERIALIZED_SIZE)
@@ -255,9 +255,9 @@ impl Serializer {
 
     /// As [`Serializer::serialize`], but stops adding entries once the file grows past `max_size`.
     /// Exposed separately so tests can exercise the size cap without writing tens of megabytes.
-    fn serialize_with_max_size(
+    fn serialize_with_max_size<'a>(
         &self,
-        entries: &[Weak<Entry>],
+        entries: impl IntoIterator<Item = &'a Arc<Entry>>,
         current_epoch: Epoch,
         max_size: u64,
     ) -> io::Result<SerializeStats> {
@@ -284,17 +284,13 @@ impl Serializer {
         output.write_all(&started_at.to_le_bytes())?;
 
         let mut written = 0;
-        for entry in entries.iter() {
+        for entry in entries {
             // Stop adding new entries once the file has grown past the maximum serialized size.
             // Entries are tiny (tens of bytes) relative to the margin we keep below MAX_FILE_SIZE,
             // so checking after the fact rather than predicting each entry's size is fine.
             if output.bytes_written() > max_size {
                 break;
             }
-
-            let Some(entry) = entry.upgrade() else {
-                continue;
-            };
 
             // Skip entries idle for longer than the configured window.
             if min_epoch.is_some_and(|min| entry.accessed_at_epoch().get() < min) {

--- a/dc/s2n-quic-dc/src/path/secret/map/disk/test.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/disk/test.rs
@@ -35,13 +35,11 @@ fn roundtrip_with(
     current_epoch: Epoch,
     configure: impl FnOnce(SerializerBuilder) -> SerializerBuilder,
 ) -> (SystemTime, Vec<DiskEntry>) {
-    let weak: Vec<Weak<Entry>> = entries.iter().map(Arc::downgrade).collect();
-
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("secrets");
 
     let serializer = configure(Serializer::builder(&path)).build().unwrap();
-    serializer.serialize(&weak, current_epoch).unwrap();
+    serializer.serialize(entries, current_epoch).unwrap();
 
     let entries = deserialize(serializer.path()).unwrap();
     let started_at = entries.started_at;
@@ -197,7 +195,6 @@ fn max_size_stops_adding_entries() {
         .map(|i| SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(10, 0, 0, i as u8), i)))
         .collect();
     let entries: Vec<Arc<Entry>> = peers.iter().map(|peer| Entry::fake(*peer, None)).collect();
-    let weak: Vec<Weak<Entry>> = entries.iter().map(Arc::downgrade).collect();
 
     let dir = tempfile::tempdir().unwrap();
     let path = dir.path().join("secrets");
@@ -206,7 +203,7 @@ fn max_size_stops_adding_entries() {
     // Prefix is HEADER + VERSION + 8-byte timestamp; allow ~3 more entries' worth of room.
     let prefix = (HEADER.len() + VERSION.len() + 8) as u64;
     serializer
-        .serialize_with_max_size(&weak, Epoch(0), prefix + 20)
+        .serialize_with_max_size(&entries, Epoch(0), prefix + 20)
         .unwrap();
 
     let decoded: Vec<DiskEntry> = deserialize(serializer.path())

--- a/dc/s2n-quic-dc/src/path/secret/map/state.rs
+++ b/dc/s2n-quic-dc/src/path/secret/map/state.rs
@@ -19,6 +19,7 @@ use s2n_quic_core::{
     varint::VarInt,
 };
 use std::{
+    cmp::Reverse,
     collections::VecDeque,
     hash::BuildHasher,
     mem::ManuallyDrop,
@@ -614,32 +615,31 @@ where
             return Ok(());
         };
 
-        // Clone the weak references out under the lock so we don't hold it across the write.
-        let mut entries: Vec<Weak<Entry>> = {
+        // Snapshot the live entries under the lock so we don't hold it across the write. The sort
+        // key is captured here too: `accessed_at_epoch` can change concurrently, and sorting on a
+        // key that changes mid-sort violates the total order the sort requires (and may panic).
+        let mut entries: Vec<(Reverse<u64>, Arc<Entry>)> = {
             let queue = self
                 .eviction_queue
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
-            queue.iter().cloned().collect()
+            queue
+                .iter()
+                .filter_map(|weak| {
+                    let entry = weak.upgrade()?;
+                    Some((Reverse(entry.accessed_at_epoch().get()), entry))
+                })
+                .collect()
         };
 
         // Order by access recency (newest first), so the most-active peers come first regardless
-        // of when they were created.
-        //
-        // Caching the key is required for correctness, not just speed: entries are still live and
-        // `accessed_at_epoch` can change concurrently (and `upgrade()` can start failing) while we
-        // sort. Recomputing the key on every comparison would then violate the total order the
-        // sort requires, which is allowed to panic. Caching reads each key exactly once, sorting a
-        // consistent snapshot.
-        entries.sort_by_cached_key(|weak| {
-            core::cmp::Reverse(
-                weak.upgrade()
-                    .map_or(0, |entry| entry.accessed_at_epoch().get()),
-            )
-        });
+        // of when they were created. The sort is stable, so peers with the same access epoch keep
+        // their eviction-queue (creation) order.
+        entries.sort_by_key(|(recency, _)| *recency);
 
         let start = self.clock.get_time();
-        let result = serializer.serialize(&entries, self.cleaner.epoch());
+        let result =
+            serializer.serialize(entries.iter().map(|(_, entry)| entry), self.cleaner.epoch());
         let duration = self.clock.get_time().saturating_duration_since(start);
 
         let (entries_written, file_size) = match &result {


### PR DESCRIPTION
@Mark-Simulacrum suggested this in #3276. Implementing here as a follow up.

Serializing 500k entries to tmpfs drops from ~73ms to ~52ms.

### Testing:
Unit tests cover this well. No additional testing.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

